### PR TITLE
[codex] Add playground Monaco diagnostics regression tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ node_modules/
 
 # TypeScript
 dist/
+playwright-report/
+test-results/
 
 # NAPI CI-generated files
 crates/celox-napi/npm/

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -8,10 +8,12 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "test:watch": "vitest",
     "test:wasm": "NAPI_RS_FORCE_WASI=1 vitest run --config vitest.wasm.config.ts"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.1",
     "@celox-sim/celox": "workspace:*",
     "@celox-sim/vite-plugin": "workspace:*",
     "monaco-editor": "^0.55.1",

--- a/packages/playground/playwright.config.ts
+++ b/packages/playground/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+	testDir: "./test/e2e",
+	timeout: 30_000,
+	use: {
+		baseURL: "http://127.0.0.1:4173",
+		headless: true,
+	},
+	webServer: {
+		command: "pnpm exec vite --host 127.0.0.1 --port 4173",
+		port: 4173,
+		reuseExistingServer: !process.env.CI,
+		timeout: 120_000,
+	},
+});

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -9,6 +9,7 @@ import celoxSimulatorDts from "../../celox/dist/simulator.d.ts?raw";
 // Import real .d.ts files from @celox-sim/celox for Monaco type injection
 import celoxTypesDts from "../../celox/dist/types.d.ts?raw";
 import celoxWasmBridgeDts from "../../celox/dist/wasm-bridge.d.ts?raw";
