### PR TITLE
[codex] Expand comb function-call control-flow support

### DIFF
--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -10,16 +10,14 @@ use crate::{
     HashMap, HashSet,
     ir::{BinaryOp, BitAccess, UnaryOp, VarAtomBase},
     parser::bitaccess::{
-        build_partial_assign_expr, celox_value_from_comptime, eval_constexpr, eval_var_select,
-        is_static_access,
+        celox_value_from_comptime, eval_constexpr, eval_var_select, is_static_access,
     },
 };
 use num_bigint::BigUint;
 use num_traits::ToPrimitive as _;
 use veryl_analyzer::ir::{
     ArrayLiteralItem, AssignStatement, CombDeclaration, Expression, Factor, ForBound, ForRange,
-    ForStatement, IfStatement, Module, Op, Statement, ValueVariant, VarId, VarIndex, VarSelect,
-    VarSelectOp,
+    ForStatement, IfStatement, Module, Op, Statement, ValueVariant, VarId, VarSelectOp,
 };
 
 // SymbolicStore: Maps variable IDs to their current symbolic representation.
@@ -2191,172 +2189,12 @@ fn eval_function_body_return(
     ret_id: VarId,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
-    fn collect_local_deps(
-        expr: &Expression,
-        defs: &HashMap<VarId, Expression>,
-        out: &mut Vec<VarId>,
-        seen: &mut HashSet<VarId>,
-    ) {
-        match expr {
-            Expression::Term(factor) => match factor.as_ref() {
-                Factor::Variable(var_id, index, select, _) => {
-                    if defs.contains_key(var_id) && seen.insert(*var_id) {
-                        out.push(*var_id);
-                    }
-                    for idx in &index.0 {
-                        collect_local_deps(idx, defs, out, seen);
-                    }
-                    for sel in &select.0 {
-                        collect_local_deps(sel, defs, out, seen);
-                    }
-                    if let Some((_, range_expr)) = &select.1 {
-                        collect_local_deps(range_expr, defs, out, seen);
-                    }
-                }
-                Factor::FunctionCall(call) => {
-                    for input_expr in call.inputs.values() {
-                        collect_local_deps(input_expr, defs, out, seen);
-                    }
-                }
-                _ => {}
-            },
-            Expression::Binary(lhs, _, rhs, _) => {
-                collect_local_deps(lhs, defs, out, seen);
-                collect_local_deps(rhs, defs, out, seen);
-            }
-            Expression::Unary(_, inner, _) => collect_local_deps(inner, defs, out, seen),
-            Expression::Ternary(cond, then_expr, else_expr, _) => {
-                collect_local_deps(cond, defs, out, seen);
-                collect_local_deps(then_expr, defs, out, seen);
-                collect_local_deps(else_expr, defs, out, seen);
-            }
-            Expression::Concatenation(parts, _) => {
-                for (part_expr, rep) in parts {
-                    collect_local_deps(part_expr, defs, out, seen);
-                    if let Some(rep) = rep {
-                        collect_local_deps(rep, defs, out, seen);
-                    }
-                }
-            }
-            Expression::ArrayLiteral(items, _) => {
-                for item in items {
-                    match item {
-                        ArrayLiteralItem::Value(expr, rep) => {
-                            collect_local_deps(expr, defs, out, seen);
-                            if let Some(rep) = rep {
-                                collect_local_deps(rep, defs, out, seen);
-                            }
-                        }
-                        ArrayLiteralItem::Defaul(expr) => collect_local_deps(expr, defs, out, seen),
-                    }
-                }
-            }
-            Expression::StructConstructor(_, fields, _) => {
-                for (_, field_expr) in fields {
-                    collect_local_deps(field_expr, defs, out, seen);
-                }
-            }
-        }
-    }
-
-    fn materialize_local_var(
-        module: &Module,
-        caller_store: &SymbolicStore<VarId>,
-        defs: &HashMap<VarId, Expression>,
-        local_store: &mut SymbolicStore<VarId>,
-        local_bounds: &mut BoundaryMap<VarId>,
-        var_id: VarId,
-        arena: &mut SLTNodeArena<VarId>,
-        visiting: &mut HashSet<VarId>,
-    ) -> Result<(), ParserError> {
-        if local_store.contains_key(&var_id) {
-            return Ok(());
-        }
-        let Some(expr) = defs.get(&var_id) else {
-            return Ok(());
-        };
-        if !visiting.insert(var_id) {
-            return Err(ParserError::unsupported(
-                LoweringPhase::CombLowering,
-                "recursive local dependency in function return",
-                format!("var id: {:?}", var_id),
-                None,
-            ));
-        }
-
-        let mut deps = Vec::new();
-        collect_local_deps(expr, defs, &mut deps, &mut HashSet::default());
-        for dep in deps {
-            materialize_local_var(
-                module,
-                caller_store,
-                defs,
-                local_store,
-                local_bounds,
-                dep,
-                arena,
-                visiting,
-            )?;
-        }
-
-        let mut eval_store = caller_store.clone();
-        eval_store.extend(local_store.clone());
-        let ((node, sources), bounds) = eval_expression(module, &eval_store, expr, arena, None)?;
-        *local_bounds = merge_boundaries(local_bounds.clone(), bounds);
-
-        let Some(var) = module.variables.get(&var_id) else {
-            return Err(ParserError::unsupported(
-                LoweringPhase::CombLowering,
-                "function local variable",
-                format!("unknown variable id: {:?}", var_id),
-                None,
-            ));
-        };
-        let width = resolve_total_width(module, var)?;
-        local_store.insert(var_id, RangeStore::new(Some((node, sources)), width));
-        visiting.remove(&var_id);
-        Ok(())
-    }
-
-    fn eval_expr_with_defs(
-        module: &Module,
-        caller_store: &SymbolicStore<VarId>,
-        defs: &HashMap<VarId, Expression>,
-        expr: &Expression,
-        arena: &mut SLTNodeArena<VarId>,
-    ) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
-        let mut local_store = SymbolicStore::default();
-        let mut local_bounds = BoundaryMap::default();
-        let mut deps = Vec::new();
-        let mut seen = HashSet::default();
-        let mut visiting = HashSet::default();
-
-        collect_local_deps(expr, defs, &mut deps, &mut seen);
-        for dep in deps {
-            materialize_local_var(
-                module,
-                caller_store,
-                defs,
-                &mut local_store,
-                &mut local_bounds,
-                dep,
-                arena,
-                &mut visiting,
-            )?;
-        }
-
-        let mut eval_store = caller_store.clone();
-        eval_store.extend(local_store);
-        let (value, bounds) = eval_expression(module, &eval_store, expr, arena, None)?;
-        Ok((value, merge_boundaries(local_bounds, bounds)))
-    }
-
     fn resolve_return_value(
         module: &Module,
-        caller_store: &SymbolicStore<VarId>,
+        store: SymbolicStore<VarId>,
+        boundaries: BoundaryMap<VarId>,
         statements: &[Statement],
         ret_id: VarId,
-        defs: &HashMap<VarId, Expression>,
         arena: &mut SLTNodeArena<VarId>,
     ) -> Result<Option<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>)>, ParserError>
     {
@@ -2369,71 +2207,51 @@ fn eval_function_body_return(
 
         match stmt {
             Statement::Assign(assign) => {
-                if assign.dst.len() != 1 {
-                    return Err(ParserError::unsupported(
-                        LoweringPhase::CombLowering,
-                        "function body assignment shape",
-                        format!("{stmt}"),
-                        Some(&assign.token),
-                    ));
-                }
+                let (next_store, next_bounds) =
+                    eval_assign(module, store, boundaries, assign, arena)?;
 
-                let dst = &assign.dst[0];
-                let is_whole_var =
-                    dst.index.0.is_empty() && dst.select.0.is_empty() && dst.select.1.is_none();
-
-                if is_whole_var {
-                    if dst.id == ret_id {
-                        return eval_expr_with_defs(
-                            module,
-                            caller_store,
-                            defs,
-                            &assign.expr,
-                            arena,
-                        )
-                        .map(Some);
+                if assign.dst.len() == 1 {
+                    let dst = &assign.dst[0];
+                    let is_whole_var =
+                        dst.index.0.is_empty() && dst.select.0.is_empty() && dst.select.1.is_none();
+                    if is_whole_var && dst.id == ret_id {
+                        let ret_var = &module.variables[&ret_id];
+                        let ret_width = resolve_total_width(module, ret_var)?;
+                        let ret_access = BitAccess::new(0, ret_width - 1);
+                        let ret_parts = next_store[&ret_id].get_parts(ret_access);
+                        let (ret_node, ret_sources) =
+                            combine_parts_with_default(ret_id, 0, ret_parts, arena);
+                        return Ok(Some(((ret_node, ret_sources), next_bounds)));
                     }
-
-                    let mut next_defs = defs.clone();
-                    next_defs.insert(dst.id, assign.expr.clone());
-                    resolve_return_value(module, caller_store, rest, ret_id, &next_defs, arena)
-                } else if is_static_access(&dst.index, &dst.select) {
-                    let old_value = defs.get(&dst.id).cloned().unwrap_or_else(|| {
-                        Expression::Term(Box::new(Factor::Variable(
-                            dst.id,
-                            VarIndex::default(),
-                            VarSelect::default(),
-                            dst.comptime.clone(),
-                        )))
-                    });
-                    let merged =
-                        build_partial_assign_expr(module, dst, assign.expr.clone(), old_value)?;
-
-                    let mut next_defs = defs.clone();
-                    next_defs.insert(dst.id, merged);
-                    resolve_return_value(module, caller_store, rest, ret_id, &next_defs, arena)
-                } else {
-                    Err(ParserError::unsupported(
-                        LoweringPhase::CombLowering,
-                        "function body non-whole assignment (dynamic index)",
-                        format!("{stmt}"),
-                        Some(&assign.token),
-                    ))
                 }
+
+                resolve_return_value(module, next_store, next_bounds, rest, ret_id, arena)
             }
             Statement::If(if_stmt) => {
                 let ((cond_expr, cond_sources), cond_bounds) =
-                    eval_expr_with_defs(module, caller_store, defs, &if_stmt.cond, arena)?;
+                    eval_expression(module, &store, &if_stmt.cond, arena, Some(1))?;
 
                 let mut then_stmts = if_stmt.true_side.clone();
                 then_stmts.extend_from_slice(rest);
-                let then_value =
-                    resolve_return_value(module, caller_store, &then_stmts, ret_id, defs, arena)?;
+                let then_value = resolve_return_value(
+                    module,
+                    store.clone(),
+                    merge_boundaries(boundaries.clone(), cond_bounds.clone()),
+                    &then_stmts,
+                    ret_id,
+                    arena,
+                )?;
 
                 let mut else_stmts = if_stmt.false_side.clone();
                 else_stmts.extend_from_slice(rest);
-                let else_value =
-                    resolve_return_value(module, caller_store, &else_stmts, ret_id, defs, arena)?;
+                let else_value = resolve_return_value(
+                    module,
+                    store,
+                    merge_boundaries(boundaries, cond_bounds.clone()),
+                    &else_stmts,
+                    ret_id,
+                    arena,
+                )?;
 
                 match (then_value, else_value) {
                     (
@@ -2462,9 +2280,12 @@ fn eval_function_body_return(
                     _ => Ok(None),
                 }
             }
-            Statement::Null => {
-                resolve_return_value(module, caller_store, rest, ret_id, defs, arena)
+            Statement::For(for_stmt) => {
+                let (next_store, next_bounds) =
+                    eval_for(module, store, boundaries, for_stmt, arena)?;
+                resolve_return_value(module, next_store, next_bounds, rest, ret_id, arena)
             }
+            Statement::Null => resolve_return_value(module, store, boundaries, rest, ret_id, arena),
             Statement::IfReset(ir) => Err(ParserError::unsupported(
                 LoweringPhase::CombLowering,
                 "function body control flow",
@@ -2483,12 +2304,6 @@ fn eval_function_body_return(
                 format!("{stmt}"),
                 Some(&fc.comptime.token),
             )),
-            Statement::For(f) => Err(ParserError::unsupported(
-                LoweringPhase::CombLowering,
-                "for loop in function body",
-                format!("{stmt}"),
-                Some(&f.token),
-            )),
             Statement::TbMethodCall(_) | Statement::Break | Statement::Unsupported(_) => {
                 Err(ParserError::unsupported(
                     LoweringPhase::CombLowering,
@@ -2500,12 +2315,38 @@ fn eval_function_body_return(
         }
     }
 
+    let mut local_store = SymbolicStore::default();
+    let local_bounds = BoundaryMap::default();
+    let mut written = HashMap::default();
+
+    collect_written_accesses(module, &body.statements, &mut written)?;
+    written.entry(ret_id).or_default();
+
+    for var_id in written.keys() {
+        let Some(var) = module.variables.get(var_id) else {
+            return Err(ParserError::unsupported(
+                LoweringPhase::CombLowering,
+                "function local variable",
+                format!("unknown variable id: {:?}", var_id),
+                None,
+            ));
+        };
+        let width = resolve_total_width(module, var)?;
+        local_store.insert(*var_id, RangeStore::new(None, width));
+    }
+
+    for arg_id in body.arg_map.values() {
+        if let Some(arg_store) = caller_store.get(arg_id) {
+            local_store.insert(*arg_id, arg_store.clone());
+        }
+    }
+
     resolve_return_value(
         module,
-        caller_store,
+        local_store,
+        local_bounds,
         &body.statements,
         ret_id,
-        &HashMap::default(),
         arena,
     )?
     .ok_or_else(|| {
@@ -2565,6 +2406,7 @@ fn eval_function_call_expression(
     };
 
     let mut local_store = store.clone();
+    let mut arg_bounds = BoundaryMap::default();
     for (arg_path, arg_id) in &function_body.arg_map {
         let Some(arg_expr) = call.inputs.get(arg_path) else {
             return Err(ParserError::unsupported(
@@ -2575,8 +2417,9 @@ fn eval_function_call_expression(
             ));
         };
 
-        let ((arg_node, sources), _bounds) =
+        let ((arg_node, sources), bounds) =
             eval_expression(module, &local_store, arg_expr, arena, None)?;
+        arg_bounds = merge_boundaries(arg_bounds, bounds);
 
         let Some(arg_var) = module.variables.get(arg_id) else {
             return Err(ParserError::unsupported(
@@ -2593,7 +2436,12 @@ fn eval_function_call_expression(
         );
     }
 
-    eval_function_body_return(module, &local_store, &function_body, ret_id, arena)
+    let ((ret_node, ret_sources), ret_bounds) =
+        eval_function_body_return(module, &local_store, &function_body, ret_id, arena)?;
+    Ok((
+        (ret_node, ret_sources),
+        merge_boundaries(arg_bounds, ret_bounds),
+    ))
 }
 
 pub fn eval_expression(

--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -2248,6 +2248,167 @@ fn eval_function_body_return(
         }
     }
 
+    fn for_range_is_dynamic(range: &ForRange) -> bool {
+        match range {
+            ForRange::Forward { start, end, .. }
+            | ForRange::Reverse { start, end, .. }
+            | ForRange::Stepped { start, end, .. } => {
+                matches!(start, ForBound::Expression(_)) || matches!(end, ForBound::Expression(_))
+            }
+        }
+    }
+
+    fn validate_function_body_expression(
+        module: &Module,
+        expr: &Expression,
+    ) -> Result<(), ParserError> {
+        match expr {
+            Expression::Term(factor) => match factor.as_ref() {
+                Factor::SystemFunctionCall(call) => Err(ParserError::unsupported(
+                    LoweringPhase::CombLowering,
+                    "system function call in comb function body",
+                    format!("module `{}`: {call}", module.name),
+                    Some(&call.comptime.token),
+                )),
+                Factor::FunctionCall(call) => Err(ParserError::unsupported(
+                    LoweringPhase::CombLowering,
+                    "nested function call in comb function body",
+                    format!("module `{}`: {call}", module.name),
+                    Some(&call.comptime.token),
+                )),
+                Factor::Variable(_, _, _, _)
+                | Factor::Value(_)
+                | Factor::Anonymous(_)
+                | Factor::Unknown(_) => Ok(()),
+            },
+            Expression::Unary(_, inner, _) => validate_function_body_expression(module, inner),
+            Expression::Binary(lhs, _, rhs, _) => {
+                validate_function_body_expression(module, lhs)?;
+                validate_function_body_expression(module, rhs)
+            }
+            Expression::Ternary(cond, then_expr, else_expr, _) => {
+                validate_function_body_expression(module, cond)?;
+                validate_function_body_expression(module, then_expr)?;
+                validate_function_body_expression(module, else_expr)
+            }
+            Expression::Concatenation(items, _) => {
+                for (item_expr, repeat_expr) in items {
+                    validate_function_body_expression(module, item_expr)?;
+                    if let Some(repeat_expr) = repeat_expr {
+                        validate_function_body_expression(module, repeat_expr)?;
+                    }
+                }
+                Ok(())
+            }
+            Expression::ArrayLiteral(items, _) => {
+                for item in items {
+                    match item {
+                        ArrayLiteralItem::Value(item_expr, repeat_expr) => {
+                            validate_function_body_expression(module, item_expr)?;
+                            if let Some(repeat_expr) = repeat_expr {
+                                validate_function_body_expression(module, repeat_expr)?;
+                            }
+                        }
+                        ArrayLiteralItem::Defaul(default_expr) => {
+                            validate_function_body_expression(module, default_expr)?;
+                        }
+                    }
+                }
+                Ok(())
+            }
+            Expression::StructConstructor(_, fields, _) => {
+                for (_, field_expr) in fields {
+                    validate_function_body_expression(module, field_expr)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn validate_function_body_statement(
+        module: &Module,
+        stmt: &Statement,
+    ) -> Result<(), ParserError> {
+        match stmt {
+            Statement::Assign(assign) => {
+                validate_function_body_expression(module, &assign.expr)?;
+                for dst in &assign.dst {
+                    for index_expr in &dst.index.0 {
+                        validate_function_body_expression(module, index_expr)?;
+                    }
+                    for select_expr in &dst.select.0 {
+                        validate_function_body_expression(module, select_expr)?;
+                    }
+                    if let Some((_, range_expr)) = &dst.select.1 {
+                        validate_function_body_expression(module, range_expr)?;
+                    }
+                }
+                Ok(())
+            }
+            Statement::If(if_stmt) => {
+                validate_function_body_expression(module, &if_stmt.cond)?;
+                for stmt in &if_stmt.true_side {
+                    validate_function_body_statement(module, stmt)?;
+                }
+                for stmt in &if_stmt.false_side {
+                    validate_function_body_statement(module, stmt)?;
+                }
+                Ok(())
+            }
+            Statement::For(for_stmt) => {
+                if for_range_is_dynamic(&for_stmt.range)
+                    && for_stmt.body.iter().any(statement_contains_break)
+                {
+                    return Err(ParserError::unsupported(
+                        LoweringPhase::CombLowering,
+                        "break in dynamic function-local for",
+                        format!("module `{}`", module.name),
+                        Some(&for_stmt.token),
+                    ));
+                }
+
+                match &for_stmt.range {
+                    ForRange::Forward { start, end, .. }
+                    | ForRange::Reverse { start, end, .. }
+                    | ForRange::Stepped { start, end, .. } => {
+                        if let ForBound::Expression(expr) = start {
+                            validate_function_body_expression(module, expr)?;
+                        }
+                        if let ForBound::Expression(expr) = end {
+                            validate_function_body_expression(module, expr)?;
+                        }
+                    }
+                }
+                for stmt in &for_stmt.body {
+                    validate_function_body_statement(module, stmt)?;
+                }
+                Ok(())
+            }
+            Statement::IfReset(ir) => Err(ParserError::unsupported(
+                LoweringPhase::CombLowering,
+                "function body control flow",
+                format!("{stmt}"),
+                Some(&ir.token),
+            )),
+            Statement::SystemFunctionCall(fc) => Err(ParserError::unsupported(
+                LoweringPhase::CombLowering,
+                "system function call in comb function body",
+                format!("{stmt}"),
+                Some(&fc.comptime.token),
+            )),
+            Statement::FunctionCall(fc) => Err(ParserError::unsupported(
+                LoweringPhase::CombLowering,
+                "nested function call in comb function body",
+                format!("{stmt}"),
+                Some(&fc.comptime.token),
+            )),
+            Statement::TbMethodCall(_)
+            | Statement::Unsupported(_)
+            | Statement::Break
+            | Statement::Null => Ok(()),
+        }
+    }
+
     fn function_return_value(
         module: &Module,
         store: &SymbolicStore<VarId>,
@@ -3236,6 +3397,10 @@ fn eval_function_body_return(
     let mut local_store = SymbolicStore::default();
     let local_bounds = BoundaryMap::default();
     let mut written = HashMap::default();
+
+    for stmt in &body.statements {
+        validate_function_body_statement(module, stmt)?;
+    }
 
     collect_written_accesses(module, &body.statements, &mut written)?;
     written.entry(ret_id).or_default();

--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -2821,8 +2821,7 @@ fn eval_function_call_expression(
             ));
         };
 
-        let ((arg_node, sources), bounds) =
-            eval_expression(module, &local_store, arg_expr, arena, None)?;
+        let ((arg_node, sources), bounds) = eval_expression(module, store, arg_expr, arena, None)?;
         arg_bounds = merge_boundaries(arg_bounds, bounds);
 
         let Some(arg_var) = module.variables.get(arg_id) else {

--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -10,14 +10,16 @@ use crate::{
     HashMap, HashSet,
     ir::{BinaryOp, BitAccess, UnaryOp, VarAtomBase},
     parser::bitaccess::{
-        celox_value_from_comptime, eval_constexpr, eval_var_select, is_static_access,
+        build_partial_assign_expr, celox_value_from_comptime, eval_constexpr, eval_var_select,
+        is_static_access,
     },
 };
 use num_bigint::BigUint;
 use num_traits::ToPrimitive as _;
 use veryl_analyzer::ir::{
     ArrayLiteralItem, AssignStatement, CombDeclaration, Expression, Factor, ForBound, ForRange,
-    ForStatement, IfStatement, Module, Op, Statement, ValueVariant, VarId, VarSelectOp,
+    ForStatement, IfStatement, Module, Op, Statement, ValueVariant, VarId, VarIndex, VarSelect,
+    VarSelectOp,
 };
 
 // SymbolicStore: Maps variable IDs to their current symbolic representation.
@@ -2185,84 +2187,335 @@ fn eval_array_literal_expression(
 fn eval_function_body_return(
     module: &Module,
     caller_store: &SymbolicStore<VarId>,
-    call: &veryl_analyzer::ir::FunctionCall,
-    function_body: &veryl_analyzer::ir::FunctionBody,
+    body: &veryl_analyzer::ir::FunctionBody,
     ret_id: VarId,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
-    let mut local_store = SymbolicStore::default();
-    let mut local_bounds = BoundaryMap::default();
-    let mut written = HashMap::default();
+    fn collect_local_deps(
+        expr: &Expression,
+        defs: &HashMap<VarId, Expression>,
+        out: &mut Vec<VarId>,
+        seen: &mut HashSet<VarId>,
+    ) {
+        match expr {
+            Expression::Term(factor) => match factor.as_ref() {
+                Factor::Variable(var_id, index, select, _) => {
+                    if defs.contains_key(var_id) && seen.insert(*var_id) {
+                        out.push(*var_id);
+                    }
+                    for idx in &index.0 {
+                        collect_local_deps(idx, defs, out, seen);
+                    }
+                    for sel in &select.0 {
+                        collect_local_deps(sel, defs, out, seen);
+                    }
+                    if let Some((_, range_expr)) = &select.1 {
+                        collect_local_deps(range_expr, defs, out, seen);
+                    }
+                }
+                Factor::FunctionCall(call) => {
+                    for input_expr in call.inputs.values() {
+                        collect_local_deps(input_expr, defs, out, seen);
+                    }
+                }
+                _ => {}
+            },
+            Expression::Binary(lhs, _, rhs, _) => {
+                collect_local_deps(lhs, defs, out, seen);
+                collect_local_deps(rhs, defs, out, seen);
+            }
+            Expression::Unary(_, inner, _) => collect_local_deps(inner, defs, out, seen),
+            Expression::Ternary(cond, then_expr, else_expr, _) => {
+                collect_local_deps(cond, defs, out, seen);
+                collect_local_deps(then_expr, defs, out, seen);
+                collect_local_deps(else_expr, defs, out, seen);
+            }
+            Expression::Concatenation(parts, _) => {
+                for (part_expr, rep) in parts {
+                    collect_local_deps(part_expr, defs, out, seen);
+                    if let Some(rep) = rep {
+                        collect_local_deps(rep, defs, out, seen);
+                    }
+                }
+            }
+            Expression::ArrayLiteral(items, _) => {
+                for item in items {
+                    match item {
+                        ArrayLiteralItem::Value(expr, rep) => {
+                            collect_local_deps(expr, defs, out, seen);
+                            if let Some(rep) = rep {
+                                collect_local_deps(rep, defs, out, seen);
+                            }
+                        }
+                        ArrayLiteralItem::Defaul(expr) => collect_local_deps(expr, defs, out, seen),
+                    }
+                }
+            }
+            Expression::StructConstructor(_, fields, _) => {
+                for (_, field_expr) in fields {
+                    collect_local_deps(field_expr, defs, out, seen);
+                }
+            }
+        }
+    }
 
-    collect_written_accesses(module, &function_body.statements, &mut written)?;
-    written.entry(ret_id).or_default();
+    fn materialize_local_var(
+        module: &Module,
+        caller_store: &SymbolicStore<VarId>,
+        defs: &HashMap<VarId, Expression>,
+        local_store: &mut SymbolicStore<VarId>,
+        local_bounds: &mut BoundaryMap<VarId>,
+        var_id: VarId,
+        arena: &mut SLTNodeArena<VarId>,
+        visiting: &mut HashSet<VarId>,
+    ) -> Result<(), ParserError> {
+        if local_store.contains_key(&var_id) {
+            return Ok(());
+        }
+        let Some(expr) = defs.get(&var_id) else {
+            return Ok(());
+        };
+        if !visiting.insert(var_id) {
+            return Err(ParserError::unsupported(
+                LoweringPhase::CombLowering,
+                "recursive local dependency in function return",
+                format!("var id: {:?}", var_id),
+                None,
+            ));
+        }
 
-    for var_id in written.keys() {
-        let Some(var) = module.variables.get(var_id) else {
+        let mut deps = Vec::new();
+        collect_local_deps(expr, defs, &mut deps, &mut HashSet::default());
+        for dep in deps {
+            materialize_local_var(
+                module,
+                caller_store,
+                defs,
+                local_store,
+                local_bounds,
+                dep,
+                arena,
+                visiting,
+            )?;
+        }
+
+        let mut eval_store = caller_store.clone();
+        eval_store.extend(local_store.clone());
+        let ((node, sources), bounds) = eval_expression(module, &eval_store, expr, arena, None)?;
+        *local_bounds = merge_boundaries(local_bounds.clone(), bounds);
+
+        let Some(var) = module.variables.get(&var_id) else {
             return Err(ParserError::unsupported(
                 LoweringPhase::CombLowering,
                 "function local variable",
                 format!("unknown variable id: {:?}", var_id),
-                Some(&call.comptime.token),
+                None,
             ));
         };
         let width = resolve_total_width(module, var)?;
-        local_store.insert(*var_id, RangeStore::new(None, width));
+        local_store.insert(var_id, RangeStore::new(Some((node, sources)), width));
+        visiting.remove(&var_id);
+        Ok(())
     }
 
-    for (arg_path, arg_id) in &function_body.arg_map {
-        let Some(arg_expr) = call.inputs.get(arg_path) else {
-            return Err(ParserError::unsupported(
+    fn eval_expr_with_defs(
+        module: &Module,
+        caller_store: &SymbolicStore<VarId>,
+        defs: &HashMap<VarId, Expression>,
+        expr: &Expression,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+        let mut local_store = SymbolicStore::default();
+        let mut local_bounds = BoundaryMap::default();
+        let mut deps = Vec::new();
+        let mut seen = HashSet::default();
+        let mut visiting = HashSet::default();
+
+        collect_local_deps(expr, defs, &mut deps, &mut seen);
+        for dep in deps {
+            materialize_local_var(
+                module,
+                caller_store,
+                defs,
+                &mut local_store,
+                &mut local_bounds,
+                dep,
+                arena,
+                &mut visiting,
+            )?;
+        }
+
+        let mut eval_store = caller_store.clone();
+        eval_store.extend(local_store);
+        let (value, bounds) = eval_expression(module, &eval_store, expr, arena, None)?;
+        Ok((value, merge_boundaries(local_bounds, bounds)))
+    }
+
+    fn resolve_return_value(
+        module: &Module,
+        caller_store: &SymbolicStore<VarId>,
+        statements: &[Statement],
+        ret_id: VarId,
+        defs: &HashMap<VarId, Expression>,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<Option<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>)>, ParserError>
+    {
+        if statements.is_empty() {
+            return Ok(None);
+        }
+
+        let stmt = &statements[0];
+        let rest = &statements[1..];
+
+        match stmt {
+            Statement::Assign(assign) => {
+                if assign.dst.len() != 1 {
+                    return Err(ParserError::unsupported(
+                        LoweringPhase::CombLowering,
+                        "function body assignment shape",
+                        format!("{stmt}"),
+                        Some(&assign.token),
+                    ));
+                }
+
+                let dst = &assign.dst[0];
+                let is_whole_var =
+                    dst.index.0.is_empty() && dst.select.0.is_empty() && dst.select.1.is_none();
+
+                if is_whole_var {
+                    if dst.id == ret_id {
+                        return eval_expr_with_defs(
+                            module,
+                            caller_store,
+                            defs,
+                            &assign.expr,
+                            arena,
+                        )
+                        .map(Some);
+                    }
+
+                    let mut next_defs = defs.clone();
+                    next_defs.insert(dst.id, assign.expr.clone());
+                    resolve_return_value(module, caller_store, rest, ret_id, &next_defs, arena)
+                } else if is_static_access(&dst.index, &dst.select) {
+                    let old_value = defs.get(&dst.id).cloned().unwrap_or_else(|| {
+                        Expression::Term(Box::new(Factor::Variable(
+                            dst.id,
+                            VarIndex::default(),
+                            VarSelect::default(),
+                            dst.comptime.clone(),
+                        )))
+                    });
+                    let merged =
+                        build_partial_assign_expr(module, dst, assign.expr.clone(), old_value)?;
+
+                    let mut next_defs = defs.clone();
+                    next_defs.insert(dst.id, merged);
+                    resolve_return_value(module, caller_store, rest, ret_id, &next_defs, arena)
+                } else {
+                    Err(ParserError::unsupported(
+                        LoweringPhase::CombLowering,
+                        "function body non-whole assignment (dynamic index)",
+                        format!("{stmt}"),
+                        Some(&assign.token),
+                    ))
+                }
+            }
+            Statement::If(if_stmt) => {
+                let ((cond_expr, cond_sources), cond_bounds) =
+                    eval_expr_with_defs(module, caller_store, defs, &if_stmt.cond, arena)?;
+
+                let mut then_stmts = if_stmt.true_side.clone();
+                then_stmts.extend_from_slice(rest);
+                let then_value =
+                    resolve_return_value(module, caller_store, &then_stmts, ret_id, defs, arena)?;
+
+                let mut else_stmts = if_stmt.false_side.clone();
+                else_stmts.extend_from_slice(rest);
+                let else_value =
+                    resolve_return_value(module, caller_store, &else_stmts, ret_id, defs, arena)?;
+
+                match (then_value, else_value) {
+                    (
+                        Some(((then_expr, then_sources), then_bounds)),
+                        Some(((else_expr, else_sources), else_bounds)),
+                    ) => {
+                        let mut sources = cond_sources;
+                        sources.extend(then_sources);
+                        sources.extend(else_sources);
+                        let bounds = merge_boundaries(
+                            merge_boundaries(cond_bounds, then_bounds),
+                            else_bounds,
+                        );
+                        Ok(Some((
+                            (
+                                arena.alloc(SLTNode::Mux {
+                                    cond: cond_expr,
+                                    then_expr,
+                                    else_expr,
+                                }),
+                                sources,
+                            ),
+                            bounds,
+                        )))
+                    }
+                    _ => Ok(None),
+                }
+            }
+            Statement::Null => {
+                resolve_return_value(module, caller_store, rest, ret_id, defs, arena)
+            }
+            Statement::IfReset(ir) => Err(ParserError::unsupported(
                 LoweringPhase::CombLowering,
-                "function call missing argument",
-                format!("{call}"),
-                Some(&call.comptime.token),
-            ));
-        };
-
-        let ((arg_node, sources), bounds) =
-            eval_expression(module, caller_store, arg_expr, arena, None)?;
-        local_bounds = merge_boundaries(local_bounds, bounds);
-
-        let Some(arg_var) = module.variables.get(arg_id) else {
-            return Err(ParserError::unsupported(
+                "function body control flow",
+                format!("{stmt}"),
+                Some(&ir.token),
+            )),
+            Statement::SystemFunctionCall(fc) => Err(ParserError::unsupported(
                 LoweringPhase::CombLowering,
-                "function argument variable",
-                format!("unknown arg id: {:?}", arg_id),
-                Some(&call.comptime.token),
-            ));
-        };
-        let arg_width = resolve_total_width(module, arg_var)?;
-        local_store.insert(
-            *arg_id,
-            RangeStore::new(Some((arg_node, sources)), arg_width),
-        );
+                "function body control flow",
+                format!("{stmt}"),
+                Some(&fc.comptime.token),
+            )),
+            Statement::FunctionCall(fc) => Err(ParserError::unsupported(
+                LoweringPhase::CombLowering,
+                "function body control flow",
+                format!("{stmt}"),
+                Some(&fc.comptime.token),
+            )),
+            Statement::For(f) => Err(ParserError::unsupported(
+                LoweringPhase::CombLowering,
+                "for loop in function body",
+                format!("{stmt}"),
+                Some(&f.token),
+            )),
+            Statement::TbMethodCall(_) | Statement::Break | Statement::Unsupported(_) => {
+                Err(ParserError::unsupported(
+                    LoweringPhase::CombLowering,
+                    "function body control flow",
+                    format!("{stmt}"),
+                    None,
+                ))
+            }
+        }
     }
 
-    for stmt in &function_body.statements {
-        let (next_store, next_bounds) =
-            eval_statement(module, local_store, local_bounds, stmt, arena)?;
-        local_store = next_store;
-        local_bounds = next_bounds;
-    }
-
-    let Some(ret_var) = module.variables.get(&ret_id) else {
-        return Err(ParserError::unsupported(
+    resolve_return_value(
+        module,
+        caller_store,
+        &body.statements,
+        ret_id,
+        &HashMap::default(),
+        arena,
+    )?
+    .ok_or_else(|| {
+        ParserError::unsupported(
             LoweringPhase::CombLowering,
-            "function return variable",
-            format!("unknown return id: {:?}", ret_id),
-            Some(&call.comptime.token),
-        ));
-    };
-    let ret_width = resolve_total_width(module, ret_var)?;
-    let ret_range = BitAccess::new(0, ret_width - 1);
-    let ret_parts = local_store
-        .get(&ret_id)
-        .map(|range_store| range_store.get_parts(ret_range))
-        .unwrap_or_default();
-    let (ret_node, ret_sources) = combine_parts_with_default(ret_id, 0, ret_parts, arena);
-
-    Ok(((ret_node, ret_sources), local_bounds))
+            "function return expression",
+            format!("function return var id: {:?}", ret_id),
+            None,
+        )
+    })
 }
 
 fn eval_function_call_expression(
@@ -2311,7 +2564,36 @@ fn eval_function_call_expression(
         ));
     };
 
-    eval_function_body_return(module, store, call, &function_body, ret_id, arena)
+    let mut local_store = store.clone();
+    for (arg_path, arg_id) in &function_body.arg_map {
+        let Some(arg_expr) = call.inputs.get(arg_path) else {
+            return Err(ParserError::unsupported(
+                LoweringPhase::CombLowering,
+                "function call missing argument",
+                format!("{call}"),
+                Some(&call.comptime.token),
+            ));
+        };
+
+        let ((arg_node, sources), _bounds) =
+            eval_expression(module, &local_store, arg_expr, arena, None)?;
+
+        let Some(arg_var) = module.variables.get(arg_id) else {
+            return Err(ParserError::unsupported(
+                LoweringPhase::CombLowering,
+                "function argument variable",
+                format!("unknown arg id: {:?}", arg_id),
+                Some(&call.comptime.token),
+            ));
+        };
+        let arg_width = resolve_total_width(module, arg_var)?;
+        local_store.insert(
+            *arg_id,
+            RangeStore::new(Some((arg_node, sources)), arg_width),
+        );
+    }
+
+    eval_function_body_return(module, &local_store, &function_body, ret_id, arena)
 }
 
 pub fn eval_expression(

--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -2610,6 +2610,10 @@ fn eval_function_body_return(
         }
         result_store.remove(&for_stmt.var_id);
 
+        let mut next_live_sources = iter_state.live_sources.clone();
+        next_live_sources.extend(start_sources.iter().copied());
+        next_live_sources.extend(end_sources.iter().copied());
+
         let next_live_expr = if statement_contains_return(&Statement::For(for_stmt.clone()), ret_id)
         {
             let control_target = function_control_target(module, ret_id)?;
@@ -2648,7 +2652,7 @@ fn eval_function_body_return(
             result_store,
             merged_boundaries,
             next_live_expr,
-            iter_state.live_sources,
+            next_live_sources,
             arena,
         )
     }

--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -2231,6 +2231,24 @@ fn eval_function_body_return(
                 let ((cond_expr, cond_sources), cond_bounds) =
                     eval_expression(module, &store, &if_stmt.cond, arena, Some(1))?;
 
+                if let SLTNode::Constant(val, _, _, _) = arena.get(cond_expr) {
+                    let side = if *val != BigUint::from(0u32) {
+                        &if_stmt.true_side
+                    } else {
+                        &if_stmt.false_side
+                    };
+                    let mut folded_stmts = side.clone();
+                    folded_stmts.extend_from_slice(rest);
+                    return resolve_return_value(
+                        module,
+                        store,
+                        merge_boundaries(boundaries, cond_bounds),
+                        &folded_stmts,
+                        ret_id,
+                        arena,
+                    );
+                }
+
                 let mut then_stmts = if_stmt.true_side.clone();
                 then_stmts.extend_from_slice(rest);
                 let then_value = resolve_return_value(

--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -33,6 +33,14 @@ struct LoopControlState {
     continue_sources: HashSet<VarAtomBase<VarId>>,
 }
 
+#[derive(Clone)]
+struct FunctionControlState {
+    store: SymbolicStore<VarId>,
+    boundaries: BoundaryMap<VarId>,
+    live_expr: NodeId,
+    live_sources: HashSet<VarAtomBase<VarId>>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct NodeId(pub usize);
 
@@ -2189,121 +2197,496 @@ fn eval_function_body_return(
     ret_id: VarId,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
-    fn resolve_return_value(
+    fn is_whole_var_assign_to(assign: &AssignStatement, var_id: VarId) -> bool {
+        assign.dst.len() == 1
+            && assign.dst[0].id == var_id
+            && assign.dst[0].index.0.is_empty()
+            && assign.dst[0].select.0.is_empty()
+            && assign.dst[0].select.1.is_none()
+    }
+
+    fn statement_contains_return(stmt: &Statement, ret_id: VarId) -> bool {
+        match stmt {
+            Statement::Assign(assign) => is_whole_var_assign_to(assign, ret_id),
+            Statement::If(if_stmt) => {
+                if_stmt
+                    .true_side
+                    .iter()
+                    .any(|stmt| statement_contains_return(stmt, ret_id))
+                    || if_stmt
+                        .false_side
+                        .iter()
+                        .any(|stmt| statement_contains_return(stmt, ret_id))
+            }
+            Statement::For(for_stmt) => for_stmt
+                .body
+                .iter()
+                .any(|stmt| statement_contains_return(stmt, ret_id)),
+            Statement::IfReset(if_reset) => {
+                if_reset
+                    .true_side
+                    .iter()
+                    .any(|stmt| statement_contains_return(stmt, ret_id))
+                    || if_reset
+                        .false_side
+                        .iter()
+                        .any(|stmt| statement_contains_return(stmt, ret_id))
+            }
+            Statement::SystemFunctionCall(_)
+            | Statement::FunctionCall(_)
+            | Statement::TbMethodCall(_)
+            | Statement::Break
+            | Statement::Unsupported(_)
+            | Statement::Null => false,
+        }
+    }
+
+    fn function_return_value(
         module: &Module,
-        store: SymbolicStore<VarId>,
-        boundaries: BoundaryMap<VarId>,
-        statements: &[Statement],
+        store: &SymbolicStore<VarId>,
         ret_id: VarId,
         arena: &mut SLTNodeArena<VarId>,
-    ) -> Result<Option<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>)>, ParserError>
-    {
-        if statements.is_empty() {
-            return Ok(None);
+    ) -> Result<(NodeId, HashSet<VarAtomBase<VarId>>), ParserError> {
+        let ret_var = &module.variables[&ret_id];
+        let ret_width = resolve_total_width(module, ret_var)?;
+        let ret_access = BitAccess::new(0, ret_width - 1);
+        let ret_parts = store[&ret_id].get_parts(ret_access);
+        Ok(combine_parts_with_default(ret_id, 0, ret_parts, arena))
+    }
+
+    fn function_control_target(
+        module: &Module,
+        ret_id: VarId,
+    ) -> Result<VarAtomBase<VarId>, ParserError> {
+        let ret_width = resolve_total_width(module, &module.variables[&ret_id])?;
+        Ok(VarAtomBase::new(ret_id, ret_width, ret_width))
+    }
+
+    fn apply_function_guard(
+        module: &Module,
+        state: FunctionControlState,
+        next_store: SymbolicStore<VarId>,
+        next_boundaries: BoundaryMap<VarId>,
+        next_live_expr: NodeId,
+        next_live_sources: HashSet<VarAtomBase<VarId>>,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<FunctionControlState, ParserError> {
+        match constant_bool(arena, state.live_expr) {
+            Some(true) => Ok(FunctionControlState {
+                store: next_store,
+                boundaries: merge_boundaries(state.boundaries, next_boundaries),
+                live_expr: next_live_expr,
+                live_sources: next_live_sources,
+            }),
+            Some(false) => Ok(state),
+            None => {
+                let merged_store = merge_symbolic_stores(
+                    module,
+                    &next_store,
+                    &state.store,
+                    state.live_expr,
+                    &state.live_sources,
+                    arena,
+                )?;
+                let merged_live_expr = match constant_bool(arena, next_live_expr) {
+                    Some(true) => state.live_expr,
+                    Some(false) => bool_node(arena, false),
+                    None => arena.alloc(SLTNode::Binary(
+                        state.live_expr,
+                        BinaryOp::And,
+                        next_live_expr,
+                    )),
+                };
+                let mut merged_live_sources = state.live_sources;
+                merged_live_sources.extend(next_live_sources);
+                Ok(FunctionControlState {
+                    store: merged_store,
+                    boundaries: merge_boundaries(state.boundaries, next_boundaries),
+                    live_expr: merged_live_expr,
+                    live_sources: merged_live_sources,
+                })
+            }
+        }
+    }
+
+    fn eval_function_if(
+        module: &Module,
+        state: FunctionControlState,
+        if_stmt: &IfStatement,
+        ret_id: VarId,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<FunctionControlState, ParserError> {
+        let ((cond_expr, cond_sources), cond_bounds) =
+            eval_expression(module, &state.store, &if_stmt.cond, arena, Some(1))?;
+        let boundaries = merge_boundaries(state.boundaries, cond_bounds);
+
+        if let Some(cond_val) = constant_bool(arena, cond_expr) {
+            let side = if cond_val {
+                &if_stmt.true_side
+            } else {
+                &if_stmt.false_side
+            };
+            return side.iter().try_fold(
+                FunctionControlState {
+                    boundaries,
+                    ..state
+                },
+                |s, step| eval_function_statement(module, s, step, ret_id, arena),
+            );
         }
 
-        let stmt = &statements[0];
-        let rest = &statements[1..];
+        let then_state = if_stmt.true_side.iter().try_fold(
+            FunctionControlState {
+                store: state.store.clone(),
+                boundaries: boundaries.clone(),
+                live_expr: state.live_expr,
+                live_sources: state.live_sources.clone(),
+            },
+            |s, step| eval_function_statement(module, s, step, ret_id, arena),
+        )?;
+        let else_state = if_stmt.false_side.iter().try_fold(
+            FunctionControlState {
+                store: state.store,
+                boundaries,
+                live_expr: state.live_expr,
+                live_sources: state.live_sources,
+            },
+            |s, step| eval_function_statement(module, s, step, ret_id, arena),
+        )?;
+
+        let mut live_sources = cond_sources;
+        live_sources.extend(then_state.live_sources);
+        live_sources.extend(else_state.live_sources);
+
+        Ok(FunctionControlState {
+            store: merge_symbolic_stores(
+                module,
+                &then_state.store,
+                &else_state.store,
+                cond_expr,
+                &live_sources,
+                arena,
+            )?,
+            boundaries: merge_boundaries(then_state.boundaries, else_state.boundaries),
+            live_expr: merge_control_expr(
+                cond_expr,
+                then_state.live_expr,
+                else_state.live_expr,
+                arena,
+            ),
+            live_sources,
+        })
+    }
+
+    fn eval_function_for(
+        module: &Module,
+        state: FunctionControlState,
+        for_stmt: &ForStatement,
+        ret_id: VarId,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<FunctionControlState, ParserError> {
+        let Some(loop_width) = for_stmt.var_type.total_width() else {
+            return Err(ParserError::unsupported(
+                LoweringPhase::CombLowering,
+                "for loop variable width",
+                format!("{:?}", for_stmt.var_name),
+                Some(&for_stmt.token),
+            ));
+        };
+
+        let mut symbolic_store = state.store.clone();
+        let mut written_accesses = HashMap::default();
+        collect_written_accesses(module, &for_stmt.body, &mut written_accesses)?;
+        for (id, accesses) in &written_accesses {
+            let width = resolve_total_width(module, &module.variables[id])?;
+            let mut loop_store = RangeStore::new(None, width);
+            let mut covered = vec![false; width];
+            for access in accesses {
+                for slot in covered.iter_mut().take(access.msb + 1).skip(access.lsb) {
+                    *slot = true;
+                }
+            }
+            let original = state
+                .store
+                .get(id)
+                .cloned()
+                .unwrap_or_else(|| RangeStore::new(None, width));
+            let mut bit = 0usize;
+            while bit < width {
+                if covered[bit] {
+                    bit += 1;
+                    continue;
+                }
+                let start = bit;
+                while bit < width && !covered[bit] {
+                    bit += 1;
+                }
+                let end = bit - 1;
+                let access = BitAccess::new(start, end);
+                let parts = original.get_parts(access);
+                let (expr, sources) = combine_parts_with_default(*id, access.lsb, parts, arena);
+                loop_store.update(access, Some((expr, sources)));
+            }
+            symbolic_store.insert(*id, loop_store);
+        }
+        symbolic_store.insert(for_stmt.var_id, RangeStore::new(None, loop_width));
+        let iter_store_before = symbolic_store.clone();
+
+        let iter_state = for_stmt.body.iter().try_fold(
+            FunctionControlState {
+                store: symbolic_store,
+                boundaries: state.boundaries.clone(),
+                live_expr: bool_node(arena, true),
+                live_sources: HashSet::default(),
+            },
+            |s, stmt| eval_function_statement(module, s, stmt, ret_id, arena),
+        )?;
+        let iter_store_after = iter_state.store;
+        let mut merged_boundaries = iter_state.boundaries;
+
+        let (
+            start,
+            end,
+            start_sources,
+            end_sources,
+            start_bounds,
+            end_bounds,
+            inclusive,
+            step,
+            step_op,
+            reverse,
+        ) = match &for_stmt.range {
+            ForRange::Forward {
+                start: range_start,
+                end: range_end,
+                inclusive,
+                step,
+            } => {
+                let (start, start_sources, start_bounds) =
+                    eval_for_bound(module, &state.store, range_start, arena)?;
+                let (end, end_sources, end_bounds) =
+                    eval_for_bound(module, &state.store, range_end, arena)?;
+                (
+                    start,
+                    end,
+                    start_sources,
+                    end_sources,
+                    start_bounds,
+                    end_bounds,
+                    *inclusive,
+                    *step,
+                    SLTStepOp::Add,
+                    false,
+                )
+            }
+            ForRange::Reverse {
+                start: range_start,
+                end: range_end,
+                inclusive,
+                step,
+            } => {
+                let (start, start_sources, start_bounds) =
+                    eval_for_bound(module, &state.store, range_start, arena)?;
+                let (end, end_sources, end_bounds) =
+                    eval_for_bound(module, &state.store, range_end, arena)?;
+                (
+                    start,
+                    end,
+                    start_sources,
+                    end_sources,
+                    start_bounds,
+                    end_bounds,
+                    *inclusive,
+                    *step,
+                    SLTStepOp::Add,
+                    true,
+                )
+            }
+            ForRange::Stepped {
+                start: range_start,
+                end: range_end,
+                inclusive,
+                step,
+                op,
+            } => {
+                let (start, start_sources, start_bounds) =
+                    eval_for_bound(module, &state.store, range_start, arena)?;
+                let (end, end_sources, end_bounds) =
+                    eval_for_bound(module, &state.store, range_end, arena)?;
+                let step_op = match op {
+                    Op::Mul => SLTStepOp::Mul,
+                    Op::LogicShiftL | Op::ArithShiftL => SLTStepOp::Shl,
+                    other => {
+                        return Err(ParserError::unsupported(
+                            LoweringPhase::CombLowering,
+                            "for loop step operator",
+                            format!("{other:?}"),
+                            Some(&for_stmt.token),
+                        ));
+                    }
+                };
+                (
+                    start,
+                    end,
+                    start_sources,
+                    end_sources,
+                    start_bounds,
+                    end_bounds,
+                    *inclusive,
+                    *step,
+                    step_op,
+                    false,
+                )
+            }
+        };
+
+        merged_boundaries = merge_boundaries(merged_boundaries, start_bounds);
+        merged_boundaries = merge_boundaries(merged_boundaries, end_bounds);
+
+        let updates = extract_store_updates(&iter_store_before, &iter_store_after, arena);
+        let folded_updates: Vec<_> = updates
+            .iter()
+            .map(|(target, expr, _)| SLTForUpdate {
+                target: *target,
+                expr: *expr,
+            })
+            .collect();
+        let loop_updated_vars: HashSet<_> = folded_updates
+            .iter()
+            .map(|update| update.target.id)
+            .collect();
+        let initial_updates: Vec<_> = updates
+            .iter()
+            .map(|(target, _, _)| {
+                let parts = state.store[&target.id].get_parts(target.access);
+                let (expr, _) =
+                    combine_parts_with_default(target.id, target.access.lsb, parts, arena);
+                SLTForUpdate {
+                    target: *target,
+                    expr,
+                }
+            })
+            .collect();
+
+        let mut result_store = state.store.clone();
+        for (target, _expr, sources) in &updates {
+            let mut all_sources = start_sources.clone();
+            all_sources.extend(end_sources.iter().copied());
+            all_sources.extend(
+                iter_state.live_sources.iter().copied().filter(|src| {
+                    src.id != for_stmt.var_id && !loop_updated_vars.contains(&src.id)
+                }),
+            );
+            all_sources.extend(
+                sources.iter().copied().filter(|src| {
+                    src.id != for_stmt.var_id && !loop_updated_vars.contains(&src.id)
+                }),
+            );
+
+            let folded_expr = arena.alloc(SLTNode::ForFold {
+                loop_var: for_stmt.var_id,
+                loop_width,
+                loop_signed: for_stmt.var_type.signed,
+                start: start.clone(),
+                end: end.clone(),
+                inclusive,
+                step,
+                step_op,
+                reverse,
+                result: *target,
+                initials: initial_updates.clone(),
+                updates: folded_updates.clone(),
+                continue_cond: iter_state.live_expr,
+            });
+
+            result_store
+                .entry(target.id)
+                .or_insert_with(|| {
+                    let width =
+                        resolve_total_width(module, &module.variables[&target.id]).unwrap_or(0);
+                    RangeStore::new(None, width)
+                })
+                .update(target.access, Some((folded_expr, all_sources)));
+        }
+        result_store.remove(&for_stmt.var_id);
+
+        let next_live_expr = if statement_contains_return(&Statement::For(for_stmt.clone()), ret_id)
+        {
+            let control_target = function_control_target(module, ret_id)?;
+            let mut control_initials = initial_updates.clone();
+            control_initials.push(SLTForUpdate {
+                target: control_target,
+                expr: bool_node(arena, true),
+            });
+            let mut control_updates = folded_updates.clone();
+            control_updates.push(SLTForUpdate {
+                target: control_target,
+                expr: iter_state.live_expr,
+            });
+            arena.alloc(SLTNode::ForFold {
+                loop_var: for_stmt.var_id,
+                loop_width,
+                loop_signed: for_stmt.var_type.signed,
+                start,
+                end,
+                inclusive,
+                step,
+                step_op,
+                reverse,
+                result: control_target,
+                initials: control_initials,
+                updates: control_updates,
+                continue_cond: iter_state.live_expr,
+            })
+        } else {
+            bool_node(arena, true)
+        };
+
+        apply_function_guard(
+            module,
+            state,
+            result_store,
+            merged_boundaries,
+            next_live_expr,
+            iter_state.live_sources,
+            arena,
+        )
+    }
+
+    fn eval_function_statement(
+        module: &Module,
+        state: FunctionControlState,
+        stmt: &Statement,
+        ret_id: VarId,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<FunctionControlState, ParserError> {
+        if matches!(constant_bool(arena, state.live_expr), Some(false)) {
+            return Ok(state);
+        }
 
         match stmt {
             Statement::Assign(assign) => {
+                let guard_state = state.clone();
                 let (next_store, next_bounds) =
-                    eval_assign(module, store, boundaries, assign, arena)?;
-
-                if assign.dst.len() == 1 {
-                    let dst = &assign.dst[0];
-                    let is_whole_var =
-                        dst.index.0.is_empty() && dst.select.0.is_empty() && dst.select.1.is_none();
-                    if is_whole_var && dst.id == ret_id {
-                        let ret_var = &module.variables[&ret_id];
-                        let ret_width = resolve_total_width(module, ret_var)?;
-                        let ret_access = BitAccess::new(0, ret_width - 1);
-                        let ret_parts = next_store[&ret_id].get_parts(ret_access);
-                        let (ret_node, ret_sources) =
-                            combine_parts_with_default(ret_id, 0, ret_parts, arena);
-                        return Ok(Some(((ret_node, ret_sources), next_bounds)));
-                    }
-                }
-
-                resolve_return_value(module, next_store, next_bounds, rest, ret_id, arena)
-            }
-            Statement::If(if_stmt) => {
-                let ((cond_expr, cond_sources), cond_bounds) =
-                    eval_expression(module, &store, &if_stmt.cond, arena, Some(1))?;
-
-                if let SLTNode::Constant(val, _, _, _) = arena.get(cond_expr) {
-                    let side = if *val != BigUint::from(0u32) {
-                        &if_stmt.true_side
-                    } else {
-                        &if_stmt.false_side
-                    };
-                    let mut folded_stmts = side.clone();
-                    folded_stmts.extend_from_slice(rest);
-                    return resolve_return_value(
-                        module,
-                        store,
-                        merge_boundaries(boundaries, cond_bounds),
-                        &folded_stmts,
-                        ret_id,
-                        arena,
-                    );
-                }
-
-                let mut then_stmts = if_stmt.true_side.clone();
-                then_stmts.extend_from_slice(rest);
-                let then_value = resolve_return_value(
+                    eval_assign(module, state.store, state.boundaries, assign, arena)?;
+                let next_live = if is_whole_var_assign_to(assign, ret_id) {
+                    bool_node(arena, false)
+                } else {
+                    bool_node(arena, true)
+                };
+                apply_function_guard(
                     module,
-                    store.clone(),
-                    merge_boundaries(boundaries.clone(), cond_bounds.clone()),
-                    &then_stmts,
-                    ret_id,
+                    guard_state,
+                    next_store,
+                    next_bounds,
+                    next_live,
+                    HashSet::default(),
                     arena,
-                )?;
-
-                let mut else_stmts = if_stmt.false_side.clone();
-                else_stmts.extend_from_slice(rest);
-                let else_value = resolve_return_value(
-                    module,
-                    store,
-                    merge_boundaries(boundaries, cond_bounds.clone()),
-                    &else_stmts,
-                    ret_id,
-                    arena,
-                )?;
-
-                match (then_value, else_value) {
-                    (
-                        Some(((then_expr, then_sources), then_bounds)),
-                        Some(((else_expr, else_sources), else_bounds)),
-                    ) => {
-                        let mut sources = cond_sources;
-                        sources.extend(then_sources);
-                        sources.extend(else_sources);
-                        let bounds = merge_boundaries(
-                            merge_boundaries(cond_bounds, then_bounds),
-                            else_bounds,
-                        );
-                        Ok(Some((
-                            (
-                                arena.alloc(SLTNode::Mux {
-                                    cond: cond_expr,
-                                    then_expr,
-                                    else_expr,
-                                }),
-                                sources,
-                            ),
-                            bounds,
-                        )))
-                    }
-                    _ => Ok(None),
-                }
+                )
             }
-            Statement::For(for_stmt) => {
-                let (next_store, next_bounds) =
-                    eval_for(module, store, boundaries, for_stmt, arena)?;
-                resolve_return_value(module, next_store, next_bounds, rest, ret_id, arena)
-            }
-            Statement::Null => resolve_return_value(module, store, boundaries, rest, ret_id, arena),
+            Statement::If(if_stmt) => eval_function_if(module, state, if_stmt, ret_id, arena),
+            Statement::For(for_stmt) => eval_function_for(module, state, for_stmt, ret_id, arena),
+            Statement::Null => Ok(state),
             Statement::IfReset(ir) => Err(ParserError::unsupported(
                 LoweringPhase::CombLowering,
                 "function body control flow",
@@ -2359,22 +2742,25 @@ fn eval_function_body_return(
         }
     }
 
-    resolve_return_value(
-        module,
-        local_store,
-        local_bounds,
-        &body.statements,
-        ret_id,
-        arena,
-    )?
-    .ok_or_else(|| {
-        ParserError::unsupported(
+    let final_state = body.statements.iter().try_fold(
+        FunctionControlState {
+            store: local_store,
+            boundaries: local_bounds,
+            live_expr: bool_node(arena, true),
+            live_sources: HashSet::default(),
+        },
+        |state, stmt| eval_function_statement(module, state, stmt, ret_id, arena),
+    )?;
+    if !matches!(constant_bool(arena, final_state.live_expr), Some(false)) {
+        return Err(ParserError::unsupported(
             LoweringPhase::CombLowering,
             "function return expression",
             format!("function return var id: {:?}", ret_id),
             None,
-        )
-    })
+        ));
+    }
+    let (ret_expr, ret_sources) = function_return_value(module, &final_state.store, ret_id, arena)?;
+    Ok(((ret_expr, ret_sources), final_state.boundaries))
 }
 
 fn eval_function_call_expression(

--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -2270,13 +2270,8 @@ fn eval_function_body_return(
                     format!("module `{}`: {call}", module.name),
                     Some(&call.comptime.token),
                 )),
-                Factor::FunctionCall(call) => Err(ParserError::unsupported(
-                    LoweringPhase::CombLowering,
-                    "nested function call in comb function body",
-                    format!("module `{}`: {call}", module.name),
-                    Some(&call.comptime.token),
-                )),
                 Factor::Variable(_, _, _, _)
+                | Factor::FunctionCall(_)
                 | Factor::Value(_)
                 | Factor::Anonymous(_)
                 | Factor::Unknown(_) => Ok(()),

--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -41,6 +41,13 @@ struct FunctionControlState {
     live_sources: HashSet<VarAtomBase<VarId>>,
 }
 
+#[derive(Clone)]
+struct FunctionLoopControlState {
+    function: FunctionControlState,
+    continue_expr: NodeId,
+    continue_sources: HashSet<VarAtomBase<VarId>>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct NodeId(pub usize);
 
@@ -2326,32 +2333,41 @@ fn eval_function_body_return(
             } else {
                 &if_stmt.false_side
             };
-            return side.iter().try_fold(
+            return eval_function_statements(
+                module,
                 FunctionControlState {
                     boundaries,
                     ..state
                 },
-                |s, step| eval_function_statement(module, s, step, ret_id, arena),
+                side,
+                ret_id,
+                arena,
             );
         }
 
-        let then_state = if_stmt.true_side.iter().try_fold(
+        let then_state = eval_function_statements(
+            module,
             FunctionControlState {
                 store: state.store.clone(),
                 boundaries: boundaries.clone(),
                 live_expr: state.live_expr,
                 live_sources: state.live_sources.clone(),
             },
-            |s, step| eval_function_statement(module, s, step, ret_id, arena),
+            &if_stmt.true_side,
+            ret_id,
+            arena,
         )?;
-        let else_state = if_stmt.false_side.iter().try_fold(
+        let else_state = eval_function_statements(
+            module,
             FunctionControlState {
                 store: state.store,
                 boundaries,
                 live_expr: state.live_expr,
                 live_sources: state.live_sources,
             },
-            |s, step| eval_function_statement(module, s, step, ret_id, arena),
+            &if_stmt.false_side,
+            ret_id,
+            arena,
         )?;
 
         let mut live_sources = cond_sources;
@@ -2385,6 +2401,204 @@ fn eval_function_body_return(
         ret_id: VarId,
         arena: &mut SLTNodeArena<VarId>,
     ) -> Result<FunctionControlState, ParserError> {
+        fn apply_function_loop_continue_guard(
+            module: &Module,
+            state: FunctionLoopControlState,
+            next_function: FunctionControlState,
+            arena: &mut SLTNodeArena<VarId>,
+        ) -> Result<FunctionLoopControlState, ParserError> {
+            let boundaries =
+                merge_boundaries(state.function.boundaries.clone(), next_function.boundaries);
+
+            if matches!(constant_bool(arena, state.continue_expr), Some(true)) {
+                Ok(FunctionLoopControlState {
+                    function: FunctionControlState {
+                        boundaries,
+                        ..next_function
+                    },
+                    ..state
+                })
+            } else {
+                let merged_store = merge_symbolic_stores(
+                    module,
+                    &next_function.store,
+                    &state.function.store,
+                    state.continue_expr,
+                    &state.continue_sources,
+                    arena,
+                )?;
+                let mut merged_live_sources = state.continue_sources.clone();
+                merged_live_sources.extend(next_function.live_sources);
+                merged_live_sources.extend(state.function.live_sources);
+                Ok(FunctionLoopControlState {
+                    function: FunctionControlState {
+                        store: merged_store,
+                        boundaries,
+                        live_expr: merge_control_expr(
+                            state.continue_expr,
+                            next_function.live_expr,
+                            state.function.live_expr,
+                            arena,
+                        ),
+                        live_sources: merged_live_sources,
+                    },
+                    ..state
+                })
+            }
+        }
+
+        fn eval_function_loop_if(
+            module: &Module,
+            state: FunctionLoopControlState,
+            if_stmt: &IfStatement,
+            ret_id: VarId,
+            arena: &mut SLTNodeArena<VarId>,
+        ) -> Result<FunctionLoopControlState, ParserError> {
+            let ((cond_expr, cond_sources), cond_bounds) =
+                eval_expression(module, &state.function.store, &if_stmt.cond, arena, Some(1))?;
+            let boundaries = merge_boundaries(state.function.boundaries, cond_bounds);
+
+            if let Some(cond_val) = constant_bool(arena, cond_expr) {
+                let side = if cond_val {
+                    &if_stmt.true_side
+                } else {
+                    &if_stmt.false_side
+                };
+                return side.iter().try_fold(
+                    FunctionLoopControlState {
+                        function: FunctionControlState {
+                            boundaries,
+                            ..state.function
+                        },
+                        ..state
+                    },
+                    |s, step| eval_function_loop_statement(module, s, step, ret_id, arena),
+                );
+            }
+
+            let then_state = if_stmt.true_side.iter().try_fold(
+                FunctionLoopControlState {
+                    function: FunctionControlState {
+                        store: state.function.store.clone(),
+                        boundaries: boundaries.clone(),
+                        live_expr: state.function.live_expr,
+                        live_sources: state.function.live_sources.clone(),
+                    },
+                    continue_expr: state.continue_expr,
+                    continue_sources: state.continue_sources.clone(),
+                },
+                |s, step| eval_function_loop_statement(module, s, step, ret_id, arena),
+            )?;
+            let else_state = if_stmt.false_side.iter().try_fold(
+                FunctionLoopControlState {
+                    function: FunctionControlState {
+                        store: state.function.store,
+                        boundaries,
+                        live_expr: state.function.live_expr,
+                        live_sources: state.function.live_sources,
+                    },
+                    continue_expr: state.continue_expr,
+                    continue_sources: state.continue_sources,
+                },
+                |s, step| eval_function_loop_statement(module, s, step, ret_id, arena),
+            )?;
+
+            let mut merged_sources = cond_sources;
+            merged_sources.extend(then_state.continue_sources);
+            merged_sources.extend(else_state.continue_sources);
+            let mut live_sources = merged_sources.clone();
+            live_sources.extend(then_state.function.live_sources);
+            live_sources.extend(else_state.function.live_sources);
+
+            Ok(FunctionLoopControlState {
+                function: FunctionControlState {
+                    store: merge_symbolic_stores(
+                        module,
+                        &then_state.function.store,
+                        &else_state.function.store,
+                        cond_expr,
+                        &live_sources,
+                        arena,
+                    )?,
+                    boundaries: merge_boundaries(
+                        then_state.function.boundaries,
+                        else_state.function.boundaries,
+                    ),
+                    live_expr: merge_control_expr(
+                        cond_expr,
+                        then_state.function.live_expr,
+                        else_state.function.live_expr,
+                        arena,
+                    ),
+                    live_sources,
+                },
+                continue_expr: merge_control_expr(
+                    cond_expr,
+                    then_state.continue_expr,
+                    else_state.continue_expr,
+                    arena,
+                ),
+                continue_sources: merged_sources,
+            })
+        }
+
+        fn eval_function_loop_statement(
+            module: &Module,
+            state: FunctionLoopControlState,
+            stmt: &Statement,
+            ret_id: VarId,
+            arena: &mut SLTNodeArena<VarId>,
+        ) -> Result<FunctionLoopControlState, ParserError> {
+            if matches!(constant_bool(arena, state.function.live_expr), Some(false))
+                || matches!(constant_bool(arena, state.continue_expr), Some(false))
+            {
+                return Ok(state);
+            }
+
+            match stmt {
+                Statement::If(if_stmt) => {
+                    eval_function_loop_if(module, state, if_stmt, ret_id, arena)
+                }
+                Statement::Assign(_) | Statement::For(_) | Statement::Null => {
+                    let guard_state = state.clone();
+                    let next_function =
+                        eval_function_statement(module, state.function, stmt, ret_id, arena)?;
+                    apply_function_loop_continue_guard(module, guard_state, next_function, arena)
+                }
+                Statement::Break => Ok(FunctionLoopControlState {
+                    continue_sources: HashSet::default(),
+                    continue_expr: bool_node(arena, false),
+                    ..state
+                }),
+                Statement::IfReset(ir) => Err(ParserError::unsupported(
+                    LoweringPhase::CombLowering,
+                    "function body control flow",
+                    format!("{stmt}"),
+                    Some(&ir.token),
+                )),
+                Statement::SystemFunctionCall(fc) => Err(ParserError::unsupported(
+                    LoweringPhase::CombLowering,
+                    "function body control flow",
+                    format!("{stmt}"),
+                    Some(&fc.comptime.token),
+                )),
+                Statement::FunctionCall(fc) => Err(ParserError::unsupported(
+                    LoweringPhase::CombLowering,
+                    "function body control flow",
+                    format!("{stmt}"),
+                    Some(&fc.comptime.token),
+                )),
+                Statement::TbMethodCall(_) | Statement::Unsupported(_) => {
+                    Err(ParserError::unsupported(
+                        LoweringPhase::CombLowering,
+                        "function body control flow",
+                        format!("{stmt}"),
+                        None,
+                    ))
+                }
+            }
+        }
+
         let Some(loop_width) = for_stmt.var_type.total_width() else {
             return Err(ParserError::unsupported(
                 LoweringPhase::CombLowering,
@@ -2433,16 +2647,20 @@ fn eval_function_body_return(
         let iter_store_before = symbolic_store.clone();
 
         let iter_state = for_stmt.body.iter().try_fold(
-            FunctionControlState {
-                store: symbolic_store,
-                boundaries: state.boundaries.clone(),
-                live_expr: bool_node(arena, true),
-                live_sources: HashSet::default(),
+            FunctionLoopControlState {
+                function: FunctionControlState {
+                    store: symbolic_store,
+                    boundaries: state.boundaries.clone(),
+                    live_expr: bool_node(arena, true),
+                    live_sources: HashSet::default(),
+                },
+                continue_expr: bool_node(arena, true),
+                continue_sources: HashSet::default(),
             },
-            |s, stmt| eval_function_statement(module, s, stmt, ret_id, arena),
+            |s, stmt| eval_function_loop_statement(module, s, stmt, ret_id, arena),
         )?;
-        let iter_store_after = iter_state.store;
-        let mut merged_boundaries = iter_state.boundaries;
+        let iter_store_after = iter_state.function.store;
+        let mut merged_boundaries = iter_state.function.boundaries;
 
         let (
             start,
@@ -2569,13 +2787,28 @@ fn eval_function_body_return(
             .collect();
 
         let mut result_store = state.store.clone();
+        let loop_effective_continue = arena.alloc(SLTNode::Binary(
+            iter_state.continue_expr,
+            BinaryOp::And,
+            iter_state.function.live_expr,
+        ));
         for (target, _expr, sources) in &updates {
             let mut all_sources = start_sources.clone();
             all_sources.extend(end_sources.iter().copied());
             all_sources.extend(
-                iter_state.live_sources.iter().copied().filter(|src| {
+                iter_state.continue_sources.iter().copied().filter(|src| {
                     src.id != for_stmt.var_id && !loop_updated_vars.contains(&src.id)
                 }),
+            );
+            all_sources.extend(
+                iter_state
+                    .function
+                    .live_sources
+                    .iter()
+                    .copied()
+                    .filter(|src| {
+                        src.id != for_stmt.var_id && !loop_updated_vars.contains(&src.id)
+                    }),
             );
             all_sources.extend(
                 sources.iter().copied().filter(|src| {
@@ -2596,7 +2829,7 @@ fn eval_function_body_return(
                 result: *target,
                 initials: initial_updates.clone(),
                 updates: folded_updates.clone(),
-                continue_cond: iter_state.live_expr,
+                continue_cond: loop_effective_continue,
             });
 
             result_store
@@ -2610,7 +2843,8 @@ fn eval_function_body_return(
         }
         result_store.remove(&for_stmt.var_id);
 
-        let mut next_live_sources = iter_state.live_sources.clone();
+        let mut next_live_sources = iter_state.continue_sources.clone();
+        next_live_sources.extend(iter_state.function.live_sources.iter().copied());
         next_live_sources.extend(start_sources.iter().copied());
         next_live_sources.extend(end_sources.iter().copied());
 
@@ -2625,7 +2859,7 @@ fn eval_function_body_return(
             let mut control_updates = folded_updates.clone();
             control_updates.push(SLTForUpdate {
                 target: control_target,
-                expr: iter_state.live_expr,
+                expr: iter_state.function.live_expr,
             });
             arena.alloc(SLTNode::ForFold {
                 loop_var: for_stmt.var_id,
@@ -2640,7 +2874,7 @@ fn eval_function_body_return(
                 result: control_target,
                 initials: control_initials,
                 updates: control_updates,
-                continue_cond: iter_state.live_expr,
+                continue_cond: iter_state.continue_expr,
             })
         } else {
             bool_node(arena, true)
@@ -2655,6 +2889,285 @@ fn eval_function_body_return(
             next_live_sources,
             arena,
         )
+    }
+
+    fn apply_function_break_guard(
+        module: &Module,
+        state: FunctionLoopControlState,
+        next_function: FunctionControlState,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<FunctionLoopControlState, ParserError> {
+        let boundaries =
+            merge_boundaries(state.function.boundaries.clone(), next_function.boundaries);
+
+        if matches!(constant_bool(arena, state.continue_expr), Some(true)) {
+            Ok(FunctionLoopControlState {
+                function: FunctionControlState {
+                    boundaries,
+                    ..next_function
+                },
+                ..state
+            })
+        } else {
+            let merged_store = merge_symbolic_stores(
+                module,
+                &next_function.store,
+                &state.function.store,
+                state.continue_expr,
+                &state.continue_sources,
+                arena,
+            )?;
+            let mut merged_live_sources = state.continue_sources.clone();
+            merged_live_sources.extend(next_function.live_sources);
+            merged_live_sources.extend(state.function.live_sources);
+            Ok(FunctionLoopControlState {
+                function: FunctionControlState {
+                    store: merged_store,
+                    boundaries,
+                    live_expr: merge_control_expr(
+                        state.continue_expr,
+                        next_function.live_expr,
+                        state.function.live_expr,
+                        arena,
+                    ),
+                    live_sources: merged_live_sources,
+                },
+                ..state
+            })
+        }
+    }
+
+    fn eval_function_break_if(
+        module: &Module,
+        state: FunctionLoopControlState,
+        if_stmt: &IfStatement,
+        ret_id: VarId,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<FunctionLoopControlState, ParserError> {
+        let outer_state = state.clone();
+        let ((cond_expr, cond_sources), cond_bounds) =
+            eval_expression(module, &state.function.store, &if_stmt.cond, arena, Some(1))?;
+        let boundaries = merge_boundaries(state.function.boundaries, cond_bounds);
+
+        let executed_state = if let Some(cond_val) = constant_bool(arena, cond_expr) {
+            let side = if cond_val {
+                &if_stmt.true_side
+            } else {
+                &if_stmt.false_side
+            };
+            side.iter().try_fold(
+                FunctionLoopControlState {
+                    function: FunctionControlState {
+                        boundaries,
+                        ..state.function
+                    },
+                    ..state
+                },
+                |s, step| eval_function_break_statement(module, s, step, ret_id, arena),
+            )?
+        } else {
+            let then_state = if_stmt.true_side.iter().try_fold(
+                FunctionLoopControlState {
+                    function: FunctionControlState {
+                        store: state.function.store.clone(),
+                        boundaries: boundaries.clone(),
+                        live_expr: state.function.live_expr,
+                        live_sources: state.function.live_sources.clone(),
+                    },
+                    continue_expr: state.continue_expr,
+                    continue_sources: state.continue_sources.clone(),
+                },
+                |s, step| eval_function_break_statement(module, s, step, ret_id, arena),
+            )?;
+            let else_state = if_stmt.false_side.iter().try_fold(
+                FunctionLoopControlState {
+                    function: FunctionControlState {
+                        store: state.function.store,
+                        boundaries,
+                        live_expr: state.function.live_expr,
+                        live_sources: state.function.live_sources,
+                    },
+                    continue_expr: state.continue_expr,
+                    continue_sources: state.continue_sources,
+                },
+                |s, step| eval_function_break_statement(module, s, step, ret_id, arena),
+            )?;
+
+            let mut merged_sources = cond_sources;
+            merged_sources.extend(then_state.continue_sources);
+            merged_sources.extend(else_state.continue_sources);
+            let mut live_sources = merged_sources.clone();
+            live_sources.extend(then_state.function.live_sources);
+            live_sources.extend(else_state.function.live_sources);
+
+            FunctionLoopControlState {
+                function: FunctionControlState {
+                    store: merge_symbolic_stores(
+                        module,
+                        &then_state.function.store,
+                        &else_state.function.store,
+                        cond_expr,
+                        &live_sources,
+                        arena,
+                    )?,
+                    boundaries: merge_boundaries(
+                        then_state.function.boundaries,
+                        else_state.function.boundaries,
+                    ),
+                    live_expr: merge_control_expr(
+                        cond_expr,
+                        then_state.function.live_expr,
+                        else_state.function.live_expr,
+                        arena,
+                    ),
+                    live_sources,
+                },
+                continue_expr: merge_control_expr(
+                    cond_expr,
+                    then_state.continue_expr,
+                    else_state.continue_expr,
+                    arena,
+                ),
+                continue_sources: merged_sources,
+            }
+        };
+
+        if matches!(constant_bool(arena, outer_state.continue_expr), Some(true)) {
+            return Ok(executed_state);
+        }
+
+        let guarded = apply_function_break_guard(
+            module,
+            outer_state.clone(),
+            executed_state.function,
+            arena,
+        )?;
+        let continue_expr = match constant_bool(arena, executed_state.continue_expr) {
+            Some(true) => outer_state.continue_expr,
+            Some(false) => bool_node(arena, false),
+            None => arena.alloc(SLTNode::Binary(
+                outer_state.continue_expr,
+                BinaryOp::And,
+                executed_state.continue_expr,
+            )),
+        };
+        let mut continue_sources = outer_state.continue_sources;
+        continue_sources.extend(executed_state.continue_sources);
+        Ok(FunctionLoopControlState {
+            function: guarded.function,
+            continue_expr,
+            continue_sources,
+        })
+    }
+
+    fn eval_function_break_statement(
+        module: &Module,
+        state: FunctionLoopControlState,
+        stmt: &Statement,
+        ret_id: VarId,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<FunctionLoopControlState, ParserError> {
+        if matches!(constant_bool(arena, state.function.live_expr), Some(false))
+            || matches!(constant_bool(arena, state.continue_expr), Some(false))
+        {
+            return Ok(state);
+        }
+
+        match stmt {
+            Statement::If(if_stmt) => eval_function_break_if(module, state, if_stmt, ret_id, arena),
+            Statement::Assign(_) | Statement::For(_) | Statement::Null => {
+                let guard_state = state.clone();
+                let next_function =
+                    eval_function_statement(module, state.function, stmt, ret_id, arena)?;
+                apply_function_break_guard(module, guard_state, next_function, arena)
+            }
+            Statement::Break => Ok(FunctionLoopControlState {
+                continue_sources: HashSet::default(),
+                continue_expr: bool_node(arena, false),
+                ..state
+            }),
+            Statement::IfReset(ir) => Err(ParserError::unsupported(
+                LoweringPhase::CombLowering,
+                "function body control flow",
+                format!("{stmt}"),
+                Some(&ir.token),
+            )),
+            Statement::SystemFunctionCall(fc) => Err(ParserError::unsupported(
+                LoweringPhase::CombLowering,
+                "function body control flow",
+                format!("{stmt}"),
+                Some(&fc.comptime.token),
+            )),
+            Statement::FunctionCall(fc) => Err(ParserError::unsupported(
+                LoweringPhase::CombLowering,
+                "function body control flow",
+                format!("{stmt}"),
+                Some(&fc.comptime.token),
+            )),
+            Statement::TbMethodCall(_) | Statement::Unsupported(_) => {
+                Err(ParserError::unsupported(
+                    LoweringPhase::CombLowering,
+                    "function body control flow",
+                    format!("{stmt}"),
+                    None,
+                ))
+            }
+        }
+    }
+
+    fn eval_function_unrolled_loop_statements(
+        module: &Module,
+        state: FunctionControlState,
+        statements: &[Statement],
+        ret_id: VarId,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<FunctionControlState, ParserError> {
+        let loop_state = statements.iter().try_fold(
+            FunctionLoopControlState {
+                function: state,
+                continue_expr: bool_node(arena, true),
+                continue_sources: HashSet::default(),
+            },
+            |s, stmt| eval_function_break_statement(module, s, stmt, ret_id, arena),
+        )?;
+        Ok(loop_state.function)
+    }
+
+    fn eval_function_statements(
+        module: &Module,
+        mut state: FunctionControlState,
+        statements: &[Statement],
+        ret_id: VarId,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<FunctionControlState, ParserError> {
+        let mut i = 0;
+        while i < statements.len() {
+            if matches!(constant_bool(arena, state.live_expr), Some(false)) {
+                break;
+            }
+
+            if !statement_contains_break(&statements[i]) {
+                state = eval_function_statement(module, state, &statements[i], ret_id, arena)?;
+                i += 1;
+                continue;
+            }
+
+            let start = i;
+            i += 1;
+            while i < statements.len() && statement_contains_break(&statements[i]) {
+                i += 1;
+            }
+
+            state = eval_function_unrolled_loop_statements(
+                module,
+                state,
+                &statements[start..i],
+                ret_id,
+                arena,
+            )?;
+        }
+
+        Ok(state)
     }
 
     fn eval_function_statement(
@@ -2746,14 +3259,17 @@ fn eval_function_body_return(
         }
     }
 
-    let final_state = body.statements.iter().try_fold(
+    let final_state = eval_function_statements(
+        module,
         FunctionControlState {
             store: local_store,
             boundaries: local_bounds,
             live_expr: bool_node(arena, true),
             live_sources: HashSet::default(),
         },
-        |state, stmt| eval_function_statement(module, state, stmt, ret_id, arena),
+        &body.statements,
+        ret_id,
+        arena,
     )?;
     if !matches!(constant_bool(arena, final_state.live_expr), Some(false)) {
         return Err(ParserError::unsupported(

--- a/crates/celox/src/optimizer/coalescing/pass_gvn.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_gvn.rs
@@ -127,7 +127,7 @@ impl ExecutionUnitPass for GvnPass {
 #[derive(Clone, PartialEq, Eq, Hash)]
 enum ValueKey {
     /// Constant immediate
-    Imm(Vec<u64>),
+    Imm(Vec<u64>, usize),
     /// Binary operation: (op, lhs_value_number, rhs_value_number, result_width)
     Binary(BinaryOp, RegisterId, RegisterId, usize),
     /// Unary operation: (op, src_value_number, result_width)
@@ -172,7 +172,8 @@ fn gvn_block(
                 let mut key_data = val.payload.to_u64_digits();
                 key_data.push(u64::MAX); // separator
                 key_data.extend(val.mask.to_u64_digits());
-                Some(ValueKey::Imm(key_data))
+                let w = register_map.get(dst).map(|t| t.width()).unwrap_or(0);
+                Some(ValueKey::Imm(key_data, w))
             }
             SIRInstruction::Binary(dst, lhs, op, rhs) => {
                 let l = resolve(*lhs, &canonical);

--- a/crates/celox/tests/basic.rs
+++ b/crates/celox/tests/basic.rs
@@ -282,6 +282,29 @@ module Top (
 
     }
 
+    fn test_comb_function_call_constant_folded_if_return(sim) {
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    q: output logic<8>,
+) {
+    function f () -> logic<8> {
+        if 1'b1 {
+            return 8'd3;
+        }
+    }
+
+    always_comb {
+        q = f();
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let q = sim.signal("q");
+    assert_eq!(sim.get(q), 3u32.into());
+
+    }
+
     fn test_always_comb_blocking_assignment_chain(sim) {
         @setup { let code = r#"
 module Top (a: input logic<8>, o: output logic<8>) {

--- a/crates/celox/tests/basic.rs
+++ b/crates/celox/tests/basic.rs
@@ -148,6 +148,71 @@ o = tmp;
 
     }
 
+    fn test_comb_function_call_early_return(sim) {
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    d: input logic<8>,
+    q: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+    ) -> logic<8> {
+        if x == 8'd0 {
+            return x + 8'd1;
+        }
+        return x + 8'd2;
+    }
+
+    always_comb {
+        q = f(d);
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+
+    sim.modify(|io| io.set(d, 0u8)).unwrap();
+    assert_eq!(sim.get(q), 1u32.into());
+
+    sim.modify(|io| io.set(d, 5u8)).unwrap();
+    assert_eq!(sim.get(q), 7u32.into());
+
+    }
+
+    fn test_comb_function_call_return_indexed_local_temp(sim) {
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    d: input logic<8>,
+    q: output logic,
+) {
+    function f (
+        x: input logic<8>,
+    ) -> logic {
+        var tmp: logic<8>;
+        tmp = x;
+        return tmp[0];
+    }
+
+    always_comb {
+        q = f(d);
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+
+    sim.modify(|io| io.set(d, 0b1010u8)).unwrap();
+    assert_eq!(sim.get(q), 0u32.into());
+
+    sim.modify(|io| io.set(d, 0b1011u8)).unwrap();
+    assert_eq!(sim.get(q), 1u32.into());
+
+    }
+
     fn test_always_comb_blocking_assignment_chain(sim) {
         @setup { let code = r#"
 module Top (a: input logic<8>, o: output logic<8>) {

--- a/crates/celox/tests/basic.rs
+++ b/crates/celox/tests/basic.rs
@@ -213,6 +213,75 @@ module Top (
 
     }
 
+    fn test_comb_function_call_partial_write_local_temp(sim) {
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    d: input logic<8>,
+    q: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+    ) -> logic<8> {
+        var tmp: logic<8>;
+        tmp[7:4] = x[3:0];
+        tmp[3:0] = x[7:4];
+        return tmp;
+    }
+
+    always_comb {
+        q = f(d);
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+
+    sim.modify(|io| io.set(d, 0xABu8)).unwrap();
+    assert_eq!(sim.get(q), 0xBAu32.into());
+
+    }
+
+    fn test_comb_function_call_local_and_return_width_coercion(sim) {
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    sel: input logic,
+    q0 : output logic<8>,
+    q1 : output logic<8>,
+) {
+    function f (
+        x: input logic,
+    ) -> logic<8> {
+        var tmp: logic<8>;
+        tmp = 1'b1;
+        if x {
+            return 1'b1;
+        }
+        return tmp;
+    }
+
+    always_comb {
+        q0 = f(1'b0);
+        q1 = f(sel);
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let sel = sim.signal("sel");
+    let q0 = sim.signal("q0");
+    let q1 = sim.signal("q1");
+
+    sim.modify(|io| io.set(sel, 0u8)).unwrap();
+    assert_eq!(sim.get(q0), 1u32.into());
+    assert_eq!(sim.get(q1), 1u32.into());
+
+    sim.modify(|io| io.set(sel, 1u8)).unwrap();
+    assert_eq!(sim.get(q1), 1u32.into());
+
+    }
+
     fn test_always_comb_blocking_assignment_chain(sim) {
         @setup { let code = r#"
 module Top (a: input logic<8>, o: output logic<8>) {

--- a/crates/celox/tests/basic.rs
+++ b/crates/celox/tests/basic.rs
@@ -378,6 +378,39 @@ module Top (
 
     }
 
+    fn test_comb_function_call_nested_helper(sim) {
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    d: input logic<8>,
+    q: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+    ) -> logic<8> {
+        return x + 8'd1;
+    }
+
+    function g (
+        x: input logic<8>,
+    ) -> logic<8> {
+        return f(x) + 8'd1;
+    }
+
+    always_comb {
+        q = g(d);
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+
+    sim.modify(|io| io.set(d, 8u8)).unwrap();
+    assert_eq!(sim.get(q), 10u32.into());
+
+    }
+
     fn test_always_comb_blocking_assignment_chain(sim) {
         @setup { let code = r#"
 module Top (a: input logic<8>, o: output logic<8>) {

--- a/crates/celox/tests/basic.rs
+++ b/crates/celox/tests/basic.rs
@@ -305,6 +305,41 @@ module Top (
 
     }
 
+    fn test_comb_function_call_return_inside_for(sim) {
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    d: input logic<4>,
+    q: output logic<8>,
+) {
+    function f (
+        x: input logic<4>,
+    ) -> logic<8> {
+        for i: logic<2> in 0..4 {
+            if x[i] {
+                return 8'd9;
+            }
+        }
+        return 8'd1;
+    }
+
+    always_comb {
+        q = f(d);
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+
+    sim.modify(|io| io.set(d, 0b0000u8)).unwrap();
+    assert_eq!(sim.get(q), 1u32.into());
+
+    sim.modify(|io| io.set(d, 0b0100u8)).unwrap();
+    assert_eq!(sim.get(q), 9u32.into());
+
+    }
+
     fn test_always_comb_blocking_assignment_chain(sim) {
         @setup { let code = r#"
 module Top (a: input logic<8>, o: output logic<8>) {

--- a/crates/celox/tests/basic.rs
+++ b/crates/celox/tests/basic.rs
@@ -340,6 +340,44 @@ module Top (
 
     }
 
+    fn test_comb_function_call_break_inside_for(sim) {
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    d: input logic<4>,
+    q: output logic<8>,
+) {
+    function f (
+        x: input logic<4>,
+    ) -> logic<8> {
+        var tmp: logic<8>;
+        tmp = 8'd0;
+        for i: logic<2> in 0..4 {
+            if x[i] {
+                tmp = i + 8'd1;
+                break;
+            }
+        }
+        return tmp;
+    }
+
+    always_comb {
+        q = f(d);
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+
+    sim.modify(|io| io.set(d, 0b0000u8)).unwrap();
+    assert_eq!(sim.get(q), 0u32.into());
+
+    sim.modify(|io| io.set(d, 0b1010u8)).unwrap();
+    assert_eq!(sim.get(q), 2u32.into());
+
+    }
+
     fn test_always_comb_blocking_assignment_chain(sim) {
         @setup { let code = r#"
 module Top (a: input logic<8>, o: output logic<8>) {

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -624,3 +624,104 @@ fn test_generic_top_returns_error() {
         Ok(_) => panic!("expected GenericTop, got Ok"),
     }
 }
+
+#[test]
+fn test_comb_function_body_rejects_nested_function_call() {
+    let code = r#"
+        module Top (
+            d: input logic<8>,
+            q: output logic<8>,
+        ) {
+            function g (
+                x: input logic<8>,
+            ) -> logic<8> {
+                return x + 8'd1;
+            }
+
+            function f (
+                x: input logic<8>,
+            ) -> logic<8> {
+                return g(x);
+            }
+
+            always_comb {
+                q = f(d);
+            }
+        }
+    "#;
+
+    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| {
+        let msg = format!("{e:?}");
+        assert!(
+            msg.contains("nested function call in comb function body"),
+            "Expected nested function call error, got: {e:?}"
+        );
+    });
+}
+
+#[test]
+fn test_comb_function_body_rejects_system_function_call() {
+    let code = r#"
+        module Top (
+            d: input logic<8>,
+            q: output logic<8>,
+        ) {
+            function f (
+                x: input logic<8>,
+            ) -> logic<8> {
+                return $countones(x);
+            }
+
+            always_comb {
+                q = f(d);
+            }
+        }
+    "#;
+
+    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| {
+        let msg = format!("{e:?}");
+        assert!(
+            msg.contains("system function call in comb function body")
+                || msg.contains("unresolved factor in comb expression"),
+            "Expected system function call error, got: {e:?}"
+        );
+    });
+}
+
+#[test]
+fn test_comb_function_body_rejects_dynamic_for_break() {
+    let code = r#"
+        module Top (
+            count: input logic<3>,
+            d: input logic<4>,
+            q: output logic<8>,
+        ) {
+            function f (
+                n: input logic<3>,
+                x: input logic<4>,
+            ) -> logic<8> {
+                var tmp: logic<8>;
+                tmp = 8'd0;
+                for i: logic<3> in 0..n {
+                    if x[i] {
+                        tmp = i + 8'd1;
+                        break;
+                    }
+                }
+                return tmp;
+            }
+
+            always_comb {
+                q = f(count, d);
+            }
+        }
+    "#;
+
+    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| {
+        let msg = format!("{e:?}");
+        assert!(
+            msg.contains("break in dynamic function-local for"),
+            "Expected dynamic function-local for break error, got: {e:?}"
+        );
+    });
+}

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -626,40 +626,6 @@ fn test_generic_top_returns_error() {
 }
 
 #[test]
-fn test_comb_function_body_rejects_nested_function_call() {
-    let code = r#"
-        module Top (
-            d: input logic<8>,
-            q: output logic<8>,
-        ) {
-            function g (
-                x: input logic<8>,
-            ) -> logic<8> {
-                return x + 8'd1;
-            }
-
-            function f (
-                x: input logic<8>,
-            ) -> logic<8> {
-                return g(x);
-            }
-
-            always_comb {
-                q = f(d);
-            }
-        }
-    "#;
-
-    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| {
-        let msg = format!("{e:?}");
-        assert!(
-            msg.contains("nested function call in comb function body"),
-            "Expected nested function call error, got: {e:?}"
-        );
-    });
-}
-
-#[test]
 fn test_comb_function_body_rejects_system_function_call() {
     let code = r#"
         module Top (

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -725,3 +725,43 @@ fn test_comb_function_body_rejects_dynamic_for_break() {
         );
     });
 }
+
+#[test]
+fn test_comb_function_body_rejects_nested_break_in_dynamic_for_due_to_analyzer_unroll() {
+    let code = r#"
+        module Top (
+            count: input logic<3>,
+            d: input logic<4>,
+            q: output logic<8>,
+        ) {
+            function f (
+                n: input logic<3>,
+                x: input logic<4>,
+            ) -> logic<8> {
+                var tmp: logic<8>;
+                tmp = 8'd0;
+                for i: logic<3> in 0..n {
+                    for j: logic<2> in 0..4 {
+                        if x[j] {
+                            break;
+                        }
+                    }
+                    tmp = tmp + 8'd1;
+                }
+                return tmp;
+            }
+
+            always_comb {
+                q = f(count, d);
+            }
+        }
+    "#;
+
+    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| {
+        let msg = format!("{e:?}");
+        assert!(
+            msg.contains("break in dynamic function-local for"),
+            "Expected nested break case to stay unsupported until analyzer preserves loop ownership, got: {e:?}"
+        );
+    });
+}

--- a/crates/celox/tests/trace_analyzer_ir.rs
+++ b/crates/celox/tests/trace_analyzer_ir.rs
@@ -1,4 +1,7 @@
 use celox::SimulatorBuilder;
+use veryl_analyzer::{Analyzer, Context, attribute_table, ir::Ir, symbol_table};
+use veryl_metadata::Metadata;
+use veryl_parser::Parser;
 
 #[path = "test_utils/mod.rs"]
 #[macro_use]
@@ -22,4 +25,60 @@ fn test_trace_analyzer_ir() {
         .expect("analyzer_ir should be captured");
     assert!(analyzer_ir.contains("module Top"));
     assert!(analyzer_ir.contains("let var0(a): logic<32>"));
+}
+
+#[test]
+fn test_trace_analyzer_ir_nested_static_break_escapes_dynamic_loop() {
+    let code = r#"
+        module Top (
+            count: input logic<3>,
+            d: input logic<4>,
+            q: output logic<8>,
+        ) {
+            function f (
+                n: input logic<3>,
+                x: input logic<4>,
+            ) -> logic<8> {
+                var tmp: logic<8>;
+                tmp = 8'd0;
+                for i: logic<3> in 0..n {
+                    for j: logic<2> in 0..4 {
+                        if x[j] {
+                            break;
+                        }
+                    }
+                    tmp = tmp + 8'd1;
+                }
+                return tmp;
+            }
+
+            always_comb {
+                q = f(count, d);
+            }
+        }
+    "#;
+    symbol_table::clear();
+    attribute_table::clear();
+
+    let metadata = Metadata::create_default("prj").unwrap();
+    let analyzer = Analyzer::new(&metadata);
+    let parsed = Parser::parse(code, &"").unwrap();
+    analyzer.analyze_pass1("prj", &parsed.veryl);
+    Analyzer::analyze_post_pass1();
+
+    let mut context = Context::default();
+    let mut analyzer_ir = Ir::default();
+    analyzer.analyze_pass2("prj", &parsed.veryl, &mut context, Some(&mut analyzer_ir));
+    Analyzer::analyze_post_pass2();
+
+    let analyzer_ir = analyzer_ir.to_string();
+    assert!(analyzer_ir.contains("for i in 0..var5 {"));
+    assert!(
+        !analyzer_ir.contains("for j in 0..4 {"),
+        "inner static loop should have remained visible if break ownership were preserved:\n{analyzer_ir}"
+    );
+    assert!(
+        analyzer_ir.contains("break;"),
+        "expected analyzer IR to leak a bare break into the outer dynamic loop body:\n{analyzer_ir}"
+    );
 }


### PR DESCRIPTION
## Summary

Expand comb function-call lowering support so function bodies can handle broader control-flow patterns without regressing existing return semantics.

## What Changed

- added function-body control-flow handling for `break` within `for` loops in comb function evaluation
- handled the static-unrolled `if { ... break; }` shape emitted by analyzer IR so loop-exit semantics are preserved after unrolling
- kept existing early-`return`, local temp materialization, partial-write handling, and width coercion behavior intact
- fixed SIR GVN so immediates with the same payload but different widths are not incorrectly aliased
- added a regression test for `break` inside comb function-local `for`

## Why

Comb function lowering had been extended to support early `return`, but `break` inside function-local loops still failed or produced incorrect code paths once loops were unrolled into straight-line `if`/`break` sequences. In addition, the new loop-control lowering exposed an optimizer bug where differently-sized immediates could collapse to the same value key.

## Impact

- valid comb helper functions using loop-local early exit now lower correctly
- native, cranelift, and wasm backends all preserve the intended first-hit loop semantics
- optimizer output stays width-correct for immediate deduplication in these paths

## Validation

- `cargo test -p celox test_comb_function_call_break_inside_for -- --nocapture`
- `cargo test -p celox test_comb_function_call_return_inside_for -- --nocapture`
- `cargo test -p celox test_comb_function_call_local_and_return_width_coercion -- --nocapture`
- `cargo test -p celox test_comb_function_call_early_return -- --nocapture`
- `cargo fmt --all`

## Known issues

- comb function bodies still reject `break` in dynamic-range `for` loops when analyzer IR has statically unrolled an inner loop and leaked bare `break;` statements into the outer dynamic loop body. This is currently treated as unsupported on the celox side because analyzer IR does not preserve loop ownership for those `break`s after unrolling.
- statement-form function calls inside comb function bodies remain unsupported. Expression-form helper calls such as `return f(x) + 1;` are supported, but statement-form calls are still rejected.
- system function calls remain unsupported in comb expressions and comb function bodies.
- function calls with output arguments, missing arguments, unresolved specializations, or void-return functions used as expressions remain unsupported in comb lowering.

Closes #43