### PR TITLE
[codex] improve runtime true loop diagnostics

### DIFF
--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -652,7 +652,7 @@ type SharedCode = celox::SharedJitCode;
 /// Cached compilation result shared across simulator instances.
 struct CachedBuild {
     shared_code: Arc<SharedCode>,
-    runtime_error_sources: HashMap<i64, Vec<String>>,
+    runtime_errors: HashMap<i64, (String, Vec<String>)>,
     layout_json: String,
     events_json: String,
     hierarchy_json: String,
@@ -757,14 +757,20 @@ fn build_cache_key(
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn runtime_error_sources_by_name(program: &celox::Program) -> HashMap<i64, Vec<String>> {
+fn runtime_errors_by_name(program: &celox::Program) -> HashMap<i64, (String, Vec<String>)> {
     program
-        .runtime_error_sources
+        .runtime_errors
         .iter()
-        .map(|(&code, addrs)| {
+        .map(|(&code, info)| {
             (
                 code,
-                addrs.iter().map(|addr| program.get_path(addr)).collect(),
+                (
+                    info.message.clone(),
+                    info.signals
+                        .iter()
+                        .map(|addr| program.get_path(addr))
+                        .collect(),
+                ),
             )
         })
         .collect()
@@ -772,18 +778,28 @@ fn runtime_error_sources_by_name(program: &celox::Program) -> HashMap<i64, Vec<S
 
 #[cfg(not(target_arch = "wasm32"))]
 fn napi_runtime_error(
-    runtime_error_sources: &HashMap<i64, Vec<String>>,
+    runtime_errors: &HashMap<i64, (String, Vec<String>)>,
     err: celox::RuntimeErrorCode,
 ) -> Error {
     match err {
         celox::RuntimeErrorCode::DetectedTrueLoopCode(code) => {
-            if let Some(signals) = runtime_error_sources.get(&code) {
-                Error::from_reason(format!(
-                    "{}",
-                    celox::RuntimeErrorCode::DetectedTrueLoopAt {
-                        signals: signals.clone(),
-                    }
-                ))
+            if let Some((message, signals)) = runtime_errors.get(&code) {
+                if message == "Detected True Loop" {
+                    Error::from_reason(format!(
+                        "{}",
+                        celox::RuntimeErrorCode::DetectedTrueLoopAt {
+                            signals: signals.clone(),
+                        }
+                    ))
+                } else {
+                    Error::from_reason(format!(
+                        "{}",
+                        celox::RuntimeErrorCode::Runtime {
+                            message: message.clone(),
+                            signals: signals.clone(),
+                        }
+                    ))
+                }
             } else {
                 Error::from_reason(format!("{}", celox::RuntimeErrorCode::DetectedTrueLoop))
             }
@@ -799,7 +815,7 @@ fn napi_runtime_error(
 #[napi]
 pub struct NativeSimulatorHandle {
     backend: Option<celox::DefaultBackend>,
-    runtime_error_sources: HashMap<i64, Vec<String>>,
+    runtime_errors: HashMap<i64, (String, Vec<String>)>,
     vcd_writer: Option<celox::VcdWriter>,
     layout_json: String,
     events_json: String,
@@ -827,7 +843,7 @@ impl NativeSimulatorHandle {
         let (_, total_size) = sim.memory_as_ptr();
         let stable_size = sim.stable_region_size();
         let vcd_descs = sim.build_vcd_descs(four_state);
-        let runtime_error_sources = runtime_error_sources_by_name(sim.program());
+        let runtime_errors = runtime_errors_by_name(sim.program());
 
         let layout_map = build_signal_layout(&signals, four_state);
         let event_map = build_event_map(&events);
@@ -844,7 +860,7 @@ impl NativeSimulatorHandle {
         if let Some(key) = cache_key {
             let cached = Arc::new(CachedBuild {
                 shared_code: sim.shared_code(),
-                runtime_error_sources: runtime_error_sources.clone(),
+                runtime_errors: runtime_errors.clone(),
                 layout_json: layout_json.clone(),
                 events_json: events_json.clone(),
                 hierarchy_json: hierarchy_json.clone(),
@@ -872,7 +888,7 @@ impl NativeSimulatorHandle {
 
         Ok(Self {
             backend: Some(backend),
-            runtime_error_sources,
+            runtime_errors,
             vcd_writer,
             layout_json,
             events_json,
@@ -899,7 +915,7 @@ impl NativeSimulatorHandle {
         };
         Ok(Self {
             backend: Some(backend),
-            runtime_error_sources: cached.runtime_error_sources.clone(),
+            runtime_errors: cached.runtime_errors.clone(),
             vcd_writer,
             layout_json: cached.layout_json.clone(),
             events_json: cached.events_json.clone(),
@@ -1024,24 +1040,24 @@ impl NativeSimulatorHandle {
     /// Trigger a clock/event by its numeric ID.
     #[napi]
     pub fn tick(&mut self, event_id: u32) -> Result<()> {
-        let runtime_error_sources = self.runtime_error_sources.clone();
+        let runtime_errors = self.runtime_errors.clone();
         let b = self
             .backend
             .as_mut()
             .ok_or_else(|| Error::from_reason("Simulator has been disposed"))?;
         let event = b.id_to_event_slice()[event_id as usize];
         b.eval_comb()
-            .map_err(|e| napi_runtime_error(&runtime_error_sources, e))?;
+            .map_err(|e| napi_runtime_error(&runtime_errors, e))?;
         b.eval_apply_ff_at(event)
-            .map_err(|e| napi_runtime_error(&runtime_error_sources, e))?;
+            .map_err(|e| napi_runtime_error(&runtime_errors, e))?;
         b.eval_comb()
-            .map_err(|e| napi_runtime_error(&runtime_error_sources, e))
+            .map_err(|e| napi_runtime_error(&runtime_errors, e))
     }
 
     /// Trigger a clock/event N times in a single NAPI call.
     #[napi]
     pub fn tick_n(&mut self, event_id: u32, count: u32) -> Result<()> {
-        let runtime_error_sources = self.runtime_error_sources.clone();
+        let runtime_errors = self.runtime_errors.clone();
         let b = self
             .backend
             .as_mut()
@@ -1049,11 +1065,11 @@ impl NativeSimulatorHandle {
         let event = b.id_to_event_slice()[event_id as usize];
         for _ in 0..count {
             b.eval_comb()
-                .map_err(|e| napi_runtime_error(&runtime_error_sources, e))?;
+                .map_err(|e| napi_runtime_error(&runtime_errors, e))?;
             b.eval_apply_ff_at(event)
-                .map_err(|e| napi_runtime_error(&runtime_error_sources, e))?;
+                .map_err(|e| napi_runtime_error(&runtime_errors, e))?;
             b.eval_comb()
-                .map_err(|e| napi_runtime_error(&runtime_error_sources, e))?;
+                .map_err(|e| napi_runtime_error(&runtime_errors, e))?;
         }
         Ok(())
     }
@@ -1061,13 +1077,13 @@ impl NativeSimulatorHandle {
     /// Evaluate combinational logic.
     #[napi]
     pub fn eval_comb(&mut self) -> Result<()> {
-        let runtime_error_sources = self.runtime_error_sources.clone();
+        let runtime_errors = self.runtime_errors.clone();
         let b = self
             .backend
             .as_mut()
             .ok_or_else(|| Error::from_reason("Simulator has been disposed"))?;
         b.eval_comb()
-            .map_err(|e| napi_runtime_error(&runtime_error_sources, e))
+            .map_err(|e| napi_runtime_error(&runtime_errors, e))
     }
 
     /// Write VCD dump at the given timestamp.

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -652,6 +652,7 @@ type SharedCode = celox::SharedJitCode;
 /// Cached compilation result shared across simulator instances.
 struct CachedBuild {
     shared_code: Arc<SharedCode>,
+    runtime_error_sources: HashMap<i64, Vec<String>>,
     layout_json: String,
     events_json: String,
     hierarchy_json: String,
@@ -755,6 +756,42 @@ fn build_cache_key(
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+fn runtime_error_sources_by_name(program: &celox::Program) -> HashMap<i64, Vec<String>> {
+    program
+        .runtime_error_sources
+        .iter()
+        .map(|(&code, addrs)| {
+            (
+                code,
+                addrs.iter().map(|addr| program.get_path(addr)).collect(),
+            )
+        })
+        .collect()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn napi_runtime_error(
+    runtime_error_sources: &HashMap<i64, Vec<String>>,
+    err: celox::RuntimeErrorCode,
+) -> Error {
+    match err {
+        celox::RuntimeErrorCode::DetectedTrueLoopCode(code) => {
+            if let Some(signals) = runtime_error_sources.get(&code) {
+                Error::from_reason(format!(
+                    "{}",
+                    celox::RuntimeErrorCode::DetectedTrueLoopAt {
+                        signals: signals.clone(),
+                    }
+                ))
+            } else {
+                Error::from_reason(format!("{}", celox::RuntimeErrorCode::DetectedTrueLoop))
+            }
+        }
+        other => Error::from_reason(format!("{}", other)),
+    }
+}
+
 /// Low-level handle wrapping a JIT backend and optional VCD writer.
 ///
 /// JS holds this as an opaque class; all operations go through methods.
@@ -762,6 +799,7 @@ fn build_cache_key(
 #[napi]
 pub struct NativeSimulatorHandle {
     backend: Option<celox::DefaultBackend>,
+    runtime_error_sources: HashMap<i64, Vec<String>>,
     vcd_writer: Option<celox::VcdWriter>,
     layout_json: String,
     events_json: String,
@@ -789,6 +827,7 @@ impl NativeSimulatorHandle {
         let (_, total_size) = sim.memory_as_ptr();
         let stable_size = sim.stable_region_size();
         let vcd_descs = sim.build_vcd_descs(four_state);
+        let runtime_error_sources = runtime_error_sources_by_name(sim.program());
 
         let layout_map = build_signal_layout(&signals, four_state);
         let event_map = build_event_map(&events);
@@ -805,6 +844,7 @@ impl NativeSimulatorHandle {
         if let Some(key) = cache_key {
             let cached = Arc::new(CachedBuild {
                 shared_code: sim.shared_code(),
+                runtime_error_sources: runtime_error_sources.clone(),
                 layout_json: layout_json.clone(),
                 events_json: events_json.clone(),
                 hierarchy_json: hierarchy_json.clone(),
@@ -832,6 +872,7 @@ impl NativeSimulatorHandle {
 
         Ok(Self {
             backend: Some(backend),
+            runtime_error_sources,
             vcd_writer,
             layout_json,
             events_json,
@@ -858,6 +899,7 @@ impl NativeSimulatorHandle {
         };
         Ok(Self {
             backend: Some(backend),
+            runtime_error_sources: cached.runtime_error_sources.clone(),
             vcd_writer,
             layout_json: cached.layout_json.clone(),
             events_json: cached.events_json.clone(),
@@ -982,22 +1024,24 @@ impl NativeSimulatorHandle {
     /// Trigger a clock/event by its numeric ID.
     #[napi]
     pub fn tick(&mut self, event_id: u32) -> Result<()> {
+        let runtime_error_sources = self.runtime_error_sources.clone();
         let b = self
             .backend
             .as_mut()
             .ok_or_else(|| Error::from_reason("Simulator has been disposed"))?;
         let event = b.id_to_event_slice()[event_id as usize];
         b.eval_comb()
-            .map_err(|e| Error::from_reason(format!("{}", e)))?;
+            .map_err(|e| napi_runtime_error(&runtime_error_sources, e))?;
         b.eval_apply_ff_at(event)
-            .map_err(|e| Error::from_reason(format!("{}", e)))?;
+            .map_err(|e| napi_runtime_error(&runtime_error_sources, e))?;
         b.eval_comb()
-            .map_err(|e| Error::from_reason(format!("{}", e)))
+            .map_err(|e| napi_runtime_error(&runtime_error_sources, e))
     }
 
     /// Trigger a clock/event N times in a single NAPI call.
     #[napi]
     pub fn tick_n(&mut self, event_id: u32, count: u32) -> Result<()> {
+        let runtime_error_sources = self.runtime_error_sources.clone();
         let b = self
             .backend
             .as_mut()
@@ -1005,11 +1049,11 @@ impl NativeSimulatorHandle {
         let event = b.id_to_event_slice()[event_id as usize];
         for _ in 0..count {
             b.eval_comb()
-                .map_err(|e| Error::from_reason(format!("{}", e)))?;
+                .map_err(|e| napi_runtime_error(&runtime_error_sources, e))?;
             b.eval_apply_ff_at(event)
-                .map_err(|e| Error::from_reason(format!("{}", e)))?;
+                .map_err(|e| napi_runtime_error(&runtime_error_sources, e))?;
             b.eval_comb()
-                .map_err(|e| Error::from_reason(format!("{}", e)))?;
+                .map_err(|e| napi_runtime_error(&runtime_error_sources, e))?;
         }
         Ok(())
     }
@@ -1017,12 +1061,13 @@ impl NativeSimulatorHandle {
     /// Evaluate combinational logic.
     #[napi]
     pub fn eval_comb(&mut self) -> Result<()> {
+        let runtime_error_sources = self.runtime_error_sources.clone();
         let b = self
             .backend
             .as_mut()
             .ok_or_else(|| Error::from_reason("Simulator has been disposed"))?;
         b.eval_comb()
-            .map_err(|e| Error::from_reason(format!("{}", e)))
+            .map_err(|e| napi_runtime_error(&runtime_error_sources, e))
     }
 
     /// Write VCD dump at the given timestamp.

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -302,7 +302,7 @@ impl NativeBackend {
         let ret = unsafe { func(ptr) };
         match ret {
             0 => Ok(()),
-            1 => Err(SimulatorErrorCode::DetectedTrueLoop),
+            code if code > 0 => Err(SimulatorErrorCode::DetectedTrueLoopCode(code)),
             _ => Err(SimulatorErrorCode::InternalError),
         }
     }

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -43,6 +43,7 @@ impl super::EventHandle for EventRef {
 #[derive(Debug, Clone, Eq)]
 pub enum SimulatorErrorCode {
     DetectedTrueLoop,
+    DetectedTrueLoopCode(i64),
     DetectedTrueLoopAt { signals: Vec<String> },
     InternalError,
     NotAnEvent(String),
@@ -52,7 +53,11 @@ impl PartialEq for SimulatorErrorCode {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::DetectedTrueLoop, Self::DetectedTrueLoop)
+            | (Self::DetectedTrueLoop, Self::DetectedTrueLoopCode(_))
             | (Self::DetectedTrueLoop, Self::DetectedTrueLoopAt { .. })
+            | (Self::DetectedTrueLoopCode(_), Self::DetectedTrueLoop)
+            | (Self::DetectedTrueLoopCode(_), Self::DetectedTrueLoopAt { .. })
+            | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoopCode(_))
             | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoop)
             | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoopAt { .. }) => true,
             (Self::InternalError, Self::InternalError) => true,
@@ -65,7 +70,9 @@ impl PartialEq for SimulatorErrorCode {
 impl std::fmt::Display for SimulatorErrorCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::DetectedTrueLoop => write!(f, "Detected True Loop"),
+            Self::DetectedTrueLoop | Self::DetectedTrueLoopCode(_) => {
+                write!(f, "Detected True Loop")
+            }
             Self::DetectedTrueLoopAt { signals } if signals.is_empty() => {
                 write!(f, "Detected True Loop")
             }
@@ -530,7 +537,7 @@ impl JitBackend {
         let res = unsafe { (func)(ptr) };
         match res {
             0 => Ok(()),
-            1 => Err(SimulatorErrorCode::DetectedTrueLoop),
+            code if code > 0 => Err(SimulatorErrorCode::DetectedTrueLoopCode(code as i64)),
             _ => unreachable!(),
         }
     }

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -62,6 +62,7 @@ impl PartialEq for SimulatorErrorCode {
             | (Self::DetectedTrueLoop, Self::DetectedTrueLoopCode(_))
             | (Self::DetectedTrueLoop, Self::DetectedTrueLoopAt { .. })
             | (Self::DetectedTrueLoopCode(_), Self::DetectedTrueLoop)
+            | (Self::DetectedTrueLoopCode(_), Self::DetectedTrueLoopCode(_))
             | (Self::DetectedTrueLoopCode(_), Self::DetectedTrueLoopAt { .. })
             | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoopCode(_))
             | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoop)

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -44,7 +44,13 @@ impl super::EventHandle for EventRef {
 pub enum SimulatorErrorCode {
     DetectedTrueLoop,
     DetectedTrueLoopCode(i64),
-    DetectedTrueLoopAt { signals: Vec<String> },
+    DetectedTrueLoopAt {
+        signals: Vec<String>,
+    },
+    Runtime {
+        message: String,
+        signals: Vec<String>,
+    },
     InternalError,
     NotAnEvent(String),
 }
@@ -61,6 +67,16 @@ impl PartialEq for SimulatorErrorCode {
             | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoop)
             | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoopAt { .. }) => true,
             (Self::InternalError, Self::InternalError) => true,
+            (
+                Self::Runtime {
+                    message: a,
+                    signals: sa,
+                },
+                Self::Runtime {
+                    message: b,
+                    signals: sb,
+                },
+            ) => a == b && sa == sb,
             (Self::NotAnEvent(a), Self::NotAnEvent(b)) => a == b,
             _ => false,
         }
@@ -78,6 +94,10 @@ impl std::fmt::Display for SimulatorErrorCode {
             }
             Self::DetectedTrueLoopAt { signals } => {
                 write!(f, "Detected True Loop: {}", signals.join(", "))
+            }
+            Self::Runtime { message, signals } if signals.is_empty() => write!(f, "{message}"),
+            Self::Runtime { message, signals } => {
+                write!(f, "{}: {}", message, signals.join(", "))
             }
             Self::InternalError => write!(f, "Internal Error"),
             Self::NotAnEvent(name) => write!(

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -8,7 +8,6 @@ use crate::{
 };
 
 use super::{JitEngine, MemoryLayout, get_byte_size};
-use thiserror::Error;
 pub type SimFunc = unsafe extern "C" fn(*mut u8) -> u64;
 
 /// Opaque handle to a compiled event (clock / async-reset) function.
@@ -41,16 +40,38 @@ impl super::EventHandle for EventRef {
         self.addr
     }
 }
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Clone, Eq)]
 pub enum SimulatorErrorCode {
     DetectedTrueLoop,
+    DetectedTrueLoopAt { signals: Vec<String> },
     InternalError,
     NotAnEvent(String),
 }
+
+impl PartialEq for SimulatorErrorCode {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::DetectedTrueLoop, Self::DetectedTrueLoop)
+            | (Self::DetectedTrueLoop, Self::DetectedTrueLoopAt { .. })
+            | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoop)
+            | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoopAt { .. }) => true,
+            (Self::InternalError, Self::InternalError) => true,
+            (Self::NotAnEvent(a), Self::NotAnEvent(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
 impl std::fmt::Display for SimulatorErrorCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::DetectedTrueLoop => write!(f, "Detected True Loop"),
+            Self::DetectedTrueLoopAt { signals } if signals.is_empty() => {
+                write!(f, "Detected True Loop")
+            }
+            Self::DetectedTrueLoopAt { signals } => {
+                write!(f, "Detected True Loop: {}", signals.join(", "))
+            }
             Self::InternalError => write!(f, "Internal Error"),
             Self::NotAnEvent(name) => write!(
                 f,
@@ -60,6 +81,8 @@ impl std::fmt::Display for SimulatorErrorCode {
         }
     }
 }
+
+impl std::error::Error for SimulatorErrorCode {}
 
 /// Immutable compilation result that can be shared across simulator instances.
 ///

--- a/crates/celox/src/backend/traits.rs
+++ b/crates/celox/src/backend/traits.rs
@@ -10,18 +10,39 @@ use super::MemoryLayout;
 pub use super::runtime::SimulatorErrorCode;
 
 #[cfg(target_arch = "wasm32")]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Eq)]
 #[allow(dead_code)]
 pub enum SimulatorErrorCode {
     DetectedTrueLoop,
+    DetectedTrueLoopAt { signals: Vec<String> },
     InternalError,
     NotAnEvent(String),
+}
+#[cfg(target_arch = "wasm32")]
+impl PartialEq for SimulatorErrorCode {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::DetectedTrueLoop, Self::DetectedTrueLoop)
+            | (Self::DetectedTrueLoop, Self::DetectedTrueLoopAt { .. })
+            | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoop)
+            | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoopAt { .. }) => true,
+            (Self::InternalError, Self::InternalError) => true,
+            (Self::NotAnEvent(a), Self::NotAnEvent(b)) => a == b,
+            _ => false,
+        }
+    }
 }
 #[cfg(target_arch = "wasm32")]
 impl std::fmt::Display for SimulatorErrorCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::DetectedTrueLoop => write!(f, "Detected True Loop"),
+            Self::DetectedTrueLoopAt { signals } if signals.is_empty() => {
+                write!(f, "Detected True Loop")
+            }
+            Self::DetectedTrueLoopAt { signals } => {
+                write!(f, "Detected True Loop: {}", signals.join(", "))
+            }
             Self::InternalError => write!(f, "Internal Error"),
             Self::NotAnEvent(name) => write!(f, "Not an event: {name}"),
         }

--- a/crates/celox/src/backend/traits.rs
+++ b/crates/celox/src/backend/traits.rs
@@ -14,6 +14,7 @@ pub use super::runtime::SimulatorErrorCode;
 #[allow(dead_code)]
 pub enum SimulatorErrorCode {
     DetectedTrueLoop,
+    DetectedTrueLoopCode(i64),
     DetectedTrueLoopAt { signals: Vec<String> },
     InternalError,
     NotAnEvent(String),
@@ -23,7 +24,11 @@ impl PartialEq for SimulatorErrorCode {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::DetectedTrueLoop, Self::DetectedTrueLoop)
+            | (Self::DetectedTrueLoop, Self::DetectedTrueLoopCode(_))
             | (Self::DetectedTrueLoop, Self::DetectedTrueLoopAt { .. })
+            | (Self::DetectedTrueLoopCode(_), Self::DetectedTrueLoop)
+            | (Self::DetectedTrueLoopCode(_), Self::DetectedTrueLoopAt { .. })
+            | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoopCode(_))
             | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoop)
             | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoopAt { .. }) => true,
             (Self::InternalError, Self::InternalError) => true,
@@ -36,7 +41,9 @@ impl PartialEq for SimulatorErrorCode {
 impl std::fmt::Display for SimulatorErrorCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::DetectedTrueLoop => write!(f, "Detected True Loop"),
+            Self::DetectedTrueLoop | Self::DetectedTrueLoopCode(_) => {
+                write!(f, "Detected True Loop")
+            }
             Self::DetectedTrueLoopAt { signals } if signals.is_empty() => {
                 write!(f, "Detected True Loop")
             }

--- a/crates/celox/src/backend/traits.rs
+++ b/crates/celox/src/backend/traits.rs
@@ -33,6 +33,7 @@ impl PartialEq for SimulatorErrorCode {
             | (Self::DetectedTrueLoop, Self::DetectedTrueLoopCode(_))
             | (Self::DetectedTrueLoop, Self::DetectedTrueLoopAt { .. })
             | (Self::DetectedTrueLoopCode(_), Self::DetectedTrueLoop)
+            | (Self::DetectedTrueLoopCode(_), Self::DetectedTrueLoopCode(_))
             | (Self::DetectedTrueLoopCode(_), Self::DetectedTrueLoopAt { .. })
             | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoopCode(_))
             | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoop)

--- a/crates/celox/src/backend/traits.rs
+++ b/crates/celox/src/backend/traits.rs
@@ -15,7 +15,13 @@ pub use super::runtime::SimulatorErrorCode;
 pub enum SimulatorErrorCode {
     DetectedTrueLoop,
     DetectedTrueLoopCode(i64),
-    DetectedTrueLoopAt { signals: Vec<String> },
+    DetectedTrueLoopAt {
+        signals: Vec<String>,
+    },
+    Runtime {
+        message: String,
+        signals: Vec<String>,
+    },
     InternalError,
     NotAnEvent(String),
 }
@@ -32,6 +38,16 @@ impl PartialEq for SimulatorErrorCode {
             | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoop)
             | (Self::DetectedTrueLoopAt { .. }, Self::DetectedTrueLoopAt { .. }) => true,
             (Self::InternalError, Self::InternalError) => true,
+            (
+                Self::Runtime {
+                    message: a,
+                    signals: sa,
+                },
+                Self::Runtime {
+                    message: b,
+                    signals: sb,
+                },
+            ) => a == b && sa == sb,
             (Self::NotAnEvent(a), Self::NotAnEvent(b)) => a == b,
             _ => false,
         }
@@ -49,6 +65,10 @@ impl std::fmt::Display for SimulatorErrorCode {
             }
             Self::DetectedTrueLoopAt { signals } => {
                 write!(f, "Detected True Loop: {}", signals.join(", "))
+            }
+            Self::Runtime { message, signals } if signals.is_empty() => write!(f, "{message}"),
+            Self::Runtime { message, signals } => {
+                write!(f, "{}: {}", message, signals.join(", "))
             }
             Self::InternalError => write!(f, "Internal Error"),
             Self::NotAnEvent(name) => write!(f, "Not an event: {name}"),

--- a/crates/celox/src/backend/wasm_runtime.rs
+++ b/crates/celox/src/backend/wasm_runtime.rs
@@ -366,7 +366,7 @@ impl WasmBackend {
         let res = func.call(&mut self.store, ()).unwrap_or(2);
         match res {
             0 => Ok(()),
-            1 => Err(SimulatorErrorCode::DetectedTrueLoop),
+            code if code > 0 => Err(SimulatorErrorCode::DetectedTrueLoopCode(code)),
             _ => Err(SimulatorErrorCode::InternalError),
         }
     }

--- a/crates/celox/src/backend/wasm_runtime.rs
+++ b/crates/celox/src/backend/wasm_runtime.rs
@@ -366,7 +366,8 @@ impl WasmBackend {
         let res = func.call(&mut self.store, ()).unwrap_or(2);
         match res {
             0 => Ok(()),
-            code if code > 0 => Err(SimulatorErrorCode::DetectedTrueLoopCode(code)),
+            1 => Err(SimulatorErrorCode::DetectedTrueLoopCode(1)),
+            code if code >= 2000 => Err(SimulatorErrorCode::DetectedTrueLoopCode(code)),
             _ => Err(SimulatorErrorCode::InternalError),
         }
     }

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -93,6 +93,7 @@ pub struct Program {
     pub eval_only_ffs: HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
     pub apply_ffs: HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
     pub eval_comb: Vec<ExecutionUnit<RegionedAbsoluteAddr>>,
+    pub runtime_error_sources: HashMap<i64, Vec<AbsoluteAddr>>,
     /// Tail-call chain compilation plan, populated by the optimizer when the
     /// estimated CLIF instruction count exceeds Cranelift's limit.
     pub eval_comb_plan: Option<EvalCombPlan>,

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -88,12 +88,18 @@ pub enum EvalCombPlan {
 }
 
 #[derive(Clone)]
+pub struct RuntimeErrorInfo<Addr = AbsoluteAddr> {
+    pub message: String,
+    pub signals: Vec<Addr>,
+}
+
+#[derive(Clone)]
 pub struct Program {
     pub eval_apply_ffs: HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
     pub eval_only_ffs: HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
     pub apply_ffs: HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
     pub eval_comb: Vec<ExecutionUnit<RegionedAbsoluteAddr>>,
-    pub runtime_error_sources: HashMap<i64, Vec<AbsoluteAddr>>,
+    pub runtime_errors: HashMap<i64, RuntimeErrorInfo<AbsoluteAddr>>,
     /// Tail-call chain compilation plan, populated by the optimizer when the
     /// estimated CLIF instruction count exceeds Cranelift's limit.
     pub eval_comb_plan: Option<EvalCombPlan>,
@@ -572,6 +578,7 @@ pub struct SimModule {
     pub eval_apply_ff_blocks: HashMap<TriggerSet<VarId>, ExecutionUnit<RegionedVarAddr>>,
     pub glue_blocks: HashMap<StrId, Vec<GlueBlock>>,
     pub comb_blocks: Vec<LogicPath<VarId>>,
+    pub runtime_errors: HashMap<i64, RuntimeErrorInfo<VarId>>,
     pub comb_boundaries: HashMap<VarId, std::collections::BTreeSet<usize>>,
     pub arena: SLTNodeArena<VarId>,
     pub store: SymbolicStore<VarId>,

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -57,7 +57,7 @@ pub use debug::CompilationTraceResult;
 pub use debug::{CompilationTrace, TraceOptions};
 pub(crate) use fxhash::FxHashMap as HashMap;
 pub(crate) use fxhash::FxHashSet as HashSet;
-pub use ir::{AbsoluteAddr, AddrLookupError, PortTypeKind, Program, SignalRef};
+pub use ir::{AbsoluteAddr, AddrLookupError, PortTypeKind, Program, RuntimeErrorInfo, SignalRef};
 #[cfg(target_arch = "x86_64")]
 pub mod native_backend {
     //! Re-exports for the native x86-64 backend (for testing/integration).

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -39,7 +39,7 @@ pub mod registry;
 mod scheduler;
 use crate::ir::{
     AbsoluteAddr, DomainKind, ExecutionUnit, GlueAddr, InstanceId, InstancePath, ModuleId, Program,
-    RegionedAbsoluteAddr, STABLE_REGION, SimModule, VariableInfo,
+    RegionedAbsoluteAddr, RuntimeErrorInfo, STABLE_REGION, SimModule, VariableInfo,
 };
 use crate::logic_tree::{LogicPath, SLTNodeArena};
 pub use scheduler::SchedulerError;
@@ -614,7 +614,14 @@ pub(crate) fn flatten(
         "unify_clock_domains",
         unify_clock_domains(&expanded, &instance_modules, &modules)
     );
-    let (mut global_arena, mut eval_apply_ffs, eval_only_ffs, apply_ffs, mut comb_blocks) = timed_sub!(
+    let (
+        mut global_arena,
+        mut eval_apply_ffs,
+        eval_only_ffs,
+        apply_ffs,
+        mut comb_blocks,
+        mut runtime_errors,
+    ) = timed_sub!(
         "relocate_units",
         relocate_units(
             &expanded,
@@ -716,7 +723,7 @@ pub(crate) fn flatten(
             eval_only_ffs: HashMap::default(),
             apply_ffs: HashMap::default(),
             eval_comb: Vec::new(),
-            runtime_error_sources: HashMap::default(),
+            runtime_errors: HashMap::default(),
             eval_comb_plan: None,
             instance_ids: expanded.clone(),
             instance_module: instance_modules.clone(),
@@ -751,7 +758,7 @@ pub(crate) fn flatten(
     if let Some(s) = sched_start {
         eprintln!("[flatten] scheduler::sort: {:?}", s.elapsed());
     }
-    let runtime_error_sources = schedule.runtime_error_sources;
+    runtime_errors.extend(schedule.runtime_errors);
     let schduled: Vec<crate::ir::ExecutionUnit<RegionedAbsoluteAddr>> = schedule
         .execution_units
         .into_iter()
@@ -823,7 +830,7 @@ pub(crate) fn flatten(
         eval_only_ffs,
         apply_ffs,
         eval_comb: schduled,
-        runtime_error_sources,
+        runtime_errors,
         eval_comb_plan: None,
         instance_ids: expanded,
         instance_module: instance_modules,
@@ -1346,9 +1353,10 @@ pub fn parse(
     Ok(program)
 }
 
-fn relocate_executation_unit<A, B>(
+fn relocate_executation_unit_with_errors<A, B>(
     eu: &ExecutionUnit<A>,
     f: &impl Fn(&A) -> B,
+    runtime_error_codes: &HashMap<i64, i64>,
 ) -> ExecutionUnit<B> {
     ExecutionUnit {
         entry_block_id: eu.entry_block_id,
@@ -1366,7 +1374,14 @@ fn relocate_executation_unit<A, B>(
                             .map(|inst| inst.map_addr(f))
                             .collect(),
                         params: block.params.clone(),
-                        terminator: block.terminator.clone(),
+                        terminator: match block.terminator {
+                            crate::ir::SIRTerminator::Error(code) => {
+                                crate::ir::SIRTerminator::Error(
+                                    runtime_error_codes.get(&code).copied().unwrap_or(code),
+                                )
+                            }
+                            ref terminator => terminator.clone(),
+                        },
                     },
                 )
             })
@@ -1512,6 +1527,7 @@ fn relocate_units(
     HashMap<AbsoluteAddr, Vec<crate::ir::ExecutionUnit<RegionedAbsoluteAddr>>>,
     HashMap<AbsoluteAddr, Vec<crate::ir::ExecutionUnit<RegionedAbsoluteAddr>>>,
     Vec<crate::logic_tree::LogicPath<AbsoluteAddr>>,
+    HashMap<i64, RuntimeErrorInfo<AbsoluteAddr>>,
 ) {
     let mut global_arena = SLTNodeArena::<AbsoluteAddr>::new();
     let mut eval_apply_ffs: HashMap<
@@ -1525,10 +1541,33 @@ fn relocate_units(
     let mut apply_ffs: HashMap<AbsoluteAddr, Vec<crate::ir::ExecutionUnit<RegionedAbsoluteAddr>>> =
         HashMap::default();
     let mut comb_blocks = Vec::new();
+    let mut runtime_errors = HashMap::default();
+    let mut next_runtime_error_code = 2000;
 
     for (path, id) in expanded {
         let module_id = &instance_modules[id];
         let sim_module = &modules[module_id];
+        let mut runtime_error_codes = HashMap::default();
+        for (&local_code, info) in &sim_module.runtime_errors {
+            let global_code = next_runtime_error_code;
+            next_runtime_error_code += 1;
+            runtime_error_codes.insert(local_code, global_code);
+            runtime_errors.insert(
+                global_code,
+                RuntimeErrorInfo {
+                    message: info.message.clone(),
+                    signals: info
+                        .signals
+                        .iter()
+                        .filter(|var_id| sim_module.variables.contains_key(var_id))
+                        .map(|&var_id| AbsoluteAddr {
+                            instance_id: *id,
+                            var_id,
+                        })
+                        .collect(),
+                },
+            );
+        }
 
         let relocated_module = flatting::flatting(
             sim_module,
@@ -1552,16 +1591,17 @@ fn relocate_units(
                 .copied()
                 .unwrap_or(clock_addr);
 
-            eval_apply_ffs
-                .entry(canonical_addr)
-                .or_default()
-                .push(relocate_executation_unit(eu, &|addr| {
-                    RegionedAbsoluteAddr {
+            eval_apply_ffs.entry(canonical_addr).or_default().push(
+                relocate_executation_unit_with_errors(
+                    eu,
+                    &|addr| RegionedAbsoluteAddr {
                         region: addr.region,
                         instance_id: *id,
                         var_id: addr.var_id,
-                    }
-                }));
+                    },
+                    &runtime_error_codes,
+                ),
+            );
 
             for &reset in &trigger_set.resets {
                 let reset_addr = AbsoluteAddr {
@@ -1572,16 +1612,17 @@ fn relocate_units(
                     .get(&reset_addr)
                     .copied()
                     .unwrap_or(reset_addr);
-                eval_apply_ffs
-                    .entry(canonical_addr)
-                    .or_default()
-                    .push(relocate_executation_unit(eu, &|addr| {
-                        RegionedAbsoluteAddr {
+                eval_apply_ffs.entry(canonical_addr).or_default().push(
+                    relocate_executation_unit_with_errors(
+                        eu,
+                        &|addr| RegionedAbsoluteAddr {
                             region: addr.region,
                             instance_id: *id,
                             var_id: addr.var_id,
-                        }
-                    }));
+                        },
+                        &runtime_error_codes,
+                    ),
+                );
             }
         }
 
@@ -1594,16 +1635,17 @@ fn relocate_units(
                 .get(&clock_addr)
                 .copied()
                 .unwrap_or(clock_addr);
-            eval_only_ffs
-                .entry(canonical_addr)
-                .or_default()
-                .push(relocate_executation_unit(eu, &|addr| {
-                    RegionedAbsoluteAddr {
+            eval_only_ffs.entry(canonical_addr).or_default().push(
+                relocate_executation_unit_with_errors(
+                    eu,
+                    &|addr| RegionedAbsoluteAddr {
                         region: addr.region,
                         instance_id: *id,
                         var_id: addr.var_id,
-                    }
-                }));
+                    },
+                    &runtime_error_codes,
+                ),
+            );
 
             for &reset in &trigger_set.resets {
                 let reset_addr = AbsoluteAddr {
@@ -1614,16 +1656,17 @@ fn relocate_units(
                     .get(&reset_addr)
                     .copied()
                     .unwrap_or(reset_addr);
-                eval_only_ffs
-                    .entry(canonical_addr)
-                    .or_default()
-                    .push(relocate_executation_unit(eu, &|addr| {
-                        RegionedAbsoluteAddr {
+                eval_only_ffs.entry(canonical_addr).or_default().push(
+                    relocate_executation_unit_with_errors(
+                        eu,
+                        &|addr| RegionedAbsoluteAddr {
                             region: addr.region,
                             instance_id: *id,
                             var_id: addr.var_id,
-                        }
-                    }));
+                        },
+                        &runtime_error_codes,
+                    ),
+                );
             }
         }
 
@@ -1636,16 +1679,17 @@ fn relocate_units(
                 .get(&clock_addr)
                 .copied()
                 .unwrap_or(clock_addr);
-            apply_ffs
-                .entry(canonical_addr)
-                .or_default()
-                .push(relocate_executation_unit(eu, &|addr| {
-                    RegionedAbsoluteAddr {
+            apply_ffs.entry(canonical_addr).or_default().push(
+                relocate_executation_unit_with_errors(
+                    eu,
+                    &|addr| RegionedAbsoluteAddr {
                         region: addr.region,
                         instance_id: *id,
                         var_id: addr.var_id,
-                    }
-                }));
+                    },
+                    &runtime_error_codes,
+                ),
+            );
 
             for &reset in &trigger_set.resets {
                 let reset_addr = AbsoluteAddr {
@@ -1656,16 +1700,17 @@ fn relocate_units(
                     .get(&reset_addr)
                     .copied()
                     .unwrap_or(reset_addr);
-                apply_ffs
-                    .entry(canonical_addr)
-                    .or_default()
-                    .push(relocate_executation_unit(eu, &|addr| {
-                        RegionedAbsoluteAddr {
+                apply_ffs.entry(canonical_addr).or_default().push(
+                    relocate_executation_unit_with_errors(
+                        eu,
+                        &|addr| RegionedAbsoluteAddr {
                             region: addr.region,
                             instance_id: *id,
                             var_id: addr.var_id,
-                        }
-                    }));
+                        },
+                        &runtime_error_codes,
+                    ),
+                );
             }
         }
     }
@@ -1675,6 +1720,7 @@ fn relocate_units(
         eval_only_ffs,
         apply_ffs,
         comb_blocks,
+        runtime_errors,
     )
 }
 

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -64,6 +64,13 @@ impl SourceLocation {
             span: token.into(),
         }
     }
+
+    fn path(&self) -> Option<&str> {
+        self.source
+            .sources
+            .first()
+            .map(|source| source.path.as_str())
+    }
 }
 
 /// The compilation phase where an unsupported feature was encountered.
@@ -88,6 +95,12 @@ impl std::fmt::Display for LoweringPhase {
 pub enum ParserError {
     #[error(transparent)]
     Scheduler(SchedulerError<String>),
+
+    #[error("{error}")]
+    SchedulerWithLocation {
+        error: SchedulerError<String>,
+        source_locations: Vec<SourceLocation>,
+    },
 
     #[error("Unsupported in {phase}: {feature} [tracking issue #{issue}] ({detail})")]
     Unsupported {
@@ -179,7 +192,9 @@ impl miette::Diagnostic for ParserError {
             ))),
             ParserError::IllegalContext { .. } => Some(Box::new("illegal_context")),
             ParserError::UnresolvedWidth { .. } => Some(Box::new("unresolved_width")),
-            ParserError::Scheduler(_) => Some(Box::new("scheduler")),
+            ParserError::Scheduler(_) | ParserError::SchedulerWithLocation { .. } => {
+                Some(Box::new("scheduler"))
+            }
             ParserError::TopNotFound { .. } => Some(Box::new("top_not_found")),
             ParserError::GenericTop { .. } => Some(Box::new("generic_top")),
         }
@@ -200,6 +215,9 @@ impl miette::Diagnostic for ParserError {
             | ParserError::UnresolvedWidth {
                 source_location, ..
             } => source_location.as_ref(),
+            ParserError::SchedulerWithLocation {
+                source_locations, ..
+            } => source_locations.first(),
             _ => None,
         };
         loc.map(|l| &l.source as &dyn miette::SourceCode)
@@ -218,12 +236,35 @@ impl miette::Diagnostic for ParserError {
             } => source_location.as_ref(),
             _ => None,
         };
-        loc.map(|l| {
-            Box::new(std::iter::once(miette::LabeledSpan::new_with_span(
-                Some("Error location".to_string()),
-                l.span,
-            ))) as Box<dyn Iterator<Item = miette::LabeledSpan>>
-        })
+        if let Some(loc) = loc {
+            return Some(Box::new(std::iter::once(
+                miette::LabeledSpan::new_with_span(Some("Error location".to_string()), loc.span),
+            )));
+        }
+
+        match self {
+            ParserError::SchedulerWithLocation {
+                source_locations, ..
+            } => {
+                let first_path = source_locations.first().and_then(SourceLocation::path)?;
+                let labels = source_locations
+                    .iter()
+                    .filter(move |loc| loc.path() == Some(first_path))
+                    .map(|loc| {
+                        miette::LabeledSpan::new_with_span(
+                            Some("loop participant".to_string()),
+                            loc.span,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                if labels.is_empty() {
+                    None
+                } else {
+                    Some(Box::new(labels.into_iter()))
+                }
+            }
+            _ => None,
+        }
     }
 }
 
@@ -497,6 +538,32 @@ fn parse_true_loops(
     }
     res
 }
+
+fn scheduler_source_locations(
+    error: &SchedulerError<AbsoluteAddr>,
+    module_ir: &HashMap<ModuleId, &Module>,
+    instance_modules: &HashMap<InstanceId, ModuleId>,
+) -> Vec<SourceLocation> {
+    let blocks = match error {
+        SchedulerError::CombinationalLoop { blocks } => blocks,
+        SchedulerError::MultipleDriver { blocks } => blocks,
+    };
+    let mut seen = HashSet::default();
+    blocks
+        .iter()
+        .filter_map(|block| {
+            let addr = block.target.id;
+            if !seen.insert(addr) {
+                return None;
+            }
+            let module_id = instance_modules.get(&addr.instance_id)?;
+            let module = module_ir.get(module_id)?;
+            let var = module.variables.get(&addr.var_id)?;
+            Some(SourceLocation::from_token(&var.token))
+        })
+        .collect()
+}
+
 pub(crate) fn flatten(
     root_id: &ModuleId,
     module_ir: &HashMap<ModuleId, &Module>,
@@ -666,10 +733,19 @@ pub(crate) fn flatten(
             initial_statements: None,
             tb_functions: fxhash::FxHashMap::default(),
         };
+        let source_locations = scheduler_source_locations(&e, module_ir, &instance_modules);
         let mut target_arena = SLTNodeArena::new();
-        ParserError::Scheduler(e.map_addr(&global_arena, &mut target_arena, &|addr| {
+        let error = e.map_addr(&global_arena, &mut target_arena, &|addr| {
             program.get_path(addr)
-        }))
+        });
+        if source_locations.is_empty() {
+            ParserError::Scheduler(error)
+        } else {
+            ParserError::SchedulerWithLocation {
+                error,
+                source_locations,
+            }
+        }
     })?;
     if let Some(s) = sched_start {
         eprintln!("[flatten] scheduler::sort: {:?}", s.elapsed());

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -564,26 +564,6 @@ fn scheduler_source_locations(
         .collect()
 }
 
-fn runtime_error_sources(
-    true_loops: &HashMap<(AbsoluteAddr, AbsoluteAddr), usize>,
-) -> HashMap<i64, Vec<AbsoluteAddr>> {
-    let mut sources = Vec::new();
-    let mut seen = HashSet::default();
-    for &(from, to) in true_loops.keys() {
-        if seen.insert(from) {
-            sources.push(from);
-        }
-        if seen.insert(to) {
-            sources.push(to);
-        }
-    }
-    if sources.is_empty() {
-        HashMap::default()
-    } else {
-        HashMap::from_iter([(1, sources)])
-    }
-}
-
 pub(crate) fn flatten(
     root_id: &ModuleId,
     module_ir: &HashMap<ModuleId, &Module>,
@@ -721,7 +701,7 @@ pub(crate) fn flatten(
         .collect();
 
     let sched_start = flatten_timing.then(crate::timing::now);
-    let schduled = scheduler::sort(
+    let schedule = scheduler::sort(
         comb_blocks,
         &global_arena,
         &ignored_loops,
@@ -771,7 +751,9 @@ pub(crate) fn flatten(
     if let Some(s) = sched_start {
         eprintln!("[flatten] scheduler::sort: {:?}", s.elapsed());
     }
-    let schduled: Vec<crate::ir::ExecutionUnit<RegionedAbsoluteAddr>> = schduled
+    let runtime_error_sources = schedule.runtime_error_sources;
+    let schduled: Vec<crate::ir::ExecutionUnit<RegionedAbsoluteAddr>> = schedule
+        .execution_units
         .into_iter()
         .map(|eu| crate::ir::ExecutionUnit {
             entry_block_id: eu.entry_block_id,
@@ -836,7 +818,6 @@ pub(crate) fn flatten(
 
     let num_events = topological_clocks.len();
     let (mod_vars, mod_path_idx) = module_variables(module_ir, config)?;
-    let runtime_error_sources = runtime_error_sources(&true_loops);
     let program = Program {
         eval_apply_ffs,
         eval_only_ffs,

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -564,6 +564,26 @@ fn scheduler_source_locations(
         .collect()
 }
 
+fn runtime_error_sources(
+    true_loops: &HashMap<(AbsoluteAddr, AbsoluteAddr), usize>,
+) -> HashMap<i64, Vec<AbsoluteAddr>> {
+    let mut sources = Vec::new();
+    let mut seen = HashSet::default();
+    for &(from, to) in true_loops.keys() {
+        if seen.insert(from) {
+            sources.push(from);
+        }
+        if seen.insert(to) {
+            sources.push(to);
+        }
+    }
+    if sources.is_empty() {
+        HashMap::default()
+    } else {
+        HashMap::from_iter([(1, sources)])
+    }
+}
+
 pub(crate) fn flatten(
     root_id: &ModuleId,
     module_ir: &HashMap<ModuleId, &Module>,
@@ -716,6 +736,7 @@ pub(crate) fn flatten(
             eval_only_ffs: HashMap::default(),
             apply_ffs: HashMap::default(),
             eval_comb: Vec::new(),
+            runtime_error_sources: HashMap::default(),
             eval_comb_plan: None,
             instance_ids: expanded.clone(),
             instance_module: instance_modules.clone(),
@@ -815,11 +836,13 @@ pub(crate) fn flatten(
 
     let num_events = topological_clocks.len();
     let (mod_vars, mod_path_idx) = module_variables(module_ir, config)?;
+    let runtime_error_sources = runtime_error_sources(&true_loops);
     let program = Program {
         eval_apply_ffs,
         eval_only_ffs,
         apply_ffs,
         eval_comb: schduled,
+        runtime_error_sources,
         eval_comb_plan: None,
         instance_ids: expanded,
         instance_module: instance_modules,

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -621,6 +621,7 @@ pub(crate) fn flatten(
         apply_ffs,
         mut comb_blocks,
         mut runtime_errors,
+        next_runtime_error_code,
     ) = timed_sub!(
         "relocate_units",
         relocate_units(
@@ -715,6 +716,7 @@ pub(crate) fn flatten(
         &true_loops,
         four_state,
         &var_widths,
+        next_runtime_error_code,
     )
     .map_err(|e| {
         let (err_vars, err_path_idx) = module_variables(module_ir, config).unwrap_or_default();
@@ -1528,6 +1530,7 @@ fn relocate_units(
     HashMap<AbsoluteAddr, Vec<crate::ir::ExecutionUnit<RegionedAbsoluteAddr>>>,
     Vec<crate::logic_tree::LogicPath<AbsoluteAddr>>,
     HashMap<i64, RuntimeErrorInfo<AbsoluteAddr>>,
+    i64,
 ) {
     let mut global_arena = SLTNodeArena::<AbsoluteAddr>::new();
     let mut eval_apply_ffs: HashMap<
@@ -1721,6 +1724,7 @@ fn relocate_units(
         apply_ffs,
         comb_blocks,
         runtime_errors,
+        next_runtime_error_code,
     )
 }
 

--- a/crates/celox/src/parser/ff.rs
+++ b/crates/celox/src/parser/ff.rs
@@ -1,8 +1,8 @@
 use std::collections::VecDeque;
 
 use crate::ir::{
-    RegisterId, RegisterType, SIRBuilder, SIRInstruction, SIRTerminator, TriggerSet, UnaryOp,
-    VarAtomBase, WORKING_REGION,
+    RegisterId, RegisterType, RuntimeErrorInfo, SIRBuilder, SIRInstruction, SIRTerminator,
+    TriggerSet, UnaryOp, VarAtomBase, WORKING_REGION,
 };
 use crate::{
     HashMap, HashSet,
@@ -73,6 +73,8 @@ pub struct FfParser<'a> {
     loop_exit_blocks: Vec<crate::ir::BlockId>,
     reset: Option<FfReset>,
     function_arg_stack: Vec<HashMap<VarId, Expression>>,
+    runtime_errors: HashMap<i64, RuntimeErrorInfo<VarId>>,
+    next_runtime_error_code: i64,
     config: BuildConfig,
 }
 
@@ -93,8 +95,27 @@ impl<'a> FfParser<'a> {
             loop_exit_blocks: Vec::new(),
             reset: None,
             function_arg_stack: Vec::new(),
+            runtime_errors: HashMap::default(),
+            next_runtime_error_code: 2000,
             config,
         }
+    }
+
+    pub fn runtime_errors(&self) -> &HashMap<i64, RuntimeErrorInfo<VarId>> {
+        &self.runtime_errors
+    }
+
+    fn runtime_error(&mut self, message: impl Into<String>, signals: Vec<VarId>) -> i64 {
+        let code = self.next_runtime_error_code;
+        self.next_runtime_error_code += 1;
+        self.runtime_errors.insert(
+            code,
+            RuntimeErrorInfo {
+                message: message.into(),
+                signals,
+            },
+        );
+        code
     }
 
     fn get_constant_value(&self, expr: &Expression) -> Option<u64> {
@@ -820,6 +841,13 @@ impl<'a> FfParser<'a> {
                     Self::bound_const_value(end),
                 ),
             };
+        let loop_var_name = veryl_parser::resource_table::get_str_value(stmt.var_name)
+            .unwrap_or_else(|| "<unknown>".to_string());
+        let non_progress_message =
+            format!("Non-progressing for loop in always_ff (loop variable `{loop_var_name}`)");
+        let range_message = format!(
+            "For loop value exceeds loop variable range in always_ff (loop variable `{loop_var_name}`)"
+        );
 
         let const_empty = Self::const_range_is_empty(reverse, start_const, end_const, inclusive);
         let const_singleton =
@@ -1081,7 +1109,9 @@ impl<'a> FfParser<'a> {
                     ir_builder.seal_block(SIRTerminator::Jump(true_loop_bb, vec![]));
                 }
                 ir_builder.switch_to_block(true_loop_bb);
-                ir_builder.seal_block(SIRTerminator::Error(1));
+                let error_code =
+                    self.runtime_error(non_progress_message.clone(), vec![stmt.var_id]);
+                ir_builder.seal_block(SIRTerminator::Error(error_code));
                 ir_builder.switch_to_block(singleton_bb);
                 ir_builder.seal_block(SIRTerminator::Jump(fitcheck_bb, vec![header_counter]));
             } else {
@@ -1275,7 +1305,8 @@ impl<'a> FfParser<'a> {
             ir_builder.seal_block(SIRTerminator::Jump(body_bb, vec![fitcheck_counter]));
         }
         ir_builder.switch_to_block(range_error_bb);
-        ir_builder.seal_block(SIRTerminator::Error(1));
+        let error_code = self.runtime_error(range_message, vec![stmt.var_id]);
+        ir_builder.seal_block(SIRTerminator::Error(error_code));
         ir_builder.switch_to_block(body_bb);
         self.local_working_vars.insert(stmt.var_id);
 
@@ -1400,7 +1431,8 @@ impl<'a> FfParser<'a> {
                 false_block: (exit_bb, vec![]),
             });
             ir_builder.switch_to_block(stall_bb);
-            ir_builder.seal_block(SIRTerminator::Error(1));
+            let error_code = self.runtime_error(non_progress_message, vec![stmt.var_id]);
+            ir_builder.seal_block(SIRTerminator::Error(error_code));
         } else {
             let current_math =
                 self.cast_reg_width_ext(ir_builder, body_counter, math_width, loop_signed);

--- a/crates/celox/src/parser/module.rs
+++ b/crates/celox/src/parser/module.rs
@@ -390,6 +390,7 @@ impl<'a> ModuleParser<'a> {
             apply_ff_blocks,
             eval_apply_ff_blocks,
             comb_blocks: self.comb_blocks,
+            runtime_errors: self.ff_parser.runtime_errors().clone(),
             comb_boundaries,
             arena: self.arena,
             store: self.store,

--- a/crates/celox/src/parser/scheduler.rs
+++ b/crates/celox/src/parser/scheduler.rs
@@ -7,7 +7,7 @@ use crate::ir::SIRInstruction;
 use crate::ir::SIROffset;
 use crate::ir::SIRTerminator;
 use crate::ir::SIRValue;
-use crate::ir::{BitAccess, BlockId, ExecutionUnit};
+use crate::ir::{BitAccess, BlockId, ExecutionUnit, RuntimeErrorInfo};
 use crate::logic_tree::NodeId;
 use crate::logic_tree::{LogicPath, SLTNodeArena};
 use std::fmt::Debug;
@@ -321,7 +321,7 @@ impl<A: Display + Debug + Eq + Hash + Clone> SchedulerError<A> {
 
 pub struct ScheduleResult<Addr> {
     pub execution_units: Vec<ExecutionUnit<Addr>>,
-    pub runtime_error_sources: HashMap<i64, Vec<Addr>>,
+    pub runtime_errors: HashMap<i64, RuntimeErrorInfo<Addr>>,
 }
 
 /// Flush pending DAG nodes, optionally coalescing contiguous stores to the
@@ -639,7 +639,7 @@ pub fn sort<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display>(
     const EU_BLOCK_LIMIT: usize = 20_000;
 
     let mut result_eus: Vec<ExecutionUnit<Addr>> = Vec::new();
-    let mut runtime_error_sources: HashMap<i64, Vec<Addr>> = HashMap::default();
+    let mut runtime_errors: HashMap<i64, RuntimeErrorInfo<Addr>> = HashMap::default();
     let mut next_runtime_error_code = 1000;
 
     let mut pending_indices: Vec<usize> = Vec::new();
@@ -726,7 +726,13 @@ pub fn sort<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display>(
                         seen.insert(addr).then_some(addr)
                     })
                     .collect::<Vec<_>>();
-                runtime_error_sources.insert(runtime_error_code, sources);
+                runtime_errors.insert(
+                    runtime_error_code,
+                    RuntimeErrorInfo {
+                        message: "Detected True Loop".to_string(),
+                        signals: sources,
+                    },
+                );
 
                 // Strategy B: Dynamic Convergence
                 // Implements a runtime loop that continues executing the SCC until all signals converge (dirty flag is false).
@@ -937,6 +943,6 @@ pub fn sort<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display>(
     });
     Ok(ScheduleResult {
         execution_units: result_eus,
-        runtime_error_sources,
+        runtime_errors,
     })
 }

--- a/crates/celox/src/parser/scheduler.rs
+++ b/crates/celox/src/parser/scheduler.rs
@@ -319,6 +319,11 @@ impl<A: Display + Debug + Eq + Hash + Clone> SchedulerError<A> {
     }
 }
 
+pub struct ScheduleResult<Addr> {
+    pub execution_units: Vec<ExecutionUnit<Addr>>,
+    pub runtime_error_sources: HashMap<i64, Vec<Addr>>,
+}
+
 /// Flush pending DAG nodes, optionally coalescing contiguous stores to the
 /// same variable into a single `Concat` + `Store`.
 fn flush_pending_coalesce<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display>(
@@ -500,7 +505,7 @@ pub fn sort<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display>(
     true_loops: &HashMap<(Addr, Addr), usize>,
     four_state: bool,
     var_widths: &HashMap<Addr, usize>,
-) -> Result<Vec<ExecutionUnit<Addr>>, SchedulerError<Addr>> {
+) -> Result<ScheduleResult<Addr>, SchedulerError<Addr>> {
     // 1. Build Atom Map & Multiple Driver Check
     let mut atoms_map: HashMap<Addr, Vec<(BitAccess, usize)>> = HashMap::default();
     for (i, path) in input.iter().enumerate() {
@@ -634,6 +639,8 @@ pub fn sort<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display>(
     const EU_BLOCK_LIMIT: usize = 20_000;
 
     let mut result_eus: Vec<ExecutionUnit<Addr>> = Vec::new();
+    let mut runtime_error_sources: HashMap<i64, Vec<Addr>> = HashMap::default();
+    let mut next_runtime_error_code = 1000;
 
     let mut pending_indices: Vec<usize> = Vec::new();
     let mut pending_target: Option<Addr> = None;
@@ -709,6 +716,18 @@ pub fn sort<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display>(
                     }
                 }
             } else {
+                let runtime_error_code = next_runtime_error_code;
+                next_runtime_error_code += 1;
+                let mut seen = HashSet::default();
+                let sources = scc
+                    .iter()
+                    .filter_map(|idx| {
+                        let addr = input[*idx].target.id;
+                        seen.insert(addr).then_some(addr)
+                    })
+                    .collect::<Vec<_>>();
+                runtime_error_sources.insert(runtime_error_code, sources);
+
                 // Strategy B: Dynamic Convergence
                 // Implements a runtime loop that continues executing the SCC until all signals converge (dirty flag is false).
                 // Includes a safety limit to detect non-converging "True Loops" and avoid infinite hang.
@@ -838,7 +857,7 @@ pub fn sort<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display>(
                 builder.switch_to_block(error_block);
                 // Emit a trap or special instruction to indicate "Combinational Loop Oscillation"
                 // builder.emit(SIRInstruction::Trap(1));
-                builder.seal_block(SIRTerminator::Error(1));
+                builder.seal_block(SIRTerminator::Error(runtime_error_code));
 
                 // 5. Exit Block
                 builder.switch_to_block(exit_block);
@@ -916,5 +935,8 @@ pub fn sort<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display>(
         blocks,
         register_map: reg_map,
     });
-    Ok(result_eus)
+    Ok(ScheduleResult {
+        execution_units: result_eus,
+        runtime_error_sources,
+    })
 }

--- a/crates/celox/src/parser/scheduler.rs
+++ b/crates/celox/src/parser/scheduler.rs
@@ -505,6 +505,7 @@ pub fn sort<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display>(
     true_loops: &HashMap<(Addr, Addr), usize>,
     four_state: bool,
     var_widths: &HashMap<Addr, usize>,
+    first_runtime_error_code: i64,
 ) -> Result<ScheduleResult<Addr>, SchedulerError<Addr>> {
     // 1. Build Atom Map & Multiple Driver Check
     let mut atoms_map: HashMap<Addr, Vec<(BitAccess, usize)>> = HashMap::default();
@@ -640,7 +641,7 @@ pub fn sort<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display>(
 
     let mut result_eus: Vec<ExecutionUnit<Addr>> = Vec::new();
     let mut runtime_errors: HashMap<i64, RuntimeErrorInfo<Addr>> = HashMap::default();
-    let mut next_runtime_error_code = 1000;
+    let mut next_runtime_error_code = first_runtime_error_code;
 
     let mut pending_indices: Vec<usize> = Vec::new();
     let mut pending_target: Option<Addr> = None;

--- a/crates/celox/src/simulation.rs
+++ b/crates/celox/src/simulation.rs
@@ -290,7 +290,7 @@ impl<B: SimBackend> Simulation<B> {
             }
         }
 
-        self.simulator.backend.eval_comb()?;
+        self.simulator.eval_comb_checked()?;
 
         let mut comb_already_done = false;
         loop {
@@ -328,8 +328,8 @@ impl<B: SimBackend> Simulation<B> {
                             triggered_domains.insert(info.canonical_id);
                             any_new_outer_loop_trigger = true;
 
-                            self.simulator.backend.eval_apply_ff_at(ev)?;
-                            self.simulator.backend.eval_comb()?;
+                            self.simulator.eval_apply_ff_at_checked(ev)?;
+                            self.simulator.eval_comb_checked()?;
                             comb_already_done = true;
                             break;
                         }
@@ -349,11 +349,11 @@ impl<B: SimBackend> Simulation<B> {
                         newly_triggered.push(info.canonical_id);
 
                         if let Some(ev) = info.eval_only_event {
-                            self.simulator.backend.eval_only_ff_at(ev)?;
+                            self.simulator.eval_only_ff_at_checked(ev)?;
                         } else if let Some(ev) = info.eval_ff_event {
                             // If this domain wasn't split into eval/apply, we can safely use the
                             // unified eval_apply_ff_at since no cascade optimizations applied to it.
-                            self.simulator.backend.eval_apply_ff_at(ev)?;
+                            self.simulator.eval_apply_ff_at_checked(ev)?;
                         } else {
                             unreachable!(
                                 "FF trigger discovered but no corresponding execution unit found for domain"
@@ -375,7 +375,7 @@ impl<B: SimBackend> Simulation<B> {
             for id in &newly_triggered {
                 let info = self.event_info[*id];
                 if let Some(ev) = info.apply_event {
-                    self.simulator.backend.apply_ff_at(ev)?;
+                    self.simulator.apply_ff_at_checked(ev)?;
                 }
             }
 
@@ -384,7 +384,7 @@ impl<B: SimBackend> Simulation<B> {
             if comb_already_done {
                 comb_already_done = false;
             } else {
-                self.simulator.backend.eval_comb()?;
+                self.simulator.eval_comb_checked()?;
             }
 
             if !any_new_outer_loop_trigger && newly_triggered.is_empty() {

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -76,6 +76,22 @@ impl<B: SimBackend> std::fmt::Debug for Simulator<B> {
 // ── Generic methods available for any backend ────────────────────────
 #[cfg(not(target_arch = "wasm32"))]
 impl<B: SimBackend> Simulator<B> {
+    fn decorate_runtime_error(&self, err: RuntimeErrorCode) -> RuntimeErrorCode {
+        match err {
+            RuntimeErrorCode::DetectedTrueLoop => {
+                let Some(addrs) = self.program.runtime_error_sources.get(&1) else {
+                    return RuntimeErrorCode::DetectedTrueLoop;
+                };
+                let signals = addrs
+                    .iter()
+                    .map(|addr| self.program.get_path(addr))
+                    .collect::<Vec<_>>();
+                RuntimeErrorCode::DetectedTrueLoopAt { signals }
+            }
+            other => other,
+        }
+    }
+
     pub fn with_backend_and_program(
         backend: B,
         program: Program,
@@ -152,13 +168,21 @@ impl<B: SimBackend> Simulator<B> {
     /// Manually triggers a clock or event to process sequential logic.
     pub fn tick(&mut self, event: B::Event) -> Result<(), RuntimeErrorCode> {
         if self.dirty {
-            self.backend.eval_comb()?;
-            self.backend.eval_apply_ff_at(event)?;
+            self.backend
+                .eval_comb()
+                .map_err(|e| self.decorate_runtime_error(e))?;
+            self.backend
+                .eval_apply_ff_at(event)
+                .map_err(|e| self.decorate_runtime_error(e))?;
             self.dirty = false;
         } else {
-            self.backend.eval_apply_ff_at(event)?;
+            self.backend
+                .eval_apply_ff_at(event)
+                .map_err(|e| self.decorate_runtime_error(e))?;
         }
-        self.backend.eval_comb()?;
+        self.backend
+            .eval_comb()
+            .map_err(|e| self.decorate_runtime_error(e))?;
         self.dirty = false;
         Ok(())
     }
@@ -220,7 +244,9 @@ impl<B: SimBackend> Simulator<B> {
 
     /// Directly execute combinational logic evaluation.
     pub fn eval_comb(&mut self) -> Result<(), RuntimeErrorCode> {
-        self.backend.eval_comb()?;
+        self.backend
+            .eval_comb()
+            .map_err(|e| self.decorate_runtime_error(e))?;
         self.dirty = false;
         Ok(())
     }

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -78,8 +78,8 @@ impl<B: SimBackend> std::fmt::Debug for Simulator<B> {
 impl<B: SimBackend> Simulator<B> {
     fn decorate_runtime_error(&self, err: RuntimeErrorCode) -> RuntimeErrorCode {
         match err {
-            RuntimeErrorCode::DetectedTrueLoop => {
-                let Some(addrs) = self.program.runtime_error_sources.get(&1) else {
+            RuntimeErrorCode::DetectedTrueLoopCode(code) => {
+                let Some(addrs) = self.program.runtime_error_sources.get(&code) else {
                     return RuntimeErrorCode::DetectedTrueLoop;
                 };
                 let signals = addrs

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -79,14 +79,22 @@ impl<B: SimBackend> Simulator<B> {
     fn decorate_runtime_error(&self, err: RuntimeErrorCode) -> RuntimeErrorCode {
         match err {
             RuntimeErrorCode::DetectedTrueLoopCode(code) => {
-                let Some(addrs) = self.program.runtime_error_sources.get(&code) else {
+                let Some(info) = self.program.runtime_errors.get(&code) else {
                     return RuntimeErrorCode::DetectedTrueLoop;
                 };
-                let signals = addrs
+                let signals = info
+                    .signals
                     .iter()
                     .map(|addr| self.program.get_path(addr))
                     .collect::<Vec<_>>();
-                RuntimeErrorCode::DetectedTrueLoopAt { signals }
+                if info.message == "Detected True Loop" {
+                    RuntimeErrorCode::DetectedTrueLoopAt { signals }
+                } else {
+                    RuntimeErrorCode::Runtime {
+                        message: info.message.clone(),
+                        signals,
+                    }
+                }
             }
             other => other,
         }

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -173,24 +173,46 @@ impl<B: SimBackend> Simulator<B> {
         Ok(())
     }
 
+    pub(crate) fn eval_comb_checked(&mut self) -> Result<(), RuntimeErrorCode> {
+        self.backend
+            .eval_comb()
+            .map_err(|e| self.decorate_runtime_error(e))
+    }
+
+    pub(crate) fn eval_apply_ff_at_checked(
+        &mut self,
+        event: B::Event,
+    ) -> Result<(), RuntimeErrorCode> {
+        self.backend
+            .eval_apply_ff_at(event)
+            .map_err(|e| self.decorate_runtime_error(e))
+    }
+
+    pub(crate) fn eval_only_ff_at_checked(
+        &mut self,
+        event: B::Event,
+    ) -> Result<(), RuntimeErrorCode> {
+        self.backend
+            .eval_only_ff_at(event)
+            .map_err(|e| self.decorate_runtime_error(e))
+    }
+
+    pub(crate) fn apply_ff_at_checked(&mut self, event: B::Event) -> Result<(), RuntimeErrorCode> {
+        self.backend
+            .apply_ff_at(event)
+            .map_err(|e| self.decorate_runtime_error(e))
+    }
+
     /// Manually triggers a clock or event to process sequential logic.
     pub fn tick(&mut self, event: B::Event) -> Result<(), RuntimeErrorCode> {
         if self.dirty {
-            self.backend
-                .eval_comb()
-                .map_err(|e| self.decorate_runtime_error(e))?;
-            self.backend
-                .eval_apply_ff_at(event)
-                .map_err(|e| self.decorate_runtime_error(e))?;
+            self.eval_comb_checked()?;
+            self.eval_apply_ff_at_checked(event)?;
             self.dirty = false;
         } else {
-            self.backend
-                .eval_apply_ff_at(event)
-                .map_err(|e| self.decorate_runtime_error(e))?;
+            self.eval_apply_ff_at_checked(event)?;
         }
-        self.backend
-            .eval_comb()
-            .map_err(|e| self.decorate_runtime_error(e))?;
+        self.eval_comb_checked()?;
         self.dirty = false;
         Ok(())
     }
@@ -252,9 +274,7 @@ impl<B: SimBackend> Simulator<B> {
 
     /// Directly execute combinational logic evaluation.
     pub fn eval_comb(&mut self) -> Result<(), RuntimeErrorCode> {
-        self.backend
-            .eval_comb()
-            .map_err(|e| self.decorate_runtime_error(e))?;
+        self.eval_comb_checked()?;
         self.dirty = false;
         Ok(())
     }

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -1,6 +1,4 @@
-use celox::{
-    LoweringPhase, ParserError, RuntimeErrorCode, SchedulerError, Simulator, SimulatorErrorKind,
-};
+use celox::{LoweringPhase, ParserError, SchedulerError, Simulator, SimulatorErrorKind};
 
 /// Helper: assert the error is either Analyzer or a specific SIRParser variant.
 /// The updated Veryl analyzer may catch issues before the SIR scheduler does.
@@ -352,9 +350,10 @@ fn test_always_ff_runtime_for_non_progress_is_rejected() {
     let clk = sim.event("clk");
     let count = sim.signal("count");
     sim.modify(|io| io.set(count, 4u8)).unwrap();
+    let err = sim.tick(clk).unwrap_err();
     assert_eq!(
-        sim.tick(clk).unwrap_err(),
-        RuntimeErrorCode::DetectedTrueLoop
+        err.to_string(),
+        "Non-progressing for loop in always_ff (loop variable `i`): i"
     );
 }
 
@@ -379,9 +378,10 @@ fn test_always_ff_runtime_for_zero_start_mul_non_progress_is_rejected() {
     let clk = sim.event("clk");
     let count = sim.signal("count");
     sim.modify(|io| io.set(count, 4u8)).unwrap();
+    let err = sim.tick(clk).unwrap_err();
     assert_eq!(
-        sim.tick(clk).unwrap_err(),
-        RuntimeErrorCode::DetectedTrueLoop
+        err.to_string(),
+        "Non-progressing for loop in always_ff (loop variable `i`): i"
     );
 }
 

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -38,9 +38,13 @@ fn test_scheduler_loop_detection() {
 
     if let Err(e) = result {
         match e.kind() {
-            SimulatorErrorKind::SIRParser(ParserError::Scheduler(
-                SchedulerError::CombinationalLoop { blocks },
-            )) => {
+            SimulatorErrorKind::SIRParser(
+                ParserError::Scheduler(SchedulerError::CombinationalLoop { blocks })
+                | ParserError::SchedulerWithLocation {
+                    error: SchedulerError::CombinationalLoop { blocks },
+                    ..
+                },
+            ) => {
                 assert_eq!(blocks.len(), 3, "Loop should involve exactly 3 blocks");
             }
             _ => panic!("Expected CombinationalLoop error, but got: {:?}", e),
@@ -65,9 +69,13 @@ fn test_combinational_loop() {
 
     let result = Simulator::builder(code, "Top").build();
     match result.as_ref().map_err(|e| e.kind()) {
-        Err(SimulatorErrorKind::SIRParser(ParserError::Scheduler(
-            SchedulerError::CombinationalLoop { blocks },
-        ))) => {
+        Err(SimulatorErrorKind::SIRParser(
+            ParserError::Scheduler(SchedulerError::CombinationalLoop { blocks })
+            | ParserError::SchedulerWithLocation {
+                error: SchedulerError::CombinationalLoop { blocks },
+                ..
+            },
+        )) => {
             assert_eq!(blocks.len(), 2);
         }
         Err(k) => panic!("Expected CombinationalLoop error, but got: {:?}", k),
@@ -309,9 +317,13 @@ fn test_runtime_for_loop_external_feedback_is_still_scheduler_loop() {
 
     let result = Simulator::builder(code, "Top").build();
     match result.as_ref().map_err(|e| e.kind()) {
-        Err(SimulatorErrorKind::SIRParser(ParserError::Scheduler(
-            SchedulerError::CombinationalLoop { blocks },
-        ))) => {
+        Err(SimulatorErrorKind::SIRParser(
+            ParserError::Scheduler(SchedulerError::CombinationalLoop { blocks })
+            | ParserError::SchedulerWithLocation {
+                error: SchedulerError::CombinationalLoop { blocks },
+                ..
+            },
+        )) => {
             assert_eq!(blocks.len(), 2);
         }
         Err(k) => panic!("Expected CombinationalLoop error, but got: {:?}", k),
@@ -383,9 +395,13 @@ fn test_multiple_driver_error() {
     "#;
     let result = Simulator::builder(code, "Top").build();
     assert_analyzer_or_sir(result, |e| match e.kind() {
-        SimulatorErrorKind::SIRParser(ParserError::Scheduler(SchedulerError::MultipleDriver {
-            ..
-        })) => {}
+        SimulatorErrorKind::SIRParser(
+            ParserError::Scheduler(SchedulerError::MultipleDriver { .. })
+            | ParserError::SchedulerWithLocation {
+                error: SchedulerError::MultipleDriver { .. },
+                ..
+            },
+        ) => {}
         _ => panic!("Expected MultipleDriver error, got: {e:?}"),
     });
 }
@@ -462,9 +478,13 @@ fn detect_hierarchical_true_concat_feedback_loop() {
     );
 
     match result.as_ref().map_err(|e| e.kind()) {
-        Err(SimulatorErrorKind::SIRParser(ParserError::Scheduler(
-            SchedulerError::CombinationalLoop { .. },
-        ))) => {}
+        Err(SimulatorErrorKind::SIRParser(
+            ParserError::Scheduler(SchedulerError::CombinationalLoop { .. })
+            | ParserError::SchedulerWithLocation {
+                error: SchedulerError::CombinationalLoop { .. },
+                ..
+            },
+        )) => {}
         Err(k) => panic!("expected CombinationalLoop error, got {k:?}"),
         Ok(_) => panic!("expected CombinationalLoop error, got Ok"),
     }

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -1,4 +1,4 @@
-use celox::{BigUint, RuntimeErrorCode, Simulation, Simulator, SimulatorBuilder};
+use celox::{BigUint, Simulation, Simulator, SimulatorBuilder};
 use insta::assert_snapshot;
 
 #[path = "test_utils/mod.rs"]
@@ -188,7 +188,10 @@ fn test_ff_runtime_for_dynamic_zero_start_mul_reports_true_loop(sim) {
         io.set(count, 4u8);
     })
     .unwrap();
-    assert_eq!(sim.tick(clk).unwrap_err(), RuntimeErrorCode::DetectedTrueLoop);
+    assert_eq!(
+        sim.tick(clk).unwrap_err().to_string(),
+        "Non-progressing for loop in always_ff (loop variable `i`): i"
+    );
 }
 
 fn test_ff_runtime_for_zero_iteration_mul_loop_is_allowed(sim) {
@@ -1522,8 +1525,8 @@ fn test_ff_runtime_for_wide_dynamic_bound_out_of_i32_range_errors() {
     sim.modify(|io| io.set_wide(bound, (BigUint::from(1u32) << 31) + BigUint::from(1u32)))
         .unwrap();
     assert_eq!(
-        sim.tick(clk).unwrap_err(),
-        RuntimeErrorCode::DetectedTrueLoop
+        sim.tick(clk).unwrap_err().to_string(),
+        "For loop value exceeds loop variable range in always_ff (loop variable `i`): i"
     );
 }
 
@@ -1551,8 +1554,8 @@ fn test_ff_runtime_for_wide_dynamic_end_errors_before_iteration() {
     sim.modify(|io| io.set_wide(count, BigUint::from(1u64) << 40))
         .unwrap();
     assert_eq!(
-        sim.tick(clk).unwrap_err(),
-        RuntimeErrorCode::DetectedTrueLoop
+        sim.tick(clk).unwrap_err().to_string(),
+        "For loop value exceeds loop variable range in always_ff (loop variable `i`): i"
     );
 }
 
@@ -1580,8 +1583,8 @@ fn test_ff_runtime_for_wide_dynamic_start_errors_before_empty_exit() {
     sim.modify(|io| io.set_wide(start, BigUint::from(1u64) << 40))
         .unwrap();
     assert_eq!(
-        sim.tick(clk).unwrap_err(),
-        RuntimeErrorCode::DetectedTrueLoop
+        sim.tick(clk).unwrap_err().to_string(),
+        "For loop value exceeds loop variable range in always_ff (loop variable `i`): i"
     );
 }
 
@@ -1609,8 +1612,8 @@ fn test_ff_runtime_for_wide_dynamic_reverse_start_errors_before_empty_exit() {
     sim.modify(|io| io.set_wide(start, BigUint::from(1u64) << 40))
         .unwrap();
     assert_eq!(
-        sim.tick(clk).unwrap_err(),
-        RuntimeErrorCode::DetectedTrueLoop
+        sim.tick(clk).unwrap_err().to_string(),
+        "For loop value exceeds loop variable range in always_ff (loop variable `i`): i"
     );
 }
 

--- a/crates/celox/tests/simulation_step.rs
+++ b/crates/celox/tests/simulation_step.rs
@@ -64,3 +64,38 @@ fn test_next_event_time() {
     vsim.step().unwrap();
     assert_eq!(vsim.next_event_time(), Some(100));
 }
+
+#[test]
+fn test_step_decorates_runtime_errors() {
+    let code = r#"
+        module Top (
+            clk: input clock,
+            start: input logic<8>,
+            count: input logic<8>,
+            q: output logic<8>
+        ) {
+            always_ff (clk) {
+                q = 0;
+                for i in start..count step *= 2 {
+                    q = i as 8;
+                }
+            }
+        }
+    "#;
+
+    let mut vsim = Simulation::builder(code, "Top").build().unwrap();
+    let start = vsim.signal("start");
+    let count = vsim.signal("count");
+
+    vsim.modify(|io| {
+        io.set(start, 0u8);
+        io.set(count, 4u8);
+    })
+    .unwrap();
+    vsim.add_clock("clk", 10, 0);
+
+    assert_eq!(
+        vsim.step().unwrap_err().to_string(),
+        "Non-progressing for loop in always_ff (loop variable `i`): i"
+    );
+}

--- a/crates/celox/tests/snapshots/error_readability__combinational_loop_error_readability.snap
+++ b/crates/celox/tests/snapshots/error_readability__combinational_loop_error_readability.snap
@@ -5,6 +5,13 @@ expression: err
 scheduler
 
   × Combinational loop detected: y[0]
+   ╭─[:4:13]
+ 3 │             a: input logic,
+ 4 │             y: output logic
+   ·             ┬
+   ·             ╰── loop participant
+ 5 │         ) {
+   ╰────
 
 
 --- warnings ---

--- a/crates/celox/tests/snapshots/error_readability__combinational_loop_sir_error_readability.snap
+++ b/crates/celox/tests/snapshots/error_readability__combinational_loop_sir_error_readability.snap
@@ -5,3 +5,16 @@ expression: err
 scheduler
 
   × Combinational loop detected: y[0] -> z[0] -> x[0]
+   ╭─[:3:17]
+ 2 │         module Top (a: input logic, o: output logic) {
+ 3 │             var x: logic;
+   ·                 ┬
+   ·                 ╰── loop participant
+ 4 │             var y: logic;
+   ·                 ┬
+   ·                 ╰── loop participant
+ 5 │             var z: logic;
+   ·                 ┬
+   ·                 ╰── loop participant
+ 6 │             assign x = y;
+   ╰────

--- a/crates/celox/tests/snapshots/error_readability__multiple_errors_readability.snap
+++ b/crates/celox/tests/snapshots/error_readability__multiple_errors_readability.snap
@@ -5,6 +5,13 @@ expression: err
 scheduler
 
   × Combinational loop detected: y[0]
+   ╭─[:5:13]
+ 4 │             x: output logic,
+ 5 │             y: output logic
+   ·             ┬
+   ·             ╰── loop participant
+ 6 │         ) {
+   ╰────
 
 
 --- warnings ---

--- a/crates/celox/tests/snapshots/false_loop__large_scc_dynamic_loop.snap
+++ b/crates/celox/tests/snapshots/false_loop__large_scc_dynamic_loop.snap
@@ -197,4 +197,4 @@ Execution Unit 0:
     Store(addr=o (region=0), offset=0, bits=20, src_reg = 89)
     Return
   b4:
-    Error(1)
+    Error(2000)

--- a/crates/celox/tests/snapshots/false_loop__large_scc_dynamic_loop_bidirectional.snap
+++ b/crates/celox/tests/snapshots/false_loop__large_scc_dynamic_loop_bidirectional.snap
@@ -865,4 +865,4 @@ Execution Unit 0:
     Store(addr=o (region=0), offset=0, bits=20, src_reg = 310)
     Return
   b4:
-    Error(1)
+    Error(2000)

--- a/crates/celox/tests/true_loop.rs
+++ b/crates/celox/tests/true_loop.rs
@@ -68,4 +68,55 @@ fn test_true_loop_oscillation_detected(sim) {
     assert_eq!(err.to_string(), "Detected True Loop: v");
 }
 
+fn test_runtime_true_loop_reports_only_failing_scc(sim) {
+    @omit_veryl;
+    @setup {
+    let code = r#"
+        module Top (
+            a: input logic,
+            b: input logic,
+            y: output logic
+        ) {
+            var v: logic<2>;
+            var w: logic<2>;
+            assign v[0] = ~v[1] & a;
+            assign v[1] = v[0];
+            assign w[0] = ~w[1] & b;
+            assign w[1] = w[0];
+            assign y = v[0] ^ w[0];
+        }
+    "#;
+    }
+    @build SimulatorBuilder::new(code, "Top")
+        .true_loop(
+            (vec![], vec!["v".to_string()]),
+            (vec![], vec!["v".to_string()]),
+            10,
+        )
+        .true_loop(
+            (vec![], vec!["w".to_string()]),
+            (vec![], vec!["w".to_string()]),
+            10,
+        );
+
+    let id_a = sim.signal("a");
+    let id_b = sim.signal("b");
+
+    sim.modify(|io| {
+        io.set(id_a, 1u8);
+        io.set(id_b, 0u8);
+    })
+    .unwrap();
+    let err = sim.eval_comb().unwrap_err().to_string();
+    assert_eq!(err, "Detected True Loop: v");
+
+    sim.modify(|io| {
+        io.set(id_a, 0u8);
+        io.set(id_b, 1u8);
+    })
+    .unwrap();
+    let err = sim.eval_comb().unwrap_err().to_string();
+    assert_eq!(err, "Detected True Loop: w");
+}
+
 }

--- a/crates/celox/tests/true_loop.rs
+++ b/crates/celox/tests/true_loop.rs
@@ -63,7 +63,9 @@ fn test_true_loop_oscillation_detected(sim) {
     sim.modify(|io| io.set(id_a, 1u8)).unwrap();
     let res = sim.eval_comb();
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err(), RuntimeErrorCode::DetectedTrueLoop);
+    let err = res.unwrap_err();
+    assert_eq!(err, RuntimeErrorCode::DetectedTrueLoop);
+    assert_eq!(err.to_string(), "Detected True Loop: v");
 }
 
 }


### PR DESCRIPTION
## Summary

- Report scheduler true-loop diagnostics with source locations and involved signals.
- Generalize runtime diagnostic metadata so generated runtime error codes can map to actionable messages and signals.
- Decorate runtime errors consistently through Simulator, timed Simulation, WASM, and NAPI paths.
- Reserve runtime error codes through a shared allocator and update affected SIR snapshots.

## Root Cause

Runtime-generated error codes were previously treated as opaque true-loop sentinels in some paths, while other public execution APIs either skipped decoration or collided with separate code ranges.

## Validation

- `cargo test -p celox --test simulation_step`
- `cargo test -p celox --test false_loop`
- `cargo test -p celox --test wasm_backend`
- `cargo test -p celox --test wasm_regression`
- `cargo test -q -p celox`
- pre-push hook: submodule-check, cargo-fmt, biome, cargo-clippy, test, clean-tree