### PR TITLE
Improve FF expression coercion and diagnostics

### DIFF
--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -206,14 +206,17 @@ impl<'a> FfParser<'a> {
     ) -> RegisterId {
         let widened = self.cast_reg_width_ext(ir_builder, reg, target_width, extend_signed);
         if target_is_2state {
-            if ir_builder.register(&widened).is_signed() == result_signed
-                && ir_builder.register(&widened).width() == target_width
-            {
-                widened
-            } else {
-                let bit_reg = ir_builder.alloc_bit(target_width, result_signed);
-                ir_builder.emit(SIRInstruction::Unary(bit_reg, UnaryOp::Ident, widened));
-                bit_reg
+            match ir_builder.register(&widened) {
+                crate::ir::RegisterType::Bit { width, signed }
+                    if *width == target_width && *signed == result_signed =>
+                {
+                    widened
+                }
+                _ => {
+                    let bit_reg = ir_builder.alloc_bit(target_width, result_signed);
+                    ir_builder.emit(SIRInstruction::Unary(bit_reg, UnaryOp::Ident, widened));
+                    bit_reg
+                }
             }
         } else {
             if matches!(ir_builder.register(&widened), crate::ir::RegisterType::Logic { .. }) {

--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -185,6 +185,7 @@ impl<'a> FfParser<'a> {
                 formal_width,
                 bound_expr.comptime().r#type.signed,
                 var.r#type.signed,
+                var.r#type.is_2state(),
             )
         } else {
             bound_reg
@@ -201,21 +202,21 @@ impl<'a> FfParser<'a> {
         target_width: usize,
         extend_signed: bool,
         result_signed: bool,
+        target_is_2state: bool,
     ) -> RegisterId {
         let widened = self.cast_reg_width_ext(ir_builder, reg, target_width, extend_signed);
-        if result_signed {
-            if ir_builder.register(&widened).is_signed()
+        if target_is_2state {
+            if ir_builder.register(&widened).is_signed() == result_signed
                 && ir_builder.register(&widened).width() == target_width
             {
                 widened
             } else {
-                let signed_reg = ir_builder.alloc_bit(target_width, true);
-                ir_builder.emit(SIRInstruction::Unary(signed_reg, UnaryOp::Ident, widened));
-                signed_reg
+                let bit_reg = ir_builder.alloc_bit(target_width, result_signed);
+                ir_builder.emit(SIRInstruction::Unary(bit_reg, UnaryOp::Ident, widened));
+                bit_reg
             }
         } else {
-            let src = ir_builder.register(&widened);
-            if src.width() == target_width && !src.is_signed() {
+            if matches!(ir_builder.register(&widened), crate::ir::RegisterType::Logic { .. }) {
                 widened
             } else {
                 let logic_reg = ir_builder.alloc_logic(target_width);
@@ -293,6 +294,7 @@ impl<'a> FfParser<'a> {
             access_width,
             selected_expr.comptime().r#type.signed,
             formal.r#type.signed,
+            formal.r#type.is_2state(),
         );
         self.stack.push_back(coerced);
         Ok(true)
@@ -1336,30 +1338,34 @@ impl<'a> FfParser<'a> {
         // Apply context_width adjustment
         if let Some(target_width) = context_width {
             let src_reg = self.stack.pop_back().unwrap();
-            let src_width = ir_builder.register(&src_reg).width();
+            let adjusted = match ir_builder.register(&src_reg) {
+                crate::ir::RegisterType::Bit { signed, .. } => {
+                    self.cast_reg_width_ext(ir_builder, src_reg, target_width, *signed)
+                }
+                crate::ir::RegisterType::Logic { width } => {
+                    if *width < target_width {
+                        let dest_reg = ir_builder.alloc_logic(target_width);
+                        ir_builder.emit(SIRInstruction::Unary(dest_reg, UnaryOp::Ident, src_reg));
+                        dest_reg
+                    } else if *width > target_width {
+                        let mask_val = (BigUint::from(1u64) << target_width) - BigUint::from(1u64);
+                        let mask_reg = ir_builder.alloc_bit(target_width, false);
+                        ir_builder.emit(SIRInstruction::Imm(mask_reg, SIRValue::new(mask_val)));
 
-            if src_width < target_width {
-                // Extension
-                let dest_reg = ir_builder.alloc_logic(target_width);
-                ir_builder.emit(SIRInstruction::Unary(dest_reg, UnaryOp::Ident, src_reg));
-                self.stack.push_back(dest_reg);
-            } else if src_width > target_width {
-                // Truncation
-                let mask_val = (BigUint::from(1u64) << target_width) - BigUint::from(1u64);
-                let mask_reg = ir_builder.alloc_bit(target_width, false);
-                ir_builder.emit(SIRInstruction::Imm(mask_reg, SIRValue::new(mask_val)));
-
-                let trunc_reg = ir_builder.alloc_logic(target_width);
-                ir_builder.emit(SIRInstruction::Binary(
-                    trunc_reg,
-                    src_reg,
-                    BinaryOp::And,
-                    mask_reg,
-                ));
-                self.stack.push_back(trunc_reg);
-            } else {
-                self.stack.push_back(src_reg);
-            }
+                        let trunc_reg = ir_builder.alloc_logic(target_width);
+                        ir_builder.emit(SIRInstruction::Binary(
+                            trunc_reg,
+                            src_reg,
+                            BinaryOp::And,
+                            mask_reg,
+                        ));
+                        trunc_reg
+                    } else {
+                        src_reg
+                    }
+                }
+            };
+            self.stack.push_back(adjusted);
         }
 
         Ok(())
@@ -1830,26 +1836,11 @@ impl<'a> FfParser<'a> {
         convert: &impl Fn(VarId, u32) -> A,
         sources: &mut Vec<VarAtomBase<A>>,
         ir_builder: &mut SIRBuilder<A>,
-        context_width: Option<usize>,
+        _context_width: Option<usize>,
     ) -> Result<(), ParserError> {
         let mut parts: Vec<(RegisterId, usize)> = Vec::new();
 
         for (name, expr) in fields {
-            self.parse_expression(
-                expr,
-                targets,
-                domain,
-                convert,
-                sources,
-                ir_builder,
-                context_width,
-            )?;
-            let mut reg = self
-                .stack
-                .pop_back()
-                .expect("Struct constructor part evaluation failed");
-            let src_width = ir_builder.register(&reg).width();
-
             let Some(member_type) = ty.get_member_type(*name) else {
                 return Err(ParserError::unsupported(
                     68,
@@ -1868,27 +1859,27 @@ impl<'a> FfParser<'a> {
                     Some(&expr.token_range()),
                 ));
             };
-
-            if src_width > member_width {
-                let mask_val = (BigUint::from(1u64) << member_width) - BigUint::from(1u64);
-                let mask_reg = ir_builder.alloc_bit(member_width, false);
-                ir_builder.emit(SIRInstruction::Imm(mask_reg, SIRValue::new(mask_val)));
-
-                let trunc_reg = ir_builder.alloc_logic(member_width);
-                ir_builder.emit(SIRInstruction::Binary(
-                    trunc_reg,
-                    reg,
-                    BinaryOp::And,
-                    mask_reg,
-                ));
-                reg = trunc_reg;
-            } else if src_width < member_width {
-                let pad_width = member_width - src_width;
-                let zero_reg = ir_builder.alloc_bit(pad_width, false);
-                ir_builder.emit(SIRInstruction::Imm(zero_reg, SIRValue::new(0u32)));
-                reg = self
-                    .emit_concat_registers(&[(zero_reg, pad_width), (reg, src_width)], ir_builder);
-            }
+            self.parse_expression(
+                expr,
+                targets,
+                domain,
+                convert,
+                sources,
+                ir_builder,
+                Some(member_width),
+            )?;
+            let mut reg = self
+                .stack
+                .pop_back()
+                .expect("Struct constructor part evaluation failed");
+            reg = self.coerce_register_to_formal(
+                ir_builder,
+                reg,
+                member_width,
+                expr.comptime().r#type.signed,
+                member_type.signed,
+                member_type.is_2state(),
+            );
 
             parts.push((reg, member_width));
         }

--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -219,7 +219,10 @@ impl<'a> FfParser<'a> {
                 }
             }
         } else {
-            if matches!(ir_builder.register(&widened), crate::ir::RegisterType::Logic { .. }) {
+            if matches!(
+                ir_builder.register(&widened),
+                crate::ir::RegisterType::Logic { .. }
+            ) {
                 widened
             } else {
                 let logic_reg = ir_builder.alloc_logic(target_width);

--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -219,15 +219,30 @@ impl<'a> FfParser<'a> {
                 }
             }
         } else {
-            if matches!(
-                ir_builder.register(&widened),
-                crate::ir::RegisterType::Logic { .. }
-            ) {
-                widened
+            if result_signed {
+                match ir_builder.register(&widened) {
+                    crate::ir::RegisterType::Bit { width, signed }
+                        if *width == target_width && *signed =>
+                    {
+                        widened
+                    }
+                    _ => {
+                        let signed_reg = ir_builder.alloc_bit(target_width, true);
+                        ir_builder.emit(SIRInstruction::Unary(signed_reg, UnaryOp::Ident, widened));
+                        signed_reg
+                    }
+                }
             } else {
-                let logic_reg = ir_builder.alloc_logic(target_width);
-                ir_builder.emit(SIRInstruction::Unary(logic_reg, UnaryOp::Ident, widened));
-                logic_reg
+                if matches!(
+                    ir_builder.register(&widened),
+                    crate::ir::RegisterType::Logic { .. }
+                ) {
+                    widened
+                } else {
+                    let logic_reg = ir_builder.alloc_logic(target_width);
+                    ir_builder.emit(SIRInstruction::Unary(logic_reg, UnaryOp::Ident, widened));
+                    logic_reg
+                }
             }
         }
     }

--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -1917,9 +1917,7 @@ impl<'a> FfParser<'a> {
 
                     let rep_count = if let Some(rep_expr) = repeat {
                         self.get_constant_value(rep_expr).ok_or_else(|| {
-                            ParserError::unsupported(
-                                68,
-                                LoweringPhase::FfLowering,
+                            ParserError::illegal_context(
                                 "array literal non-constant repeat",
                                 format!("{:?}", rep_expr),
                                 Some(&rep_expr.token_range()),
@@ -1936,9 +1934,7 @@ impl<'a> FfParser<'a> {
                 }
                 ArrayLiteralItem::Defaul(expr) => {
                     if default_part.is_some() {
-                        return Err(ParserError::unsupported(
-                            68,
-                            LoweringPhase::FfLowering,
+                        return Err(ParserError::illegal_context(
                             "array literal multiple default",
                             format!("{:?}", items),
                             Some(&expr.token_range()),
@@ -1970,9 +1966,7 @@ impl<'a> FfParser<'a> {
             };
 
             if explicit_width > target_width {
-                return Err(ParserError::unsupported(
-                    68,
-                    LoweringPhase::FfLowering,
+                return Err(ParserError::illegal_context(
                     "array literal width overflow",
                     format!("explicit_width={explicit_width}, target_width={target_width}"),
                     items.first().map(|it| it.token_range()).as_ref(),
@@ -1981,9 +1975,7 @@ impl<'a> FfParser<'a> {
 
             let remaining = target_width - explicit_width;
             if default_width == 0 || !remaining.is_multiple_of(default_width) {
-                return Err(ParserError::unsupported(
-                    68,
-                    LoweringPhase::FfLowering,
+                return Err(ParserError::illegal_context(
                     "array literal default width mismatch",
                     format!(
                         "remaining={remaining}, default_width={default_width}, target_width={target_width}"

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -810,3 +810,73 @@ fn test_ff_function_call_rejects_mismatched_unpacked_array_shape() {
         );
     });
 }
+
+#[test]
+fn test_ff_array_literal_multiple_default_is_illegal_context() {
+    let code = r#"
+        module Top (
+            clk: input clock,
+            out_q: output logic<8>[2]
+        ) {
+            var r: logic<8>[2];
+            always_ff (clk) {
+                r = '{default: 8'h11, default: 8'h22};
+            }
+            assign out_q = r;
+        }
+    "#;
+
+    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| match e.kind() {
+        SimulatorErrorKind::SIRParser(ParserError::IllegalContext { feature, .. }) => {
+            assert_eq!(*feature, "array literal multiple default");
+        }
+        k => panic!("expected IllegalContext for multiple default array literal, got {k:?}"),
+    });
+}
+
+#[test]
+fn test_ff_array_literal_non_constant_repeat_is_illegal_context() {
+    let code = r#"
+        module Top (
+            clk: input clock,
+            n: input logic<2>,
+            out_q: output logic<8>[2]
+        ) {
+            var r: logic<8>[2];
+            always_ff (clk) {
+                r = '{8'h11 repeat n};
+            }
+            assign out_q = r;
+        }
+    "#;
+
+    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| match e.kind() {
+        SimulatorErrorKind::SIRParser(ParserError::IllegalContext { feature, .. }) => {
+            assert_eq!(*feature, "array literal non-constant repeat");
+        }
+        k => panic!("expected IllegalContext for non-constant repeat array literal, got {k:?}"),
+    });
+}
+
+#[test]
+fn test_ff_array_literal_width_overflow_is_illegal_context() {
+    let code = r#"
+        module Top (
+            clk: input clock,
+            out_q: output logic<8>
+        ) {
+            var r: logic<8>[1];
+            always_ff (clk) {
+                r = '{8'h11, 8'h22, default: 8'h33};
+            }
+            assign out_q = r[0];
+        }
+    "#;
+
+    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| match e.kind() {
+        SimulatorErrorKind::SIRParser(ParserError::IllegalContext { feature, .. }) => {
+            assert_eq!(*feature, "array literal width overflow");
+        }
+        k => panic!("expected IllegalContext for array literal width overflow, got {k:?}"),
+    });
+}

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -826,11 +826,13 @@ fn test_ff_array_literal_multiple_default_is_illegal_context() {
         }
     "#;
 
-    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| match e.kind() {
-        SimulatorErrorKind::SIRParser(ParserError::IllegalContext { feature, .. }) => {
-            assert_eq!(*feature, "array literal multiple default");
+    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| {
+        match e.kind() {
+            SimulatorErrorKind::SIRParser(ParserError::IllegalContext { feature, .. }) => {
+                assert_eq!(*feature, "array literal multiple default");
+            }
+            k => panic!("expected IllegalContext for multiple default array literal, got {k:?}"),
         }
-        k => panic!("expected IllegalContext for multiple default array literal, got {k:?}"),
     });
 }
 
@@ -850,11 +852,13 @@ fn test_ff_array_literal_non_constant_repeat_is_illegal_context() {
         }
     "#;
 
-    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| match e.kind() {
-        SimulatorErrorKind::SIRParser(ParserError::IllegalContext { feature, .. }) => {
-            assert_eq!(*feature, "array literal non-constant repeat");
+    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| {
+        match e.kind() {
+            SimulatorErrorKind::SIRParser(ParserError::IllegalContext { feature, .. }) => {
+                assert_eq!(*feature, "array literal non-constant repeat");
+            }
+            k => panic!("expected IllegalContext for non-constant repeat array literal, got {k:?}"),
         }
-        k => panic!("expected IllegalContext for non-constant repeat array literal, got {k:?}"),
     });
 }
 
@@ -873,10 +877,12 @@ fn test_ff_array_literal_width_overflow_is_illegal_context() {
         }
     "#;
 
-    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| match e.kind() {
-        SimulatorErrorKind::SIRParser(ParserError::IllegalContext { feature, .. }) => {
-            assert_eq!(*feature, "array literal width overflow");
+    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| {
+        match e.kind() {
+            SimulatorErrorKind::SIRParser(ParserError::IllegalContext { feature, .. }) => {
+                assert_eq!(*feature, "array literal width overflow");
+            }
+            k => panic!("expected IllegalContext for array literal width overflow, got {k:?}"),
         }
-        k => panic!("expected IllegalContext for array literal width overflow, got {k:?}"),
     });
 }

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -691,6 +691,34 @@ fn test_ff_struct_constructor_expression_literal_order(sim) {
     assert_eq!(sim.get(out_b), 0x34u32.into());
 }
 
+fn test_ff_struct_constructor_signed_member_extension(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            in_neg: input i8,
+            out_pad: output i16
+        ) {
+            struct S {
+                x: i16,
+            }
+            var r: S;
+            always_ff (clk) {
+                r = S'{x: in_neg};
+            }
+            assign out_pad = r.x;
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let in_neg = sim.signal("in_neg");
+    let out_pad = sim.signal("out_pad");
+
+    sim.modify(|io| io.set(in_neg, 0xFFu8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_pad), 0xFFFFu32.into());
+}
+
 fn test_ff_array_literal_expression_order(sim) {
     @ignore_on(veryl);
     @setup { let code = r#"

--- a/crates/celox/tests/four_state.rs
+++ b/crates/celox/tests/four_state.rs
@@ -116,6 +116,43 @@ fn test_four_state_initial_and_set(sim) {
     );
 }
 
+fn test_ff_struct_logic_to_bit_coercion_clears_mask(sim) {
+    @ignore_on(veryl);
+    @setup {
+    let code = r#"
+        module Top (
+            clk: input clock,
+            in_logic: input logic<8>,
+            out_bit: output bit<8>
+        ) {
+            struct S {
+                x: bit<8>,
+            }
+            var r: S;
+            always_ff (clk) {
+                r = S'{x: in_logic};
+            }
+            assign out_bit = r.x;
+        }
+    "#;
+    }
+    @build SimulatorBuilder::new(code, "Top")
+        .four_state(true);
+
+    let clk = sim.event("clk");
+    let in_logic = sim.signal("in_logic");
+    let out_bit = sim.signal("out_bit");
+
+    sim.modify(|io| {
+        io.set_four_state(in_logic, BigUint::from(0xA5u32), BigUint::from(0x0Fu32));
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+
+    let (_value, mask) = sim.get_four_state(out_bit);
+    assert_eq!(mask, BigUint::from(0u32), "logic -> bit coercion must clear X/Z mask");
+}
+
 fn test_four_state_mixing(sim) {
     @ignore_on(veryl);
     @setup {

--- a/crates/celox/tests/snapshots/flip_flop__async_reset_sir.snap
+++ b/crates/celox/tests/snapshots/flip_flop__async_reset_sir.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/celox/tests/flip_flop.rs
-assertion_line: 891
+assertion_line: 1895
 expression: sir_output
 ---
 === Evaluation Flip-Flops (eval_apply_ffs) ===
@@ -11,7 +11,7 @@ Trigger Group: clk (AbsoluteAddr(inst0, var0))
       r0: logic<1>
       r1: bit<32>
       r2: bit<8>
-      r3: logic<8>
+      r3: bit<8>
       r4: logic<8>
     b0:
       r0 = Load(addr=rst (region=0), offset=0, bits=1)
@@ -35,7 +35,7 @@ Trigger Group: rst (AbsoluteAddr(inst0, var1))
       r0: logic<1>
       r1: bit<32>
       r2: bit<8>
-      r3: logic<8>
+      r3: bit<8>
       r4: logic<8>
     b0:
       r0 = Load(addr=rst (region=0), offset=0, bits=1)
@@ -61,7 +61,7 @@ Trigger Group: clk (AbsoluteAddr(inst0, var0))
       r0: logic<1>
       r1: bit<32>
       r2: bit<8>
-      r3: logic<8>
+      r3: bit<8>
       r4: logic<8>
     b0:
       Commit(src=q (region=0), dst=q (region=1), offset=0, bits=8)
@@ -86,7 +86,7 @@ Trigger Group: rst (AbsoluteAddr(inst0, var1))
       r0: logic<1>
       r1: bit<32>
       r2: bit<8>
-      r3: logic<8>
+      r3: bit<8>
       r4: logic<8>
     b0:
       Commit(src=q (region=0), dst=q (region=1), offset=0, bits=8)

--- a/crates/celox/tests/snapshots/flip_flop__commit_sinking_multi_store_sir.snap
+++ b/crates/celox/tests/snapshots/flip_flop__commit_sinking_multi_store_sir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/celox/tests/flip_flop.rs
+assertion_line: 1816
 expression: output
 ---
 === Evaluation Flip-Flops (eval_apply_ffs) ===
@@ -11,16 +12,16 @@ Trigger Group: clk (AbsoluteAddr(inst0, var0))
       r1: bit<1>
       r2: bit<32>
       r3: bit<8>
-      r4: logic<8>
+      r4: bit<8>
       r5: bit<32>
       r6: bit<8>
-      r7: logic<8>
+      r7: bit<8>
       r8: bit<32>
       r9: bit<8>
-      r10: logic<8>
+      r10: bit<8>
       r11: bit<32>
       r12: bit<8>
-      r13: logic<8>
+      r13: bit<8>
     b0:
       r0 = Load(addr=rst (region=0), offset=0, bits=1)
       r1 = LogicNot r0
@@ -51,16 +52,16 @@ Trigger Group: rst (AbsoluteAddr(inst0, var1))
       r1: bit<1>
       r2: bit<32>
       r3: bit<8>
-      r4: logic<8>
+      r4: bit<8>
       r5: bit<32>
       r6: bit<8>
-      r7: logic<8>
+      r7: bit<8>
       r8: bit<32>
       r9: bit<8>
-      r10: logic<8>
+      r10: bit<8>
       r11: bit<32>
       r12: bit<8>
-      r13: logic<8>
+      r13: bit<8>
     b0:
       r0 = Load(addr=rst (region=0), offset=0, bits=1)
       r1 = LogicNot r0
@@ -93,16 +94,16 @@ Trigger Group: clk (AbsoluteAddr(inst0, var0))
       r1: bit<1>
       r2: bit<32>
       r3: bit<8>
-      r4: logic<8>
+      r4: bit<8>
       r5: bit<32>
       r6: bit<8>
-      r7: logic<8>
+      r7: bit<8>
       r8: bit<32>
       r9: bit<8>
-      r10: logic<8>
+      r10: bit<8>
       r11: bit<32>
       r12: bit<8>
-      r13: logic<8>
+      r13: bit<8>
     b0:
       Commit(src=a (region=0), dst=a (region=1), offset=0, bits=8)
       Commit(src=b (region=0), dst=b (region=1), offset=0, bits=8)
@@ -135,16 +136,16 @@ Trigger Group: rst (AbsoluteAddr(inst0, var1))
       r1: bit<1>
       r2: bit<32>
       r3: bit<8>
-      r4: logic<8>
+      r4: bit<8>
       r5: bit<32>
       r6: bit<8>
-      r7: logic<8>
+      r7: bit<8>
       r8: bit<32>
       r9: bit<8>
-      r10: logic<8>
+      r10: bit<8>
       r11: bit<32>
       r12: bit<8>
-      r13: logic<8>
+      r13: bit<8>
     b0:
       Commit(src=a (region=0), dst=a (region=1), offset=0, bits=8)
       Commit(src=b (region=0), dst=b (region=1), offset=0, bits=8)


### PR DESCRIPTION
## Summary
- fix FF struct/member coercion so signed widening and logic-to-bit coercion preserve the intended simulation semantics
- tighten several FF array-literal diagnostics from generic `unsupported` to clearer invalid-context errors
- add regression coverage for signed struct-member extension, logic-to-bit mask clearing, and FF array-literal diagnostic paths
- update affected FF SIR snapshots after the coercion changes

## Why
Issue #68 tracks remaining FF expression-lowering gaps. This branch does not close the issue, but it removes a few concrete correctness and diagnostics problems in the FF path:
- signed struct/member coercion could lose signedness in FF lowering
- unsigned `logic -> bit` coercion could leave a 4-state register uncoerced
- some clearly invalid FF array-literal forms still surfaced as generic `unsupported`

## Scope
Partially addresses #68.

Remaining tracked #68 work still includes at least:
- `as cast target`
- `pow non-constant exponent`
- `array literal default without context width`
- `array literal default width mismatch`

## Validation
- targeted regression tests for FF signed coercion and logic-to-bit coercion
- `cargo test -p celox --test error_detection -- --nocapture`
- `cargo test -p celox --test flip_flop test_ff_struct_constructor_signed_member_extension -- --nocapture`
- `cargo test -p celox --test four_state test_ff_struct_logic_to_bit_coercion_clears_mask -- --nocapture`
- full pre-push hook suite (`cargo fmt`, `biome`, `cargo clippy`, Rust test suite, workspace build/test)
