### PR TITLE
fix(playground): type 4-state virtual module ports

### DIFF
--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -10,6 +10,11 @@ import celoxSimulatorDts from "../../celox/dist/simulator.d.ts?raw";
 import celoxTypesDts from "../../celox/dist/types.d.ts?raw";
 import celoxWasmBridgeDts from "../../celox/dist/wasm-bridge.d.ts?raw";
 import { buildMonacoTestbenchCompilerOptions } from "./monaco-testbench-options.js";
+import {
+	buildVirtualModuleDts,
+	extractPortsFromSource,
+	type VirtualPortInfo,
+} from "./playground-dts.js";
 import { transpileTestbench } from "./testbench-transpile.js";
 import {
 	generateVcdText,
@@ -1118,37 +1123,23 @@ function getTestModels(): { path: string; model: monaco.editor.ITextModel }[] {
 	return [];
 }
 
-function updateDutTypes(
-	ports: Record<string, { direction: string; width: number }>,
-) {
+function updateDutTypes(ports: Record<string, VirtualPortInfo>) {
 	if (currentExtraLib) currentExtraLib.dispose();
 
 	// Extract module name from Veryl source
 	const topMatch = getVerylSource().match(/module\s+(\w+)/);
 	const moduleName = topMatch?.[1] || "Top";
 
-	const portEntries = Object.entries(ports)
-		.filter(([_, p]) => p.direction === "input" || p.direction === "output")
-		.map(([name, _]) => `    ${name}: bigint;`)
-		.join("\n");
-
 	// Only generate .veryl module declarations — @celox-sim/celox types are
 	// registered once at startup from the real .d.ts files.
+	const virtualModuleDts = buildVirtualModuleDts(moduleName, ports);
 	const dts = `
 declare module "./${moduleName}.veryl" {
-  import type { ModuleDefinition } from "@celox-sim/celox";
-  export interface ${moduleName}Ports {
-${portEntries}
-  }
-  export const ${moduleName}: ModuleDefinition<${moduleName}Ports>;
+${virtualModuleDts}
 }
 
 declare module "../src/${moduleName}.veryl" {
-  import type { ModuleDefinition } from "@celox-sim/celox";
-  export interface ${moduleName}Ports {
-${portEntries}
-  }
-  export const ${moduleName}: ModuleDefinition<${moduleName}Ports>;
+${virtualModuleDts}
 }
 `;
 	currentExtraLib = monaco.languages.typescript.typescriptDefaults.addExtraLib(
@@ -1157,13 +1148,7 @@ ${portEntries}
 	);
 
 	// Also register the .veryl module as a virtual file so TS can resolve the import
-	const verylModuleDts = `
-import type { ModuleDefinition } from "@celox-sim/celox";
-export interface ${moduleName}Ports {
-${portEntries}
-}
-export declare const ${moduleName}: ModuleDefinition<${moduleName}Ports>;
-`;
+	const verylModuleDts = virtualModuleDts;
 	// Register under multiple paths to ensure resolution works
 	// test/foo.test.ts imports "../src/Adder.veryl" → resolves to file:///src/Adder.veryl
 	monaco.languages.typescript.typescriptDefaults.addExtraLib(
@@ -1174,21 +1159,6 @@ export declare const ${moduleName}: ModuleDefinition<${moduleName}Ports>;
 		verylModuleDts,
 		`file:///src/${moduleName}.d.veryl.ts`,
 	);
-}
-
-// Extract port names from Veryl source with regex (works without WASM)
-function extractPortsFromSource(
-	source: string,
-): Record<string, { direction: string; width: number }> {
-	const ports: Record<string, { direction: string; width: number }> = {};
-	// Match: name: input/output logic<N> or clock/reset
-	const portRe =
-		/(\w+)\s*:\s*(input|output|inout)\s+(?:'[_a-zA-Z]*\s+)?(logic|bit|clock|reset)(?:<(\d+)>)?/g;
-	let m;
-	while ((m = portRe.exec(source)) !== null) {
-		ports[m[1]] = { direction: m[2], width: m[4] ? parseInt(m[4], 10) : 1 };
-	}
-	return ports;
 }
 
 // Parse error messages from genTsFromSource/NativeSimulatorHandle into Monaco markers

--- a/packages/playground/src/playground-dts.ts
+++ b/packages/playground/src/playground-dts.ts
@@ -16,11 +16,10 @@ function setterTypeForPort(port: VirtualPortInfo): string {
 	return port.is4state ? "FourStateSignalValue" : "bigint";
 }
 
-function needsFourStateImport(
-	ports: Record<string, VirtualPortInfo>,
-): boolean {
+function needsFourStateImport(ports: Record<string, VirtualPortInfo>): boolean {
 	return Object.values(ports).some(
-		(port) => port.kind !== "clock" && port.direction !== "output" && port.is4state,
+		(port) =>
+			port.kind !== "clock" && port.direction !== "output" && port.is4state,
 	);
 }
 

--- a/packages/playground/src/playground-dts.ts
+++ b/packages/playground/src/playground-dts.ts
@@ -1,0 +1,77 @@
+export type VirtualPortDirection = "input" | "output" | "inout";
+export type VirtualPortKind = "logic" | "bit" | "clock" | "reset";
+
+export interface VirtualPortInfo {
+	direction: VirtualPortDirection;
+	kind: VirtualPortKind;
+	width: number;
+	is4state: boolean;
+}
+
+function isFourStatePortKind(kind: VirtualPortKind): boolean {
+	return kind === "logic" || kind === "clock" || kind === "reset";
+}
+
+function setterTypeForPort(port: VirtualPortInfo): string {
+	return port.is4state ? "FourStateSignalValue" : "bigint";
+}
+
+function needsFourStateImport(
+	ports: Record<string, VirtualPortInfo>,
+): boolean {
+	return Object.values(ports).some(
+		(port) => port.kind !== "clock" && port.direction !== "output" && port.is4state,
+	);
+}
+
+export function buildVirtualModuleDts(
+	moduleName: string,
+	ports: Record<string, VirtualPortInfo>,
+): string {
+	const importLine = needsFourStateImport(ports)
+		? 'import type { FourStateSignalValue, ModuleDefinition } from "@celox-sim/celox";'
+		: 'import type { ModuleDefinition } from "@celox-sim/celox";';
+
+	const portEntries = Object.entries(ports)
+		.filter(([, port]) => port.kind !== "clock")
+		.map(([name, port]) => {
+			if (port.direction === "output") {
+				return `  readonly ${name}: bigint;`;
+			}
+			return [
+				`  get ${name}(): bigint;`,
+				`  set ${name}(value: ${setterTypeForPort(port)});`,
+			].join("\n");
+		})
+		.join("\n");
+
+	return `${importLine}
+
+export interface ${moduleName}Ports {
+${portEntries}
+}
+
+export declare const ${moduleName}: ModuleDefinition<${moduleName}Ports>;
+`;
+}
+
+export function extractPortsFromSource(
+	source: string,
+): Record<string, VirtualPortInfo> {
+	const ports: Record<string, VirtualPortInfo> = {};
+	const portRe =
+		/(\w+)\s*:\s*(input|output|inout)\s+(?:'[_a-zA-Z]*\s+)?(logic|bit|clock|reset)(?:<(\d+)>)?/g;
+	let match: RegExpExecArray | null;
+
+	while ((match = portRe.exec(source)) !== null) {
+		const kind = match[3] as VirtualPortKind;
+		ports[match[1]] = {
+			direction: match[2] as VirtualPortDirection,
+			kind,
+			width: match[4] ? parseInt(match[4], 10) : 1,
+			is4state: isFourStatePortKind(kind),
+		};
+	}
+
+	return ports;
+}

--- a/packages/playground/test/playground-dts.test.ts
+++ b/packages/playground/test/playground-dts.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	buildVirtualModuleDts,
+	extractPortsFromSource,
+} from "../src/playground-dts";
+
+describe("playground-dts", () => {
+	test("4-state inputs accept FourStateSignalValue in virtual module DTS", () => {
+		const ports = extractPortsFromSource(`module FourStateDemo (
+    a: input logic<8>,
+    b: input logic<8>,
+    snapshot: output logic<8>,
+) {
+    assign snapshot = a;
+}`);
+
+		const dts = buildVirtualModuleDts("FourStateDemo", ports);
+
+		expect(dts).toContain("import type { FourStateSignalValue, ModuleDefinition }");
+		expect(dts).toContain("get a(): bigint;");
+		expect(dts).toContain("set a(value: FourStateSignalValue);");
+		expect(dts).toContain("readonly snapshot: bigint;");
+	});
+
+	test("clock ports are excluded and bit inputs stay bigint-writable", () => {
+		const ports = extractPortsFromSource(`module Counter (
+    clk: input clock,
+    en: input bit,
+    count: output logic<8>,
+) {
+}`);
+
+		const dts = buildVirtualModuleDts("Counter", ports);
+
+		expect(dts).not.toContain("clk");
+		expect(dts).toContain("set en(value: bigint);");
+		expect(dts).toContain("readonly count: bigint;");
+	});
+});


### PR DESCRIPTION
## Summary
- align playground's virtual `.veryl` DTS generation with `celox-ts-gen`
- type 4-state writable ports as `FourStateSignalValue` instead of `bigint`
- add a regression test for 4-state virtual module typings

## Verification
- `pnpm --filter @celox-sim/playground test`
- pre-push hooks (`biome`, `cargo-clippy`, full test suite)

Closes #54