### PR TITLE
[codex] support onehot system function in comb functions

### DIFF
--- a/crates/celox-macros/src/generator/snapshots/celox_macros__generator__test_generator__tests__generate_full_project.snap
+++ b/crates/celox-macros/src/generator/snapshots/celox_macros__generator__test_generator__tests__generate_full_project.snap
@@ -6456,6 +6456,48 @@ pub struct test_lzc_128IO<'a, 'b> {
     ids: &'a test_lzc_128,
 }
 impl<'a, 'b> test_lzc_128IO<'a, 'b> {}
+pub struct test_utils_clog2_clipped {}
+impl test_utils_clog2_clipped {
+    pub fn new(sim: &celox::Simulator) -> Self {
+        Self {}
+    }
+    pub fn bind<'a>(
+        &'a self,
+        sim: &'a mut celox::Simulator,
+    ) -> test_utils_clog2_clippedBound<'a> {
+        test_utils_clog2_clippedBound {
+            sim,
+            ids: self,
+        }
+    }
+    pub fn tick(&self, sim: &mut celox::Simulator) {}
+}
+pub struct test_utils_clog2_clippedBound<'a> {
+    sim: &'a mut celox::Simulator,
+    ids: &'a test_utils_clog2_clipped,
+}
+impl<'a> test_utils_clog2_clippedBound<'a> {
+    pub fn tick(&mut self) {}
+    pub fn modify<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut test_utils_clog2_clippedIO<'_, '_>),
+    {
+        self.sim
+            .modify(|io| {
+                let mut a_io = test_utils_clog2_clippedIO {
+                    io,
+                    ids: self.ids,
+                };
+                f(&mut a_io);
+            })
+            .unwrap();
+    }
+}
+pub struct test_utils_clog2_clippedIO<'a, 'b> {
+    io: &'a mut celox::IOContext<'b>,
+    ids: &'a test_utils_clog2_clipped,
+}
+impl<'a, 'b> test_utils_clog2_clippedIO<'a, 'b> {}
 pub struct ram {
     pub i_adrb: celox::SignalRef,
     pub i_adra: celox::SignalRef,
@@ -6868,38 +6910,17 @@ impl<'a, 'b> ramIO<'a, 'b> {
     }
 }
 pub struct demux {
-    pub o_data: celox::SignalRef,
     pub i_select: celox::SignalRef,
     pub i_data: celox::SignalRef,
+    pub o_data: celox::SignalRef,
 }
 impl demux {
     pub fn new(sim: &celox::Simulator) -> Self {
         Self {
-            o_data: sim.signal("o_data"),
             i_select: sim.signal("i_select"),
             i_data: sim.signal("i_data"),
+            o_data: sim.signal("o_data"),
         }
-    }
-    pub fn set_o_data(&self, sim: &mut celox::Simulator, val: u8) {
-        sim.modify(|io| io.set(self.o_data, val)).unwrap();
-    }
-    pub fn get_o_data(&self, sim: &mut celox::Simulator) -> u8 {
-        let val = sim.get(self.o_data);
-        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "o_data"))
-    }
-    pub fn set_o_data_4state(
-        &self,
-        sim: &mut celox::Simulator,
-        val: celox::BigUint,
-        mask: celox::BigUint,
-    ) {
-        sim.modify(|io| io.set_four_state(self.o_data, val, mask)).unwrap();
-    }
-    pub fn get_o_data_4state(
-        &self,
-        sim: &mut celox::Simulator,
-    ) -> (celox::BigUint, celox::BigUint) {
-        sim.get_four_state(self.o_data)
     }
     pub fn set_i_select(&self, sim: &mut celox::Simulator, val: u8) {
         sim.modify(|io| io.set(self.i_select, val)).unwrap();
@@ -6943,6 +6964,27 @@ impl demux {
     ) -> (celox::BigUint, celox::BigUint) {
         sim.get_four_state(self.i_data)
     }
+    pub fn set_o_data(&self, sim: &mut celox::Simulator, val: u8) {
+        sim.modify(|io| io.set(self.o_data, val)).unwrap();
+    }
+    pub fn get_o_data(&self, sim: &mut celox::Simulator) -> u8 {
+        let val = sim.get(self.o_data);
+        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "o_data"))
+    }
+    pub fn set_o_data_4state(
+        &self,
+        sim: &mut celox::Simulator,
+        val: celox::BigUint,
+        mask: celox::BigUint,
+    ) {
+        sim.modify(|io| io.set_four_state(self.o_data, val, mask)).unwrap();
+    }
+    pub fn get_o_data_4state(
+        &self,
+        sim: &mut celox::Simulator,
+    ) -> (celox::BigUint, celox::BigUint) {
+        sim.get_four_state(self.o_data)
+    }
     pub fn bind<'a>(&'a self, sim: &'a mut celox::Simulator) -> demuxBound<'a> {
         demuxBound { sim, ids: self }
     }
@@ -6953,18 +6995,6 @@ pub struct demuxBound<'a> {
     ids: &'a demux,
 }
 impl<'a> demuxBound<'a> {
-    pub fn set_o_data(&mut self, val: u8) {
-        self.ids.set_o_data(self.sim, val);
-    }
-    pub fn get_o_data(&mut self) -> u8 {
-        self.ids.get_o_data(self.sim)
-    }
-    pub fn set_o_data_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.ids.set_o_data_4state(self.sim, val, mask);
-    }
-    pub fn get_o_data_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
-        self.ids.get_o_data_4state(self.sim)
-    }
     pub fn set_i_select(&mut self, val: u8) {
         self.ids.set_i_select(self.sim, val);
     }
@@ -6988,6 +7018,18 @@ impl<'a> demuxBound<'a> {
     }
     pub fn get_i_data_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
         self.ids.get_i_data_4state(self.sim)
+    }
+    pub fn set_o_data(&mut self, val: u8) {
+        self.ids.set_o_data(self.sim, val);
+    }
+    pub fn get_o_data(&mut self) -> u8 {
+        self.ids.get_o_data(self.sim)
+    }
+    pub fn set_o_data_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.ids.set_o_data_4state(self.sim, val, mask);
+    }
+    pub fn get_o_data_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
+        self.ids.get_o_data_4state(self.sim)
     }
     pub fn tick(&mut self) {}
     pub fn modify<F>(&mut self, f: F)
@@ -7007,12 +7049,6 @@ pub struct demuxIO<'a, 'b> {
     ids: &'a demux,
 }
 impl<'a, 'b> demuxIO<'a, 'b> {
-    pub fn set_o_data(&mut self, val: u8) {
-        self.io.set(self.ids.o_data, val);
-    }
-    pub fn set_o_data_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.io.set_four_state(self.ids.o_data, val, mask);
-    }
     pub fn set_i_select(&mut self, val: u8) {
         self.io.set(self.ids.i_select, val);
     }
@@ -7025,40 +7061,25 @@ impl<'a, 'b> demuxIO<'a, 'b> {
     pub fn set_i_data_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
         self.io.set_four_state(self.ids.i_data, val, mask);
     }
