### PR TITLE
[codex] Run CI on merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## What changed
Add the `merge_group` trigger to the `CI` GitHub Actions workflow.

## Why
GitHub merge queue validates a temporary merge-group ref before merging into `master`. The current `CI` workflow only runs on `push` and `pull_request`, so required checks are never reported for merge-queue runs. That leaves `queue/master` stuck waiting for checks that never start.

## Impact
This allows the existing required `CI` checks to run for merge queue candidates without changing normal PR or `master` push behavior.

## Root cause
The repository enabled merge queue requirements, but the required workflow was not configured to listen for the `merge_group` event.

## Validation
- Local workflow inspection confirmed `merge_group` was missing from `.github/workflows/ci.yml`.
- Pre-push validation passed locally via the repository hook:
  - `cargo fmt`
  - `cargo clippy`
  - `pnpm run lint`
  - `pnpm run build:napi && cargo test && pnpm run build && pnpm --filter="!@celox-sim/celox-napi" --filter="!@celox-sim/playground" -r test`