### PR TITLE
Support interface port members as nested DUT accessors (dut.bus.data)

### DIFF
--- a/crates/celox-ts-gen/src/generator.rs
+++ b/crates/celox-ts-gen/src/generator.rs
@@ -25,6 +25,9 @@ pub struct JsonPortInfo {
     pub is4state: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub array_dims: Option<Vec<usize>>,
+    /// Nested members for interface ports (e.g. `bus.data` grouped under `bus`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interface: Option<HashMap<String, JsonPortInfo>>,
 }
 
 /// Top-level JSON output for `celox-gen-ts --json`.
@@ -159,22 +162,49 @@ fn extract_instances(module: &Module) -> Vec<InstanceInfo> {
 }
 
 /// Convert ports to JSON-serializable format.
+///
+/// Hierarchical ports (var_path length > 1, e.g. `bus.data`) are grouped
+/// under a synthetic parent entry with an `interface` map so that the
+/// TypeScript DUT can expose them as `dut.bus.data`.
 fn ports_to_json(ports: &[PortInfo]) -> HashMap<String, JsonPortInfo> {
-    ports
-        .iter()
-        .map(|p| {
-            (
-                p.name.clone(),
-                JsonPortInfo {
-                    direction: p.direction,
-                    r#type: type_info_str(p.type_info),
-                    width: p.width,
-                    is4state: p.is_4state,
-                    array_dims: p.array_dims.clone(),
-                },
-            )
-        })
-        .collect()
+    let mut result: HashMap<String, JsonPortInfo> = HashMap::new();
+    // Accumulate interface members for each parent name separately so we can
+    // insert the parent entry once at the end.
+    let mut iface_maps: HashMap<String, HashMap<String, JsonPortInfo>> = HashMap::new();
+
+    for p in ports {
+        let json = JsonPortInfo {
+            direction: p.direction,
+            r#type: type_info_str(p.type_info),
+            width: p.width,
+            is4state: p.is_4state,
+            array_dims: p.array_dims.clone(),
+            interface: None,
+        };
+        if p.is_hierarchical {
+            if let Some(dot) = p.name.find('.') {
+                let parent = p.name[..dot].to_string();
+                let member = p.name[dot + 1..].to_string();
+                iface_maps.entry(parent).or_default().insert(member, json);
+            }
+        } else {
+            result.insert(p.name.clone(), json);
+        }
+    }
+
+    // Build synthetic parent entries for every interface group
+    for (parent_name, iface_map) in iface_maps {
+        result.insert(parent_name, JsonPortInfo {
+            direction: "inout",
+            r#type: "logic",
+            width: 0,
+            is4state: false,
+            array_dims: None,
+            interface: Some(iface_map),
+        });
+    }
+
+    result
 }
 
 /// Convert instance info to JSON-serializable format.