+    pub fn set_o_data(&mut self, val: u8) {
+        self.io.set(self.ids.o_data, val);
+    }
+    pub fn set_o_data_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.io.set_four_state(self.ids.o_data, val, mask);
+    }
 }
 pub struct mux {
-    pub o_data: celox::SignalRef,
     pub i_data: celox::SignalRef,
     pub i_select: celox::SignalRef,
+    pub o_data: celox::SignalRef,
 }
 impl mux {
     pub fn new(sim: &celox::Simulator) -> Self {
         Self {
-            o_data: sim.signal("o_data"),
             i_data: sim.signal("i_data"),
             i_select: sim.signal("i_select"),
+            o_data: sim.signal("o_data"),
         }
-    }
-    pub fn set_o_data(&self, sim: &mut celox::Simulator, val: u8) {
-        sim.modify(|io| io.set(self.o_data, val)).unwrap();
-    }
-    pub fn get_o_data(&self, sim: &mut celox::Simulator) -> u8 {
-        let val = sim.get(self.o_data);
-        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "o_data"))
-    }
-    pub fn set_o_data_4state(
-        &self,
-        sim: &mut celox::Simulator,
-        val: celox::BigUint,
-        mask: celox::BigUint,
-    ) {
-        sim.modify(|io| io.set_four_state(self.o_data, val, mask)).unwrap();
-    }
-    pub fn get_o_data_4state(
-        &self,
-        sim: &mut celox::Simulator,
-    ) -> (celox::BigUint, celox::BigUint) {
-        sim.get_four_state(self.o_data)
     }
     pub fn set_i_data(&self, sim: &mut celox::Simulator, val: u8) {
         sim.modify(|io| io.set(self.i_data, val)).unwrap();
@@ -7102,6 +7123,27 @@ impl mux {
     ) -> (celox::BigUint, celox::BigUint) {
         sim.get_four_state(self.i_select)
     }
+    pub fn set_o_data(&self, sim: &mut celox::Simulator, val: u8) {
+        sim.modify(|io| io.set(self.o_data, val)).unwrap();
+    }
+    pub fn get_o_data(&self, sim: &mut celox::Simulator) -> u8 {
+        let val = sim.get(self.o_data);
+        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "o_data"))
+    }
+    pub fn set_o_data_4state(
+        &self,
+        sim: &mut celox::Simulator,
+        val: celox::BigUint,
+        mask: celox::BigUint,
+    ) {
+        sim.modify(|io| io.set_four_state(self.o_data, val, mask)).unwrap();
+    }
+    pub fn get_o_data_4state(
+        &self,
+        sim: &mut celox::Simulator,
+    ) -> (celox::BigUint, celox::BigUint) {
+        sim.get_four_state(self.o_data)
+    }
     pub fn bind<'a>(&'a self, sim: &'a mut celox::Simulator) -> muxBound<'a> {
         muxBound { sim, ids: self }
     }
@@ -7112,18 +7154,6 @@ pub struct muxBound<'a> {
     ids: &'a mux,
 }
 impl<'a> muxBound<'a> {
-    pub fn set_o_data(&mut self, val: u8) {
-        self.ids.set_o_data(self.sim, val);
-    }
-    pub fn get_o_data(&mut self) -> u8 {
-        self.ids.get_o_data(self.sim)
-    }
-    pub fn set_o_data_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.ids.set_o_data_4state(self.sim, val, mask);
-    }
-    pub fn get_o_data_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
-        self.ids.get_o_data_4state(self.sim)
-    }
     pub fn set_i_data(&mut self, val: u8) {
         self.ids.set_i_data(self.sim, val);
     }
@@ -7148,6 +7178,18 @@ impl<'a> muxBound<'a> {
     pub fn get_i_select_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
         self.ids.get_i_select_4state(self.sim)
     }
+    pub fn set_o_data(&mut self, val: u8) {
+        self.ids.set_o_data(self.sim, val);
+    }
+    pub fn get_o_data(&mut self) -> u8 {
+        self.ids.get_o_data(self.sim)
+    }
+    pub fn set_o_data_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.ids.set_o_data_4state(self.sim, val, mask);
+    }
+    pub fn get_o_data_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
+        self.ids.get_o_data_4state(self.sim)
+    }
     pub fn tick(&mut self) {}
     pub fn modify<F>(&mut self, f: F)
     where
@@ -7166,12 +7208,6 @@ pub struct muxIO<'a, 'b> {
     ids: &'a mux,
 }
 impl<'a, 'b> muxIO<'a, 'b> {
-    pub fn set_o_data(&mut self, val: u8) {
-        self.io.set(self.ids.o_data, val);
-    }
-    pub fn set_o_data_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.io.set_four_state(self.ids.o_data, val, mask);
-    }
     pub fn set_i_data(&mut self, val: u8) {
         self.io.set(self.ids.i_data, val);
     }
@@ -7183,6 +7219,12 @@ impl<'a, 'b> muxIO<'a, 'b> {
     }
     pub fn set_i_select_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
         self.io.set_four_state(self.ids.i_select, val, mask);
+    }
+    pub fn set_o_data(&mut self, val: u8) {
+        self.io.set(self.ids.o_data, val);
+    }
+    pub fn set_o_data_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.io.set_four_state(self.ids.o_data, val, mask);
     }
 }
 pub struct test_binary_mux {}
@@ -7312,48 +7354,27 @@ pub struct test_onehot_muxIO<'a, 'b> {
 }
 impl<'a, 'b> test_onehot_muxIO<'a, 'b> {}
 pub struct slicer {
-    pub i_valid: celox::SignalRef,
     pub i_data: celox::SignalRef,
     pub o_valid: celox::SignalRef,
     pub i_clk: celox::NativeEventRef,
-    pub i_ready: celox::SignalRef,
-    pub i_rst: celox::SignalRef,
     pub o_ready: celox::SignalRef,
+    pub i_valid: celox::SignalRef,
+    pub i_rst: celox::SignalRef,
+    pub i_ready: celox::SignalRef,
     pub o_data: celox::SignalRef,
 }
 impl slicer {
     pub fn new(sim: &celox::Simulator) -> Self {
         Self {
-            i_valid: sim.signal("i_valid"),
             i_data: sim.signal("i_data"),
             o_valid: sim.signal("o_valid"),
             i_clk: sim.event("i_clk"),
-            i_ready: sim.signal("i_ready"),
-            i_rst: sim.signal("i_rst"),
             o_ready: sim.signal("o_ready"),
+            i_valid: sim.signal("i_valid"),
+            i_rst: sim.signal("i_rst"),
+            i_ready: sim.signal("i_ready"),
             o_data: sim.signal("o_data"),
         }
-    }
-    pub fn set_i_valid(&self, sim: &mut celox::Simulator, val: u8) {
-        sim.modify(|io| io.set(self.i_valid, val)).unwrap();
-    }
-    pub fn get_i_valid(&self, sim: &mut celox::Simulator) -> u8 {
-        let val = sim.get(self.i_valid);
-        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "i_valid"))
-    }
-    pub fn set_i_valid_4state(
-        &self,
-        sim: &mut celox::Simulator,
-        val: celox::BigUint,
-        mask: celox::BigUint,
-    ) {
-        sim.modify(|io| io.set_four_state(self.i_valid, val, mask)).unwrap();
-    }
-    pub fn get_i_valid_4state(
-        &self,
-        sim: &mut celox::Simulator,
-    ) -> (celox::BigUint, celox::BigUint) {
-        sim.get_four_state(self.i_valid)
     }
     pub fn set_i_data(&self, sim: &mut celox::Simulator, val: u8) {
         sim.modify(|io| io.set(self.i_data, val)).unwrap();
@@ -7397,26 +7418,47 @@ impl slicer {
     ) -> (celox::BigUint, celox::BigUint) {
         sim.get_four_state(self.o_valid)
     }
-    pub fn set_i_ready(&self, sim: &mut celox::Simulator, val: u8) {
-        sim.modify(|io| io.set(self.i_ready, val)).unwrap();
+    pub fn set_o_ready(&self, sim: &mut celox::Simulator, val: u8) {
+        sim.modify(|io| io.set(self.o_ready, val)).unwrap();
     }
-    pub fn get_i_ready(&self, sim: &mut celox::Simulator) -> u8 {
-        let val = sim.get(self.i_ready);
-        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "i_ready"))
+    pub fn get_o_ready(&self, sim: &mut celox::Simulator) -> u8 {
+        let val = sim.get(self.o_ready);
+        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "o_ready"))
     }
