### PR TITLE
Support indexed non-variable FF function arguments

### DIFF
--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -258,7 +258,7 @@ impl<'a> FfParser<'a> {
             return Ok(false);
         }
 
-        let mut linear_index = 0usize;
+        let mut resolved_indices = Vec::with_capacity(all_indices.len());
         for (i, expr) in all_indices.iter().enumerate() {
             let Some(idx) = self.get_constant_value(expr).map(|x| x as usize) else {
                 return Ok(false);
@@ -267,52 +267,12 @@ impl<'a> FfParser<'a> {
             if idx >= dim {
                 return Ok(false);
             }
-            let stride = array_dims[i + 1..].iter().product::<usize>().max(1);
-            linear_index += idx * stride;
+            resolved_indices.push(idx);
         }
 
-        let mut expanded: Vec<&Expression> = Vec::new();
-        let mut default_expr: Option<&Expression> = None;
-        for item in items {
-            match item {
-                ArrayLiteralItem::Value(expr, repeat) => {
-                    let rep_count = if let Some(rep_expr) = repeat {
-                        self.get_constant_value(rep_expr).ok_or_else(|| {
-                            ParserError::unsupported(
-                                 68,
-                                LoweringPhase::FfLowering,
-                                "array literal non-constant repeat",
-                                format!("{:?}", rep_expr),
-                                Some(&rep_expr.token_range()),
-                            )
-                        })? as usize
-                    } else {
-                        1
-                    };
-                    for _ in 0..rep_count {
-                        expanded.push(expr);
-                    }
-                }
-                ArrayLiteralItem::Defaul(expr) => {
-                    if default_expr.is_some() {
-                        return Err(ParserError::unsupported(
-                             68,
-                            LoweringPhase::FfLowering,
-                            "array literal multiple default",
-                            format!("{:?}", items),
-                            Some(&expr.token_range()),
-                        ));
-                    }
-                    default_expr = Some(expr);
-                }
-            }
-        }
-
-        let selected_expr = if let Some(expr) = expanded.get(linear_index) {
-            *expr
-        } else if let Some(default_expr) = default_expr {
-            default_expr
-        } else {
+        let Some(selected_expr) =
+            self.select_array_literal_element(items, &resolved_indices, &array_dims)?
+        else {
             return Ok(false);
         };
 
@@ -336,6 +296,83 @@ impl<'a> FfParser<'a> {
         );
         self.stack.push_back(coerced);
         Ok(true)
+    }
+
+    fn select_array_literal_element<'b>(
+        &self,
+        items: &'b [ArrayLiteralItem],
+        indices: &[usize],
+        dims: &[usize],
+    ) -> Result<Option<&'b Expression>, ParserError> {
+        let Some((&target_idx, rest_indices)) = indices.split_first() else {
+            return Ok(None);
+        };
+        let Some((_dim, rest_dims)) = dims.split_first() else {
+            return Ok(None);
+        };
+
+        let mut pos = 0usize;
+        let mut default_expr: Option<&Expression> = None;
+
+        for item in items {
+            match item {
+                ArrayLiteralItem::Value(expr, repeat) => {
+                    let rep_count = if let Some(rep_expr) = repeat {
+                        self.get_constant_value(rep_expr).ok_or_else(|| {
+                            ParserError::unsupported(
+                                68,
+                                LoweringPhase::FfLowering,
+                                "array literal non-constant repeat",
+                                format!("{:?}", rep_expr),
+                                Some(&rep_expr.token_range()),
+                            )
+                        })? as usize
+                    } else {
+                        1
+                    };
+
+                    if target_idx < pos + rep_count {
+                        if rest_dims.is_empty() {
+                            return Ok(Some(expr));
+                        }
+                        return match expr.as_ref() {
+                            Expression::ArrayLiteral(nested, _) => {
+                                self.select_array_literal_element(nested, rest_indices, rest_dims)
+                            }
+                            _ if expr.comptime().r#type.array.is_empty() => Ok(Some(expr)),
+                            _ => Ok(None),
+                        };
+                    }
+                    pos += rep_count;
+                }
+                ArrayLiteralItem::Defaul(expr) => {
+                    if default_expr.is_some() {
+                        return Err(ParserError::unsupported(
+                            68,
+                            LoweringPhase::FfLowering,
+                            "array literal multiple default",
+                            format!("{:?}", items),
+                            Some(&expr.token_range()),
+                        ));
+                    }
+                    default_expr = Some(expr);
+                }
+            }
+        }
+
+        let Some(default_expr) = default_expr else {
+            return Ok(None);
+        };
+        if rest_dims.is_empty() {
+            return Ok(Some(default_expr));
+        }
+        match default_expr {
+            Expression::ArrayLiteral(nested, _) => {
+                self.select_array_literal_element(nested, rest_indices, rest_dims)
+            }
+            _ if default_expr.comptime().r#type.array.is_empty() => Ok(Some(default_expr)),
+            _ => Ok(None),
+        }
     }
 
     fn eval_formal_type_select(
@@ -1428,7 +1465,7 @@ impl<'a> FfParser<'a> {
                 self.get_cast_target_info(right)
             else {
                 return Err(ParserError::unsupported(
-                     68,
+                    68,
                     LoweringPhase::FfLowering,
                     "as cast target",
                     format!("{:?}", right),
@@ -1449,7 +1486,7 @@ impl<'a> FfParser<'a> {
         if matches!(op, Op::Pow) {
             let Some(exp) = self.get_constant_value(right) else {
                 return Err(ParserError::unsupported(
-                     68,
+                    68,
                     LoweringPhase::FfLowering,
                     "pow non-constant exponent",
                     format!("{:?}", right),
@@ -1815,7 +1852,7 @@ impl<'a> FfParser<'a> {
 
             let Some(member_type) = ty.get_member_type(*name) else {
                 return Err(ParserError::unsupported(
-                     68,
+                    68,
                     LoweringPhase::FfLowering,
                     "struct constructor member",
                     format!("unknown member: {:?} in {:?}", name, ty),
@@ -1824,7 +1861,7 @@ impl<'a> FfParser<'a> {
             };
             let Some(member_width) = member_type.total_width() else {
                 return Err(ParserError::unsupported(
-                     68,
+                    68,
                     LoweringPhase::FfLowering,
                     "struct constructor member width",
                     format!("member: {:?}, type: {:?}", name, member_type),
@@ -1890,7 +1927,7 @@ impl<'a> FfParser<'a> {
                     let rep_count = if let Some(rep_expr) = repeat {
                         self.get_constant_value(rep_expr).ok_or_else(|| {
                             ParserError::unsupported(
-                                 68,
+                                68,
                                 LoweringPhase::FfLowering,
                                 "array literal non-constant repeat",
                                 format!("{:?}", rep_expr),
@@ -1909,7 +1946,7 @@ impl<'a> FfParser<'a> {
                 ArrayLiteralItem::Defaul(expr) => {
                     if default_part.is_some() {
                         return Err(ParserError::unsupported(
-                             68,
+                            68,
                             LoweringPhase::FfLowering,
                             "array literal multiple default",
                             format!("{:?}", items),
@@ -1933,7 +1970,7 @@ impl<'a> FfParser<'a> {
         if let Some((default_reg, default_width)) = default_part {
             let Some(target_width) = expected_width else {
                 return Err(ParserError::unsupported(
-                     68,
+                    68,
                     LoweringPhase::FfLowering,
                     "array literal default without context width",
                     format!("{:?}", items),
@@ -1943,7 +1980,7 @@ impl<'a> FfParser<'a> {
 
             if explicit_width > target_width {
                 return Err(ParserError::unsupported(
-                     68,
+                    68,
                     LoweringPhase::FfLowering,
                     "array literal width overflow",
                     format!("explicit_width={explicit_width}, target_width={target_width}"),
@@ -1954,7 +1991,7 @@ impl<'a> FfParser<'a> {
             let remaining = target_width - explicit_width;
             if default_width == 0 || !remaining.is_multiple_of(default_width) {
                 return Err(ParserError::unsupported(
-                     68,
+                    68,
                     LoweringPhase::FfLowering,
                     "array literal default width mismatch",
                     format!(

--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -279,6 +279,7 @@ impl<'a> FfParser<'a> {
                     let rep_count = if let Some(rep_expr) = repeat {
                         self.get_constant_value(rep_expr).ok_or_else(|| {
                             ParserError::unsupported(
+                                 68,
                                 LoweringPhase::FfLowering,
                                 "array literal non-constant repeat",
                                 format!("{:?}", rep_expr),
@@ -295,6 +296,7 @@ impl<'a> FfParser<'a> {
                 ArrayLiteralItem::Defaul(expr) => {
                     if default_expr.is_some() {
                         return Err(ParserError::unsupported(
+                             68,
                             LoweringPhase::FfLowering,
                             "array literal multiple default",
                             format!("{:?}", items),
@@ -1144,6 +1146,7 @@ impl<'a> FfParser<'a> {
                             self.eval_formal_type_select(*var_id, var_index, var_select)
                         else {
                             return Err(ParserError::unsupported(
+                                 68,
                                 LoweringPhase::FfLowering,
                                 "function argument indexed access",
                                 format!(
@@ -1173,6 +1176,7 @@ impl<'a> FfParser<'a> {
                             self.eval_formal_type_select(*var_id, var_index, var_select)
                         else {
                             return Err(ParserError::unsupported(
+                                 68,
                                 LoweringPhase::FfLowering,
                                 "function argument indexed access",
                                 format!(
@@ -1200,6 +1204,7 @@ impl<'a> FfParser<'a> {
                             self.eval_formal_type_select(*var_id, var_index, var_select)
                         else {
                             return Err(ParserError::unsupported(
+                                 68,
                                 LoweringPhase::FfLowering,
                                 "function argument indexed access",
                                 format!(
@@ -1276,6 +1281,7 @@ impl<'a> FfParser<'a> {
             }
             Factor::SystemFunctionCall(call) => {
                 return Err(ParserError::unsupported(
+                     68,
                     LoweringPhase::FfLowering,
                     "system function call",
                     format!("{call}"),
@@ -1422,6 +1428,7 @@ impl<'a> FfParser<'a> {
                 self.get_cast_target_info(right)
             else {
                 return Err(ParserError::unsupported(
+                     68,
                     LoweringPhase::FfLowering,
                     "as cast target",
                     format!("{:?}", right),
@@ -1442,6 +1449,7 @@ impl<'a> FfParser<'a> {
         if matches!(op, Op::Pow) {
             let Some(exp) = self.get_constant_value(right) else {
                 return Err(ParserError::unsupported(
+                     68,
                     LoweringPhase::FfLowering,
                     "pow non-constant exponent",
                     format!("{:?}", right),
@@ -1807,6 +1815,7 @@ impl<'a> FfParser<'a> {
 
             let Some(member_type) = ty.get_member_type(*name) else {
                 return Err(ParserError::unsupported(
+                     68,
                     LoweringPhase::FfLowering,
                     "struct constructor member",
                     format!("unknown member: {:?} in {:?}", name, ty),
@@ -1815,6 +1824,7 @@ impl<'a> FfParser<'a> {
             };
             let Some(member_width) = member_type.total_width() else {
                 return Err(ParserError::unsupported(
+                     68,
                     LoweringPhase::FfLowering,
                     "struct constructor member width",
                     format!("member: {:?}, type: {:?}", name, member_type),
@@ -1880,6 +1890,7 @@ impl<'a> FfParser<'a> {
                     let rep_count = if let Some(rep_expr) = repeat {
                         self.get_constant_value(rep_expr).ok_or_else(|| {
                             ParserError::unsupported(
+                                 68,
                                 LoweringPhase::FfLowering,
                                 "array literal non-constant repeat",
                                 format!("{:?}", rep_expr),
@@ -1898,6 +1909,7 @@ impl<'a> FfParser<'a> {
                 ArrayLiteralItem::Defaul(expr) => {
                     if default_part.is_some() {
                         return Err(ParserError::unsupported(
+                             68,
                             LoweringPhase::FfLowering,
                             "array literal multiple default",
                             format!("{:?}", items),
@@ -1921,6 +1933,7 @@ impl<'a> FfParser<'a> {
         if let Some((default_reg, default_width)) = default_part {
             let Some(target_width) = expected_width else {
                 return Err(ParserError::unsupported(
+                     68,
                     LoweringPhase::FfLowering,
                     "array literal default without context width",
                     format!("{:?}", items),
@@ -1930,6 +1943,7 @@ impl<'a> FfParser<'a> {
 
             if explicit_width > target_width {
                 return Err(ParserError::unsupported(
+                     68,
                     LoweringPhase::FfLowering,
                     "array literal width overflow",
                     format!("explicit_width={explicit_width}, target_width={target_width}"),
@@ -1940,6 +1954,7 @@ impl<'a> FfParser<'a> {
             let remaining = target_width - explicit_width;
             if default_width == 0 || !remaining.is_multiple_of(default_width) {
                 return Err(ParserError::unsupported(
+                     68,
                     LoweringPhase::FfLowering,
                     "array literal default width mismatch",
                     format!(

--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -6,6 +6,7 @@ use crate::ir::{
 use crate::parser::{
     LoweringPhase, ParserError,
     bitaccess::{celox_value_from_comptime, eval_var_select, get_access_width, is_static_access},
+    resolve_total_width,
 };
 use num_bigint::BigUint;
 
@@ -16,6 +17,335 @@ use veryl_analyzer::ir::{
 use veryl_parser::token_range::TokenRange;
 
 impl<'a> FfParser<'a> {
+    fn eval_type_select(
+        &self,
+        typ: &Type,
+        index: &VarIndex,
+        select: &VarSelect,
+    ) -> Option<BitAccess> {
+        let mut dims: Vec<usize> = typ.array.iter().copied().collect::<Option<Vec<_>>>()?;
+        if typ.width().is_empty() {
+            if let Some(kind_width) = typ.kind.width() {
+                dims.push(kind_width);
+            }
+        } else {
+            dims.extend(typ.width().iter().copied().collect::<Option<Vec<_>>>()?);
+        }
+
+        let mut strides = vec![1; dims.len()];
+        let mut current_stride = 1usize;
+        for i in (0..dims.len()).rev() {
+            strides[i] = current_stride;
+            current_stride *= dims[i];
+        }
+        let total_width = current_stride;
+
+        let to_u = |e: &Expression| {
+            self.get_constant_value(e)
+                .or_else(|| {
+                    crate::parser::bitaccess::eval_constexpr(e)
+                        .and_then(|v| v.to_u64_digits().first().copied())
+                })
+                .map(|v| v as usize)
+        };
+
+        let get_slice_fallback = |base: usize, i: usize| -> BitAccess {
+            let width = if i == 0 { total_width } else { strides[i - 1] };
+            BitAccess::new(base, base + width - 1)
+        };
+
+        let mut all_indices = index.0.clone();
+        all_indices.extend(select.0.iter().cloned());
+
+        let mut base_offset = 0usize;
+        let mut processed_count = 0usize;
+        let limit = if select.1.is_some() {
+            all_indices.len().saturating_sub(1)
+        } else {
+            all_indices.len()
+        };
+
+        for (i, index_val) in all_indices[..limit].iter().enumerate() {
+            let idx = to_u(index_val)?;
+            let stride = *strides.get(i)?;
+            base_offset += idx * stride;
+            processed_count += 1;
+        }
+
+        if let Some((op, range_expr)) = &select.1 {
+            let anchor_expr = all_indices.last()?;
+            let anchor = to_u(anchor_expr)?;
+            let val = to_u(range_expr)?;
+            let weight = *strides.get(processed_count).unwrap_or(&1);
+            let (lsb_rel, msb_rel) = match op {
+                VarSelectOp::Colon => (val * weight, anchor * weight + (weight - 1)),
+                VarSelectOp::PlusColon => (anchor * weight, (anchor + val) * weight - 1),
+                VarSelectOp::MinusColon => {
+                    let msb = anchor * weight + (weight - 1);
+                    let lsb = (anchor + 1).checked_sub(val)? * weight;
+                    (lsb, msb)
+                }
+                VarSelectOp::Step => {
+                    let actual_lsb = anchor * val;
+                    let actual_msb = actual_lsb + val - 1;
+                    (actual_lsb * weight, (actual_msb + 1) * weight - 1)
+                }
+            };
+            Some(BitAccess::new(base_offset + lsb_rel, base_offset + msb_rel))
+        } else if processed_count == dims.len() {
+            Some(BitAccess::new(base_offset, base_offset))
+        } else {
+            Some(get_slice_fallback(base_offset, processed_count))
+        }
+    }
+
+    fn emit_register_slice<A>(
+        &mut self,
+        src_reg: RegisterId,
+        access: BitAccess,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> RegisterId {
+        let src_width = ir_builder.register(&src_reg).width();
+        if access.lsb == 0 && access.msb + 1 == src_width {
+            return src_reg;
+        }
+
+        let slice_width = access.msb - access.lsb + 1;
+        let shifted_reg = if access.lsb == 0 {
+            src_reg
+        } else {
+            let shift_amt_reg = ir_builder.alloc_bit(64, false);
+            ir_builder.emit(SIRInstruction::Imm(
+                shift_amt_reg,
+                SIRValue::new(access.lsb as u64),
+            ));
+            let shifted_reg = ir_builder.alloc_logic(src_width);
+            ir_builder.emit(SIRInstruction::Binary(
+                shifted_reg,
+                src_reg,
+                BinaryOp::Shr,
+                shift_amt_reg,
+            ));
+            shifted_reg
+        };
+
+        if slice_width == src_width && access.lsb == 0 {
+            shifted_reg
+        } else {
+            let mask_val = (BigUint::from(1u64) << slice_width) - BigUint::from(1u64);
+            let mask_reg = ir_builder.alloc_bit(slice_width, false);
+            ir_builder.emit(SIRInstruction::Imm(mask_reg, SIRValue::new(mask_val)));
+            let sliced_reg = if ir_builder.register(&src_reg).is_signed() {
+                ir_builder.alloc_bit(slice_width, true)
+            } else {
+                ir_builder.alloc_logic(slice_width)
+            };
+            ir_builder.emit(SIRInstruction::Binary(
+                sliced_reg,
+                shifted_reg,
+                BinaryOp::And,
+                mask_reg,
+            ));
+            sliced_reg
+        }
+    }
+
+    fn materialize_bound_function_access<A>(
+        &mut self,
+        var_id: VarId,
+        bound_expr: &Expression,
+        access: BitAccess,
+        targets: &mut Vec<VarAtomBase<A>>,
+        domain: &Domain,
+        convert: &impl Fn(VarId, u32) -> A,
+        sources: &mut Vec<VarAtomBase<A>>,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<(), ParserError> {
+        let formal_width = self
+            .module
+            .variables
+            .get(&var_id)
+            .map(|var| resolve_total_width(self.module, var))
+            .transpose()?;
+        self.parse_expression(
+            bound_expr,
+            targets,
+            domain,
+            convert,
+            sources,
+            ir_builder,
+            formal_width,
+        )?;
+        let bound_reg = self.stack.pop_back().unwrap();
+        let coerced_reg = if let Some(var) = self.module.variables.get(&var_id) {
+            let formal_width = formal_width.expect("formal width must exist for bound argument");
+            self.coerce_register_to_formal(
+                ir_builder,
+                bound_reg,
+                formal_width,
+                bound_expr.comptime().r#type.signed,
+                var.r#type.signed,
+            )
+        } else {
+            bound_reg
+        };
+        let sliced = self.emit_register_slice(coerced_reg, access, ir_builder);
+        self.stack.push_back(sliced);
+        Ok(())
+    }
+
+    fn coerce_register_to_formal<A>(
+        &self,
+        ir_builder: &mut SIRBuilder<A>,
+        reg: RegisterId,
+        target_width: usize,
+        extend_signed: bool,
+        result_signed: bool,
+    ) -> RegisterId {
+        let widened = self.cast_reg_width_ext(ir_builder, reg, target_width, extend_signed);
+        if result_signed {
+            if ir_builder.register(&widened).is_signed()
+                && ir_builder.register(&widened).width() == target_width
+            {
+                widened
+            } else {
+                let signed_reg = ir_builder.alloc_bit(target_width, true);
+                ir_builder.emit(SIRInstruction::Unary(signed_reg, UnaryOp::Ident, widened));
+                signed_reg
+            }
+        } else {
+            let src = ir_builder.register(&widened);
+            if src.width() == target_width && !src.is_signed() {
+                widened
+            } else {
+                let logic_reg = ir_builder.alloc_logic(target_width);
+                ir_builder.emit(SIRInstruction::Unary(logic_reg, UnaryOp::Ident, widened));
+                logic_reg
+            }
+        }
+    }
+
+    fn materialize_bound_array_literal_access<A>(
+        &mut self,
+        var_id: VarId,
+        items: &[ArrayLiteralItem],
+        index: &VarIndex,
+        select: &VarSelect,
+        targets: &mut Vec<VarAtomBase<A>>,
+        domain: &Domain,
+        convert: &impl Fn(VarId, u32) -> A,
+        sources: &mut Vec<VarAtomBase<A>>,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<bool, ParserError> {
+        let Some(formal) = self.module.variables.get(&var_id) else {
+            return Ok(false);
+        };
+        if formal.r#type.array.is_empty() {
+            return Ok(false);
+        }
+        if select.1.is_some() {
+            return Ok(false);
+        }
+
+        let array_dims: Option<Vec<usize>> = formal.r#type.array.iter().copied().collect();
+        let Some(array_dims) = array_dims else {
+            return Ok(false);
+        };
+
+        let mut all_indices = index.0.clone();
+        all_indices.extend(select.0.iter().cloned());
+        if all_indices.len() != array_dims.len() {
+            return Ok(false);
+        }
+
+        let mut linear_index = 0usize;
+        for (i, expr) in all_indices.iter().enumerate() {
+            let Some(idx) = self.get_constant_value(expr).map(|x| x as usize) else {
+                return Ok(false);
+            };
+            let dim = array_dims[i];
+            if idx >= dim {
+                return Ok(false);
+            }
+            let stride = array_dims[i + 1..].iter().product::<usize>().max(1);
+            linear_index += idx * stride;
+        }
+
+        let mut expanded: Vec<&Expression> = Vec::new();
+        let mut default_expr: Option<&Expression> = None;
+        for item in items {
+            match item {
+                ArrayLiteralItem::Value(expr, repeat) => {
+                    let rep_count = if let Some(rep_expr) = repeat {
+                        self.get_constant_value(rep_expr).ok_or_else(|| {
+                            ParserError::unsupported(
+                                LoweringPhase::FfLowering,
+                                "array literal non-constant repeat",
+                                format!("{:?}", rep_expr),
+                                Some(&rep_expr.token_range()),
+                            )
+                        })? as usize
+                    } else {
+                        1
+                    };
+                    for _ in 0..rep_count {
+                        expanded.push(expr);
+                    }
+                }
+                ArrayLiteralItem::Defaul(expr) => {
+                    if default_expr.is_some() {
+                        return Err(ParserError::unsupported(
+                            LoweringPhase::FfLowering,
+                            "array literal multiple default",
+                            format!("{:?}", items),
+                            Some(&expr.token_range()),
+                        ));
+                    }
+                    default_expr = Some(expr);
+                }
+            }
+        }
+
+        let selected_expr = if let Some(expr) = expanded.get(linear_index) {
+            *expr
+        } else if let Some(default_expr) = default_expr {
+            default_expr
+        } else {
+            return Ok(false);
+        };
+
+        let access_width = get_access_width(self.module, var_id, index, select)?;
+        self.parse_expression(
+            selected_expr,
+            targets,
+            domain,
+            convert,
+            sources,
+            ir_builder,
+            Some(access_width),
+        )?;
+        let selected_reg = self.stack.pop_back().unwrap();
+        let coerced = self.coerce_register_to_formal(
+            ir_builder,
+            selected_reg,
+            access_width,
+            selected_expr.comptime().r#type.signed,
+            formal.r#type.signed,
+        );
+        self.stack.push_back(coerced);
+        Ok(true)
+    }
+
+    fn eval_formal_type_select(
+        &self,
+        var_id: VarId,
+        index: &VarIndex,
+        select: &VarSelect,
+    ) -> Option<BitAccess> {
+        let formal_type = &self.module.variables.get(&var_id)?.r#type;
+        self.eval_type_select(formal_type, index, select)
+    }
+
     pub(super) fn emit_offset_calc<A>(
         &mut self,
         var_id: VarId,
@@ -800,42 +1130,96 @@ impl<'a> FfParser<'a> {
                         return Ok(());
                     }
 
+                    if let Expression::ArrayLiteral(items, _) = &bound_expr {
+                        if self.materialize_bound_array_literal_access(
+                            *var_id, items, var_index, var_select, targets, domain, convert,
+                            sources, ir_builder,
+                        )? {
+                            return Ok(());
+                        }
+                    }
+
                     let Expression::Term(bound_factor) = &bound_expr else {
-                        return Err(ParserError::unsupported(
-                            68,
-                            LoweringPhase::FfLowering,
-                            "function argument indexed access",
-                            format!(
-                                "non-variable argument expression with indexed access: var_id={:?}",
-                                var_id
-                            ),
-                            Some(&factor.token_range()),
-                        ));
+                        let Some(access) =
+                            self.eval_formal_type_select(*var_id, var_index, var_select)
+                        else {
+                            return Err(ParserError::unsupported(
+                                LoweringPhase::FfLowering,
+                                "function argument indexed access",
+                                format!(
+                                    "non-variable argument expression with dynamic indexed access: var_id={:?}",
+                                    var_id
+                                ),
+                                Some(&factor.token_range()),
+                            ));
+                        };
+                        self.materialize_bound_function_access(
+                            *var_id,
+                            &bound_expr,
+                            access,
+                            targets,
+                            domain,
+                            convert,
+                            sources,
+                            ir_builder,
+                        )?;
+                        return Ok(());
                     };
 
                     let Factor::Variable(bound_var_id, bound_var_index, bound_var_select, _) =
                         bound_factor.as_ref()
                     else {
-                        return Err(ParserError::unsupported(
-                            68,
-                            LoweringPhase::FfLowering,
-                            "function argument indexed access",
-                            format!(
-                                "non-variable argument expression with indexed access: var_id={:?}",
-                                var_id
-                            ),
-                            Some(&factor.token_range()),
-                        ));
+                        let Some(access) =
+                            self.eval_formal_type_select(*var_id, var_index, var_select)
+                        else {
+                            return Err(ParserError::unsupported(
+                                LoweringPhase::FfLowering,
+                                "function argument indexed access",
+                                format!(
+                                    "non-variable argument expression with dynamic indexed access: var_id={:?}",
+                                    var_id
+                                ),
+                                Some(&factor.token_range()),
+                            ));
+                        };
+                        self.materialize_bound_function_access(
+                            *var_id,
+                            &bound_expr,
+                            access,
+                            targets,
+                            domain,
+                            convert,
+                            sources,
+                            ir_builder,
+                        )?;
+                        return Ok(());
                     };
 
                     if bound_var_select.1.is_some() {
-                        return Err(ParserError::unsupported(
-                            68,
-                            LoweringPhase::FfLowering,
-                            "function argument indexed access",
-                            format!("chained range access is unsupported: var_id={:?}", var_id),
-                            Some(&factor.token_range()),
-                        ));
+                        let Some(access) =
+                            self.eval_formal_type_select(*var_id, var_index, var_select)
+                        else {
+                            return Err(ParserError::unsupported(
+                                LoweringPhase::FfLowering,
+                                "function argument indexed access",
+                                format!(
+                                    "chained range access with dynamic indices: var_id={:?}",
+                                    var_id
+                                ),
+                                Some(&factor.token_range()),
+                            ));
+                        };
+                        self.materialize_bound_function_access(
+                            *var_id,
+                            &bound_expr,
+                            access,
+                            targets,
+                            domain,
+                            convert,
+                            sources,
+                            ir_builder,
+                        )?;
+                        return Ok(());
                     }
 
                     let mut merged_index = bound_var_index.clone();
@@ -892,7 +1276,6 @@ impl<'a> FfParser<'a> {
             }
             Factor::SystemFunctionCall(call) => {
                 return Err(ParserError::unsupported(
-                    66,
                     LoweringPhase::FfLowering,
                     "system function call",
                     format!("{call}"),
@@ -1039,7 +1422,6 @@ impl<'a> FfParser<'a> {
                 self.get_cast_target_info(right)
             else {
                 return Err(ParserError::unsupported(
-                    68,
                     LoweringPhase::FfLowering,
                     "as cast target",
                     format!("{:?}", right),
@@ -1060,7 +1442,6 @@ impl<'a> FfParser<'a> {
         if matches!(op, Op::Pow) {
             let Some(exp) = self.get_constant_value(right) else {
                 return Err(ParserError::unsupported(
-                    68,
                     LoweringPhase::FfLowering,
                     "pow non-constant exponent",
                     format!("{:?}", right),
@@ -1426,7 +1807,6 @@ impl<'a> FfParser<'a> {
 
             let Some(member_type) = ty.get_member_type(*name) else {
                 return Err(ParserError::unsupported(
-                    68,
                     LoweringPhase::FfLowering,
                     "struct constructor member",
                     format!("unknown member: {:?} in {:?}", name, ty),
@@ -1435,7 +1815,6 @@ impl<'a> FfParser<'a> {
             };
             let Some(member_width) = member_type.total_width() else {
                 return Err(ParserError::unsupported(
-                    68,
                     LoweringPhase::FfLowering,
                     "struct constructor member width",
                     format!("member: {:?}, type: {:?}", name, member_type),
@@ -1501,7 +1880,6 @@ impl<'a> FfParser<'a> {
                     let rep_count = if let Some(rep_expr) = repeat {
                         self.get_constant_value(rep_expr).ok_or_else(|| {
                             ParserError::unsupported(
-                                68,
                                 LoweringPhase::FfLowering,
                                 "array literal non-constant repeat",
                                 format!("{:?}", rep_expr),
@@ -1520,7 +1898,6 @@ impl<'a> FfParser<'a> {
                 ArrayLiteralItem::Defaul(expr) => {
                     if default_part.is_some() {
                         return Err(ParserError::unsupported(
-                            68,
                             LoweringPhase::FfLowering,
                             "array literal multiple default",
                             format!("{:?}", items),
@@ -1544,7 +1921,6 @@ impl<'a> FfParser<'a> {
         if let Some((default_reg, default_width)) = default_part {
             let Some(target_width) = expected_width else {
                 return Err(ParserError::unsupported(
-                    68,
                     LoweringPhase::FfLowering,
                     "array literal default without context width",
                     format!("{:?}", items),
@@ -1554,7 +1930,6 @@ impl<'a> FfParser<'a> {
 
             if explicit_width > target_width {
                 return Err(ParserError::unsupported(
-                    68,
                     LoweringPhase::FfLowering,
                     "array literal width overflow",
                     format!("explicit_width={explicit_width}, target_width={target_width}"),
@@ -1565,7 +1940,6 @@ impl<'a> FfParser<'a> {
             let remaining = target_width - explicit_width;
             if default_width == 0 || !remaining.is_multiple_of(default_width) {
                 return Err(ParserError::unsupported(
-                    68,
                     LoweringPhase::FfLowering,
                     "array literal default width mismatch",
                     format!(

--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -1146,7 +1146,7 @@ impl<'a> FfParser<'a> {
                             self.eval_formal_type_select(*var_id, var_index, var_select)
                         else {
                             return Err(ParserError::unsupported(
-                                 68,
+                                43,
                                 LoweringPhase::FfLowering,
                                 "function argument indexed access",
                                 format!(
@@ -1176,7 +1176,7 @@ impl<'a> FfParser<'a> {
                             self.eval_formal_type_select(*var_id, var_index, var_select)
                         else {
                             return Err(ParserError::unsupported(
-                                 68,
+                                43,
                                 LoweringPhase::FfLowering,
                                 "function argument indexed access",
                                 format!(
@@ -1204,7 +1204,7 @@ impl<'a> FfParser<'a> {
                             self.eval_formal_type_select(*var_id, var_index, var_select)
                         else {
                             return Err(ParserError::unsupported(
-                                 68,
+                                43,
                                 LoweringPhase::FfLowering,
                                 "function argument indexed access",
                                 format!(
@@ -1281,7 +1281,7 @@ impl<'a> FfParser<'a> {
             }
             Factor::SystemFunctionCall(call) => {
                 return Err(ParserError::unsupported(
-                     68,
+                    66,
                     LoweringPhase::FfLowering,
                     "system function call",
                     format!("{call}"),

--- a/crates/celox/src/parser/ff/function_call.rs
+++ b/crates/celox/src/parser/ff/function_call.rs
@@ -14,6 +14,11 @@ use veryl_analyzer::ir::{
 use veryl_parser::token_range::TokenRange;
 
 impl<'a> FfParser<'a> {
+    fn default_expr_matches_formal(expr: &Expression, formal_shape: &[usize]) -> bool {
+        Self::expr_shape_matches_formal(expr, formal_shape)
+            || (!formal_shape.is_empty() && expr.comptime().r#type.array.is_empty())
+    }
+
     fn expr_shape_matches_formal(expr: &Expression, formal_shape: &[usize]) -> bool {
         match expr {
             Expression::ArrayLiteral(items, _) => {
@@ -49,7 +54,7 @@ impl<'a> FfParser<'a> {
                                 return false;
                             }
                             saw_default = true;
-                            if !Self::expr_shape_matches_formal(inner, formal_tail) {
+                            if !Self::default_expr_matches_formal(inner, formal_tail) {
                                 return false;
                             }
                         }

--- a/crates/celox/src/parser/ff/function_call.rs
+++ b/crates/celox/src/parser/ff/function_call.rs
@@ -7,24 +7,94 @@ use crate::{
         bitaccess::{build_partial_assign_expr, is_static_access},
     },
 };
+use num_traits::ToPrimitive;
 use veryl_analyzer::ir::{
     ArrayLiteralItem, Comptime, Expression, Factor, Statement, VarId, VarIndex, VarSelect,
 };
 use veryl_parser::token_range::TokenRange;
 
 impl<'a> FfParser<'a> {
-    fn actual_matches_formal_shape(&self, formal: &veryl_analyzer::ir::Variable, expr: &Expression) -> bool {
-        if formal.r#type.array.is_empty() {
+    fn expr_unpacked_shape(expr: &Expression) -> Option<Vec<usize>> {
+        match expr {
+            Expression::ArrayLiteral(items, _) => {
+                let mut explicit_len = 0usize;
+                let mut element_shape: Option<Vec<usize>> = None;
+
+                for item in items {
+                    match item {
+                        ArrayLiteralItem::Value(inner, repeat) => {
+                            let rep_count = if let Some(rep_expr) = repeat {
+                                crate::parser::bitaccess::eval_constexpr(rep_expr)
+                                    .and_then(|v| v.to_u64())
+                                    .map(|v| v as usize)?
+                            } else {
+                                1
+                            };
+                            explicit_len += rep_count;
+
+                            let inner_shape = Self::expr_unpacked_shape(inner)
+                                .or_else(|| {
+                                    let shape: Option<Vec<usize>> =
+                                        inner.comptime().r#type.array.iter().copied().collect();
+                                    shape
+                                })
+                                .unwrap_or_default();
+                            if let Some(existing) = &element_shape {
+                                if *existing != inner_shape {
+                                    return None;
+                                }
+                            } else {
+                                element_shape = Some(inner_shape);
+                            }
+                        }
+                        ArrayLiteralItem::Defaul(inner) => {
+                            let inner_shape = Self::expr_unpacked_shape(inner)
+                                .or_else(|| {
+                                    let shape: Option<Vec<usize>> =
+                                        inner.comptime().r#type.array.iter().copied().collect();
+                                    shape
+                                })
+                                .unwrap_or_default();
+                            if let Some(existing) = &element_shape {
+                                if *existing != inner_shape {
+                                    return None;
+                                }
+                            } else {
+                                element_shape = Some(inner_shape);
+                            }
+                        }
+                    }
+                }
+
+                let mut shape = vec![explicit_len];
+                if let Some(inner_shape) = element_shape {
+                    shape.extend(inner_shape);
+                }
+                Some(shape)
+            }
+            _ => {
+                let shape: Option<Vec<usize>> = expr.comptime().r#type.array.iter().copied().collect();
+                shape
+            }
+        }
+    }
+
+    fn actual_matches_formal_shape(
+        &self,
+        formal: &veryl_analyzer::ir::Variable,
+        expr: &Expression,
+    ) -> bool {
+        let formal_shape: Option<Vec<usize>> = formal.r#type.array.iter().copied().collect();
+        let formal_shape = formal_shape.unwrap_or_default();
+        if formal_shape.is_empty() {
             return true;
         }
 
-        match expr {
-            Expression::ArrayLiteral(_, _) => true,
-            Expression::Term(factor) if matches!(factor.as_ref(), Factor::Variable(_, _, _, _)) => {
-                !expr.comptime().r#type.array.is_empty()
-            }
-            _ => !expr.comptime().r#type.array.is_empty(),
-        }
+        let Some(actual_shape) = Self::expr_unpacked_shape(expr) else {
+            return false;
+        };
+
+        actual_shape == formal_shape
     }
 
     fn validate_function_call_bindings(

--- a/crates/celox/src/parser/ff/function_call.rs
+++ b/crates/celox/src/parser/ff/function_call.rs
@@ -13,6 +13,32 @@ use veryl_analyzer::ir::{
 use veryl_parser::token_range::TokenRange;
 
 impl<'a> FfParser<'a> {
+    fn validate_function_call_bindings(
+        &self,
+        call: &veryl_analyzer::ir::FunctionCall,
+        function_body: &veryl_analyzer::ir::FunctionBody,
+    ) -> Result<(), ParserError> {
+        for (arg_path, arg_id) in &function_body.arg_map {
+            let Some(arg_expr) = call.inputs.get(arg_path) else {
+                continue;
+            };
+            let formal = &self.module.variables[arg_id];
+            if !formal.r#type.array.is_empty() && matches!(arg_expr, Expression::Concatenation(_, _))
+            {
+                return Err(ParserError::unsupported(
+                    LoweringPhase::FfLowering,
+                    "function call argument shape",
+                    format!(
+                        "packed concatenation passed to unpacked array formal `{}`",
+                        formal.path
+                    ),
+                    Some(&call.comptime.token),
+                ));
+            }
+        }
+        Ok(())
+    }
+
     fn apply_function_call_to_state(
         &self,
         call: &veryl_analyzer::ir::FunctionCall,
@@ -41,6 +67,8 @@ impl<'a> FfParser<'a> {
                 Some(&call.comptime.token),
             ));
         };
+
+        self.validate_function_call_bindings(call, &function_body)?;
 
         let mut bindings: HashMap<VarId, Expression> = HashMap::default();
         for (arg_path, arg_id) in &function_body.arg_map {
@@ -552,6 +580,8 @@ impl<'a> FfParser<'a> {
             ));
         };
 
+        self.validate_function_call_bindings(call, &function_body)?;
+
         let mut bindings: HashMap<VarId, Expression> = HashMap::default();
         for (arg_path, arg_id) in &function_body.arg_map {
             if let Some(arg_expr) = call.inputs.get(arg_path) {
@@ -637,6 +667,8 @@ impl<'a> FfParser<'a> {
                 Some(&call.comptime.token),
             ));
         };
+
+        self.validate_function_call_bindings(call, &function_body)?;
 
         if call.outputs.is_empty() {
             // No side effect through output arguments: statement-form function call

--- a/crates/celox/src/parser/ff/function_call.rs
+++ b/crates/celox/src/parser/ff/function_call.rs
@@ -13,6 +13,20 @@ use veryl_analyzer::ir::{
 use veryl_parser::token_range::TokenRange;
 
 impl<'a> FfParser<'a> {
+    fn actual_matches_formal_shape(&self, formal: &veryl_analyzer::ir::Variable, expr: &Expression) -> bool {
+        if formal.r#type.array.is_empty() {
+            return true;
+        }
+
+        match expr {
+            Expression::ArrayLiteral(_, _) => true,
+            Expression::Term(factor) if matches!(factor.as_ref(), Factor::Variable(_, _, _, _)) => {
+                !expr.comptime().r#type.array.is_empty()
+            }
+            _ => !expr.comptime().r#type.array.is_empty(),
+        }
+    }
+
     fn validate_function_call_bindings(
         &self,
         call: &veryl_analyzer::ir::FunctionCall,
@@ -23,13 +37,12 @@ impl<'a> FfParser<'a> {
                 continue;
             };
             let formal = &self.module.variables[arg_id];
-            if !formal.r#type.array.is_empty() && matches!(arg_expr, Expression::Concatenation(_, _))
-            {
+            if !self.actual_matches_formal_shape(formal, arg_expr) {
                 return Err(ParserError::unsupported(
                     LoweringPhase::FfLowering,
                     "function call argument shape",
                     format!(
-                        "packed concatenation passed to unpacked array formal `{}`",
+                        "actual expression shape does not match unpacked array formal `{}`",
                         formal.path
                     ),
                     Some(&call.comptime.token),

--- a/crates/celox/src/parser/ff/function_call.rs
+++ b/crates/celox/src/parser/ff/function_call.rs
@@ -100,6 +100,7 @@ impl<'a> FfParser<'a> {
             let formal = &self.module.variables[arg_id];
             if !self.actual_matches_formal_shape(formal, arg_expr) {
                 return Err(ParserError::unsupported(
+                     66,
                     LoweringPhase::FfLowering,
                     "function call argument shape",
                     format!(

--- a/crates/celox/src/parser/ff/function_call.rs
+++ b/crates/celox/src/parser/ff/function_call.rs
@@ -14,67 +14,58 @@ use veryl_analyzer::ir::{
 use veryl_parser::token_range::TokenRange;
 
 impl<'a> FfParser<'a> {
-    fn expr_unpacked_shape(expr: &Expression) -> Option<Vec<usize>> {
+    fn expr_shape_matches_formal(expr: &Expression, formal_shape: &[usize]) -> bool {
         match expr {
             Expression::ArrayLiteral(items, _) => {
+                let Some((&formal_len, formal_tail)) = formal_shape.split_first() else {
+                    return false;
+                };
                 let mut explicit_len = 0usize;
-                let mut element_shape: Option<Vec<usize>> = None;
+                let mut saw_default = false;
 
                 for item in items {
                     match item {
                         ArrayLiteralItem::Value(inner, repeat) => {
                             let rep_count = if let Some(rep_expr) = repeat {
-                                crate::parser::bitaccess::eval_constexpr(rep_expr)
+                                match crate::parser::bitaccess::eval_constexpr(rep_expr)
                                     .and_then(|v| v.to_u64())
-                                    .map(|v| v as usize)?
+                                {
+                                    Some(v) => v as usize,
+                                    None => return false,
+                                }
                             } else {
                                 1
                             };
                             explicit_len += rep_count;
-
-                            let inner_shape = Self::expr_unpacked_shape(inner)
-                                .or_else(|| {
-                                    let shape: Option<Vec<usize>> =
-                                        inner.comptime().r#type.array.iter().copied().collect();
-                                    shape
-                                })
-                                .unwrap_or_default();
-                            if let Some(existing) = &element_shape {
-                                if *existing != inner_shape {
-                                    return None;
-                                }
-                            } else {
-                                element_shape = Some(inner_shape);
+                            if explicit_len > formal_len {
+                                return false;
+                            }
+                            if !Self::expr_shape_matches_formal(inner, formal_tail) {
+                                return false;
                             }
                         }
                         ArrayLiteralItem::Defaul(inner) => {
-                            let inner_shape = Self::expr_unpacked_shape(inner)
-                                .or_else(|| {
-                                    let shape: Option<Vec<usize>> =
-                                        inner.comptime().r#type.array.iter().copied().collect();
-                                    shape
-                                })
-                                .unwrap_or_default();
-                            if let Some(existing) = &element_shape {
-                                if *existing != inner_shape {
-                                    return None;
-                                }
-                            } else {
-                                element_shape = Some(inner_shape);
+                            if saw_default {
+                                return false;
+                            }
+                            saw_default = true;
+                            if !Self::expr_shape_matches_formal(inner, formal_tail) {
+                                return false;
                             }
                         }
                     }
                 }
 
-                let mut shape = vec![explicit_len];
-                if let Some(inner_shape) = element_shape {
-                    shape.extend(inner_shape);
+                if saw_default {
+                    explicit_len <= formal_len
+                } else {
+                    explicit_len == formal_len
                 }
-                Some(shape)
             }
             _ => {
-                let shape: Option<Vec<usize>> = expr.comptime().r#type.array.iter().copied().collect();
-                shape
+                let shape: Option<Vec<usize>> =
+                    expr.comptime().r#type.array.iter().copied().collect();
+                shape.unwrap_or_default() == formal_shape
             }
         }
     }
@@ -89,12 +80,7 @@ impl<'a> FfParser<'a> {
         if formal_shape.is_empty() {
             return true;
         }
-
-        let Some(actual_shape) = Self::expr_unpacked_shape(expr) else {
-            return false;
-        };
-
-        actual_shape == formal_shape
+        Self::expr_shape_matches_formal(expr, &formal_shape)
     }
 
     fn validate_function_call_bindings(

--- a/crates/celox/src/parser/ff/function_call.rs
+++ b/crates/celox/src/parser/ff/function_call.rs
@@ -100,7 +100,7 @@ impl<'a> FfParser<'a> {
             let formal = &self.module.variables[arg_id];
             if !self.actual_matches_formal_shape(formal, arg_expr) {
                 return Err(ParserError::unsupported(
-                     66,
+                    43,
                     LoweringPhase::FfLowering,
                     "function call argument shape",
                     format!(

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -785,3 +785,28 @@ fn test_ff_function_call_rejects_wrapped_packed_concat_for_unpacked_array_formal
         );
     });
 }
+
+#[test]
+fn test_ff_function_call_rejects_mismatched_unpacked_array_shape() {
+    let code = r#"
+        module Top (
+            clk: input clock,
+            out_q: output logic<8>
+        ) {
+            function f (x: input logic<8>[2, 2]) -> logic<8> {
+                return x[1][0];
+            }
+            always_ff (clk) {
+                out_q = f('{'{8'h11, 8'h22, 8'h33}});
+            }
+        }
+    "#;
+
+    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| {
+        let msg = format!("{e:?}");
+        assert!(
+            msg.contains("actual expression shape does not match unpacked array formal"),
+            "Expected mismatched unpacked shape error, got: {e:?}"
+        );
+    });
+}

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -731,3 +731,30 @@ fn test_comb_function_body_rejects_nested_break_in_dynamic_for_due_to_analyzer_u
         );
     });
 }
+
+#[test]
+fn test_ff_function_call_rejects_packed_concat_for_unpacked_array_formal() {
+    let code = r#"
+        module Top (
+            clk: input clock,
+            in_hi: input logic<4>,
+            in_lo: input logic<4>,
+            out_q: output logic<4>
+        ) {
+            function f (x: input logic<4>[2]) -> logic<4> {
+                return x[1];
+            }
+            always_ff (clk) {
+                out_q = f({in_hi, in_lo});
+            }
+        }
+    "#;
+
+    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| {
+        let msg = format!("{e:?}");
+        assert!(
+            msg.contains("packed concatenation passed to unpacked array formal"),
+            "Expected unpacked array formal shape error, got: {e:?}"
+        );
+    });
+}

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -753,8 +753,35 @@ fn test_ff_function_call_rejects_packed_concat_for_unpacked_array_formal() {
     assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| {
         let msg = format!("{e:?}");
         assert!(
-            msg.contains("packed concatenation passed to unpacked array formal"),
+            msg.contains("actual expression shape does not match unpacked array formal"),
             "Expected unpacked array formal shape error, got: {e:?}"
+        );
+    });
+}
+
+#[test]
+fn test_ff_function_call_rejects_wrapped_packed_concat_for_unpacked_array_formal() {
+    let code = r#"
+        module Top (
+            clk: input clock,
+            in_hi: input logic<4>,
+            in_lo: input logic<4>,
+            out_q: output logic<4>
+        ) {
+            function f (x: input logic<4>[2]) -> logic<4> {
+                return x[1];
+            }
+            always_ff (clk) {
+                out_q = f(({in_hi, in_lo}) as u8);
+            }
+        }
+    "#;
+
+    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| {
+        let msg = format!("{e:?}");
+        assert!(
+            msg.contains("actual expression shape does not match unpacked array formal"),
+            "Expected wrapped packed concat shape error, got: {e:?}"
         );
     });
 }

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -1339,6 +1339,29 @@ fn test_ff_function_call_multidim_array_literal_default_fill_matches_formal_shap
     assert_eq!(sim.get(out_q), 0x55u32.into());
 }
 
+fn test_ff_function_call_multidim_array_literal_indexing_preserves_element_order(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            out_q: output logic<8>
+        ) {
+            function f (x: input logic<8>[2, 2]) -> logic<8> {
+                return x[0][0];
+            }
+            always_ff (clk) {
+                out_q = f('{'{8'h11, 8'h22}, '{8'h33, 8'h44}});
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let out_q = sim.signal("out_q");
+
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x11u32.into());
+}
+
 fn test_ff_function_call_bit_select_on_nonvariable_one_bit_formal(sim) {
     @ignore_on(veryl);
     @setup { let code = r#"

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -660,6 +660,71 @@ fn test_ff_struct_constructor_expression(sim) {
     assert_eq!(sim.get(out_b), 0x34u32.into());
 }
 
+fn test_ff_struct_constructor_expression_literal_order(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            in_a: input logic<8>,
+            in_b: input logic<8>,
+            out_a: output logic<8>,
+            out_b: output logic<8>
+        ) {
+            struct S {
+                a: logic<8>,
+                b: logic<8>,
+            }
+            var r: S;
+            always_ff (clk) {
+                r = S'{a: in_a, b: in_b};
+            }
+            assign out_a = r.a;
+            assign out_b = r.b;
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let in_a = sim.signal("in_a");
+    let in_b = sim.signal("in_b");
+    let out_a = sim.signal("out_a");
+    let out_b = sim.signal("out_b");
+
+    sim.modify(|io| {
+        io.set(in_a, 0x12u8);
+        io.set(in_b, 0x34u8);
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_a), 0x12u32.into());
+    assert_eq!(sim.get(out_b), 0x34u32.into());
+}
+
+fn test_ff_array_literal_expression_order(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            o0: output logic<8>,
+            o1: output logic<8>
+        ) {
+            var r: logic<8>[2];
+            always_ff (clk) {
+                r = '{8'h12, 8'h34};
+            }
+            assign o0 = r[0];
+            assign o1 = r[1];
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let o0 = sim.signal("o0");
+    let o1 = sim.signal("o1");
+
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(o0), 0x12u32.into());
+    assert_eq!(sim.get(o1), 0x34u32.into());
+}
+
 fn test_ff_array_literal_default_expression(sim) {
     @ignore_on(veryl);
     @setup { let code = r#"
@@ -1007,6 +1072,297 @@ fn test_ff_function_call_chained_range_access_on_argument(sim) {
     sim.modify(|io| io.set(in_a, 0b1101_0110u8)).unwrap();
     sim.tick(clk).unwrap();
     assert_eq!(sim.get(out_q), 0b0101u32.into());
+}
+
+fn test_ff_function_call_step_access_on_nonvariable_argument(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (clk: input clock, in_a: input logic<8>, out_q: output logic<4>) {
+            function f (x: input logic<8>) -> logic<4> {
+                return x[1 step 4];
+            }
+            always_ff (clk) {
+                out_q = f(in_a + 8'b0000_0001);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let in_a = sim.signal("in_a");
+    let out_q = sim.signal("out_q");
+
+    sim.modify(|io| io.set(in_a, 0b1010_0100u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0b1010u32.into());
+}
+
+fn test_ff_function_call_nonvariable_argument_uses_formal_width_before_slice(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (clk: input clock, out_q: output logic) {
+            function f (x: input logic<4>) -> logic {
+                return x[3];
+            }
+            always_ff (clk) {
+                out_q = f('1);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let out_q = sim.signal("out_q");
+
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 1u32.into());
+}
+
+fn test_ff_function_call_nonvariable_argument_preserves_self_sized_overflow_before_coercion(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (clk: input clock, out_q: output logic) {
+            function f (x: input logic<4>) -> logic {
+                return x[2];
+            }
+            always_ff (clk) {
+                out_q = f(2'b11 + 2'b01);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let out_q = sim.signal("out_q");
+
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0u32.into());
+}
+
+fn test_ff_function_call_nonvariable_argument_preserves_signed_logic_formal(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            in_a: input signed logic<8>,
+            out_direct: output signed logic<8>,
+            out_expr: output signed logic<8>
+        ) {
+            function f (x: input signed logic<8>) -> signed logic<8> {
+                return x[7:0] >>> 1;
+            }
+            always_ff (clk) {
+                out_direct = f(in_a);
+                out_expr = f(in_a + 0);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let in_a = sim.signal("in_a");
+    let out_direct = sim.signal("out_direct");
+    let out_expr = sim.signal("out_expr");
+
+    sim.modify(|io| io.set(in_a, 0xFEu8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_direct), 0xFFu32.into());
+    assert_eq!(sim.get(out_expr), 0xFFu32.into());
+}
+
+fn test_ff_function_call_sign_extends_narrow_signed_actual_before_slice(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            out_q: output signed logic<8>
+        ) {
+            function f (x: input signed logic<8>) -> signed logic<8> {
+                return x >>> 4;
+            }
+            always_ff (clk) {
+                out_q = f(4'shf);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let out_q = sim.signal("out_q");
+
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0xFFu32.into());
+}
+
+fn test_ff_function_call_preserves_unsigned_actual_when_widening_to_signed_formal(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            out_q: output logic
+        ) {
+            function f (x: input signed logic<8>) -> logic {
+                return x[7];
+            }
+            always_ff (clk) {
+                out_q = f(4'hf);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let out_q = sim.signal("out_q");
+
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0u32.into());
+}
+
+fn test_ff_function_call_preserves_unsigned_formal_signedness_for_nonvariable_actual(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            in_a: input signed logic<8>,
+            out_q: output logic<8>
+        ) {
+            function f (x: input logic<8>) -> logic<8> {
+                return x[7:0] >>> 1;
+            }
+            always_ff (clk) {
+                out_q = f(in_a + 0);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let in_a = sim.signal("in_a");
+    let out_q = sim.signal("out_q");
+
+    sim.modify(|io| io.set(in_a, 0xFEu8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x7Fu32.into());
+}
+
+fn test_ff_function_call_nonvariable_argument_uses_formal_shape_for_indexing(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            in_hi: input logic<4>,
+            in_lo: input logic<4>,
+            out_q: output logic<4>
+        ) {
+            function f (x: input logic<4>[2]) -> logic<4> {
+                return x[1];
+            }
+            always_ff (clk) {
+                out_q = f('{in_hi, in_lo});
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let in_hi = sim.signal("in_hi");
+    let in_lo = sim.signal("in_lo");
+    let out_q = sim.signal("out_q");
+
+    sim.modify(|io| {
+        io.set(in_hi, 0xAu8);
+        io.set(in_lo, 0x3u8);
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x3u32.into());
+}
+
+fn test_ff_function_call_array_literal_element_uses_element_width(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            out_q: output signed logic<4>
+        ) {
+            function f (x: input signed logic<4>[2]) -> signed logic<4> {
+                return x[1] >>> 3;
+            }
+            always_ff (clk) {
+                out_q = f('{4'sh1, 4'sh8});
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let out_q = sim.signal("out_q");
+
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0xFu32.into());
+}
+
+fn test_ff_function_call_array_literal_default_fill_matches_formal_shape(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            out_q: output logic<8>
+        ) {
+            function f (x: input logic<8>[3]) -> logic<8> {
+                return x[2];
+            }
+            always_ff (clk) {
+                out_q = f('{default: 8'h55});
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let out_q = sim.signal("out_q");
+
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x55u32.into());
+}
+
+fn test_ff_function_call_multidim_array_literal_default_fill_matches_formal_shape(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            out_q: output logic<8>
+        ) {
+            function f (x: input logic<8>[2, 2]) -> logic<8> {
+                return x[1][1];
+            }
+            always_ff (clk) {
+                out_q = f('{default: 8'h55});
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let out_q = sim.signal("out_q");
+
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x55u32.into());
+}
+
+fn test_ff_function_call_bit_select_on_nonvariable_one_bit_formal(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            in_a: input logic,
+            out_q: output logic
+        ) {
+            function f (x: input logic) -> logic {
+                return x[0];
+            }
+            always_ff (clk) {
+                out_q = f(in_a | 1'b0);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let in_a = sim.signal("in_a");
+    let out_q = sim.signal("out_q");
+
+    sim.modify(|io| io.set(in_a, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 1u32.into());
 }
 
 }

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -961,6 +961,54 @@ fn test_ff_function_call_nested_output_statement_in_function_body(sim) {
     assert_eq!(sim.get(out_q), 8u32.into());
 }
 
+fn test_ff_function_call_indexed_nonvariable_argument_expression(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (clk: input clock, in_a: input logic<4>, out_q: output logic) {
+            function f (x: input logic<4>) -> logic {
+                return x[1];
+            }
+            always_ff (clk) {
+                out_q = f(in_a + 4'b0001);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let in_a = sim.signal("in_a");
+    let out_q = sim.signal("out_q");
+
+    sim.modify(|io| io.set(in_a, 0b0010u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 1u32.into());
+
+    sim.modify(|io| io.set(in_a, 0b0101u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 1u32.into());
+}
+
+fn test_ff_function_call_chained_range_access_on_argument(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (clk: input clock, in_a: input logic<8>, out_q: output logic<4>) {
+            function f (x: input logic<8>) -> logic<4> {
+                return x[5:2];
+            }
+            always_ff (clk) {
+                out_q = f(in_a[7:0]);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let in_a = sim.signal("in_a");
+    let out_q = sim.signal("out_q");
+
+    sim.modify(|io| io.set(in_a, 0b1101_0110u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0b0101u32.into());
+}
+
 }
 
 // Tests that use setup_and_trace/snapshot/Simulation::builder stay as regular #[test]


### PR DESCRIPTION
## Summary

Extend FF function-call lowering so indexed accesses on non-variable actual arguments work more like ordinary bound variables, and add shape validation for unpacked-array formals.

## What changed

- added indexed/chained access support for non-variable FF function arguments
- preserved actual-width and formal-signedness semantics during argument materialization
- validated unpacked-array actual shapes against formal shapes, including `default:`-filled array literals
- fixed multidimensional array-literal indexing in the FF function-argument fast path
- added targeted regressions for width coercion, signedness, scalar/array shape checks, and multidimensional array literals

## Why

FF function-call lowering was rejecting or mis-lowering several valid patterns:
- bound arguments that were expressions rather than plain variables
- unpacked-array actuals whose shape only becomes clear through the formal
- multidimensional array literals used as function-call actuals

These cases either produced `unsupported` errors too eagerly or silently returned the wrong element.

## Validation

- `cargo test -p celox --test flip_flop test_ff_function_call -- --nocapture`
- `cargo test -p celox --test error_detection ff_function_call_rejects_ -- --nocapture`
- `cargo fmt --all`

## Tracking

No tracking issues are fully closed by this PR.

Related:
- #43
- #66
- #68