### PR TITLE
chore: reduce GitHub Actions permissions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_INCREMENTAL: "0"
@@ -96,6 +96,8 @@ jobs:
   publish:
     needs: [bench-rust, bench-verilator, bench-ts]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci-napi.yml
+++ b/.github/workflows/ci-napi.yml
@@ -10,8 +10,7 @@ env:
   CARGO_INCREMENTAL: "0"
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
   build:
@@ -137,6 +136,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     name: Publish
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -227,6 +229,9 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     name: Publish JS Packages
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
 env:
   CARGO_INCREMENTAL: "0"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint & Format

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: pages
@@ -15,6 +15,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: pages
@@ -20,6 +20,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- set default GitHub Actions workflow permissions to `contents: read` where explicit permissions were missing or overly broad
- scope `contents: write` to publish/deploy jobs that actually need repository write access
- scope `id-token: write` to npm publish jobs that need provenance support