-    pub fn set_i_ready_4state(
+    pub fn set_o_ready_4state(
         &self,
         sim: &mut celox::Simulator,
         val: celox::BigUint,
         mask: celox::BigUint,
     ) {
-        sim.modify(|io| io.set_four_state(self.i_ready, val, mask)).unwrap();
+        sim.modify(|io| io.set_four_state(self.o_ready, val, mask)).unwrap();
     }
-    pub fn get_i_ready_4state(
+    pub fn get_o_ready_4state(
         &self,
         sim: &mut celox::Simulator,
     ) -> (celox::BigUint, celox::BigUint) {
-        sim.get_four_state(self.i_ready)
+        sim.get_four_state(self.o_ready)
+    }
+    pub fn set_i_valid(&self, sim: &mut celox::Simulator, val: u8) {
+        sim.modify(|io| io.set(self.i_valid, val)).unwrap();
+    }
+    pub fn get_i_valid(&self, sim: &mut celox::Simulator) -> u8 {
+        let val = sim.get(self.i_valid);
+        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "i_valid"))
+    }
+    pub fn set_i_valid_4state(
+        &self,
+        sim: &mut celox::Simulator,
+        val: celox::BigUint,
+        mask: celox::BigUint,
+    ) {
+        sim.modify(|io| io.set_four_state(self.i_valid, val, mask)).unwrap();
+    }
+    pub fn get_i_valid_4state(
+        &self,
+        sim: &mut celox::Simulator,
+    ) -> (celox::BigUint, celox::BigUint) {
+        sim.get_four_state(self.i_valid)
     }
     pub fn set_i_rst(&self, sim: &mut celox::Simulator, val: u8) {
         sim.modify(|io| io.set(self.i_rst, val)).unwrap();
@@ -7439,26 +7481,26 @@ impl slicer {
     ) -> (celox::BigUint, celox::BigUint) {
         sim.get_four_state(self.i_rst)
     }
-    pub fn set_o_ready(&self, sim: &mut celox::Simulator, val: u8) {
-        sim.modify(|io| io.set(self.o_ready, val)).unwrap();
+    pub fn set_i_ready(&self, sim: &mut celox::Simulator, val: u8) {
+        sim.modify(|io| io.set(self.i_ready, val)).unwrap();
     }
-    pub fn get_o_ready(&self, sim: &mut celox::Simulator) -> u8 {
-        let val = sim.get(self.o_ready);
-        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "o_ready"))
+    pub fn get_i_ready(&self, sim: &mut celox::Simulator) -> u8 {
+        let val = sim.get(self.i_ready);
+        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "i_ready"))
     }