+import { buildMonacoTestbenchCompilerOptions } from "./monaco-testbench-options.js";
 import { transpileTestbench } from "./testbench-transpile.js";
 import {
 	generateVcdText,
@@ -702,28 +703,9 @@ const editorOpts: monaco.editor.IStandaloneEditorConstructionOptions = {
 
 // Configure TS compiler options for testbench files
 monaco.languages.typescript.typescriptDefaults.setEagerModelSync(true);
-const monacoTestbenchCompilerOptions: monaco.languages.typescript.CompilerOptions =
-	{
-	target: monaco.languages.typescript.ScriptTarget.ES2022,
-	module: monaco.languages.typescript.ModuleKind.ES2022,
-	moduleResolution: monaco.languages.typescript.ModuleResolutionKind.Bundler,
-	// Monaco's implicit lib selection can still drift to an older baseline.
-	// Keep BigInt support explicit so bigint literals in examples/tests stay valid.
-	lib: ["es2022", "es2020.bigint", "dom", "dom.iterable"],
-	allowArbitraryExtensions: true,
-	esModuleInterop: true,
-	skipLibCheck: true,
-	strict: true,
-	noEmit: true,
-	rootDirs: ["file:///src", "file:///test", "file:///.celox/src"],
-	paths: {
-		"@celox-sim/celox": ["file:///node_modules/@celox-sim/celox/index.d.ts"],
-		"@celox-sim/celox/*": [
-			"file:///node_modules/@celox-sim/celox/*.d.ts",
-			"file:///node_modules/@celox-sim/celox/dist/*.d.ts",
-		],
-	},
-	};
+const monacoTestbenchCompilerOptions = buildMonacoTestbenchCompilerOptions(
+	monaco.languages.typescript,
+);
 monaco.languages.typescript.typescriptDefaults.setCompilerOptions(
 	monacoTestbenchCompilerOptions,
 );
@@ -750,6 +732,23 @@ interface PlaygroundFile {
 	model: monaco.editor.ITextModel;
 	viewState: monaco.editor.ICodeEditorViewState | null;
 }
+
+type PlaygroundTestMarker = {
+	code: string | number | undefined;
+	message: string;
+	severity: number;
+	startLineNumber: number;
+	startColumn: number;
+	endLineNumber: number;
+	endColumn: number;
+};
+
+type PlaygroundTestApi = {
+	loadExample: (name: string) => void;
+	setFileContent: (path: string, content: string) => void;
+	getModelMarkers: (path: string) => PlaygroundTestMarker[];
+	getStatusText: () => string;
+};
 
 const files = new Map<string, PlaygroundFile>();
 let activeFilePath: string | null = null;
@@ -780,6 +779,10 @@ function createFile(path: string, content: string): PlaygroundFile {
 	}
 
 	return file;
+}
+
+function getFile(path: string): PlaygroundFile | null {
+	return files.get(path) ?? null;
 }
 
 function removeAllFiles() {
@@ -2121,6 +2124,42 @@ function loadExample(name: string) {
 	onVerylChange();
 }
 
+function installPlaygroundTestApi() {
+	const api: PlaygroundTestApi = {
+		loadExample,
+		setFileContent(path: string, content: string) {
+			const file = getFile(path);
+			if (!file) throw new Error(`File not found: ${path}`);
+			file.model.setValue(content);
+		},
+		getModelMarkers(path: string) {
+			const file = getFile(path);
+			if (!file) throw new Error(`File not found: ${path}`);
+			return monaco.editor
+				.getModelMarkers({ resource: file.model.uri })
+				.map((marker) => ({
+					code:
+						typeof marker.code === "object" ? marker.code.value : marker.code,
+					message: marker.message,
+					severity: marker.severity,
+					startLineNumber: marker.startLineNumber,
+					startColumn: marker.startColumn,
+					endLineNumber: marker.endLineNumber,
+					endColumn: marker.endColumn,
+				}));
+		},
+		getStatusText() {
+			return statusEl.textContent ?? "";
+		},
+	};
+
+	(
+		globalThis as typeof globalThis & {
+			__CELOX_PLAYGROUND_TEST_API__?: PlaygroundTestApi;
+		}
+	).__CELOX_PLAYGROUND_TEST_API__ = api;
+}
+
 examplesEl.addEventListener("change", () => {
 	if (examplesEl.value) loadExample(examplesEl.value);
 });
@@ -2131,4 +2170,5 @@ document.addEventListener("keydown", (e) => {
 
 loadExample("adder");
 onVerylChange(); // Inject types immediately from regex (no WASM needed)
+installPlaygroundTestApi();
 init();

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -702,10 +702,14 @@ const editorOpts: monaco.editor.IStandaloneEditorConstructionOptions = {
 
 // Configure TS compiler options for testbench files
 monaco.languages.typescript.typescriptDefaults.setEagerModelSync(true);
-monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+const monacoTestbenchCompilerOptions: monaco.languages.typescript.CompilerOptions =
+	{
 	target: monaco.languages.typescript.ScriptTarget.ES2022,
 	module: monaco.languages.typescript.ModuleKind.ES2022,
 	moduleResolution: monaco.languages.typescript.ModuleResolutionKind.Bundler,
+	// Monaco's implicit lib selection can still drift to an older baseline.
+	// Keep BigInt support explicit so bigint literals in examples/tests stay valid.
+	lib: ["es2022", "es2020.bigint", "dom", "dom.iterable"],
 	allowArbitraryExtensions: true,
 	esModuleInterop: true,
 	skipLibCheck: true,
@@ -719,7 +723,13 @@ monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
 			"file:///node_modules/@celox-sim/celox/dist/*.d.ts",
 		],
 	},
-});
+	};
+monaco.languages.typescript.typescriptDefaults.setCompilerOptions(
+	monacoTestbenchCompilerOptions,
+);
+monaco.languages.typescript.javascriptDefaults.setCompilerOptions(
+	monacoTestbenchCompilerOptions,
+);
 monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
 	diagnosticsOptions: {
 		noSemanticValidation: false,

--- a/packages/playground/src/monaco-testbench-options.ts
+++ b/packages/playground/src/monaco-testbench-options.ts
@@ -1,0 +1,38 @@
+import type * as monaco from "monaco-editor";
+
+type TypeScriptDefaultsApi = Pick<
+	typeof monaco.languages.typescript,
+	"ScriptTarget" | "ModuleKind" | "ModuleResolutionKind"
+>;
+
+export const MONACO_TESTBENCH_LIBS = [
+	"es2022",
+	"es2020.bigint",
+	"dom",
+	"dom.iterable",
+] as const;
+
+export function buildMonacoTestbenchCompilerOptions(
+	ts: TypeScriptDefaultsApi,
+): monaco.languages.typescript.CompilerOptions {
+	return {
+		target: ts.ScriptTarget.ES2022,
+		module: ts.ModuleKind.ES2022,
+		moduleResolution: ts.ModuleResolutionKind.Bundler,
+		// Keep BigInt support explicit so bigint literals in examples/tests stay valid.
+		lib: [...MONACO_TESTBENCH_LIBS],
+		allowArbitraryExtensions: true,
+		esModuleInterop: true,
+		skipLibCheck: true,
+		strict: true,
+		noEmit: true,
+		rootDirs: ["file:///src", "file:///test", "file:///.celox/src"],
+		paths: {
+			"@celox-sim/celox": ["file:///node_modules/@celox-sim/celox/index.d.ts"],
+			"@celox-sim/celox/*": [
+				"file:///node_modules/@celox-sim/celox/*.d.ts",
+				"file:///node_modules/@celox-sim/celox/dist/*.d.ts",
+			],
+		},
+	};
+}

--- a/packages/playground/test/e2e/monaco-diagnostics.spec.ts
+++ b/packages/playground/test/e2e/monaco-diagnostics.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+type PlaygroundTestMarker = {
+	code?: string | number;
+	message: string;
+};
+
+declare global {
+	interface Window {
+		__CELOX_PLAYGROUND_TEST_API__?: {
+			loadExample: (name: string) => void;
+			setFileContent: (path: string, content: string) => void;
+			getModelMarkers: (path: string) => PlaygroundTestMarker[];
+			getStatusText: () => string;
+		};
+	}
+}
+
+const bigintTestbench = `import { describe, it, expect } from "vitest";
+
+describe("bigint literals", () => {
+	it("accepts bigint literals in Monaco diagnostics", () => {
+		const value = 100n;
+		expect(value).toBe(100n);
+	});
+});
+`;
+
+test("playground does not report TS2737 for bigint literals", async ({ page }) => {
+	await page.goto("/");
+
+	await page.waitForFunction(
+		() => typeof window.__CELOX_PLAYGROUND_TEST_API__ !== "undefined",
+	);
+
+	await page.evaluate((source) => {
+		const api = window.__CELOX_PLAYGROUND_TEST_API__;
+		if (!api) throw new Error("Missing playground test API");
+		api.loadExample("adder");
+		api.setFileContent("test/adder.test.ts", source);
+	}, bigintTestbench);
+
+	await expect
+		.poll(
+			async () => {
+				const markers = await page.evaluate(() => {
+					const api = window.__CELOX_PLAYGROUND_TEST_API__;
+					if (!api) throw new Error("Missing playground test API");
+					return api.getModelMarkers("test/adder.test.ts");
+				});
+				return !markers.some((marker) => {
+					const code = String(marker.code ?? "");
+					return (
+						code === "2737" ||
+						/BigInt literals are not available when targeting lower than ES2020/i.test(
+							marker.message,
+						)
+					);
+				});
+			},
+			{ timeout: 60_000 },
+		)
+		.toBe(true);
+});

--- a/packages/playground/test/monaco-testbench-options.test.ts
+++ b/packages/playground/test/monaco-testbench-options.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	buildMonacoTestbenchCompilerOptions,
+	MONACO_TESTBENCH_LIBS,
+} from "../src/monaco-testbench-options";
+
+describe("buildMonacoTestbenchCompilerOptions", () => {
+	test("pins libs needed for bigint-aware diagnostics", () => {
+		const options = buildMonacoTestbenchCompilerOptions({
+			ScriptTarget: { ES2022: "target-es2022" },
+			ModuleKind: { ES2022: "module-es2022" },
+			ModuleResolutionKind: { Bundler: "resolution-bundler" },
+		} as never);
+
+		expect(options.target).toBe("target-es2022");
+		expect(options.module).toBe("module-es2022");
+		expect(options.moduleResolution).toBe("resolution-bundler");
+		expect(options.lib).toEqual([...MONACO_TESTBENCH_LIBS]);
+		expect(options.lib).toContain("es2020.bigint");
+		expect(options.rootDirs).toEqual([
+			"file:///src",
+			"file:///test",
+			"file:///.celox/src",
+		]);
+	});
+
+	test("keeps celox declaration paths resolvable for Monaco", () => {
+		const options = buildMonacoTestbenchCompilerOptions({
+			ScriptTarget: { ES2022: 1 },
+			ModuleKind: { ES2022: 2 },
+			ModuleResolutionKind: { Bundler: 3 },
+		} as never);
+
+		expect(options.paths?.["@celox-sim/celox"]).toEqual([
+			"file:///node_modules/@celox-sim/celox/index.d.ts",
+		]);
+		expect(options.paths?.["@celox-sim/celox/*"]).toEqual([
+			"file:///node_modules/@celox-sim/celox/*.d.ts",
+			"file:///node_modules/@celox-sim/celox/dist/*.d.ts",
+		]);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@celox-sim/vite-plugin':
         specifier: workspace:*
         version: link:../vite-plugin
+      '@playwright/test':
+        specifier: ^1.55.1
+        version: 1.59.1
       monaco-editor:
         specifier: ^0.55.1
         version: 0.55.1
@@ -1149,6 +1152,11 @@ packages:
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
     cpu: [arm]
@@ -1811,6 +1819,11 @@ packages:
   focus-trap@7.8.0:
     resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2010,6 +2023,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -3225,6 +3248,10 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
 
@@ -3848,6 +3875,9 @@ snapshots:
     dependencies:
       tabbable: 6.4.0
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4036,6 +4066,14 @@ snapshots:
   picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.10:
     dependencies:


### PR DESCRIPTION
Closes #53

## Summary
- extract the playground Monaco testbench compiler options into a dedicated helper
- add unit coverage that locks in the BigInt-related Monaco compiler settings
- add a Playwright regression test that opens the playground and asserts TS2737 is not reported for `100n` in a testbench
- ignore Playwright output directories in git

## Why
The playground hit a regression where Monaco reported `TS2737` (`BigInt literals are not available when targeting lower than ES2020`) even though the intended target was newer. Manual browser checks are not enough for this class of issue because the failure happens in Monaco's browser-side worker configuration.

This PR makes that configuration testable and adds a browser E2E regression test so the diagnostics path is exercised directly.

## Validation
- `pnpm --filter @celox-sim/playground test -- --run monaco-testbench-options.test.ts transpile.test.ts`
- `pnpm --filter @celox-sim/playground build`
- `pnpm --filter @celox-sim/playground test:e2e`
- pre-push hooks (`biome`, `cargo-clippy`, repo tests)

## Impact
Playground Monaco diagnostics for testbench files are now covered by automated tests, including an end-to-end browser check for the BigInt literal regression.