### PR TITLE
Return proper errors when top module is missing or generic

### DIFF
--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -74,6 +74,12 @@ pub enum ParserError {
         variable: String,
         typ: String,
     },
+
+    #[error("Top module `{name}` not found in IR")]
+    TopNotFound { name: String },
+
+    #[error("Top module `{name}` is generic and cannot be used as a top-level module")]
+    GenericTop { name: String },
 }
 
 /// Resolve the total bit width of a variable (width * kind), returning
@@ -184,7 +190,14 @@ pub fn parse_ir<'a>(
     // Allocate root
     let root_id = ModuleId(next_id);
     next_id += 1;
-    let root_ir = name_to_ir[top];
+    let root_ir = name_to_ir.get(top).ok_or_else(|| ParserError::TopNotFound {
+        name: resource_table::get_str_value(*top).unwrap_or_default(),
+    })?;
+    if generic_names.contains(top) {
+        return Err(ParserError::GenericTop {
+            name: resource_table::get_str_value(*top).unwrap_or_default(),
+        });
+    }
     name_to_id.insert(*top, root_id);
     module_names.insert(root_id, *top);
     module_ir.insert(root_id, root_ir);

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -412,3 +412,44 @@ fn test_sv_module_instance_returns_unsupported_parser_error() {
         Ok(_) => panic!("expected UnsupportedSimulatorParser for $sv module, got Ok"),
     }
 }
+
+#[test]
+fn test_top_not_found_returns_error() {
+    let code = r#"
+        module Foo (a: input logic, b: output logic) {
+            assign b = a;
+        }
+    "#;
+
+    let result = Simulator::builder(code, "NonExistentTop").build();
+
+    match result {
+        Err(SimulatorError::SIRParser(ParserError::TopNotFound { name })) => {
+            assert_eq!(name, "NonExistentTop");
+        }
+        Err(e) => panic!("expected TopNotFound, got {e:?}"),
+        Ok(_) => panic!("expected TopNotFound, got Ok"),
+    }
+}
+
+#[test]
+fn test_generic_top_returns_error() {
+    let code = r#"
+        module GenericPass::<T: type> (
+            a: input  T,
+            b: output T,
+        ) {
+            assign b = a;
+        }
+    "#;
+
+    let result = Simulator::builder(code, "GenericPass").build();
+
+    match result {
+        Err(SimulatorError::SIRParser(ParserError::GenericTop { name })) => {
+            assert_eq!(name, "GenericPass");
+        }
+        Err(e) => panic!("expected GenericTop, got {e:?}"),
+        Ok(_) => panic!("expected GenericTop, got Ok"),
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ParserError::TopNotFound` — returned when the specified top module name does not exist in the analyzed IR
- Add `ParserError::GenericTop` — returned when the specified top module is a generic template (has variables with unresolved type parameters)

Previously `parse_ir` would panic with an index-out-of-map access in both cases. Callers now receive a typed, descriptive error carrying the module name.

## Test plan

- [ ] `test_top_not_found_returns_error` — defines `module Foo` but requests `"NonExistentTop"` as the top; asserts `ParserError::TopNotFound { name: "NonExistentTop" }`
- [ ] `test_generic_top_returns_error` — defines `module GenericPass::<T: type>` and requests `"GenericPass"` as the top; asserts `ParserError::GenericTop { name: "GenericPass" }`
- [ ] All existing tests in `error_detection.rs` continue to pass