### PR TITLE
[codex] Fix playground bigint diagnostics

### DIFF
--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -2135,7 +2135,9 @@ function installPlaygroundTestApi() {
 					.filter(Boolean)
 					.join("\n")
 			: "";
-		return next ? `${messageText.messageText}\n${next}` : messageText.messageText;
+		return next
+			? `${messageText.messageText}\n${next}`
+			: messageText.messageText;
 	}
 
 	const api: PlaygroundTestApi = {
@@ -2186,8 +2188,8 @@ function installPlaygroundTestApi() {
 					startColumn: startPos.column,
 					endLineNumber: endPos.lineNumber,
 					endColumn: endPos.column,
-					};
-				});
+				};
+			});
 		},
 		getStatusText() {
 			return statusEl.textContent ?? "";

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -747,6 +747,7 @@ type PlaygroundTestApi = {
 	loadExample: (name: string) => void;
 	setFileContent: (path: string, content: string) => void;
 	getModelMarkers: (path: string) => PlaygroundTestMarker[];
+	getTypeScriptDiagnostics: (path: string) => Promise<PlaygroundTestMarker[]>;
 	getStatusText: () => string;
 };
 
@@ -2125,6 +2126,18 @@ function loadExample(name: string) {
 }
 
 function installPlaygroundTestApi() {
+	function flattenDiagnosticMessageText(messageText: any): string {
+		if (typeof messageText === "string") return messageText;
+		if (!messageText || typeof messageText.messageText !== "string") return "";
+		const next = Array.isArray(messageText.next)
+			? messageText.next
+					.map((child: any) => flattenDiagnosticMessageText(child))
+					.filter(Boolean)
+					.join("\n")
+			: "";
+		return next ? `${messageText.messageText}\n${next}` : messageText.messageText;
+	}
+
 	const api: PlaygroundTestApi = {
 		loadExample,
 		setFileContent(path: string, content: string) {
@@ -2147,6 +2160,34 @@ function installPlaygroundTestApi() {
 					endLineNumber: marker.endLineNumber,
 					endColumn: marker.endColumn,
 				}));
+		},
+		async getTypeScriptDiagnostics(path: string) {
+			const file = getFile(path);
+			if (!file) throw new Error(`File not found: ${path}`);
+			const workerFactory =
+				await monaco.languages.typescript.getTypeScriptWorker();
+			const worker = await workerFactory(file.model.uri);
+			const uri = file.model.uri.toString();
+			const [semantic, syntactic, suggestion] = await Promise.all([
+				worker.getSemanticDiagnostics(uri),
+				worker.getSyntacticDiagnostics(uri),
+				worker.getSuggestionDiagnostics(uri),
+			]);
+			return [...semantic, ...syntactic, ...suggestion].map((diag: any) => {
+				const start = typeof diag.start === "number" ? diag.start : 0;
+				const length = typeof diag.length === "number" ? diag.length : 0;
+				const startPos = file.model.getPositionAt(start);
+				const endPos = file.model.getPositionAt(start + length);
+				return {
+					code: diag.code,
+					message: flattenDiagnosticMessageText(diag.messageText),
+					severity: monaco.MarkerSeverity.Error,
+					startLineNumber: startPos.lineNumber,
+					startColumn: startPos.column,
+					endLineNumber: endPos.lineNumber,
+					endColumn: endPos.column,
+					};
+				});
 		},
 		getStatusText() {
 			return statusEl.textContent ?? "";

--- a/packages/playground/src/monaco-testbench-options.ts
+++ b/packages/playground/src/monaco-testbench-options.ts
@@ -5,6 +5,17 @@ type TypeScriptDefaultsApi = Pick<
 	"ScriptTarget" | "ModuleKind" | "ModuleResolutionKind"
 >;
 
+function pickEnumValue<T extends Record<string, string | number | undefined>>(
+	enumObject: T,
+	keys: readonly string[],
+): string | number {
+	for (const key of keys) {
+		const value = enumObject[key];
+		if (value !== undefined) return value;
+	}
+	throw new Error(`Missing Monaco enum value for ${keys.join(" / ")}`);
+}
+
 export const MONACO_TESTBENCH_LIBS = [
 	"es2022",
 	"es2020.bigint",
@@ -16,9 +27,15 @@ export function buildMonacoTestbenchCompilerOptions(
 	ts: TypeScriptDefaultsApi,
 ): monaco.languages.typescript.CompilerOptions {
 	return {
-		target: ts.ScriptTarget.ES2022,
-		module: ts.ModuleKind.ES2022,
-		moduleResolution: ts.ModuleResolutionKind.Bundler,
+		target: pickEnumValue(ts.ScriptTarget, ["ES2022", "ES2021", "ES2020"]),
+		module: pickEnumValue(ts.ModuleKind, ["ES2022", "ES2020", "ESNext"]),
+		moduleResolution: pickEnumValue(ts.ModuleResolutionKind, [
+			"Bundler",
+			"NodeNext",
+			"Node16",
+			"NodeJs",
+			"Node",
+		]),
 		// Keep BigInt support explicit so bigint literals in examples/tests stay valid.
 		lib: [...MONACO_TESTBENCH_LIBS],
 		allowArbitraryExtensions: true,

--- a/packages/playground/test/e2e/monaco-diagnostics.spec.ts
+++ b/packages/playground/test/e2e/monaco-diagnostics.spec.ts
@@ -11,6 +11,7 @@ declare global {
 			loadExample: (name: string) => void;
 			setFileContent: (path: string, content: string) => void;
 			getModelMarkers: (path: string) => PlaygroundTestMarker[];
+			getTypeScriptDiagnostics: (path: string) => Promise<PlaygroundTestMarker[]>;
 			getStatusText: () => string;
 		};
 	}
@@ -43,12 +44,12 @@ test("playground does not report TS2737 for bigint literals", async ({ page }) =
 	await expect
 		.poll(
 			async () => {
-				const markers = await page.evaluate(() => {
+				const diagnostics = await page.evaluate(async () => {
 					const api = window.__CELOX_PLAYGROUND_TEST_API__;
 					if (!api) throw new Error("Missing playground test API");
-					return api.getModelMarkers("test/adder.test.ts");
+					return api.getTypeScriptDiagnostics("test/adder.test.ts");
 				});
-				return !markers.some((marker) => {
+				return !diagnostics.some((marker) => {
 					const code = String(marker.code ?? "");
 					return (
 						code === "2737" ||

--- a/packages/playground/test/monaco-testbench-options.test.ts
+++ b/packages/playground/test/monaco-testbench-options.test.ts
@@ -25,6 +25,18 @@ describe("buildMonacoTestbenchCompilerOptions", () => {
 		]);
 	});
 
+	test("falls back to Monaco runtime enums that predate ES2022/Bundler", () => {
+		const options = buildMonacoTestbenchCompilerOptions({
+			ScriptTarget: { ES2020: "target-es2020" },
+			ModuleKind: { ESNext: "module-esnext" },
+			ModuleResolutionKind: { NodeJs: "resolution-nodejs" },
+		} as never);
+
+		expect(options.target).toBe("target-es2020");
+		expect(options.module).toBe("module-esnext");
+		expect(options.moduleResolution).toBe("resolution-nodejs");
+	});
+
 	test("keeps celox declaration paths resolvable for Monaco", () => {
 		const options = buildMonacoTestbenchCompilerOptions({
 			ScriptTarget: { ES2022: 1 },


### PR DESCRIPTION
## Summary
Fix the playground's Monaco TypeScript compiler options so bigint literals are diagnosed against an ES2020-capable target, and tighten the Playwright E2E to read actual TypeScript diagnostics instead of relying on potentially empty Monaco markers.

## Root Cause
The playground configured Monaco with `ScriptTarget.ES2022`, `ModuleKind.ES2022`, and `ModuleResolutionKind.Bundler`, but the runtime `monaco-editor` enums available in the browser do not always expose those members. That left `target`, `module`, and `moduleResolution` undefined at runtime, so the TS worker fell back to an older target and continued emitting `TS2737` for bigint literals.

## Changes
- add runtime enum fallbacks for Monaco compiler options
- add a unit test that covers older Monaco enum surfaces
- expose a Playwright-only helper to read TS worker diagnostics directly
- update the playground E2E to assert against actual TypeScript diagnostics

## Impact
Playground testbench files no longer report false `TS2737` bigint-literal errors, and the E2E now fails only when the TypeScript worker actually reports that regression.

## Validation
- `pnpm test -- test/monaco-testbench-options.test.ts`
- `pnpm --filter @celox-sim/playground test:e2e -- test/e2e/monaco-diagnostics.spec.ts`
- local pre-push hook: `cargo-fmt`, `biome`, `cargo-clippy`, `test`, `clean-tree`