-    pub fn set_o_ready_4state(
+    pub fn set_i_ready_4state(
         &self,
         sim: &mut celox::Simulator,
         val: celox::BigUint,
         mask: celox::BigUint,
     ) {
-        sim.modify(|io| io.set_four_state(self.o_ready, val, mask)).unwrap();
+        sim.modify(|io| io.set_four_state(self.i_ready, val, mask)).unwrap();
     }
-    pub fn get_o_ready_4state(
+    pub fn get_i_ready_4state(
         &self,
         sim: &mut celox::Simulator,
     ) -> (celox::BigUint, celox::BigUint) {
-        sim.get_four_state(self.o_ready)
+        sim.get_four_state(self.i_ready)
     }
     pub fn set_o_data(&self, sim: &mut celox::Simulator, val: u8) {
         sim.modify(|io| io.set(self.o_data, val)).unwrap();
@@ -7493,18 +7535,6 @@ pub struct slicerBound<'a> {
     ids: &'a slicer,
 }
 impl<'a> slicerBound<'a> {
-    pub fn set_i_valid(&mut self, val: u8) {
-        self.ids.set_i_valid(self.sim, val);
-    }
-    pub fn get_i_valid(&mut self) -> u8 {
-        self.ids.get_i_valid(self.sim)
-    }
-    pub fn set_i_valid_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.ids.set_i_valid_4state(self.sim, val, mask);
-    }
-    pub fn get_i_valid_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
-        self.ids.get_i_valid_4state(self.sim)
-    }
     pub fn set_i_data(&mut self, val: u8) {
         self.ids.set_i_data(self.sim, val);
     }
@@ -7529,17 +7559,29 @@ impl<'a> slicerBound<'a> {
     pub fn get_o_valid_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
         self.ids.get_o_valid_4state(self.sim)
     }
-    pub fn set_i_ready(&mut self, val: u8) {
-        self.ids.set_i_ready(self.sim, val);
+    pub fn set_o_ready(&mut self, val: u8) {
+        self.ids.set_o_ready(self.sim, val);
     }
-    pub fn get_i_ready(&mut self) -> u8 {
-        self.ids.get_i_ready(self.sim)
+    pub fn get_o_ready(&mut self) -> u8 {
+        self.ids.get_o_ready(self.sim)
     }
-    pub fn set_i_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.ids.set_i_ready_4state(self.sim, val, mask);
+    pub fn set_o_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.ids.set_o_ready_4state(self.sim, val, mask);
     }
-    pub fn get_i_ready_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
-        self.ids.get_i_ready_4state(self.sim)
+    pub fn get_o_ready_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
+        self.ids.get_o_ready_4state(self.sim)
+    }
+    pub fn set_i_valid(&mut self, val: u8) {
+        self.ids.set_i_valid(self.sim, val);
+    }
+    pub fn get_i_valid(&mut self) -> u8 {
+        self.ids.get_i_valid(self.sim)
+    }
+    pub fn set_i_valid_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.ids.set_i_valid_4state(self.sim, val, mask);
+    }
+    pub fn get_i_valid_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
+        self.ids.get_i_valid_4state(self.sim)
     }
     pub fn set_i_rst(&mut self, val: u8) {
         self.ids.set_i_rst(self.sim, val);
@@ -7553,17 +7595,17 @@ impl<'a> slicerBound<'a> {
     pub fn get_i_rst_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
         self.ids.get_i_rst_4state(self.sim)
     }
-    pub fn set_o_ready(&mut self, val: u8) {
-        self.ids.set_o_ready(self.sim, val);
+    pub fn set_i_ready(&mut self, val: u8) {
+        self.ids.set_i_ready(self.sim, val);
     }
-    pub fn get_o_ready(&mut self) -> u8 {
-        self.ids.get_o_ready(self.sim)
+    pub fn get_i_ready(&mut self) -> u8 {
+        self.ids.get_i_ready(self.sim)
     }
-    pub fn set_o_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.ids.set_o_ready_4state(self.sim, val, mask);
+    pub fn set_i_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.ids.set_i_ready_4state(self.sim, val, mask);
     }
-    pub fn get_o_ready_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
-        self.ids.get_o_ready_4state(self.sim)
+    pub fn get_i_ready_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
+        self.ids.get_i_ready_4state(self.sim)
     }
     pub fn set_o_data(&mut self, val: u8) {
         self.ids.set_o_data(self.sim, val);
@@ -7597,12 +7639,6 @@ pub struct slicerIO<'a, 'b> {
     ids: &'a slicer,
 }
 impl<'a, 'b> slicerIO<'a, 'b> {
-    pub fn set_i_valid(&mut self, val: u8) {
-        self.io.set(self.ids.i_valid, val);
-    }
-    pub fn set_i_valid_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.io.set_four_state(self.ids.i_valid, val, mask);
-    }
     pub fn set_i_data(&mut self, val: u8) {
         self.io.set(self.ids.i_data, val);
     }
@@ -7615,11 +7651,17 @@ impl<'a, 'b> slicerIO<'a, 'b> {
     pub fn set_o_valid_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
         self.io.set_four_state(self.ids.o_valid, val, mask);
     }
-    pub fn set_i_ready(&mut self, val: u8) {
-        self.io.set(self.ids.i_ready, val);
+    pub fn set_o_ready(&mut self, val: u8) {
+        self.io.set(self.ids.o_ready, val);
     }
-    pub fn set_i_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.io.set_four_state(self.ids.i_ready, val, mask);
+    pub fn set_o_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.io.set_four_state(self.ids.o_ready, val, mask);
+    }
+    pub fn set_i_valid(&mut self, val: u8) {
+        self.io.set(self.ids.i_valid, val);
+    }
+    pub fn set_i_valid_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.io.set_four_state(self.ids.i_valid, val, mask);
     }
     pub fn set_i_rst(&mut self, val: u8) {
         self.io.set(self.ids.i_rst, val);
@@ -7627,11 +7669,11 @@ impl<'a, 'b> slicerIO<'a, 'b> {
     pub fn set_i_rst_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
         self.io.set_four_state(self.ids.i_rst, val, mask);
     }
-    pub fn set_o_ready(&mut self, val: u8) {
-        self.io.set(self.ids.o_ready, val);
+    pub fn set_i_ready(&mut self, val: u8) {
+        self.io.set(self.ids.i_ready, val);
     }
-    pub fn set_o_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.io.set_four_state(self.ids.o_ready, val, mask);
+    pub fn set_i_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.io.set_four_state(self.ids.i_ready, val, mask);
     }
     pub fn set_o_data(&mut self, val: u8) {
         self.io.set(self.ids.o_data, val);
@@ -7641,48 +7683,27 @@ impl<'a, 'b> slicerIO<'a, 'b> {
     }
 }
 pub struct slicer_unit_fb {
-    pub i_valid: celox::SignalRef,
     pub i_data: celox::SignalRef,
     pub o_valid: celox::SignalRef,
     pub i_clk: celox::NativeEventRef,
-    pub i_ready: celox::SignalRef,
-    pub i_rst: celox::SignalRef,
     pub o_ready: celox::SignalRef,
+    pub i_valid: celox::SignalRef,
+    pub i_rst: celox::SignalRef,
+    pub i_ready: celox::SignalRef,
     pub o_data: celox::SignalRef,
 }
 impl slicer_unit_fb {
     pub fn new(sim: &celox::Simulator) -> Self {
         Self {
-            i_valid: sim.signal("i_valid"),
             i_data: sim.signal("i_data"),
             o_valid: sim.signal("o_valid"),
             i_clk: sim.event("i_clk"),
-            i_ready: sim.signal("i_ready"),
-            i_rst: sim.signal("i_rst"),
             o_ready: sim.signal("o_ready"),
+            i_valid: sim.signal("i_valid"),
+            i_rst: sim.signal("i_rst"),
+            i_ready: sim.signal("i_ready"),
             o_data: sim.signal("o_data"),
         }
-    }
-    pub fn set_i_valid(&self, sim: &mut celox::Simulator, val: u8) {
-        sim.modify(|io| io.set(self.i_valid, val)).unwrap();
-    }
-    pub fn get_i_valid(&self, sim: &mut celox::Simulator) -> u8 {
-        let val = sim.get(self.i_valid);
-        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "i_valid"))
-    }
-    pub fn set_i_valid_4state(
-        &self,
-        sim: &mut celox::Simulator,
-        val: celox::BigUint,
-        mask: celox::BigUint,
-    ) {
-        sim.modify(|io| io.set_four_state(self.i_valid, val, mask)).unwrap();
-    }
-    pub fn get_i_valid_4state(
-        &self,
-        sim: &mut celox::Simulator,
-    ) -> (celox::BigUint, celox::BigUint) {
-        sim.get_four_state(self.i_valid)
     }
     pub fn set_i_data(&self, sim: &mut celox::Simulator, val: u8) {
         sim.modify(|io| io.set(self.i_data, val)).unwrap();
@@ -7726,26 +7747,47 @@ impl slicer_unit_fb {
     ) -> (celox::BigUint, celox::BigUint) {
         sim.get_four_state(self.o_valid)
     }
-    pub fn set_i_ready(&self, sim: &mut celox::Simulator, val: u8) {
-        sim.modify(|io| io.set(self.i_ready, val)).unwrap();
+    pub fn set_o_ready(&self, sim: &mut celox::Simulator, val: u8) {
+        sim.modify(|io| io.set(self.o_ready, val)).unwrap();
     }
-    pub fn get_i_ready(&self, sim: &mut celox::Simulator) -> u8 {
-        let val = sim.get(self.i_ready);
-        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "i_ready"))
+    pub fn get_o_ready(&self, sim: &mut celox::Simulator) -> u8 {
+        let val = sim.get(self.o_ready);
+        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "o_ready"))
     }
