### PR TITLE
[codex] Enforce tracking issues for unsupported parser errors

### DIFF
--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -1040,46 +1040,39 @@ fn eval_statement(
         Statement::Assign(assign) => eval_assign(module, store, boundaries, assign, arena),
         Statement::If(if_stmt) => eval_if(module, store, boundaries, if_stmt, arena),
         Statement::For(for_stmt) => eval_for(module, store, boundaries, for_stmt, arena),
-        Statement::IfReset(ir) => Err(ParserError::unsupported(
-            LoweringPhase::SimulatorParser,
-            "unsupported statement in always_comb",
-            "illegal statement in always_comb: if_reset".to_string(),
+        Statement::IfReset(ir) => Err(ParserError::illegal_context(
+            "statement in always_comb",
+            "if_reset".to_string(),
             Some(&ir.token),
         )),
-        Statement::SystemFunctionCall(fc) => Err(ParserError::unsupported(
-            LoweringPhase::SimulatorParser,
-            "unsupported statement in always_comb",
-            "illegal statement in always_comb: system function call".to_string(),
+        Statement::SystemFunctionCall(fc) => Err(ParserError::illegal_context(
+            "statement in always_comb",
+            "system function call".to_string(),
             Some(&fc.comptime.token),
         )),
-        Statement::FunctionCall(fc) => Err(ParserError::unsupported(
-            LoweringPhase::SimulatorParser,
-            "unsupported statement in always_comb",
-            "illegal statement in always_comb: function call".to_string(),
+        Statement::FunctionCall(fc) => Err(ParserError::illegal_context(
+            "statement in always_comb",
+            "function call".to_string(),
             Some(&fc.comptime.token),
         )),
-        Statement::TbMethodCall(_) => Err(ParserError::unsupported(
-            LoweringPhase::SimulatorParser,
-            "unsupported statement in always_comb",
-            "illegal statement in always_comb: testbench method call".to_string(),
+        Statement::TbMethodCall(_) => Err(ParserError::illegal_context(
+            "statement in always_comb",
+            "testbench method call".to_string(),
             None,
         )),
-        Statement::Break => Err(ParserError::unsupported(
-            LoweringPhase::SimulatorParser,
-            "unsupported statement in always_comb",
-            "illegal statement in always_comb: break".to_string(),
+        Statement::Break => Err(ParserError::illegal_context(
+            "statement in always_comb",
+            "break".to_string(),
             None,
         )),
-        Statement::Unsupported(_) => Err(ParserError::unsupported(
-            LoweringPhase::SimulatorParser,
-            "unsupported statement in always_comb",
-            "illegal statement in always_comb: unsupported".to_string(),
+        Statement::Unsupported(_) => Err(ParserError::illegal_context(
+            "statement in always_comb",
+            "unsupported statement".to_string(),
             None,
         )),
-        Statement::Null => Err(ParserError::unsupported(
-            LoweringPhase::SimulatorParser,
-            "unsupported statement in always_comb",
-            "illegal statement in always_comb: null".to_string(),
+        Statement::Null => Err(ParserError::illegal_context(
+            "statement in always_comb",
+            "null".to_string(),
             None,
         )),
     }
@@ -1282,40 +1275,34 @@ fn eval_loop_statement(
             continue_sources: HashSet::default(),
             ..state
         }),
-        Statement::IfReset(ir) => Err(ParserError::unsupported(
-            LoweringPhase::SimulatorParser,
-            "unsupported statement in always_comb",
-            "illegal statement in always_comb: if_reset".to_string(),
+        Statement::IfReset(ir) => Err(ParserError::illegal_context(
+            "statement in always_comb",
+            "if_reset".to_string(),
             Some(&ir.token),
         )),
-        Statement::SystemFunctionCall(fc) => Err(ParserError::unsupported(
-            LoweringPhase::SimulatorParser,
-            "unsupported statement in always_comb",
-            "illegal statement in always_comb: system function call".to_string(),
+        Statement::SystemFunctionCall(fc) => Err(ParserError::illegal_context(
+            "statement in always_comb",
+            "system function call".to_string(),
             Some(&fc.comptime.token),
         )),
-        Statement::FunctionCall(fc) => Err(ParserError::unsupported(
-            LoweringPhase::SimulatorParser,
-            "unsupported statement in always_comb",
-            "illegal statement in always_comb: function call".to_string(),
+        Statement::FunctionCall(fc) => Err(ParserError::illegal_context(
+            "statement in always_comb",
+            "function call".to_string(),
             Some(&fc.comptime.token),
         )),
-        Statement::TbMethodCall(_) => Err(ParserError::unsupported(
-            LoweringPhase::SimulatorParser,
-            "unsupported statement in always_comb",
-            "illegal statement in always_comb: testbench method call".to_string(),
+        Statement::TbMethodCall(_) => Err(ParserError::illegal_context(
+            "statement in always_comb",
+            "testbench method call".to_string(),
             None,
         )),
-        Statement::Unsupported(_) => Err(ParserError::unsupported(
-            LoweringPhase::SimulatorParser,
-            "unsupported statement in always_comb",
-            "illegal statement in always_comb: unsupported".to_string(),
+        Statement::Unsupported(_) => Err(ParserError::illegal_context(
+            "statement in always_comb",
+            "unsupported statement".to_string(),
             None,
         )),
-        Statement::Null => Err(ParserError::unsupported(
-            LoweringPhase::SimulatorParser,
-            "unsupported statement in always_comb",
-            "illegal statement in always_comb: null".to_string(),
+        Statement::Null => Err(ParserError::illegal_context(
+            "statement in always_comb",
+            "null".to_string(),
             None,
         )),
     }
@@ -1503,6 +1490,7 @@ fn eval_for(
 ) -> Result<(SymbolicStore<VarId>, HashMap<VarId, BTreeSet<usize>>), ParserError> {
     let Some(loop_width) = for_stmt.var_type.total_width() else {
         return Err(ParserError::unsupported(
+            65,
             LoweringPhase::CombLowering,
             "for loop variable width",
             format!("{:?}", for_stmt.var_name),
@@ -1630,6 +1618,7 @@ fn eval_for(
                 Op::LogicShiftL | Op::ArithShiftL => SLTStepOp::Shl,
                 other => {
                     return Err(ParserError::unsupported(
+                        65,
                         LoweringPhase::CombLowering,
                         "for loop step operator",
                         format!("{other:?}"),
@@ -2116,6 +2105,7 @@ fn eval_array_literal_expression(
                 let rep_count = if let Some(rep_expr) = repeat {
                     let Some(rep_count) = eval_constexpr(rep_expr).and_then(|x| x.to_u64()) else {
                         return Err(ParserError::unsupported(
+                            43,
                             LoweringPhase::CombLowering,
                             "array literal non-constant repeat",
                             format!("{:?}", rep_expr),
@@ -2136,6 +2126,7 @@ fn eval_array_literal_expression(
                 if default_part.is_some() {
                     let token = default_expr.token_range();
                     return Err(ParserError::unsupported(
+                        43,
                         LoweringPhase::CombLowering,
                         "array literal multiple default",
                         format!("{:?}", items),
@@ -2157,6 +2148,7 @@ fn eval_array_literal_expression(
         let Some(target_width) = expected_width else {
             let token = items.first().map(|i| i.token_range());
             return Err(ParserError::unsupported(
+                43,
                 LoweringPhase::CombLowering,
                 "array literal default without context width",
                 format!("{:?}", items),
@@ -2167,6 +2159,7 @@ fn eval_array_literal_expression(
         if explicit_width > target_width {
             let token = items.first().map(|i| i.token_range());
             return Err(ParserError::unsupported(
+                43,
                 LoweringPhase::CombLowering,
                 "array literal width overflow",
                 format!("explicit_width={explicit_width}, target_width={target_width}"),
@@ -2177,6 +2170,7 @@ fn eval_array_literal_expression(
         let remaining = target_width - explicit_width;
         if default_width == 0 || !remaining.is_multiple_of(default_width) {
             return Err(ParserError::unsupported(
+                43,
                 LoweringPhase::CombLowering,
                 "array literal default width mismatch",
                 format!(
@@ -2265,6 +2259,7 @@ fn eval_function_body_return(
         match expr {
             Expression::Term(factor) => match factor.as_ref() {
                 Factor::SystemFunctionCall(call) => Err(ParserError::unsupported(
+                    59,
                     LoweringPhase::CombLowering,
                     "system function call in comb function body",
                     format!("module `{}`: {call}", module.name),
@@ -2355,6 +2350,7 @@ fn eval_function_body_return(
                     && for_stmt.body.iter().any(statement_contains_break)
                 {
                     return Err(ParserError::unsupported(
+                        57,
                         LoweringPhase::CombLowering,
                         "break in dynamic function-local for",
                         format!("module `{}`", module.name),
@@ -2379,21 +2375,22 @@ fn eval_function_body_return(
                 }
                 Ok(())
             }
-            Statement::IfReset(ir) => Err(ParserError::unsupported(
-                LoweringPhase::CombLowering,
-                "function body control flow",
+            Statement::IfReset(ir) => Err(ParserError::illegal_context(
+                "statement in comb function body",
                 format!("{stmt}"),
                 Some(&ir.token),
             )),
             Statement::SystemFunctionCall(fc) => Err(ParserError::unsupported(
+                59,
                 LoweringPhase::CombLowering,
                 "system function call in comb function body",
                 format!("{stmt}"),
                 Some(&fc.comptime.token),
             )),
             Statement::FunctionCall(fc) => Err(ParserError::unsupported(
+                58,
                 LoweringPhase::CombLowering,
-                "nested function call in comb function body",
+                "statement-form function call in comb function body",
                 format!("{stmt}"),
                 Some(&fc.comptime.token),
             )),
@@ -2726,28 +2723,28 @@ fn eval_function_body_return(
                     continue_expr: bool_node(arena, false),
                     ..state
                 }),
-                Statement::IfReset(ir) => Err(ParserError::unsupported(
-                    LoweringPhase::CombLowering,
-                    "function body control flow",
+                Statement::IfReset(ir) => Err(ParserError::illegal_context(
+                    "statement in comb function body",
                     format!("{stmt}"),
                     Some(&ir.token),
                 )),
                 Statement::SystemFunctionCall(fc) => Err(ParserError::unsupported(
+                    59,
                     LoweringPhase::CombLowering,
-                    "function body control flow",
+                    "system function call in comb function body",
                     format!("{stmt}"),
                     Some(&fc.comptime.token),
                 )),
                 Statement::FunctionCall(fc) => Err(ParserError::unsupported(
+                    58,
                     LoweringPhase::CombLowering,
-                    "function body control flow",
+                    "statement-form function call in comb function body",
                     format!("{stmt}"),
                     Some(&fc.comptime.token),
                 )),
                 Statement::TbMethodCall(_) | Statement::Unsupported(_) => {
-                    Err(ParserError::unsupported(
-                        LoweringPhase::CombLowering,
-                        "function body control flow",
+                    Err(ParserError::illegal_context(
+                        "statement in comb function body",
                         format!("{stmt}"),
                         None,
                     ))
@@ -2757,6 +2754,7 @@ fn eval_function_body_return(
 
         let Some(loop_width) = for_stmt.var_type.total_width() else {
             return Err(ParserError::unsupported(
+                65,
                 LoweringPhase::CombLowering,
                 "for loop variable width",
                 format!("{:?}", for_stmt.var_name),
@@ -2892,6 +2890,7 @@ fn eval_function_body_return(
                     Op::LogicShiftL | Op::ArithShiftL => SLTStepOp::Shl,
                     other => {
                         return Err(ParserError::unsupported(
+                            65,
                             LoweringPhase::CombLowering,
                             "for loop step operator",
                             format!("{other:?}"),
@@ -3242,28 +3241,28 @@ fn eval_function_body_return(
                 continue_expr: bool_node(arena, false),
                 ..state
             }),
-            Statement::IfReset(ir) => Err(ParserError::unsupported(
-                LoweringPhase::CombLowering,
-                "function body control flow",
+            Statement::IfReset(ir) => Err(ParserError::illegal_context(
+                "statement in comb function body",
                 format!("{stmt}"),
                 Some(&ir.token),
             )),
             Statement::SystemFunctionCall(fc) => Err(ParserError::unsupported(
+                59,
                 LoweringPhase::CombLowering,
-                "function body control flow",
+                "system function call in comb function body",
                 format!("{stmt}"),
                 Some(&fc.comptime.token),
             )),
             Statement::FunctionCall(fc) => Err(ParserError::unsupported(
+                58,
                 LoweringPhase::CombLowering,
-                "function body control flow",
+                "statement-form function call in comb function body",
                 format!("{stmt}"),
                 Some(&fc.comptime.token),
             )),
             Statement::TbMethodCall(_) | Statement::Unsupported(_) => {
-                Err(ParserError::unsupported(
-                    LoweringPhase::CombLowering,
-                    "function body control flow",
+                Err(ParserError::illegal_context(
+                    "statement in comb function body",
                     format!("{stmt}"),
                     None,
                 ))
@@ -3360,28 +3359,28 @@ fn eval_function_body_return(
             Statement::If(if_stmt) => eval_function_if(module, state, if_stmt, ret_id, arena),
             Statement::For(for_stmt) => eval_function_for(module, state, for_stmt, ret_id, arena),
             Statement::Null => Ok(state),
-            Statement::IfReset(ir) => Err(ParserError::unsupported(
-                LoweringPhase::CombLowering,
-                "function body control flow",
+            Statement::IfReset(ir) => Err(ParserError::illegal_context(
+                "statement in comb function body",
                 format!("{stmt}"),
                 Some(&ir.token),
             )),
             Statement::SystemFunctionCall(fc) => Err(ParserError::unsupported(
+                59,
                 LoweringPhase::CombLowering,
-                "function body control flow",
+                "system function call in comb function body",
                 format!("{stmt}"),
                 Some(&fc.comptime.token),
             )),
             Statement::FunctionCall(fc) => Err(ParserError::unsupported(
+                58,
                 LoweringPhase::CombLowering,
-                "function body control flow",
+                "statement-form function call in comb function body",
                 format!("{stmt}"),
                 Some(&fc.comptime.token),
             )),
             Statement::TbMethodCall(_) | Statement::Break | Statement::Unsupported(_) => {
-                Err(ParserError::unsupported(
-                    LoweringPhase::CombLowering,
-                    "function body control flow",
+                Err(ParserError::illegal_context(
+                    "statement in comb function body",
                     format!("{stmt}"),
                     None,
                 ))
@@ -3403,6 +3402,7 @@ fn eval_function_body_return(
     for var_id in written.keys() {
         let Some(var) = module.variables.get(var_id) else {
             return Err(ParserError::unsupported(
+                67,
                 LoweringPhase::CombLowering,
                 "function local variable",
                 format!("unknown variable id: {:?}", var_id),
@@ -3433,6 +3433,7 @@ fn eval_function_body_return(
     )?;
     if !matches!(constant_bool(arena, final_state.live_expr), Some(false)) {
         return Err(ParserError::unsupported(
+            67,
             LoweringPhase::CombLowering,
             "function return expression",
             format!("function return var id: {:?}", ret_id),
@@ -3451,6 +3452,7 @@ fn eval_function_call_expression(
 ) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
     if !call.outputs.is_empty() {
         return Err(ParserError::unsupported(
+            60,
             LoweringPhase::CombLowering,
             "function call with output arguments",
             format!("{call}"),
@@ -3460,6 +3462,7 @@ fn eval_function_call_expression(
 
     let Some(function) = module.functions.get(&call.id) else {
         return Err(ParserError::unsupported(
+            62,
             LoweringPhase::CombLowering,
             "function call",
             format!("unknown function id: {:?}", call.id),
@@ -3473,6 +3476,7 @@ fn eval_function_call_expression(
         function.get_function(&[])
     }) else {
         return Err(ParserError::unsupported(
+            62,
             LoweringPhase::CombLowering,
             "function call specialization",
             format!("{call}"),
@@ -3482,6 +3486,7 @@ fn eval_function_call_expression(
 
     let Some(ret_id) = function_body.ret else {
         return Err(ParserError::unsupported(
+            63,
             LoweringPhase::CombLowering,
             "void function call in comb expression",
             format!("{call}"),
@@ -3494,6 +3499,7 @@ fn eval_function_call_expression(
     for (arg_path, arg_id) in &function_body.arg_map {
         let Some(arg_expr) = call.inputs.get(arg_path) else {
             return Err(ParserError::unsupported(
+                61,
                 LoweringPhase::CombLowering,
                 "function call missing argument",
                 format!("{call}"),
@@ -3506,6 +3512,7 @@ fn eval_function_call_expression(
 
         let Some(arg_var) = module.variables.get(arg_id) else {
             return Err(ParserError::unsupported(
+                67,
                 LoweringPhase::CombLowering,
                 "function argument variable",
                 format!("unknown arg id: {:?}", arg_id),
@@ -3631,6 +3638,7 @@ pub fn eval_expression(
                 };
                 let Some(target_width) = target_width else {
                     return Err(ParserError::unsupported(
+                        67,
                         LoweringPhase::CombLowering,
                         "as cast target",
                         format!("{:?}", rhs),
@@ -3680,6 +3688,7 @@ pub fn eval_expression(
                 let Some(exp) = eval_constexpr(rhs).and_then(|x| x.to_u64().map(|v| v as usize))
                 else {
                     return Err(ParserError::unsupported(
+                        67,
                         LoweringPhase::CombLowering,
                         "pow non-constant exponent",
                         format!("{:?}", rhs),
@@ -3833,6 +3842,7 @@ pub fn eval_expression(
                     let v = eval_constexpr(rep_expr);
                     v.ok_or_else(|| {
                         ParserError::unsupported(
+                            67,
                             LoweringPhase::CombLowering,
                             "concatenation non-constant repeat",
                             format!("{:?}", rep_expr),
@@ -3911,6 +3921,7 @@ pub fn eval_expression(
 
                 let Some(member_type) = ty.get_member_type(*name) else {
                     return Err(ParserError::unsupported(
+                        67,
                         LoweringPhase::CombLowering,
                         "struct constructor member",
                         format!("unknown member: {:?} in {:?}", name, ty),
@@ -3919,6 +3930,7 @@ pub fn eval_expression(
                 };
                 let Some(member_width) = member_type.total_width() else {
                     return Err(ParserError::unsupported(
+                        67,
                         LoweringPhase::CombLowering,
                         "struct constructor member width",
                         format!("member: {:?}, type: {:?}", name, member_type),
@@ -4270,6 +4282,7 @@ fn eval_factor(
             ))
         }
         Factor::SystemFunctionCall(call) => Err(ParserError::unsupported(
+            59,
             LoweringPhase::CombLowering,
             "system function call in comb expression",
             format!("module `{}`: {call}", module.name),
@@ -4277,6 +4290,7 @@ fn eval_factor(
         )),
         Factor::FunctionCall(call) => eval_function_call_expression(module, store, call, arena),
         Factor::Anonymous(_) | Factor::Unknown(_) => Err(ParserError::unsupported(
+            67,
             LoweringPhase::CombLowering,
             "unresolved factor in comb expression",
             format!("{:?}", factor),

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -89,9 +89,17 @@ pub enum ParserError {
     #[error(transparent)]
     Scheduler(SchedulerError<String>),
 
-    #[error("Unsupported in {phase}: {feature} ({detail})")]
+    #[error("Unsupported in {phase}: {feature} [tracking issue #{issue}] ({detail})")]
     Unsupported {
+        issue: u32,
         phase: LoweringPhase,
+        feature: &'static str,
+        detail: String,
+        source_location: Option<SourceLocation>,
+    },
+
+    #[error("Illegal in current context: {feature} ({detail})")]
+    IllegalContext {
         feature: &'static str,
         detail: String,
         source_location: Option<SourceLocation>,
@@ -117,13 +125,27 @@ pub enum ParserError {
 
 impl ParserError {
     pub fn unsupported(
+        issue: u32,
         phase: LoweringPhase,
         feature: &'static str,
         detail: impl Into<String>,
         token: Option<&TokenRange>,
     ) -> Self {
         ParserError::Unsupported {
+            issue,
             phase,
+            feature,
+            detail: detail.into(),
+            source_location: token.map(SourceLocation::from_token),
+        }
+    }
+
+    pub fn illegal_context(
+        feature: &'static str,
+        detail: impl Into<String>,
+        token: Option<&TokenRange>,
+    ) -> Self {
+        ParserError::IllegalContext {
             feature,
             detail: detail.into(),
             source_location: token.map(SourceLocation::from_token),
@@ -155,6 +177,7 @@ impl miette::Diagnostic for ParserError {
                     LoweringPhase::SimulatorParser => "simulator_parser",
                 }
             ))),
+            ParserError::IllegalContext { .. } => Some(Box::new("illegal_context")),
             ParserError::UnresolvedWidth { .. } => Some(Box::new("unresolved_width")),
             ParserError::Scheduler(_) => Some(Box::new("scheduler")),
             ParserError::TopNotFound { .. } => Some(Box::new("top_not_found")),
@@ -171,6 +194,9 @@ impl miette::Diagnostic for ParserError {
             ParserError::Unsupported {
                 source_location, ..
             }
+            | ParserError::IllegalContext {
+                source_location, ..
+            }
             | ParserError::UnresolvedWidth {
                 source_location, ..
             } => source_location.as_ref(),
@@ -182,6 +208,9 @@ impl miette::Diagnostic for ParserError {
     fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
         let loc = match self {
             ParserError::Unsupported {
+                source_location, ..
+            }
+            | ParserError::IllegalContext {
                 source_location, ..
             }
             | ParserError::UnresolvedWidth {
@@ -264,6 +293,7 @@ pub fn parse_ir<'a>(
             }
             Component::SystemVerilog(sv) => {
                 return Err(ParserError::unsupported(
+                    64,
                     LoweringPhase::SimulatorParser,
                     "systemverilog component",
                     format!("name: \"{}\"", sv.name),

--- a/crates/celox/src/parser/ff.rs
+++ b/crates/celox/src/parser/ff.rs
@@ -416,6 +416,7 @@ impl<'a> FfParser<'a> {
             Statement::Null => {}
             Statement::SystemFunctionCall(call) => {
                 return Err(ParserError::unsupported(
+                    66,
                     LoweringPhase::FfLowering,
                     "system function call",
                     format!("{call}"),
@@ -432,10 +433,9 @@ impl<'a> FfParser<'a> {
             }
             Statement::Break => {
                 let Some(exit_bb) = self.loop_exit_blocks.last().copied() else {
-                    return Err(ParserError::unsupported(
-                        LoweringPhase::FfLowering,
-                        "unsupported statement",
-                        "break;".to_string(),
+                    return Err(ParserError::illegal_context(
+                        "statement in always_ff",
+                        "break outside loop".to_string(),
                         None,
                     ));
                 };
@@ -443,9 +443,8 @@ impl<'a> FfParser<'a> {
                 return Ok(ControlFlow::Break);
             }
             Statement::TbMethodCall(_) | Statement::Unsupported(_) => {
-                return Err(ParserError::unsupported(
-                    LoweringPhase::FfLowering,
-                    "unsupported statement",
+                return Err(ParserError::illegal_context(
+                    "statement in always_ff",
                     format!("{stmt}"),
                     None,
                 ));
@@ -527,6 +526,7 @@ impl<'a> FfParser<'a> {
     ) -> Result<(), ParserError> {
         let Some(loop_width) = stmt.var_type.total_width() else {
             return Err(ParserError::unsupported(
+                65,
                 LoweringPhase::FfLowering,
                 "for loop variable width",
                 format!("{:?}", stmt.var_name),
@@ -595,6 +595,7 @@ impl<'a> FfParser<'a> {
             && !const_singleton
         {
             return Err(ParserError::unsupported(
+                65,
                 LoweringPhase::FfLowering,
                 "non-progressing for loop in always_ff",
                 format!("{:?}", stmt.var_name),
@@ -864,6 +865,7 @@ impl<'a> FfParser<'a> {
                 Some(other) => {
                     self.local_working_vars.remove(&stmt.var_id);
                     return Err(ParserError::unsupported(
+                        65,
                         LoweringPhase::FfLowering,
                         "for loop step operator in always_ff",
                         format!("{other:?}"),

--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -802,6 +802,7 @@ impl<'a> FfParser<'a> {
 
                     let Expression::Term(bound_factor) = &bound_expr else {
                         return Err(ParserError::unsupported(
+                            68,
                             LoweringPhase::FfLowering,
                             "function argument indexed access",
                             format!(
@@ -816,6 +817,7 @@ impl<'a> FfParser<'a> {
                         bound_factor.as_ref()
                     else {
                         return Err(ParserError::unsupported(
+                            68,
                             LoweringPhase::FfLowering,
                             "function argument indexed access",
                             format!(
@@ -828,6 +830,7 @@ impl<'a> FfParser<'a> {
 
                     if bound_var_select.1.is_some() {
                         return Err(ParserError::unsupported(
+                            68,
                             LoweringPhase::FfLowering,
                             "function argument indexed access",
                             format!("chained range access is unsupported: var_id={:?}", var_id),
@@ -889,6 +892,7 @@ impl<'a> FfParser<'a> {
             }
             Factor::SystemFunctionCall(call) => {
                 return Err(ParserError::unsupported(
+                    66,
                     LoweringPhase::FfLowering,
                     "system function call",
                     format!("{call}"),
@@ -1035,6 +1039,7 @@ impl<'a> FfParser<'a> {
                 self.get_cast_target_info(right)
             else {
                 return Err(ParserError::unsupported(
+                    68,
                     LoweringPhase::FfLowering,
                     "as cast target",
                     format!("{:?}", right),
@@ -1055,6 +1060,7 @@ impl<'a> FfParser<'a> {
         if matches!(op, Op::Pow) {
             let Some(exp) = self.get_constant_value(right) else {
                 return Err(ParserError::unsupported(
+                    68,
                     LoweringPhase::FfLowering,
                     "pow non-constant exponent",
                     format!("{:?}", right),
@@ -1420,6 +1426,7 @@ impl<'a> FfParser<'a> {
 
             let Some(member_type) = ty.get_member_type(*name) else {
                 return Err(ParserError::unsupported(
+                    68,
                     LoweringPhase::FfLowering,
                     "struct constructor member",
                     format!("unknown member: {:?} in {:?}", name, ty),
@@ -1428,6 +1435,7 @@ impl<'a> FfParser<'a> {
             };
             let Some(member_width) = member_type.total_width() else {
                 return Err(ParserError::unsupported(
+                    68,
                     LoweringPhase::FfLowering,
                     "struct constructor member width",
                     format!("member: {:?}, type: {:?}", name, member_type),
@@ -1493,6 +1501,7 @@ impl<'a> FfParser<'a> {
                     let rep_count = if let Some(rep_expr) = repeat {
                         self.get_constant_value(rep_expr).ok_or_else(|| {
                             ParserError::unsupported(
+                                68,
                                 LoweringPhase::FfLowering,
                                 "array literal non-constant repeat",
                                 format!("{:?}", rep_expr),
@@ -1511,6 +1520,7 @@ impl<'a> FfParser<'a> {
                 ArrayLiteralItem::Defaul(expr) => {
                     if default_part.is_some() {
                         return Err(ParserError::unsupported(
+                            68,
                             LoweringPhase::FfLowering,
                             "array literal multiple default",
                             format!("{:?}", items),
@@ -1534,6 +1544,7 @@ impl<'a> FfParser<'a> {
         if let Some((default_reg, default_width)) = default_part {
             let Some(target_width) = expected_width else {
                 return Err(ParserError::unsupported(
+                    68,
                     LoweringPhase::FfLowering,
                     "array literal default without context width",
                     format!("{:?}", items),
@@ -1543,6 +1554,7 @@ impl<'a> FfParser<'a> {
 
             if explicit_width > target_width {
                 return Err(ParserError::unsupported(
+                    68,
                     LoweringPhase::FfLowering,
                     "array literal width overflow",
                     format!("explicit_width={explicit_width}, target_width={target_width}"),
@@ -1553,6 +1565,7 @@ impl<'a> FfParser<'a> {
             let remaining = target_width - explicit_width;
             if default_width == 0 || !remaining.is_multiple_of(default_width) {
                 return Err(ParserError::unsupported(
+                    68,
                     LoweringPhase::FfLowering,
                     "array literal default width mismatch",
                     format!(

--- a/crates/celox/src/parser/ff/function_call.rs
+++ b/crates/celox/src/parser/ff/function_call.rs
@@ -20,6 +20,7 @@ impl<'a> FfParser<'a> {
     ) -> Result<HashMap<VarId, Expression>, ParserError> {
         let Some(function) = self.module.functions.get(&call.id) else {
             return Err(ParserError::unsupported(
+                43,
                 LoweringPhase::FfLowering,
                 "function call",
                 format!("unknown function id: {:?}", call.id),
@@ -33,6 +34,7 @@ impl<'a> FfParser<'a> {
             function.get_function(&[])
         }) else {
             return Err(ParserError::unsupported(
+                62,
                 LoweringPhase::FfLowering,
                 "function call specialization",
                 format!("{call}"),
@@ -51,6 +53,7 @@ impl<'a> FfParser<'a> {
         for (arg_path, dsts) in &call.outputs {
             let Some(arg_id) = function_body.arg_map.get(arg_path) else {
                 return Err(ParserError::unsupported(
+                    61,
                     LoweringPhase::FfLowering,
                     "function call missing argument",
                     format!("{call}"),
@@ -60,6 +63,7 @@ impl<'a> FfParser<'a> {
 
             if dsts.len() != 1 {
                 return Err(ParserError::unsupported(
+                    60,
                     LoweringPhase::FfLowering,
                     "function body call output assignment shape",
                     format!("{call}"),
@@ -89,6 +93,7 @@ impl<'a> FfParser<'a> {
                 next.insert(dst.id, merged);
             } else {
                 return Err(ParserError::unsupported(
+                    60,
                     LoweringPhase::FfLowering,
                     "function body call output non-whole assignment (dynamic index)",
                     format!("{call}"),
@@ -249,6 +254,7 @@ impl<'a> FfParser<'a> {
                 Statement::Assign(assign) => {
                     if assign.dst.len() != 1 {
                         return Err(ParserError::unsupported(
+                            43,
                             LoweringPhase::FfLowering,
                             "function body assignment shape",
                             format!("{stmt}"),
@@ -278,6 +284,7 @@ impl<'a> FfParser<'a> {
                         next.insert(dst.id, merged);
                     } else {
                         return Err(ParserError::unsupported(
+                            43,
                             LoweringPhase::FfLowering,
                             "function body non-whole assignment (dynamic index)",
                             format!("{stmt}"),
@@ -300,12 +307,14 @@ impl<'a> FfParser<'a> {
                 }
                 Statement::Null => Ok(state.clone()),
                 Statement::IfReset(ir) => Err(ParserError::unsupported(
+                    43,
                     LoweringPhase::FfLowering,
                     "function body control flow",
                     format!("{stmt}"),
                     Some(&ir.token),
                 )),
                 Statement::SystemFunctionCall(sc) => Err(ParserError::unsupported(
+                    66,
                     LoweringPhase::FfLowering,
                     "function body control flow",
                     format!("{stmt}"),
@@ -313,6 +322,7 @@ impl<'a> FfParser<'a> {
                 )),
                 Statement::FunctionCall(call) => parser.apply_function_call_to_state(call, state),
                 Statement::For(f) => Err(ParserError::unsupported(
+                    43,
                     LoweringPhase::FfLowering,
                     "for loop in function body",
                     format!("{stmt}"),
@@ -320,6 +330,7 @@ impl<'a> FfParser<'a> {
                 )),
                 Statement::TbMethodCall(_) | Statement::Break | Statement::Unsupported(_) => {
                     Err(ParserError::unsupported(
+                        43,
                         LoweringPhase::FfLowering,
                         "function body control flow",
                         format!("{stmt}"),
@@ -347,6 +358,7 @@ impl<'a> FfParser<'a> {
         })?;
         state.get(&target_id).cloned().ok_or_else(|| {
             ParserError::unsupported(
+                43,
                 LoweringPhase::FfLowering,
                 "function return expression",
                 format!("function target var id: {:?}", target_id),
@@ -378,6 +390,7 @@ impl<'a> FfParser<'a> {
                 Statement::Assign(assign) => {
                     if assign.dst.len() != 1 {
                         return Err(ParserError::unsupported(
+                            43,
                             LoweringPhase::FfLowering,
                             "function body assignment shape",
                             format!("{stmt}"),
@@ -419,6 +432,7 @@ impl<'a> FfParser<'a> {
                         resolve_return_expr(parser, rest, ret_id, &next_defs, substitute)
                     } else {
                         Err(ParserError::unsupported(
+                            43,
                             LoweringPhase::FfLowering,
                             "function body non-whole assignment (dynamic index)",
                             format!("{stmt}"),
@@ -451,12 +465,14 @@ impl<'a> FfParser<'a> {
                 }
                 Statement::Null => resolve_return_expr(parser, rest, ret_id, defs, substitute),
                 Statement::IfReset(ir) => Err(ParserError::unsupported(
+                    43,
                     LoweringPhase::FfLowering,
                     "function body control flow",
                     format!("{stmt}"),
                     Some(&ir.token),
                 )),
                 Statement::SystemFunctionCall(sc) => Err(ParserError::unsupported(
+                    66,
                     LoweringPhase::FfLowering,
                     "function body control flow",
                     format!("{stmt}"),
@@ -467,6 +483,7 @@ impl<'a> FfParser<'a> {
                     resolve_return_expr(parser, rest, ret_id, &next_defs, substitute)
                 }
                 Statement::For(f) => Err(ParserError::unsupported(
+                    43,
                     LoweringPhase::FfLowering,
                     "for loop in function body",
                     format!("{stmt}"),
@@ -474,6 +491,7 @@ impl<'a> FfParser<'a> {
                 )),
                 Statement::TbMethodCall(_) | Statement::Break | Statement::Unsupported(_) => {
                     Err(ParserError::unsupported(
+                        43,
                         LoweringPhase::FfLowering,
                         "function body control flow",
                         format!("{stmt}"),
@@ -492,6 +510,7 @@ impl<'a> FfParser<'a> {
         )?
         .ok_or_else(|| {
             ParserError::unsupported(
+                43,
                 LoweringPhase::FfLowering,
                 "function return expression",
                 format!("function call to id {:?}", ret_id),
@@ -511,6 +530,7 @@ impl<'a> FfParser<'a> {
     ) -> Result<(), ParserError> {
         let Some(function) = self.module.functions.get(&call.id) else {
             return Err(ParserError::unsupported(
+                43,
                 LoweringPhase::FfLowering,
                 "function call",
                 format!("unknown function id: {:?}", call.id),
@@ -524,6 +544,7 @@ impl<'a> FfParser<'a> {
             function.get_function(&[])
         }) else {
             return Err(ParserError::unsupported(
+                62,
                 LoweringPhase::FfLowering,
                 "function call specialization",
                 format!("{call}"),
@@ -541,6 +562,7 @@ impl<'a> FfParser<'a> {
         for (arg_path, dsts) in &call.outputs {
             let Some(arg_id) = function_body.arg_map.get(arg_path) else {
                 return Err(ParserError::unsupported(
+                    61,
                     LoweringPhase::FfLowering,
                     "function call missing argument",
                     format!("{call}"),
@@ -564,6 +586,7 @@ impl<'a> FfParser<'a> {
 
         let Some(ret_id) = function_body.ret else {
             return Err(ParserError::unsupported(
+                63,
                 LoweringPhase::FfLowering,
                 "void function call in expression",
                 format!("{call}"),
@@ -593,6 +616,7 @@ impl<'a> FfParser<'a> {
     ) -> Result<(), ParserError> {
         let Some(function) = self.module.functions.get(&call.id) else {
             return Err(ParserError::unsupported(
+                43,
                 LoweringPhase::FfLowering,
                 "function call",
                 format!("unknown function id: {:?}", call.id),
@@ -606,6 +630,7 @@ impl<'a> FfParser<'a> {
             function.get_function(&[])
         }) else {
             return Err(ParserError::unsupported(
+                62,
                 LoweringPhase::FfLowering,
                 "function call specialization",
                 format!("{call}"),
@@ -631,6 +656,7 @@ impl<'a> FfParser<'a> {
         for (arg_path, dsts) in &call.outputs {
             let Some(arg_id) = function_body.arg_map.get(arg_path) else {
                 return Err(ParserError::unsupported(
+                    61,
                     LoweringPhase::FfLowering,
                     "function call missing argument",
                     format!("{call}"),

--- a/crates/celox/src/parser/module.rs
+++ b/crates/celox/src/parser/module.rs
@@ -81,6 +81,7 @@ impl<'a> ModuleParser<'a> {
     ) -> Result<(), ParserError> {
         if let Component::SystemVerilog(system_verilog) = &*decl.component {
             return Err(ParserError::unsupported(
+                64,
                 LoweringPhase::SimulatorParser,
                 "systemverilog module instantiation",
                 format!("name: \"{}\"", system_verilog.name),

--- a/crates/celox/src/parser/registry.rs
+++ b/crates/celox/src/parser/registry.rs
@@ -7,6 +7,7 @@ use veryl_analyzer::ir::{Module, VarId};
 pub fn get_port_type(module: &Module, port_id: &VarId) -> Result<RegisterType, ParserError> {
     let var = module.variables.get(port_id).ok_or_else(|| {
         ParserError::unsupported(
+            64,
             LoweringPhase::SimulatorParser,
             "port lookup",
             format!("port ID not found in child module: {}", module.name),

--- a/crates/celox/tests/snapshots/error_readability__sv_module_unsupported_error_readability.snap
+++ b/crates/celox/tests/snapshots/error_readability__sv_module_unsupported_error_readability.snap
@@ -4,4 +4,4 @@ expression: err
 ---
 unsupported_simulator_parser
 
-  × Unsupported in simulator parser: systemverilog module instantiation (name: "delay")
+  × Unsupported in simulator parser: systemverilog module instantiation [tracking issue #64] (name: "delay")


### PR DESCRIPTION
## Summary

Split parser/lowering error classification between `illegal_context` and `unsupported`, and require tracking issue IDs for every remaining `unsupported` path.

## What Changed

- added `ParserError::IllegalContext` for contextually invalid constructs
- changed `ParserError::unsupported(...)` to require a tracking issue number
- reclassified clear context violations such as illegal statements in `always_comb` / `always_ff` to `illegal_context`
- attached issue IDs to the remaining unsupported parser and lowering paths
- updated the readability snapshot for the new unsupported error formatting

## Why

`unsupported` had been serving two different roles:
- truly illegal syntax/context that should never be accepted
- legal-but-unimplemented lowering gaps that need follow-up work

Separating those makes the error surface more honest and forces every real unsupported gap to have a tracked follow-up.

## Validation

- `cargo check -p celox`
- `cargo test -p celox`

## Related

- #57
- #58
- #59
- #60
- #61
- #62
- #63
- #64
- #65
- #66
- #67
- #68