### PR TITLE
[codex] add generic argument error hint

### DIFF
--- a/crates/celox/src/simulator/error.rs
+++ b/crates/celox/src/simulator/error.rs
@@ -22,6 +22,20 @@ pub fn render_diagnostic(diag: &dyn miette::Diagnostic) -> String {
     }
 }
 
+fn render_analyzer_error(error: &veryl_analyzer::AnalyzerError) -> String {
+    let mut rendered = render_diagnostic(error);
+    if let veryl_analyzer::AnalyzerError::UnresolvableGenericExpression { identifier, .. } = error {
+        rendered.push_str("\nhelp: if this is a module `param ");
+        rendered.push_str(identifier);
+        rendered.push_str(
+            ": type`, declare it as a module generic parameter like `module ModuleName::<",
+        );
+        rendered.push_str(identifier);
+        rendered.push_str(": type>` instead");
+    }
+    rendered
+}
+
 /// The specific kind of simulator error.
 #[derive(Debug)]
 pub enum SimulatorErrorKind {
@@ -74,7 +88,7 @@ impl fmt::Display for SimulatorError {
                     if i > 0 {
                         f.write_str("\n")?;
                     }
-                    f.write_str(&render_diagnostic(e))?;
+                    f.write_str(&render_analyzer_error(e))?;
                 }
             }
             #[cfg(not(target_arch = "wasm32"))]

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -626,6 +626,46 @@ fn test_generic_top_returns_error() {
 }
 
 #[test]
+fn test_module_param_type_generic_argument_error_has_hint() {
+    let code = r#"
+        interface Bus::<T: type> {
+            var data: T;
+            modport consumer {
+                data: input,
+            }
+        }
+
+        module Top #(
+            param T: type = logic<8>,
+        ) (
+            bus: modport Bus::<T>::consumer,
+        ) {}
+    "#;
+
+    let result = Simulator::builder(code, "Top").build();
+    let err = result.expect_err("expected analyzer error");
+    match err.kind() {
+        SimulatorErrorKind::Analyzer(errors) => {
+            assert!(
+                format!("{errors:?}").contains("UnresolvableGenericExpression"),
+                "expected UnresolvableGenericExpression, got: {errors:?}"
+            );
+        }
+        other => panic!("expected analyzer error, got: {other:?}"),
+    }
+
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("if this is a module `param T: type`"),
+        "expected Celox hint in rendered error, got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("module ModuleName::<T: type>"),
+        "expected generic parameter suggestion in rendered error, got:\n{rendered}"
+    );
+}
+
+#[test]
 fn test_comb_function_body_rejects_system_function_call() {
     let code = r#"
         module Top (


### PR DESCRIPTION
## Summary

- Add a Celox-side rendered hint for Veryl `UnresolvableGenericExpression` analyzer errors.
- Cover the module `param T: type` used as a generic argument case from #24 without changing the Veryl analyzer.

## Validation

- `cargo test -p celox --test error_detection test_module_param_type_generic_argument_error_has_hint`
- pre-push hook: `submodule-check`, `cargo-fmt`, `biome`, `cargo-clippy`, full `pnpm test`, `clean-tree`