### PR TITLE
[codex] Exclude Playwright e2e specs from Vitest

### DIFF
--- a/packages/playground/vitest.config.ts
+++ b/packages/playground/vitest.config.ts
@@ -3,4 +3,7 @@ import celox from "@celox-sim/vite-plugin";
 
 export default defineConfig({
   plugins: [celox()],
+  test: {
+    exclude: ["test/e2e/**/*.spec.ts"],
+  },
 });


### PR DESCRIPTION
## Summary
Exclude `packages/playground/test/e2e/**/*.spec.ts` from the Vitest config used by `packages/playground`.

## Why
The GitHub Actions job `Test - aarch64-apple-darwin` failed because `pnpm -r test` ran `vitest` in `packages/playground`, which picked up the Playwright file `test/e2e/monaco-diagnostics.spec.ts`. Vitest then evaluated Playwright's `test()` at module load and failed before the actual unit tests ran.

## Impact
`pnpm --filter @celox-sim/playground test` now runs only the Vitest suite, while Playwright e2e coverage remains under `pnpm --filter @celox-sim/playground test:e2e`.

## Validation
- `pnpm --filter @celox-sim/playground test`
- `pnpm -r test`
- local pre-push hook (`cargo-fmt`, `biome`, `cargo-clippy`, `test`)
