### PR TITLE
[codex] fix playground 4-state example compilation

### DIFF
--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -14,7 +14,12 @@ import {
 	buildVirtualModuleDts,
 	extractPortsFromSource,
 	type VirtualPortInfo,
-} from "./playground-dts.js";
+} from "./virtual-module-dts.js";
+import {
+	FourState,
+	X,
+	Z,
+} from "./playground-runtime-helpers.js";
 import { transpileTestbench } from "./testbench-transpile.js";
 import {
 	generateVcdText,
@@ -1969,6 +1974,9 @@ async function run() {
 				"afterEach",
 				"Simulator",
 				"Simulation",
+				"FourState",
+				"X",
+				"Z",
 				"console",
 				...moduleNames,
 			];
@@ -1981,6 +1989,9 @@ async function run() {
 				() => {},
 				Simulator,
 				Simulation,
+				FourState,
+				X,
+				Z,
 				playgroundConsole,
 				...moduleNames.map((n: string) => moduleBindings[n]),
 			];

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -10,17 +10,13 @@ import celoxSimulatorDts from "../../celox/dist/simulator.d.ts?raw";
 import celoxTypesDts from "../../celox/dist/types.d.ts?raw";
 import celoxWasmBridgeDts from "../../celox/dist/wasm-bridge.d.ts?raw";
 import { buildMonacoTestbenchCompilerOptions } from "./monaco-testbench-options.js";
+import { FourState, X, Z } from "./playground-runtime-helpers.js";
+import { transpileTestbench } from "./testbench-transpile.js";
 import {
 	buildVirtualModuleDts,
 	extractPortsFromSource,
 	type VirtualPortInfo,
 } from "./virtual-module-dts.js";
-import {
-	FourState,
-	X,
-	Z,
-} from "./playground-runtime-helpers.js";
-import { transpileTestbench } from "./testbench-transpile.js";
 import {
 	generateVcdText,
 	type VcdSignalInfo,

--- a/packages/playground/src/playground-runtime-helpers.ts
+++ b/packages/playground/src/playground-runtime-helpers.ts
@@ -1,0 +1,10 @@
+export const X = Symbol.for("veryl:X");
+export const Z = Symbol.for("veryl:Z");
+
+export function FourState(value: number | bigint, mask: number | bigint) {
+	return {
+		__fourState: true as const,
+		value: BigInt(value),
+		mask: BigInt(mask),
+	};
+}

--- a/packages/playground/src/virtual-module-dts.ts
+++ b/packages/playground/src/virtual-module-dts.ts
@@ -1,0 +1,76 @@
+export type VirtualPortDirection = "input" | "output" | "inout";
+export type VirtualPortKind = "logic" | "bit" | "clock" | "reset";
+
+export interface VirtualPortInfo {
+	direction: VirtualPortDirection;
+	kind: VirtualPortKind;
+	width: number;
+	is4state: boolean;
+}
+
+function isFourStatePortKind(kind: VirtualPortKind): boolean {
+	return kind === "logic" || kind === "clock" || kind === "reset";
+}
+
+function setterTypeForPort(port: VirtualPortInfo): string {
+	return port.is4state ? "FourStateSignalValue" : "bigint";
+}
+
+function needsFourStateImport(ports: Record<string, VirtualPortInfo>): boolean {
+	return Object.values(ports).some(
+		(port) =>
+			port.kind !== "clock" && port.direction !== "output" && port.is4state,
+	);
+}
+
+export function buildVirtualModuleDts(
+	moduleName: string,
+	ports: Record<string, VirtualPortInfo>,
+): string {
+	const importLine = needsFourStateImport(ports)
+		? 'import type { FourStateSignalValue, ModuleDefinition } from "@celox-sim/celox";'
+		: 'import type { ModuleDefinition } from "@celox-sim/celox";';
+
+	const portEntries = Object.entries(ports)
+		.filter(([, port]) => port.kind !== "clock")
+		.map(([name, port]) => {
+			if (port.direction === "output") {
+				return `  readonly ${name}: bigint;`;
+			}
+			return [
+				`  get ${name}(): bigint;`,
+				`  set ${name}(value: ${setterTypeForPort(port)});`,
+			].join("\n");
+		})
+		.join("\n");
+
+	return `${importLine}
+
+export interface ${moduleName}Ports {
+${portEntries}
+}
+
+export declare const ${moduleName}: ModuleDefinition<${moduleName}Ports>;
+`;
+}
+
+export function extractPortsFromSource(
+	source: string,
+): Record<string, VirtualPortInfo> {
+	const ports: Record<string, VirtualPortInfo> = {};
+	const portRe =
+		/(\w+)\s*:\s*(input|output|inout)\s+(?:'[_a-zA-Z]*\s+)?(logic|bit|clock|reset)(?:<(\d+)>)?/g;
+	let match: RegExpExecArray | null;
+
+	while ((match = portRe.exec(source)) !== null) {
+		const kind = match[3] as VirtualPortKind;
+		ports[match[1]] = {
+			direction: match[2] as VirtualPortDirection,
+			kind,
+			width: match[4] ? parseInt(match[4], 10) : 1,
+			is4state: isFourStatePortKind(kind),
+		};
+	}
+
+	return ports;
+}

--- a/packages/playground/test/playground-runtime-helpers.test.ts
+++ b/packages/playground/test/playground-runtime-helpers.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest";
+
+import { FourState, X, Z } from "../src/playground-runtime-helpers";
+
+describe("playground-runtime-helpers", () => {
+	test("provides 4-state sentinels compatible with celox runtime encoding", () => {
+		expect(X).toBe(Symbol.for("veryl:X"));
+		expect(Z).toBe(Symbol.for("veryl:Z"));
+
+		const value = FourState(0x05, 0xf0);
+
+		expect(value).toEqual({
+			__fourState: true,
+			value: 0x05n,
+			mask: 0xf0n,
+		});
+	});
+});

--- a/packages/playground/test/virtual-module-dts.test.ts
+++ b/packages/playground/test/virtual-module-dts.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	buildVirtualModuleDts,
+	extractPortsFromSource,
+} from "../src/virtual-module-dts";
+
+describe("virtual-module-dts", () => {
+	test("4-state inputs accept FourStateSignalValue in virtual module DTS", () => {
+		const ports = extractPortsFromSource(`module FourStateDemo (
+    a: input logic<8>,
+    b: input logic<8>,
+    snapshot: output logic<8>,
+) {
+    assign snapshot = a;
+}`);
+
+		const dts = buildVirtualModuleDts("FourStateDemo", ports);
+
+		expect(dts).toContain("import type { FourStateSignalValue, ModuleDefinition }");
+		expect(dts).toContain("get a(): bigint;");
+		expect(dts).toContain("set a(value: FourStateSignalValue);");
+		expect(dts).toContain("readonly snapshot: bigint;");
+	});
+
+	test("clock ports are excluded and bit inputs stay bigint-writable", () => {
+		const ports = extractPortsFromSource(`module Counter (
+    clk: input clock,
+    en: input bit,
+    count: output logic<8>,
+) {
+}`);
+
+		const dts = buildVirtualModuleDts("Counter", ports);
+
+		expect(dts).not.toContain("clk");
+		expect(dts).toContain("set en(value: bigint);");
+		expect(dts).toContain("readonly count: bigint;");
+	});
+});


### PR DESCRIPTION
## Summary
Fix the playground 4-state example so its testbench can use `X`, `Z`, and `FourState` at runtime again, and restore 4-state-aware virtual `.veryl` DTS generation.

## What Changed
- inject `FourState`, `X`, and `Z` into the playground testbench runtime context
- move virtual module DTS generation into a dedicated helper and restore `FourStateSignalValue` setters for 4-state input ports
- add focused tests for runtime helpers and virtual module DTS generation
- apply the import formatting required by the pre-push checks

## Root Cause
The playground testbench transpilation strips import statements before execution, but the runtime context no longer provided the 4-state helpers those testbenches referenced. In parallel, the simplified virtual module type generation had dropped the 4-state setter typing used by `.veryl` imports.

## Validation
- `pnpm --filter @celox-sim/playground test -- test/virtual-module-dts.test.ts test/playground-runtime-helpers.test.ts test/transpile.test.ts`
- repository pre-push hook: `biome`, `cargo-fmt`, `cargo-clippy`

Closes #81