### PR TITLE
[codex] Add triage guide and close out issue #42 cleanup

### DIFF
--- a/crates/celox/tests/std_mux.rs
+++ b/crates/celox/tests/std_mux.rs
@@ -12,8 +12,8 @@ const DEMUX_SRC: &str =
 
 all_backends! {
 
-    // Build-only smoke test: mux with selector_pkg requires `calc_select_width` function
-    // evaluation at compile time. Currently Celox cannot resolve this, so this test is ignored.
+    // Build-only smoke test: mux with selector_pkg requires `calc_select_width`
+    // evaluation while resolving module parameters and widths.
     fn test_mux_build_smoke(sim) {
         @ignore_on(veryl);
         @setup { let top = r#"
@@ -48,7 +48,8 @@ let code = format!("{SELECTOR_PKG_SRC}\n{MUX_SRC}\n{top}"); }
 
     }
 
-    // Build-only: binary demux
+    // Build-only smoke test: binary demux also depends on selector_pkg compile-time
+    // width resolution through `calc_select_width`.
     fn test_demux_build_smoke(sim) {
         @ignore_on(veryl);
         @setup { let top = r#"

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -150,6 +150,7 @@ export default defineConfig({
               link: "/internals/cascade-limitations",
             },
             { text: "Status", link: "/internals/status" },
+            { text: "Triage", link: "/internals/triage" },
           ],
         },
       ],

--- a/docs/internals/triage.md
+++ b/docs/internals/triage.md
@@ -1,0 +1,148 @@
+# Triage
+
+This page defines the lightweight maintainer workflow for prioritizing GitHub work in `celox`.
+
+## Goal
+
+Keep the queue small, visible, and biased toward:
+
+1. correctness of simulator behavior
+2. user-facing usability regressions
+3. mergeable work already in flight
+
+GitHub Projects can still be used as a view layer, but the source of truth should remain:
+
+- Issues for work items
+- Pull requests for implementation
+- Tracking issues for multi-step themes
+
+## Queue Buckets
+
+Every open issue and PR should fit one of these buckets.
+
+### Now
+
+Work that should be reviewed, merged, or fixed before taking on new feature work.
+
+Typical criteria:
+
+- open PR that is already testable and close to merge
+- bug that breaks CI, docs, playground, or common workflows
+- semantic bug that can produce incorrect simulation results
+
+### Next
+
+Important follow-up work that should start after `Now` is cleared.
+
+Typical criteria:
+
+- core feature gaps with direct user impact
+- support gaps already split into concrete issues
+- diagnostics improvements around common failure cases
+
+### Later
+
+Useful work that is real but not on the immediate path.
+
+Typical criteria:
+
+- dependency maintenance
+- future backend expansion
+- cleanup that depends on upstream release timing
+
+### Tracking
+
+Umbrella issues that organize a theme but should not compete directly with execution issues.
+
+Typical criteria:
+
+- parent issue for a family of sub-issues
+- inventory / classification issue
+- roadmap marker spanning several PRs
+
+## Priority Rules
+
+Use these precedence rules when two tasks compete.
+
+1. Merge or unblock high-signal open PRs before opening fresh work.
+2. Prefer correctness over optimization unless a proven perf regression is blocking a release.
+3. Prefer user-visible breakage over internal cleanup.
+4. Prefer concrete child issues over broad tracking issues.
+5. Keep upstream-waiting tasks out of the active queue unless the external blocker moved.
+
+## Recommended Fields
+
+If a GitHub Project is used, keep the schema minimal:
+
+- `Bucket`: `Now`, `Next`, `Later`, `Tracking`
+- `Area`: `sim-core`, `backend-native`, `ts-runtime`, `playground`, `ci/docs`, `upstream-veryl`
+- `Kind`: `bug`, `feature`, `tracking`, `debt`, `dependency`
+
+Avoid duplicating the same meaning in both labels and project fields.
+
+## 2026-04-27 Snapshot
+
+This snapshot reflects the open GitHub queue inspected on April 27, 2026.
+
+### Now
+
+- PR [#79](https://github.com/celox-sim/celox/pull/79): playground 4-state virtual module port typing fix
+- PR [#78](https://github.com/celox-sim/celox/pull/78): align loop variables with Veryl `i32` semantics
+
+### Next
+
+- Issue [#54](https://github.com/celox-sim/celox/issues/54): playground 4-state typing regression
+  This should close with PR #79, so it stays effectively in `Now` until merged.
+- Issue [#44](https://github.com/celox-sim/celox/issues/44): array literal lowering gaps
+- Issue [#45](https://github.com/celox-sim/celox/issues/45): expression lowering gaps
+- Issue [#33](https://github.com/celox-sim/celox/issues/33): report true loop location
+
+### Later
+
+- Issue [#42](https://github.com/celox-sim/celox/issues/42): const function evaluation in module params
+  The current `std_mux` / `std_demux` smoke tests pass on Celox backends, so this issue likely
+  needs closure or scope correction rather than new implementation work.
+- Issue [#72](https://github.com/celox-sim/celox/issues/72): remove `deps/veryl` submodule once `veryl` `0.20.0` is available
+- Issue [#36](https://github.com/celox-sim/celox/issues/36): dependency dashboard
+- Issue [#16](https://github.com/celox-sim/celox/issues/16): instance-contiguous `MemoryLayout`
+- Issue [#30](https://github.com/celox-sim/celox/issues/30): native testbench DSE
+- Issue [#25](https://github.com/celox-sim/celox/issues/25): support Veryl native testbench
+- Issue [#26](https://github.com/celox-sim/celox/issues/26): native ARM backend
+- Issue [#27](https://github.com/celox-sim/celox/issues/27): native RISC-V backend
+- Issue [#24](https://github.com/celox-sim/celox/issues/24): improve generic-argument error message
+
+### Tracking
+
+- Issue [#41](https://github.com/celox-sim/celox/issues/41): simulator support gaps by category
+- Issue [#43](https://github.com/celox-sim/celox/issues/43): function-call lowering support
+- Issues [#57](https://github.com/celox-sim/celox/issues/57), [#58](https://github.com/celox-sim/celox/issues/58), [#59](https://github.com/celox-sim/celox/issues/59), [#60](https://github.com/celox-sim/celox/issues/60), [#61](https://github.com/celox-sim/celox/issues/61), [#62](https://github.com/celox-sim/celox/issues/62), [#63](https://github.com/celox-sim/celox/issues/63): concrete child issues under the broader function-call support theme
+
+## Operating Cadence
+
+Run this review whenever a PR merges or a new user-visible bug appears.
+
+1. Re-evaluate all open PRs and move mergeable ones into `Now`.
+2. Remove closed issues from the bucket list.
+3. Promote only one or two `Next` items at a time.
+4. Leave broad roadmap or upstream-waiting tasks in `Later` or `Tracking`.
+
+## Should This Be A Skill?
+
+Usually not at first.
+
+For this repository, the stable asset should be this document because:
+
+- the queue is repo-specific
+- issue numbers and priorities change over time
+- maintainers need a visible policy in the repo itself
+
+A skill becomes useful when the workflow is reused across repositories, for example:
+
+- a personal weekly GitHub triage routine
+- a standard way to classify PRs and issues across several projects
+- a repeatable sequence of GitHub connector actions with consistent output
+
+Good split:
+
+- repo-specific policy: docs page in this repository
+- reusable personal workflow: skill


### PR DESCRIPTION
## Summary
- add a lightweight maintainer triage guide under the internals docs and expose it in the VitePress sidebar
- update the `std_mux` / `std_demux` smoke-test comments to match current Celox behavior
- document and reflect that issue #42 was already resolved on Celox backends rather than needing new implementation work

## Why
The repository needed a simple, repo-local way to track issue priority without relying on heavy project configuration. While triaging open issues, issue #42 also turned out to be stale: the selector package smoke tests already pass on Celox backends, but the test comments still claimed the feature was unsupported.

## Impact
- maintainers now have a documented `Now / Next / Later / Tracking` triage policy in the docs
- the docs sidebar links directly to that policy
- the `std_mux` smoke tests no longer describe a non-existent limitation
- the GitHub issue queue is more accurate because #42 can stay closed

## Validation
- pre-push hook suite
- `cargo fmt --all -- --check`
- `pnpm run lint`
- `cargo clippy --locked -p celox -p celox-macros -p celox-napi -p celox-ts-gen --all-targets --no-deps`
- `pnpm run test`
- `cargo test -p celox --test std_mux -- --nocapture`