### PR TITLE
[codex] Support FF system functions

### DIFF
--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -11,8 +11,9 @@ use crate::parser::{
 use num_bigint::BigUint;
 
 use veryl_analyzer::ir::{
-    ArrayLiteralItem, AssignDestination, AssignStatement, Comptime, Expression, Factor, Op, Type,
-    ValueVariant, VarId, VarIndex, VarSelect, VarSelectOp,
+    ArrayLiteralItem, AssignDestination, AssignStatement, Comptime, Expression, Factor, Op,
+    SystemFunctionCall, SystemFunctionKind, Type, ValueVariant, VarId, VarIndex, VarSelect,
+    VarSelectOp,
 };
 use veryl_parser::token_range::TokenRange;
 
@@ -1127,6 +1128,75 @@ impl<'a> FfParser<'a> {
         self.stack.push_back(reg);
     }
 
+    fn parse_system_function_call<A>(
+        &mut self,
+        call: &SystemFunctionCall,
+        targets: &mut Vec<VarAtomBase<A>>,
+        domain: &Domain,
+        convert: &impl Fn(VarId, u32) -> A,
+        sources: &mut Vec<VarAtomBase<A>>,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<(), ParserError> {
+        match &call.kind {
+            SystemFunctionKind::Onehot(input) => {
+                self.parse_expression(
+                    &input.0, targets, domain, convert, sources, ir_builder, None,
+                )?;
+                let arg = self.stack.pop_back().expect("Invalid $onehot input");
+                let width = ir_builder.register(&arg).width();
+
+                let zero = ir_builder.alloc_bit(width, false);
+                ir_builder.emit(SIRInstruction::Imm(zero, SIRValue::new(0u8)));
+                let one = ir_builder.alloc_bit(width, false);
+                ir_builder.emit(SIRInstruction::Imm(one, SIRValue::new(1u8)));
+
+                let arg_minus_one = ir_builder.alloc_logic(width);
+                ir_builder.emit(SIRInstruction::Binary(
+                    arg_minus_one,
+                    arg,
+                    BinaryOp::Sub,
+                    one,
+                ));
+
+                let overlap = ir_builder.alloc_logic(width);
+                ir_builder.emit(SIRInstruction::Binary(
+                    overlap,
+                    arg,
+                    BinaryOp::And,
+                    arg_minus_one,
+                ));
+
+                let non_zero = ir_builder.alloc_bit(1, false);
+                ir_builder.emit(SIRInstruction::Binary(non_zero, arg, BinaryOp::Ne, zero));
+
+                let no_overlap = ir_builder.alloc_bit(1, false);
+                ir_builder.emit(SIRInstruction::Binary(
+                    no_overlap,
+                    overlap,
+                    BinaryOp::Eq,
+                    zero,
+                ));
+
+                let result = ir_builder.alloc_logic(1);
+                ir_builder.emit(SIRInstruction::Binary(
+                    result,
+                    non_zero,
+                    BinaryOp::LogicAnd,
+                    no_overlap,
+                ));
+                self.stack.push_back(result);
+                Ok(())
+            }
+            _ => Err(ParserError::unsupported(
+                66,
+                LoweringPhase::FfLowering,
+                "system function call",
+                format!("{call}"),
+                Some(&call.comptime.token),
+            )),
+        }
+    }
+
     pub(super) fn parse_factor<A>(
         &mut self,
         factor: &Factor,
@@ -1340,13 +1410,9 @@ impl<'a> FfParser<'a> {
                 );
             }
             Factor::SystemFunctionCall(call) => {
-                return Err(ParserError::unsupported(
-                    66,
-                    LoweringPhase::FfLowering,
-                    "system function call",
-                    format!("{call}"),
-                    Some(&call.comptime.token),
-                ));
+                self.parse_system_function_call(
+                    call, targets, domain, convert, sources, ir_builder,
+                )?;
             }
             Factor::FunctionCall(call) => {
                 self.parse_function_call_expr(call, targets, domain, convert, sources, ir_builder)?;

--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -1,7 +1,7 @@
 use super::{Domain, FfParser};
 use crate::ir::{
-    BinaryOp, BitAccess, RegisterId, SIRBuilder, SIRInstruction, SIROffset, SIRTerminator,
-    SIRValue, STABLE_REGION, UnaryOp, VarAtomBase, WORKING_REGION,
+    BinaryOp, BitAccess, RegisterId, RegisterType, SIRBuilder, SIRInstruction, SIROffset,
+    SIRTerminator, SIRValue, STABLE_REGION, UnaryOp, VarAtomBase, WORKING_REGION,
 };
 use crate::parser::{
     LoweringPhase, ParserError,
@@ -1128,6 +1128,18 @@ impl<'a> FfParser<'a> {
         self.stack.push_back(reg);
     }
 
+    fn system_function_input_width(
+        &self,
+        input: &veryl_analyzer::ir::SystemFunctionInput,
+    ) -> usize {
+        input
+            .0
+            .comptime()
+            .r#type
+            .total_width()
+            .unwrap_or_else(|| self.get_expression_width(&input.0))
+    }
+
     fn parse_system_function_call<A>(
         &mut self,
         call: &SystemFunctionCall,
@@ -1136,8 +1148,45 @@ impl<'a> FfParser<'a> {
         convert: &impl Fn(VarId, u32) -> A,
         sources: &mut Vec<VarAtomBase<A>>,
         ir_builder: &mut SIRBuilder<A>,
+        context_width: Option<usize>,
     ) -> Result<(), ParserError> {
         match &call.kind {
+            SystemFunctionKind::Bits(input) => {
+                let width = self.system_function_input_width(input);
+                self.op_constant(SIRValue::new(width as u64), 32, ir_builder);
+                Ok(())
+            }
+            SystemFunctionKind::Size(input) => {
+                let size = input.0.comptime().r#type.total_width().unwrap_or(0);
+                self.op_constant(SIRValue::new(size as u64), 32, ir_builder);
+                Ok(())
+            }
+            SystemFunctionKind::Clog2(input) => {
+                self.parse_expression(
+                    &input.0, targets, domain, convert, sources, ir_builder, None,
+                )?;
+                let arg = self.stack.pop_back().expect("Invalid $clog2 input");
+                let width = ir_builder.register(&arg).width();
+
+                let mut result = ir_builder.alloc_bit(32, false);
+                ir_builder.emit(SIRInstruction::Imm(result, SIRValue::new(0u8)));
+                for k in 1..=width {
+                    let threshold = ir_builder.alloc_bit(width, false);
+                    ir_builder.emit(SIRInstruction::Imm(
+                        threshold,
+                        SIRValue::new(BigUint::from(1u8) << (k - 1)),
+                    ));
+                    let cond = ir_builder.alloc_bit(1, false);
+                    ir_builder.emit(SIRInstruction::Binary(cond, arg, BinaryOp::GtU, threshold));
+                    let value = ir_builder.alloc_bit(32, false);
+                    ir_builder.emit(SIRInstruction::Imm(value, SIRValue::new(k as u64)));
+                    let next = ir_builder.alloc_logic(32);
+                    ir_builder.emit(SIRInstruction::Mux(next, cond, value, result));
+                    result = next;
+                }
+                self.stack.push_back(result);
+                Ok(())
+            }
             SystemFunctionKind::Onehot(input) => {
                 self.parse_expression(
                     &input.0, targets, domain, convert, sources, ir_builder, None,
@@ -1185,6 +1234,27 @@ impl<'a> FfParser<'a> {
                     no_overlap,
                 ));
                 self.stack.push_back(result);
+                Ok(())
+            }
+            SystemFunctionKind::Signed(input) | SystemFunctionKind::Unsigned(input) => {
+                self.parse_expression(
+                    &input.0,
+                    targets,
+                    domain,
+                    convert,
+                    sources,
+                    ir_builder,
+                    context_width,
+                )?;
+                let src = self
+                    .stack
+                    .pop_back()
+                    .expect("Invalid $signed/$unsigned input");
+                let width = ir_builder.register(&src).width();
+                let signed = matches!(call.kind, SystemFunctionKind::Signed(_));
+                let casted = ir_builder.alloc_reg(RegisterType::Bit { width, signed });
+                ir_builder.emit(SIRInstruction::Unary(casted, UnaryOp::Ident, src));
+                self.stack.push_back(casted);
                 Ok(())
             }
             _ => Err(ParserError::unsupported(
@@ -1411,7 +1481,13 @@ impl<'a> FfParser<'a> {
             }
             Factor::SystemFunctionCall(call) => {
                 self.parse_system_function_call(
-                    call, targets, domain, convert, sources, ir_builder,
+                    call,
+                    targets,
+                    domain,
+                    convert,
+                    sources,
+                    ir_builder,
+                    context_width,
                 )?;
             }
             Factor::FunctionCall(call) => {

--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -1132,12 +1132,14 @@ impl<'a> FfParser<'a> {
         &self,
         input: &veryl_analyzer::ir::SystemFunctionInput,
     ) -> usize {
-        input
-            .0
-            .comptime()
-            .r#type
-            .total_width()
-            .unwrap_or_else(|| self.get_expression_width(&input.0))
+        let comptime = input.0.comptime();
+        match &comptime.value {
+            ValueVariant::Type(ty) => ty.total_width().unwrap_or(0),
+            _ => comptime
+                .r#type
+                .total_width()
+                .unwrap_or_else(|| self.get_expression_width(&input.0)),
+        }
     }
 
     fn parse_system_function_call<A>(
@@ -1156,7 +1158,7 @@ impl<'a> FfParser<'a> {
                 Ok(())
             }
             SystemFunctionKind::Size(input) => {
-                let size = input.0.comptime().r#type.total_width().unwrap_or(0);
+                let size = self.system_function_input_width(input);
                 self.op_constant(SIRValue::new(size as u64), 32, ir_builder);
                 Ok(())
             }

--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -1128,16 +1128,36 @@ impl<'a> FfParser<'a> {
         self.stack.push_back(reg);
     }
 
-    fn system_function_input_width(
+    fn system_function_type_bits_width(ty: &Type) -> Option<usize> {
+        ty.total_width()
+            .map(|width| width * ty.total_array().unwrap_or(1))
+    }
+
+    fn system_function_type_size(ty: &Type) -> Option<usize> {
+        if let Some(size) = ty.array.first() {
+            *size
+        } else {
+            ty.total_width()
+        }
+    }
+
+    fn system_function_input_bits_width(
         &self,
         input: &veryl_analyzer::ir::SystemFunctionInput,
     ) -> usize {
         let comptime = input.0.comptime();
         match &comptime.value {
-            ValueVariant::Type(ty) => ty.total_width().unwrap_or(0),
-            _ => comptime
-                .r#type
-                .total_width()
+            ValueVariant::Type(ty) => Self::system_function_type_bits_width(ty).unwrap_or(0),
+            _ => Self::system_function_type_bits_width(&comptime.r#type)
+                .unwrap_or_else(|| self.get_expression_width(&input.0)),
+        }
+    }
+
+    fn system_function_input_size(&self, input: &veryl_analyzer::ir::SystemFunctionInput) -> usize {
+        let comptime = input.0.comptime();
+        match &comptime.value {
+            ValueVariant::Type(ty) => Self::system_function_type_size(ty).unwrap_or(0),
+            _ => Self::system_function_type_size(&comptime.r#type)
                 .unwrap_or_else(|| self.get_expression_width(&input.0)),
         }
     }
@@ -1153,12 +1173,12 @@ impl<'a> FfParser<'a> {
     ) -> Result<(), ParserError> {
         match &call.kind {
             SystemFunctionKind::Bits(input) => {
-                let width = self.system_function_input_width(input);
+                let width = self.system_function_input_bits_width(input);
                 self.op_constant(SIRValue::new(width as u64), 32, ir_builder);
                 Ok(())
             }
             SystemFunctionKind::Size(input) => {
-                let size = self.system_function_input_width(input);
+                let size = self.system_function_input_size(input);
                 self.op_constant(SIRValue::new(size as u64), 32, ir_builder);
                 Ok(())
             }

--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -1136,6 +1136,10 @@ impl<'a> FfParser<'a> {
     fn system_function_type_size(ty: &Type) -> Option<usize> {
         if let Some(size) = ty.array.first() {
             *size
+        } else if let Some(size) = ty.width_expr().first().and_then(|expr| expr.numeric()) {
+            Some(size)
+        } else if let Some(size) = ty.width().first() {
+            *size
         } else {
             ty.total_width()
         }

--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -1148,7 +1148,6 @@ impl<'a> FfParser<'a> {
         convert: &impl Fn(VarId, u32) -> A,
         sources: &mut Vec<VarAtomBase<A>>,
         ir_builder: &mut SIRBuilder<A>,
-        context_width: Option<usize>,
     ) -> Result<(), ParserError> {
         match &call.kind {
             SystemFunctionKind::Bits(input) => {
@@ -1238,13 +1237,7 @@ impl<'a> FfParser<'a> {
             }
             SystemFunctionKind::Signed(input) | SystemFunctionKind::Unsigned(input) => {
                 self.parse_expression(
-                    &input.0,
-                    targets,
-                    domain,
-                    convert,
-                    sources,
-                    ir_builder,
-                    context_width,
+                    &input.0, targets, domain, convert, sources, ir_builder, None,
                 )?;
                 let src = self
                     .stack
@@ -1481,13 +1474,7 @@ impl<'a> FfParser<'a> {
             }
             Factor::SystemFunctionCall(call) => {
                 self.parse_system_function_call(
-                    call,
-                    targets,
-                    domain,
-                    convert,
-                    sources,
-                    ir_builder,
-                    context_width,
+                    call, targets, domain, convert, sources, ir_builder,
                 )?;
             }
             Factor::FunctionCall(call) => {

--- a/crates/celox/tests/system_function.rs
+++ b/crates/celox/tests/system_function.rs
@@ -85,6 +85,25 @@ module Top (
         assert_eq!(sim.get_as::<u32>(q), 8);
     }
 
+    fn test_direct_ff_bits_type_system_function(sim) {
+        @build Simulator::builder(r#"
+module Top (
+    clk: input clock,
+    q: output logic<32>,
+) {
+    always_ff (clk) {
+        q = $bits(logic<8>);
+    }
+}
+"#, "Top");
+
+        let clk = sim.event("clk");
+        let q = sim.signal("q");
+
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get_as::<u32>(q), 8);
+    }
+
     fn test_direct_ff_size_system_function(sim) {
         @ignore_on(veryl);
         @build Simulator::builder(r#"
@@ -95,6 +114,26 @@ module Top (
 ) {
     always_ff (clk) {
         q = $size(d);
+    }
+}
+"#, "Top");
+
+        let clk = sim.event("clk");
+        let q = sim.signal("q");
+
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get_as::<u32>(q), 8);
+    }
+
+    fn test_direct_ff_size_type_system_function(sim) {
+        @ignore_on(veryl);
+        @build Simulator::builder(r#"
+module Top (
+    clk: input clock,
+    q: output logic<32>,
+) {
+    always_ff (clk) {
+        q = $size(logic<8>);
     }
 }
 "#, "Top");

--- a/crates/celox/tests/system_function.rs
+++ b/crates/celox/tests/system_function.rs
@@ -166,6 +166,47 @@ module Top (
         assert_eq!(sim.get_as::<u32>(q), 8);
     }
 
+    #[ignore = "$size on packed multidimensional types is folded to total width by Veryl analyzer before Celox FF lowering"]
+    fn test_direct_ff_size_packed_multidimensional_system_function(sim) {
+        @build Simulator::builder(r#"
+module Top (
+    clk: input clock,
+    d: input logic<10, 20>,
+    q: output logic<32>,
+) {
+    always_ff (clk) {
+        q = $size(d);
+    }
+}
+"#, "Top");
+
+        let clk = sim.event("clk");
+        let q = sim.signal("q");
+
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get_as::<u32>(q), 10);
+    }
+
+    #[ignore = "$size on packed multidimensional type arguments is folded to total width by Veryl analyzer before Celox FF lowering"]
+    fn test_direct_ff_size_packed_multidimensional_type_system_function(sim) {
+        @build Simulator::builder(r#"
+module Top (
+    clk: input clock,
+    q: output logic<32>,
+) {
+    always_ff (clk) {
+        q = $size(logic<10, 20>);
+    }
+}
+"#, "Top");
+
+        let clk = sim.event("clk");
+        let q = sim.signal("q");
+
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get_as::<u32>(q), 10);
+    }
+
     #[ignore = "direct $clog2 in always_ff is folded from X payload by Veryl analyzer before Celox FF lowering"]
     fn test_direct_ff_clog2_system_function(sim) {
         @build Simulator::builder(r#"

--- a/crates/celox/tests/system_function.rs
+++ b/crates/celox/tests/system_function.rs
@@ -196,6 +196,29 @@ module Top (
         assert_eq!(sim.get_as::<u8>(q), 0x80);
     }
 
+    fn test_direct_ff_signed_system_function_sign_extends_to_context(sim) {
+        @ignore_on(veryl);
+        @build Simulator::builder(r#"
+module Top (
+    clk: input clock,
+    d: input logic<8>,
+    q: output logic<16>,
+) {
+    always_ff (clk) {
+        q = $signed(d);
+    }
+}
+"#, "Top");
+
+        let clk = sim.event("clk");
+        let d = sim.signal("d");
+        let q = sim.signal("q");
+
+        sim.modify(|io| io.set(d, 0x80u8)).unwrap();
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get_as::<u16>(q), 0xff80);
+    }
+
     fn test_direct_ff_unsigned_system_function(sim) {
         @build Simulator::builder(r#"
 module Top (
@@ -216,6 +239,28 @@ module Top (
         sim.modify(|io| io.set(d, 0x80u8)).unwrap();
         sim.tick(clk).unwrap();
         assert_eq!(sim.get_as::<u8>(q), 0x80);
+    }
+
+    fn test_direct_ff_unsigned_system_function_zero_extends_to_context(sim) {
+        @build Simulator::builder(r#"
+module Top (
+    clk: input clock,
+    d: input logic<8>,
+    q: output logic<16>,
+) {
+    always_ff (clk) {
+        q = $unsigned(d);
+    }
+}
+"#, "Top");
+
+        let clk = sim.event("clk");
+        let d = sim.signal("d");
+        let q = sim.signal("q");
+
+        sim.modify(|io| io.set(d, 0x80u8)).unwrap();
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get_as::<u16>(q), 0x0080);
     }
 
     #[ignore = "direct $onehot in always_ff is folded to 1'h0 by Veryl analyzer before Celox FF lowering"]

--- a/crates/celox/tests/system_function.rs
+++ b/crates/celox/tests/system_function.rs
@@ -85,8 +85,8 @@ module Top (
         assert_eq!(sim.get_as::<u32>(q), 8);
     }
 
-    #[ignore = "direct $size on an array in always_ff reaches Celox FF lowering but is not supported there yet"]
     fn test_direct_ff_size_system_function(sim) {
+        @ignore_on(veryl);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -103,7 +103,7 @@ module Top (
         let q = sim.signal("q");
 
         sim.tick(clk).unwrap();
-        assert_eq!(sim.get_as::<u32>(q), 32);
+        assert_eq!(sim.get_as::<u32>(q), 8);
     }
 
     #[ignore = "direct $clog2 in always_ff is folded from X payload by Veryl analyzer before Celox FF lowering"]
@@ -137,7 +137,43 @@ module Top (
         }
     }
 
-    #[ignore = "direct $signed in always_ff reaches Celox FF lowering but is not supported there yet"]
+    fn test_ff_function_body_clog2_system_function(sim) {
+        @ignore_on(veryl);
+        @build Simulator::builder(r#"
+module Top (
+    clk: input clock,
+    d: input logic<8>,
+    q: output logic<32>,
+) {
+    function clog2_value (
+        x: input logic<8>,
+    ) -> logic<32> {
+        return $clog2(x);
+    }
+
+    always_ff (clk) {
+        q = clog2_value(d);
+    }
+}
+"#, "Top");
+
+        let clk = sim.event("clk");
+        let d = sim.signal("d");
+        let q = sim.signal("q");
+
+        for value in 0u16..256 {
+            let value = value as u8;
+            sim.modify(|io| io.set(d, value)).unwrap();
+            sim.tick(clk).unwrap();
+            let expected = if value == 0 {
+                0
+            } else {
+                u32::BITS - (u32::from(value) - 1).leading_zeros()
+            };
+            assert_eq!(sim.get_as::<u32>(q), expected, "value={value}");
+        }
+    }
+
     fn test_direct_ff_signed_system_function(sim) {
         @build Simulator::builder(r#"
 module Top (
@@ -160,7 +196,6 @@ module Top (
         assert_eq!(sim.get_as::<u8>(q), 0x80);
     }
 
-    #[ignore = "direct $unsigned in always_ff reaches Celox FF lowering but is not supported there yet"]
     fn test_direct_ff_unsigned_system_function(sim) {
         @build Simulator::builder(r#"
 module Top (

--- a/crates/celox/tests/system_function.rs
+++ b/crates/celox/tests/system_function.rs
@@ -104,6 +104,27 @@ module Top (
         assert_eq!(sim.get_as::<u32>(q), 8);
     }
 
+    fn test_direct_ff_bits_array_system_function(sim) {
+        @ignore_on(veryl);
+        @build Simulator::builder(r#"
+module Top (
+    clk: input clock,
+    d: input logic<8>[4],
+    q: output logic<32>,
+) {
+    always_ff (clk) {
+        q = $bits(d);
+    }
+}
+"#, "Top");
+
+        let clk = sim.event("clk");
+        let q = sim.signal("q");
+
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get_as::<u32>(q), 32);
+    }
+
     fn test_direct_ff_size_system_function(sim) {
         @ignore_on(veryl);
         @build Simulator::builder(r#"
@@ -122,7 +143,7 @@ module Top (
         let q = sim.signal("q");
 
         sim.tick(clk).unwrap();
-        assert_eq!(sim.get_as::<u32>(q), 8);
+        assert_eq!(sim.get_as::<u32>(q), 4);
     }
 
     fn test_direct_ff_size_type_system_function(sim) {

--- a/crates/celox/tests/system_function.rs
+++ b/crates/celox/tests/system_function.rs
@@ -65,6 +65,124 @@ module Top (
         }
     }
 
+    fn test_direct_ff_bits_system_function(sim) {
+        @build Simulator::builder(r#"
+module Top (
+    clk: input clock,
+    d: input logic<8>,
+    q: output logic<32>,
+) {
+    always_ff (clk) {
+        q = $bits(d);
+    }
+}
+"#, "Top");
+
+        let clk = sim.event("clk");
+        let q = sim.signal("q");
+
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get_as::<u32>(q), 8);
+    }
+
+    #[ignore = "direct $size on an array in always_ff reaches Celox FF lowering but is not supported there yet"]
+    fn test_direct_ff_size_system_function(sim) {
+        @build Simulator::builder(r#"
+module Top (
+    clk: input clock,
+    d: input logic<8>[4],
+    q: output logic<32>,
+) {
+    always_ff (clk) {
+        q = $size(d);
+    }
+}
+"#, "Top");
+
+        let clk = sim.event("clk");
+        let q = sim.signal("q");
+
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get_as::<u32>(q), 32);
+    }
+
+    #[ignore = "direct $clog2 in always_ff is folded from X payload by Veryl analyzer before Celox FF lowering"]
+    fn test_direct_ff_clog2_system_function(sim) {
+        @build Simulator::builder(r#"
+module Top (
+    clk: input clock,
+    d: input logic<8>,
+    q: output logic<32>,
+) {
+    always_ff (clk) {
+        q = $clog2(d);
+    }
+}
+"#, "Top");
+
+        let clk = sim.event("clk");
+        let d = sim.signal("d");
+        let q = sim.signal("q");
+
+        for value in 0u16..256 {
+            let value = value as u8;
+            sim.modify(|io| io.set(d, value)).unwrap();
+            sim.tick(clk).unwrap();
+            let expected = if value == 0 {
+                0
+            } else {
+                u32::BITS - (u32::from(value) - 1).leading_zeros()
+            };
+            assert_eq!(sim.get_as::<u32>(q), expected, "value={value}");
+        }
+    }
+
+    #[ignore = "direct $signed in always_ff reaches Celox FF lowering but is not supported there yet"]
+    fn test_direct_ff_signed_system_function(sim) {
+        @build Simulator::builder(r#"
+module Top (
+    clk: input clock,
+    d: input logic<8>,
+    q: output logic<8>,
+) {
+    always_ff (clk) {
+        q = $signed(d);
+    }
+}
+"#, "Top");
+
+        let clk = sim.event("clk");
+        let d = sim.signal("d");
+        let q = sim.signal("q");
+
+        sim.modify(|io| io.set(d, 0x80u8)).unwrap();
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get_as::<u8>(q), 0x80);
+    }
+
+    #[ignore = "direct $unsigned in always_ff reaches Celox FF lowering but is not supported there yet"]
+    fn test_direct_ff_unsigned_system_function(sim) {
+        @build Simulator::builder(r#"
+module Top (
+    clk: input clock,
+    d: input logic<8>,
+    q: output logic<8>,
+) {
+    always_ff (clk) {
+        q = $unsigned(d);
+    }
+}
+"#, "Top");
+
+        let clk = sim.event("clk");
+        let d = sim.signal("d");
+        let q = sim.signal("q");
+
+        sim.modify(|io| io.set(d, 0x80u8)).unwrap();
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get_as::<u8>(q), 0x80);
+    }
+
     #[ignore = "direct $onehot in always_ff is folded to 1'h0 by Veryl analyzer before Celox FF lowering"]
     fn test_direct_ff_onehot_system_function(sim) {
         @build Simulator::builder(r#"
@@ -129,5 +247,73 @@ module Top (
                 "value={value:#010b}",
             );
         }
+    }
+}
+
+#[test]
+fn test_ff_statement_system_functions_are_reported_as_unsupported() {
+    let cases = [
+        (
+            "display",
+            r#"
+module Top (clk: input clock, d: input logic) {
+    always_ff (clk) {
+        $display("d=%0d", d);
+    }
+}
+"#,
+        ),
+        (
+            "write",
+            r#"
+module Top (clk: input clock, d: input logic) {
+    always_ff (clk) {
+        $write("d=%0d", d);
+    }
+}
+"#,
+        ),
+        (
+            "readmemh",
+            r#"
+module Top (clk: input clock) {
+    var mem: logic<8>[4];
+    always_ff (clk) {
+        $readmemh("mem.hex", mem);
+    }
+}
+"#,
+        ),
+        (
+            "assert",
+            r#"
+module Top (clk: input clock, d: input logic) {
+    always_ff (clk) {
+        $assert(d);
+    }
+}
+"#,
+        ),
+        (
+            "finish",
+            r#"
+module Top (clk: input clock) {
+    always_ff (clk) {
+        $finish();
+    }
+}
+"#,
+        ),
+    ];
+
+    for (name, code) in cases {
+        let err = Simulator::builder(code, "Top")
+            .build()
+            .expect_err("statement system function should be unsupported in FF lowering");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("system function call"),
+            "expected system function unsupported error for {name}, got: {err:?}"
+        );
     }
 }

--- a/crates/celox/tests/system_function.rs
+++ b/crates/celox/tests/system_function.rs
@@ -64,4 +64,70 @@ module Top (
             );
         }
     }
+
+    #[ignore = "direct $onehot in always_ff is folded to 1'h0 by Veryl analyzer before Celox FF lowering"]
+    fn test_direct_ff_onehot_system_function(sim) {
+        @build Simulator::builder(r#"
+module Top (
+    clk: input clock,
+    d: input logic<8>,
+    q: output logic,
+) {
+    always_ff (clk) {
+        q = $onehot(d);
+    }
+}
+"#, "Top");
+
+        let clk = sim.event("clk");
+        let d = sim.signal("d");
+        let q = sim.signal("q");
+
+        for value in 0u16..256 {
+            let value = value as u8;
+            sim.modify(|io| io.set(d, value)).unwrap();
+            sim.tick(clk).unwrap();
+            assert_eq!(
+                sim.get_as::<u8>(q),
+                u8::from(value.count_ones() == 1),
+                "value={value:#010b}",
+            );
+        }
+    }
+
+    fn test_ff_function_body_onehot_system_function(sim) {
+        @ignore_on(veryl);
+        @build Simulator::builder(r#"
+module Top (
+    clk: input clock,
+    d: input logic<8>,
+    q: output logic,
+) {
+    function is_onehot (
+        x: input logic<8>,
+    ) -> logic {
+        return $onehot(x);
+    }
+
+    always_ff (clk) {
+        q = is_onehot(d);
+    }
+}
+"#, "Top");
+
+        let clk = sim.event("clk");
+        let d = sim.signal("d");
+        let q = sim.signal("q");
+
+        for value in 0u16..256 {
+            let value = value as u8;
+            sim.modify(|io| io.set(d, value)).unwrap();
+            sim.tick(clk).unwrap();
+            assert_eq!(
+                sim.get_as::<u8>(q),
+                u8::from(value.count_ones() == 1),
+                "value={value:#010b}",
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds FF lowering support for supported system functions, including `$bits`, `$size`, `$clog2`, `$onehot`, `$signed`, and `$unsigned`.

## Details

- Lowers supported value-returning system functions in `always_ff` expressions.
- Preserves self-determined operand width for `$signed` / `$unsigned` before outer context extension.
- Handles type-valued `$bits` / `$size` arguments where the analyzer represents the argument as `ValueVariant::Type`.
- Splits `$bits` and `$size` semantics for unpacked arrays: `$bits(logic<8>[4]) == 32`, `$size(logic<8>[4]) == 4`.
- Documents the remaining upstream Veryl analyzer limitation where `$size(logic<10, 20>)` is folded to total width before Celox FF lowering can see it.

## Validation

- `cargo test -p celox --test system_function`
- pre-push hook: submodule-check, biome, cargo-fmt, cargo-clippy, full test, clean-tree
- Verilator spot checks for `$bits` / `$size` on scalar, vector, unpacked array, and packed multidimensional SystemVerilog types.