@@ -319,11 +349,32 @@ fn generate_dts(module_name: &str, ports: &[PortInfo], instances: &[InstanceInfo
 }
 
 /// Write port members to a DTS interface body at the given indentation level.
+///
+/// Hierarchical ports (e.g. `bus.data`, `bus.valid`) are grouped into a nested
+/// object type `bus: { data: bigint; valid: bigint; }` instead of emitting the
+/// dot-qualified name directly (which would be a TypeScript syntax error).
 fn write_dts_port_members(out: &mut String, ports: &[PortInfo], indent: &str) {
+    use std::collections::BTreeMap;
+
+    // Separate scalar ports from hierarchical ones and group the latter by parent
+    let mut scalar: Vec<&PortInfo> = Vec::new();
+    let mut groups: BTreeMap<String, Vec<&PortInfo>> = BTreeMap::new();
+
     for port in ports {
         if port.type_info == TypeInfo::Clock {
             continue;
         }
+        if port.is_hierarchical {
+            if let Some(dot) = port.name.find('.') {
+                groups.entry(port.name[..dot].to_string()).or_default().push(port);
+                continue;
+            }
+        }
+        scalar.push(port);
+    }
+
+    // Emit scalar ports
+    for port in scalar {
         let ts_type = ts_type_for_width(port.width);
         let readonly = if port.is_output { "readonly " } else { "" };
         if port.array_dims.is_some() {
@@ -339,6 +390,19 @@ fn write_dts_port_members(out: &mut String, ports: &[PortInfo], indent: &str) {
         } else {
             out.push_str(&format!("{}{}{}: {};\n", indent, readonly, port.name, ts_type));
         }
+    }
+
+    // Emit interface port groups as nested object types
+    let child_indent = format!("{}  ", indent);
+    for (parent_name, members) in groups {
+        out.push_str(&format!("{}{}: {{\n", indent, parent_name));
+        for member in members {
+            let member_name = &member.name[member.name.find('.').unwrap() + 1..];
+            let ts_type = ts_type_for_width(member.width);
+            let readonly = if member.is_output { "readonly " } else { "" };
+            out.push_str(&format!("{}{}{}: {};\n", child_indent, readonly, member_name, ts_type));
+        }
+        out.push_str(&format!("{}}};\n", indent));
     }
 }
 
@@ -365,16 +429,26 @@ fn generate_js(module_name: &str, ports: &[PortInfo]) -> String {
         module_name
     ));
 
-    // Ports object
-    out.push_str("  ports: {\n");
+    // Ports object — hierarchical ports (e.g. "bus.data") are grouped into a
+    // nested { interface: { ... } } entry so that the TS DUT can expose them
+    // as dut.bus.data rather than the raw "bus.data" flat key.
+    use std::collections::BTreeMap;
+    let mut scalar_ports: Vec<&PortInfo> = Vec::new();
+    let mut iface_groups: BTreeMap<String, Vec<&PortInfo>> = BTreeMap::new();
     for port in ports {
+        if port.is_hierarchical {
+            if let Some(dot) = port.name.find('.') {
+                iface_groups.entry(port.name[..dot].to_string()).or_default().push(port);
+                continue;
+            }
+        }
+        scalar_ports.push(port);
+    }
+
+    out.push_str("  ports: {\n");
+    for port in scalar_ports {
         let type_str = type_info_str(port.type_info);
         let four_state_str = if port.is_4state { ", is4state: true" } else { "" };
-        let hierarchical_str = if port.is_hierarchical {
-            ", hierarchical: true"
-        } else {
-            ""
-        };
         let array_dims_str = match &port.array_dims {
             Some(dims) => {
                 let dims_str = dims
@@ -387,9 +461,22 @@ fn generate_js(module_name: &str, ports: &[PortInfo]) -> String {
             None => String::new(),
         };
         out.push_str(&format!(
-            "    {}: {{ direction: \"{}\", type: \"{}\", width: {}{}{}{} }},\n",
-            port.name, port.direction, type_str, port.width, four_state_str, hierarchical_str, array_dims_str
+            "    {}: {{ direction: \"{}\", type: \"{}\", width: {}{}{} }},\n",
+            port.name, port.direction, type_str, port.width, four_state_str, array_dims_str
         ));
+    }
+    for (parent_name, members) in iface_groups {
+        out.push_str(&format!("    {}: {{ direction: \"inout\", type: \"logic\", width: 0, interface: {{\n", parent_name));
+        for member in members {
+            let member_name = &member.name[member.name.find('.').unwrap() + 1..];
+            let type_str = type_info_str(member.type_info);
+            let four_state_str = if member.is_4state { ", is4state: true" } else { "" };
+            out.push_str(&format!(
+                "      {}: {{ direction: \"{}\", type: \"{}\", width: {}{} }},\n",
+                member_name, member.direction, type_str, member.width, four_state_str
+            ));
+        }
+        out.push_str("    } },\n");
     }
     out.push_str("  },\n");
 
@@ -658,5 +745,57 @@ module Top (
         assert_eq!(top.instances[0].name, "u_sub");
         assert!(top.instances[0].ports.contains_key("i_data"));
         assert!(top.instances[0].ports.contains_key("o_data"));
+    }
+
+    /// Interface port: a module that takes a modport as a top-level port.
+    /// The generated DTS must emit a nested object type (not "bus.data: bigint"),
+    /// and the generated JS must emit a nested `interface` object.
+    #[test]
+    fn test_interface_port() {
+        let code = r#"
+interface Bus {
+    var data:  logic<8>;
+    var valid: logic;
+    modport producer {
+        data:  output,
+        valid: output,
+    }
+    modport consumer {
+        data:  input,
+        valid: input,
+    }
+}
+
+module Top (
+    bus: modport Bus::consumer,
+    out: output logic<8>,
+) {
+    assign out = bus.data;
+}
+"#;
+        let modules = generate_from_source(code);
+        let top = modules.iter().find(|m| m.module_name == "Top").unwrap();
+
+        assert_snapshot!("interface_port_dts", top.dts_content);
+        assert_snapshot!("interface_port_js", top.js_content);
+        assert_snapshot!("interface_port_md", top.md_content);
+
+        // The DTS must NOT contain "bus.data" as a raw key (would be a syntax error)
+        assert!(!top.dts_content.contains("bus.data:"), "DTS must not have dot-separated port name");
+        // The DTS must have a nested `bus` object type
+        assert!(top.dts_content.contains("bus:"), "DTS must have 'bus' as top-level port name");
+
+        // The JS ports object must have a nested `interface` key for `bus`
+        let bus_port = top.ports.get("bus").expect("ports map must have 'bus' key");
+        assert!(bus_port.interface.is_some(), "JsonPortInfo for 'bus' must have interface");
+        let iface = bus_port.interface.as_ref().unwrap();
+        assert!(iface.contains_key("data"), "interface must contain 'data'");
+        assert!(iface.contains_key("valid"), "interface must contain 'valid'");
+        assert_eq!(iface["data"].direction, "input");
+        assert_eq!(iface["valid"].direction, "input");
+        assert_eq!(iface["data"].width, 8);
+
+        // Flat ports must NOT contain "bus.data"
+        assert!(!top.ports.contains_key("bus.data"), "ports map must not have flat 'bus.data' key");
     }
 }

--- a/crates/celox-ts-gen/src/snapshots/celox_ts_gen__generator__tests__interface_port_dts.snap
+++ b/crates/celox-ts-gen/src/snapshots/celox_ts_gen__generator__tests__interface_port_dts.snap
@@ -1,0 +1,15 @@
+---
+source: crates/celox-ts-gen/src/generator.rs
+expression: top.dts_content
+---
+import type { ModuleDefinition } from "@celox-sim/celox";
+
+export interface TopPorts {
+  readonly out: bigint;
+  bus: {
+    data: bigint;
+    valid: bigint;
+  };
+}
+
+export declare const Top: ModuleDefinition<TopPorts>;

--- a/crates/celox-ts-gen/src/snapshots/celox_ts_gen__generator__tests__interface_port_js.snap
+++ b/crates/celox-ts-gen/src/snapshots/celox_ts_gen__generator__tests__interface_port_js.snap
@@ -1,0 +1,17 @@
+---
+source: crates/celox-ts-gen/src/generator.rs
+expression: top.js_content
+---
+exports.Top = {
+  __celox_module: true,
+  name: "Top",
+  source: require("fs").readFileSync(__dirname + "/../Top.veryl", "utf-8"),
+  ports: {
+    out: { direction: "output", type: "logic", width: 8, is4state: true },
+    bus: { direction: "inout", type: "logic", width: 0, interface: {
+      data: { direction: "input", type: "logic", width: 8, is4state: true },
+      valid: { direction: "input", type: "logic", width: 1, is4state: true },
+    } },
+  },
+  events: [],
+};

--- a/crates/celox-ts-gen/src/snapshots/celox_ts_gen__generator__tests__interface_port_md.snap
+++ b/crates/celox-ts-gen/src/snapshots/celox_ts_gen__generator__tests__interface_port_md.snap
@@ -1,0 +1,13 @@
+---
+source: crates/celox-ts-gen/src/generator.rs
+expression: top.md_content
+---
+# Top
+
+## Ports
+
+| Port | Direction | Type | Width | TS Type | 4-State |
+|------|-----------|------|-------|---------|--------|
+| bus.data | input | logic | 8 | `bigint` | yes |
+| bus.valid | input | logic | 1 | `bigint` | yes |
+| out | output | logic | 8 | `bigint` (readonly) | yes |

--- a/packages/celox/src/dut.ts
+++ b/packages/celox/src/dut.ts
@@ -288,6 +288,25 @@ export function createChildDut(
   for (const [name, port] of Object.entries(hierarchy.ports)) {
     if (port.type === "clock") continue;
 
+    // Handle nested interface port
+    if (port.interface) {
+      const nestedObj = createNestedDut(
+        view,
+        hierarchy.forDut,
+        port.interface,
+        name,
+        handle,
+        state,
+      );
+      Object.defineProperty(obj, name, {
+        value: nestedObj,
+        enumerable: true,
+        configurable: false,
+        writable: false,
+      });
+      continue;
+    }
+
     const sig = hierarchy.forDut[name];
     if (!sig) continue;
 

--- a/packages/celox/src/e2e.test.ts
+++ b/packages/celox/src/e2e.test.ts
@@ -1721,3 +1721,165 @@ describe("E2E: celox.toml test sources", () => {
     sim.dispose();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Interface port DUT accessor tests
+// ---------------------------------------------------------------------------
+
+// A module whose top-level port is a modport interface.
+// After Veryl expansion "sig.data" and "sig.valid" become individual ports.
+// buildPortsFromLayout must group them into a nested PortInfo so that the
+// DUT exposes them as dut.sig.data / dut.sig.valid.
+const INTERFACE_PORT_SOURCE = `
+interface Signal {
+    var data:  logic<8>;
+    var valid: logic;
+    modport src {
+        data:  output,
+        valid: output,
+    }
+    modport dst {
+        data:  input,
+        valid: input,
+    }
+}
+
+module Top (
+    sig: modport Signal::dst,
+    out: output logic<8>,
+) {
+    assign out = sig.data;
+}
+`;
+
+// A module that uses two instances connected via an interface so we can verify
+// that the hierarchy DUT also exposes nested accessors correctly.
+const INTERFACE_HIERARCHY_SOURCE = `
+interface Bus {
+    var data:  logic<8>;
+    var valid: logic;
+    modport producer {
+        data:  output,
+        valid: output,
+    }
+    modport consumer {
+        data:  input,
+        valid: input,
+    }
+}
+
+module Producer (
+    bus: modport Bus::producer,
+    val: input logic<8>,
+) {
+    assign bus.data  = val;
+    assign bus.valid = 1'b1;
+}
+
+module Consumer (
+    bus:  modport Bus::consumer,
+    out:  output logic<8>,
+    got:  output logic,
+) {
+    assign out = bus.data;
+    assign got = bus.valid;
+}
+
+module Top (
+    val: input  logic<8>,
+    out: output logic<8>,
+    got: output logic,
+) {
+    inst b:   Bus;
+    inst p:   Producer (bus: b, val: val);
+    inst c:   Consumer (bus: b, out: out, got: got);
+}
+`;
+
+describe("E2E: interface port DUT accessor", () => {
+  test("top-level interface port members accessible as nested dut properties", () => {
+    interface TopPorts {
+      sig: { data: bigint; valid: bigint };
+      readonly out: bigint;
+    }
+
+    const sim = Simulator.fromSource<TopPorts>(INTERFACE_PORT_SOURCE, "Top");
+
+    sim.dut.sig.data = 0x42n;
+    expect(sim.dut.out).toBe(0x42n);
+
+    sim.dut.sig.data = 0xFFn;
+    expect(sim.dut.out).toBe(0xFFn);
+
+    sim.dut.sig.data = 0x00n;
+    expect(sim.dut.out).toBe(0x00n);
+
+    sim.dispose();
+  });
+
+  test("writing to interface output member throws", () => {
+    // bus.data / bus.valid are outputs of Top — writing should throw.
+    const PRODUCER_ONLY = `
+interface Bus {
+    var data:  logic<8>;
+    var valid: logic;
+    modport src {
+        data:  output,
+        valid: output,
+    }
+}
+module Top (
+    bus: modport Bus::src,
+    val: input logic<8>,
+) {
+    assign bus.data  = val;
+    assign bus.valid = 1'b1;
+}
+`;
+    const sim = Simulator.fromSource(PRODUCER_ONLY, "Top");
+
+    expect(() => {
+      (sim.dut as any).bus.data = 0n;
+    }).toThrow("Cannot write to output port 'data'");
+
+    sim.dispose();
+  });
+
+  test("interface port propagates through sub-module instances", () => {
+    interface TopPorts {
+      val: bigint;
+      readonly out: bigint;
+      readonly got: bigint;
+    }
+
+    const sim = Simulator.fromSource<TopPorts>(INTERFACE_HIERARCHY_SOURCE, "Top");
+
+    sim.dut.val = 0xABn;
+    expect(sim.dut.out).toBe(0xABn);
+    expect(sim.dut.got).toBe(1n);
+
+    sim.dut.val = 0x00n;
+    expect(sim.dut.out).toBe(0x00n);
+
+    sim.dispose();
+  });
+
+  test("multiple interface port members are independently accessible", () => {
+    interface TopPorts {
+      sig: { data: bigint; valid: bigint };
+      readonly out: bigint;
+    }
+
+    const sim = Simulator.fromSource<TopPorts>(INTERFACE_PORT_SOURCE, "Top");
+
+    sim.dut.sig.data = 0x77n;
+    sim.dut.sig.valid = 1n;
+    expect(sim.dut.out).toBe(0x77n);
+
+    sim.dut.sig.data = 0x33n;
+    sim.dut.sig.valid = 0n;
+    expect(sim.dut.out).toBe(0x33n);
+
+    sim.dispose();
+  });
+});

--- a/packages/celox/src/napi-helpers.ts
+++ b/packages/celox/src/napi-helpers.ts
@@ -301,12 +301,17 @@ export function parseNapiLayout(json: string): {
 /**
  * Build PortInfo records from the NAPI layout signals.
  * This auto-detects port metadata so users don't need to hand-write ModuleDefinition.
+ *
+ * Hierarchical signal names (e.g. "bus.data", "bus.valid" from an interface port)
+ * are grouped into a nested PortInfo with an `interface` map so that createDut can
+ * expose them as `dut.bus.data` and `dut.bus.valid`.
  */
 export function buildPortsFromLayout(
   signals: Record<string, SignalLayout & { typeKind: string; arrayDims?: number[] }>,
   _events: Record<string, number>,
 ): Record<string, PortInfo> {
-  const ports: Record<string, PortInfo> = {};
+  // Step 1: Build flat PortInfo for every signal name
+  const flat: Record<string, PortInfo> = {};
 
   for (const [name, sig] of Object.entries(signals)) {
     const typeKind = sig.typeKind;
@@ -330,7 +335,36 @@ export function buildPortsFromLayout(
     if (sig.arrayDims && sig.arrayDims.length > 0) {
       (port as { arrayDims: readonly number[] }).arrayDims = sig.arrayDims;
     }
-    ports[name] = port;
+    flat[name] = port;
+  }
+
+  // Step 2: Group hierarchical signals (e.g. "bus.data") into nested PortInfo.
+  // Veryl interface ports are exactly one level deep, so "bus.data" → parent "bus",
+  // member "data". The parent entry receives an `interface` map of its members;
+  // the flat layout keys are kept as-is so createNestedDut can look them up.
+  const ports: Record<string, PortInfo> = {};
+  const ifMaps = new Map<string, Record<string, PortInfo>>();
+
+  for (const [name, port] of Object.entries(flat)) {
+    const dotIdx = name.indexOf(".");
+    if (dotIdx < 0) {
+      ports[name] = port;
+      continue;
+    }
+    // Hierarchical signal: first segment is the interface port name
+    const parentName = name.slice(0, dotIdx);
+    const memberName = name.slice(dotIdx + 1);
+    if (!ifMaps.has(parentName)) {
+      const ifMap: Record<string, PortInfo> = {};
+      ifMaps.set(parentName, ifMap);
+      ports[parentName] = {
+        direction: "inout",
+        type: "logic",
+        width: 0,
+        interface: ifMap,
+      };
+    }
+    ifMaps.get(parentName)![memberName] = port;
   }
 
   return ports;


### PR DESCRIPTION
## Summary

- **バグ修正**: Veryl のインターフェースポート (`bus: modport Bus::consumer`) が TypeScript DUT で `dut.bus.data` としてアクセスできなかった問題を修正
- **根本原因**: `buildPortsFromLayout` が `"bus.data"` をフラットな `PortInfo` として渡していたため、`createDut` がドット入りのプロパティ名を定義していた
- **テスト追加**: E2E テスト 4 件 + generator スナップショットテスト 1 件

## Changes

### `packages/celox/src/napi-helpers.ts`
`buildPortsFromLayout` に階層的シグナルのグループ化を追加。`"bus.data"` / `"bus.valid"` → `"bus": { interface: { "data": …, "valid": … } }` に変換することで `createDut` が `dut.bus.data` アクセサを正しく生成できるようになった。

### `packages/celox/src/dut.ts`
`createChildDut` に `port.interface` ハンドリングを追加（`createDut` と同等）。子インスタンスの階層 DUT でもインターフェースポートが正しくネスト化される。

### `crates/celox-ts-gen/src/generator.rs`
- `JsonPortInfo` に `interface?: HashMap<String, JsonPortInfo>` フィールドを追加
- `ports_to_json`：階層的ポートを親の `interface` マップにグループ化
- `write_dts_port_members`：`bus.data: bigint`（TypeScript 構文エラー）ではなく `bus: { data: bigint; }` 形式で出力
- `generate_js`：生成 JS に `interface` ネスト構造を出力

## Test plan

- [ ] `cargo test` — 全 Rust テスト通過
- [ ] `pnpm --filter @celox-sim/celox test` — TypeScript 121 件通過（新規 E2E 4 件含む）
- [ ] generator スナップショット確認（`interface_port_dts`, `interface_port_js`, `interface_port_md`）