### PR TITLE
[codex] Remove Veryl submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "deps/veryl"]
-	path = deps/veryl
-	url = https://github.com/tignear/veryl.git
-	branch = for-celox
 [submodule "examples/template"]
 	path = examples/template
 	url = https://github.com/celox-sim/celox-template.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,12 +32,12 @@ cargo insta accept       # Accept snapshot changes
 | `packages/celox` | TypeScript runtime package |
 | `packages/vite-plugin` | Vite plugin |
 
-## Veryl Submodule
+## Veryl Dependencies
 
-The `deps/veryl/` directory contains a fork of Veryl (`tignear/veryl`). The workspace depends on `veryl-analyzer`, `veryl-emitter`, `veryl-parser`, `veryl-metadata`, and `veryl-path` from this submodule.
+The workspace depends on released Veryl crates: `veryl-analyzer`, `veryl-emitter`, `veryl-parser`, `veryl-metadata`, `veryl-path`, and `veryl-simulator`.
 
 - `default-features = false` is set on `veryl-parser` to suppress parser regeneration during builds.
-- After updating the submodule, run `cargo test` to verify compatibility.
+- After updating Veryl crate versions, run `cargo test` to verify compatibility.
 
 ### Analyzer API
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,34 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "aligned-vec"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
-dependencies = [
- "equator",
 ]
 
 [[package]]
@@ -91,7 +69,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -110,6 +103,15 @@ name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -141,28 +143,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-
-[[package]]
-name = "arc-swap"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
-dependencies = [
- "rustversion",
-]
 
 [[package]]
 name = "arrayref"
@@ -203,38 +187,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
 
 [[package]]
 name = "backtrace"