-    pub fn set_i_ready_4state(
+    pub fn set_o_ready_4state(
         &self,
         sim: &mut celox::Simulator,
         val: celox::BigUint,
         mask: celox::BigUint,
     ) {
-        sim.modify(|io| io.set_four_state(self.i_ready, val, mask)).unwrap();
+        sim.modify(|io| io.set_four_state(self.o_ready, val, mask)).unwrap();
     }
-    pub fn get_i_ready_4state(
+    pub fn get_o_ready_4state(
         &self,
         sim: &mut celox::Simulator,
     ) -> (celox::BigUint, celox::BigUint) {
-        sim.get_four_state(self.i_ready)
+        sim.get_four_state(self.o_ready)
+    }
+    pub fn set_i_valid(&self, sim: &mut celox::Simulator, val: u8) {
+        sim.modify(|io| io.set(self.i_valid, val)).unwrap();
+    }
+    pub fn get_i_valid(&self, sim: &mut celox::Simulator) -> u8 {
+        let val = sim.get(self.i_valid);
+        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "i_valid"))
+    }
+    pub fn set_i_valid_4state(
+        &self,
+        sim: &mut celox::Simulator,
+        val: celox::BigUint,
+        mask: celox::BigUint,
+    ) {
+        sim.modify(|io| io.set_four_state(self.i_valid, val, mask)).unwrap();
+    }
+    pub fn get_i_valid_4state(
+        &self,
+        sim: &mut celox::Simulator,
+    ) -> (celox::BigUint, celox::BigUint) {
+        sim.get_four_state(self.i_valid)
     }
     pub fn set_i_rst(&self, sim: &mut celox::Simulator, val: u8) {
         sim.modify(|io| io.set(self.i_rst, val)).unwrap();
@@ -7768,26 +7810,26 @@ impl slicer_unit_fb {
     ) -> (celox::BigUint, celox::BigUint) {
         sim.get_four_state(self.i_rst)
     }
-    pub fn set_o_ready(&self, sim: &mut celox::Simulator, val: u8) {
-        sim.modify(|io| io.set(self.o_ready, val)).unwrap();
+    pub fn set_i_ready(&self, sim: &mut celox::Simulator, val: u8) {
+        sim.modify(|io| io.set(self.i_ready, val)).unwrap();
     }
-    pub fn get_o_ready(&self, sim: &mut celox::Simulator) -> u8 {
-        let val = sim.get(self.o_ready);
-        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "o_ready"))
+    pub fn get_i_ready(&self, sim: &mut celox::Simulator) -> u8 {
+        let val = sim.get(self.i_ready);
+        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "i_ready"))
     }
-    pub fn set_o_ready_4state(
+    pub fn set_i_ready_4state(
         &self,
         sim: &mut celox::Simulator,
         val: celox::BigUint,
         mask: celox::BigUint,
     ) {
-        sim.modify(|io| io.set_four_state(self.o_ready, val, mask)).unwrap();
+        sim.modify(|io| io.set_four_state(self.i_ready, val, mask)).unwrap();
     }
-    pub fn get_o_ready_4state(
+    pub fn get_i_ready_4state(
         &self,
         sim: &mut celox::Simulator,
     ) -> (celox::BigUint, celox::BigUint) {
-        sim.get_four_state(self.o_ready)
+        sim.get_four_state(self.i_ready)
     }
     pub fn set_o_data(&self, sim: &mut celox::Simulator, val: u8) {
         sim.modify(|io| io.set(self.o_data, val)).unwrap();
@@ -7825,18 +7867,6 @@ pub struct slicer_unit_fbBound<'a> {
     ids: &'a slicer_unit_fb,
 }
 impl<'a> slicer_unit_fbBound<'a> {
-    pub fn set_i_valid(&mut self, val: u8) {
-        self.ids.set_i_valid(self.sim, val);
-    }
-    pub fn get_i_valid(&mut self) -> u8 {
-        self.ids.get_i_valid(self.sim)
-    }
-    pub fn set_i_valid_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.ids.set_i_valid_4state(self.sim, val, mask);
-    }
-    pub fn get_i_valid_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
-        self.ids.get_i_valid_4state(self.sim)
-    }
     pub fn set_i_data(&mut self, val: u8) {
         self.ids.set_i_data(self.sim, val);
     }
@@ -7861,17 +7891,29 @@ impl<'a> slicer_unit_fbBound<'a> {
     pub fn get_o_valid_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
         self.ids.get_o_valid_4state(self.sim)
     }
-    pub fn set_i_ready(&mut self, val: u8) {
-        self.ids.set_i_ready(self.sim, val);
+    pub fn set_o_ready(&mut self, val: u8) {
+        self.ids.set_o_ready(self.sim, val);
     }
-    pub fn get_i_ready(&mut self) -> u8 {
-        self.ids.get_i_ready(self.sim)
+    pub fn get_o_ready(&mut self) -> u8 {
+        self.ids.get_o_ready(self.sim)
     }
-    pub fn set_i_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.ids.set_i_ready_4state(self.sim, val, mask);
+    pub fn set_o_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.ids.set_o_ready_4state(self.sim, val, mask);
     }
-    pub fn get_i_ready_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
-        self.ids.get_i_ready_4state(self.sim)
+    pub fn get_o_ready_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
+        self.ids.get_o_ready_4state(self.sim)
+    }
+    pub fn set_i_valid(&mut self, val: u8) {
+        self.ids.set_i_valid(self.sim, val);
+    }
+    pub fn get_i_valid(&mut self) -> u8 {
+        self.ids.get_i_valid(self.sim)
+    }
+    pub fn set_i_valid_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.ids.set_i_valid_4state(self.sim, val, mask);
+    }
+    pub fn get_i_valid_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
+        self.ids.get_i_valid_4state(self.sim)
     }
     pub fn set_i_rst(&mut self, val: u8) {
         self.ids.set_i_rst(self.sim, val);
@@ -7885,17 +7927,17 @@ impl<'a> slicer_unit_fbBound<'a> {
     pub fn get_i_rst_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
         self.ids.get_i_rst_4state(self.sim)
     }
-    pub fn set_o_ready(&mut self, val: u8) {
-        self.ids.set_o_ready(self.sim, val);
+    pub fn set_i_ready(&mut self, val: u8) {
+        self.ids.set_i_ready(self.sim, val);
     }
-    pub fn get_o_ready(&mut self) -> u8 {
-        self.ids.get_o_ready(self.sim)
+    pub fn get_i_ready(&mut self) -> u8 {
+        self.ids.get_i_ready(self.sim)
     }
-    pub fn set_o_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.ids.set_o_ready_4state(self.sim, val, mask);
+    pub fn set_i_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.ids.set_i_ready_4state(self.sim, val, mask);
     }
-    pub fn get_o_ready_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
-        self.ids.get_o_ready_4state(self.sim)
+    pub fn get_i_ready_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
+        self.ids.get_i_ready_4state(self.sim)
     }
     pub fn set_o_data(&mut self, val: u8) {
         self.ids.set_o_data(self.sim, val);
@@ -7932,12 +7974,6 @@ pub struct slicer_unit_fbIO<'a, 'b> {
     ids: &'a slicer_unit_fb,
 }
 impl<'a, 'b> slicer_unit_fbIO<'a, 'b> {
-    pub fn set_i_valid(&mut self, val: u8) {
-        self.io.set(self.ids.i_valid, val);
-    }
-    pub fn set_i_valid_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.io.set_four_state(self.ids.i_valid, val, mask);
-    }
     pub fn set_i_data(&mut self, val: u8) {
         self.io.set(self.ids.i_data, val);
     }
@@ -7950,11 +7986,17 @@ impl<'a, 'b> slicer_unit_fbIO<'a, 'b> {
     pub fn set_o_valid_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
         self.io.set_four_state(self.ids.o_valid, val, mask);
     }
-    pub fn set_i_ready(&mut self, val: u8) {
-        self.io.set(self.ids.i_ready, val);
+    pub fn set_o_ready(&mut self, val: u8) {
+        self.io.set(self.ids.o_ready, val);
     }
-    pub fn set_i_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.io.set_four_state(self.ids.i_ready, val, mask);
+    pub fn set_o_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.io.set_four_state(self.ids.o_ready, val, mask);
+    }
+    pub fn set_i_valid(&mut self, val: u8) {
+        self.io.set(self.ids.i_valid, val);
+    }
+    pub fn set_i_valid_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.io.set_four_state(self.ids.i_valid, val, mask);
     }
     pub fn set_i_rst(&mut self, val: u8) {
         self.io.set(self.ids.i_rst, val);
@@ -7962,11 +8004,11 @@ impl<'a, 'b> slicer_unit_fbIO<'a, 'b> {
     pub fn set_i_rst_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
         self.io.set_four_state(self.ids.i_rst, val, mask);
     }
-    pub fn set_o_ready(&mut self, val: u8) {
-        self.io.set(self.ids.o_ready, val);
+    pub fn set_i_ready(&mut self, val: u8) {
+        self.io.set(self.ids.i_ready, val);
     }
-    pub fn set_o_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.io.set_four_state(self.ids.o_ready, val, mask);
+    pub fn set_i_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.io.set_four_state(self.ids.i_ready, val, mask);
     }
     pub fn set_o_data(&mut self, val: u8) {
         self.io.set(self.ids.o_data, val);
@@ -7976,48 +8018,27 @@ impl<'a, 'b> slicer_unit_fbIO<'a, 'b> {
     }
 }
 pub struct slicer_unit_hb {
-    pub i_valid: celox::SignalRef,
     pub i_data: celox::SignalRef,
     pub o_valid: celox::SignalRef,
     pub i_clk: celox::NativeEventRef,
-    pub i_ready: celox::SignalRef,
-    pub i_rst: celox::SignalRef,
     pub o_ready: celox::SignalRef,
+    pub i_valid: celox::SignalRef,
+    pub i_rst: celox::SignalRef,
+    pub i_ready: celox::SignalRef,
     pub o_data: celox::SignalRef,
 }
 impl slicer_unit_hb {
     pub fn new(sim: &celox::Simulator) -> Self {
         Self {
-            i_valid: sim.signal("i_valid"),
             i_data: sim.signal("i_data"),
             o_valid: sim.signal("o_valid"),
             i_clk: sim.event("i_clk"),
-            i_ready: sim.signal("i_ready"),
-            i_rst: sim.signal("i_rst"),
             o_ready: sim.signal("o_ready"),
+            i_valid: sim.signal("i_valid"),
+            i_rst: sim.signal("i_rst"),
+            i_ready: sim.signal("i_ready"),
             o_data: sim.signal("o_data"),
         }
-    }
-    pub fn set_i_valid(&self, sim: &mut celox::Simulator, val: u8) {
-        sim.modify(|io| io.set(self.i_valid, val)).unwrap();
-    }
-    pub fn get_i_valid(&self, sim: &mut celox::Simulator) -> u8 {
-        let val = sim.get(self.i_valid);
-        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "i_valid"))
-    }
-    pub fn set_i_valid_4state(
-        &self,
-        sim: &mut celox::Simulator,
-        val: celox::BigUint,
-        mask: celox::BigUint,
-    ) {
-        sim.modify(|io| io.set_four_state(self.i_valid, val, mask)).unwrap();
-    }
-    pub fn get_i_valid_4state(
-        &self,
-        sim: &mut celox::Simulator,
-    ) -> (celox::BigUint, celox::BigUint) {
-        sim.get_four_state(self.i_valid)
     }
     pub fn set_i_data(&self, sim: &mut celox::Simulator, val: u8) {
         sim.modify(|io| io.set(self.i_data, val)).unwrap();
@@ -8061,26 +8082,47 @@ impl slicer_unit_hb {
     ) -> (celox::BigUint, celox::BigUint) {
         sim.get_four_state(self.o_valid)
     }
-    pub fn set_i_ready(&self, sim: &mut celox::Simulator, val: u8) {
-        sim.modify(|io| io.set(self.i_ready, val)).unwrap();
+    pub fn set_o_ready(&self, sim: &mut celox::Simulator, val: u8) {
+        sim.modify(|io| io.set(self.o_ready, val)).unwrap();
     }
-    pub fn get_i_ready(&self, sim: &mut celox::Simulator) -> u8 {
-        let val = sim.get(self.i_ready);
-        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "i_ready"))
+    pub fn get_o_ready(&self, sim: &mut celox::Simulator) -> u8 {
+        let val = sim.get(self.o_ready);
+        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "o_ready"))
     }
