### PR TITLE
Fix playground TypeScript fallback and add tests

### DIFF
--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -5,23 +5,20 @@ use serde::{Deserialize, Serialize};
 use crate::ParserError;
 use crate::context_width::get_context_width;
 use crate::logic_tree::range_store::RangeStore;
-use crate::parser::{LoweringPhase, resolve_total_width, resolve_width};
+use crate::parser::{LoweringPhase, resolve_total_width};
 use crate::{
     HashMap, HashSet,
     ir::{BinaryOp, BitAccess, UnaryOp, VarAtomBase},
     parser::bitaccess::{
-        build_partial_assign_expr, celox_value_from_comptime, eval_constexpr, eval_var_select,
-        is_static_access,
+        celox_value_from_comptime, eval_constexpr, eval_var_select, is_static_access,
     },
 };
 use num_bigint::BigUint;
 use num_traits::ToPrimitive as _;
 use veryl_analyzer::ir::{
-    ArrayLiteralItem, AssignStatement, CombDeclaration, Comptime, Expression, Factor, ForBound,
-    ForRange, ForStatement, IfStatement, Module, Op, Statement, ValueVariant, VarId, VarIndex,
-    VarSelect, VarSelectOp,
+    ArrayLiteralItem, AssignStatement, CombDeclaration, Expression, Factor, ForBound, ForRange,
+    ForStatement, IfStatement, Module, Op, Statement, ValueVariant, VarId, VarSelectOp,
 };
-use veryl_parser::token_range::TokenRange;
 
 // SymbolicStore: Maps variable IDs to their current symbolic representation.
 // Each variable is managed by a RangeStore, which tracks bit-ranges and their associated SLT nodes.
@@ -1903,229 +1900,87 @@ fn eval_array_literal_expression(
     ))
 }
 
