### PR TITLE
[codex] Add Renovate Cargo.lock update workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/renovate-cargo-lock.yml
+++ b/.github/workflows/renovate-cargo-lock.yml
@@ -1,0 +1,45 @@
+name: Renovate Cargo Lock
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: write
+
+concurrency:
+  group: renovate-cargo-lock-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  update-lockfile:
+    if: >-
+      github.actor == 'renovate[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'renovate/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          submodules: recursive
+
+      - uses: ./.github/actions/setup-rust
+
+      - name: Update Cargo.lock
+        run: cargo update --manifest-path crates/celox/Cargo.toml --workspace
+
+      - name: Commit Cargo.lock
+        run: |
+          if git diff --quiet -- Cargo.lock; then
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.lock
+          git commit -m "chore(deps): update Cargo.lock"
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,12 @@
     },
     {
       "matchManagers": [
+        "cargo"
+      ],
+      "skipArtifactsUpdate": true
+    },
+    {
+      "matchManagers": [
         "npm"
       ],
       "minimumReleaseAge": "7 days"


### PR DESCRIPTION
## Summary
- stop Renovate's built-in Cargo artifact updates so PRs no longer fail before lockfile generation
- add a GitHub Actions workflow that runs only on Renovate PRs, checks out submodules recursively, updates `Cargo.lock`, and pushes the result back to the Renovate branch

## Why
Renovate's Cargo artifact update runs in an environment where the `deps/veryl` submodule is unavailable, so `cargo update --manifest-path crates/celox/Cargo.toml --workspace` fails before `Cargo.lock` can be refreshed. Running the lockfile update in GitHub Actions avoids that limitation because the workflow can checkout submodules recursively.

## Validation
- `git diff --check`
- local commit created successfully
- branch pushed to `origin/codex-renovate-cargo-lock`
