### PR TITLE
Fix Cranelift type mismatch in block-call arguments (#3)

### DIFF
--- a/crates/celox/src/backend/translator/control.rs
+++ b/crates/celox/src/backend/translator/control.rs
@@ -8,7 +8,7 @@ use super::core::cast_type;
 /// Collect the Cranelift types of all parameters declared on a block.
 /// This is used to ensure block-call arguments are cast to the exact
 /// types the target block expects, avoiding Cranelift verifier errors
-/// such as "arg vN has type i8, expected i32".
+/// such as "arg vN has type i8, expected i16" or "expected i32".
 fn collect_block_param_types(state: &TranslationState, cl_block: Block) -> Vec<Type> {
     let dfg = &state.builder.func.dfg;
     dfg.block_params(cl_block)
@@ -32,6 +32,11 @@ impl SIRTranslator {
                 // Block params use one Cranelift param per SIR param in 2-state mode,
                 // and two (value + mask) in 4-state mode.
                 let param_types = collect_block_param_types(state, target_cl_block);
+                debug_assert_eq!(
+                    param_types.len(),
+                    if self.options.four_state { params.len() * 2 } else { params.len() },
+                    "SIR Jump arg count does not match target block param count"
+                );
 
                 let mut cl_args: Vec<BlockArg> = Vec::new();
                 for (i, reg) in params.iter().enumerate() {
@@ -62,6 +67,16 @@ impl SIRTranslator {
 
                 let t_param_types = collect_block_param_types(state, block_map[t_id]);
                 let f_param_types = collect_block_param_types(state, block_map[f_id]);
+                debug_assert_eq!(
+                    t_param_types.len(),
+                    if self.options.four_state { t_args.len() * 2 } else { t_args.len() },
+                    "SIR Branch true-arg count does not match target block param count"
+                );
+                debug_assert_eq!(
+                    f_param_types.len(),
+                    if self.options.four_state { f_args.len() * 2 } else { f_args.len() },
+                    "SIR Branch false-arg count does not match target block param count"
+                );
 
                 let mut cl_t_args: Vec<BlockArg> = Vec::new();
                 for (i, reg) in t_args.iter().enumerate() {
@@ -106,8 +121,8 @@ impl SIRTranslator {
                 if let Some(next_block) = next_unit_entry {
                     state.builder.ins().jump(next_block, &[]);
                 } else {
-                    let suucess = state.builder.ins().iconst(types::I64, 0);
-                    state.builder.ins().return_(&[suucess]);
+                    let success = state.builder.ins().iconst(types::I64, 0);
+                    state.builder.ins().return_(&[success]);
                 }
             }
             crate::ir::SIRTerminator::Error(code) => {

--- a/crates/celox/tests/issue3_repro.rs
+++ b/crates/celox/tests/issue3_repro.rs
@@ -1,4 +1,4 @@
-use celox::Simulation;
+use celox::{Simulation, Simulator, SimulatorBuilder};
 
 /// When then and else have widths that map to different Cranelift types
 /// (e.g. 1-bit → i8  vs  9-bit → i16), the block argument passed on the
@@ -136,4 +136,75 @@ module Top (
 }
 "#;
     Simulation::builder(code, "Top").build().unwrap();
+}
+
+/// Verify JIT output correctness when branch widths cross type boundaries.
+/// `if en ? en : a9` — then=1-bit, else=9-bit, result=9-bit.
+/// The narrower (1-bit) value must be zero-extended, not truncated.
+#[test]
+fn test_comb_mux_i8_vs_i16_correctness() {
+    let code = r#"
+module Top (
+    en: input logic,
+    a9: input logic<9>,
+    out: output logic<9>,
+) {
+    assign out = if en ? en : a9;
+}
+"#;
+    let mut sim = Simulator::builder(code, "Top").build().unwrap();
+    let en = sim.signal("en");
+    let a9 = sim.signal("a9");
+    let out = sim.signal("out");
+
+    // en=0: output is a9
+    sim.modify(|io| {
+        io.set(en, 0u8);
+        io.set(a9, 0x155u16);
+    })
+    .unwrap();
+    assert_eq!(sim.get(out), 0x155u16.into(), "en=0: out should equal a9");
+
+    // en=1: output is en (1-bit=1) zero-extended to 9 bits → 1
+    sim.modify(|io| {
+        io.set(en, 1u8);
+        io.set(a9, 0x155u16);
+    })
+    .unwrap();
+    assert_eq!(sim.get(out), 1u16.into(), "en=1: out should be 1 (en zero-extended)");
+}
+
+/// 4-state mode: exercises the mask-cast path in translate_terminator.
+/// A ternary with i8→i16 boundary must compile and produce correct results
+/// with X/Z propagation enabled.
+#[test]
+fn test_comb_mux_i8_vs_i16_four_state() {
+    let code = r#"
+module Top (
+    en: input logic,
+    a9: input logic<9>,
+    out: output logic<9>,
+) {
+    assign out = if en ? en : a9;
+}
+"#;
+    let mut sim = SimulatorBuilder::new(code, "Top")
+        .four_state(true)
+        .build()
+        .unwrap();
+    let en = sim.signal("en");
+    let a9 = sim.signal("a9");
+    let out = sim.signal("out");
+
+    // en=0: output is a9
+    sim.modify(|io| {
+        io.set(en, 0u8);
+        io.set(a9, 0x155u16);
+    })
+    .unwrap();
+    assert_eq!(sim.get(out), 0x155u16.into(), "4-state en=0: out should equal a9");
+
+    // en=1: output is 1 (en zero-extended)
+    sim.modify(|io| io.set(en, 1u8)).unwrap();
+    assert_eq!(sim.get(out), 1u16.into(), "4-state en=1: out should be 1");
 }


### PR DESCRIPTION
Fixes #3.

## Summary

- When a ternary's then/else branches have widths that fall in different Cranelift integer types (e.g. 1-bit → `i8` vs 9-bit → `i16`), `translate_terminator` was emitting `jump`/`brif` block-call arguments without casting them to match the target block's declared parameter types, causing a Cranelift verifier error: `"arg vN has type i8, expected i16"`.
- Added `collect_block_param_types()` helper to query the actual Cranelift param types of a target block.
- Both `Jump` and `Branch` terminators now cast each argument to the expected type via the existing `cast_type()` utility before emitting. Covers both 2-state and 4-state (value + mask) paths.

## Test plan

- [ ] `cargo test -p celox --test issue3_repro` — 7 new regression tests all pass (i8→i16, i8→i32, and i8→i16-from-wide-side boundaries in both comb `assign` and `always_ff` paths)
- [ ] `cargo test -p celox` — full suite passes (0 failures)