@@ -245,7 +201,7 @@ dependencies = [
  "addr2line 0.25.1",
  "cfg-if",
  "libc",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
  "object 0.37.3",
  "rustc-demangle",
  "windows-link",
@@ -392,28 +348,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "bytesize"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "camino"
@@ -448,10 +386,10 @@ dependencies = [
  "chrono",
  "clap",
  "cranelift",
- "cranelift-frontend 0.131.0",
+ "cranelift-frontend 0.131.1",
  "cranelift-jit",
  "cranelift-module",
- "cranelift-native 0.131.0",
+ "cranelift-native 0.131.1",
  "criterion",
  "fxhash",
  "iced-x86",
@@ -467,12 +405,13 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror 2.0.18",
- "toml 1.0.3+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "veryl-analyzer",
  "veryl-metadata",
  "veryl-parser",
  "veryl-path",
  "veryl-simulator",
+ "veryl-std",
  "wasm-encoder 0.245.1",
  "wasmtime",
 ]
@@ -485,6 +424,7 @@ dependencies = [
  "veryl-emitter",
  "veryl-metadata",
  "veryl-parser",
+ "veryl-std",
 ]
 
 [[package]]
@@ -515,7 +455,7 @@ dependencies = [
  "napi-derive",
  "serde",
  "serde_json",
- "toml 1.0.3+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "veryl-analyzer",
  "veryl-metadata",
  "veryl-parser",
@@ -546,22 +486,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -605,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -615,11 +543,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -627,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -642,21 +570,6 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
-
-[[package]]
-name = "clru"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
-
-[[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "cobs"
@@ -679,88 +592,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "codspeed"
-version = "4.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b684e94583e85a5ca7e1a6454a89d76a5121240f2fb67eb564129d9bafdb9db0"
-dependencies = [
- "anyhow",
- "cc",
- "colored",
- "getrandom 0.2.17",
- "glob",
- "libc",
- "nix 0.31.2",
- "serde",
- "serde_json",
- "statrs",
-]
-
-[[package]]
-name = "codspeed-criterion-compat"
-version = "4.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e65444156eb73ad7f57618188f8d4a281726d133ef55b96d1dcff89528609ab"
-dependencies = [
- "clap",
- "codspeed",
- "codspeed-criterion-compat-walltime",
- "colored",
- "regex",
-]
-
-[[package]]
-name = "codspeed-criterion-compat-walltime"
-version = "4.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96389aaa4bbb872ea4924dc0335b2bb181bcf28d6eedbe8fea29afcc5bde36a6"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "codspeed",
- "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
 
 [[package]]
 name = "console"
@@ -800,16 +635,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,15 +659,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpp_demangle"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,12 +669,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1066593fdf4b6d44cd851d2324b24bc0faa94f44c18c8dc65e182ceae318d1b"
+checksum = "cfe07d3554a07c7e60c112ddf4aa5eeab69a4eb632881a59c2add0fdc4596cc7"
 dependencies = [
- "cranelift-codegen 0.131.0",
- "cranelift-frontend 0.131.0",
+ "cranelift-codegen 0.131.1",
+ "cranelift-frontend 0.131.1",
  "cranelift-module",
 ]
 
@@ -873,11 +689,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb5bdd1af46714e3224a017fabbbd57f70df4e840eb5ad6a7429dc456119d6"
+checksum = "f8628cc4ba7f88a9205a7ee42327697abc61195a1e3d92cfae172d6a946e722e"
 dependencies = [
- "cranelift-assembler-x64-meta 0.131.0",
+ "cranelift-assembler-x64-meta 0.131.1",
 ]
 
 [[package]]
@@ -891,11 +707,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a819599186e1b1a1f88d464e06045696afc7aa3e0cc018aa0b2999cb63d1d088"
+checksum = "d582754487e6c9a065a91c42ccf1bdd8d5977af33468dac5ae9bec0ce88acb3e"
 dependencies = [
- "cranelift-srcgen 0.131.0",
+ "cranelift-srcgen 0.131.1",
 ]
 
 [[package]]
@@ -910,12 +726,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e2c152d488e03c87b913bc2ed3414416eb1e0d66d61b49af60bf456a9665c7"
+checksum = "fb59c81ace12ee7c33074db7903d4d75d1f40b28cd3e8e6f491de57b29129eb9"
 dependencies = [
- "cranelift-entity 0.131.0",
- "wasmtime-internal-core 44.0.0",
+ "cranelift-entity 0.131.1",
+ "wasmtime-internal-core 44.0.1",
 ]
 
 [[package]]
@@ -931,11 +747,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6559d4fbc253d1396e1f6beeae57fa88a244f02aaf0cde2a735afd3492d9b2e"
+checksum = "f25c06993a681be9cf3140798a3d4ac5bec955e7444416a2fdc87fda8567285d"
 dependencies = [
- "wasmtime-internal-core 44.0.0",
+ "wasmtime-internal-core 44.0.1",
 ]
 
 [[package]]
@@ -968,19 +784,19 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d9315d98d6e0a64454d4c83be2ee0e8055c3f80c3b2d7bcad7079f281a06ff"
+checksum = "27b61f95c5a211918f5d336254a61a488b36a5818de47a868e8c4658dce9cccc"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64 0.131.0",
- "cranelift-bforest 0.131.0",
- "cranelift-bitset 0.131.0",
- "cranelift-codegen-meta 0.131.0",
- "cranelift-codegen-shared 0.131.0",
- "cranelift-control 0.131.0",
- "cranelift-entity 0.131.0",
- "cranelift-isle 0.131.0",
+ "cranelift-assembler-x64 0.131.1",
+ "cranelift-bforest 0.131.1",
+ "cranelift-bitset 0.131.1",
+ "cranelift-codegen-meta 0.131.1",
+ "cranelift-codegen-shared 0.131.1",
+ "cranelift-control 0.131.1",
+ "cranelift-entity 0.131.1",
+ "cranelift-isle 0.131.1",
  "gimli 0.33.0",
  "hashbrown 0.16.1",
  "libm",
@@ -990,7 +806,7 @@ dependencies = [
  "serde",
  "smallvec",
  "target-lexicon",
- "wasmtime-internal-core 44.0.0",
+ "wasmtime-internal-core 44.0.1",
 ]
 
 [[package]]
@@ -1008,13 +824,13 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89c00a88081c55e3087c45bebc77e0cc973de2d7b44ef6a943c7122647b89f5"
+checksum = "0b85aa822fce72080d041d7c2cf7c3f5c6ecdea7afae68379ba4ef85269c4fa5"
 dependencies = [
- "cranelift-assembler-x64-meta 0.131.0",
- "cranelift-codegen-shared 0.131.0",
- "cranelift-srcgen 0.131.0",
+ "cranelift-assembler-x64-meta 0.131.1",
+ "cranelift-codegen-shared 0.131.1",
+ "cranelift-srcgen 0.131.1",
  "heck",
 ]
 
@@ -1026,9 +842,9 @@ checksum = "f583cf203d1aa8b79560e3b01f929bdacf9070b015eec4ea9c46e22a3f83e4a0"
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f77c497a1eb6273482aa1ac3b23cb8563ff04edb39ed5dfcfd28c8deff8f5"
+checksum = "833eb9fc89326cd072cc19e96892f09b5692c0dfe17cd4da2858ba30c2cd85c0"
 
 [[package]]
 name = "cranelift-control"
@@ -1041,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-control"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498dc1f17a6910c88316d49c7176d8fa97cf10c30859c32a266040449317f963"
+checksum = "9d005320f487e6e8a3edcc7f2fd4f43fcc9946d1013bf206ea649789ac1617fc"
 dependencies = [
  "arbitrary",
 ]
@@ -1062,12 +878,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2acba797f6a46042ce82aaf7680d0c3567fe2001e238db9df649fd104a2727f"
+checksum = "5e62ef34c6e720f347a79ece043e8584e242d168911da640bac654a33a6aaaf5"
 dependencies = [
- "cranelift-bitset 0.131.0",
- "wasmtime-internal-core 44.0.0",
+ "cranelift-bitset 0.131.1",
+ "wasmtime-internal-core 44.0.1",
 ]
 
 [[package]]
@@ -1084,11 +900,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dca3df1d107d98d88f159ad1d5eaa2d5cdb678b3d5bcfadc6fc83d8ebb448ea"
+checksum = "dfa2ad00399dd47e7e7e33cb1dc23b0e39ed9dcd01e8f026fc37af91655031b8"
 dependencies = [
- "cranelift-codegen 0.131.0",
+ "cranelift-codegen 0.131.1",
  "log",
  "smallvec",
  "target-lexicon",
@@ -1102,39 +918,39 @@ checksum = "ec66ea5025c7317383699778282ac98741d68444f956e3b1d7b62f12b7216e67"
 
 [[package]]
 name = "cranelift-isle"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62dd18116d88bed649871feceda79dad7b59cc685ea8998c2b3e64d0e689602"
+checksum = "02c51975ed217b4e8e5a7fd11e9ec83a96104bdff311dddcb505d1d8a9fd7fc6"
 
 [[package]]
 name = "cranelift-jit"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4942770ce6662b44d903493d7c5b00f9a986a713a61aae148306eaef21ebd4"
+checksum = "4070d2acc5c976887c10c273d38dd2bebebb472fd1ba65fa17b548adf5f56350"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.131.0",
- "cranelift-control 0.131.0",
- "cranelift-entity 0.131.0",
+ "cranelift-codegen 0.131.1",
+ "cranelift-control 0.131.1",
+ "cranelift-entity 0.131.1",
  "cranelift-module",
- "cranelift-native 0.131.0",
+ "cranelift-native 0.131.1",
  "libc",
  "log",
  "region",
  "target-lexicon",
- "wasmtime-internal-jit-icache-coherence 44.0.0",
+ "wasmtime-internal-jit-icache-coherence 44.0.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "cranelift-module"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5ca0d214ecee44405ea9f0c65a5318b41ac469e8258fd9fe944e564c1c1b0b"
+checksum = "052a396328dbc7dadc29d1bd27d4aa57d9e9e493ead8ef6e2ab3b75c1bf9644c"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.131.0",
- "cranelift-control 0.131.0",
+ "cranelift-codegen 0.131.1",
+ "cranelift-control 0.131.1",
 ]
 
 [[package]]
@@ -1150,11 +966,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f843b80360d7fdf61a6124642af7597f6d55724cf521210c34af8a1c66daca6e"
+checksum = "f9b1889e00da9729d8f8525f3c12998ded86ea709058ff844ebe00b97548de0e"
 dependencies = [
- "cranelift-codegen 0.131.0",
+ "cranelift-codegen 0.131.1",
  "libc",
  "target-lexicon",
 ]
@@ -1167,9 +983,9 @@ checksum = "ef53619d3cd5c78fd998c6d9420547af26b72e6456f94c2a8a2334cb76b42baa"
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.131.0"
+version = "0.131.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090ee5de58c6f17eb5e3a5ae8cf1695c7efea04ec4dd0ecba6a5b996c9bad7dc"
+checksum = "d5a8f82fd5124f009f72167e60139245cd3b56cfd4b53050f22110c48c5f4da1"
 
 [[package]]
 name = "crc32fast"
@@ -1214,15 +1030,6 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1331,20 +1138,6 @@ name = "dary_heap"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
 
 [[package]]
 name = "data-encoding"
@@ -1478,12 +1271,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,31 +1325,11 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "env_filter",
  "jiff",
  "log",
-]
-
-[[package]]
-name = "equator"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
-dependencies = [
- "equator-macro",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1582,49 +1349,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "faster-hex"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
-dependencies = [
- "heapless",
- "serde",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "filetime"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "findshlibs"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
-dependencies = [
- "cc",
- "lazy_static",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "fixedbitset"
@@ -1667,30 +1401,12 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f8fa43de52e33bb8fc545448eb07d6e6248971c5d6b4947937e9395f6ff339d"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
 dependencies = [
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fst-reader"
-version = "0.16.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa0a533dbe4b9bf7acd06e9c583b9c912d4ad7387e523ce87142b234f84510f8"
-dependencies = [
- "lz4_flex 0.13.0",
- "miniz_oxide 0.9.1",
- "num_enum",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1699,8 +1415,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77be37fdc968866fa4f0cee73e42185e6d4699a761a51a54e6ebc9a3d73ed537"
 dependencies = [
- "lz4_flex 0.11.6",
- "miniz_oxide 0.8.9",
+ "lz4_flex",
+ "miniz_oxide",
  "thiserror 2.0.18",
 ]
 
@@ -1853,10 +1569,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1866,11 +1580,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1905,943 +1617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix"
-version = "0.81.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0473c64d9ccbcfb9953a133b47c8b9a335b87ac6c52b983ee4b03d49000b0f3f"
-dependencies = [
- "gix-actor",
- "gix-archive",
- "gix-attributes",
- "gix-blame",
- "gix-command",
- "gix-commitgraph",
- "gix-config",
- "gix-credentials",
- "gix-date",
- "gix-diff",
- "gix-dir",
- "gix-discover",
- "gix-error",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-hashtable",
- "gix-ignore",
- "gix-index",
- "gix-lock",
- "gix-mailmap",
- "gix-merge",
- "gix-negotiate",
- "gix-object",
- "gix-odb",
- "gix-pack",
- "gix-path",
- "gix-pathspec",
- "gix-prompt",
- "gix-protocol",
- "gix-ref",
- "gix-refspec",
- "gix-revision",
- "gix-revwalk",
- "gix-sec",
- "gix-shallow",
- "gix-status",
- "gix-submodule",
- "gix-tempfile",
- "gix-trace",
- "gix-transport",
- "gix-traverse",
- "gix-url",
- "gix-utils",
- "gix-validate",
- "gix-worktree",
- "gix-worktree-state",
- "gix-worktree-stream",
- "nonempty",
- "parking_lot",
- "regex",
- "signal-hook",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-actor"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5e5b518339d5e6718af108fd064d4e9ba33caf728cf487352873d76411df35"
-dependencies = [
- "bstr",
- "gix-date",
- "gix-error",
- "winnow",
-]
-
-[[package]]
-name = "gix-archive"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "651c99be11aac9b303483193ae50b45eb6e094da4f5ed797019b03948f51aad6"
-dependencies = [
- "bstr",
- "gix-date",
- "gix-error",
- "gix-object",
- "gix-worktree-stream",
-]
-
-[[package]]
-name = "gix-attributes"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c233d6eaa098c0ca5ce03236fd7a96e27f1abe72fad74b46003fbd11fe49563c"
-dependencies = [
- "bstr",
- "gix-glob",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "kstring",
- "smallvec",
- "thiserror 2.0.18",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-bitmap"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7add20f40d060db8c9b1314d499bac6ed7480f33eb113ce3e1cf5d6ff85d989"
-dependencies = [
- "gix-error",
-]
-
-[[package]]
-name = "gix-blame"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77aaf9f7348f4da3ebfbfbbc35fa0d07155d98377856198dde6f695fd648705"
-dependencies = [
- "gix-commitgraph",
- "gix-date",
- "gix-diff",
- "gix-error",
- "gix-hash",
- "gix-object",
- "gix-revwalk",
- "gix-trace",
- "gix-traverse",
- "gix-worktree",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-chunk"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1096b6608fbe5d27fb4984e20f992b4e76fb8c613f6acb87d07c5831b53a6959"
-dependencies = [
- "gix-error",
-]
-
-[[package]]
-name = "gix-command"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b849c65a609f50d02f8a2774fe371650b3384a743c79c2a070ce0da49b7fb7da"
-dependencies = [
- "bstr",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "shell-words",
-]
-
-[[package]]
-name = "gix-commitgraph"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3196655fd1443f3c58a48c114aa480be3e4e87b393d7292daaa0d543862eb445"
-dependencies = [
- "bstr",
- "gix-chunk",
- "gix-error",
- "gix-hash",
- "memmap2",
- "nonempty",
-]
-
-[[package]]
-name = "gix-config"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08939b4c4ed7a663d0e64be9e1e9bdf23a1fb4fcee1febdf449f12229542e50d"
-dependencies = [
- "bstr",
- "gix-config-value",
- "gix-features",
- "gix-glob",
- "gix-path",
- "gix-ref",
- "gix-sec",
- "memchr",
- "smallvec",
- "thiserror 2.0.18",
- "unicode-bom",
- "winnow",
-]
-
-[[package]]
-name = "gix-config-value"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441a300bc3645a1f45cba495b9175f90f47256ce43f2ee161da0031e3ac77c92"
-dependencies = [
- "bitflags 2.11.0",
- "bstr",
- "gix-path",
- "libc",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-credentials"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b2a34b8715e3bbd514f3d1705f5d51c4b250e5bfe506b9fb60b133c85c93d9"
-dependencies = [
- "bstr",
- "gix-command",
- "gix-config-value",
- "gix-date",
- "gix-path",
- "gix-prompt",
- "gix-sec",
- "gix-trace",
- "gix-url",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-date"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39acf819aa9fee65e4838a2eec5cb2506e47ebb89e02a5ab9918196e491571ea"
-dependencies = [
- "bstr",
- "gix-error",
- "itoa",
- "jiff",
- "smallvec",
-]
-
-[[package]]
-name = "gix-diff"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88f3b3475e5d3877d7c30c40827cc2441936ce890efc226e5ba4afe3a7ae33f0"
-dependencies = [
- "bstr",
- "gix-attributes",
- "gix-command",
- "gix-filter",
- "gix-fs",
- "gix-hash",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-pathspec",
- "gix-tempfile",
- "gix-trace",
- "gix-traverse",
- "gix-worktree",
- "imara-diff 0.1.8",
- "imara-diff 0.2.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-dir"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da4604a360988f0ba8efe6f90093ca5a844f4a7f8e1a3dcda501ec44e600ea9"
-dependencies = [
- "bstr",
- "gix-discover",
- "gix-fs",
- "gix-ignore",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-pathspec",
- "gix-trace",
- "gix-utils",
- "gix-worktree",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-discover"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65bd3330fe0cb9d40d875bf862fd5e8ad6fa4164ddbc4842fbeb889c3f0b2c6"
-dependencies = [
- "bstr",
- "dunce",
- "gix-fs",
- "gix-path",
- "gix-ref",
- "gix-sec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-error"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e86d01da904d4a9265def43bd42a18c5e6dc7000a73af512946ba14579c9fbd"
-dependencies = [
- "bstr",
-]
-
-[[package]]
-name = "gix-features"
-version = "0.46.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "752493cd4b1d5eaaa0138a7493f65c96863fefa990fc021e0e519579e389ab20"
-dependencies = [
- "bytes",
- "bytesize",
- "crc32fast",
- "crossbeam-channel",
- "gix-path",
- "gix-trace",
- "gix-utils",
- "libc",
- "once_cell",
- "parking_lot",
- "prodash",
- "thiserror 2.0.18",
- "walkdir",
- "zlib-rs",
-]
-
-[[package]]
-name = "gix-filter"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d37598282a6566da6fb52667570c7fe0aedcb122ac886724a9e62a2180523e35"
-dependencies = [
- "bstr",
- "encoding_rs",
- "gix-attributes",
- "gix-command",
- "gix-hash",
- "gix-object",
- "gix-packetline",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "gix-utils",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-fs"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a964b4aec683eb0bacb87533defa80805bb4768056371a47ab38b00a2d377b72"
-dependencies = [
- "bstr",
- "fastrand",
- "gix-features",
- "gix-path",
- "gix-utils",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-glob"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
-dependencies = [
- "bitflags 2.11.0",
- "bstr",
- "gix-features",
- "gix-path",
-]
-
-[[package]]
-name = "gix-hash"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb896a02d9ab96fa518475a5f30ad3952010f801a8de5840f633f4a6b985dfb"
-dependencies = [
- "faster-hex",
- "gix-features",
- "sha1-checked",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-hashtable"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2664216fc5e89b51e756a4a3ac676315602ce2dac07acf1da959a22038d69b33"
-dependencies = [
- "gix-hash",
- "hashbrown 0.16.1",
- "parking_lot",
-]
-
-[[package]]
-name = "gix-ignore"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f915dcf6911e3027537166d34e13f0fe101ed12225178d2ae29cd1272cff26"
-dependencies = [
- "bstr",
- "gix-glob",
- "gix-path",
- "gix-trace",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-index"
-version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bae54ab14e4e74d5dda60b82ea7afad7c8eb3be68283d6d5f29bd2e6d47fff7"
-dependencies = [
- "bitflags 2.11.0",
- "bstr",
- "filetime",
- "fnv",
- "gix-bitmap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-traverse",
- "gix-utils",
- "gix-validate",
- "hashbrown 0.16.1",
- "itoa",
- "libc",
- "memmap2",
- "rustix",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-lock"
-version = "21.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054fbd0989700c69dc5aa80bc66944f05df1e15aa7391a9e42aca7366337905f"
-dependencies = [
- "gix-tempfile",
- "gix-utils",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-mailmap"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b4818da522786ec7e32a00884ee8fc40fa4c215c3997c0b15f7b62684d1199"
-dependencies = [
- "bstr",
- "gix-actor",
- "gix-date",
- "gix-error",
-]
-
-[[package]]
-name = "gix-merge"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4606747466512d22c2dffc019142e1941238f543987ea51353c938cca80c500"
-dependencies = [
- "bstr",
- "gix-command",
- "gix-diff",
- "gix-filter",
- "gix-fs",
- "gix-hash",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-quote",
- "gix-revision",
- "gix-revwalk",
- "gix-tempfile",
- "gix-trace",
- "gix-worktree",
- "imara-diff 0.1.8",
- "nonempty",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-negotiate"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea064c7595eea08fdd01c70748af747d9acc40f727b61f4c8a2145a5c5fc28c"
-dependencies = [
- "bitflags 2.11.0",
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-object",
- "gix-revwalk",
-]
-
-[[package]]
-name = "gix-object"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cafb802bb688a7c1e69ef965612ff5ff859f046bfb616377e4a0ba4c01e43d47"
-dependencies = [
- "bstr",
- "gix-actor",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-path",
- "gix-utils",
- "gix-validate",
- "itoa",
- "smallvec",
- "thiserror 2.0.18",
- "winnow",
-]
-
-[[package]]
-name = "gix-odb"
-version = "0.78.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24833ae9323b4f7079575fb9f961cf9c414b0afbec428a536ab8e7dd93bc002b"
-dependencies = [
- "arc-swap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-pack",
- "gix-path",
- "gix-quote",
- "parking_lot",
- "tempfile",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-pack"
-version = "0.68.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3484119cd19859d7d7639413c27e192478fa354d3f4ff5f7e3c041e8040f0f4"
-dependencies = [
- "clru",
- "gix-chunk",
- "gix-error",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-path",
- "gix-tempfile",
- "memmap2",
- "parking_lot",
- "smallvec",
- "thiserror 2.0.18",
- "uluru",
-]
-
-[[package]]
-name = "gix-packetline"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be19313dcdb7dff75a3ce2f99be00878458295bcc3b6c7f0005591597573345c"
-dependencies = [
- "bstr",
- "faster-hex",
- "gix-trace",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-path"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c31d4373bda7fab9eb01822927b55185a378d6e1bf737e0a54c743ad806658"
-dependencies = [
- "bstr",
- "gix-trace",
- "gix-validate",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-pathspec"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89611f13544ca5ebeb68a502673814ef57200df60c24a61c2ce7b96f612f08b"
-dependencies = [
- "bitflags 2.11.0",
- "bstr",
- "gix-attributes",
- "gix-config-value",
- "gix-glob",
- "gix-path",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-prompt"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f61f6264e1f6c5a951531fe127722c7522bc02ebda80c4528286bda4642055f"
-dependencies = [
- "gix-command",
- "gix-config-value",
- "parking_lot",
- "rustix",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-protocol"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38666350736b5877c79f57ddae02bde07a4ce186d889adc391e831cddcbe76"
-dependencies = [
- "bstr",
- "gix-credentials",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-lock",
- "gix-negotiate",
- "gix-object",
- "gix-ref",
- "gix-refspec",
- "gix-revwalk",
- "gix-shallow",
- "gix-trace",
- "gix-transport",
- "gix-utils",
- "maybe-async",
- "nonempty",
- "thiserror 2.0.18",
- "winnow",
-]
-
-[[package]]
-name = "gix-quote"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68533db71259c8776dd4e770d2b7b98696213ecdc1f5c9e3507119e274e0c578"
-dependencies = [
- "bstr",
- "gix-error",
- "gix-utils",
-]
-
-[[package]]
-name = "gix-ref"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2159978abb99b7027c8579d15211e262ef0ef2594d5cecb3334fbcbdfe2997c"
-dependencies = [
- "gix-actor",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-path",
- "gix-tempfile",
- "gix-utils",
- "gix-validate",
- "memmap2",
- "thiserror 2.0.18",
- "winnow",
-]
-
-[[package]]
-name = "gix-refspec"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc806ee13f437428f8a1ba4c72ecfaa3f20e14f5f0d4c2bc17d0b33e794aa6ac"
-dependencies = [
- "bstr",
- "gix-error",
- "gix-glob",
- "gix-hash",
- "gix-revision",
- "gix-validate",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-revision"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c08f1ec5d1e6a524f8ba291c41f0ccaef64e48ed0e8cf790b3461cae45f6d3d"
-dependencies = [
- "bitflags 2.11.0",
- "bstr",
- "gix-commitgraph",
- "gix-date",
- "gix-error",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-revwalk",
- "gix-trace",
- "nonempty",
-]
-
-[[package]]
-name = "gix-revwalk"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4b2b87772b21ca449249e86d32febadba5cba32b0fcce804ab9cefc6f2111c"
-dependencies = [
- "gix-commitgraph",
- "gix-date",
- "gix-error",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-sec"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf82ae037de9c62850ce67beaa92ec8e3e17785ea307cdde7618edc215603b4f"
-dependencies = [
- "bitflags 2.11.0",
- "gix-path",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "gix-shallow"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf60711c9083b2364b3fac8a352444af76b17201f3682fdebe74fa66d89a772"
-dependencies = [
- "bstr",
- "gix-hash",
- "gix-lock",
- "nonempty",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-status"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d6c598e3fdbc352fba1c5ba7e709e69402fafbc44d9295edad2e3c4738996b"
-dependencies = [
- "bstr",
- "filetime",
- "gix-diff",
- "gix-dir",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-hash",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-pathspec",
- "gix-worktree",
- "portable-atomic",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-submodule"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5c3929c5e6821f651d35e8420f72fea3cfafe9fc1e928a61e718b462c72a5"
-dependencies = [
- "bstr",
- "gix-config",
- "gix-path",
- "gix-pathspec",
- "gix-refspec",
- "gix-url",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-tempfile"
-version = "21.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22227f6b203f511ff451c33c89899e87e4f571fc596b06f68e6e613a6508528"
-dependencies = [
- "dashmap",
- "gix-fs",
- "libc",
- "parking_lot",
- "signal-hook",
- "signal-hook-registry",
- "tempfile",
-]
-
-[[package]]
-name = "gix-trace"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
-
-[[package]]
-name = "gix-transport"
-version = "0.55.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a521e39c6235ce63ed6c001e2dd79818c830b82c3b7b59247ee7b229c39ec9bb"
-dependencies = [
- "base64",
- "bstr",
- "gix-command",
- "gix-credentials",
- "gix-features",
- "gix-packetline",
- "gix-quote",
- "gix-sec",
- "gix-url",
- "reqwest",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-traverse"
-version = "0.55.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963dc2afcdb611092aa587c3f9365e749ac0a0892ff27662dbc75f26c953fbec"
-dependencies = [
- "bitflags 2.11.0",
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-revwalk",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-url"
-version = "0.35.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d28e8af3d42581190da884f013caf254d2fd4d6ab102408f08d21bfa11de6c8d"
-dependencies = [
- "bstr",
- "gix-path",
- "percent-encoding",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-utils"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
-dependencies = [
- "bstr",
- "fastrand",
- "unicode-normalization",
-]
-
-[[package]]
-name = "gix-validate"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec1eff98d91941f47766367cba1be746bab662bad761d9891ae6f7882f7840b"
-dependencies = [
- "bstr",
-]
-
-[[package]]
-name = "gix-worktree"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6bd5830cbc43c9c00918b826467d2afad685b195cb82329cde2b2d116d2c578"
-dependencies = [
- "bstr",
- "gix-attributes",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-ignore",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-validate",
-]
-
-[[package]]
-name = "gix-worktree-state"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644a1681f96e1be43c2a8384337d9d220e7624f50db54beda70997052aebf707"
-dependencies = [
- "bstr",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-worktree",
- "io-close",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-worktree-stream"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e3fb70a1f650a5cec7d5b8d10d6d6fe86daf3cf15bde08ba0c70988a2932c3"
-dependencies = [
- "gix-attributes",
- "gix-error",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-hash",
- "gix-object",
- "gix-path",
- "gix-traverse",
- "parking_lot",
-]
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2855,25 +1630,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2883,21 +1639,6 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
-
-[[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2922,16 +1663,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2942,112 +1673,6 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "http"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
-dependencies = [
- "bytes",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "human_format"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaec953f16e5bcf6b8a3cb3aa959b17e5577dbd2693e94554c462c08be22624b"
-
-[[package]]
-name = "hyper"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
-dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "h2",
- "http",
- "http-body",
- "httparse",
- "itoa",
- "pin-project-lite",
- "pin-utils",
- "smallvec",
- "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
-]
 
 [[package]]
 name = "iana-time-zone"
@@ -3217,25 +1842,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "imara-diff"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "imara-diff"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c"
-dependencies = [
- "hashbrown 0.15.5",
- "memchr",
-]
-
-[[package]]
 name = "include-flate"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3291,24 +1897,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inferno"
-version = "0.11.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
-dependencies = [
- "ahash",
- "indexmap",
- "is-terminal",
- "itoa",
- "log",
- "num-format",
- "once_cell",
- "quick-xml",
- "rgb",
- "str_stack",
-]
-
-[[package]]
 name = "insta"
 version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3316,34 +1904,8 @@ checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
 dependencies = [
  "console",
  "once_cell",
- "similar",
+ "similar 2.7.0",
  "tempfile",
-]
-
-[[package]]
-name = "io-close"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "ipnet"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]
@@ -3420,12 +1982,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3e3d65f018c6ae946ab16e80944b97096ed73c35b221d1c478a6c81d8f57940"
 dependencies = [
  "jiff-static",
- "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3435,65 +1995,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a17c2b211d863c7fde02cbea8a3c1a439b98e109286554f2860bdded7ff83818"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "jiff-tzdb"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
-
-[[package]]
-name = "jiff-tzdb-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
-dependencies = [
- "jiff-tzdb",
-]
-
-[[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
  "quote",
  "syn 2.0.117",
 ]
@@ -3519,15 +2020,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kstring"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
 name = "lalry"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3538,12 +2030,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "leb128fmt"
@@ -3605,7 +2091,6 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -3621,25 +2106,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
@@ -3651,32 +2121,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "lz4_flex"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
-dependencies = [
- "twox-hash",
-]
-
-[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "maybe-async"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3745,39 +2195,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
-dependencies = [
- "adler2",
- "serde",
-]
-
-[[package]]
-name = "mio"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3840,39 +2263,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
-
-[[package]]
-name = "nonempty"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "num-bigint"
@@ -3882,16 +2276,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "num-format"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
-dependencies = [
- "arrayvec",
- "itoa",
 ]
 
 [[package]]
@@ -3920,28 +2304,6 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
-dependencies = [
- "num_enum_derive",
- "rustversion",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3984,12 +2346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4006,29 +2362,6 @@ name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.5.18",
- "smallvec",
- "windows-link",
-]
 
 [[package]]
 name = "parol"
@@ -4143,12 +2476,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4219,28 +2546,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pprof"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
-dependencies = [
- "aligned-vec",
- "backtrace",
- "cfg-if",
- "findshlibs",
- "inferno",
- "libc",
- "log",
- "nix 0.26.4",
- "once_cell",
- "smallvec",
- "spin",
- "symbolic-demangle",
- "tempfile",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4287,15 +2592,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4326,17 +2622,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prodash"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
-dependencies = [
- "bytesize",
- "human_format",
- "parking_lot",
 ]
 
 [[package]]
@@ -4388,75 +2673,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick-xml"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -4557,24 +2777,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4661,69 +2863,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "rgb"
-version = "0.8.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4791,81 +2930,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.23.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
-dependencies = [
- "aws-lc-rs",
- "once_cell",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
-dependencies = [
- "web-time",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
-dependencies = [
- "aws-lc-rs",
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4899,19 +2963,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scnr2"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4966feadc6f0a47d60296ffc30ea515cdeb5876c5c81ac2660f1040e349ec1ae"
+checksum = "7e9430a2a48165bc07428868fd12b6fbe5c25673cc6a69b46a7a6a671f9a5fb3"
 dependencies = [
  "log",
  "scnr2_macro",
@@ -4919,9 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "scnr2_generate"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f192b40e716209c169328fbc0d9eb353747948587b5e94afad972e3b5ef868"
+checksum = "6e6b30f88a8ab5674c296158f142a1735495be2ab20cea952ce582458e0a5440"
 dependencies = [
  "log",
  "proc-macro2",
@@ -4933,40 +2988,11 @@ dependencies = [
 
 [[package]]
 name = "scnr2_macro"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ab98ffcf4285d5b841d3c3a84d32da23e29804bf9ab5452fe5f62e07416540"
+checksum = "cea9c4ecb8832894e8fc7c22e57697b31886b715d999a06806824cb39d9bdcfa"
 dependencies = [
  "scnr2_generate",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -5034,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -5052,27 +3078,6 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sha1-checked"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
-dependencies = [
- "digest",
- "sha1",
 ]
 
 [[package]]
@@ -5093,42 +3098,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b57709da74f9ff9f4a27dce9526eec25ca8407c45a7887243b031a58935fb8e"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "similar"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d93e861ede2e497b47833469b8ec9d5c07fa4c78ce7a00f6eb7dd8168b4b3f"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "sized-chunks"
@@ -5153,16 +3141,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5193,41 +3171,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "statrs"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
-dependencies = [
- "approx",
- "num-traits",
-]
-
-[[package]]
-name = "str_stack"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
 name = "strnum_bitwidth"
@@ -5260,12 +3207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
 name = "supports-color"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5287,29 +3228,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
-name = "symbolic-common"
-version = "12.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ca086c1eb5c7ee74b151ba83c6487d5d33f8c08ad991b86f3f58f6629e68d5"
-dependencies = [
- "debugid",
- "memmap2",
- "stable_deref_trait",
- "uuid",
-]
-
-[[package]]
-name = "symbolic-demangle"
-version = "12.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa911a28a62823aaf2cc2e074212492a3ee69d0d926cc8f5b12b4a108ff5c0c"
-dependencies = [
- "cpp_demangle 0.5.1",
- "rustc-demangle",
- "symbolic-common",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5328,15 +3246,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
 ]
 
 [[package]]
@@ -5522,58 +3431,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "pin-project-lite",
- "socket2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5585,22 +3442,22 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
 name = "toml"
-version = "1.0.3+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -5614,109 +3471,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
-dependencies = [
- "indexmap",
- "toml_datetime 1.0.0+spec-1.1.0",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
-
-[[package]]
-name = "tower"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
-dependencies = [
- "bitflags 2.11.0",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "iri-string",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
-
-[[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
-name = "tracing"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "ts-rs"
@@ -5753,15 +3528,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
-name = "uluru"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
 name = "ume"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5772,12 +3538,6 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
-name = "unicode-bom"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
 name = "unicode-id-start"
@@ -5796,15 +3556,6 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -5835,12 +3586,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -5893,14 +3638,18 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "veryl-aligner"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d338ab35f8af8049cd0c5c0e7912256f39e65b52cfed2d4c84c76933ff26e891"
 dependencies = [
  "veryl-parser",
 ]
 
 [[package]]
 name = "veryl-analyzer"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "118fe21242e6e4e6bcf7bc5d3507d779ebdcbffcfa9663b2b09eba190475b445"
 dependencies = [
  "bimap",
  "daggy",
@@ -5913,13 +3662,12 @@ dependencies = [
  "num-traits",
  "paste",
  "serde_json",
- "similar",
+ "similar 3.1.0",
  "smallvec",
  "strnum_bitwidth",
  "strum",
  "strum_macros",
  "thiserror 2.0.18",
- "toml 1.0.3+spec-1.1.0",
  "vcd",
  "veryl-metadata",
  "veryl-parser",
@@ -5927,11 +3675,12 @@ dependencies = [
 
 [[package]]
 name = "veryl-emitter"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace0fd826e20dd5ef253e9188880875c8600dfb9b68b35f2f728e0bb19d09eb4"
 dependencies = [
  "serde",
  "strnum_bitwidth",
- "toml 1.0.3+spec-1.1.0",
  "veryl-aligner",
  "veryl-analyzer",
  "veryl-metadata",
@@ -5941,9 +3690,10 @@ dependencies = [
 
 [[package]]
 name = "veryl-metadata"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e194c86141f6012a33274c751b4f2a1c106be884b832abed37a65c27d2e13a"
 dependencies = [
- "gix",
  "log",
  "miette",
  "once_cell",
@@ -5953,9 +3703,8 @@ dependencies = [
  "serde",
  "serde_regex",
  "spdx",
- "tempfile",
  "thiserror 2.0.18",
- "toml 1.0.3+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "uuid",
  "veryl-parser",
@@ -5967,7 +3716,9 @@ dependencies = [
 
 [[package]]
 name = "veryl-parser"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f5eb6de7e3ad0d12e9fbc50694e1578d57c74549343ff82660833a6543dc2a7"
 dependencies = [
  "anyhow",
  "bimap",
@@ -5983,7 +3734,9 @@ dependencies = [
 
 [[package]]
 name = "veryl-path"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed796b004951aabca0878f6a518f50f8fd6410d88055ac999015246445125ee5"
 dependencies = [
  "directories",
  "fs4",
@@ -5995,10 +3748,11 @@ dependencies = [
 
 [[package]]
 name = "veryl-simulator"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667fa663f394b18fe47ad06fbc06aaed1d42666f2d38f8dc9e4ca289c0fe5bf1"
 dependencies = [
  "clap",
- "codspeed-criterion-compat",
  "cranelift",
  "daggy",
  "fst-writer",
@@ -6008,23 +3762,23 @@ dependencies = [
  "memmap2",
  "miette",
  "num-traits",
- "pprof",
  "serde_json",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "toml 1.0.3+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "vcd",
  "veryl-analyzer",
  "veryl-metadata",
  "veryl-parser",
  "veryl-path",
- "wellen",
 ]
 
 [[package]]
 name = "veryl-sourcemap"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f9ca6a8806fa077b03298ee9db04caeda79c81adbe8490c507fa81bd9bf12"
 dependencies = [
  "miette",
  "relative-path",
@@ -6034,7 +3788,9 @@ dependencies = [
 
 [[package]]
 name = "veryl-std"
-version = "0.19.1"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f06dc9231d7ae8d0c349428adbf857a8e39b905bb7e518ee14aa6c0f11cca43f"
 dependencies = [
  "merkle_hash",
  "miette",
@@ -6066,15 +3822,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
 ]
 
 [[package]]
@@ -6112,20 +3859,6 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
-dependencies = [
- "cfg-if",
- "futures-util",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -6309,7 +4042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8b78abf3677d4a0a5db82e5015b4d085ff3a1b8b472cbb8c70d4b769f019ce"
 dependencies = [
  "anyhow",
- "cpp_demangle 0.4.5",
+ "cpp_demangle",
  "cranelift-bforest 0.130.1",
  "cranelift-bitset 0.130.1",
  "cranelift-entity 0.130.1",
@@ -6388,9 +4121,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "44.0.0"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816a61a75275c6be435131fc625a4f5956daf24d9f9f59443e81cbef228929b3"
+checksum = "8f2c7fa6523647262bfb4095dbdf4087accefe525813e783f81a0c682f418ce4"
 dependencies = [
  "hashbrown 0.16.1",
  "libm",
@@ -6464,13 +4197,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "44.0.0"
+version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd683a94490bf755d016a09697b0955602c50106b1ded97d16983ab2ded9fed"
+checksum = "6a1859e920871515d324fb9757c3e448d6ed1512ca6ccdff14b6e016505d6ada"
 dependencies = [
  "cfg-if",
  "libc",
- "wasmtime-internal-core 44.0.0",
+ "wasmtime-internal-core 44.0.1",
  "windows-sys 0.61.2",
 ]
 
@@ -6558,43 +4291,6 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "wellen"
-version = "0.20.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2bca6041f0b336e40333f8875d441292edc75fa36a15415a14f20bea7f9c93"
-dependencies = [
- "fst-reader",
- "indexmap",
- "leb128",
- "lz4_flex 0.13.0",
- "memmap2",
- "miniz_oxide 0.9.1",
- "num_enum",
- "rayon",
- "rustc-hash",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6719,15 +4415,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6760,21 +4447,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6812,12 +4484,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6830,12 +4496,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6845,12 +4505,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6878,12 +4532,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6893,12 +4541,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6914,12 +4556,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6929,12 +4565,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6953,9 +4583,12 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-dependencies = [
- "memchr",
-]
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "winsafe"
@@ -7156,12 +4789,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-
-[[package]]
 name = "zerotrie"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7193,12 +4820,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "zlib-rs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,49 +22,26 @@ description = "Celox HDL Simulator"
 rust-version = "1.95.0"
 
 [workspace.dependencies]
-# Veryl dependencies via submodule path
-veryl-analyzer = { path = "deps/veryl/crates/analyzer" }
-veryl-emitter  = { path = "deps/veryl/crates/emitter" }
-veryl-metadata = { path = "deps/veryl/crates/metadata" }
-veryl-parser   = { path = "deps/veryl/crates/parser", default-features = false }
-veryl-path      = { path = "deps/veryl/crates/path" }
-veryl-simulator = { path = "deps/veryl/crates/simulator" }
+veryl-analyzer = "0.20.0"
+veryl-emitter  = "0.20.0"
+veryl-metadata = "0.20.0"
+veryl-parser   = { version = "0.20.0", default-features = false }
+veryl-path      = "0.20.0"
+veryl-simulator = "0.20.0"
+veryl-std       = "0.20.0"
 
-# Shared dependencies (also needed by veryl submodule crates)
-anyhow          = "1.0"
 bit-set         = "0.10"
 clap            = { version = "4.5.60", features = ["derive"] }
-daggy           = "0.9.0"
 fxhash          = "0.2.1"
-indent          = "0.1.1"
 itertools       = "0.14.0"
-log             = "0.4.29"
 miette          = { version = "7.6" }
 num-bigint      = "0.4"
 num-traits      = "0.2.19"
-once_cell       = "1.21"
-parol           = "4.3"
-parol_runtime   = "4.3"
-paste           = "1.0"
-regex           = "1.12.3"
-scnr2           = "0.5.0"
-semver          = { version = "1.0", features = ["serde"] }
 serde           = { version = "1.0", features = ["derive"] }
 serde_json      = "1.0"
-similar         = { version = "2.7.0", features = ["text", "inline"] }
-smallvec        = "1.15"
-strnum_bitwidth = "0.1.2"
 tempfile        = "3.26"
 thiserror       = "2.0"
 toml            = "1.0.3"
-url             = { version = "2.5", features = ["serde"] }
-vcd             = "0.7.0"
-walkdir         = "2.5.0"
-
-# Dependencies needed by veryl-simulator (inherited via workspace)
-criterion       = { package = "codspeed-criterion-compat", version = "4.0" }
-fst-writer      = "0.3.1"
-pprof           = { version = "0.15.0", features = ["flamegraph"] }
 
 [workspace.lints.rust]
 warnings = "deny"

--- a/crates/celox-bench-sv/Cargo.toml
+++ b/crates/celox-bench-sv/Cargo.toml
@@ -11,6 +11,7 @@ veryl-analyzer = { workspace = true }
 veryl-emitter  = { workspace = true }
 veryl-metadata = { workspace = true }
 veryl-parser   = { workspace = true }
+veryl-std      = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/celox-bench-sv/src/main.rs
+++ b/crates/celox-bench-sv/src/main.rs
@@ -4,11 +4,14 @@
 //!
 //! Outputs .sv files to benches/verilator/
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use veryl_analyzer::{Analyzer, Context, attribute_table, symbol_table};
 use veryl_emitter::Emitter;
 use veryl_metadata::Metadata;
 use veryl_parser::Parser;
+
+#[path = "../../celox/tests/fixtures/veryl_std.rs"]
+mod veryl_std;
 
 #[allow(clippy::needless_borrow)]
 fn emit_sv(code: &str) -> String {
@@ -84,15 +87,8 @@ fn strip_test_blocks(code: &str) -> String {
     result
 }
 
-fn read_veryl(veryl_std: &Path, parts: &[&str]) -> String {
-    let mut path = veryl_std.to_path_buf();
-    for p in parts {
-        path = path.join(p);
-    }
-    strip_test_blocks(
-        &std::fs::read_to_string(&path)
-            .unwrap_or_else(|e| panic!("Failed to read {}: {}", path.display(), e)),
-    )
+fn read_veryl(parts: &[&str]) -> String {
+    strip_test_blocks(&veryl_std::source(parts))
 }
 
 /// Strip the sourceMappingURL comment from emitter output.
@@ -108,7 +104,6 @@ fn main() {
         .join("../..")
         .canonicalize()
         .unwrap();
-    let veryl_std = project_root.join("deps/veryl/crates/std/veryl/src");
     let out_dir = project_root.join("benches/verilator");
 
     // Wrapper modules are shared with the Celox Rust benchmarks
@@ -124,8 +119,8 @@ fn main() {
     // --- LinearSec (P=6: 57-bit data, 63-bit codeword) ---
     let linear_sec_code = format!(
         "{}\n{}\n{}",
-        read_veryl(&veryl_std, &["coding", "linear_sec_encoder.veryl"]),
-        read_veryl(&veryl_std, &["coding", "linear_sec_decoder.veryl"]),
+        read_veryl(&["coding", "linear_sec_encoder.veryl"]),
+        read_veryl(&["coding", "linear_sec_decoder.veryl"]),
         include_str!("../../../benches/veryl/linear_sec_top.veryl"),
     );
     let sv = strip_sourcemap(&emit_sv(&linear_sec_code));
@@ -135,7 +130,7 @@ fn main() {
     // --- Countones (W=64): combinational popcount tree ---
     let countones_code = format!(
         "{}\n{}",
-        read_veryl(&veryl_std, &["countones", "countones.veryl"]),
+        read_veryl(&["countones", "countones.veryl"]),
         include_str!("../../../benches/veryl/countones_top.veryl"),
     );
     let sv = strip_sourcemap(&emit_sv(&countones_code));
@@ -145,7 +140,7 @@ fn main() {
     // --- std::counter (WIDTH=32) ---
     let std_counter_code = format!(
         "{}\n{}",
-        read_veryl(&veryl_std, &["counter", "counter.veryl"]),
+        read_veryl(&["counter", "counter.veryl"]),
         include_str!("../../../benches/veryl/std_counter_top.veryl"),
     );
     let sv = strip_sourcemap(&emit_sv(&std_counter_code));
@@ -155,9 +150,9 @@ fn main() {
     // --- std::gray_counter (WIDTH=32) ---
     let gray_counter_code = format!(
         "{}\n{}\n{}\n{}",
-        read_veryl(&veryl_std, &["counter", "counter.veryl"]),
-        read_veryl(&veryl_std, &["gray", "gray_encoder.veryl"]),
-        read_veryl(&veryl_std, &["gray", "gray_counter.veryl"]),
+        read_veryl(&["counter", "counter.veryl"]),
+        read_veryl(&["gray", "gray_encoder.veryl"]),
+        read_veryl(&["gray", "gray_counter.veryl"]),
         include_str!("../../../benches/veryl/gray_counter_top.veryl"),
     );
     let sv = strip_sourcemap(&emit_sv(&gray_counter_code));
@@ -167,9 +162,9 @@ fn main() {
     // --- std::fifo (WIDTH=8, DEPTH=16) ---
     let fifo_code = format!(
         "{}\n{}\n{}\n{}",
-        read_veryl(&veryl_std, &["ram", "ram.veryl"]),
-        read_veryl(&veryl_std, &["fifo", "fifo_controller.veryl"]),
-        read_veryl(&veryl_std, &["fifo", "fifo.veryl"]),
+        read_veryl(&["ram", "ram.veryl"]),
+        read_veryl(&["fifo", "fifo_controller.veryl"]),
+        read_veryl(&["fifo", "fifo.veryl"]),
         include_str!("../../../benches/veryl/fifo_top.veryl"),
     );
     let sv = strip_sourcemap(&emit_sv(&fifo_code));
@@ -179,8 +174,8 @@ fn main() {
     // --- std::gray_encoder + gray_decoder (WIDTH=32) ---
     let gray_codec_code = format!(
         "{}\n{}\n{}",
-        read_veryl(&veryl_std, &["gray", "gray_encoder.veryl"]),
-        read_veryl(&veryl_std, &["gray", "gray_decoder.veryl"]),
+        read_veryl(&["gray", "gray_encoder.veryl"]),
+        read_veryl(&["gray", "gray_decoder.veryl"]),
         include_str!("../../../benches/veryl/gray_codec_top.veryl"),
     );
     let sv = strip_sourcemap(&emit_sv(&gray_codec_code));
@@ -190,7 +185,7 @@ fn main() {
     // --- std::edge_detector (WIDTH=32) ---
     let edge_detector_code = format!(
         "{}\n{}",
-        read_veryl(&veryl_std, &["edge_detector", "edge_detector.veryl"]),
+        read_veryl(&["edge_detector", "edge_detector.veryl"]),
         include_str!("../../../benches/veryl/edge_detector_top.veryl"),
     );
     let sv = strip_sourcemap(&emit_sv(&edge_detector_code));
@@ -200,7 +195,7 @@ fn main() {
     // --- std::onehot (W=64) ---
     let onehot_code = format!(
         "{}\n{}",
-        read_veryl(&veryl_std, &["countones", "onehot.veryl"]),
+        read_veryl(&["countones", "onehot.veryl"]),
         include_str!("../../../benches/veryl/onehot_top.veryl"),
     );
     let sv = strip_sourcemap(&emit_sv(&onehot_code));
@@ -210,7 +205,7 @@ fn main() {
     // --- std::lfsr_galois (SIZE=32) ---
     let lfsr_code = format!(
         "{}\n{}",
-        read_veryl(&veryl_std, &["lfsr", "lfsr_galois.veryl"]),
+        read_veryl(&["lfsr", "lfsr_galois.veryl"]),
         include_str!("../../../benches/veryl/lfsr_top.veryl"),
     );
     let sv = strip_sourcemap(&emit_sv(&lfsr_code));

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -44,6 +44,7 @@ proptest   = "1.10"
 test-case  = "3"
 tempfile.workspace = true
 veryl-simulator = { workspace = true }
+veryl-std = { workspace = true }
 
 [[bench]]
 name = "simulation"

--- a/crates/celox/benches/simulation.rs
+++ b/crates/celox/benches/simulation.rs
@@ -1,5 +1,9 @@
 use celox::{DeadStorePolicy, Simulator, TestResult};
 use criterion::{Criterion, criterion_group, criterion_main};
+use std::sync::LazyLock;
+
+#[path = "../tests/fixtures/veryl_std.rs"]
+mod veryl_std;
 
 // Wrapper modules are shared with celox-bench-sv (Verilator SV generation)
 // via benches/veryl/*.veryl to guarantee identical circuits.
@@ -11,71 +15,101 @@ const NATIVE_TB_COUNTER_N1000: &str = concat!(
     include_str!("../../../benches/veryl/top_n1000.veryl"),
     include_str!("../../../benches/veryl/native_tb_counter_n1000.veryl"),
 );
-const NATIVE_TB_STD_COUNTER: &str = concat!(
-    include_str!("../../../deps/veryl/crates/std/veryl/src/counter/counter.veryl"),
-    include_str!("../../../benches/veryl/std_counter_top.veryl"),
-    include_str!("../../../benches/veryl/native_tb_std_counter.veryl"),
-);
+static NATIVE_TB_STD_COUNTER: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "{}\n{}\n{}",
+        veryl_std::source(&["counter", "counter.veryl"]),
+        include_str!("../../../benches/veryl/std_counter_top.veryl"),
+        include_str!("../../../benches/veryl/native_tb_std_counter.veryl"),
+    )
+});
 
 // P=6: K=63-bit codeword, N=57-bit data
-const LINEAR_SEC_SRC: &str = concat!(
-    include_str!("../../../deps/veryl/crates/std/veryl/src/coding/linear_sec_encoder.veryl"),
-    include_str!("../../../deps/veryl/crates/std/veryl/src/coding/linear_sec_decoder.veryl"),
-    include_str!("../../../benches/veryl/linear_sec_top.veryl"),
-);
+static LINEAR_SEC_SRC: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "{}\n{}\n{}",
+        veryl_std::source(&["coding", "linear_sec_encoder.veryl"]),
+        veryl_std::source(&["coding", "linear_sec_decoder.veryl"]),
+        include_str!("../../../benches/veryl/linear_sec_top.veryl"),
+    )
+});
 
 // std::countones W=64: recursive combinational popcount tree
-const COUNTONES_SRC: &str = concat!(
-    include_str!("../../../deps/veryl/crates/std/veryl/src/countones/countones.veryl"),
-    include_str!("../../../benches/veryl/countones_top.veryl"),
-);
+static COUNTONES_SRC: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "{}\n{}",
+        veryl_std::source(&["countones", "countones.veryl"]),
+        include_str!("../../../benches/veryl/countones_top.veryl"),
+    )
+});
 
 // std::counter WIDTH=32
-const STD_COUNTER_SRC: &str = concat!(
-    include_str!("../../../deps/veryl/crates/std/veryl/src/counter/counter.veryl"),
-    include_str!("../../../benches/veryl/std_counter_top.veryl"),
-);
+static STD_COUNTER_SRC: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "{}\n{}",
+        veryl_std::source(&["counter", "counter.veryl"]),
+        include_str!("../../../benches/veryl/std_counter_top.veryl"),
+    )
+});
 
 // std::fifo WIDTH=8 DEPTH=16
-const FIFO_SRC: &str = concat!(
-    include_str!("../../../deps/veryl/crates/std/veryl/src/ram/ram.veryl"),
-    include_str!("../../../deps/veryl/crates/std/veryl/src/fifo/fifo_controller.veryl"),
-    include_str!("../../../deps/veryl/crates/std/veryl/src/fifo/fifo.veryl"),
-    include_str!("../../../benches/veryl/fifo_top.veryl"),
-);
+static FIFO_SRC: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "{}\n{}\n{}\n{}",
+        veryl_std::source(&["ram", "ram.veryl"]),
+        veryl_std::source(&["fifo", "fifo_controller.veryl"]),
+        veryl_std::source(&["fifo", "fifo.veryl"]),
+        include_str!("../../../benches/veryl/fifo_top.veryl"),
+    )
+});
 
 // std::gray_encoder + gray_decoder WIDTH=32 (combinational roundtrip)
-const GRAY_CODEC_SRC: &str = concat!(
-    include_str!("../../../deps/veryl/crates/std/veryl/src/gray/gray_encoder.veryl"),
-    include_str!("../../../deps/veryl/crates/std/veryl/src/gray/gray_decoder.veryl"),
-    include_str!("../../../benches/veryl/gray_codec_top.veryl"),
-);
+static GRAY_CODEC_SRC: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "{}\n{}\n{}",
+        veryl_std::source(&["gray", "gray_encoder.veryl"]),
+        veryl_std::source(&["gray", "gray_decoder.veryl"]),
+        include_str!("../../../benches/veryl/gray_codec_top.veryl"),
+    )
+});
 
 // std::edge_detector WIDTH=32
-const EDGE_DETECTOR_SRC: &str = concat!(
-    include_str!("../../../deps/veryl/crates/std/veryl/src/edge_detector/edge_detector.veryl"),
-    include_str!("../../../benches/veryl/edge_detector_top.veryl"),
-);
+static EDGE_DETECTOR_SRC: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "{}\n{}",
+        veryl_std::source(&["edge_detector", "edge_detector.veryl"]),
+        include_str!("../../../benches/veryl/edge_detector_top.veryl"),
+    )
+});
 
 // std::onehot W=64
-const ONEHOT_SRC: &str = concat!(
-    include_str!("../../../deps/veryl/crates/std/veryl/src/countones/onehot.veryl"),
-    include_str!("../../../benches/veryl/onehot_top.veryl"),
-);
+static ONEHOT_SRC: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "{}\n{}",
+        veryl_std::source(&["countones", "onehot.veryl"]),
+        include_str!("../../../benches/veryl/onehot_top.veryl"),
+    )
+});
 
 // std::lfsr_galois SIZE=32
-const LFSR_SRC: &str = concat!(
-    include_str!("../../../deps/veryl/crates/std/veryl/src/lfsr/lfsr_galois.veryl"),
-    include_str!("../../../benches/veryl/lfsr_top.veryl"),
-);
+static LFSR_SRC: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "{}\n{}",
+        veryl_std::source(&["lfsr", "lfsr_galois.veryl"]),
+        include_str!("../../../benches/veryl/lfsr_top.veryl"),
+    )
+});
 
 // std::gray_counter WIDTH=32
-const GRAY_COUNTER_SRC: &str = concat!(
-    include_str!("../../../deps/veryl/crates/std/veryl/src/counter/counter.veryl"),
-    include_str!("../../../deps/veryl/crates/std/veryl/src/gray/gray_encoder.veryl"),
-    include_str!("../../../deps/veryl/crates/std/veryl/src/gray/gray_counter.veryl"),
-    include_str!("../../../benches/veryl/gray_counter_top.veryl"),
-);
+static GRAY_COUNTER_SRC: LazyLock<String> = LazyLock::new(|| {
+    format!(
+        "{}\n{}\n{}\n{}",
+        veryl_std::source(&["counter", "counter.veryl"]),
+        veryl_std::source(&["gray", "gray_encoder.veryl"]),
+        veryl_std::source(&["gray", "gray_counter.veryl"]),
+        include_str!("../../../benches/veryl/gray_counter_top.veryl"),
+    )
+});
 
 fn benchmark_counter(c: &mut Criterion) {
     c.bench_function("simulation_build_top_n1000", |b| {
@@ -129,11 +163,11 @@ fn benchmark_counter(c: &mut Criterion) {
 fn benchmark_linear_sec(c: &mut Criterion) {
     c.bench_function("simulation_build_linear_sec_p6", |b| {
         b.iter(|| {
-            let _sim = Simulator::builder(LINEAR_SEC_SRC, "Top").build().unwrap();
+            let _sim = Simulator::builder(&LINEAR_SEC_SRC, "Top").build().unwrap();
         })
     });
 
-    let mut sim = Simulator::builder(LINEAR_SEC_SRC, "Top").build().unwrap();
+    let mut sim = Simulator::builder(&LINEAR_SEC_SRC, "Top").build().unwrap();
     let i_word = sim.signal("i_word");
     let o_word = sim.signal("o_word");
     let o_corrected = sim.signal("o_corrected");
@@ -172,7 +206,7 @@ fn benchmark_linear_sec(c: &mut Criterion) {
 }
 
 fn benchmark_linear_sec_isolation(c: &mut Criterion) {
-    let mut sim = Simulator::builder(LINEAR_SEC_SRC, "Top").build().unwrap();
+    let mut sim = Simulator::builder(&LINEAR_SEC_SRC, "Top").build().unwrap();
     let i_word = sim.signal("i_word");
     let o_word = sim.signal("o_word");
 
@@ -282,11 +316,11 @@ fn benchmark_linear_sec_isolation(c: &mut Criterion) {
 fn benchmark_countones(c: &mut Criterion) {
     c.bench_function("simulation_build_countones_w64", |b| {
         b.iter(|| {
-            let _sim = Simulator::builder(COUNTONES_SRC, "Top").build().unwrap();
+            let _sim = Simulator::builder(&COUNTONES_SRC, "Top").build().unwrap();
         })
     });
 
-    let mut sim = Simulator::builder(COUNTONES_SRC, "Top").build().unwrap();
+    let mut sim = Simulator::builder(&COUNTONES_SRC, "Top").build().unwrap();
     let i_data = sim.signal("i_data");
     let o_ones = sim.signal("o_ones");
 
@@ -314,14 +348,14 @@ fn benchmark_countones(c: &mut Criterion) {
 fn benchmark_countones_dse(c: &mut Criterion) {
     c.bench_function("dse_build_countones_w64", |b| {
         b.iter(|| {
-            let _sim = Simulator::builder(COUNTONES_SRC, "Top")
+            let _sim = Simulator::builder(&COUNTONES_SRC, "Top")
                 .dead_store_policy(DeadStorePolicy::PreserveTopPorts)
                 .build()
                 .unwrap();
         })
     });
 
-    let mut sim = Simulator::builder(COUNTONES_SRC, "Top")
+    let mut sim = Simulator::builder(&COUNTONES_SRC, "Top")
         .dead_store_policy(DeadStorePolicy::PreserveTopPorts)
         .build()
         .unwrap();
@@ -352,14 +386,14 @@ fn benchmark_countones_dse(c: &mut Criterion) {
 fn benchmark_linear_sec_dse(c: &mut Criterion) {
     c.bench_function("dse_build_linear_sec_p6", |b| {
         b.iter(|| {
-            let _sim = Simulator::builder(LINEAR_SEC_SRC, "Top")
+            let _sim = Simulator::builder(&LINEAR_SEC_SRC, "Top")
                 .dead_store_policy(DeadStorePolicy::PreserveTopPorts)
                 .build()
                 .unwrap();
         })
     });
 
-    let mut sim = Simulator::builder(LINEAR_SEC_SRC, "Top")
+    let mut sim = Simulator::builder(&LINEAR_SEC_SRC, "Top")
         .dead_store_policy(DeadStorePolicy::PreserveTopPorts)
         .build()
         .unwrap();
@@ -399,11 +433,11 @@ fn benchmark_linear_sec_dse(c: &mut Criterion) {
 fn benchmark_std_counter(c: &mut Criterion) {
     c.bench_function("simulation_build_std_counter_w32", |b| {
         b.iter(|| {
-            let _sim = Simulator::builder(STD_COUNTER_SRC, "Top").build().unwrap();
+            let _sim = Simulator::builder(&STD_COUNTER_SRC, "Top").build().unwrap();
         })
     });
 
-    let mut sim = Simulator::builder(STD_COUNTER_SRC, "Top").build().unwrap();
+    let mut sim = Simulator::builder(&STD_COUNTER_SRC, "Top").build().unwrap();
     let clk = sim.event("clk");
     let rst = sim.signal("rst");
     let i_up = sim.signal("i_up");
@@ -450,11 +484,15 @@ fn benchmark_std_counter(c: &mut Criterion) {
 fn benchmark_gray_counter(c: &mut Criterion) {
     c.bench_function("simulation_build_gray_counter_w32", |b| {
         b.iter(|| {
-            let _sim = Simulator::builder(GRAY_COUNTER_SRC, "Top").build().unwrap();
+            let _sim = Simulator::builder(&GRAY_COUNTER_SRC, "Top")
+                .build()
+                .unwrap();
         })
     });
 
-    let mut sim = Simulator::builder(GRAY_COUNTER_SRC, "Top").build().unwrap();
+    let mut sim = Simulator::builder(&GRAY_COUNTER_SRC, "Top")
+        .build()
+        .unwrap();
     let clk = sim.event("clk");
     let rst = sim.signal("rst");
     let i_up = sim.signal("i_up");
@@ -501,11 +539,11 @@ fn benchmark_gray_counter(c: &mut Criterion) {
 fn benchmark_fifo(c: &mut Criterion) {
     c.bench_function("simulation_build_fifo_w8_d16", |b| {
         b.iter(|| {
-            let _sim = Simulator::builder(FIFO_SRC, "Top").build().unwrap();
+            let _sim = Simulator::builder(&FIFO_SRC, "Top").build().unwrap();
         })
     });
 
-    let mut sim = Simulator::builder(FIFO_SRC, "Top").build().unwrap();
+    let mut sim = Simulator::builder(&FIFO_SRC, "Top").build().unwrap();
     let clk = sim.event("clk");
     let rst = sim.signal("rst");
     let i_push = sim.signal("i_push");
@@ -566,11 +604,11 @@ fn benchmark_fifo(c: &mut Criterion) {
 fn benchmark_gray_codec(c: &mut Criterion) {
     c.bench_function("simulation_build_gray_codec_w32", |b| {
         b.iter(|| {
-            let _sim = Simulator::builder(GRAY_CODEC_SRC, "Top").build().unwrap();
+            let _sim = Simulator::builder(&GRAY_CODEC_SRC, "Top").build().unwrap();
         })
     });
 
-    let mut sim = Simulator::builder(GRAY_CODEC_SRC, "Top").build().unwrap();
+    let mut sim = Simulator::builder(&GRAY_CODEC_SRC, "Top").build().unwrap();
     let i_bin = sim.signal("i_bin");
     let o_bin = sim.signal("o_bin");
 
@@ -598,13 +636,13 @@ fn benchmark_gray_codec(c: &mut Criterion) {
 fn benchmark_edge_detector(c: &mut Criterion) {
     c.bench_function("simulation_build_edge_detector_w32", |b| {
         b.iter(|| {
-            let _sim = Simulator::builder(EDGE_DETECTOR_SRC, "Top")
+            let _sim = Simulator::builder(&EDGE_DETECTOR_SRC, "Top")
                 .build()
                 .unwrap();
         })
     });
 
-    let mut sim = Simulator::builder(EDGE_DETECTOR_SRC, "Top")
+    let mut sim = Simulator::builder(&EDGE_DETECTOR_SRC, "Top")
         .build()
         .unwrap();
     let clk = sim.event("clk");
@@ -645,11 +683,11 @@ fn benchmark_edge_detector(c: &mut Criterion) {
 fn benchmark_onehot(c: &mut Criterion) {
     c.bench_function("simulation_build_onehot_w64", |b| {
         b.iter(|| {
-            let _sim = Simulator::builder(ONEHOT_SRC, "Top").build().unwrap();
+            let _sim = Simulator::builder(&ONEHOT_SRC, "Top").build().unwrap();
         })
     });
 
-    let mut sim = Simulator::builder(ONEHOT_SRC, "Top").build().unwrap();
+    let mut sim = Simulator::builder(&ONEHOT_SRC, "Top").build().unwrap();
     let i_data = sim.signal("i_data");
     let o_onehot = sim.signal("o_onehot");
 
@@ -677,7 +715,7 @@ fn benchmark_onehot(c: &mut Criterion) {
 fn benchmark_onehot_dse(c: &mut Criterion) {
     c.bench_function("dse_build_onehot_w64", |b| {
         b.iter(|| {
-            let _sim = Simulator::builder(ONEHOT_SRC, "Top")
+            let _sim = Simulator::builder(&ONEHOT_SRC, "Top")
                 .dead_store_policy(DeadStorePolicy::PreserveListedSignals)
                 .live_signal(vec![], vec!["o_onehot".to_string()])
                 .build()
@@ -685,7 +723,7 @@ fn benchmark_onehot_dse(c: &mut Criterion) {
         })
     });
 
-    let mut sim = Simulator::builder(ONEHOT_SRC, "Top")
+    let mut sim = Simulator::builder(&ONEHOT_SRC, "Top")
         .dead_store_policy(DeadStorePolicy::PreserveListedSignals)
         .live_signal(vec![], vec!["o_onehot".to_string()])
         .build()
@@ -717,11 +755,11 @@ fn benchmark_onehot_dse(c: &mut Criterion) {
 fn benchmark_lfsr(c: &mut Criterion) {
     c.bench_function("simulation_build_lfsr_w32", |b| {
         b.iter(|| {
-            let _sim = Simulator::builder(LFSR_SRC, "Top").build().unwrap();
+            let _sim = Simulator::builder(&LFSR_SRC, "Top").build().unwrap();
         })
     });
 
-    let mut sim = Simulator::builder(LFSR_SRC, "Top").build().unwrap();
+    let mut sim = Simulator::builder(&LFSR_SRC, "Top").build().unwrap();
     let clk = sim.event("clk");
     let rst = sim.signal("rst");
     let i_en = sim.signal("i_en");
@@ -817,14 +855,14 @@ fn benchmark_native_tb_counter(c: &mut Criterion) {
 fn benchmark_native_tb_std_counter(c: &mut Criterion) {
     c.bench_function("native_tb_run_std_counter_w32_x1000000", |b| {
         b.iter(|| {
-            let result = Simulator::builder(NATIVE_TB_STD_COUNTER, "bench_std_counter")
+            let result = Simulator::builder(&NATIVE_TB_STD_COUNTER, "bench_std_counter")
                 .run_test()
                 .unwrap();
             assert_eq!(result, TestResult::Pass);
         })
     });
 
-    let mut sim = Simulator::builder(NATIVE_TB_STD_COUNTER, "bench_std_counter")
+    let mut sim = Simulator::builder(&NATIVE_TB_STD_COUNTER, "bench_std_counter")
         .build()
         .unwrap();
     let tb = celox::testbench::compile_initial_testbench(&sim).unwrap();

--- a/crates/celox/examples/dump_linear_sec_ir.rs
+++ b/crates/celox/examples/dump_linear_sec_ir.rs
@@ -3,10 +3,15 @@
 
 use celox::Simulator;
 
-const LINEAR_SEC_SRC: &str = concat!(
-    include_str!("../../../deps/veryl/crates/std/veryl/src/coding/linear_sec_encoder.veryl"),
-    include_str!("../../../deps/veryl/crates/std/veryl/src/coding/linear_sec_decoder.veryl"),
-    r#"
+#[path = "../tests/fixtures/veryl_std.rs"]
+mod veryl_std;
+
+fn linear_sec_source() -> String {
+    format!(
+        "{}\n{}\n{}",
+        veryl_std::source(&["coding", "linear_sec_encoder.veryl"]),
+        veryl_std::source(&["coding", "linear_sec_decoder.veryl"]),
+        r#"
 module Top #(
     param P: u32 = 6,
     const K: u32 = (1 << P) - 1,
@@ -32,10 +37,11 @@ module Top #(
     );
 }
 "#
-);
+    )
+}
 
 fn main() {
-    let trace_result = Simulator::builder(LINEAR_SEC_SRC, "Top")
+    let trace_result = Simulator::builder(&linear_sec_source(), "Top")
         .trace_post_optimized_sir()
         .trace_pre_optimized_clif()
         .trace_post_optimized_clif()

--- a/crates/celox/examples/pass_benchmark.rs
+++ b/crates/celox/examples/pass_benchmark.rs
@@ -16,13 +16,19 @@ use celox::{
     SimulatorBuilder, SirPass,
 };
 
+#[path = "../tests/fixtures/veryl_std.rs"]
+mod veryl_std;
+
 const TOP_N1000: &str = include_str!("../../../benches/veryl/top_n1000.veryl");
 
-const LINEAR_SEC_SRC: &str = concat!(
-    include_str!("../../../deps/veryl/crates/std/veryl/src/coding/linear_sec_encoder.veryl"),
-    include_str!("../../../deps/veryl/crates/std/veryl/src/coding/linear_sec_decoder.veryl"),
-    include_str!("../../../benches/veryl/linear_sec_top.veryl"),
-);
+fn linear_sec_source() -> String {
+    format!(
+        "{}\n{}\n{}",
+        veryl_std::source(&["coding", "linear_sec_encoder.veryl"]),
+        veryl_std::source(&["coding", "linear_sec_decoder.veryl"]),
+        include_str!("../../../benches/veryl/linear_sec_top.veryl"),
+    )
+}
 
 const WARMUP_ITERS: u32 = 2;
 const BENCH_ITERS: u32 = 5;
@@ -187,6 +193,7 @@ fn main() {
         ("reschedule", SirPass::Reschedule),
     ];
 
+    let linear_sec_src = linear_sec_source();
     for (design_name, code, top, sim_label, sim_count, is_seq) in [
         (
             "top_n1000 (sequential)",
@@ -198,7 +205,7 @@ fn main() {
         ),
         (
             "linear_sec_p6 (combinational)",
-            LINEAR_SEC_SRC,
+            &linear_sec_src,
             "Top",
             "eval",
             EVAL_COUNT,
@@ -290,6 +297,7 @@ fn main() {
         ),
     ];
 
+    let linear_sec_src = linear_sec_source();
     for (design_name, code, top, sim_label, sim_count, is_seq) in [
         (
             "top_n1000 (sequential)",
@@ -301,7 +309,7 @@ fn main() {
         ),
         (
             "linear_sec_p6 (combinational)",
-            LINEAR_SEC_SRC,
+            &linear_sec_src,
             "Top",
             "eval",
             EVAL_COUNT,
@@ -372,6 +380,7 @@ fn main() {
         ("fast_compile()", |c| *c = CraneliftOptions::fast_compile()),
     ];
 
+    let linear_sec_src = linear_sec_source();
     for (design_name, code, top, sim_label, sim_count, is_seq) in [
         (
             "top_n1000 (sequential)",
@@ -383,7 +392,7 @@ fn main() {
         ),
         (
             "linear_sec_p6 (combinational)",
-            LINEAR_SEC_SRC,
+            &linear_sec_src,
             "Top",
             "eval",
             EVAL_COUNT,
@@ -475,7 +484,7 @@ fn main() {
         ),
         (
             "linear_sec_p6 (combinational)",
-            LINEAR_SEC_SRC,
+            &linear_sec_src,
             "Top",
             "eval",
             EVAL_COUNT,

--- a/crates/celox/tests/fifo_issue5.rs
+++ b/crates/celox/tests/fifo_issue5.rs
@@ -7,10 +7,10 @@ mod test_utils;
 all_backends! {
 
     fn test_fifo_issue5_subtract_overflow(sim) {
-        @setup { let ram = include_str!("../../../deps/veryl/crates/std/veryl/src/ram/ram.veryl");
+        @setup { let ram = test_utils::veryl_std::source(&["ram", "ram.veryl"]);
 let fifo_ctrl =
-include_str!("../../../deps/veryl/crates/std/veryl/src/fifo/fifo_controller.veryl");
-let fifo = include_str!("../../../deps/veryl/crates/std/veryl/src/fifo/fifo.veryl");
+test_utils::veryl_std::source(&["fifo", "fifo_controller.veryl"]);
+let fifo = test_utils::veryl_std::source(&["fifo", "fifo.veryl"]);
 let top = r#"
 module Top (
 i_clk: input clock,

--- a/crates/celox/tests/fixtures/veryl_std.rs
+++ b/crates/celox/tests/fixtures/veryl_std.rs
@@ -1,0 +1,13 @@
+use std::path::{Path, PathBuf};
+
+pub fn source(parts: &[&str]) -> String {
+    veryl_std::expand().expect("failed to expand veryl-std sources");
+    let rel = parts.iter().collect::<PathBuf>();
+    let paths = veryl_std::paths(Path::new("")).expect("failed to resolve veryl-std sources");
+    let src = paths
+        .iter()
+        .find(|path| path.src.ends_with(&rel))
+        .unwrap_or_else(|| panic!("veryl-std source not found: {}", rel.display()));
+    std::fs::read_to_string(&src.src)
+        .unwrap_or_else(|err| panic!("failed to read {}: {}", src.src.display(), err))
+}

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -130,8 +130,8 @@ fn test_ff_runtime_for_break(sim) {
 #[ignore]
 fn test_ff_constant_signed_bounds_in_unrolled_loops(sim) {
     // Constant signed reverse bounds are currently broken in the upstream
-    // Veryl analyzer unroller, so this regression is parked until deps/veryl
-    // is fixed.
+    // Veryl analyzer unroller, so this regression is parked until upstream
+    // Veryl is fixed.
     @setup { let code = r#"
         module Top (
             clk: input clock,

--- a/crates/celox/tests/linear_sec.rs
+++ b/crates/celox/tests/linear_sec.rs
@@ -2,18 +2,28 @@
 
 use celox::{DeadStorePolicy, Simulator};
 
-const LINEAR_SEC_SRC: &str = concat!(
-    include_str!("../../../deps/veryl/crates/std/veryl/src/coding/linear_sec_encoder.veryl"),
-    include_str!("../../../deps/veryl/crates/std/veryl/src/coding/linear_sec_decoder.veryl"),
-    include_str!("../../../benches/veryl/linear_sec_top.veryl"),
-);
+#[path = "test_utils/mod.rs"]
+#[macro_use]
+#[allow(unused_macros)]
+mod test_utils;
+
+fn linear_sec_source() -> String {
+    format!(
+        "{}\n{}\n{}",
+        test_utils::veryl_std::source(&["coding", "linear_sec_encoder.veryl"]),
+        test_utils::veryl_std::source(&["coding", "linear_sec_decoder.veryl"]),
+        include_str!("../../../benches/veryl/linear_sec_top.veryl"),
+    )
+}
 
 fn build_sim() -> Simulator {
-    Simulator::builder(LINEAR_SEC_SRC, "Top").build().unwrap()
+    Simulator::builder(&linear_sec_source(), "Top")
+        .build()
+        .unwrap()
 }
 
 fn build_sim_dse() -> Simulator {
-    Simulator::builder(LINEAR_SEC_SRC, "Top")
+    Simulator::builder(&linear_sec_source(), "Top")
         .dead_store_policy(DeadStorePolicy::PreserveTopPorts)
         .build()
         .unwrap()

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -1,5 +1,10 @@
 use celox::{ResetType, Simulator, TestResult};
 
+#[path = "test_utils/mod.rs"]
+#[macro_use]
+#[allow(unused_macros)]
+mod test_utils;
+
 const COUNTER: &str = r#"
     module Counter (
         clk: input  clock    ,
@@ -21,11 +26,14 @@ const BENCH_NATIVE_TB_COUNTER_N1000: &str = concat!(
     include_str!("../../../benches/veryl/native_tb_counter_n1000.veryl"),
 );
 
-const BENCH_NATIVE_TB_STD_COUNTER: &str = concat!(
-    include_str!("../../../deps/veryl/crates/std/veryl/src/counter/counter.veryl"),
-    include_str!("../../../benches/veryl/std_counter_top.veryl"),
-    include_str!("../../../benches/veryl/native_tb_std_counter.veryl"),
-);
+fn bench_native_tb_std_counter() -> String {
+    format!(
+        "{}\n{}\n{}",
+        test_utils::veryl_std::source(&["counter", "counter.veryl"]),
+        include_str!("../../../benches/veryl/std_counter_top.veryl"),
+        include_str!("../../../benches/veryl/native_tb_std_counter.veryl"),
+    )
+}
 
 // ── Basic ──────────────────────────────────────────────────────────────
 
@@ -1096,7 +1104,7 @@ fn test_benchmark_native_testbench_fixtures_build() {
     Simulator::builder(BENCH_NATIVE_TB_COUNTER_N1000, "Top")
         .build()
         .unwrap();
-    Simulator::builder(BENCH_NATIVE_TB_STD_COUNTER, "Top")
+    Simulator::builder(&bench_native_tb_std_counter(), "Top")
         .build()
         .unwrap();
 }

--- a/crates/celox/tests/optimizer_scaling.rs
+++ b/crates/celox/tests/optimizer_scaling.rs
@@ -22,10 +22,8 @@ use std::time::Instant;
 // ---------------------------------------------------------------------------
 
 fn linear_sec_source(p: u32) -> String {
-    let encoder =
-        include_str!("../../../deps/veryl/crates/std/veryl/src/coding/linear_sec_encoder.veryl");
-    let decoder =
-        include_str!("../../../deps/veryl/crates/std/veryl/src/coding/linear_sec_decoder.veryl");
+    let encoder = test_utils::veryl_std::source(&["coding", "linear_sec_encoder.veryl"]);
+    let decoder = test_utils::veryl_std::source(&["coding", "linear_sec_decoder.veryl"]);
     let top = format!(
         r#"
 module Top #(

--- a/crates/celox/tests/std_binary_codec.rs
+++ b/crates/celox/tests/std_binary_codec.rs
@@ -4,11 +4,6 @@ use celox::Simulator;
 #[macro_use]
 mod test_utils;
 
-const BINARY_ENCODER_SRC: &str =
-    include_str!("../../../deps/veryl/crates/std/veryl/src/binary_enc_dec/binary_encoder.veryl");
-const BINARY_DECODER_SRC: &str =
-    include_str!("../../../deps/veryl/crates/std/veryl/src/binary_enc_dec/binary_decoder.veryl");
-
 all_backends! {
 
     // Binary encoder: onehot input -> binary output (UNARY_WIDTH=8, BIN_WIDTH=3)
@@ -25,7 +20,7 @@ o_bin,
 );
 }
 "#;
-let code = format!("{BINARY_ENCODER_SRC}\n{top}"); }
+let code = format!("{}\n{top}", test_utils::veryl_std::source(&["binary_enc_dec", "binary_encoder.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let i_unary = sim.signal("i_unary");
     let o_bin = sim.signal("o_bin");
@@ -57,7 +52,7 @@ o_unary,
 );
 }
 "#;
-let code = format!("{BINARY_DECODER_SRC}\n{top}"); }
+let code = format!("{}\n{top}", test_utils::veryl_std::source(&["binary_enc_dec", "binary_decoder.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let i_bin = sim.signal("i_bin");
     let o_unary = sim.signal("o_unary");
@@ -95,7 +90,11 @@ o_unary,
 );
 }
 "#;
-let code = format!("{BINARY_ENCODER_SRC}\n{BINARY_DECODER_SRC}\n{top}"); }
+let code = format!(
+    "{}\n{}\n{top}",
+    test_utils::veryl_std::source(&["binary_enc_dec", "binary_encoder.veryl"]),
+    test_utils::veryl_std::source(&["binary_enc_dec", "binary_decoder.veryl"]),
+); }
         @build Simulator::builder(&code, "Top");
     let i_unary = sim.signal("i_unary");
     let o_unary = sim.signal("o_unary");
@@ -128,7 +127,7 @@ o_bin,
 );
 }
 "#;
-let code = format!("{BINARY_ENCODER_SRC}\n{top}"); }
+let code = format!("{}\n{top}", test_utils::veryl_std::source(&["binary_enc_dec", "binary_encoder.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let i_en = sim.signal("i_en");
     let i_unary = sim.signal("i_unary");

--- a/crates/celox/tests/std_delay.rs
+++ b/crates/celox/tests/std_delay.rs
@@ -4,8 +4,6 @@ use celox::Simulator;
 #[macro_use]
 mod test_utils;
 
-const DELAY_SRC: &str = include_str!("../../../deps/veryl/crates/std/veryl/src/delay/delay.veryl");
-
 all_backends! {
 
     // DELAY=0: passthrough (no delay)
@@ -25,7 +23,7 @@ o_d,
 );
 }
 "#;
-let code = format!("{DELAY_SRC}\n{top}"); }
+let code = format!("{}\n{top}", test_utils::veryl_std::source(&["delay", "delay.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let i_d = sim.signal("i_d");
     let o_d = sim.signal("o_d");
@@ -56,7 +54,7 @@ o_d,
 );
 }
 "#;
-let code = format!("{DELAY_SRC}\n{top}"); }
+let code = format!("{}\n{top}", test_utils::veryl_std::source(&["delay", "delay.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let clk = sim.event("clk");
     let rst = sim.signal("rst");
@@ -104,7 +102,7 @@ o_d,
 );
 }
 "#;
-let code = format!("{DELAY_SRC}\n{top}"); }
+let code = format!("{}\n{top}", test_utils::veryl_std::source(&["delay", "delay.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let clk = sim.event("clk");
     let rst = sim.signal("rst");

--- a/crates/celox/tests/std_edge_detector.rs
+++ b/crates/celox/tests/std_edge_detector.rs
@@ -4,9 +4,6 @@ use celox::Simulator;
 #[macro_use]
 mod test_utils;
 
-const EDGE_DETECTOR_SRC: &str =
-    include_str!("../../../deps/veryl/crates/std/veryl/src/edge_detector/edge_detector.veryl");
-
 const TOP_W1: &str = r#"
 module Top (
     clk      : input  clock,
@@ -38,7 +35,7 @@ all_backends! {
     // Flow: set i_data -> tick (FF captures i_data into `data`) -> change i_data
     //       -> eval_comb -> read outputs (edge between old data and new i_data)
     fn test_edge_detector_basic(sim) {
-        @setup { let code = format!("{EDGE_DETECTOR_SRC}\n{TOP_W1}"); }
+        @setup { let code = format!("{}\n{TOP_W1}", test_utils::veryl_std::source(&["edge_detector", "edge_detector.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let clk = sim.event("clk");
     let rst = sim.signal("rst");
@@ -98,7 +95,7 @@ all_backends! {
     //   o_posedge = i_data & ~data & ~i_clear     -- AND, fully masked by clear
     //   o_negedge = ~i_data & data & ~i_clear     -- AND, fully masked by clear
     fn test_edge_detector_clear(sim) {
-        @setup { let code = format!("{EDGE_DETECTOR_SRC}\n{TOP_W1}"); }
+        @setup { let code = format!("{}\n{TOP_W1}", test_utils::veryl_std::source(&["edge_detector", "edge_detector.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let clk = sim.event("clk");
     let rst = sim.signal("rst");
@@ -166,7 +163,7 @@ o_negedge,
 );
 }
 "#;
-let code = format!("{EDGE_DETECTOR_SRC}\n{top}"); }
+let code = format!("{}\n{top}", test_utils::veryl_std::source(&["edge_detector", "edge_detector.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let clk = sim.event("clk");
     let rst = sim.signal("rst");

--- a/crates/celox/tests/std_fifo.rs
+++ b/crates/celox/tests/std_fifo.rs
@@ -5,11 +5,6 @@ use celox::{SimBackend, Simulator};
 #[allow(unused_macros)]
 mod test_utils;
 
-const RAM_SRC: &str = include_str!("../../../deps/veryl/crates/std/veryl/src/ram/ram.veryl");
-const FIFO_CTRL_SRC: &str =
-    include_str!("../../../deps/veryl/crates/std/veryl/src/fifo/fifo_controller.veryl");
-const FIFO_SRC: &str = include_str!("../../../deps/veryl/crates/std/veryl/src/fifo/fifo.veryl");
-
 const TOP: &str = r#"
 module Top (
     clk        : input  clock,
@@ -43,6 +38,15 @@ module Top (
 }
 "#;
 
+fn fifo_source() -> String {
+    format!(
+        "{}\n{}\n{}\n{TOP}",
+        test_utils::veryl_std::source(&["ram", "ram.veryl"]),
+        test_utils::veryl_std::source(&["fifo", "fifo_controller.veryl"]),
+        test_utils::veryl_std::source(&["fifo", "fifo.veryl"]),
+    )
+}
+
 fn reset<B: SimBackend>(sim: &mut Simulator<B>) {
     let clk = sim.event("clk");
     let rst = sim.signal("rst");
@@ -67,7 +71,7 @@ all_backends! {
 // After reset, FIFO should be empty
 fn test_fifo_initial_empty(sim) {
     @omit_veryl;
-    @setup { let code = format!("{RAM_SRC}\n{FIFO_CTRL_SRC}\n{FIFO_SRC}\n{TOP}"); }
+    @setup { let code = fifo_source(); }
     @build Simulator::builder(&code, "Top");
     reset(&mut sim);
 
@@ -87,7 +91,7 @@ fn test_fifo_initial_empty(sim) {
 // Push one item, verify not empty, pop it back
 fn test_fifo_push_pop_single(sim) {
     @omit_veryl;
-    @setup { let code = format!("{RAM_SRC}\n{FIFO_CTRL_SRC}\n{FIFO_SRC}\n{TOP}"); }
+    @setup { let code = fifo_source(); }
     @build Simulator::builder(&code, "Top");
     reset(&mut sim);
 
@@ -132,7 +136,7 @@ fn test_fifo_push_pop_single(sim) {
 // Push until full (DEPTH=4), verify full flag
 fn test_fifo_full(sim) {
     @omit_veryl;
-    @setup { let code = format!("{RAM_SRC}\n{FIFO_CTRL_SRC}\n{FIFO_SRC}\n{TOP}"); }
+    @setup { let code = fifo_source(); }
     @build Simulator::builder(&code, "Top");
     reset(&mut sim);
 
@@ -161,7 +165,7 @@ fn test_fifo_full(sim) {
 // Push 4 items then pop all, verify FIFO ordering
 fn test_fifo_ordering(sim) {
     @omit_veryl;
-    @setup { let code = format!("{RAM_SRC}\n{FIFO_CTRL_SRC}\n{FIFO_SRC}\n{TOP}"); }
+    @setup { let code = fifo_source(); }
     @build Simulator::builder(&code, "Top");
     reset(&mut sim);
 
@@ -200,7 +204,7 @@ fn test_fifo_ordering(sim) {
 // Clear resets the FIFO to empty
 fn test_fifo_clear(sim) {
     @omit_veryl;
-    @setup { let code = format!("{RAM_SRC}\n{FIFO_CTRL_SRC}\n{FIFO_SRC}\n{TOP}"); }
+    @setup { let code = fifo_source(); }
     @build Simulator::builder(&code, "Top");
     reset(&mut sim);
 

--- a/crates/celox/tests/std_gray_codec.rs
+++ b/crates/celox/tests/std_gray_codec.rs
@@ -4,11 +4,6 @@ use celox::Simulator;
 #[macro_use]
 mod test_utils;
 
-const GRAY_ENCODER_SRC: &str =
-    include_str!("../../../deps/veryl/crates/std/veryl/src/gray/gray_encoder.veryl");
-const GRAY_DECODER_SRC: &str =
-    include_str!("../../../deps/veryl/crates/std/veryl/src/gray/gray_decoder.veryl");
-
 all_backends! {
 
     // Gray encode → decode roundtrip: o_bin == i_bin for all 8-bit values
@@ -29,7 +24,11 @@ o_bin,
 );
 }
 "#;
-let code = format!("{GRAY_ENCODER_SRC}\n{GRAY_DECODER_SRC}\n{top}"); }
+let code = format!(
+    "{}\n{}\n{top}",
+    test_utils::veryl_std::source(&["gray", "gray_encoder.veryl"]),
+    test_utils::veryl_std::source(&["gray", "gray_decoder.veryl"]),
+); }
         @build Simulator::builder(&code, "Top");
     let i_bin = sim.signal("i_bin");
     let o_gray = sim.signal("o_gray");
@@ -62,7 +61,7 @@ o_gray,
 );
 }
 "#;
-let code = format!("{GRAY_ENCODER_SRC}\n{top}"); }
+let code = format!("{}\n{top}", test_utils::veryl_std::source(&["gray", "gray_encoder.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let i_bin = sim.signal("i_bin");
     let o_gray = sim.signal("o_gray");

--- a/crates/celox/tests/std_lfsr.rs
+++ b/crates/celox/tests/std_lfsr.rs
@@ -5,9 +5,6 @@ use std::collections::HashSet;
 #[macro_use]
 mod test_utils;
 
-const LFSR_SRC: &str =
-    include_str!("../../../deps/veryl/crates/std/veryl/src/lfsr/lfsr_galois.veryl");
-
 /// LFSR Galois has no reset port -- uses i_set for initialization.
 /// The Top module wraps it with a clock but no reset connection.
 const TOP: &str = r#"
@@ -39,7 +36,7 @@ all_backends! {
     // cycle length incorrect (9 instead of 255 for SIZE=8). These tests verify
     // the simulation mechanics (seed, shift, hold) but not LFSR correctness.
     fn test_lfsr_basic_shift(sim) {
-        @setup { let code = format!("{LFSR_SRC}\n{TOP}"); }
+        @setup { let code = format!("{}\n{TOP}", test_utils::veryl_std::source(&["lfsr", "lfsr_galois.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let clk = sim.event("clk");
     let rst = sim.signal("rst");
@@ -91,7 +88,7 @@ all_backends! {
 
     // Cycle detection: LFSR should produce a deterministic repeating cycle
     fn test_lfsr_deterministic_cycle(sim) {
-        @setup { let code = format!("{LFSR_SRC}\n{TOP}"); }
+        @setup { let code = format!("{}\n{TOP}", test_utils::veryl_std::source(&["lfsr", "lfsr_galois.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let clk = sim.event("clk");
     let rst = sim.signal("rst");
@@ -169,7 +166,7 @@ all_backends! {
 
     // LFSR disabled (i_en=0) should hold its value
     fn test_lfsr_enable_hold(sim) {
-        @setup { let code = format!("{LFSR_SRC}\n{TOP}"); }
+        @setup { let code = format!("{}\n{TOP}", test_utils::veryl_std::source(&["lfsr", "lfsr_galois.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let clk = sim.event("clk");
     let rst = sim.signal("rst");

--- a/crates/celox/tests/std_mux.rs
+++ b/crates/celox/tests/std_mux.rs
@@ -4,12 +4,6 @@ use celox::Simulator;
 #[macro_use]
 mod test_utils;
 
-const SELECTOR_PKG_SRC: &str =
-    include_str!("../../../deps/veryl/crates/std/veryl/src/selector/selector_pkg.veryl");
-const MUX_SRC: &str = include_str!("../../../deps/veryl/crates/std/veryl/src/selector/mux.veryl");
-const DEMUX_SRC: &str =
-    include_str!("../../../deps/veryl/crates/std/veryl/src/selector/demux.veryl");
-
 all_backends! {
 
     // Build-only smoke test: mux with selector_pkg requires `calc_select_width`
@@ -43,7 +37,11 @@ o_data,
 );
 }
 "#;
-let code = format!("{SELECTOR_PKG_SRC}\n{MUX_SRC}\n{top}"); }
+let code = format!(
+    "{}\n{}\n{top}",
+    test_utils::veryl_std::source(&["selector", "selector_pkg.veryl"]),
+    test_utils::veryl_std::source(&["selector", "mux.veryl"]),
+); }
         @build Simulator::builder(&code, "Top");
 
     }
@@ -79,7 +77,11 @@ o_data3 = data_arr[3];
 }
 }
 "#;
-let code = format!("{SELECTOR_PKG_SRC}\n{DEMUX_SRC}\n{top}"); }
+let code = format!(
+    "{}\n{}\n{top}",
+    test_utils::veryl_std::source(&["selector", "selector_pkg.veryl"]),
+    test_utils::veryl_std::source(&["selector", "demux.veryl"]),
+); }
         @build Simulator::builder(&code, "Top");
 
     }

--- a/crates/celox/tests/std_onehot.rs
+++ b/crates/celox/tests/std_onehot.rs
@@ -4,9 +4,6 @@ use celox::Simulator;
 #[macro_use]
 mod test_utils;
 
-const ONEHOT_SRC: &str =
-    include_str!("../../../deps/veryl/crates/std/veryl/src/countones/onehot.veryl");
-
 all_backends! {
 
     // Exhaustive 8-bit onehot detection
@@ -24,7 +21,7 @@ o_zero,
 );
 }
 "#;
-let code = format!("{ONEHOT_SRC}\n{top}"); }
+let code = format!("{}\n{top}", test_utils::veryl_std::source(&["countones", "onehot.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let i_data = sim.signal("i_data");
     let o_onehot = sim.signal("o_onehot");

--- a/crates/celox/tests/std_ram.rs
+++ b/crates/celox/tests/std_ram.rs
@@ -4,8 +4,6 @@ use celox::Simulator;
 #[macro_use]
 mod test_utils;
 
-const RAM_SRC: &str = include_str!("../../../deps/veryl/crates/std/veryl/src/ram/ram.veryl");
-
 all_backends! {
 
     // Dual-port RAM: write via port A, read via port B (BUFFER_OUT=false, combinational read)
@@ -40,7 +38,7 @@ o_qb,
 );
 }
 "#;
-let code = format!("{RAM_SRC}\n{top}"); }
+let code = format!("{}\n{top}", test_utils::veryl_std::source(&["ram", "ram.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let clk = sim.event("clk");
     let rst = sim.signal("rst");
@@ -137,7 +135,7 @@ o_qb,
 );
 }
 "#;
-let code = format!("{RAM_SRC}\n{top}"); }
+let code = format!("{}\n{top}", test_utils::veryl_std::source(&["ram", "ram.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let clk = sim.event("clk");
     let rst = sim.signal("rst");
@@ -217,7 +215,7 @@ o_qb,
 );
 }
 "#;
-let code = format!("{RAM_SRC}\n{top}"); }
+let code = format!("{}\n{top}", test_utils::veryl_std::source(&["ram", "ram.veryl"])); }
         @build Simulator::builder(&code, "Top");
     let clk = sim.event("clk");
     let rst = sim.signal("rst");

--- a/crates/celox/tests/synth_dynamic_loop.rs
+++ b/crates/celox/tests/synth_dynamic_loop.rs
@@ -81,8 +81,8 @@ fn test_constant_break_in_synth_comb_loop(sim) {
 #[ignore]
 fn test_constant_signed_bounds_in_unrolled_synth_loops(sim) {
     // Constant signed reverse bounds are currently broken in the upstream
-    // Veryl analyzer unroller, so this regression is parked until deps/veryl
-    // is fixed.
+    // Veryl analyzer unroller, so this regression is parked until upstream
+    // Veryl is fixed.
     @setup { let code = r#"
         module Top (
             sum_fwd: output logic<32>,

--- a/crates/celox/tests/test_utils/mod.rs
+++ b/crates/celox/tests/test_utils/mod.rs
@@ -1,5 +1,9 @@
 pub mod veryl_sim;
 
+#[path = "../fixtures/veryl_std.rs"]
+#[allow(dead_code)]
+pub mod veryl_std;
+
 /// Generates four `#[test]` functions (native, cranelift, wasm, veryl) per test.
 ///
 /// ```rust

--- a/docs/internals/triage.md
+++ b/docs/internals/triage.md
@@ -100,7 +100,6 @@ This snapshot reflects the open GitHub queue inspected on April 27, 2026.
 - Issue [#42](https://github.com/celox-sim/celox/issues/42): const function evaluation in module params
   The current `std_mux` / `std_demux` smoke tests pass on Celox backends, so this issue likely
   needs closure or scope correction rather than new implementation work.
-- Issue [#72](https://github.com/celox-sim/celox/issues/72): remove `deps/veryl` submodule once `veryl` `0.20.0` is available
 - Issue [#36](https://github.com/celox-sim/celox/issues/36): dependency dashboard
 - Issue [#16](https://github.com/celox-sim/celox/issues/16): instance-contiguous `MemoryLayout`
 - Issue [#30](https://github.com/celox-sim/celox/issues/30): native testbench DSE

--- a/packages/celox/src/e2e.bench.ts
+++ b/packages/celox/src/e2e.bench.ts
@@ -9,7 +9,8 @@
  *   4. Simulator::tick vs Simulation::step overhead
  */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, bench, describe } from "vitest";
@@ -25,10 +26,17 @@ import type { ModuleDefinition } from "./types.js";
 const addon = loadNativeAddon();
 
 const __benchDir = dirname(fileURLToPath(import.meta.url));
-const VERYL_STD = resolve(
-	__benchDir,
-	"../../../deps/veryl/crates/std/veryl/src",
-);
+function resolveVerylStd(): string {
+	const cargoHome = process.env.CARGO_HOME ?? resolve(homedir(), ".cargo");
+	const registrySrc = resolve(cargoHome, "registry/src");
+	for (const registry of readdirSync(registrySrc)) {
+		const source = resolve(registrySrc, registry, "veryl-std-0.20.0/veryl/src");
+		if (existsSync(source)) return source;
+	}
+	throw new Error("veryl-std 0.20.0 source not found; run cargo fetch first");
+}
+
+const VERYL_STD = resolveVerylStd();
 function readVeryl(...parts: string[]): string {
 	return readFileSync(resolve(VERYL_STD, ...parts), "utf8");
 }


### PR DESCRIPTION
## Summary

- Switch Veryl workspace dependencies from the `deps/veryl` submodule to released `veryl-*` crates at `0.20.0`.
- Remove the `deps/veryl` submodule and its `.gitmodules` entry.
- Read stdlib benchmark/test sources through the released `veryl-std` crate instead of vendoring `.veryl` fixtures in this repo.

## Why

Veryl 0.20.0 is now available, so Celox no longer needs to carry the temporary forked submodule used to unblock upstream analyzer/IR work.

## Validation

- `cargo check --workspace`
- `cargo test --workspace`
- `pnpm exec biome check packages/celox/src/e2e.bench.ts`
- pre-push hook: submodule check, cargo fmt, biome, cargo clippy, full `pnpm test` flow