-fn extract_function_return_expr(
+fn eval_function_body_return(
     module: &Module,
-    body: &veryl_analyzer::ir::FunctionBody,
+    caller_store: &SymbolicStore<VarId>,
+    call: &veryl_analyzer::ir::FunctionCall,
+    function_body: &veryl_analyzer::ir::FunctionBody,
     ret_id: VarId,
-) -> Result<Expression, ParserError> {
-    fn substitute_expr(expr: &Expression, defs: &HashMap<VarId, Expression>) -> Expression {
-        substitute_expr_inner(expr, defs, &mut HashSet::default())
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+    let mut local_store = SymbolicStore::default();
+    let mut local_bounds = BoundaryMap::default();
+    let mut written = HashMap::default();
+
+    collect_written_accesses(module, &function_body.statements, &mut written)?;
+    written.entry(ret_id).or_default();
+
+    for var_id in written.keys() {
+        let Some(var) = module.variables.get(var_id) else {
+            return Err(ParserError::unsupported(
+                LoweringPhase::CombLowering,
+                "function local variable",
+                format!("unknown variable id: {:?}", var_id),
+                Some(&call.comptime.token),
+            ));
+        };
+        let width = resolve_total_width(module, var)?;
+        local_store.insert(*var_id, RangeStore::new(None, width));
     }
 
-    fn substitute_expr_inner(
-        expr: &Expression,
-        defs: &HashMap<VarId, Expression>,
-        expanding: &mut HashSet<VarId>,
-    ) -> Expression {
-        match expr {
-            Expression::Term(factor) => match factor.as_ref() {
-                Factor::Variable(var_id, index, select, _)
-                    if index.0.is_empty() && select.0.is_empty() && select.1.is_none() =>
-                {
-                    if let Some(bound) = defs.get(var_id) {
-                        if expanding.insert(*var_id) {
-                            let result = substitute_expr_inner(bound, defs, expanding);
-                            expanding.remove(var_id);
-                            return result;
-                        }
-                    }
-                    expr.clone()
-                }
-                Factor::FunctionCall(call) => {
-                    let mut call = call.clone();
-                    for input_expr in call.inputs.values_mut() {
-                        *input_expr = substitute_expr_inner(input_expr, defs, expanding);
-                    }
-                    Expression::Term(Box::new(Factor::FunctionCall(call)))
-                }
-                _ => expr.clone(),
-            },
-            Expression::Binary(lhs, op, rhs, _) => Expression::Binary(
-                Box::new(substitute_expr_inner(lhs, defs, expanding)),
-                *op,
-                Box::new(substitute_expr_inner(rhs, defs, expanding)),
-                Box::new(Comptime::create_unknown(TokenRange::default())),
-            ),
-            Expression::Unary(op, inner, _) => Expression::Unary(
-                *op,
-                Box::new(substitute_expr_inner(inner, defs, expanding)),
-                Box::new(Comptime::create_unknown(TokenRange::default())),
-            ),
-            Expression::Ternary(cond, then_expr, else_expr, _) => Expression::Ternary(
-                Box::new(substitute_expr_inner(cond, defs, expanding)),
-                Box::new(substitute_expr_inner(then_expr, defs, expanding)),
-                Box::new(substitute_expr_inner(else_expr, defs, expanding)),
-                Box::new(Comptime::create_unknown(TokenRange::default())),
-            ),
-            Expression::Concatenation(parts, _) => Expression::Concatenation(
-                parts
-                    .iter()
-                    .map(|(x, rep)| {
-                        (
-                            substitute_expr_inner(x, defs, expanding),
-                            rep.as_ref()
-                                .map(|r| substitute_expr_inner(r, defs, expanding)),
-                        )
-                    })
-                    .collect(),
-                Box::new(Comptime::create_unknown(TokenRange::default())),
-            ),
-            Expression::ArrayLiteral(items, _) => Expression::ArrayLiteral(
-                items
-                    .iter()
-                    .map(|item| match item {
-                        ArrayLiteralItem::Value(x, rep) => ArrayLiteralItem::Value(
-                            Box::new(substitute_expr_inner(x, defs, expanding)),
-                            rep.as_ref()
-                                .map(|r| Box::new(substitute_expr_inner(r, defs, expanding))),
-                        ),
-                        ArrayLiteralItem::Defaul(x) => ArrayLiteralItem::Defaul(Box::new(
-                            substitute_expr_inner(x, defs, expanding),
-                        )),
-                    })
-                    .collect(),
-                Box::new(Comptime::create_unknown(TokenRange::default())),
-            ),
-            Expression::StructConstructor(ty, fields, _) => Expression::StructConstructor(
-                ty.clone(),
-                fields
-                    .iter()
-                    .map(|(name, x)| (*name, substitute_expr_inner(x, defs, expanding)))
-                    .collect(),
-                Box::new(Comptime::create_unknown(TokenRange::default())),
-            ),
-        }
+    for (arg_path, arg_id) in &function_body.arg_map {
+        let Some(arg_expr) = call.inputs.get(arg_path) else {
+            return Err(ParserError::unsupported(
+                LoweringPhase::CombLowering,
+                "function call missing argument",
+                format!("{call}"),
+                Some(&call.comptime.token),
+            ));
+        };
+
+        let ((arg_node, sources), bounds) =
+            eval_expression(module, caller_store, arg_expr, arena, None)?;
+        local_bounds = merge_boundaries(local_bounds, bounds);
+
+        let Some(arg_var) = module.variables.get(arg_id) else {
+            return Err(ParserError::unsupported(
+                LoweringPhase::CombLowering,
+                "function argument variable",
+                format!("unknown arg id: {:?}", arg_id),
+                Some(&call.comptime.token),
+            ));
+        };
+        let arg_width = resolve_total_width(module, arg_var)?;
+        local_store.insert(
+            *arg_id,
+            RangeStore::new(Some((arg_node, sources)), arg_width),
+        );
     }
 
-    fn resolve_return_expr(
-        module: &Module,
-        statements: &[Statement],
-        ret_id: VarId,
-        defs: &HashMap<VarId, Expression>,
-    ) -> Result<Option<Expression>, ParserError> {
-        if statements.is_empty() {
-            return Ok(None);
-        }
-
-        let stmt = &statements[0];
-        let rest = &statements[1..];
-
-        match stmt {
-            Statement::Assign(assign) => {
-                if assign.dst.len() != 1 {
-                    return Err(ParserError::unsupported(
-                        LoweringPhase::CombLowering,
-                        "function body assignment shape",
-                        format!("{stmt}"),
-                        Some(&assign.token),
-                    ));
-                }
-
-                let dst = &assign.dst[0];
-                let is_whole_var =
-                    dst.index.0.is_empty() && dst.select.0.is_empty() && dst.select.1.is_none();
-
-                let rhs = substitute_expr(&assign.expr, defs);
-
-                if is_whole_var {
-                    if dst.id == ret_id {
-                        // Assignment to return variable corresponds to `return` and terminates
-                        // this path.
-                        return Ok(Some(rhs));
-                    }
-
-                    let mut next_defs = defs.clone();
-                    next_defs.insert(dst.id, rhs);
-                    resolve_return_expr(module, rest, ret_id, &next_defs)
-                } else if is_static_access(&dst.index, &dst.select) {
-                    let old_value = defs.get(&dst.id).cloned().unwrap_or_else(|| {
-                        Expression::Term(Box::new(Factor::Variable(
-                            dst.id,
-                            VarIndex::default(),
-                            VarSelect::default(),
-                            dst.comptime.clone(),
-                        )))
-                    });
-                    let merged = build_partial_assign_expr(module, dst, rhs, old_value)?;
-
-                    // Partial write does NOT terminate the path.
-                    let mut next_defs = defs.clone();
-                    next_defs.insert(dst.id, merged);
-                    resolve_return_expr(module, rest, ret_id, &next_defs)
-                } else {
-                    Err(ParserError::unsupported(
-                        LoweringPhase::CombLowering,
-                        "function body non-whole assignment (dynamic index)",
-                        format!("{stmt}"),
-                        Some(&assign.token),
-                    ))
-                }
-            }
-            Statement::If(if_stmt) => {
-                let cond = substitute_expr(&if_stmt.cond, defs);
-
-                let mut then_stmts = if_stmt.true_side.clone();
-                then_stmts.extend_from_slice(rest);
-                let then_expr = resolve_return_expr(module, &then_stmts, ret_id, defs)?;
-
-                let mut else_stmts = if_stmt.false_side.clone();
-                else_stmts.extend_from_slice(rest);
-                let else_expr = resolve_return_expr(module, &else_stmts, ret_id, defs)?;
-
-                match (then_expr, else_expr) {
-                    (Some(then_expr), Some(else_expr)) => Ok(Some(Expression::Ternary(
-                        Box::new(cond),
-                        Box::new(then_expr),
-                        Box::new(else_expr),
-                        Box::new(Comptime::create_unknown(TokenRange::default())),
-                    ))),
-                    _ => Ok(None),
-                }
-            }
-            Statement::Null => resolve_return_expr(module, rest, ret_id, defs),
-            Statement::IfReset(ir) => Err(ParserError::unsupported(
-                LoweringPhase::CombLowering,
-                "function body control flow",
-                format!("{stmt}"),
-                Some(&ir.token),
-            )),
-            Statement::SystemFunctionCall(fc) => Err(ParserError::unsupported(
-                LoweringPhase::CombLowering,
-                "function body control flow",
-                format!("{stmt}"),
-                Some(&fc.comptime.token),
-            )),
-            Statement::FunctionCall(fc) => Err(ParserError::unsupported(
-                LoweringPhase::CombLowering,
-                "function body control flow",
-                format!("{stmt}"),
-                Some(&fc.comptime.token),
-            )),
-            Statement::For(f) => Err(ParserError::unsupported(
-                LoweringPhase::CombLowering,
-                "for loop in function body",
-                format!("{stmt}"),
-                Some(&f.token),
-            )),
-            Statement::TbMethodCall(_) | Statement::Break | Statement::Unsupported(_) => {
-                Err(ParserError::unsupported(
-                    LoweringPhase::CombLowering,
-                    "function body control flow",
-                    format!("{stmt}"),
-                    None,
-                ))
-            }
-        }
+    for stmt in &function_body.statements {
+        let (next_store, next_bounds) =
+            eval_statement(module, local_store, local_bounds, stmt, arena)?;
+        local_store = next_store;
+        local_bounds = next_bounds;
     }
 
-    resolve_return_expr(module, &body.statements, ret_id, &HashMap::default())?.ok_or_else(|| {
-        ParserError::unsupported(
+    let Some(ret_var) = module.variables.get(&ret_id) else {
+        return Err(ParserError::unsupported(
             LoweringPhase::CombLowering,
-            "function return expression",
-            format!("function return var id: {:?}", ret_id),
-            None,
-        )
-    })
+            "function return variable",
+            format!("unknown return id: {:?}", ret_id),
+            Some(&call.comptime.token),
+        ));
+    };
+    let ret_width = resolve_total_width(module, ret_var)?;
+    let ret_range = BitAccess::new(0, ret_width - 1);
+    let ret_parts = local_store
+        .get(&ret_id)
+        .map(|range_store| range_store.get_parts(ret_range))
+        .unwrap_or_default();
+    let (ret_node, ret_sources) = combine_parts_with_default(ret_id, 0, ret_parts, arena);
+
+    Ok(((ret_node, ret_sources), local_bounds))
 }
 
 fn eval_function_call_expression(
@@ -2174,50 +2029,7 @@ fn eval_function_call_expression(
         ));
     };
 
-    let ret_expr = extract_function_return_expr(module, &function_body, ret_id)?;
-
-    let mut local_store = store.clone();
-    let mut arg_sources = HashSet::default();
-    let mut arg_bounds = BoundaryMap::default();
-
-    for (arg_path, arg_id) in &function_body.arg_map {
-        let Some(arg_expr) = call.inputs.get(arg_path) else {
-            return Err(ParserError::unsupported(
-                LoweringPhase::CombLowering,
-                "function call missing argument",
-                format!("{call}"),
-                Some(&call.comptime.token),
-            ));
-        };
-
-        let ((arg_node, sources), bounds) =
-            eval_expression(module, &local_store, arg_expr, arena, None)?;
-        arg_sources.extend(sources.clone());
-        arg_bounds = merge_boundaries(arg_bounds, bounds);
-
-        let Some(arg_var) = module.variables.get(arg_id) else {
-            return Err(ParserError::unsupported(
-                LoweringPhase::CombLowering,
-                "function argument variable",
-                format!("unknown arg id: {:?}", arg_id),
-                Some(&call.comptime.token),
-            ));
-        };
-        let arg_width = resolve_width(module, arg_var)?;
-        local_store.insert(
-            *arg_id,
-            RangeStore::new(Some((arg_node, sources)), arg_width),
-        );
-    }
-
-    let ((ret_node, ret_sources), ret_bounds) =
-        eval_expression(module, &local_store, &ret_expr, arena, None)?;
-
-    let mut merged_sources = ret_sources;
-    merged_sources.extend(arg_sources);
-    let merged_bounds = merge_boundaries(arg_bounds, ret_bounds);
-
-    Ok(((ret_node, merged_sources), merged_bounds))
+    eval_function_body_return(module, store, call, &function_body, ret_id, arena)
 }
 
 pub fn eval_expression(

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -198,16 +198,6 @@ impl miette::Diagnostic for ParserError {
     }
 }
 
-/// Resolve the total bit width of a variable (width * kind), returning
-/// `ParserError::UnresolvedWidth` when it cannot be determined at compile time.
-pub(crate) fn resolve_width(
-    module: &veryl_analyzer::ir::Module,
-    var: &veryl_analyzer::ir::Variable,
-) -> Result<usize, ParserError> {
-    var.total_width()
-        .ok_or_else(|| ParserError::unresolved_width(module, var, var.r#type.to_string()))
-}
-
 /// Resolve the total storage size of a variable (total_width * total_array),
 /// returning `ParserError::UnresolvedWidth` when it cannot be determined.
 pub(crate) fn resolve_total_width(

--- a/crates/celox/tests/std_mux.rs
+++ b/crates/celox/tests/std_mux.rs
@@ -14,8 +14,8 @@ all_backends! {
 
     // Build-only smoke test: mux with selector_pkg requires `calc_select_width` function
     // evaluation at compile time. Currently Celox cannot resolve this, so this test is ignored.
-    #[ignore = "Celox does not yet support const function evaluation in module params (calc_select_width)"]
     fn test_mux_build_smoke(sim) {
+        @ignore_on(veryl);
         @setup { let top = r#"
 module Top (
 i_select: input  logic<2>,
@@ -35,7 +35,7 @@ data_arr[3] = i_data3;
 inst u: mux #(
 WIDTH  : 8,
 ENTRIES: 4,
-KIND   : selector_kind::BINARY,
+KIND   : selector_pkg::selector_kind::BINARY,
 ) (
 i_select,
 i_data: data_arr,
@@ -49,8 +49,8 @@ let code = format!("{SELECTOR_PKG_SRC}\n{MUX_SRC}\n{top}"); }
     }
 
     // Build-only: binary demux
-    #[ignore = "Celox does not yet support const function evaluation in module params (calc_select_width)"]
     fn test_demux_build_smoke(sim) {
+        @ignore_on(veryl);
         @setup { let top = r#"
 module Top (
 i_select: input  logic<2>,
@@ -64,7 +64,7 @@ var data_arr: logic<8>[4];
 inst u: demux #(
 WIDTH  : 8,
 ENTRIES: 4,
-KIND   : selector_kind::BINARY,
+KIND   : selector_pkg::selector_kind::BINARY,
 ) (
 i_select,
 i_data,

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -1,6 +1,5 @@
 import { chai, JestAsymmetricMatchers, JestChaiExpect } from "@vitest/expect";
 import * as monaco from "monaco-editor";
-import { transform as transformWithSucrase } from "sucrase";
 import celoxDutDts from "../../celox/dist/dut.d.ts?raw";
 import celoxIndexDts from "../../celox/dist/index.d.ts?raw";
 import celoxNapiBridgeDts from "../../celox/dist/napi-bridge.d.ts?raw";
@@ -17,6 +16,7 @@ import {
 	type VcdTrace,
 	WaveformViewer,
 } from "./waveform-viewer.js";
+import { transpileTestbench } from "./testbench-transpile.js";
 
 // ── Examples ────────────────────────────────────────────
 
@@ -1962,31 +1962,7 @@ async function run() {
 		for (const { path: testPath, model: tbMdl } of testModels) {
 			const client = await tsWorker(tbMdl.uri);
 			const output = await client.getEmitOutput(tbMdl.uri.toString());
-			const tsCode = tbMdl.getValue();
-			let jsCode = output.outputFiles.find((f) => f.name.endsWith(".js"))?.text;
-			if (!jsCode) {
-				try {
-					jsCode = transformWithSucrase(tsCode, {
-						transforms: ["typescript"],
-						filePath: testPath,
-					}).code;
-				} catch (e: any) {
-					throw new Error(
-						`Failed to transpile ${testPath} as TypeScript: ${e.message ?? String(e)}`,
-					);
-				}
-			}
-
-			// Strip import/export/require — we inject all bindings
-			jsCode = jsCode
-				.replace(
-					/^(?:import|export)\s+.*(?:from\s+)?["'][^"']*["'];?\s*$/gm,
-					"",
-				)
-				.replace(
-					/^(?:const|let|var)\s+\{[^}]*\}\s*=\s*require\s*\([^)]*\);?\s*$/gm,
-					"",
-				);
+			const jsCode = transpileTestbench(tbMdl.getValue(), testPath, output);
 
 			const suiteStack: string[] = [];
 			function _describe(name: string, fn: () => void) {

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -1,5 +1,6 @@
 import { chai, JestAsymmetricMatchers, JestChaiExpect } from "@vitest/expect";
 import * as monaco from "monaco-editor";
+import { transform as transformWithSucrase } from "sucrase";
 import celoxDutDts from "../../celox/dist/dut.d.ts?raw";
 import celoxIndexDts from "../../celox/dist/index.d.ts?raw";
 import celoxNapiBridgeDts from "../../celox/dist/napi-bridge.d.ts?raw";
@@ -700,12 +701,24 @@ const editorOpts: monaco.editor.IStandaloneEditorConstructionOptions = {
 };
 
 // Configure TS compiler options for testbench files
+monaco.languages.typescript.typescriptDefaults.setEagerModelSync(true);
 monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
-	target: monaco.languages.typescript.ScriptTarget.ESNext,
-	moduleResolution: monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+	target: monaco.languages.typescript.ScriptTarget.ES2022,
+	module: monaco.languages.typescript.ModuleKind.ES2022,
+	moduleResolution: monaco.languages.typescript.ModuleResolutionKind.Bundler,
 	allowArbitraryExtensions: true,
-	strict: false,
+	esModuleInterop: true,
+	skipLibCheck: true,
+	strict: true,
 	noEmit: true,
+	rootDirs: ["file:///src", "file:///test", "file:///.celox/src"],
+	paths: {
+		"@celox-sim/celox": ["file:///node_modules/@celox-sim/celox/index.d.ts"],
+		"@celox-sim/celox/*": [
+			"file:///node_modules/@celox-sim/celox/*.d.ts",
+			"file:///node_modules/@celox-sim/celox/dist/*.d.ts",
+		],
+	},
 });
 monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
 	diagnosticsOptions: {
@@ -1040,6 +1053,10 @@ const celoxDtsFiles: Record<string, string> = {
 	"wasm-bridge": celoxWasmBridgeDts,
 	"napi-bridge": celoxNapiBridgeDts,
 };
+monaco.languages.typescript.typescriptDefaults.addExtraLib(
+	fixDtsImports(celoxIndexDts),
+	"file:///node_modules/@celox-sim/celox/index.d.ts",
+);
 for (const [name, content] of Object.entries(celoxDtsFiles)) {
 	const fixed = fixDtsImports(content);
 	// Register as both the sub-module path and the node_modules-style path
@@ -1945,7 +1962,20 @@ async function run() {
 		for (const { path: testPath, model: tbMdl } of testModels) {
 			const client = await tsWorker(tbMdl.uri);
 			const output = await client.getEmitOutput(tbMdl.uri.toString());
-			let jsCode = output.outputFiles[0]?.text ?? tbMdl.getValue();
+			const tsCode = tbMdl.getValue();
+			let jsCode = output.outputFiles.find((f) => f.name.endsWith(".js"))?.text;
+			if (!jsCode) {
+				try {
+					jsCode = transformWithSucrase(tsCode, {
+						transforms: ["typescript"],
+						filePath: testPath,
+					}).code;
+				} catch (e: any) {
+					throw new Error(
+						`Failed to transpile ${testPath} as TypeScript: ${e.message ?? String(e)}`,
+					);
+				}
+			}
 
 			// Strip import/export/require — we inject all bindings
 			jsCode = jsCode

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -9,6 +9,7 @@ import celoxSimulatorDts from "../../celox/dist/simulator.d.ts?raw";
 // Import real .d.ts files from @celox-sim/celox for Monaco type injection
 import celoxTypesDts from "../../celox/dist/types.d.ts?raw";
 import celoxWasmBridgeDts from "../../celox/dist/wasm-bridge.d.ts?raw";
+import { transpileTestbench } from "./testbench-transpile.js";
 import {
 	generateVcdText,
 	type VcdSignalInfo,
@@ -16,7 +17,6 @@ import {
 	type VcdTrace,
 	WaveformViewer,
 } from "./waveform-viewer.js";
-import { transpileTestbench } from "./testbench-transpile.js";
 
 // ── Examples ────────────────────────────────────────────
 

--- a/packages/playground/src/testbench-transpile.ts
+++ b/packages/playground/src/testbench-transpile.ts
@@ -11,10 +11,7 @@ type EmitOutputLike = {
 
 function stripInjectedModuleSyntax(jsCode: string): string {
 	return jsCode
-		.replace(
-			/^(?:import|export)\s+.*(?:from\s+)?["'][^"']*["'];?\s*$/gm,
-			"",
-		)
+		.replace(/^(?:import|export)\s+.*(?:from\s+)?["'][^"']*["'];?\s*$/gm, "")
 		.replace(/^\s*export\s*\{[^}]*\};?\s*$/gm, "")
 		.replace(
 			/^(?:const|let|var)\s+\{[^}]*\}\s*=\s*require\s*\([^)]*\);?\s*$/gm,
@@ -28,7 +25,9 @@ export function transpileTestbench(
 	testPath: string,
 	emitOutput?: EmitOutputLike,
 ): string {
-	let jsCode = emitOutput?.outputFiles?.find((f) => f.name.endsWith(".js"))?.text;
+	let jsCode = emitOutput?.outputFiles?.find((f) =>
+		f.name.endsWith(".js"),
+	)?.text;
 
 	if (!jsCode) {
 		try {

--- a/packages/playground/src/testbench-transpile.ts
+++ b/packages/playground/src/testbench-transpile.ts
@@ -1,0 +1,47 @@
+import { transform as transformWithSucrase } from "sucrase";
+
+type EmitOutputFile = {
+	name: string;
+	text: string;
+};
+
+type EmitOutputLike = {
+	outputFiles?: EmitOutputFile[];
+};
+
+function stripInjectedModuleSyntax(jsCode: string): string {
+	return jsCode
+		.replace(
+			/^(?:import|export)\s+.*(?:from\s+)?["'][^"']*["'];?\s*$/gm,
+			"",
+		)
+		.replace(/^\s*export\s*\{[^}]*\};?\s*$/gm, "")
+		.replace(
+			/^(?:const|let|var)\s+\{[^}]*\}\s*=\s*require\s*\([^)]*\);?\s*$/gm,
+			"",
+		)
+		.replace(/^\s+/, "");
+}
+
+export function transpileTestbench(
+	tsCode: string,
+	testPath: string,
+	emitOutput?: EmitOutputLike,
+): string {
+	let jsCode = emitOutput?.outputFiles?.find((f) => f.name.endsWith(".js"))?.text;
+
+	if (!jsCode) {
+		try {
+			jsCode = transformWithSucrase(tsCode, {
+				transforms: ["typescript"],
+				filePath: testPath,
+			}).code;
+		} catch (e: any) {
+			throw new Error(
+				`Failed to transpile ${testPath} as TypeScript: ${e.message ?? String(e)}`,
+			);
+		}
+	}
+
+	return stripInjectedModuleSyntax(jsCode);
+}

--- a/packages/playground/test/transpile.test.ts
+++ b/packages/playground/test/transpile.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+
+import { transpileTestbench } from "../src/testbench-transpile";
+
+describe("transpileTestbench", () => {
+	test("uses emitted JavaScript when Monaco returns it", () => {
+		const jsCode = transpileTestbench(
+			'const value = (X as any); throw new Error("should not parse TS");',
+			"test/example.test.ts",
+			{
+				outputFiles: [
+					{
+						name: "file:///test/example.test.js",
+						text: 'import { expect } from "vitest";\nconst value = 1;\n',
+					},
+				],
+			},
+		);
+
+		expect(jsCode).toContain("const value = 1;");
+		expect(jsCode).not.toContain("import { expect }");
+		expect(jsCode).not.toContain("as any");
+	});
+
+	test("falls back to sucrase when Monaco emit output is empty", () => {
+		const jsCode = transpileTestbench(
+			'const value = (X as any);\nexport { value };\n',
+			"test/example.test.ts",
+			{ outputFiles: [] },
+		);
+
+		expect(jsCode).toContain("const value = (X );");
+		expect(jsCode).not.toContain("as any");
+		expect(jsCode).not.toContain("export { value }");
+	});
+
+	test("strips CommonJS require destructuring used by transpilers", () => {
+		const jsCode = transpileTestbench(
+			'const value = 1 as any;',
+			"test/example.test.ts",
+			{
+				outputFiles: [
+					{
+						name: "file:///test/example.test.js",
+						text: 'const { expect } = require("vitest");\nconst value = 1;\n',
+					},
+				],
+			},
+		);
+
+		expect(jsCode).toBe("const value = 1;\n");
+	});
+
+	test("throws a clear error when transpilation fails", () => {
+		expect(() =>
+			transpileTestbench("const value = (X as any;\n", "test/bad.test.ts", {
+				outputFiles: [],
+			}),
+		).toThrow(/Failed to transpile test\/bad\.test\.ts as TypeScript/);
+	});
+});


### PR DESCRIPTION
## Summary
- align Monaco TypeScript settings in the playground with the real project setup
- stop falling back to raw TypeScript source during playground test execution
- add a dedicated testbench transpile helper with unit tests for emit/fallback behavior

## Testing
- pnpm --filter @celox-sim/playground test
- pnpm --filter @celox-sim/playground build
- pre-push hook suite