-    pub fn set_i_ready_4state(
+    pub fn set_o_ready_4state(
         &self,
         sim: &mut celox::Simulator,
         val: celox::BigUint,
         mask: celox::BigUint,
     ) {
-        sim.modify(|io| io.set_four_state(self.i_ready, val, mask)).unwrap();
+        sim.modify(|io| io.set_four_state(self.o_ready, val, mask)).unwrap();
     }
-    pub fn get_i_ready_4state(
+    pub fn get_o_ready_4state(
         &self,
         sim: &mut celox::Simulator,
     ) -> (celox::BigUint, celox::BigUint) {
-        sim.get_four_state(self.i_ready)
+        sim.get_four_state(self.o_ready)
+    }
+    pub fn set_i_valid(&self, sim: &mut celox::Simulator, val: u8) {
+        sim.modify(|io| io.set(self.i_valid, val)).unwrap();
+    }
+    pub fn get_i_valid(&self, sim: &mut celox::Simulator) -> u8 {
+        let val = sim.get(self.i_valid);
+        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "i_valid"))
+    }
+    pub fn set_i_valid_4state(
+        &self,
+        sim: &mut celox::Simulator,
+        val: celox::BigUint,
+        mask: celox::BigUint,
+    ) {
+        sim.modify(|io| io.set_four_state(self.i_valid, val, mask)).unwrap();
+    }
+    pub fn get_i_valid_4state(
+        &self,
+        sim: &mut celox::Simulator,
+    ) -> (celox::BigUint, celox::BigUint) {
+        sim.get_four_state(self.i_valid)
     }
     pub fn set_i_rst(&self, sim: &mut celox::Simulator, val: u8) {
         sim.modify(|io| io.set(self.i_rst, val)).unwrap();
@@ -8103,26 +8145,26 @@ impl slicer_unit_hb {
     ) -> (celox::BigUint, celox::BigUint) {
         sim.get_four_state(self.i_rst)
     }
-    pub fn set_o_ready(&self, sim: &mut celox::Simulator, val: u8) {
-        sim.modify(|io| io.set(self.o_ready, val)).unwrap();
+    pub fn set_i_ready(&self, sim: &mut celox::Simulator, val: u8) {
+        sim.modify(|io| io.set(self.i_ready, val)).unwrap();
     }
-    pub fn get_o_ready(&self, sim: &mut celox::Simulator) -> u8 {
-        let val = sim.get(self.o_ready);
-        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "o_ready"))
+    pub fn get_i_ready(&self, sim: &mut celox::Simulator) -> u8 {
+        let val = sim.get(self.i_ready);
+        val.try_into().unwrap_or_else(|_| panic!("Value overflow for {}", "i_ready"))
     }
-    pub fn set_o_ready_4state(
+    pub fn set_i_ready_4state(
         &self,
         sim: &mut celox::Simulator,
         val: celox::BigUint,
         mask: celox::BigUint,
     ) {
-        sim.modify(|io| io.set_four_state(self.o_ready, val, mask)).unwrap();
+        sim.modify(|io| io.set_four_state(self.i_ready, val, mask)).unwrap();
     }
-    pub fn get_o_ready_4state(
+    pub fn get_i_ready_4state(
         &self,
         sim: &mut celox::Simulator,
     ) -> (celox::BigUint, celox::BigUint) {
-        sim.get_four_state(self.o_ready)
+        sim.get_four_state(self.i_ready)
     }
     pub fn set_o_data(&self, sim: &mut celox::Simulator, val: u8) {
         sim.modify(|io| io.set(self.o_data, val)).unwrap();
@@ -8160,18 +8202,6 @@ pub struct slicer_unit_hbBound<'a> {
     ids: &'a slicer_unit_hb,
 }
 impl<'a> slicer_unit_hbBound<'a> {
-    pub fn set_i_valid(&mut self, val: u8) {
-        self.ids.set_i_valid(self.sim, val);
-    }
-    pub fn get_i_valid(&mut self) -> u8 {
-        self.ids.get_i_valid(self.sim)
-    }
-    pub fn set_i_valid_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.ids.set_i_valid_4state(self.sim, val, mask);
-    }
-    pub fn get_i_valid_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
-        self.ids.get_i_valid_4state(self.sim)
-    }
     pub fn set_i_data(&mut self, val: u8) {
         self.ids.set_i_data(self.sim, val);
     }
@@ -8196,17 +8226,29 @@ impl<'a> slicer_unit_hbBound<'a> {
     pub fn get_o_valid_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
         self.ids.get_o_valid_4state(self.sim)
     }
-    pub fn set_i_ready(&mut self, val: u8) {
-        self.ids.set_i_ready(self.sim, val);
+    pub fn set_o_ready(&mut self, val: u8) {
+        self.ids.set_o_ready(self.sim, val);
     }
-    pub fn get_i_ready(&mut self) -> u8 {
-        self.ids.get_i_ready(self.sim)
+    pub fn get_o_ready(&mut self) -> u8 {
+        self.ids.get_o_ready(self.sim)
     }
-    pub fn set_i_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.ids.set_i_ready_4state(self.sim, val, mask);
+    pub fn set_o_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.ids.set_o_ready_4state(self.sim, val, mask);
     }
-    pub fn get_i_ready_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
-        self.ids.get_i_ready_4state(self.sim)
+    pub fn get_o_ready_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
+        self.ids.get_o_ready_4state(self.sim)
+    }
+    pub fn set_i_valid(&mut self, val: u8) {
+        self.ids.set_i_valid(self.sim, val);
+    }
+    pub fn get_i_valid(&mut self) -> u8 {
+        self.ids.get_i_valid(self.sim)
+    }
+    pub fn set_i_valid_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.ids.set_i_valid_4state(self.sim, val, mask);
+    }
+    pub fn get_i_valid_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
+        self.ids.get_i_valid_4state(self.sim)
     }
     pub fn set_i_rst(&mut self, val: u8) {
         self.ids.set_i_rst(self.sim, val);
@@ -8220,17 +8262,17 @@ impl<'a> slicer_unit_hbBound<'a> {
     pub fn get_i_rst_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
         self.ids.get_i_rst_4state(self.sim)
     }
-    pub fn set_o_ready(&mut self, val: u8) {
-        self.ids.set_o_ready(self.sim, val);
+    pub fn set_i_ready(&mut self, val: u8) {
+        self.ids.set_i_ready(self.sim, val);
     }
-    pub fn get_o_ready(&mut self) -> u8 {
-        self.ids.get_o_ready(self.sim)
+    pub fn get_i_ready(&mut self) -> u8 {
+        self.ids.get_i_ready(self.sim)
     }
-    pub fn set_o_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.ids.set_o_ready_4state(self.sim, val, mask);
+    pub fn set_i_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.ids.set_i_ready_4state(self.sim, val, mask);
     }
-    pub fn get_o_ready_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
-        self.ids.get_o_ready_4state(self.sim)
+    pub fn get_i_ready_4state(&mut self) -> (celox::BigUint, celox::BigUint) {
+        self.ids.get_i_ready_4state(self.sim)
     }
     pub fn set_o_data(&mut self, val: u8) {
         self.ids.set_o_data(self.sim, val);
@@ -8267,12 +8309,6 @@ pub struct slicer_unit_hbIO<'a, 'b> {
     ids: &'a slicer_unit_hb,
 }
 impl<'a, 'b> slicer_unit_hbIO<'a, 'b> {
-    pub fn set_i_valid(&mut self, val: u8) {
-        self.io.set(self.ids.i_valid, val);
-    }
-    pub fn set_i_valid_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.io.set_four_state(self.ids.i_valid, val, mask);
-    }
     pub fn set_i_data(&mut self, val: u8) {
         self.io.set(self.ids.i_data, val);
     }
@@ -8285,11 +8321,17 @@ impl<'a, 'b> slicer_unit_hbIO<'a, 'b> {
     pub fn set_o_valid_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
         self.io.set_four_state(self.ids.o_valid, val, mask);
     }
-    pub fn set_i_ready(&mut self, val: u8) {
-        self.io.set(self.ids.i_ready, val);
+    pub fn set_o_ready(&mut self, val: u8) {
+        self.io.set(self.ids.o_ready, val);
     }
-    pub fn set_i_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.io.set_four_state(self.ids.i_ready, val, mask);
+    pub fn set_o_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.io.set_four_state(self.ids.o_ready, val, mask);
+    }
+    pub fn set_i_valid(&mut self, val: u8) {
+        self.io.set(self.ids.i_valid, val);
+    }
+    pub fn set_i_valid_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.io.set_four_state(self.ids.i_valid, val, mask);
     }
     pub fn set_i_rst(&mut self, val: u8) {
         self.io.set(self.ids.i_rst, val);
@@ -8297,11 +8339,11 @@ impl<'a, 'b> slicer_unit_hbIO<'a, 'b> {
     pub fn set_i_rst_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
         self.io.set_four_state(self.ids.i_rst, val, mask);
     }
-    pub fn set_o_ready(&mut self, val: u8) {
-        self.io.set(self.ids.o_ready, val);
+    pub fn set_i_ready(&mut self, val: u8) {
+        self.io.set(self.ids.i_ready, val);
     }
-    pub fn set_o_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
-        self.io.set_four_state(self.ids.o_ready, val, mask);
+    pub fn set_i_ready_4state(&mut self, val: celox::BigUint, mask: celox::BigUint) {
+        self.io.set_four_state(self.ids.i_ready, val, mask);
     }
     pub fn set_o_data(&mut self, val: u8) {
         self.io.set(self.ids.o_data, val);

--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -17,7 +17,8 @@ use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::ToPrimitive as _;
 use veryl_analyzer::ir::{
     ArrayLiteralItem, AssignStatement, CombDeclaration, Expression, Factor, ForBound, ForRange,
-    ForStatement, IfStatement, Module, Op, Statement, ValueVariant, VarId, VarSelectOp,
+    ForStatement, IfStatement, Module, Op, Statement, SystemFunctionCall, SystemFunctionKind,
+    ValueVariant, VarId, VarSelectOp,
 };
 use veryl_analyzer::value::Value;
 
@@ -2358,13 +2359,9 @@ fn eval_function_body_return(
     ) -> Result<(), ParserError> {
         match expr {
             Expression::Term(factor) => match factor.as_ref() {
-                Factor::SystemFunctionCall(call) => Err(ParserError::unsupported(
-                    59,
-                    LoweringPhase::CombLowering,
-                    "system function call in comb function body",
-                    format!("module `{}`: {call}", module.name),
-                    Some(&call.comptime.token),
-                )),
+                Factor::SystemFunctionCall(call) => {
+                    validate_function_body_system_function(module, call)
+                }
                 Factor::Variable(_, _, _, _)
                 | Factor::FunctionCall(_)
                 | Factor::Value(_)
@@ -2412,6 +2409,24 @@ fn eval_function_body_return(
                 }
                 Ok(())
             }
+        }
+    }
+
+    fn validate_function_body_system_function(
+        module: &Module,
+        call: &SystemFunctionCall,
+    ) -> Result<(), ParserError> {
+        match &call.kind {
+            SystemFunctionKind::Onehot(input) => {
+                validate_function_body_expression(module, &input.0)
+            }
+            _ => Err(ParserError::unsupported(
+                59,
+                LoweringPhase::CombLowering,
+                "system function call in comb function body",
+                format!("module `{}`: {call}", module.name),
+                Some(&call.comptime.token),
+            )),
         }
     }
 
@@ -4402,13 +4417,7 @@ fn eval_factor(
                 BoundaryMap::default(),
             ))
         }
-        Factor::SystemFunctionCall(call) => Err(ParserError::unsupported(
-            59,
-            LoweringPhase::CombLowering,
-            "system function call in comb expression",
-            format!("module `{}`: {call}", module.name),
-            Some(&factor.token_range()),
-        )),
+        Factor::SystemFunctionCall(call) => eval_system_function_call(module, store, call, arena),
         Factor::FunctionCall(call) => eval_function_call_expression(module, store, call, arena),
         Factor::Anonymous(_) | Factor::Unknown(_) => Err(ParserError::unsupported(
             67,
@@ -4465,6 +4474,45 @@ fn merge_boundaries(mut base: BoundaryMap<VarId>, other: BoundaryMap<VarId>) -> 
         base.entry(id).or_default().extend(bits);
     }
     base
+}
+
+fn eval_system_function_call(
+    module: &Module,
+    store: &SymbolicStore<VarId>,
+    call: &SystemFunctionCall,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+    match &call.kind {
+        SystemFunctionKind::Onehot(input) => {
+            let ((arg, sources), bounds) = eval_expression(module, store, &input.0, arena, None)?;
+            let width = get_width(arg, arena);
+            let zero = arena.alloc(SLTNode::Constant(
+                BigUint::from(0u8),
+                BigUint::from(0u8),
+                width,
+                false,
+            ));
+            let one = arena.alloc(SLTNode::Constant(
+                BigUint::from(1u8),
+                BigUint::from(0u8),
+                width,
+                false,
+            ));
+            let arg_minus_one = arena.alloc(SLTNode::Binary(arg, BinaryOp::Sub, one));
+            let overlap = arena.alloc(SLTNode::Binary(arg, BinaryOp::And, arg_minus_one));
+            let non_zero = arena.alloc(SLTNode::Binary(arg, BinaryOp::Ne, zero));
+            let no_overlap = arena.alloc(SLTNode::Binary(overlap, BinaryOp::Eq, zero));
+            let result = arena.alloc(SLTNode::Binary(non_zero, BinaryOp::LogicAnd, no_overlap));
+            Ok(((result, sources), bounds))
+        }
+        _ => Err(ParserError::unsupported(
+            59,
+            LoweringPhase::CombLowering,
+            "system function call in comb expression",
+            format!("module `{}`: {call}", module.name),
+            Some(&call.comptime.token),
+        )),
+    }
 }
 
 fn is_signed(module: &Module, expr: NodeId, arena: &SLTNodeArena<VarId>) -> bool {

--- a/crates/celox/tests/system_function.rs
+++ b/crates/celox/tests/system_function.rs
@@ -1,0 +1,67 @@
+use celox::Simulator;
+
+#[path = "test_utils/mod.rs"]
+#[macro_use]
+mod test_utils;
+
+all_backends! {
+    #[ignore = "direct $onehot in always_comb currently evaluates incorrectly before Celox system-function lowering"]
+    fn test_direct_comb_onehot_system_function(sim) {
+        @build Simulator::builder(r#"
+module Top (
+    d: input logic<8>,
+    q: output logic,
+) {
+    always_comb {
+        q = $onehot(d);
+    }
+}
+"#, "Top");
+
+        let d = sim.signal("d");
+        let q = sim.signal("q");
+
+        for value in 0u16..256 {
+            let value = value as u8;
+            sim.modify(|io| io.set(d, value)).unwrap();
+            assert_eq!(
+                sim.get_as::<u8>(q),
+                u8::from(value.count_ones() == 1),
+                "value={value:#010b}",
+            );
+        }
+    }
+
+    fn test_comb_function_body_onehot_system_function(sim) {
+        @ignore_on(veryl);
+        @build Simulator::builder(r#"
+module Top (
+    d: input logic<8>,
+    q: output logic,
+) {
+    function is_onehot (
+        x: input logic<8>,
+    ) -> logic {
+        return $onehot(x);
+    }
+
+    always_comb {
+        q = is_onehot(d);
+    }
+}
+"#, "Top");
+
+        let d = sim.signal("d");
+        let q = sim.signal("q");
+
+        for value in 0u16..256 {
+            let value = value as u8;
+            sim.modify(|io| io.set(d, value)).unwrap();
+            assert_eq!(
+                sim.get_as::<u8>(q),
+                u8::from(value.count_ones() == 1),
+                "value={value:#010b}",
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Updates the `deps/veryl` submodule to include the upstream function-body const-optimization suppression changes.
- Lowers `$onehot(...)` system-function calls that remain inside comb function bodies.
- Adds regression coverage for comb-function `$onehot(...)`, plus an ignored regression for direct `always_comb { q = $onehot(d); }` which still evaluates incorrectly before Celox system-function lowering sees it.
- Updates the celox-macros generator snapshot for the newer Veryl std/module surface.

## Validation

- `cargo test -p celox --test system_function`
- `cargo test -p celox --test error_detection test_comb_function_body_rejects_system_function_call`
- pre-push hook: `submodule-check`, `cargo-fmt`, `biome`, `cargo-clippy`, full `pnpm test`