### PR TITLE
[codex] Support FF runtime system tasks

### DIFF
--- a/crates/celox/src/backend.rs
+++ b/crates/celox/src/backend.rs
@@ -5,6 +5,8 @@ pub(crate) mod memory_layout;
 pub(crate) mod native;
 #[cfg(not(target_arch = "wasm32"))]
 mod runtime;
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) mod runtime_event_buffer;
 pub mod traits;
 #[cfg(not(target_arch = "wasm32"))]
 mod translator;
@@ -22,6 +24,8 @@ pub use memory_layout::{MemoryLayout, get_byte_size};
 pub use runtime::SharedJitCode;
 #[cfg(not(target_arch = "wasm32"))]
 pub use runtime::{EventRef, JitBackend};
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) use runtime_event_buffer::RuntimeEventBuffer;
 #[cfg(target_arch = "wasm32")]
 pub use traits::EventHandle;
 pub use traits::SimulatorErrorCode;

--- a/crates/celox/src/backend.rs
+++ b/crates/celox/src/backend.rs
@@ -1,6 +1,6 @@
 #[cfg(not(target_arch = "wasm32"))]
 mod jit_engine;
-mod memory_layout;
+pub(crate) mod memory_layout;
 #[cfg(target_arch = "x86_64")]
 pub(crate) mod native;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -3,6 +3,8 @@ use crate::HashMap;
 
 pub const RUNTIME_EVENT_CAPACITY: usize = 1024;
 pub const RUNTIME_EVENT_WRITING: u64 = u64::MAX;
+pub const STATE_HEADER_SIZE: usize = 8;
+pub const STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET: usize = 0;
 pub const RUNTIME_EVENT_HEADER_SIZE: usize = 8;
 pub const RUNTIME_EVENT_SLOT_SEQ_OFFSET: usize = 0;
 pub const RUNTIME_EVENT_SLOT_SITE_OFFSET: usize = 8;
@@ -48,11 +50,11 @@ pub struct MemoryLayout {
     pub scratch_base_offset: usize,
     pub scratch_size: usize,
 
-    /// Single-producer runtime event ring. The layout is intentionally
-    /// producer-ring shaped so it can grow to multiple producers later.
-    pub runtime_event_base_offset: usize,
+    /// Runtime event ring geometry. The ring storage itself is backend-owned;
+    /// generated code finds it through the state header.
     pub runtime_event_capacity: usize,
     pub runtime_event_slot_size: usize,
+    pub runtime_event_buffer_size: usize,
     pub runtime_event_site_layouts: Vec<RuntimeEventSiteLayout>,
 }
 
@@ -89,7 +91,7 @@ impl MemoryLayout {
                 .unwrap_or(0)
                 * 8;
 
-        let mut current_offset = 0;
+        let mut current_offset = STATE_HEADER_SIZE;
 
         // 3. Execute packing
         for (addr, width, is_4state) in stable_vars_to_layout {
@@ -145,10 +147,9 @@ impl MemoryLayout {
         let triggered_bits_total_size = num_potential_triggers.div_ceil(8);
 
         let scratch_base_offset = (triggered_bits_offset + triggered_bits_total_size + 7) & !7;
-        let runtime_event_base_offset = (scratch_base_offset + scratch_bytes + 7) & !7;
-        let runtime_event_bytes =
+        let runtime_event_buffer_size =
             RUNTIME_EVENT_HEADER_SIZE + RUNTIME_EVENT_CAPACITY * runtime_event_slot_size;
-        let merged_total_size = (runtime_event_base_offset + runtime_event_bytes + 7) & !7;
+        let merged_total_size = (scratch_base_offset + scratch_bytes + 7) & !7;
 
         // Apply address aliases: aliased variables share the canonical's offset.
         // Only alias when:
@@ -190,9 +191,9 @@ impl MemoryLayout {
             triggered_bits_total_size,
             scratch_base_offset,
             scratch_size: scratch_bytes,
-            runtime_event_base_offset,
             runtime_event_capacity: RUNTIME_EVENT_CAPACITY,
             runtime_event_slot_size,
+            runtime_event_buffer_size,
             runtime_event_site_layouts,
         }
     }

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -1,17 +1,26 @@
-use crate::HashMap;
 use crate::ir::{AbsoluteAddr, Program, SIRInstruction};
+use crate::HashMap;
 
 pub const RUNTIME_EVENT_CAPACITY: usize = 1024;
-pub const RUNTIME_EVENT_MAX_ARGS: usize = 4;
 pub const RUNTIME_EVENT_WRITING: u64 = u64::MAX;
 pub const RUNTIME_EVENT_HEADER_SIZE: usize = 8;
-pub const RUNTIME_EVENT_SLOT_SIZE: usize = 8 * (3 + RUNTIME_EVENT_MAX_ARGS * 2);
 pub const RUNTIME_EVENT_SLOT_SEQ_OFFSET: usize = 0;
 pub const RUNTIME_EVENT_SLOT_SITE_OFFSET: usize = 8;
 pub const RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET: usize = 16;
-pub const RUNTIME_EVENT_SLOT_ARGS_OFFSET: usize = 24;
-pub const RUNTIME_EVENT_SLOT_MASKS_OFFSET: usize =
-    RUNTIME_EVENT_SLOT_ARGS_OFFSET + RUNTIME_EVENT_MAX_ARGS * 8;
+pub const RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET: usize = 24;
+
+#[derive(Debug, Clone)]
+pub struct RuntimeEventArgLayout {
+    pub value_word_offset: usize,
+    pub mask_word_offset: usize,
+    pub word_count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeEventSiteLayout {
+    pub args: Vec<RuntimeEventArgLayout>,
+    pub payload_words: usize,
+}
 
 #[derive(Debug, Clone)]
 pub struct MemoryLayout {
@@ -44,6 +53,7 @@ pub struct MemoryLayout {
     pub runtime_event_base_offset: usize,
     pub runtime_event_capacity: usize,
     pub runtime_event_slot_size: usize,
+    pub runtime_event_site_layouts: Vec<RuntimeEventSiteLayout>,
 }
 
 impl MemoryLayout {
@@ -70,6 +80,15 @@ impl MemoryLayout {
         let mut offsets = HashMap::default();
         let mut widths = HashMap::default();
         let mut is_4states = HashMap::default();
+        let runtime_event_site_layouts = build_runtime_event_site_layouts(program);
+        let runtime_event_slot_size = RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
+            + runtime_event_site_layouts
+                .iter()
+                .map(|site| site.payload_words)
+                .max()
+                .unwrap_or(0)
+                * 8;
+
         let mut current_offset = 0;
 
         // 3. Execute packing
@@ -128,7 +147,7 @@ impl MemoryLayout {
         let scratch_base_offset = (triggered_bits_offset + triggered_bits_total_size + 7) & !7;
         let runtime_event_base_offset = (scratch_base_offset + scratch_bytes + 7) & !7;
         let runtime_event_bytes =
-            RUNTIME_EVENT_HEADER_SIZE + RUNTIME_EVENT_CAPACITY * RUNTIME_EVENT_SLOT_SIZE;
+            RUNTIME_EVENT_HEADER_SIZE + RUNTIME_EVENT_CAPACITY * runtime_event_slot_size;
         let merged_total_size = (runtime_event_base_offset + runtime_event_bytes + 7) & !7;
 
         // Apply address aliases: aliased variables share the canonical's offset.
@@ -173,9 +192,40 @@ impl MemoryLayout {
             scratch_size: scratch_bytes,
             runtime_event_base_offset,
             runtime_event_capacity: RUNTIME_EVENT_CAPACITY,
-            runtime_event_slot_size: RUNTIME_EVENT_SLOT_SIZE,
+            runtime_event_slot_size,
+            runtime_event_site_layouts,
         }
     }
+}
+
+fn build_runtime_event_site_layouts(program: &Program) -> Vec<RuntimeEventSiteLayout> {
+    program
+        .runtime_event_sites
+        .iter()
+        .map(|site| {
+            let mut payload_words = 0;
+            let args = site
+                .arg_widths
+                .iter()
+                .map(|width| {
+                    let word_count = (*width).div_ceil(64).max(1);
+                    let value_word_offset = payload_words;
+                    payload_words += word_count;
+                    let mask_word_offset = payload_words;
+                    payload_words += word_count;
+                    RuntimeEventArgLayout {
+                        value_word_offset,
+                        mask_word_offset,
+                        word_count,
+                    }
+                })
+                .collect();
+            RuntimeEventSiteLayout {
+                args,
+                payload_words,
+            }
+        })
+        .collect()
 }
 
 /// Collect all absolute addresses referenced in FF execution units.

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -1,5 +1,5 @@
-use crate::ir::{AbsoluteAddr, Program, SIRInstruction};
 use crate::HashMap;
+use crate::ir::{AbsoluteAddr, Program, SIRInstruction};
 
 pub const RUNTIME_EVENT_CAPACITY: usize = 1024;
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -5,11 +5,13 @@ pub const RUNTIME_EVENT_CAPACITY: usize = 1024;
 pub const RUNTIME_EVENT_MAX_ARGS: usize = 4;
 pub const RUNTIME_EVENT_WRITING: u64 = u64::MAX;
 pub const RUNTIME_EVENT_HEADER_SIZE: usize = 8;
-pub const RUNTIME_EVENT_SLOT_SIZE: usize = 8 * (3 + RUNTIME_EVENT_MAX_ARGS);
+pub const RUNTIME_EVENT_SLOT_SIZE: usize = 8 * (3 + RUNTIME_EVENT_MAX_ARGS * 2);
 pub const RUNTIME_EVENT_SLOT_SEQ_OFFSET: usize = 0;
 pub const RUNTIME_EVENT_SLOT_SITE_OFFSET: usize = 8;
 pub const RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET: usize = 16;
 pub const RUNTIME_EVENT_SLOT_ARGS_OFFSET: usize = 24;
+pub const RUNTIME_EVENT_SLOT_MASKS_OFFSET: usize =
+    RUNTIME_EVENT_SLOT_ARGS_OFFSET + RUNTIME_EVENT_MAX_ARGS * 8;
 
 #[derive(Debug, Clone)]
 pub struct MemoryLayout {

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -2,12 +2,17 @@ use crate::ir::{AbsoluteAddr, Program, SIRInstruction};
 use crate::HashMap;
 
 pub const RUNTIME_EVENT_CAPACITY: usize = 1024;
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub const RUNTIME_EVENT_WRITING: u64 = u64::MAX;
 pub const STATE_HEADER_SIZE: usize = 8;
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub const STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET: usize = 0;
 pub const RUNTIME_EVENT_HEADER_SIZE: usize = 8;
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub const RUNTIME_EVENT_SLOT_SEQ_OFFSET: usize = 0;
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub const RUNTIME_EVENT_SLOT_SITE_OFFSET: usize = 8;
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub const RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET: usize = 16;
 pub const RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET: usize = 24;
 

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -1,6 +1,16 @@
 use crate::HashMap;
 use crate::ir::{AbsoluteAddr, Program, SIRInstruction};
 
+pub const RUNTIME_EVENT_CAPACITY: usize = 1024;
+pub const RUNTIME_EVENT_MAX_ARGS: usize = 4;
+pub const RUNTIME_EVENT_WRITING: u64 = u64::MAX;
+pub const RUNTIME_EVENT_HEADER_SIZE: usize = 8;
+pub const RUNTIME_EVENT_SLOT_SIZE: usize = 8 * (3 + RUNTIME_EVENT_MAX_ARGS);
+pub const RUNTIME_EVENT_SLOT_SEQ_OFFSET: usize = 0;
+pub const RUNTIME_EVENT_SLOT_SITE_OFFSET: usize = 8;
+pub const RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET: usize = 16;
+pub const RUNTIME_EVENT_SLOT_ARGS_OFFSET: usize = 24;
+
 #[derive(Debug, Clone)]
 pub struct MemoryLayout {
     /// Stable region (region = 0) offsets. Includes all declared variables.
@@ -26,6 +36,12 @@ pub struct MemoryLayout {
     /// Located after triggered bits. Zero if no spilling needed.
     pub scratch_base_offset: usize,
     pub scratch_size: usize,
+
+    /// Single-producer runtime event ring. The layout is intentionally
+    /// producer-ring shaped so it can grow to multiple producers later.
+    pub runtime_event_base_offset: usize,
+    pub runtime_event_capacity: usize,
+    pub runtime_event_slot_size: usize,
 }
 
 impl MemoryLayout {
@@ -108,7 +124,10 @@ impl MemoryLayout {
         let triggered_bits_total_size = num_potential_triggers.div_ceil(8);
 
         let scratch_base_offset = (triggered_bits_offset + triggered_bits_total_size + 7) & !7;
-        let merged_total_size = (scratch_base_offset + scratch_bytes + 7) & !7;
+        let runtime_event_base_offset = (scratch_base_offset + scratch_bytes + 7) & !7;
+        let runtime_event_bytes =
+            RUNTIME_EVENT_HEADER_SIZE + RUNTIME_EVENT_CAPACITY * RUNTIME_EVENT_SLOT_SIZE;
+        let merged_total_size = (runtime_event_base_offset + runtime_event_bytes + 7) & !7;
 
         // Apply address aliases: aliased variables share the canonical's offset.
         // Only alias when:
@@ -150,6 +169,9 @@ impl MemoryLayout {
             triggered_bits_total_size,
             scratch_base_offset,
             scratch_size: scratch_bytes,
+            runtime_event_base_offset,
+            runtime_event_capacity: RUNTIME_EVENT_CAPACITY,
+            runtime_event_slot_size: RUNTIME_EVENT_SLOT_SIZE,
         }
     }
 }

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -241,6 +241,7 @@ fn compile_program(
 pub struct NativeBackend {
     compiled: Arc<SharedNativeCode>,
     memory: Vec<u64>,
+    runtime_event_buffer: Vec<u64>,
 }
 
 impl NativeBackend {
@@ -255,6 +256,8 @@ impl NativeBackend {
         let mem_size_words =
             (shared.layout.merged_total_size + shared.layout.triggered_bits_total_size).div_ceil(8);
         let mut memory = vec![0u64; mem_size_words + 1]; // +1 for safety
+        let event_words = shared.layout.runtime_event_buffer_size.div_ceil(8);
+        let runtime_event_buffer = vec![0u64; event_words];
 
         // Initialize 4-state regions to X (v=1, m=1)
         for &(offset, allocated_size) in &shared.four_state_inits {
@@ -266,9 +269,25 @@ impl NativeBackend {
             }
         }
 
-        Self {
+        let mut backend = Self {
             compiled: shared,
             memory,
+            runtime_event_buffer,
+        };
+        backend.install_runtime_event_buffer();
+        backend
+    }
+
+    fn install_runtime_event_buffer(&mut self) {
+        use crate::backend::memory_layout::STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET;
+
+        let addr = self.runtime_event_buffer.as_mut_ptr() as u64;
+        let ptr = unsafe {
+            (self.memory.as_mut_ptr() as *mut u8).add(STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET)
+                as *mut u64
+        };
+        unsafe {
+            std::ptr::write_unaligned(ptr, addr);
         }
     }
 
@@ -477,6 +496,13 @@ impl super::super::SimBackend for NativeBackend {
 
     fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize) {
         (self.mem_mut_ptr(), self.memory.len() * 8)
+    }
+
+    fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize) {
+        (
+            self.runtime_event_buffer.as_ptr() as *const u8,
+            self.compiled.layout.runtime_event_buffer_size,
+        )
     }
 
     fn stable_region_size(&self) -> usize {

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -11,6 +11,7 @@ use num_bigint::BigUint;
 use crate::ir::{AbsoluteAddr, Program, SignalRef};
 use crate::{HashMap, SimulatorError, SimulatorOptions};
 
+use super::super::RuntimeEventBuffer;
 use super::super::traits::SimulatorErrorCode;
 use super::super::{MemoryLayout, get_byte_size};
 use super::{emit, jit_mem, regalloc};
@@ -241,7 +242,7 @@ fn compile_program(
 pub struct NativeBackend {
     compiled: Arc<SharedNativeCode>,
     memory: Vec<u64>,
-    runtime_event_buffer: Vec<u64>,
+    runtime_event_buffer: Arc<RuntimeEventBuffer>,
 }
 
 impl NativeBackend {
@@ -256,8 +257,9 @@ impl NativeBackend {
         let mem_size_words =
             (shared.layout.merged_total_size + shared.layout.triggered_bits_total_size).div_ceil(8);
         let mut memory = vec![0u64; mem_size_words + 1]; // +1 for safety
-        let event_words = shared.layout.runtime_event_buffer_size.div_ceil(8);
-        let runtime_event_buffer = vec![0u64; event_words];
+        let runtime_event_buffer = Arc::new(RuntimeEventBuffer::new(
+            shared.layout.runtime_event_buffer_size,
+        ));
 
         // Initialize 4-state regions to X (v=1, m=1)
         for &(offset, allocated_size) in &shared.four_state_inits {
@@ -500,9 +502,13 @@ impl super::super::SimBackend for NativeBackend {
 
     fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize) {
         (
-            self.runtime_event_buffer.as_ptr() as *const u8,
-            self.compiled.layout.runtime_event_buffer_size,
+            self.runtime_event_buffer.as_ptr(),
+            self.runtime_event_buffer.byte_size(),
         )
+    }
+
+    fn runtime_event_buffer(&self) -> Option<Arc<RuntimeEventBuffer>> {
+        Some(Arc::clone(&self.runtime_event_buffer))
     }
 
     fn stable_region_size(&self) -> usize {

--- a/crates/celox/src/backend/native/emit.rs
+++ b/crates/celox/src/backend/native/emit.rs
@@ -597,6 +597,12 @@ fn emit_inst(
             offset,
             src,
             size,
+        }
+        | MInst::AtomicStorePtr {
+            ptr,
+            offset,
+            src,
+            size,
         } => {
             let ptr = preg_to_reg64(resolve(assignment, *ptr));
             let s_preg = resolve(assignment, *src);
@@ -671,6 +677,13 @@ fn emit_inst(
         }
 
         MInst::StorePtrIndexed {
+            ptr,
+            offset,
+            index,
+            src,
+            size,
+        }
+        | MInst::AtomicStorePtrIndexed {
             ptr,
             offset,
             index,

--- a/crates/celox/src/backend/native/emit.rs
+++ b/crates/celox/src/backend/native/emit.rs
@@ -120,6 +120,18 @@ fn mem_operand_indexed(base: BaseReg, offset: i32, index: AsmRegister64) -> AsmM
     base_reg + index + offset
 }
 
+fn mem_operand_ptr(ptr: AsmRegister64, offset: i32) -> AsmMemoryOperand {
+    ptr + offset
+}
+
+fn mem_operand_ptr_indexed(
+    ptr: AsmRegister64,
+    offset: i32,
+    index: AsmRegister64,
+) -> AsmMemoryOperand {
+    ptr + index + offset
+}
+
 // ────────────────────────────────────────────────────────────────
 // Callee-saved register tracking
 // ────────────────────────────────────────────────────────────────
@@ -555,6 +567,56 @@ fn emit_inst(
             }
         }
 
+        MInst::LoadPtr {
+            dst,
+            ptr,
+            offset,
+            size,
+        } => {
+            let d_preg = resolve(assignment, *dst);
+            let ptr = preg_to_reg64(resolve(assignment, *ptr));
+            let mem = mem_operand_ptr(ptr, *offset);
+            match size {
+                OpSize::S8 => {
+                    asm.movzx(preg_to_reg32(d_preg), byte_ptr(mem))?;
+                }
+                OpSize::S16 => {
+                    asm.movzx(preg_to_reg32(d_preg), word_ptr(mem))?;
+                }
+                OpSize::S32 => {
+                    asm.mov(preg_to_reg32(d_preg), dword_ptr(mem))?;
+                }
+                OpSize::S64 => {
+                    asm.mov(preg_to_reg64(d_preg), qword_ptr(mem))?;
+                }
+            }
+        }
+
+        MInst::StorePtr {
+            ptr,
+            offset,
+            src,
+            size,
+        } => {
+            let ptr = preg_to_reg64(resolve(assignment, *ptr));
+            let s_preg = resolve(assignment, *src);
+            let mem = mem_operand_ptr(ptr, *offset);
+            match size {
+                OpSize::S8 => {
+                    asm.mov(byte_ptr(mem), preg_to_reg8(s_preg))?;
+                }
+                OpSize::S16 => {
+                    asm.mov(word_ptr(mem), preg_to_reg16(s_preg))?;
+                }
+                OpSize::S32 => {
+                    asm.mov(dword_ptr(mem), preg_to_reg32(s_preg))?;
+                }
+                OpSize::S64 => {
+                    asm.mov(qword_ptr(mem), preg_to_reg64(s_preg))?;
+                }
+            }
+        }
+
         MInst::LoadIndexed {
             dst,
             base,
@@ -577,6 +639,60 @@ fn emit_inst(
                 }
                 OpSize::S64 => {
                     asm.mov(preg_to_reg64(d_preg), qword_ptr(mem))?;
+                }
+            }
+        }
+
+        MInst::LoadPtrIndexed {
+            dst,
+            ptr,
+            offset,
+            index,
+            size,
+        } => {
+            let d_preg = resolve(assignment, *dst);
+            let ptr = preg_to_reg64(resolve(assignment, *ptr));
+            let idx = preg_to_reg64(resolve(assignment, *index));
+            let mem = mem_operand_ptr_indexed(ptr, *offset, idx);
+            match size {
+                OpSize::S8 => {
+                    asm.movzx(preg_to_reg32(d_preg), byte_ptr(mem))?;
+                }
+                OpSize::S16 => {
+                    asm.movzx(preg_to_reg32(d_preg), word_ptr(mem))?;
+                }
+                OpSize::S32 => {
+                    asm.mov(preg_to_reg32(d_preg), dword_ptr(mem))?;
+                }
+                OpSize::S64 => {
+                    asm.mov(preg_to_reg64(d_preg), qword_ptr(mem))?;
+                }
+            }
+        }
+
+        MInst::StorePtrIndexed {
+            ptr,
+            offset,
+            index,
+            src,
+            size,
+        } => {
+            let ptr = preg_to_reg64(resolve(assignment, *ptr));
+            let idx = preg_to_reg64(resolve(assignment, *index));
+            let s_preg = resolve(assignment, *src);
+            let mem = mem_operand_ptr_indexed(ptr, *offset, idx);
+            match size {
+                OpSize::S8 => {
+                    asm.mov(byte_ptr(mem), preg_to_reg8(s_preg))?;
+                }
+                OpSize::S16 => {
+                    asm.mov(word_ptr(mem), preg_to_reg16(s_preg))?;
+                }
+                OpSize::S32 => {
+                    asm.mov(dword_ptr(mem), preg_to_reg32(s_preg))?;
+                }
+                OpSize::S64 => {
+                    asm.mov(qword_ptr(mem), preg_to_reg64(s_preg))?;
                 }
             }
         }

--- a/crates/celox/src/backend/native/isel.rs
+++ b/crates/celox/src/backend/native/isel.rs
@@ -695,11 +695,9 @@ fn lower_instruction(
     match inst {
         SIRInstruction::RuntimeEvent { site_id, args } => {
             use crate::backend::memory_layout::{
-                RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_MAX_ARGS,
-                RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET, RUNTIME_EVENT_SLOT_ARGS_OFFSET,
-                RUNTIME_EVENT_SLOT_MASKS_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
-                RUNTIME_EVENT_SLOT_SITE_OFFSET,
-                RUNTIME_EVENT_WRITING,
+                RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET,
+                RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
+                RUNTIME_EVENT_SLOT_SITE_OFFSET, RUNTIME_EVENT_WRITING,
             };
 
             let base = ctx.layout.runtime_event_base_offset as i32;
@@ -761,7 +759,8 @@ fn lower_instruction(
                 src: site_v,
                 size: OpSize::S64,
             });
-            let arg_count = args.len().min(RUNTIME_EVENT_MAX_ARGS) as u64;
+            let site_layout = &ctx.layout.runtime_event_site_layouts[*site_id as usize];
+            let arg_count = args.len() as u64;
             let arg_count_v = ctx.alloc_vreg(SpillDesc::remat(arg_count));
             block.push(MInst::LoadImm {
                 dst: arg_count_v,
@@ -774,38 +773,62 @@ fn lower_instruction(
                 src: arg_count_v,
                 size: OpSize::S64,
             });
-            for (idx, arg) in args.iter().take(RUNTIME_EVENT_MAX_ARGS).enumerate() {
-                let vreg = if ctx.wide_regs.contains_key(arg) {
-                    ctx.get_wide_chunks(arg, block)[0].0
-                } else {
-                    ctx.reg_map.get(*arg)
+            for (idx, arg) in args.iter().enumerate() {
+                let Some(arg_layout) = site_layout.args.get(idx) else {
+                    continue;
                 };
-                block.push(MInst::StoreIndexed {
-                    base: BaseReg::SimState,
-                    offset: slot_base + (RUNTIME_EVENT_SLOT_ARGS_OFFSET + idx * 8) as i32,
-                    index: slot_off,
-                    src: vreg,
-                    size: OpSize::S64,
-                });
-                let mask_vreg = if ctx.wide_regs.contains_key(arg) {
-                    get_wide_mask_chunks(ctx, block, arg, 1)[0]
-                } else if let Some(mask) = ctx.mask_map.map.get(arg.0).copied().flatten() {
-                    mask
+                let value_chunks = if ctx.wide_regs.contains_key(arg) {
+                    ctx.get_wide_chunks(arg, block)
                 } else {
-                    let zero = ctx.alloc_vreg(SpillDesc::remat(0));
-                    block.push(MInst::LoadImm {
-                        dst: zero,
-                        value: 0,
+                    vec![(ctx.reg_map.get(*arg), ctx.sir_width(arg).min(64))]
+                };
+                let mask_chunks = if ctx.wide_regs.contains_key(arg) {
+                    get_wide_mask_chunks(ctx, block, arg, arg_layout.word_count)
+                } else {
+                    vec![ctx.get_mask(*arg, block)]
+                };
+                for word_idx in 0..arg_layout.word_count {
+                    let value_vreg = value_chunks
+                        .get(word_idx)
+                        .map(|chunk| chunk.0)
+                        .unwrap_or_else(|| {
+                            let zero = ctx.alloc_vreg(SpillDesc::remat(0));
+                            block.push(MInst::LoadImm {
+                                dst: zero,
+                                value: 0,
+                            });
+                            zero
+                        });
+                    block.push(MInst::StoreIndexed {
+                        base: BaseReg::SimState,
+                        offset: slot_base
+                            + (RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
+                                + (arg_layout.value_word_offset + word_idx) * 8)
+                                as i32,
+                        index: slot_off,
+                        src: value_vreg,
+                        size: OpSize::S64,
                     });
-                    zero
-                };
-                block.push(MInst::StoreIndexed {
-                    base: BaseReg::SimState,
-                    offset: slot_base + (RUNTIME_EVENT_SLOT_MASKS_OFFSET + idx * 8) as i32,
-                    index: slot_off,
-                    src: mask_vreg,
-                    size: OpSize::S64,
-                });
+
+                    let mask_vreg = mask_chunks.get(word_idx).copied().unwrap_or_else(|| {
+                        let zero = ctx.alloc_vreg(SpillDesc::remat(0));
+                        block.push(MInst::LoadImm {
+                            dst: zero,
+                            value: 0,
+                        });
+                        zero
+                    });
+                    block.push(MInst::StoreIndexed {
+                        base: BaseReg::SimState,
+                        offset: slot_base
+                            + (RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
+                                + (arg_layout.mask_word_offset + word_idx) * 8)
+                                as i32,
+                        index: slot_off,
+                        src: mask_vreg,
+                        size: OpSize::S64,
+                    });
+                }
             }
             block.push(MInst::StoreIndexed {
                 base: BaseReg::SimState,
@@ -2948,7 +2971,11 @@ fn lower_instruction(
                 for chunk_i in 0..n_dst_chunks {
                     let chunk_width = if chunk_i == n_dst_chunks - 1 {
                         let rem = total_width % 64;
-                        if rem == 0 { 64 } else { rem }
+                        if rem == 0 {
+                            64
+                        } else {
+                            rem
+                        }
                     } else {
                         64
                     };
@@ -3034,7 +3061,11 @@ fn lower_instruction(
                             for (i, mv) in mc.into_iter().enumerate() {
                                 let cw = if i == ISelContext::num_chunks(arg_width) - 1 {
                                     let r = arg_width % 64;
-                                    if r == 0 { 64 } else { r }
+                                    if r == 0 {
+                                        64
+                                    } else {
+                                        r
+                                    }
                                 } else {
                                     64
                                 };
@@ -3053,7 +3084,11 @@ fn lower_instruction(
                     for chunk_i in 0..n_dst_chunks {
                         let chunk_width = if chunk_i == n_dst_chunks - 1 {
                             let rem = total_width % 64;
-                            if rem == 0 { 64 } else { rem }
+                            if rem == 0 {
+                                64
+                            } else {
+                                rem
+                            }
                         } else {
                             64
                         };
@@ -4368,7 +4403,11 @@ fn lower_wide_runtime_shift(
                 let carry_i = match dir {
                     ShiftDir::Left => {
                         // carry comes from chunk below: i-1
-                        if i == 0 { usize::MAX } else { i - 1 }
+                        if i == 0 {
+                            usize::MAX
+                        } else {
+                            i - 1
+                        }
                     }
                     ShiftDir::Right | ShiftDir::ArithRight => {
                         // carry comes from chunk above: i+1
@@ -4920,8 +4959,8 @@ fn lower_terminator(ctx: &mut ISelContext, block: &mut MBlock, term: &SIRTermina
             let cond_vreg = ctx.reg_map.get(*cond);
             block.push(MInst::Branch {
                 cond: cond_vreg,
-                true_bb: BlockId(true_block.0.0 as u32),
-                false_bb: BlockId(false_block.0.0 as u32),
+                true_bb: BlockId(true_block.0 .0 as u32),
+                false_bb: BlockId(false_block.0 .0 as u32),
             });
         }
         SIRTerminator::Return => {
@@ -5686,7 +5725,11 @@ fn lower_wide_binary_mask(
                 let rv = ctx.wide_chunk_or_zero(&rv_chunks, i, block);
                 let chunk_w = if i == n_dst - 1 {
                     let r = d_width % 64;
-                    if r == 0 { 64 } else { r }
+                    if r == 0 {
+                        64
+                    } else {
+                        r
+                    }
                 } else {
                     64
                 };
@@ -5914,7 +5957,11 @@ fn lower_wide_binary_mask(
                 for (i, (m, w)) in dst_m_chunks.into_iter().enumerate() {
                     let chunk_w = if i == n_dst - 1 {
                         let r = d_width % 64;
-                        if r == 0 { 64 } else { r }
+                        if r == 0 {
+                            64
+                        } else {
+                            r
+                        }
                     } else {
                         64
                     };
@@ -5985,7 +6032,11 @@ fn lower_wide_binary_mask(
                 for i in 0..n_dst {
                     let chunk_w = if i == n_dst - 1 {
                         let r = d_width % 64;
-                        if r == 0 { 64 } else { r }
+                        if r == 0 {
+                            64
+                        } else {
+                            r
+                        }
                     } else {
                         64
                     };
@@ -6060,7 +6111,11 @@ fn lower_wide_binary_mask(
                     let chunk_m = ctx.alloc_vreg(SpillDesc::transient());
                     let chunk_w = if i == n_dst - 1 {
                         let r = d_width % 64;
-                        if r == 0 { 64 } else { r }
+                        if r == 0 {
+                            64
+                        } else {
+                            r
+                        }
                     } else {
                         64
                     };
@@ -6157,7 +6212,11 @@ fn lower_wide_unary_mask(
                     let chunk_m = ctx.alloc_vreg(SpillDesc::transient());
                     let chunk_w = if i == n_dst - 1 {
                         let r = d_width % 64;
-                        if r == 0 { 64 } else { r }
+                        if r == 0 {
+                            64
+                        } else {
+                            r
+                        }
                     } else {
                         64
                     };

--- a/crates/celox/src/backend/native/isel.rs
+++ b/crates/celox/src/backend/native/isel.rs
@@ -698,14 +698,21 @@ fn lower_instruction(
                 RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET,
                 RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
                 RUNTIME_EVENT_SLOT_SITE_OFFSET, RUNTIME_EVENT_WRITING,
+                STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET,
             };
 
-            let base = ctx.layout.runtime_event_base_offset as i32;
-            let seq_v = ctx.alloc_vreg(SpillDesc::transient());
+            let event_ptr = ctx.alloc_vreg(SpillDesc::transient());
             block.push(MInst::Load {
-                dst: seq_v,
+                dst: event_ptr,
                 base: BaseReg::SimState,
-                offset: base,
+                offset: STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET as i32,
+                size: OpSize::S64,
+            });
+            let seq_v = ctx.alloc_vreg(SpillDesc::transient());
+            block.push(MInst::LoadPtr {
+                dst: seq_v,
+                ptr: event_ptr,
+                offset: 0,
                 size: OpSize::S64,
             });
             let mask_v = ctx.alloc_vreg(SpillDesc::remat(
@@ -739,9 +746,9 @@ fn lower_instruction(
                 dst: writing,
                 value: RUNTIME_EVENT_WRITING,
             });
-            let slot_base = base + RUNTIME_EVENT_HEADER_SIZE as i32;
-            block.push(MInst::StoreIndexed {
-                base: BaseReg::SimState,
+            let slot_base = RUNTIME_EVENT_HEADER_SIZE as i32;
+            block.push(MInst::StorePtrIndexed {
+                ptr: event_ptr,
                 offset: slot_base + RUNTIME_EVENT_SLOT_SEQ_OFFSET as i32,
                 index: slot_off,
                 src: writing,
@@ -752,8 +759,8 @@ fn lower_instruction(
                 dst: site_v,
                 value: *site_id as u64,
             });
-            block.push(MInst::StoreIndexed {
-                base: BaseReg::SimState,
+            block.push(MInst::StorePtrIndexed {
+                ptr: event_ptr,
                 offset: slot_base + RUNTIME_EVENT_SLOT_SITE_OFFSET as i32,
                 index: slot_off,
                 src: site_v,
@@ -766,8 +773,8 @@ fn lower_instruction(
                 dst: arg_count_v,
                 value: arg_count,
             });
-            block.push(MInst::StoreIndexed {
-                base: BaseReg::SimState,
+            block.push(MInst::StorePtrIndexed {
+                ptr: event_ptr,
                 offset: slot_base + RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET as i32,
                 index: slot_off,
                 src: arg_count_v,
@@ -799,8 +806,8 @@ fn lower_instruction(
                             });
                             zero
                         });
-                    block.push(MInst::StoreIndexed {
-                        base: BaseReg::SimState,
+                    block.push(MInst::StorePtrIndexed {
+                        ptr: event_ptr,
                         offset: slot_base
                             + (RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
                                 + (arg_layout.value_word_offset + word_idx) * 8)
@@ -818,8 +825,8 @@ fn lower_instruction(
                         });
                         zero
                     });
-                    block.push(MInst::StoreIndexed {
-                        base: BaseReg::SimState,
+                    block.push(MInst::StorePtrIndexed {
+                        ptr: event_ptr,
                         offset: slot_base
                             + (RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
                                 + (arg_layout.mask_word_offset + word_idx) * 8)
@@ -830,8 +837,8 @@ fn lower_instruction(
                     });
                 }
             }
-            block.push(MInst::StoreIndexed {
-                base: BaseReg::SimState,
+            block.push(MInst::StorePtrIndexed {
+                ptr: event_ptr,
                 offset: slot_base + RUNTIME_EVENT_SLOT_SEQ_OFFSET as i32,
                 index: slot_off,
                 src: seq_v,
@@ -843,9 +850,9 @@ fn lower_instruction(
                 src: seq_v,
                 imm: 1,
             });
-            block.push(MInst::Store {
-                base: BaseReg::SimState,
-                offset: base,
+            block.push(MInst::StorePtr {
+                ptr: event_ptr,
+                offset: 0,
                 src: next_seq,
                 size: OpSize::S64,
             });

--- a/crates/celox/src/backend/native/isel.rs
+++ b/crates/celox/src/backend/native/isel.rs
@@ -2978,11 +2978,7 @@ fn lower_instruction(
                 for chunk_i in 0..n_dst_chunks {
                     let chunk_width = if chunk_i == n_dst_chunks - 1 {
                         let rem = total_width % 64;
-                        if rem == 0 {
-                            64
-                        } else {
-                            rem
-                        }
+                        if rem == 0 { 64 } else { rem }
                     } else {
                         64
                     };
@@ -3068,11 +3064,7 @@ fn lower_instruction(
                             for (i, mv) in mc.into_iter().enumerate() {
                                 let cw = if i == ISelContext::num_chunks(arg_width) - 1 {
                                     let r = arg_width % 64;
-                                    if r == 0 {
-                                        64
-                                    } else {
-                                        r
-                                    }
+                                    if r == 0 { 64 } else { r }
                                 } else {
                                     64
                                 };
@@ -3091,11 +3083,7 @@ fn lower_instruction(
                     for chunk_i in 0..n_dst_chunks {
                         let chunk_width = if chunk_i == n_dst_chunks - 1 {
                             let rem = total_width % 64;
-                            if rem == 0 {
-                                64
-                            } else {
-                                rem
-                            }
+                            if rem == 0 { 64 } else { rem }
                         } else {
                             64
                         };
@@ -4410,11 +4398,7 @@ fn lower_wide_runtime_shift(
                 let carry_i = match dir {
                     ShiftDir::Left => {
                         // carry comes from chunk below: i-1
-                        if i == 0 {
-                            usize::MAX
-                        } else {
-                            i - 1
-                        }
+                        if i == 0 { usize::MAX } else { i - 1 }
                     }
                     ShiftDir::Right | ShiftDir::ArithRight => {
                         // carry comes from chunk above: i+1
@@ -4966,8 +4950,8 @@ fn lower_terminator(ctx: &mut ISelContext, block: &mut MBlock, term: &SIRTermina
             let cond_vreg = ctx.reg_map.get(*cond);
             block.push(MInst::Branch {
                 cond: cond_vreg,
-                true_bb: BlockId(true_block.0 .0 as u32),
-                false_bb: BlockId(false_block.0 .0 as u32),
+                true_bb: BlockId(true_block.0.0 as u32),
+                false_bb: BlockId(false_block.0.0 as u32),
             });
         }
         SIRTerminator::Return => {
@@ -5732,11 +5716,7 @@ fn lower_wide_binary_mask(
                 let rv = ctx.wide_chunk_or_zero(&rv_chunks, i, block);
                 let chunk_w = if i == n_dst - 1 {
                     let r = d_width % 64;
-                    if r == 0 {
-                        64
-                    } else {
-                        r
-                    }
+                    if r == 0 { 64 } else { r }
                 } else {
                     64
                 };
@@ -5964,11 +5944,7 @@ fn lower_wide_binary_mask(
                 for (i, (m, w)) in dst_m_chunks.into_iter().enumerate() {
                     let chunk_w = if i == n_dst - 1 {
                         let r = d_width % 64;
-                        if r == 0 {
-                            64
-                        } else {
-                            r
-                        }
+                        if r == 0 { 64 } else { r }
                     } else {
                         64
                     };
@@ -6039,11 +6015,7 @@ fn lower_wide_binary_mask(
                 for i in 0..n_dst {
                     let chunk_w = if i == n_dst - 1 {
                         let r = d_width % 64;
-                        if r == 0 {
-                            64
-                        } else {
-                            r
-                        }
+                        if r == 0 { 64 } else { r }
                     } else {
                         64
                     };
@@ -6118,11 +6090,7 @@ fn lower_wide_binary_mask(
                     let chunk_m = ctx.alloc_vreg(SpillDesc::transient());
                     let chunk_w = if i == n_dst - 1 {
                         let r = d_width % 64;
-                        if r == 0 {
-                            64
-                        } else {
-                            r
-                        }
+                        if r == 0 { 64 } else { r }
                     } else {
                         64
                     };
@@ -6219,11 +6187,7 @@ fn lower_wide_unary_mask(
                     let chunk_m = ctx.alloc_vreg(SpillDesc::transient());
                     let chunk_w = if i == n_dst - 1 {
                         let r = d_width % 64;
-                        if r == 0 {
-                            64
-                        } else {
-                            r
-                        }
+                        if r == 0 { 64 } else { r }
                     } else {
                         64
                     };

--- a/crates/celox/src/backend/native/isel.rs
+++ b/crates/celox/src/backend/native/isel.rs
@@ -697,7 +697,8 @@ fn lower_instruction(
             use crate::backend::memory_layout::{
                 RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_MAX_ARGS,
                 RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET, RUNTIME_EVENT_SLOT_ARGS_OFFSET,
-                RUNTIME_EVENT_SLOT_SEQ_OFFSET, RUNTIME_EVENT_SLOT_SITE_OFFSET,
+                RUNTIME_EVENT_SLOT_MASKS_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
+                RUNTIME_EVENT_SLOT_SITE_OFFSET,
                 RUNTIME_EVENT_WRITING,
             };
 
@@ -784,6 +785,25 @@ fn lower_instruction(
                     offset: slot_base + (RUNTIME_EVENT_SLOT_ARGS_OFFSET + idx * 8) as i32,
                     index: slot_off,
                     src: vreg,
+                    size: OpSize::S64,
+                });
+                let mask_vreg = if ctx.wide_regs.contains_key(arg) {
+                    get_wide_mask_chunks(ctx, block, arg, 1)[0]
+                } else if let Some(mask) = ctx.mask_map.map.get(arg.0).copied().flatten() {
+                    mask
+                } else {
+                    let zero = ctx.alloc_vreg(SpillDesc::remat(0));
+                    block.push(MInst::LoadImm {
+                        dst: zero,
+                        value: 0,
+                    });
+                    zero
+                };
+                block.push(MInst::StoreIndexed {
+                    base: BaseReg::SimState,
+                    offset: slot_base + (RUNTIME_EVENT_SLOT_MASKS_OFFSET + idx * 8) as i32,
+                    index: slot_off,
+                    src: mask_vreg,
                     size: OpSize::S64,
                 });
             }

--- a/crates/celox/src/backend/native/isel.rs
+++ b/crates/celox/src/backend/native/isel.rs
@@ -747,7 +747,7 @@ fn lower_instruction(
                 value: RUNTIME_EVENT_WRITING,
             });
             let slot_base = RUNTIME_EVENT_HEADER_SIZE as i32;
-            block.push(MInst::StorePtrIndexed {
+            block.push(MInst::AtomicStorePtrIndexed {
                 ptr: event_ptr,
                 offset: slot_base + RUNTIME_EVENT_SLOT_SEQ_OFFSET as i32,
                 index: slot_off,
@@ -837,7 +837,7 @@ fn lower_instruction(
                     });
                 }
             }
-            block.push(MInst::StorePtrIndexed {
+            block.push(MInst::AtomicStorePtrIndexed {
                 ptr: event_ptr,
                 offset: slot_base + RUNTIME_EVENT_SLOT_SEQ_OFFSET as i32,
                 index: slot_off,
@@ -850,7 +850,7 @@ fn lower_instruction(
                 src: seq_v,
                 imm: 1,
             });
-            block.push(MInst::StorePtr {
+            block.push(MInst::AtomicStorePtr {
                 ptr: event_ptr,
                 offset: 0,
                 src: next_seq,

--- a/crates/celox/src/backend/native/isel.rs
+++ b/crates/celox/src/backend/native/isel.rs
@@ -166,7 +166,9 @@ pub fn lower_execution_unit(
                 | SIRInstruction::Concat(d, _)
                 | SIRInstruction::Slice(d, _, _, _)
                 | SIRInstruction::Mux(d, _, _, _) => Some(*d),
-                SIRInstruction::Store(..) | SIRInstruction::Commit(..) => None,
+                SIRInstruction::Store(..)
+                | SIRInstruction::Commit(..)
+                | SIRInstruction::RuntimeEvent { .. } => None,
             };
             if let Some(dr) = dst_reg {
                 let w = ctx.sir_width(&dr);
@@ -691,6 +693,120 @@ fn lower_instruction(
     inst: &SIRInstruction<RegionedAbsoluteAddr>,
 ) {
     match inst {
+        SIRInstruction::RuntimeEvent { site_id, args } => {
+            use crate::backend::memory_layout::{
+                RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_MAX_ARGS,
+                RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET, RUNTIME_EVENT_SLOT_ARGS_OFFSET,
+                RUNTIME_EVENT_SLOT_SEQ_OFFSET, RUNTIME_EVENT_SLOT_SITE_OFFSET,
+                RUNTIME_EVENT_WRITING,
+            };
+
+            let base = ctx.layout.runtime_event_base_offset as i32;
+            let seq_v = ctx.alloc_vreg(SpillDesc::transient());
+            block.push(MInst::Load {
+                dst: seq_v,
+                base: BaseReg::SimState,
+                offset: base,
+                size: OpSize::S64,
+            });
+            let mask_v = ctx.alloc_vreg(SpillDesc::remat(
+                (ctx.layout.runtime_event_capacity as u64) - 1,
+            ));
+            block.push(MInst::LoadImm {
+                dst: mask_v,
+                value: (ctx.layout.runtime_event_capacity as u64) - 1,
+            });
+            let slot_idx = ctx.alloc_vreg(SpillDesc::transient());
+            block.push(MInst::And {
+                dst: slot_idx,
+                lhs: seq_v,
+                rhs: mask_v,
+            });
+            let slot_size_v =
+                ctx.alloc_vreg(SpillDesc::remat(ctx.layout.runtime_event_slot_size as u64));
+            block.push(MInst::LoadImm {
+                dst: slot_size_v,
+                value: ctx.layout.runtime_event_slot_size as u64,
+            });
+            let slot_off = ctx.alloc_vreg(SpillDesc::transient());
+            block.push(MInst::Mul {
+                dst: slot_off,
+                lhs: slot_idx,
+                rhs: slot_size_v,
+            });
+
+            let writing = ctx.alloc_vreg(SpillDesc::remat(RUNTIME_EVENT_WRITING));
+            block.push(MInst::LoadImm {
+                dst: writing,
+                value: RUNTIME_EVENT_WRITING,
+            });
+            let slot_base = base + RUNTIME_EVENT_HEADER_SIZE as i32;
+            block.push(MInst::StoreIndexed {
+                base: BaseReg::SimState,
+                offset: slot_base + RUNTIME_EVENT_SLOT_SEQ_OFFSET as i32,
+                index: slot_off,
+                src: writing,
+                size: OpSize::S64,
+            });
+            let site_v = ctx.alloc_vreg(SpillDesc::remat(*site_id as u64));
+            block.push(MInst::LoadImm {
+                dst: site_v,
+                value: *site_id as u64,
+            });
+            block.push(MInst::StoreIndexed {
+                base: BaseReg::SimState,
+                offset: slot_base + RUNTIME_EVENT_SLOT_SITE_OFFSET as i32,
+                index: slot_off,
+                src: site_v,
+                size: OpSize::S64,
+            });
+            let arg_count = args.len().min(RUNTIME_EVENT_MAX_ARGS) as u64;
+            let arg_count_v = ctx.alloc_vreg(SpillDesc::remat(arg_count));
+            block.push(MInst::LoadImm {
+                dst: arg_count_v,
+                value: arg_count,
+            });
+            block.push(MInst::StoreIndexed {
+                base: BaseReg::SimState,
+                offset: slot_base + RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET as i32,
+                index: slot_off,
+                src: arg_count_v,
+                size: OpSize::S64,
+            });
+            for (idx, arg) in args.iter().take(RUNTIME_EVENT_MAX_ARGS).enumerate() {
+                let vreg = if ctx.wide_regs.contains_key(arg) {
+                    ctx.get_wide_chunks(arg, block)[0].0
+                } else {
+                    ctx.reg_map.get(*arg)
+                };
+                block.push(MInst::StoreIndexed {
+                    base: BaseReg::SimState,
+                    offset: slot_base + (RUNTIME_EVENT_SLOT_ARGS_OFFSET + idx * 8) as i32,
+                    index: slot_off,
+                    src: vreg,
+                    size: OpSize::S64,
+                });
+            }
+            block.push(MInst::StoreIndexed {
+                base: BaseReg::SimState,
+                offset: slot_base + RUNTIME_EVENT_SLOT_SEQ_OFFSET as i32,
+                index: slot_off,
+                src: seq_v,
+                size: OpSize::S64,
+            });
+            let next_seq = ctx.alloc_vreg(SpillDesc::transient());
+            block.push(MInst::AddImm {
+                dst: next_seq,
+                src: seq_v,
+                imm: 1,
+            });
+            block.push(MInst::Store {
+                base: BaseReg::SimState,
+                offset: base,
+                src: next_seq,
+                size: OpSize::S64,
+            });
+        }
         SIRInstruction::Mux(dst, cond, then_val, else_val) => {
             // Expand Mux into Binary/Unary sequence and process through standard ISel.
             // This ensures width masking, constant tracking, and 4-state mask handling

--- a/crates/celox/src/backend/native/mir.rs
+++ b/crates/celox/src/backend/native/mir.rs
@@ -369,6 +369,20 @@ pub enum MInst {
         src: VReg,
         size: OpSize,
     },
+    /// dst = load [ptr + offset]
+    LoadPtr {
+        dst: VReg,
+        ptr: VReg,
+        offset: i32,
+        size: OpSize,
+    },
+    /// store [ptr + offset] = src
+    StorePtr {
+        ptr: VReg,
+        offset: i32,
+        src: VReg,
+        size: OpSize,
+    },
     /// dst = load [base + offset + index]  (register-indexed memory access)
     LoadIndexed {
         dst: VReg,
@@ -380,6 +394,22 @@ pub enum MInst {
     /// store [base + offset + index] = src  (register-indexed memory access)
     StoreIndexed {
         base: BaseReg,
+        offset: i32,
+        index: VReg,
+        src: VReg,
+        size: OpSize,
+    },
+    /// dst = load [ptr + offset + index]
+    LoadPtrIndexed {
+        dst: VReg,
+        ptr: VReg,
+        offset: i32,
+        index: VReg,
+        size: OpSize,
+    },
+    /// store [ptr + offset + index] = src
+    StorePtrIndexed {
+        ptr: VReg,
         offset: i32,
         index: VReg,
         src: VReg,
@@ -499,6 +529,18 @@ impl fmt::Display for MInst {
                 src,
                 size,
             } => write!(f, "store.{size} [{base} + {offset}], {src}"),
+            MInst::LoadPtr {
+                dst,
+                ptr,
+                offset,
+                size,
+            } => write!(f, "{dst} = load.{size} [{ptr} + {offset}]"),
+            MInst::StorePtr {
+                ptr,
+                offset,
+                src,
+                size,
+            } => write!(f, "store.{size} [{ptr} + {offset}], {src}"),
             MInst::LoadIndexed {
                 dst,
                 base,
@@ -513,6 +555,20 @@ impl fmt::Display for MInst {
                 src,
                 size,
             } => write!(f, "store.{size} [{base} + {offset} + {index}], {src}"),
+            MInst::LoadPtrIndexed {
+                dst,
+                ptr,
+                offset,
+                index,
+                size,
+            } => write!(f, "{dst} = load.{size} [{ptr} + {offset} + {index}]"),
+            MInst::StorePtrIndexed {
+                ptr,
+                offset,
+                index,
+                src,
+                size,
+            } => write!(f, "store.{size} [{ptr} + {offset} + {index}], {src}"),
             MInst::Add { dst, lhs, rhs } => write!(f, "{dst} = add {lhs}, {rhs}"),
             MInst::Sub { dst, lhs, rhs } => write!(f, "{dst} = sub {lhs}, {rhs}"),
             MInst::Mul { dst, lhs, rhs } => write!(f, "{dst} = mul {lhs}, {rhs}"),
@@ -613,7 +669,9 @@ impl MInst {
             MInst::Mov { dst, .. }
             | MInst::LoadImm { dst, .. }
             | MInst::Load { dst, .. }
+            | MInst::LoadPtr { dst, .. }
             | MInst::LoadIndexed { dst, .. }
+            | MInst::LoadPtrIndexed { dst, .. }
             | MInst::Add { dst, .. }
             | MInst::Sub { dst, .. }
             | MInst::Mul { dst, .. }
@@ -642,7 +700,9 @@ impl MInst {
             | MInst::Select { dst, .. } => Some(*dst),
 
             MInst::Store { .. }
+            | MInst::StorePtr { .. }
             | MInst::StoreIndexed { .. }
+            | MInst::StorePtrIndexed { .. }
             | MInst::Branch { .. }
             | MInst::Jump { .. }
             | MInst::Return
@@ -657,8 +717,14 @@ impl MInst {
             MInst::Mov { src, .. } => Uses::one(*src),
             MInst::LoadImm { .. } | MInst::Load { .. } => Uses::none(),
             MInst::Store { src, .. } => Uses::one(*src),
+            MInst::LoadPtr { ptr, .. } => Uses::one(*ptr),
+            MInst::StorePtr { ptr, src, .. } => Uses::two(*ptr, *src),
             MInst::LoadIndexed { index, .. } => Uses::one(*index),
             MInst::StoreIndexed { index, src, .. } => Uses::two(*index, *src),
+            MInst::LoadPtrIndexed { ptr, index, .. } => Uses::two(*ptr, *index),
+            MInst::StorePtrIndexed {
+                ptr, index, src, ..
+            } => Uses::three(*ptr, *index, *src),
             MInst::Add { lhs, rhs, .. }
             | MInst::Sub { lhs, rhs, .. }
             | MInst::Mul { lhs, rhs, .. }
@@ -708,12 +774,46 @@ impl MInst {
                     *src = new;
                 }
             }
+            MInst::LoadPtr { ptr, .. } => {
+                if *ptr == old {
+                    *ptr = new;
+                }
+            }
+            MInst::StorePtr { ptr, src, .. } => {
+                if *ptr == old {
+                    *ptr = new;
+                }
+                if *src == old {
+                    *src = new;
+                }
+            }
             MInst::LoadIndexed { index, .. } => {
                 if *index == old {
                     *index = new;
                 }
             }
             MInst::StoreIndexed { index, src, .. } => {
+                if *index == old {
+                    *index = new;
+                }
+                if *src == old {
+                    *src = new;
+                }
+            }
+            MInst::LoadPtrIndexed { ptr, index, .. } => {
+                if *ptr == old {
+                    *ptr = new;
+                }
+                if *index == old {
+                    *index = new;
+                }
+            }
+            MInst::StorePtrIndexed {
+                ptr, index, src, ..
+            } => {
+                if *ptr == old {
+                    *ptr = new;
+                }
                 if *index == old {
                     *index = new;
                 }

--- a/crates/celox/src/backend/native/mir.rs
+++ b/crates/celox/src/backend/native/mir.rs
@@ -383,6 +383,13 @@ pub enum MInst {
         src: VReg,
         size: OpSize,
     },
+    /// atomic store [ptr + offset] = src
+    AtomicStorePtr {
+        ptr: VReg,
+        offset: i32,
+        src: VReg,
+        size: OpSize,
+    },
     /// dst = load [base + offset + index]  (register-indexed memory access)
     LoadIndexed {
         dst: VReg,
@@ -409,6 +416,14 @@ pub enum MInst {
     },
     /// store [ptr + offset + index] = src
     StorePtrIndexed {
+        ptr: VReg,
+        offset: i32,
+        index: VReg,
+        src: VReg,
+        size: OpSize,
+    },
+    /// atomic store [ptr + offset + index] = src
+    AtomicStorePtrIndexed {
         ptr: VReg,
         offset: i32,
         index: VReg,
@@ -541,6 +556,12 @@ impl fmt::Display for MInst {
                 src,
                 size,
             } => write!(f, "store.{size} [{ptr} + {offset}], {src}"),
+            MInst::AtomicStorePtr {
+                ptr,
+                offset,
+                src,
+                size,
+            } => write!(f, "atomic_store.{size} [{ptr} + {offset}], {src}"),
             MInst::LoadIndexed {
                 dst,
                 base,
@@ -569,6 +590,13 @@ impl fmt::Display for MInst {
                 src,
                 size,
             } => write!(f, "store.{size} [{ptr} + {offset} + {index}], {src}"),
+            MInst::AtomicStorePtrIndexed {
+                ptr,
+                offset,
+                index,
+                src,
+                size,
+            } => write!(f, "atomic_store.{size} [{ptr} + {offset} + {index}], {src}"),
             MInst::Add { dst, lhs, rhs } => write!(f, "{dst} = add {lhs}, {rhs}"),
             MInst::Sub { dst, lhs, rhs } => write!(f, "{dst} = sub {lhs}, {rhs}"),
             MInst::Mul { dst, lhs, rhs } => write!(f, "{dst} = mul {lhs}, {rhs}"),
@@ -701,8 +729,10 @@ impl MInst {
 
             MInst::Store { .. }
             | MInst::StorePtr { .. }
+            | MInst::AtomicStorePtr { .. }
             | MInst::StoreIndexed { .. }
             | MInst::StorePtrIndexed { .. }
+            | MInst::AtomicStorePtrIndexed { .. }
             | MInst::Branch { .. }
             | MInst::Jump { .. }
             | MInst::Return
@@ -719,10 +749,14 @@ impl MInst {
             MInst::Store { src, .. } => Uses::one(*src),
             MInst::LoadPtr { ptr, .. } => Uses::one(*ptr),
             MInst::StorePtr { ptr, src, .. } => Uses::two(*ptr, *src),
+            MInst::AtomicStorePtr { ptr, src, .. } => Uses::two(*ptr, *src),
             MInst::LoadIndexed { index, .. } => Uses::one(*index),
             MInst::StoreIndexed { index, src, .. } => Uses::two(*index, *src),
             MInst::LoadPtrIndexed { ptr, index, .. } => Uses::two(*ptr, *index),
             MInst::StorePtrIndexed {
+                ptr, index, src, ..
+            } => Uses::three(*ptr, *index, *src),
+            MInst::AtomicStorePtrIndexed {
                 ptr, index, src, ..
             } => Uses::three(*ptr, *index, *src),
             MInst::Add { lhs, rhs, .. }
@@ -787,6 +821,14 @@ impl MInst {
                     *src = new;
                 }
             }
+            MInst::AtomicStorePtr { ptr, src, .. } => {
+                if *ptr == old {
+                    *ptr = new;
+                }
+                if *src == old {
+                    *src = new;
+                }
+            }
             MInst::LoadIndexed { index, .. } => {
                 if *index == old {
                     *index = new;
@@ -809,6 +851,19 @@ impl MInst {
                 }
             }
             MInst::StorePtrIndexed {
+                ptr, index, src, ..
+            } => {
+                if *ptr == old {
+                    *ptr = new;
+                }
+                if *index == old {
+                    *index = new;
+                }
+                if *src == old {
+                    *src = new;
+                }
+            }
+            MInst::AtomicStorePtrIndexed {
                 ptr, index, src, ..
             } => {
                 if *ptr == old {

--- a/crates/celox/src/backend/native/mir_opt.rs
+++ b/crates/celox/src/backend/native/mir_opt.rs
@@ -474,7 +474,13 @@ fn gvn_bin_rr(op: u8, lhs: VReg, rhs: VReg) -> GvnKey {
 
 /// Returns true if the instruction could modify memory that Load reads.
 fn is_memory_clobber(inst: &MInst) -> bool {
-    matches!(inst, MInst::Store { .. } | MInst::StoreIndexed { .. })
+    matches!(
+        inst,
+        MInst::Store { .. }
+            | MInst::StorePtr { .. }
+            | MInst::StoreIndexed { .. }
+            | MInst::StorePtrIndexed { .. }
+    )
 }
 
 /// Global GVN: dominator-tree-scoped value numbering.
@@ -627,7 +633,8 @@ fn global_gvn(func: &mut MFunction) {
                     MInst::Store {
                         base, offset, size, ..
                     } => (Some(*base), *offset, size.bytes() as i32),
-                    MInst::StoreIndexed { .. } => (None, 0, 0), // dynamic: invalidate all
+                    MInst::StoreIndexed { .. } | MInst::StorePtrIndexed { .. } => (None, 0, 0), // dynamic: invalidate all
+                    MInst::StorePtr { .. } => (None, 0, 0),
                     _ => (None, 0, 0),
                 };
                 let load_keys: Vec<GvnKey> = value_table
@@ -1014,8 +1021,11 @@ fn if_convert(func: &mut MFunction) {
                 matches!(
                     inst,
                     MInst::Store { .. }
+                        | MInst::StorePtr { .. }
                         | MInst::StoreIndexed { .. }
+                        | MInst::StorePtrIndexed { .. }
                         | MInst::Load { .. }
+                        | MInst::LoadPtr { .. }
                         | MInst::LoadImm { .. }
                         | MInst::Mov { .. }
                         | MInst::Add { .. }
@@ -1361,7 +1371,15 @@ fn split_live_ranges(func: &mut MFunction) {
                     // Check no Store between def and use (conservative)
                     let has_store = block.insts[def_ii + 1..use_pos]
                         .iter()
-                        .any(|i| matches!(i, MInst::Store { .. } | MInst::StoreIndexed { .. }));
+                        .any(|i| {
+                            matches!(
+                                i,
+                                MInst::Store { .. }
+                                    | MInst::StorePtr { .. }
+                                    | MInst::StoreIndexed { .. }
+                                    | MInst::StorePtrIndexed { .. }
+                            )
+                        });
                     if !has_store {
                         Some(RematKind::SimLoad(*offset, *size))
                     } else {
@@ -2070,7 +2088,10 @@ fn forward_local_store_loads(func: &mut MFunction) {
                         size,
                     });
                 }
-                MInst::LoadIndexed { .. } | MInst::StoreIndexed { .. } => {
+                MInst::LoadIndexed { .. }
+                | MInst::LoadPtrIndexed { .. }
+                | MInst::StoreIndexed { .. }
+                | MInst::StorePtrIndexed { .. } => {
                     available.clear();
                     rewritten.push(inst);
                 }
@@ -2181,7 +2202,10 @@ fn eliminate_redundant_local_stores(func: &mut MFunction) {
                         });
                     }
                 }
-                MInst::LoadIndexed { .. } | MInst::StoreIndexed { .. } => {
+                MInst::LoadIndexed { .. }
+                | MInst::LoadPtrIndexed { .. }
+                | MInst::StoreIndexed { .. }
+                | MInst::StorePtrIndexed { .. } => {
                     available.clear();
                     rewritten.push(inst);
                 }
@@ -2308,7 +2332,9 @@ fn dead_code_eliminate(func: &mut MFunction) {
                         return matches!(
                             inst,
                             MInst::Store { .. }
+                                | MInst::StorePtr { .. }
                                 | MInst::StoreIndexed { .. }
+                                | MInst::StorePtrIndexed { .. }
                                 | MInst::Branch { .. }
                                 | MInst::Jump { .. }
                                 | MInst::Return

--- a/crates/celox/src/backend/native/mir_opt.rs
+++ b/crates/celox/src/backend/native/mir_opt.rs
@@ -478,8 +478,10 @@ fn is_memory_clobber(inst: &MInst) -> bool {
         inst,
         MInst::Store { .. }
             | MInst::StorePtr { .. }
+            | MInst::AtomicStorePtr { .. }
             | MInst::StoreIndexed { .. }
             | MInst::StorePtrIndexed { .. }
+            | MInst::AtomicStorePtrIndexed { .. }
     )
 }
 
@@ -633,8 +635,10 @@ fn global_gvn(func: &mut MFunction) {
                     MInst::Store {
                         base, offset, size, ..
                     } => (Some(*base), *offset, size.bytes() as i32),
-                    MInst::StoreIndexed { .. } | MInst::StorePtrIndexed { .. } => (None, 0, 0), // dynamic: invalidate all
-                    MInst::StorePtr { .. } => (None, 0, 0),
+                    MInst::StoreIndexed { .. }
+                    | MInst::StorePtrIndexed { .. }
+                    | MInst::AtomicStorePtrIndexed { .. } => (None, 0, 0), // dynamic: invalidate all
+                    MInst::StorePtr { .. } | MInst::AtomicStorePtr { .. } => (None, 0, 0),
                     _ => (None, 0, 0),
                 };
                 let load_keys: Vec<GvnKey> = value_table
@@ -1022,8 +1026,10 @@ fn if_convert(func: &mut MFunction) {
                     inst,
                     MInst::Store { .. }
                         | MInst::StorePtr { .. }
+                        | MInst::AtomicStorePtr { .. }
                         | MInst::StoreIndexed { .. }
                         | MInst::StorePtrIndexed { .. }
+                        | MInst::AtomicStorePtrIndexed { .. }
                         | MInst::Load { .. }
                         | MInst::LoadPtr { .. }
                         | MInst::LoadImm { .. }
@@ -1369,17 +1375,17 @@ fn split_live_ranges(func: &mut MFunction) {
                     ..
                 } => {
                     // Check no Store between def and use (conservative)
-                    let has_store = block.insts[def_ii + 1..use_pos]
-                        .iter()
-                        .any(|i| {
-                            matches!(
-                                i,
-                                MInst::Store { .. }
-                                    | MInst::StorePtr { .. }
-                                    | MInst::StoreIndexed { .. }
-                                    | MInst::StorePtrIndexed { .. }
-                            )
-                        });
+                    let has_store = block.insts[def_ii + 1..use_pos].iter().any(|i| {
+                        matches!(
+                            i,
+                            MInst::Store { .. }
+                                | MInst::StorePtr { .. }
+                                | MInst::AtomicStorePtr { .. }
+                                | MInst::StoreIndexed { .. }
+                                | MInst::StorePtrIndexed { .. }
+                                | MInst::AtomicStorePtrIndexed { .. }
+                        )
+                    });
                     if !has_store {
                         Some(RematKind::SimLoad(*offset, *size))
                     } else {
@@ -2091,7 +2097,8 @@ fn forward_local_store_loads(func: &mut MFunction) {
                 MInst::LoadIndexed { .. }
                 | MInst::LoadPtrIndexed { .. }
                 | MInst::StoreIndexed { .. }
-                | MInst::StorePtrIndexed { .. } => {
+                | MInst::StorePtrIndexed { .. }
+                | MInst::AtomicStorePtrIndexed { .. } => {
                     available.clear();
                     rewritten.push(inst);
                 }
@@ -2205,7 +2212,8 @@ fn eliminate_redundant_local_stores(func: &mut MFunction) {
                 MInst::LoadIndexed { .. }
                 | MInst::LoadPtrIndexed { .. }
                 | MInst::StoreIndexed { .. }
-                | MInst::StorePtrIndexed { .. } => {
+                | MInst::StorePtrIndexed { .. }
+                | MInst::AtomicStorePtrIndexed { .. } => {
                     available.clear();
                     rewritten.push(inst);
                 }
@@ -2333,8 +2341,10 @@ fn dead_code_eliminate(func: &mut MFunction) {
                             inst,
                             MInst::Store { .. }
                                 | MInst::StorePtr { .. }
+                                | MInst::AtomicStorePtr { .. }
                                 | MInst::StoreIndexed { .. }
                                 | MInst::StorePtrIndexed { .. }
+                                | MInst::AtomicStorePtrIndexed { .. }
                                 | MInst::Branch { .. }
                                 | MInst::Jump { .. }
                                 | MInst::Return

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -462,8 +462,10 @@ impl JitBackend {
         );
         debug_assert_eq!(
             engine.translator.layout.merged_total_size,
-            (engine.translator.layout.triggered_bits_offset
-                + engine.translator.layout.triggered_bits_total_size
+            (engine.translator.layout.runtime_event_base_offset
+                + crate::backend::memory_layout::RUNTIME_EVENT_HEADER_SIZE
+                + engine.translator.layout.runtime_event_capacity
+                    * engine.translator.layout.runtime_event_slot_size
                 + 7)
                 & !7
         );

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -7,6 +7,7 @@ use crate::{
     ir::{AbsoluteAddr, SignalRef},
 };
 
+use super::RuntimeEventBuffer;
 use super::{JitEngine, MemoryLayout, get_byte_size};
 pub type SimFunc = unsafe extern "C" fn(*mut u8) -> u64;
 
@@ -153,7 +154,7 @@ impl SharedJitCode {
 pub struct JitBackend {
     shared: Arc<SharedJitCode>,
     memory: Vec<u64>,
-    runtime_event_buffer: Vec<u64>,
+    runtime_event_buffer: Arc<RuntimeEventBuffer>,
     /// Cached from `shared.comb_func` to avoid Arc dereference on the hot path.
     comb_func: SimFunc,
 }
@@ -522,8 +523,9 @@ impl JitBackend {
     pub fn from_shared(shared: Arc<SharedJitCode>) -> Self {
         let num_u64 = shared.layout.merged_total_size.div_ceil(8);
         let mut memory = vec![0u64; num_u64];
-        let event_words = shared.layout.runtime_event_buffer_size.div_ceil(8);
-        let runtime_event_buffer = vec![0u64; event_words];
+        let runtime_event_buffer = Arc::new(RuntimeEventBuffer::new(
+            shared.layout.runtime_event_buffer_size,
+        ));
 
         // Initialize 4-state regions to X (v=1, m=1)
         for &(offset, allocated_size) in &shared.four_state_inits {
@@ -825,9 +827,13 @@ impl JitBackend {
 
     pub fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize) {
         (
-            self.runtime_event_buffer.as_ptr() as *const u8,
-            self.shared.layout.runtime_event_buffer_size,
+            self.runtime_event_buffer.as_ptr(),
+            self.runtime_event_buffer.byte_size(),
         )
+    }
+
+    pub fn runtime_event_buffer(&self) -> Arc<RuntimeEventBuffer> {
+        Arc::clone(&self.runtime_event_buffer)
     }
 
     /// Returns the stable region size in bytes.
@@ -987,6 +993,10 @@ impl super::SimBackend for JitBackend {
 
     fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize) {
         self.runtime_event_buffer_as_ptr()
+    }
+
+    fn runtime_event_buffer(&self) -> Option<Arc<RuntimeEventBuffer>> {
+        Some(self.runtime_event_buffer())
     }
 
     fn stable_region_size(&self) -> usize {

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -153,6 +153,7 @@ impl SharedJitCode {
 pub struct JitBackend {
     shared: Arc<SharedJitCode>,
     memory: Vec<u64>,
+    runtime_event_buffer: Vec<u64>,
     /// Cached from `shared.comb_func` to avoid Arc dereference on the hot path.
     comb_func: SimFunc,
 }
@@ -462,10 +463,7 @@ impl JitBackend {
         );
         debug_assert_eq!(
             engine.translator.layout.merged_total_size,
-            (engine.translator.layout.runtime_event_base_offset
-                + crate::backend::memory_layout::RUNTIME_EVENT_HEADER_SIZE
-                + engine.translator.layout.runtime_event_capacity
-                    * engine.translator.layout.runtime_event_slot_size
+            (engine.translator.layout.scratch_base_offset + engine.translator.layout.scratch_size
                 + 7)
                 & !7
         );
@@ -524,6 +522,8 @@ impl JitBackend {
     pub fn from_shared(shared: Arc<SharedJitCode>) -> Self {
         let num_u64 = shared.layout.merged_total_size.div_ceil(8);
         let mut memory = vec![0u64; num_u64];
+        let event_words = shared.layout.runtime_event_buffer_size.div_ceil(8);
+        let runtime_event_buffer = vec![0u64; event_words];
 
         // Initialize 4-state regions to X (v=1, m=1)
         for &(offset, allocated_size) in &shared.four_state_inits {
@@ -536,10 +536,26 @@ impl JitBackend {
         }
 
         let comb_func = shared.comb_func;
-        Self {
+        let mut backend = Self {
             shared,
             memory,
+            runtime_event_buffer,
             comb_func,
+        };
+        backend.install_runtime_event_buffer();
+        backend
+    }
+
+    fn install_runtime_event_buffer(&mut self) {
+        use crate::backend::memory_layout::STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET;
+
+        let addr = self.runtime_event_buffer.as_mut_ptr() as u64;
+        let ptr = unsafe {
+            (self.memory.as_mut_ptr() as *mut u8).add(STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET)
+                as *mut u64
+        };
+        unsafe {
+            std::ptr::write_unaligned(ptr, addr);
         }
     }
 
@@ -807,6 +823,13 @@ impl JitBackend {
         (self.memory.as_mut_ptr() as *mut u8, size)
     }
 
+    pub fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize) {
+        (
+            self.runtime_event_buffer.as_ptr() as *const u8,
+            self.shared.layout.runtime_event_buffer_size,
+        )
+    }
+
     /// Returns the stable region size in bytes.
     pub fn stable_region_size(&self) -> usize {
         self.shared.layout.total_size
@@ -960,6 +983,10 @@ impl super::SimBackend for JitBackend {
 
     fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize) {
         self.memory_as_mut_ptr()
+    }
+
+    fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize) {
+        self.runtime_event_buffer_as_ptr()
     }
 
     fn stable_region_size(&self) -> usize {

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -464,7 +464,8 @@ impl JitBackend {
         );
         debug_assert_eq!(
             engine.translator.layout.merged_total_size,
-            (engine.translator.layout.scratch_base_offset + engine.translator.layout.scratch_size
+            (engine.translator.layout.scratch_base_offset
+                + engine.translator.layout.scratch_size
                 + 7)
                 & !7
         );

--- a/crates/celox/src/backend/runtime_event_buffer.rs
+++ b/crates/celox/src/backend/runtime_event_buffer.rs
@@ -1,0 +1,50 @@
+use std::cell::UnsafeCell;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+pub struct RuntimeEventBuffer {
+    words: Box<[UnsafeCell<u64>]>,
+    byte_size: usize,
+}
+
+unsafe impl Send for RuntimeEventBuffer {}
+unsafe impl Sync for RuntimeEventBuffer {}
+
+impl RuntimeEventBuffer {
+    pub fn new(byte_size: usize) -> Self {
+        let word_count = byte_size.div_ceil(8);
+        let words = (0..word_count)
+            .map(|_| UnsafeCell::new(0u64))
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self { words, byte_size }
+    }
+
+    pub fn as_ptr(&self) -> *const u8 {
+        self.words.as_ptr() as *const u8
+    }
+
+    pub fn as_mut_ptr(&self) -> *mut u8 {
+        self.words.as_ptr() as *mut u8
+    }
+
+    pub fn byte_size(&self) -> usize {
+        self.byte_size
+    }
+
+    pub fn load_atomic_u64(&self, byte_offset: usize, ordering: Ordering) -> u64 {
+        assert_eq!(byte_offset % 8, 0);
+        assert!(byte_offset + 8 <= self.byte_size);
+        let word = byte_offset / 8;
+        unsafe {
+            let ptr = self.words[word].get() as *const AtomicU64;
+            (*ptr).load(ordering)
+        }
+    }
+
+    pub fn read_u64(&self, byte_offset: usize) -> u64 {
+        assert_eq!(byte_offset % 8, 0);
+        assert!(byte_offset + 8 <= self.byte_size);
+        let word = byte_offset / 8;
+        unsafe { std::ptr::read_volatile(self.words[word].get()) }
+    }
+}

--- a/crates/celox/src/backend/traits.rs
+++ b/crates/celox/src/backend/traits.rs
@@ -1,8 +1,12 @@
 use num_bigint::BigUint;
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::Arc;
 
 use crate::ir::{AbsoluteAddr, SignalRef};
 
 use super::MemoryLayout;
+#[cfg(not(target_arch = "wasm32"))]
+use super::RuntimeEventBuffer;
 
 // SimulatorErrorCode: on native it's defined in runtime.rs; on wasm32 we define it here.
 #[cfg(not(target_arch = "wasm32"))]
@@ -133,6 +137,10 @@ pub trait SimBackend {
     fn memory_as_ptr(&self) -> (*const u8, usize);
     fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize);
     fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize);
+    #[cfg(not(target_arch = "wasm32"))]
+    fn runtime_event_buffer(&self) -> Option<Arc<RuntimeEventBuffer>> {
+        None
+    }
     fn stable_region_size(&self) -> usize;
     fn layout(&self) -> &MemoryLayout;
 

--- a/crates/celox/src/backend/traits.rs
+++ b/crates/celox/src/backend/traits.rs
@@ -132,6 +132,7 @@ pub trait SimBackend {
     // ── memory / layout ─────────────────────────────────────────
     fn memory_as_ptr(&self) -> (*const u8, usize);
     fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize);
+    fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize);
     fn stable_region_size(&self) -> usize;
     fn layout(&self) -> &MemoryLayout;
 

--- a/crates/celox/src/backend/translator/core.rs
+++ b/crates/celox/src/backend/translator/core.rs
@@ -420,11 +420,16 @@ impl SIRTranslator {
             .builder
             .ins()
             .iconst(types::I64, RUNTIME_EVENT_WRITING as i64);
-        state.builder.ins().store(
+        let slot_seq_addr = state
+            .builder
+            .ins()
+            .iadd_imm(slot_addr, RUNTIME_EVENT_SLOT_SEQ_OFFSET as i64);
+        state.builder.ins().atomic_rmw(
+            types::I64,
             MemFlags::new(),
+            cranelift::codegen::ir::AtomicRmwOp::Xchg,
+            slot_seq_addr,
             writing,
-            slot_addr,
-            RUNTIME_EVENT_SLOT_SEQ_OFFSET as i32,
         );
         let site = state.builder.ins().iconst(types::I64, site_id as i64);
         state.builder.ins().store(
@@ -477,17 +482,25 @@ impl SIRTranslator {
                 );
             }
         }
-        state.builder.ins().store(
-            MemFlags::new(),
-            seq,
-            slot_addr,
-            RUNTIME_EVENT_SLOT_SEQ_OFFSET as i32,
-        );
-        let next = state.builder.ins().iadd_imm(seq, 1);
-        state
+        let slot_seq_addr = state
             .builder
             .ins()
-            .store(MemFlags::new(), next, write_seq_addr, 0);
+            .iadd_imm(slot_addr, RUNTIME_EVENT_SLOT_SEQ_OFFSET as i64);
+        state.builder.ins().atomic_rmw(
+            types::I64,
+            MemFlags::new(),
+            cranelift::codegen::ir::AtomicRmwOp::Xchg,
+            slot_seq_addr,
+            seq,
+        );
+        let next = state.builder.ins().iadd_imm(seq, 1);
+        state.builder.ins().atomic_rmw(
+            types::I64,
+            MemFlags::new(),
+            cranelift::codegen::ir::AtomicRmwOp::Xchg,
+            write_seq_addr,
+            next,
+        );
     }
 
     /// Slice: extract bits [bit_offset, bit_offset+width) from src register.

--- a/crates/celox/src/backend/translator/core.rs
+++ b/crates/celox/src/backend/translator/core.rs
@@ -370,7 +370,89 @@ impl SIRTranslator {
             SIRInstruction::Mux(dst, cond, then_val, else_val) => {
                 self.translate_mux_inst(state, dst, cond, then_val, else_val);
             }
+            SIRInstruction::RuntimeEvent { site_id, args } => {
+                self.translate_runtime_event_inst(state, *site_id, args);
+            }
         }
+    }
+
+    fn translate_runtime_event_inst(
+        &self,
+        state: &mut TranslationState,
+        site_id: u32,
+        args: &[RegisterId],
+    ) {
+        use crate::backend::memory_layout::{
+            RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_MAX_ARGS, RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET,
+            RUNTIME_EVENT_SLOT_ARGS_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
+            RUNTIME_EVENT_SLOT_SITE_OFFSET, RUNTIME_EVENT_WRITING,
+        };
+
+        let base = self.layout.runtime_event_base_offset as i64;
+        let write_seq_addr = state.builder.ins().iadd_imm(state.mem_ptr, base);
+        let seq = state
+            .builder
+            .ins()
+            .load(types::I64, MemFlags::new(), write_seq_addr, 0);
+        let mask = state
+            .builder
+            .ins()
+            .iconst(types::I64, (self.layout.runtime_event_capacity as i64) - 1);
+        let slot_idx = state.builder.ins().band(seq, mask);
+        let slot_size = state
+            .builder
+            .ins()
+            .iconst(types::I64, self.layout.runtime_event_slot_size as i64);
+        let slot_off = state.builder.ins().imul(slot_idx, slot_size);
+        let slot_base_off = state.builder.ins().iadd_imm(
+            slot_off,
+            base + RUNTIME_EVENT_HEADER_SIZE as i64,
+        );
+        let slot_addr = state.builder.ins().iadd(state.mem_ptr, slot_base_off);
+
+        let writing = state
+            .builder
+            .ins()
+            .iconst(types::I64, RUNTIME_EVENT_WRITING as i64);
+        state.builder.ins().store(
+            MemFlags::new(),
+            writing,
+            slot_addr,
+            RUNTIME_EVENT_SLOT_SEQ_OFFSET as i32,
+        );
+        let site = state.builder.ins().iconst(types::I64, site_id as i64);
+        state.builder.ins().store(
+            MemFlags::new(),
+            site,
+            slot_addr,
+            RUNTIME_EVENT_SLOT_SITE_OFFSET as i32,
+        );
+        let arg_count = args.len().min(RUNTIME_EVENT_MAX_ARGS);
+        let arg_count_v = state.builder.ins().iconst(types::I64, arg_count as i64);
+        state.builder.ins().store(
+            MemFlags::new(),
+            arg_count_v,
+            slot_addr,
+            RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET as i32,
+        );
+        for (idx, arg) in args.iter().take(RUNTIME_EVENT_MAX_ARGS).enumerate() {
+            let value = state.regs[arg].first_value(state.builder);
+            let value = cast_type(state.builder, value, types::I64);
+            state.builder.ins().store(
+                MemFlags::new(),
+                value,
+                slot_addr,
+                (RUNTIME_EVENT_SLOT_ARGS_OFFSET + idx * 8) as i32,
+            );
+        }
+        state.builder.ins().store(
+            MemFlags::new(),
+            seq,
+            slot_addr,
+            RUNTIME_EVENT_SLOT_SEQ_OFFSET as i32,
+        );
+        let next = state.builder.ins().iadd_imm(seq, 1);
+        state.builder.ins().store(MemFlags::new(), next, write_seq_addr, 0);
     }
 
     /// Slice: extract bits [bit_offset, bit_offset+width) from src register.

--- a/crates/celox/src/backend/translator/core.rs
+++ b/crates/celox/src/backend/translator/core.rs
@@ -386,10 +386,16 @@ impl SIRTranslator {
             RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET,
             RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
             RUNTIME_EVENT_SLOT_SITE_OFFSET, RUNTIME_EVENT_WRITING,
+            STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET,
         };
 
-        let base = self.layout.runtime_event_base_offset as i64;
-        let write_seq_addr = state.builder.ins().iadd_imm(state.mem_ptr, base);
+        let event_ptr = state.builder.ins().load(
+            types::I64,
+            MemFlags::new(),
+            state.mem_ptr,
+            STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET as i32,
+        );
+        let write_seq_addr = event_ptr;
         let seq = state
             .builder
             .ins()
@@ -407,8 +413,8 @@ impl SIRTranslator {
         let slot_base_off = state
             .builder
             .ins()
-            .iadd_imm(slot_off, base + RUNTIME_EVENT_HEADER_SIZE as i64);
-        let slot_addr = state.builder.ins().iadd(state.mem_ptr, slot_base_off);
+            .iadd_imm(slot_off, RUNTIME_EVENT_HEADER_SIZE as i64);
+        let slot_addr = state.builder.ins().iadd(event_ptr, slot_base_off);
 
         let writing = state
             .builder

--- a/crates/celox/src/backend/translator/core.rs
+++ b/crates/celox/src/backend/translator/core.rs
@@ -384,7 +384,8 @@ impl SIRTranslator {
     ) {
         use crate::backend::memory_layout::{
             RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_MAX_ARGS, RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET,
-            RUNTIME_EVENT_SLOT_ARGS_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
+            RUNTIME_EVENT_SLOT_ARGS_OFFSET, RUNTIME_EVENT_SLOT_MASKS_OFFSET,
+            RUNTIME_EVENT_SLOT_SEQ_OFFSET,
             RUNTIME_EVENT_SLOT_SITE_OFFSET, RUNTIME_EVENT_WRITING,
         };
 
@@ -436,13 +437,24 @@ impl SIRTranslator {
             RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET as i32,
         );
         for (idx, arg) in args.iter().take(RUNTIME_EVENT_MAX_ARGS).enumerate() {
-            let value = state.regs[arg].first_value(state.builder);
+            let reg = &state.regs[arg];
+            let value = reg.first_value(state.builder);
             let value = cast_type(state.builder, value, types::I64);
             state.builder.ins().store(
                 MemFlags::new(),
                 value,
                 slot_addr,
                 (RUNTIME_EVENT_SLOT_ARGS_OFFSET + idx * 8) as i32,
+            );
+            let mask = reg
+                .first_mask(state.builder)
+                .map(|mask| cast_type(state.builder, mask, types::I64))
+                .unwrap_or_else(|| state.builder.ins().iconst(types::I64, 0));
+            state.builder.ins().store(
+                MemFlags::new(),
+                mask,
+                slot_addr,
+                (RUNTIME_EVENT_SLOT_MASKS_OFFSET + idx * 8) as i32,
             );
         }
         state.builder.ins().store(

--- a/crates/celox/src/backend/translator/core.rs
+++ b/crates/celox/src/backend/translator/core.rs
@@ -3,13 +3,13 @@ use cranelift::prelude::*;
 use cranelift_frontend::FunctionBuilder;
 
 use crate::{
+    HashMap, SimulatorOptions,
     ir::{
         AbsoluteAddr, BinaryOp, BlockId, RegionedAbsoluteAddr, RegisterId, RegisterType,
         SIRInstruction, STABLE_REGION,
     },
-    optimizer::coalescing::pass_tail_call_split::{SpillSlot, SpilledChunk},
     optimizer::coalescing::TailCallChunk,
-    HashMap, SimulatorOptions,
+    optimizer::coalescing::pass_tail_call_split::{SpillSlot, SpilledChunk},
 };
 
 use super::MemoryLayout;

--- a/crates/celox/src/backend/translator/core.rs
+++ b/crates/celox/src/backend/translator/core.rs
@@ -3,13 +3,13 @@ use cranelift::prelude::*;
 use cranelift_frontend::FunctionBuilder;
 
 use crate::{
-    HashMap, SimulatorOptions,
     ir::{
         AbsoluteAddr, BinaryOp, BlockId, RegionedAbsoluteAddr, RegisterId, RegisterType,
         SIRInstruction, STABLE_REGION,
     },
-    optimizer::coalescing::TailCallChunk,
     optimizer::coalescing::pass_tail_call_split::{SpillSlot, SpilledChunk},
+    optimizer::coalescing::TailCallChunk,
+    HashMap, SimulatorOptions,
 };
 
 use super::MemoryLayout;
@@ -383,9 +383,8 @@ impl SIRTranslator {
         args: &[RegisterId],
     ) {
         use crate::backend::memory_layout::{
-            RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_MAX_ARGS, RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET,
-            RUNTIME_EVENT_SLOT_ARGS_OFFSET, RUNTIME_EVENT_SLOT_MASKS_OFFSET,
-            RUNTIME_EVENT_SLOT_SEQ_OFFSET,
+            RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET,
+            RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
             RUNTIME_EVENT_SLOT_SITE_OFFSET, RUNTIME_EVENT_WRITING,
         };
 
@@ -405,10 +404,10 @@ impl SIRTranslator {
             .ins()
             .iconst(types::I64, self.layout.runtime_event_slot_size as i64);
         let slot_off = state.builder.ins().imul(slot_idx, slot_size);
-        let slot_base_off = state.builder.ins().iadd_imm(
-            slot_off,
-            base + RUNTIME_EVENT_HEADER_SIZE as i64,
-        );
+        let slot_base_off = state
+            .builder
+            .ins()
+            .iadd_imm(slot_off, base + RUNTIME_EVENT_HEADER_SIZE as i64);
         let slot_addr = state.builder.ins().iadd(state.mem_ptr, slot_base_off);
 
         let writing = state
@@ -428,7 +427,8 @@ impl SIRTranslator {
             slot_addr,
             RUNTIME_EVENT_SLOT_SITE_OFFSET as i32,
         );
-        let arg_count = args.len().min(RUNTIME_EVENT_MAX_ARGS);
+        let site_layout = &self.layout.runtime_event_site_layouts[site_id as usize];
+        let arg_count = args.len();
         let arg_count_v = state.builder.ins().iconst(types::I64, arg_count as i64);
         state.builder.ins().store(
             MemFlags::new(),
@@ -436,26 +436,40 @@ impl SIRTranslator {
             slot_addr,
             RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET as i32,
         );
-        for (idx, arg) in args.iter().take(RUNTIME_EVENT_MAX_ARGS).enumerate() {
+        for (idx, arg) in args.iter().enumerate() {
+            let Some(arg_layout) = site_layout.args.get(idx) else {
+                continue;
+            };
             let reg = &state.regs[arg];
-            let value = reg.first_value(state.builder);
-            let value = cast_type(state.builder, value, types::I64);
-            state.builder.ins().store(
-                MemFlags::new(),
-                value,
-                slot_addr,
-                (RUNTIME_EVENT_SLOT_ARGS_OFFSET + idx * 8) as i32,
-            );
-            let mask = reg
-                .first_mask(state.builder)
-                .map(|mask| cast_type(state.builder, mask, types::I64))
-                .unwrap_or_else(|| state.builder.ins().iconst(types::I64, 0));
-            state.builder.ins().store(
-                MemFlags::new(),
-                mask,
-                slot_addr,
-                (RUNTIME_EVENT_SLOT_MASKS_OFFSET + idx * 8) as i32,
-            );
+            let values = reg.load_value_chunks(state.builder);
+            let masks = reg.load_mask_chunks(state.builder);
+            for word_idx in 0..arg_layout.word_count {
+                let value = values
+                    .get(word_idx)
+                    .copied()
+                    .map(|value| cast_type(state.builder, value, types::I64))
+                    .unwrap_or_else(|| state.builder.ins().iconst(types::I64, 0));
+                state.builder.ins().store(
+                    MemFlags::new(),
+                    value,
+                    slot_addr,
+                    (RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
+                        + (arg_layout.value_word_offset + word_idx) * 8) as i32,
+                );
+
+                let mask = masks
+                    .as_ref()
+                    .and_then(|masks| masks.get(word_idx).copied())
+                    .map(|mask| cast_type(state.builder, mask, types::I64))
+                    .unwrap_or_else(|| state.builder.ins().iconst(types::I64, 0));
+                state.builder.ins().store(
+                    MemFlags::new(),
+                    mask,
+                    slot_addr,
+                    (RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
+                        + (arg_layout.mask_word_offset + word_idx) * 8) as i32,
+                );
+            }
         }
         state.builder.ins().store(
             MemFlags::new(),
@@ -464,7 +478,10 @@ impl SIRTranslator {
             RUNTIME_EVENT_SLOT_SEQ_OFFSET as i32,
         );
         let next = state.builder.ins().iadd_imm(seq, 1);
-        state.builder.ins().store(MemFlags::new(), next, write_seq_addr, 0);
+        state
+            .builder
+            .ins()
+            .store(MemFlags::new(), next, write_seq_addr, 0);
     }
 
     /// Slice: extract bits [bit_offset, bit_offset+width) from src register.

--- a/crates/celox/src/backend/wasm_codegen.rs
+++ b/crates/celox/src/backend/wasm_codegen.rs
@@ -478,6 +478,11 @@ fn compile_instruction(
                 dst, cond, then_val, else_val, unit, four_state, locals, instrs,
             );
         }
+        SIRInstruction::RuntimeEvent { .. } => {
+            // Runtime event ring emission is implemented for CPU backends first.
+            // WASM keeps the instruction as a no-op until the shared-memory
+            // atomic path is wired through the JS bridge.
+        }
     }
 }
 

--- a/crates/celox/src/backend/wasm_runtime.rs
+++ b/crates/celox/src/backend/wasm_runtime.rs
@@ -97,6 +97,9 @@ impl super::traits::SimBackend for WasmBackend {
     fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize) {
         WasmBackend::memory_as_mut_ptr(self)
     }
+    fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize) {
+        WasmBackend::runtime_event_buffer_as_ptr(self)
+    }
     fn stable_region_size(&self) -> usize {
         WasmBackend::stable_region_size(self)
     }
@@ -279,7 +282,9 @@ impl WasmBackend {
 
         // Create store and shared memory
         let mut store = Store::new(&engine, ());
-        let mem_pages = layout.merged_total_size.div_ceil(65536) as u64;
+        let runtime_event_base = layout.merged_total_size;
+        let mem_pages =
+            (layout.merged_total_size + layout.runtime_event_buffer_size).div_ceil(65536) as u64;
         let mem_pages = mem_pages.max(1);
         let memory = Memory::new(
             &mut store,
@@ -290,6 +295,7 @@ impl WasmBackend {
         // Initialize 4-state regions to X
         {
             let mem_data = memory.data_mut(&mut store);
+            mem_data[0..8].copy_from_slice(&(runtime_event_base as u64).to_le_bytes());
             for &(offset, allocated_size) in &four_state_inits {
                 // value bytes = 0xFF, mask bytes = 0xFF
                 for i in 0..allocated_size {
@@ -547,6 +553,15 @@ impl WasmBackend {
     pub fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize) {
         let data = self.memory.data_mut(&mut self.store);
         (data.as_mut_ptr(), self.layout.merged_total_size)
+    }
+
+    pub fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize) {
+        let data = self.memory.data(&self.store);
+        let event_base = self.layout.merged_total_size;
+        (
+            unsafe { data.as_ptr().add(event_base) },
+            self.layout.runtime_event_buffer_size,
+        )
     }
 
     pub fn stable_region_size(&self) -> usize {

--- a/crates/celox/src/debug/output.rs
+++ b/crates/celox/src/debug/output.rs
@@ -268,6 +268,14 @@ fn format_instruction(inst: &SIRInstruction<RegionedAbsoluteAddr>, program: &Pro
                 dst.0, cond.0, then_val.0, else_val.0
             )
         }
+        SIRInstruction::RuntimeEvent { site_id, args } => {
+            let args = args
+                .iter()
+                .map(|r| format!("r{}", r.0))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("RuntimeEvent(site={}, args=[{}])", site_id, args)
+        }
     }
 }
 

--- a/crates/celox/src/display_format.rs
+++ b/crates/celox/src/display_format.rs
@@ -1,0 +1,172 @@
+use num_bigint::{BigInt, BigUint, Sign};
+use num_traits::ToPrimitive as _;
+
+pub(crate) struct DisplayFormatArg<'a> {
+    pub value: &'a BigUint,
+    pub mask: Option<&'a BigUint>,
+    pub width: usize,
+    pub signed: bool,
+    pub is_string: bool,
+}
+
+fn bit(value: &BigUint, bit: usize) -> bool {
+    ((value >> bit) & BigUint::from(1u8)) != BigUint::from(0u8)
+}
+
+fn has_mask(arg: &DisplayFormatArg<'_>) -> bool {
+    let Some(mask) = arg.mask else {
+        return false;
+    };
+    for bit_idx in 0..arg.width {
+        if bit(mask, bit_idx) {
+            return true;
+        }
+    }
+    false
+}
+
+fn masked_value(value: &BigUint, width: usize) -> BigUint {
+    if width > 0 {
+        value & ((BigUint::from(1u8) << width) - BigUint::from(1u8))
+    } else {
+        BigUint::from(0u8)
+    }
+}
+
+fn value_to_signed_bigint(value: &BigUint, width: usize) -> BigInt {
+    if width == 0 {
+        return BigInt::from(0);
+    }
+    let unsigned = masked_value(value, width);
+    let sign_bit = BigUint::from(1u8) << (width - 1);
+    if (&unsigned & &sign_bit) != BigUint::from(0u8) {
+        BigInt::from_biguint(Sign::Plus, unsigned) - (BigInt::from(1u8) << width)
+    } else {
+        BigInt::from_biguint(Sign::Plus, unsigned)
+    }
+}
+
+fn value_to_utf8(value: &BigUint, width: usize) -> Option<String> {
+    if !width.is_multiple_of(8) {
+        return None;
+    }
+    let num_bytes = width / 8;
+    let mut bytes = vec![0u8; num_bytes];
+    let mut payload = masked_value(value, width);
+    let byte_mask = BigUint::from(0xffu64);
+    for idx in (0..num_bytes).rev() {
+        bytes[idx] = (&payload & &byte_mask).to_u64().unwrap_or(0) as u8;
+        payload >>= 8;
+    }
+    String::from_utf8(bytes).ok()
+}
+
+fn format_binary(arg: &DisplayFormatArg<'_>) -> String {
+    let digits = arg.width.max(1);
+    if !has_mask(arg) {
+        let mut out = masked_value(arg.value, arg.width).to_str_radix(2);
+        if out.len() < digits {
+            out.insert_str(0, &"0".repeat(digits - out.len()));
+        }
+        return out;
+    }
+    let mask = arg.mask.expect("masked argument");
+    let mut out = String::with_capacity(digits);
+    for bit_idx in (0..digits).rev() {
+        if bit(mask, bit_idx) {
+            out.push('x');
+        } else if bit(arg.value, bit_idx) {
+            out.push('1');
+        } else {
+            out.push('0');
+        }
+    }
+    out
+}
+
+fn format_masked_radix(arg: &DisplayFormatArg<'_>, bits_per_digit: usize) -> String {
+    let mask = arg.mask.expect("masked argument");
+    let digits = arg.width.div_ceil(bits_per_digit).max(1);
+    let mut out = String::with_capacity(digits);
+    for digit_idx in (0..digits).rev() {
+        let start = digit_idx * bits_per_digit;
+        let end = (start + bits_per_digit).min(arg.width);
+        if (start..end).any(|bit_idx| bit(mask, bit_idx)) {
+            out.push('x');
+            continue;
+        }
+        let mut digit = 0u32;
+        for bit_idx in start..end {
+            if bit(arg.value, bit_idx) {
+                digit |= 1 << (bit_idx - start);
+            }
+        }
+        out.push(char::from_digit(digit, 1 << bits_per_digit).unwrap());
+    }
+    out
+}
+
+pub(crate) fn format_display_arg(arg: &DisplayFormatArg<'_>, spec: Option<char>) -> String {
+    if arg.is_string {
+        return value_to_utf8(arg.value, arg.width).unwrap_or_else(|| format!("{:?}", arg.value));
+    }
+    match spec.unwrap_or('d') {
+        'b' | 'B' => format_binary(arg),
+        'o' | 'O' => {
+            if has_mask(arg) {
+                format_masked_radix(arg, 3)
+            } else {
+                masked_value(arg.value, arg.width).to_str_radix(8)
+            }
+        }
+        'x' | 'h' => {
+            if has_mask(arg) {
+                format_masked_radix(arg, 4)
+            } else {
+                masked_value(arg.value, arg.width).to_str_radix(16)
+            }
+        }
+        'X' | 'H' => {
+            let mut out = if has_mask(arg) {
+                format_masked_radix(arg, 4)
+            } else {
+                masked_value(arg.value, arg.width).to_str_radix(16)
+            };
+            out.make_ascii_uppercase();
+            out
+        }
+        'd' | 'D' | 'i' | 'I' => {
+            if has_mask(arg) {
+                "x".to_string()
+            } else if arg.signed {
+                value_to_signed_bigint(arg.value, arg.width).to_string()
+            } else {
+                masked_value(arg.value, arg.width).to_string()
+            }
+        }
+        'c' | 'C' => {
+            if has_mask(arg) {
+                "x".to_string()
+            } else {
+                char::from((masked_value(arg.value, arg.width).to_u64().unwrap_or(0) & 0xff) as u8)
+                    .to_string()
+            }
+        }
+        's' | 'S' => {
+            if has_mask(arg) {
+                "x".to_string()
+            } else {
+                value_to_utf8(arg.value, arg.width).unwrap_or_else(|| format!("{:?}", arg.value))
+            }
+        }
+        _ => {
+            if has_mask(arg) {
+                "x".to_string()
+            } else if arg.signed {
+                value_to_signed_bigint(arg.value, arg.width).to_string()
+            } else {
+                masked_value(arg.value, arg.width).to_string()
+            }
+        }
+    }
+}

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -93,6 +93,21 @@ pub struct RuntimeErrorInfo<Addr = AbsoluteAddr> {
     pub signals: Vec<Addr>,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum RuntimeEventKind {
+    Display,
+    AssertContinue,
+    AssertFatal,
+}
+
+#[derive(Clone, Debug)]
+pub struct RuntimeEventSite {
+    pub kind: RuntimeEventKind,
+    pub template: Option<String>,
+    pub arg_widths: Vec<usize>,
+    pub arg_signed: Vec<bool>,
+}
+
 #[derive(Clone)]
 pub struct Program {
     pub eval_apply_ffs: HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
@@ -100,6 +115,7 @@ pub struct Program {
     pub apply_ffs: HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
     pub eval_comb: Vec<ExecutionUnit<RegionedAbsoluteAddr>>,
     pub runtime_errors: HashMap<i64, RuntimeErrorInfo<AbsoluteAddr>>,
+    pub runtime_event_sites: Vec<RuntimeEventSite>,
     /// Tail-call chain compilation plan, populated by the optimizer when the
     /// estimated CLIF instruction count exceeds Cranelift's limit.
     pub eval_comb_plan: Option<EvalCombPlan>,
@@ -579,6 +595,7 @@ pub struct SimModule {
     pub glue_blocks: HashMap<StrId, Vec<GlueBlock>>,
     pub comb_blocks: Vec<LogicPath<VarId>>,
     pub runtime_errors: HashMap<i64, RuntimeErrorInfo<VarId>>,
+    pub runtime_event_sites: Vec<RuntimeEventSite>,
     pub comb_boundaries: HashMap<VarId, std::collections::BTreeSet<usize>>,
     pub arena: SLTNodeArena<VarId>,
     pub store: SymbolicStore<VarId>,
@@ -771,6 +788,10 @@ fn renumber_sir_inst<A: Clone>(
         SIRInstruction::Mux(dst, cond, then_val, else_val) => {
             SIRInstruction::Mux(r(*dst), r(*cond), r(*then_val), r(*else_val))
         }
+        SIRInstruction::RuntimeEvent { site_id, args } => SIRInstruction::RuntimeEvent {
+            site_id: *site_id,
+            args: args.iter().map(|a| r(*a)).collect(),
+        },
     }
 }
 
@@ -1071,6 +1092,10 @@ pub enum SIRInstruction<Addr> {
     /// In 4-state mode, preserves exact mask bits (including Z) of the selected branch.
     /// When cond has X/Z bits, result is all-X.
     Mux(RegisterId, RegisterId, RegisterId, RegisterId), // dst, cond, then_val, else_val
+    RuntimeEvent {
+        site_id: u32,
+        args: Vec<RegisterId>,
+    },
 }
 
 impl<A: Display> fmt::Display for SIRInstruction<A> {
@@ -1130,6 +1155,16 @@ impl<A: Display> fmt::Display for SIRInstruction<A> {
                     dst.0, cond.0, then_val.0, else_val.0
                 )
             }
+            SIRInstruction::RuntimeEvent { site_id, args } => {
+                write!(f, "RuntimeEvent(site={}, args=[", site_id)?;
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "r{}", arg.0)?;
+                }
+                write!(f, "])")
+            }
         }
     }
 }
@@ -1154,6 +1189,9 @@ impl<A> SIRInstruction<A> {
             }
             SIRInstruction::Mux(dst, cond, then_val, else_val) => {
                 SIRInstruction::Mux(dst, cond, then_val, else_val)
+            }
+            SIRInstruction::RuntimeEvent { site_id, args } => {
+                SIRInstruction::RuntimeEvent { site_id, args }
             }
         }
     }
@@ -1182,6 +1220,10 @@ impl<A> SIRInstruction<A> {
             SIRInstruction::Mux(dst, cond, then_val, else_val) => {
                 SIRInstruction::Mux(*dst, *cond, *then_val, *else_val)
             }
+            SIRInstruction::RuntimeEvent { site_id, args } => SIRInstruction::RuntimeEvent {
+                site_id: *site_id,
+                args: args.clone(),
+            },
         }
     }
 }

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -1,6 +1,7 @@
 mod backend;
 mod context_width;
 mod debug;
+#[cfg(not(target_arch = "wasm32"))]
 mod display_format;
 mod flatting;
 mod ir;

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -97,6 +97,8 @@ pub use simulator::SimulatorBuilder;
 pub use simulator::SimulatorError;
 pub use simulator::SimulatorErrorKind;
 #[cfg(not(target_arch = "wasm32"))]
+pub use simulator::RuntimeEvent;
+#[cfg(not(target_arch = "wasm32"))]
 pub use simulator::SimulatorOptions;
 pub use simulator::render_diagnostic;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -1,6 +1,7 @@
 mod backend;
 mod context_width;
 mod debug;
+mod display_format;
 mod flatting;
 mod ir;
 mod logic_tree;

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -91,13 +91,15 @@ pub use simulation::Simulation;
 #[cfg(not(target_arch = "wasm32"))]
 pub use simulator::DeadStorePolicy;
 #[cfg(not(target_arch = "wasm32"))]
+pub use simulator::RuntimeEvent;
+#[cfg(not(target_arch = "wasm32"))]
+pub use simulator::RuntimeEventDrain;
+#[cfg(not(target_arch = "wasm32"))]
 pub use simulator::Simulator;
 #[cfg(not(target_arch = "wasm32"))]
 pub use simulator::SimulatorBuilder;
 pub use simulator::SimulatorError;
 pub use simulator::SimulatorErrorKind;
-#[cfg(not(target_arch = "wasm32"))]
-pub use simulator::RuntimeEvent;
 #[cfg(not(target_arch = "wasm32"))]
 pub use simulator::SimulatorOptions;
 pub use simulator::render_diagnostic;

--- a/crates/celox/src/optimizer/coalescing/block_opt.rs
+++ b/crates/celox/src/optimizer/coalescing/block_opt.rs
@@ -37,11 +37,15 @@ fn collect_used_regs<A>(inst: &SIRInstruction<A>, out: &mut Vec<RegisterId>) {
             out.push(*then_val);
             out.push(*else_val);
         }
+        SIRInstruction::RuntimeEvent { args, .. } => out.extend(args.iter().copied()),
     }
 }
 
 fn is_memory_barrier<A>(inst: &SIRInstruction<A>) -> bool {
-    matches!(inst, SIRInstruction::Commit(_, _, _, _, _))
+    matches!(
+        inst,
+        SIRInstruction::Commit(_, _, _, _, _) | SIRInstruction::RuntimeEvent { .. }
+    )
 }
 
 fn mem_access_info<A>(inst: &SIRInstruction<A>) -> Option<(&A, Option<usize>, usize, bool)> {

--- a/crates/celox/src/optimizer/coalescing/cost_model.rs
+++ b/crates/celox/src/optimizer/coalescing/cost_model.rs
@@ -196,6 +196,7 @@ pub fn estimate_clif_cost(
         }
         SIRInstruction::Concat(_, args) => 3 * args.len() * state_mul,
         SIRInstruction::Slice(_, _, _, _) => 3 * state_mul,
+        SIRInstruction::RuntimeEvent { args, .. } => 12 + args.len() * 2,
     }
 }
 

--- a/crates/celox/src/optimizer/coalescing/pass_bit_extract_peephole.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_bit_extract_peephole.rs
@@ -168,7 +168,24 @@ fn optimize_bit_extracts(
             SIRInstruction::Load(_, _, SIROffset::Dynamic(off), _) => {
                 *use_count.entry(*off).or_default() += 1;
             }
+            SIRInstruction::Commit(_, _, SIROffset::Dynamic(off), _, _) => {
+                *use_count.entry(*off).or_default() += 1;
+            }
+            SIRInstruction::Commit(_, _, SIROffset::Static(_), _, _) => {}
             SIRInstruction::Concat(_, args) => {
+                for arg in args {
+                    *use_count.entry(*arg).or_default() += 1;
+                }
+            }
+            SIRInstruction::Slice(_, src, _, _) => {
+                *use_count.entry(*src).or_default() += 1;
+            }
+            SIRInstruction::Mux(_, cond, then_val, else_val) => {
+                *use_count.entry(*cond).or_default() += 1;
+                *use_count.entry(*then_val).or_default() += 1;
+                *use_count.entry(*else_val).or_default() += 1;
+            }
+            SIRInstruction::RuntimeEvent { args, .. } => {
                 for arg in args {
                     *use_count.entry(*arg).or_default() += 1;
                 }
@@ -249,4 +266,55 @@ fn optimize_bit_extracts(
     }
 
     *instructions = out;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{InstanceId, STABLE_REGION};
+    use veryl_analyzer::ir::VarId;
+
+    fn test_addr() -> RegionedAbsoluteAddr {
+        RegionedAbsoluteAddr {
+            region: STABLE_REGION,
+            instance_id: InstanceId(0),
+            var_id: VarId::default(),
+        }
+    }
+
+    #[test]
+    fn keeps_shift_result_used_by_runtime_event() {
+        let addr = test_addr();
+        let mut instructions = vec![
+            SIRInstruction::Load(RegisterId(0), addr, SIROffset::Static(0), 8),
+            SIRInstruction::Imm(RegisterId(1), SIRValue::new(2u64)),
+            SIRInstruction::Binary(RegisterId(2), RegisterId(0), BinaryOp::Shr, RegisterId(1)),
+            SIRInstruction::Imm(RegisterId(3), SIRValue::new(3u64)),
+            SIRInstruction::Binary(RegisterId(4), RegisterId(2), BinaryOp::And, RegisterId(3)),
+            SIRInstruction::RuntimeEvent {
+                site_id: 0,
+                args: vec![RegisterId(2)],
+            },
+        ];
+        let mut register_map = HashMap::default();
+        register_map.insert(RegisterId(4), RegisterType::Logic { width: 8 });
+
+        optimize_bit_extracts(&mut instructions, &mut register_map);
+
+        assert!(instructions.iter().any(|inst| matches!(
+            inst,
+            SIRInstruction::Binary(RegisterId(2), RegisterId(0), BinaryOp::Shr, RegisterId(1))
+        )));
+        assert!(instructions.iter().any(|inst| matches!(
+            inst,
+            SIRInstruction::Load(RegisterId(4), _, SIROffset::Static(2), 2)
+        )));
+        assert!(instructions.iter().any(|inst| matches!(
+            inst,
+            SIRInstruction::RuntimeEvent {
+                args,
+                ..
+            } if args == &vec![RegisterId(2)]
+        )));
+    }
 }

--- a/crates/celox/src/optimizer/coalescing/pass_gvn.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_gvn.rs
@@ -218,7 +218,9 @@ fn gvn_block(
             // (Store-Load forwarding handles Load redundancy separately)
             SIRInstruction::Load(..) => None,
             // Store/Commit: side-effecting. Invalidate all Load-derived values.
-            SIRInstruction::Store(..) | SIRInstruction::Commit(..) => {
+            SIRInstruction::Store(..)
+            | SIRInstruction::Commit(..)
+            | SIRInstruction::RuntimeEvent { .. } => {
                 // Conservative: don't invalidate value table for pure
                 // computations (Binary/Unary/Concat/Slice/Imm are
                 // memory-independent). Only Loads would be affected by
@@ -315,6 +317,13 @@ fn apply_aliases(
             }
             if let Some(&a) = aliases.get(else_val) {
                 *else_val = a;
+            }
+        }
+        SIRInstruction::RuntimeEvent { args, .. } => {
+            for arg in args {
+                if let Some(&a) = aliases.get(arg) {
+                    *arg = a;
+                }
             }
         }
     }

--- a/crates/celox/src/optimizer/coalescing/pass_split_coalesced_stores.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_split_coalesced_stores.rs
@@ -184,6 +184,8 @@ fn inst_def(inst: &SIRInstruction<RegionedAbsoluteAddr>) -> Option<RegisterId> {
         | SIRInstruction::Concat(d, _)
         | SIRInstruction::Slice(d, _, _, _)
         | SIRInstruction::Mux(d, _, _, _) => Some(*d),
-        SIRInstruction::Store(..) | SIRInstruction::Commit(..) => None,
+        SIRInstruction::Store(..)
+        | SIRInstruction::Commit(..)
+        | SIRInstruction::RuntimeEvent { .. } => None,
     }
 }

--- a/crates/celox/src/optimizer/coalescing/pass_store_load_forwarding.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_store_load_forwarding.rs
@@ -217,6 +217,13 @@ fn apply_aliases_to_inst(
                 *src = to;
             }
         }
+        SIRInstruction::RuntimeEvent { args, .. } => {
+            for arg in args {
+                if let Some(&to) = aliases.get(arg) {
+                    *arg = to;
+                }
+            }
+        }
     }
 }
 

--- a/crates/celox/src/optimizer/coalescing/pass_tail_call_split.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_tail_call_split.rs
@@ -462,7 +462,9 @@ fn def_reg<A>(inst: &SIRInstruction<A>) -> Option<RegisterId> {
         | SIRInstruction::Concat(dst, _)
         | SIRInstruction::Slice(dst, _, _, _)
         | SIRInstruction::Mux(dst, _, _, _) => Some(*dst),
-        SIRInstruction::Store(..) | SIRInstruction::Commit(..) => None,
+        SIRInstruction::Store(..)
+        | SIRInstruction::Commit(..)
+        | SIRInstruction::RuntimeEvent { .. } => None,
     }
 }
 
@@ -500,6 +502,7 @@ fn collect_used_regs<A>(inst: &SIRInstruction<A>, out: &mut Vec<RegisterId>) {
             out.push(*then_val);
             out.push(*else_val);
         }
+        SIRInstruction::RuntimeEvent { args, .. } => out.extend(args.iter().copied()),
     }
 }
 

--- a/crates/celox/src/optimizer/coalescing/shared.rs
+++ b/crates/celox/src/optimizer/coalescing/shared.rs
@@ -23,7 +23,9 @@ pub(super) fn def_reg<A>(inst: &SIRInstruction<A>) -> Option<RegisterId> {
         | SIRInstruction::Concat(dst, _)
         | SIRInstruction::Slice(dst, _, _, _)
         | SIRInstruction::Mux(dst, _, _, _) => Some(*dst),
-        SIRInstruction::Store(_, _, _, _, _) | SIRInstruction::Commit(_, _, _, _, _) => None,
+        SIRInstruction::Store(_, _, _, _, _)
+        | SIRInstruction::Commit(_, _, _, _, _)
+        | SIRInstruction::RuntimeEvent { .. } => None,
     }
 }
 
@@ -111,6 +113,9 @@ fn collect_used_regs_into(
             out.insert(*cond);
             out.insert(*then_val);
             out.insert(*else_val);
+        }
+        SIRInstruction::RuntimeEvent { args, .. } => {
+            out.extend(args.iter().copied());
         }
     }
 }
@@ -403,6 +408,13 @@ pub(super) fn batch_replace_in_inst(
             }
             if let Some(&to) = map.get(else_val) {
                 *else_val = to;
+            }
+        }
+        SIRInstruction::RuntimeEvent { args, .. } => {
+            for arg in args {
+                if let Some(&to) = map.get(arg) {
+                    *arg = to;
+                }
             }
         }
     }

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -621,6 +621,7 @@ pub(crate) fn flatten(
         apply_ffs,
         mut comb_blocks,
         mut runtime_errors,
+        runtime_event_sites,
         next_runtime_error_code,
     ) = timed_sub!(
         "relocate_units",
@@ -726,6 +727,7 @@ pub(crate) fn flatten(
             apply_ffs: HashMap::default(),
             eval_comb: Vec::new(),
             runtime_errors: HashMap::default(),
+            runtime_event_sites: Vec::new(),
             eval_comb_plan: None,
             instance_ids: expanded.clone(),
             instance_module: instance_modules.clone(),
@@ -833,6 +835,7 @@ pub(crate) fn flatten(
         apply_ffs,
         eval_comb: schduled,
         runtime_errors,
+        runtime_event_sites,
         eval_comb_plan: None,
         instance_ids: expanded,
         instance_module: instance_modules,
@@ -1359,6 +1362,7 @@ fn relocate_executation_unit_with_errors<A, B>(
     eu: &ExecutionUnit<A>,
     f: &impl Fn(&A) -> B,
     runtime_error_codes: &HashMap<i64, i64>,
+    runtime_event_sites: &HashMap<u32, u32>,
 ) -> ExecutionUnit<B> {
     ExecutionUnit {
         entry_block_id: eu.entry_block_id,
@@ -1373,7 +1377,18 @@ fn relocate_executation_unit_with_errors<A, B>(
                         instructions: block
                             .instructions
                             .iter()
-                            .map(|inst| inst.map_addr(f))
+                            .map(|inst| match inst {
+                                crate::ir::SIRInstruction::RuntimeEvent { site_id, args } => {
+                                    crate::ir::SIRInstruction::RuntimeEvent {
+                                        site_id: runtime_event_sites
+                                            .get(site_id)
+                                            .copied()
+                                            .unwrap_or(*site_id),
+                                        args: args.clone(),
+                                    }
+                                }
+                                _ => inst.map_addr(f),
+                            })
                             .collect(),
                         params: block.params.clone(),
                         terminator: match block.terminator {
@@ -1530,6 +1545,7 @@ fn relocate_units(
     HashMap<AbsoluteAddr, Vec<crate::ir::ExecutionUnit<RegionedAbsoluteAddr>>>,
     Vec<crate::logic_tree::LogicPath<AbsoluteAddr>>,
     HashMap<i64, RuntimeErrorInfo<AbsoluteAddr>>,
+    Vec<crate::ir::RuntimeEventSite>,
     i64,
 ) {
     let mut global_arena = SLTNodeArena::<AbsoluteAddr>::new();
@@ -1545,6 +1561,7 @@ fn relocate_units(
         HashMap::default();
     let mut comb_blocks = Vec::new();
     let mut runtime_errors = HashMap::default();
+    let mut runtime_event_sites = Vec::new();
     let mut next_runtime_error_code = 2000;
 
     for (path, id) in expanded {
@@ -1570,6 +1587,12 @@ fn relocate_units(
                         .collect(),
                 },
             );
+        }
+        let mut runtime_event_site_map = HashMap::default();
+        for (local_site, site) in sim_module.runtime_event_sites.iter().enumerate() {
+            let global_site = runtime_event_sites.len() as u32;
+            runtime_event_site_map.insert(local_site as u32, global_site);
+            runtime_event_sites.push(site.clone());
         }
 
         let relocated_module = flatting::flatting(
@@ -1603,6 +1626,7 @@ fn relocate_units(
                         var_id: addr.var_id,
                     },
                     &runtime_error_codes,
+                    &runtime_event_site_map,
                 ),
             );
 
@@ -1624,6 +1648,7 @@ fn relocate_units(
                             var_id: addr.var_id,
                         },
                         &runtime_error_codes,
+                        &runtime_event_site_map,
                     ),
                 );
             }
@@ -1647,6 +1672,7 @@ fn relocate_units(
                         var_id: addr.var_id,
                     },
                     &runtime_error_codes,
+                    &runtime_event_site_map,
                 ),
             );
 
@@ -1668,6 +1694,7 @@ fn relocate_units(
                             var_id: addr.var_id,
                         },
                         &runtime_error_codes,
+                        &runtime_event_site_map,
                     ),
                 );
             }
@@ -1691,6 +1718,7 @@ fn relocate_units(
                         var_id: addr.var_id,
                     },
                     &runtime_error_codes,
+                    &runtime_event_site_map,
                 ),
             );
 
@@ -1712,6 +1740,7 @@ fn relocate_units(
                             var_id: addr.var_id,
                         },
                         &runtime_error_codes,
+                        &runtime_event_site_map,
                     ),
                 );
             }
@@ -1724,6 +1753,7 @@ fn relocate_units(
         apply_ffs,
         comb_blocks,
         runtime_errors,
+        runtime_event_sites,
         next_runtime_error_code,
     )
 }

--- a/crates/celox/src/parser/ff.rs
+++ b/crates/celox/src/parser/ff.rs
@@ -1,8 +1,8 @@
 use std::collections::VecDeque;
 
 use crate::ir::{
-    RegisterId, RegisterType, RuntimeErrorInfo, SIRBuilder, SIRInstruction, SIRTerminator,
-    TriggerSet, UnaryOp, VarAtomBase, WORKING_REGION,
+    RegisterId, RegisterType, RuntimeErrorInfo, RuntimeEventSite, SIRBuilder, SIRInstruction,
+    SIRTerminator, TriggerSet, UnaryOp, VarAtomBase, WORKING_REGION,
 };
 use crate::{
     HashMap, HashSet,
@@ -16,9 +16,11 @@ use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::ToPrimitive;
 
 use veryl_analyzer::ir::{
-    Expression, Factor, FfDeclaration, FfReset, ForBound, ForRange, ForStatement, IfResetStatement,
-    IfStatement, Module, Op, Statement, TypeKind, ValueVariant, VarId,
+    AssertKind, Expression, Factor, FfDeclaration, FfReset, ForBound, ForRange, ForStatement,
+    IfResetStatement, IfStatement, Module, Op, Statement, SystemFunctionCall, SystemFunctionInput,
+    SystemFunctionKind, TypeKind, ValueVariant, VarId,
 };
+use veryl_analyzer::value::byte_value_to_string;
 use veryl_analyzer::value::Value;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -74,6 +76,7 @@ pub struct FfParser<'a> {
     reset: Option<FfReset>,
     function_arg_stack: Vec<HashMap<VarId, Expression>>,
     runtime_errors: HashMap<i64, RuntimeErrorInfo<VarId>>,
+    runtime_event_sites: Vec<RuntimeEventSite>,
     next_runtime_error_code: i64,
     config: BuildConfig,
 }
@@ -96,6 +99,7 @@ impl<'a> FfParser<'a> {
             reset: None,
             function_arg_stack: Vec::new(),
             runtime_errors: HashMap::default(),
+            runtime_event_sites: Vec::new(),
             next_runtime_error_code: 2000,
             config,
         }
@@ -103,6 +107,10 @@ impl<'a> FfParser<'a> {
 
     pub fn runtime_errors(&self) -> &HashMap<i64, RuntimeErrorInfo<VarId>> {
         &self.runtime_errors
+    }
+
+    pub fn runtime_event_sites(&self) -> &Vec<RuntimeEventSite> {
+        &self.runtime_event_sites
     }
 
     fn runtime_error(&mut self, message: impl Into<String>, signals: Vec<VarId>) -> i64 {
@@ -116,6 +124,147 @@ impl<'a> FfParser<'a> {
             },
         );
         code
+    }
+
+    fn static_string_expr(expr: &Expression) -> Option<String> {
+        if !expr.comptime().r#type.is_string() {
+            return None;
+        }
+        let value = expr.comptime().get_value().ok()?;
+        byte_value_to_string(value)
+    }
+
+    fn register_runtime_event_site(
+        &mut self,
+        kind: crate::ir::RuntimeEventKind,
+        args: &[SystemFunctionInput],
+    ) -> u32 {
+        let (template, value_args) = if args
+            .first()
+            .and_then(|arg| Self::static_string_expr(&arg.0))
+            .is_some()
+        {
+            (
+                args.first().and_then(|arg| Self::static_string_expr(&arg.0)),
+                &args[1..],
+            )
+        } else {
+            (None, args)
+        };
+        let site = RuntimeEventSite {
+            kind,
+            template,
+            arg_widths: value_args
+                .iter()
+                .map(|arg| self.get_expression_width(&arg.0))
+                .collect(),
+            arg_signed: value_args
+                .iter()
+                .map(|arg| arg.0.comptime().expr_context.signed)
+                .collect(),
+        };
+        let id = self.runtime_event_sites.len() as u32;
+        self.runtime_event_sites.push(site);
+        id
+    }
+
+    fn emit_runtime_event<A>(
+        &mut self,
+        site_id: u32,
+        args: &[SystemFunctionInput],
+        targets: &mut Vec<VarAtomBase<A>>,
+        domain: &Domain,
+        convert: &impl Fn(VarId, u32) -> A,
+        sources: &mut Vec<VarAtomBase<A>>,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<(), ParserError> {
+        let value_args = if args
+            .first()
+            .and_then(|arg| Self::static_string_expr(&arg.0))
+            .is_some()
+        {
+            &args[1..]
+        } else {
+            args
+        };
+        let mut regs = Vec::new();
+        for arg in value_args {
+            self.parse_expression(&arg.0, targets, domain, convert, sources, ir_builder, None)?;
+            regs.push(self.stack.pop_back().unwrap());
+        }
+        ir_builder.emit(SIRInstruction::RuntimeEvent {
+            site_id,
+            args: regs,
+        });
+        Ok(())
+    }
+
+    fn parse_system_task_statement<A>(
+        &mut self,
+        call: &SystemFunctionCall,
+        targets: &mut Vec<VarAtomBase<A>>,
+        domain: &Domain,
+        convert: &impl Fn(VarId, u32) -> A,
+        sources: &mut Vec<VarAtomBase<A>>,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<ControlFlow, ParserError> {
+        match &call.kind {
+            SystemFunctionKind::Display(args) | SystemFunctionKind::Write(args) => {
+                let site_id =
+                    self.register_runtime_event_site(crate::ir::RuntimeEventKind::Display, args);
+                self.emit_runtime_event(
+                    site_id, args, targets, domain, convert, sources, ir_builder,
+                )?;
+                Ok(ControlFlow::Continue)
+            }
+            SystemFunctionKind::Assert { kind, cond, args } => {
+                self.parse_expression(
+                    &cond.0, targets, domain, convert, sources, ir_builder, None,
+                )?;
+                let cond_reg = self.stack.pop_back().unwrap();
+                let pass_bb = ir_builder.new_block();
+                let fail_bb = ir_builder.new_block();
+                let event_kind = match kind {
+                    AssertKind::Fatal => crate::ir::RuntimeEventKind::AssertFatal,
+                    AssertKind::Continue => crate::ir::RuntimeEventKind::AssertContinue,
+                };
+                let site_id = self.register_runtime_event_site(event_kind, args);
+                ir_builder.seal_block(SIRTerminator::Branch {
+                    cond: cond_reg,
+                    true_block: (pass_bb, vec![]),
+                    false_block: (fail_bb, vec![]),
+                });
+                ir_builder.switch_to_block(fail_bb);
+                self.emit_runtime_event(
+                    site_id, args, targets, domain, convert, sources, ir_builder,
+                )?;
+                match kind {
+                    AssertKind::Fatal => {
+                        let message = if let Some(template) =
+                            args.first().and_then(|arg| Self::static_string_expr(&arg.0))
+                        {
+                            template
+                        } else {
+                            "assertion failed".to_string()
+                        };
+                        let code = self.runtime_error(message, Vec::new());
+                        ir_builder.seal_block(SIRTerminator::Error(code));
+                    }
+                    AssertKind::Continue => {
+                        ir_builder.seal_block(SIRTerminator::Jump(pass_bb, vec![]));
+                    }
+                }
+                ir_builder.switch_to_block(pass_bb);
+                Ok(ControlFlow::Continue)
+            }
+            _ => Err(ParserError::unsupported(
+                66,
+                LoweringPhase::FfLowering,
+                "system function call",
+                format!("{call}"),
+                Some(&call.comptime.token),
+            )),
+        }
     }
 
     fn get_constant_value(&self, expr: &Expression) -> Option<u64> {
@@ -467,13 +616,9 @@ impl<'a> FfParser<'a> {
             }
             Statement::Null => {}
             Statement::SystemFunctionCall(call) => {
-                return Err(ParserError::unsupported(
-                    66,
-                    LoweringPhase::FfLowering,
-                    "system function call",
-                    format!("{call}"),
-                    Some(&call.comptime.token),
-                ));
+                return self.parse_system_task_statement(
+                    call, targets, domain, convert, sources, ir_builder,
+                );
             }
             Statement::FunctionCall(call) => {
                 self.parse_function_call_statement(

--- a/crates/celox/src/parser/ff.rs
+++ b/crates/celox/src/parser/ff.rs
@@ -20,8 +20,8 @@ use veryl_analyzer::ir::{
     IfResetStatement, IfStatement, Module, Op, Statement, SystemFunctionCall, SystemFunctionInput,
     SystemFunctionKind, TypeKind, ValueVariant, VarId,
 };
-use veryl_analyzer::value::byte_value_to_string;
 use veryl_analyzer::value::Value;
+use veryl_analyzer::value::byte_value_to_string;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum LoopBoundStatus {
@@ -145,7 +145,8 @@ impl<'a> FfParser<'a> {
             .is_some()
         {
             (
-                args.first().and_then(|arg| Self::static_string_expr(&arg.0)),
+                args.first()
+                    .and_then(|arg| Self::static_string_expr(&arg.0)),
                 &args[1..],
             )
         } else {
@@ -240,8 +241,9 @@ impl<'a> FfParser<'a> {
                 )?;
                 match kind {
                     AssertKind::Fatal => {
-                        let message = if let Some(template) =
-                            args.first().and_then(|arg| Self::static_string_expr(&arg.0))
+                        let message = if let Some(template) = args
+                            .first()
+                            .and_then(|arg| Self::static_string_expr(&arg.0))
                         {
                             template
                         } else {

--- a/crates/celox/src/parser/module.rs
+++ b/crates/celox/src/parser/module.rs
@@ -391,6 +391,7 @@ impl<'a> ModuleParser<'a> {
             eval_apply_ff_blocks,
             comb_blocks: self.comb_blocks,
             runtime_errors: self.ff_parser.runtime_errors().clone(),
+            runtime_event_sites: self.ff_parser.runtime_event_sites().clone(),
             comb_boundaries,
             arena: self.arena,
             store: self.store,

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -1,13 +1,15 @@
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
 
+#[cfg(not(target_arch = "wasm32"))]
+use crate::backend::RuntimeEventBuffer;
 #[cfg(target_arch = "x86_64")]
 use crate::backend::native::{NativeBackend, SharedNativeCode};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::{
+    IOContext, RuntimeErrorCode,
     backend::{JitBackend, MemoryLayout, SharedJitCode, SimBackend},
     ir::{InstancePath, Program, RuntimeEventKind, RuntimeEventSite, SignalRef, VariableInfo},
-    IOContext, RuntimeErrorCode,
 };
 use num_bigint::BigUint;
 
@@ -72,6 +74,26 @@ pub enum RuntimeEvent {
     AssertContinue { message: String },
     AssertFatal { message: String },
     Missed { count: u64 },
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub struct RuntimeEventDrain {
+    buffer: Arc<RuntimeEventBuffer>,
+    layout: MemoryLayout,
+    sites: Vec<RuntimeEventSite>,
+    read_seq: u64,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl RuntimeEventDrain {
+    pub fn drain(&mut self) -> Vec<RuntimeEvent> {
+        drain_runtime_events_from_buffer(
+            &self.buffer,
+            &self.layout,
+            &self.sites,
+            &mut self.read_seq,
+        )
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -256,6 +278,111 @@ fn render_runtime_event_message(site: &RuntimeEventSite, args: &[RuntimeEventArg
     out
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+fn collect_runtime_events(
+    layout: &MemoryLayout,
+    sites: &[RuntimeEventSite],
+    read_seq: &mut u64,
+    buffer_size: usize,
+    mut read_payload_u64: impl FnMut(usize) -> u64,
+    mut read_seq_u64: impl FnMut(usize) -> u64,
+) -> Vec<RuntimeEvent> {
+    use crate::backend::memory_layout::{
+        RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET,
+        RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
+        RUNTIME_EVENT_SLOT_SITE_OFFSET, RUNTIME_EVENT_WRITING,
+    };
+
+    if RUNTIME_EVENT_HEADER_SIZE > buffer_size || layout.runtime_event_capacity == 0 {
+        return Vec::new();
+    }
+
+    let write_seq = read_seq_u64(0);
+    let mut events = Vec::new();
+    let capacity = layout.runtime_event_capacity as u64;
+    if *read_seq + capacity < write_seq {
+        let new_read = write_seq - capacity;
+        events.push(RuntimeEvent::Missed {
+            count: new_read - *read_seq,
+        });
+        *read_seq = new_read;
+    }
+
+    while *read_seq < write_seq {
+        let seq = *read_seq;
+        let slot = (seq as usize) & (layout.runtime_event_capacity - 1);
+        let slot_base = RUNTIME_EVENT_HEADER_SIZE + slot * layout.runtime_event_slot_size;
+        let published = read_seq_u64(slot_base + RUNTIME_EVENT_SLOT_SEQ_OFFSET);
+        if published == RUNTIME_EVENT_WRITING || published != seq {
+            break;
+        }
+
+        let site_id = read_payload_u64(slot_base + RUNTIME_EVENT_SLOT_SITE_OFFSET) as usize;
+        if let Some(site) = sites.get(site_id) {
+            let site_layout = layout.runtime_event_site_layouts.get(site_id);
+            let arg_count =
+                read_payload_u64(slot_base + RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET) as usize;
+            let arg_count = arg_count.min(site.arg_widths.len());
+            let mut args = Vec::with_capacity(arg_count);
+            if let Some(site_layout) = site_layout {
+                for idx in 0..arg_count {
+                    let Some(arg_layout) = site_layout.args.get(idx) else {
+                        break;
+                    };
+                    let mut values = Vec::with_capacity(arg_layout.word_count);
+                    let mut masks = Vec::with_capacity(arg_layout.word_count);
+                    for word_idx in 0..arg_layout.word_count {
+                        values.push(read_payload_u64(
+                            slot_base
+                                + RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
+                                + (arg_layout.value_word_offset + word_idx) * 8,
+                        ));
+                        masks.push(read_payload_u64(
+                            slot_base
+                                + RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
+                                + (arg_layout.mask_word_offset + word_idx) * 8,
+                        ));
+                    }
+                    args.push(RuntimeEventArgValue {
+                        values,
+                        masks,
+                        width: site.arg_widths.get(idx).copied().unwrap_or(64),
+                        signed: site.arg_signed.get(idx).copied().unwrap_or(false),
+                    });
+                }
+            }
+            let message = render_runtime_event_message(site, &args);
+            events.push(match site.kind {
+                RuntimeEventKind::Display => RuntimeEvent::Display { message },
+                RuntimeEventKind::AssertContinue => RuntimeEvent::AssertContinue { message },
+                RuntimeEventKind::AssertFatal => RuntimeEvent::AssertFatal { message },
+            });
+        }
+        *read_seq += 1;
+    }
+
+    events
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn drain_runtime_events_from_buffer(
+    buffer: &RuntimeEventBuffer,
+    layout: &MemoryLayout,
+    sites: &[RuntimeEventSite],
+    read_seq: &mut u64,
+) -> Vec<RuntimeEvent> {
+    use std::sync::atomic::Ordering;
+
+    collect_runtime_events(
+        layout,
+        sites,
+        read_seq,
+        buffer.byte_size(),
+        |offset| buffer.read_u64(offset),
+        |offset| buffer.load_atomic_u64(offset, Ordering::Acquire),
+    )
+}
+
 // ── Generic methods available for any backend ────────────────────────
 #[cfg(not(target_arch = "wasm32"))]
 impl<B: SimBackend> Simulator<B> {
@@ -299,81 +426,37 @@ impl<B: SimBackend> Simulator<B> {
     }
 
     pub fn drain_runtime_events(&mut self) -> Vec<RuntimeEvent> {
-        use crate::backend::memory_layout::{
-            RUNTIME_EVENT_CAPACITY, RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET,
-            RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
-            RUNTIME_EVENT_SLOT_SITE_OFFSET, RUNTIME_EVENT_WRITING,
-        };
-
         let layout = self.backend.layout();
-        let (ptr, size) = self.backend.runtime_event_buffer_as_ptr();
-        if RUNTIME_EVENT_HEADER_SIZE > size {
-            return Vec::new();
+        if let Some(buffer) = self.backend.runtime_event_buffer() {
+            return drain_runtime_events_from_buffer(
+                &buffer,
+                layout,
+                &self.program.runtime_event_sites,
+                &mut self.runtime_event_read_seq,
+            );
         }
+
+        let (ptr, size) = self.backend.runtime_event_buffer_as_ptr();
         let read_u64 = |offset: usize| -> u64 {
             unsafe { std::ptr::read_volatile(ptr.add(offset) as *const u64) }
         };
-        let write_seq = read_u64(0);
-        let mut events = Vec::new();
-        let capacity = RUNTIME_EVENT_CAPACITY as u64;
-        if self.runtime_event_read_seq + capacity < write_seq {
-            let new_read = write_seq - capacity;
-            events.push(RuntimeEvent::Missed {
-                count: new_read - self.runtime_event_read_seq,
-            });
-            self.runtime_event_read_seq = new_read;
-        }
-        while self.runtime_event_read_seq < write_seq {
-            let seq = self.runtime_event_read_seq;
-            let slot = (seq as usize) & (layout.runtime_event_capacity - 1);
-            let slot_base = RUNTIME_EVENT_HEADER_SIZE + slot * layout.runtime_event_slot_size;
-            let published = read_u64(slot_base + RUNTIME_EVENT_SLOT_SEQ_OFFSET);
-            if published == RUNTIME_EVENT_WRITING || published != seq {
-                break;
-            }
-            let site_id = read_u64(slot_base + RUNTIME_EVENT_SLOT_SITE_OFFSET) as usize;
-            if let Some(site) = self.program.runtime_event_sites.get(site_id) {
-                let site_layout = layout.runtime_event_site_layouts.get(site_id);
-                let arg_count = read_u64(slot_base + RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET) as usize;
-                let arg_count = arg_count.min(site.arg_widths.len());
-                let mut args = Vec::with_capacity(arg_count);
-                if let Some(site_layout) = site_layout {
-                    for idx in 0..arg_count {
-                        let Some(arg_layout) = site_layout.args.get(idx) else {
-                            break;
-                        };
-                        let mut values = Vec::with_capacity(arg_layout.word_count);
-                        let mut masks = Vec::with_capacity(arg_layout.word_count);
-                        for word_idx in 0..arg_layout.word_count {
-                            values.push(read_u64(
-                                slot_base
-                                    + RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
-                                    + (arg_layout.value_word_offset + word_idx) * 8,
-                            ));
-                            masks.push(read_u64(
-                                slot_base
-                                    + RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
-                                    + (arg_layout.mask_word_offset + word_idx) * 8,
-                            ));
-                        }
-                        args.push(RuntimeEventArgValue {
-                            values,
-                            masks,
-                            width: site.arg_widths.get(idx).copied().unwrap_or(64),
-                            signed: site.arg_signed.get(idx).copied().unwrap_or(false),
-                        });
-                    }
-                }
-                let message = render_runtime_event_message(site, &args);
-                events.push(match site.kind {
-                    RuntimeEventKind::Display => RuntimeEvent::Display { message },
-                    RuntimeEventKind::AssertContinue => RuntimeEvent::AssertContinue { message },
-                    RuntimeEventKind::AssertFatal => RuntimeEvent::AssertFatal { message },
-                });
-            }
-            self.runtime_event_read_seq += 1;
-        }
-        events
+        collect_runtime_events(
+            layout,
+            &self.program.runtime_event_sites,
+            &mut self.runtime_event_read_seq,
+            size,
+            read_u64,
+            read_u64,
+        )
+    }
+
+    pub fn runtime_event_drain(&self) -> Option<RuntimeEventDrain> {
+        Some(RuntimeEventDrain {
+            buffer: self.backend.runtime_event_buffer()?,
+            layout: self.backend.layout().clone(),
+            sites: self.program.runtime_event_sites.clone(),
+            read_seq: 0,
+        })
     }
 
     /// Returns a reference to the compiled SIR program.

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -7,7 +7,7 @@ use crate::backend::native::{NativeBackend, SharedNativeCode};
 use crate::{
     IOContext, RuntimeErrorCode,
     backend::{JitBackend, MemoryLayout, SharedJitCode, SimBackend},
-    ir::{InstancePath, Program, SignalRef, VariableInfo},
+    ir::{InstancePath, Program, RuntimeEventKind, SignalRef, VariableInfo},
 };
 #[cfg(not(target_arch = "wasm32"))]
 use num_bigint::BigUint;
@@ -64,6 +64,15 @@ pub struct Simulator<B: SimBackend = crate::DefaultBackend> {
     pub(crate) vcd_writer: Option<crate::vcd::VcdWriter>,
     pub(crate) dirty: bool,
     pub(crate) warnings: Vec<veryl_analyzer::AnalyzerError>,
+    runtime_event_read_seq: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeEvent {
+    Display { message: String },
+    AssertContinue { message: String },
+    AssertFatal { message: String },
+    Missed { count: u64 },
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -71,6 +80,45 @@ impl<B: SimBackend> std::fmt::Debug for Simulator<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Simulator").finish()
     }
+}
+
+fn render_runtime_event_message(template: Option<&str>, args: &[u64]) -> String {
+    let Some(template) = template else {
+        return args
+            .iter()
+            .map(|arg| format!("{arg}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+    };
+    let mut out = String::new();
+    let mut arg_idx = 0usize;
+    let mut chars = template.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch != '%' {
+            out.push(ch);
+            continue;
+        }
+        if matches!(chars.peek(), Some('%')) {
+            chars.next();
+            out.push('%');
+            continue;
+        }
+        while matches!(chars.peek(), Some('0'..='9')) {
+            chars.next();
+        }
+        let spec = chars.next().unwrap_or('d');
+        let value = args.get(arg_idx).copied().unwrap_or(0);
+        arg_idx += 1;
+        match spec {
+            'x' => out.push_str(&format!("{value:x}")),
+            'X' => out.push_str(&format!("{value:X}")),
+            'b' | 'B' => out.push_str(&format!("{value:b}")),
+            'o' | 'O' => out.push_str(&format!("{value:o}")),
+            'c' => out.push(char::from_u32(value as u32).unwrap_or('\u{fffd}')),
+            _ => out.push_str(&format!("{value}")),
+        }
+    }
+    out
 }
 
 // ── Generic methods available for any backend ────────────────────────
@@ -111,7 +159,64 @@ impl<B: SimBackend> Simulator<B> {
             vcd_writer: None,
             dirty: false,
             warnings,
+            runtime_event_read_seq: 0,
         }
+    }
+
+    pub fn drain_runtime_events(&mut self) -> Vec<RuntimeEvent> {
+        use crate::backend::memory_layout::{
+            RUNTIME_EVENT_CAPACITY, RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_MAX_ARGS,
+            RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET, RUNTIME_EVENT_SLOT_ARGS_OFFSET,
+            RUNTIME_EVENT_SLOT_SEQ_OFFSET, RUNTIME_EVENT_SLOT_SITE_OFFSET,
+            RUNTIME_EVENT_WRITING,
+        };
+
+        let layout = self.backend.layout();
+        let (ptr, size) = self.backend.memory_as_ptr();
+        let base = layout.runtime_event_base_offset;
+        if base + RUNTIME_EVENT_HEADER_SIZE > size {
+            return Vec::new();
+        }
+        let read_u64 = |offset: usize| -> u64 {
+            unsafe { std::ptr::read_volatile(ptr.add(offset) as *const u64) }
+        };
+        let write_seq = read_u64(base);
+        let mut events = Vec::new();
+        let capacity = RUNTIME_EVENT_CAPACITY as u64;
+        if self.runtime_event_read_seq + capacity < write_seq {
+            let new_read = write_seq - capacity;
+            events.push(RuntimeEvent::Missed {
+                count: new_read - self.runtime_event_read_seq,
+            });
+            self.runtime_event_read_seq = new_read;
+        }
+        while self.runtime_event_read_seq < write_seq {
+            let seq = self.runtime_event_read_seq;
+            let slot = (seq as usize) & (layout.runtime_event_capacity - 1);
+            let slot_base =
+                base + RUNTIME_EVENT_HEADER_SIZE + slot * layout.runtime_event_slot_size;
+            let published = read_u64(slot_base + RUNTIME_EVENT_SLOT_SEQ_OFFSET);
+            if published == RUNTIME_EVENT_WRITING || published != seq {
+                break;
+            }
+            let site_id = read_u64(slot_base + RUNTIME_EVENT_SLOT_SITE_OFFSET) as usize;
+            let arg_count = (read_u64(slot_base + RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET) as usize)
+                .min(RUNTIME_EVENT_MAX_ARGS);
+            let mut args = Vec::with_capacity(arg_count);
+            for idx in 0..arg_count {
+                args.push(read_u64(slot_base + RUNTIME_EVENT_SLOT_ARGS_OFFSET + idx * 8));
+            }
+            if let Some(site) = self.program.runtime_event_sites.get(site_id) {
+                let message = render_runtime_event_message(site.template.as_deref(), &args);
+                events.push(match site.kind {
+                    RuntimeEventKind::Display => RuntimeEvent::Display { message },
+                    RuntimeEventKind::AssertContinue => RuntimeEvent::AssertContinue { message },
+                    RuntimeEventKind::AssertFatal => RuntimeEvent::AssertFatal { message },
+                });
+            }
+            self.runtime_event_read_seq += 1;
+        }
+        events
     }
 
     /// Returns a reference to the compiled SIR program.

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -7,7 +7,7 @@ use crate::backend::native::{NativeBackend, SharedNativeCode};
 use crate::{
     IOContext, RuntimeErrorCode,
     backend::{JitBackend, MemoryLayout, SharedJitCode, SimBackend},
-    ir::{InstancePath, Program, RuntimeEventKind, SignalRef, VariableInfo},
+    ir::{InstancePath, Program, RuntimeEventKind, RuntimeEventSite, SignalRef, VariableInfo},
 };
 #[cfg(not(target_arch = "wasm32"))]
 use num_bigint::BigUint;
@@ -82,11 +82,125 @@ impl<B: SimBackend> std::fmt::Debug for Simulator<B> {
     }
 }
 
-fn render_runtime_event_message(template: Option<&str>, args: &[u64]) -> String {
-    let Some(template) = template else {
+fn relevant_mask(mask: u64, width: usize) -> u64 {
+    if width == 0 {
+        0
+    } else if width >= 64 {
+        mask
+    } else {
+        mask & ((1u64 << width) - 1)
+    }
+}
+
+fn relevant_value(value: u64, width: usize) -> u64 {
+    if width == 0 {
+        0
+    } else if width >= 64 {
+        value
+    } else {
+        value & ((1u64 << width) - 1)
+    }
+}
+
+fn format_runtime_arg_decimal(value: u64, mask: u64, width: usize, signed: bool) -> String {
+    if relevant_mask(mask, width) != 0 {
+        return "x".to_string();
+    }
+    let value = relevant_value(value, width);
+    if signed && width > 0 {
+        if width >= 64 {
+            (value as i64).to_string()
+        } else {
+            let shift = 64 - width;
+            (((value << shift) as i64) >> shift).to_string()
+        }
+    } else {
+        value.to_string()
+    }
+}
+
+fn format_runtime_arg_binary(value: u64, mask: u64, width: usize) -> String {
+    let mask = relevant_mask(mask, width);
+    let value = relevant_value(value, width);
+    if mask == 0 {
+        return format!("{value:b}");
+    }
+    let digits = width.clamp(1, 64);
+    let mut out = String::with_capacity(digits);
+    for bit in (0..digits).rev() {
+        if ((mask >> bit) & 1) != 0 {
+            out.push('x');
+        } else if ((value >> bit) & 1) != 0 {
+            out.push('1');
+        } else {
+            out.push('0');
+        }
+    }
+    out
+}
+
+fn format_runtime_arg_hex(value: u64, mask: u64, width: usize, upper: bool) -> String {
+    let mask = relevant_mask(mask, width);
+    let value = relevant_value(value, width);
+    if mask == 0 {
+        return if upper {
+            format!("{value:X}")
+        } else {
+            format!("{value:x}")
+        };
+    }
+    let digits = width.div_ceil(4).clamp(1, 16);
+    let mut out = String::with_capacity(digits);
+    for nibble in (0..digits).rev() {
+        let shift = nibble * 4;
+        let nibble_mask = (mask >> shift) & 0xf;
+        if nibble_mask != 0 {
+            out.push(if upper { 'X' } else { 'x' });
+        } else {
+            let digit = ((value >> shift) & 0xf) as u8;
+            out.push(char::from_digit(digit as u32, 16).unwrap());
+        }
+    }
+    if upper {
+        out.make_ascii_uppercase();
+    }
+    out
+}
+
+fn format_runtime_arg_octal(value: u64, mask: u64, width: usize) -> String {
+    let mask = relevant_mask(mask, width);
+    let value = relevant_value(value, width);
+    if mask == 0 {
+        return format!("{value:o}");
+    }
+    let digits = width.div_ceil(3).clamp(1, 22);
+    let mut out = String::with_capacity(digits);
+    for octal in (0..digits).rev() {
+        let shift = octal * 3;
+        let octal_mask = (mask >> shift) & 0x7;
+        if octal_mask != 0 {
+            out.push('x');
+        } else {
+            let digit = ((value >> shift) & 0x7) as u8;
+            out.push(char::from_digit(digit as u32, 8).unwrap());
+        }
+    }
+    out
+}
+
+fn render_runtime_event_message(site: &RuntimeEventSite, args: &[u64], masks: &[u64]) -> String {
+    let Some(template) = site.template.as_deref() else {
         return args
             .iter()
-            .map(|arg| format!("{arg}"))
+            .enumerate()
+            .map(|(idx, arg)| {
+                format_runtime_arg_decimal(
+                    *arg,
+                    masks.get(idx).copied().unwrap_or(0),
+                    site.arg_widths.get(idx).copied().unwrap_or(64),
+                    site.arg_signed.get(idx).copied().unwrap_or(false),
+                )
+            })
             .collect::<Vec<_>>()
             .join(" ");
     };
@@ -108,14 +222,20 @@ fn render_runtime_event_message(template: Option<&str>, args: &[u64]) -> String 
         }
         let spec = chars.next().unwrap_or('d');
         let value = args.get(arg_idx).copied().unwrap_or(0);
+        let mask = masks.get(arg_idx).copied().unwrap_or(0);
+        let width = site.arg_widths.get(arg_idx).copied().unwrap_or(64);
+        let signed = site.arg_signed.get(arg_idx).copied().unwrap_or(false);
         arg_idx += 1;
         match spec {
-            'x' => out.push_str(&format!("{value:x}")),
-            'X' => out.push_str(&format!("{value:X}")),
-            'b' | 'B' => out.push_str(&format!("{value:b}")),
-            'o' | 'O' => out.push_str(&format!("{value:o}")),
-            'c' => out.push(char::from_u32(value as u32).unwrap_or('\u{fffd}')),
-            _ => out.push_str(&format!("{value}")),
+            'x' => out.push_str(&format_runtime_arg_hex(value, mask, width, false)),
+            'X' => out.push_str(&format_runtime_arg_hex(value, mask, width, true)),
+            'b' | 'B' => out.push_str(&format_runtime_arg_binary(value, mask, width)),
+            'o' | 'O' => out.push_str(&format_runtime_arg_octal(value, mask, width)),
+            'c' if relevant_mask(mask, width) == 0 => {
+                out.push(char::from_u32(relevant_value(value, width) as u32).unwrap_or('\u{fffd}'))
+            }
+            'c' => out.push('x'),
+            _ => out.push_str(&format_runtime_arg_decimal(value, mask, width, signed)),
         }
     }
     out
@@ -167,7 +287,8 @@ impl<B: SimBackend> Simulator<B> {
         use crate::backend::memory_layout::{
             RUNTIME_EVENT_CAPACITY, RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_MAX_ARGS,
             RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET, RUNTIME_EVENT_SLOT_ARGS_OFFSET,
-            RUNTIME_EVENT_SLOT_SEQ_OFFSET, RUNTIME_EVENT_SLOT_SITE_OFFSET,
+            RUNTIME_EVENT_SLOT_MASKS_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
+            RUNTIME_EVENT_SLOT_SITE_OFFSET,
             RUNTIME_EVENT_WRITING,
         };
 
@@ -206,8 +327,14 @@ impl<B: SimBackend> Simulator<B> {
             for idx in 0..arg_count {
                 args.push(read_u64(slot_base + RUNTIME_EVENT_SLOT_ARGS_OFFSET + idx * 8));
             }
+            let mut masks = Vec::with_capacity(arg_count);
+            for idx in 0..arg_count {
+                masks.push(read_u64(
+                    slot_base + RUNTIME_EVENT_SLOT_MASKS_OFFSET + idx * 8,
+                ));
+            }
             if let Some(site) = self.program.runtime_event_sites.get(site_id) {
-                let message = render_runtime_event_message(site.template.as_deref(), &args);
+                let message = render_runtime_event_message(site, &args, &masks);
                 events.push(match site.kind {
                     RuntimeEventKind::Display => RuntimeEvent::Display { message },
                     RuntimeEventKind::AssertContinue => RuntimeEvent::AssertContinue { message },

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -318,39 +318,51 @@ fn collect_runtime_events(
         }
 
         let site_id = read_payload_u64(slot_base + RUNTIME_EVENT_SLOT_SITE_OFFSET) as usize;
-        if let Some(site) = sites.get(site_id) {
-            let site_layout = layout.runtime_event_site_layouts.get(site_id);
-            let arg_count =
-                read_payload_u64(slot_base + RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET) as usize;
-            let arg_count = arg_count.min(site.arg_widths.len());
-            let mut args = Vec::with_capacity(arg_count);
-            if let Some(site_layout) = site_layout {
-                for idx in 0..arg_count {
-                    let Some(arg_layout) = site_layout.args.get(idx) else {
-                        break;
-                    };
-                    let mut values = Vec::with_capacity(arg_layout.word_count);
-                    let mut masks = Vec::with_capacity(arg_layout.word_count);
-                    for word_idx in 0..arg_layout.word_count {
-                        values.push(read_payload_u64(
-                            slot_base
-                                + RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
-                                + (arg_layout.value_word_offset + word_idx) * 8,
-                        ));
-                        masks.push(read_payload_u64(
-                            slot_base
-                                + RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
-                                + (arg_layout.mask_word_offset + word_idx) * 8,
-                        ));
-                    }
-                    args.push(RuntimeEventArgValue {
-                        values,
-                        masks,
-                        width: site.arg_widths.get(idx).copied().unwrap_or(64),
-                        signed: site.arg_signed.get(idx).copied().unwrap_or(false),
-                    });
+        let site = sites.get(site_id);
+        let site_layout = layout.runtime_event_site_layouts.get(site_id);
+        let arg_count = read_payload_u64(slot_base + RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET) as usize;
+        let arg_count = site
+            .map(|site| arg_count.min(site.arg_widths.len()))
+            .unwrap_or(0);
+        let mut args = Vec::with_capacity(arg_count);
+        if let Some(site_layout) = site_layout {
+            for idx in 0..arg_count {
+                let Some(arg_layout) = site_layout.args.get(idx) else {
+                    break;
+                };
+                let mut values = Vec::with_capacity(arg_layout.word_count);
+                let mut masks = Vec::with_capacity(arg_layout.word_count);
+                for word_idx in 0..arg_layout.word_count {
+                    values.push(read_payload_u64(
+                        slot_base
+                            + RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
+                            + (arg_layout.value_word_offset + word_idx) * 8,
+                    ));
+                    masks.push(read_payload_u64(
+                        slot_base
+                            + RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
+                            + (arg_layout.mask_word_offset + word_idx) * 8,
+                    ));
                 }
+                args.push(RuntimeEventArgValue {
+                    values,
+                    masks,
+                    width: site
+                        .and_then(|site| site.arg_widths.get(idx).copied())
+                        .unwrap_or(64),
+                    signed: site
+                        .and_then(|site| site.arg_signed.get(idx).copied())
+                        .unwrap_or(false),
+                });
             }
+        }
+
+        let published_after = read_seq_u64(slot_base + RUNTIME_EVENT_SLOT_SEQ_OFFSET);
+        if published_after == RUNTIME_EVENT_WRITING || published_after != seq {
+            break;
+        }
+
+        if let Some(site) = site {
             let message = render_runtime_event_message(site, &args);
             events.push(match site.kind {
                 RuntimeEventKind::Display => RuntimeEvent::Display { message },

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -5,11 +5,10 @@ use std::sync::Arc;
 use crate::backend::native::{NativeBackend, SharedNativeCode};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::{
-    IOContext, RuntimeErrorCode,
     backend::{JitBackend, MemoryLayout, SharedJitCode, SimBackend},
     ir::{InstancePath, Program, RuntimeEventKind, RuntimeEventSite, SignalRef, VariableInfo},
+    IOContext, RuntimeErrorCode,
 };
-#[cfg(not(target_arch = "wasm32"))]
 use num_bigint::BigUint;
 
 mod builder;
@@ -82,55 +81,64 @@ impl<B: SimBackend> std::fmt::Debug for Simulator<B> {
     }
 }
 
-fn relevant_mask(mask: u64, width: usize) -> u64 {
-    if width == 0 {
-        0
-    } else if width >= 64 {
-        mask
+struct RuntimeEventArgValue {
+    values: Vec<u64>,
+    masks: Vec<u64>,
+    width: usize,
+    signed: bool,
+}
+
+fn runtime_event_bit(words: &[u64], bit: usize) -> bool {
+    words
+        .get(bit / 64)
+        .map(|word| ((word >> (bit % 64)) & 1) != 0)
+        .unwrap_or(false)
+}
+
+fn runtime_event_has_mask(arg: &RuntimeEventArgValue) -> bool {
+    for bit in 0..arg.width {
+        if runtime_event_bit(&arg.masks, bit) {
+            return true;
+        }
+    }
+    false
+}
+
+fn runtime_event_words_to_biguint(words: &[u64], width: usize) -> BigUint {
+    let mut value = BigUint::from(0u8);
+    for (idx, word) in words.iter().enumerate() {
+        value |= BigUint::from(*word) << (idx * 64);
+    }
+    if width > 0 {
+        value & ((BigUint::from(1u8) << width) - BigUint::from(1u8))
     } else {
-        mask & ((1u64 << width) - 1)
+        BigUint::from(0u8)
     }
 }
 
-fn relevant_value(value: u64, width: usize) -> u64 {
-    if width == 0 {
-        0
-    } else if width >= 64 {
-        value
-    } else {
-        value & ((1u64 << width) - 1)
-    }
-}
-
-fn format_runtime_arg_decimal(value: u64, mask: u64, width: usize, signed: bool) -> String {
-    if relevant_mask(mask, width) != 0 {
+fn format_runtime_arg_decimal(arg: &RuntimeEventArgValue) -> String {
+    if runtime_event_has_mask(arg) {
         return "x".to_string();
     }
-    let value = relevant_value(value, width);
-    if signed && width > 0 {
-        if width >= 64 {
-            (value as i64).to_string()
-        } else {
-            let shift = 64 - width;
-            (((value << shift) as i64) >> shift).to_string()
-        }
+    let value = runtime_event_words_to_biguint(&arg.values, arg.width);
+    if arg.signed && arg.width > 0 && runtime_event_bit(&arg.values, arg.width - 1) {
+        let modulus = BigUint::from(1u8) << arg.width;
+        format!("-{}", modulus - value)
     } else {
         value.to_string()
     }
 }
 
-fn format_runtime_arg_binary(value: u64, mask: u64, width: usize) -> String {
-    let mask = relevant_mask(mask, width);
-    let value = relevant_value(value, width);
-    if mask == 0 {
-        return format!("{value:b}");
+fn format_runtime_arg_binary(arg: &RuntimeEventArgValue) -> String {
+    if !runtime_event_has_mask(arg) {
+        return runtime_event_words_to_biguint(&arg.values, arg.width).to_str_radix(2);
     }
-    let digits = width.clamp(1, 64);
+    let digits = arg.width.max(1);
     let mut out = String::with_capacity(digits);
     for bit in (0..digits).rev() {
-        if ((mask >> bit) & 1) != 0 {
+        if runtime_event_bit(&arg.masks, bit) {
             out.push('x');
-        } else if ((value >> bit) & 1) != 0 {
+        } else if runtime_event_bit(&arg.values, bit) {
             out.push('1');
         } else {
             out.push('0');
@@ -139,68 +147,70 @@ fn format_runtime_arg_binary(value: u64, mask: u64, width: usize) -> String {
     out
 }
 
-fn format_runtime_arg_hex(value: u64, mask: u64, width: usize, upper: bool) -> String {
-    let mask = relevant_mask(mask, width);
-    let value = relevant_value(value, width);
-    if mask == 0 {
-        return if upper {
-            format!("{value:X}")
-        } else {
-            format!("{value:x}")
-        };
-    }
-    let digits = width.div_ceil(4).clamp(1, 16);
+fn format_runtime_arg_radix_with_mask(arg: &RuntimeEventArgValue, bits_per_digit: usize) -> String {
+    let digits = arg.width.div_ceil(bits_per_digit).max(1);
     let mut out = String::with_capacity(digits);
-    for nibble in (0..digits).rev() {
-        let shift = nibble * 4;
-        let nibble_mask = (mask >> shift) & 0xf;
-        if nibble_mask != 0 {
-            out.push(if upper { 'X' } else { 'x' });
-        } else {
-            let digit = ((value >> shift) & 0xf) as u8;
-            out.push(char::from_digit(digit as u32, 16).unwrap());
+    for digit_idx in (0..digits).rev() {
+        let start = digit_idx * bits_per_digit;
+        let end = (start + bits_per_digit).min(arg.width);
+        if (start..end).any(|bit| runtime_event_bit(&arg.masks, bit)) {
+            out.push('x');
+            continue;
         }
+        let mut digit = 0u32;
+        for bit in start..end {
+            if runtime_event_bit(&arg.values, bit) {
+                digit |= 1 << (bit - start);
+            }
+        }
+        out.push(char::from_digit(digit, 1 << bits_per_digit).unwrap());
     }
+    out
+}
+
+fn format_runtime_arg_hex(arg: &RuntimeEventArgValue, upper: bool) -> String {
+    let mut out = if runtime_event_has_mask(arg) {
+        format_runtime_arg_radix_with_mask(arg, 4)
+    } else {
+        runtime_event_words_to_biguint(&arg.values, arg.width).to_str_radix(16)
+    };
     if upper {
         out.make_ascii_uppercase();
     }
     out
 }
 
-fn format_runtime_arg_octal(value: u64, mask: u64, width: usize) -> String {
-    let mask = relevant_mask(mask, width);
-    let value = relevant_value(value, width);
-    if mask == 0 {
-        return format!("{value:o}");
+fn format_runtime_arg_octal(arg: &RuntimeEventArgValue) -> String {
+    if runtime_event_has_mask(arg) {
+        format_runtime_arg_radix_with_mask(arg, 3)
+    } else {
+        runtime_event_words_to_biguint(&arg.values, arg.width).to_str_radix(8)
     }
-    let digits = width.div_ceil(3).clamp(1, 22);
-    let mut out = String::with_capacity(digits);
-    for octal in (0..digits).rev() {
-        let shift = octal * 3;
-        let octal_mask = (mask >> shift) & 0x7;
-        if octal_mask != 0 {
-            out.push('x');
-        } else {
-            let digit = ((value >> shift) & 0x7) as u8;
-            out.push(char::from_digit(digit as u32, 8).unwrap());
-        }
-    }
-    out
 }
 
-fn render_runtime_event_message(site: &RuntimeEventSite, args: &[u64], masks: &[u64]) -> String {
+fn format_runtime_arg_char(arg: &RuntimeEventArgValue) -> String {
+    if runtime_event_has_mask(arg) {
+        "x".to_string()
+    } else {
+        let value = arg.values.first().copied().unwrap_or(0);
+        let value = if arg.width >= 64 {
+            value
+        } else if arg.width == 0 {
+            0
+        } else {
+            value & ((1u64 << arg.width) - 1)
+        };
+        char::from_u32(value as u32)
+            .unwrap_or('\u{fffd}')
+            .to_string()
+    }
+}
+
+fn render_runtime_event_message(site: &RuntimeEventSite, args: &[RuntimeEventArgValue]) -> String {
     let Some(template) = site.template.as_deref() else {
         return args
             .iter()
-            .enumerate()
-            .map(|(idx, arg)| {
-                format_runtime_arg_decimal(
-                    *arg,
-                    masks.get(idx).copied().unwrap_or(0),
-                    site.arg_widths.get(idx).copied().unwrap_or(64),
-                    site.arg_signed.get(idx).copied().unwrap_or(false),
-                )
-            })
+            .map(format_runtime_arg_decimal)
             .collect::<Vec<_>>()
             .join(" ");
     };
@@ -221,21 +231,26 @@ fn render_runtime_event_message(site: &RuntimeEventSite, args: &[u64], masks: &[
             chars.next();
         }
         let spec = chars.next().unwrap_or('d');
-        let value = args.get(arg_idx).copied().unwrap_or(0);
-        let mask = masks.get(arg_idx).copied().unwrap_or(0);
-        let width = site.arg_widths.get(arg_idx).copied().unwrap_or(64);
-        let signed = site.arg_signed.get(arg_idx).copied().unwrap_or(false);
+        let fallback;
+        let arg = if let Some(arg) = args.get(arg_idx) {
+            arg
+        } else {
+            fallback = RuntimeEventArgValue {
+                values: vec![0],
+                masks: vec![0],
+                width: 64,
+                signed: false,
+            };
+            &fallback
+        };
         arg_idx += 1;
         match spec {
-            'x' => out.push_str(&format_runtime_arg_hex(value, mask, width, false)),
-            'X' => out.push_str(&format_runtime_arg_hex(value, mask, width, true)),
-            'b' | 'B' => out.push_str(&format_runtime_arg_binary(value, mask, width)),
-            'o' | 'O' => out.push_str(&format_runtime_arg_octal(value, mask, width)),
-            'c' if relevant_mask(mask, width) == 0 => {
-                out.push(char::from_u32(relevant_value(value, width) as u32).unwrap_or('\u{fffd}'))
-            }
-            'c' => out.push('x'),
-            _ => out.push_str(&format_runtime_arg_decimal(value, mask, width, signed)),
+            'x' => out.push_str(&format_runtime_arg_hex(arg, false)),
+            'X' => out.push_str(&format_runtime_arg_hex(arg, true)),
+            'b' | 'B' => out.push_str(&format_runtime_arg_binary(arg)),
+            'o' | 'O' => out.push_str(&format_runtime_arg_octal(arg)),
+            'c' => out.push_str(&format_runtime_arg_char(arg)),
+            _ => out.push_str(&format_runtime_arg_decimal(arg)),
         }
     }
     out
@@ -285,11 +300,9 @@ impl<B: SimBackend> Simulator<B> {
 
     pub fn drain_runtime_events(&mut self) -> Vec<RuntimeEvent> {
         use crate::backend::memory_layout::{
-            RUNTIME_EVENT_CAPACITY, RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_MAX_ARGS,
-            RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET, RUNTIME_EVENT_SLOT_ARGS_OFFSET,
-            RUNTIME_EVENT_SLOT_MASKS_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
-            RUNTIME_EVENT_SLOT_SITE_OFFSET,
-            RUNTIME_EVENT_WRITING,
+            RUNTIME_EVENT_CAPACITY, RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET,
+            RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
+            RUNTIME_EVENT_SLOT_SITE_OFFSET, RUNTIME_EVENT_WRITING,
         };
 
         let layout = self.backend.layout();
@@ -321,20 +334,39 @@ impl<B: SimBackend> Simulator<B> {
                 break;
             }
             let site_id = read_u64(slot_base + RUNTIME_EVENT_SLOT_SITE_OFFSET) as usize;
-            let arg_count = (read_u64(slot_base + RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET) as usize)
-                .min(RUNTIME_EVENT_MAX_ARGS);
-            let mut args = Vec::with_capacity(arg_count);
-            for idx in 0..arg_count {
-                args.push(read_u64(slot_base + RUNTIME_EVENT_SLOT_ARGS_OFFSET + idx * 8));
-            }
-            let mut masks = Vec::with_capacity(arg_count);
-            for idx in 0..arg_count {
-                masks.push(read_u64(
-                    slot_base + RUNTIME_EVENT_SLOT_MASKS_OFFSET + idx * 8,
-                ));
-            }
             if let Some(site) = self.program.runtime_event_sites.get(site_id) {
-                let message = render_runtime_event_message(site, &args, &masks);
+                let site_layout = layout.runtime_event_site_layouts.get(site_id);
+                let arg_count = read_u64(slot_base + RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET) as usize;
+                let arg_count = arg_count.min(site.arg_widths.len());
+                let mut args = Vec::with_capacity(arg_count);
+                if let Some(site_layout) = site_layout {
+                    for idx in 0..arg_count {
+                        let Some(arg_layout) = site_layout.args.get(idx) else {
+                            break;
+                        };
+                        let mut values = Vec::with_capacity(arg_layout.word_count);
+                        let mut masks = Vec::with_capacity(arg_layout.word_count);
+                        for word_idx in 0..arg_layout.word_count {
+                            values.push(read_u64(
+                                slot_base
+                                    + RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
+                                    + (arg_layout.value_word_offset + word_idx) * 8,
+                            ));
+                            masks.push(read_u64(
+                                slot_base
+                                    + RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
+                                    + (arg_layout.mask_word_offset + word_idx) * 8,
+                            ));
+                        }
+                        args.push(RuntimeEventArgValue {
+                            values,
+                            masks,
+                            width: site.arg_widths.get(idx).copied().unwrap_or(64),
+                            signed: site.arg_signed.get(idx).copied().unwrap_or(false),
+                        });
+                    }
+                }
+                let message = render_runtime_event_message(site, &args);
                 events.push(match site.kind {
                     RuntimeEventKind::Display => RuntimeEvent::Display { message },
                     RuntimeEventKind::AssertContinue => RuntimeEvent::AssertContinue { message },

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -306,15 +306,14 @@ impl<B: SimBackend> Simulator<B> {
         };
 
         let layout = self.backend.layout();
-        let (ptr, size) = self.backend.memory_as_ptr();
-        let base = layout.runtime_event_base_offset;
-        if base + RUNTIME_EVENT_HEADER_SIZE > size {
+        let (ptr, size) = self.backend.runtime_event_buffer_as_ptr();
+        if RUNTIME_EVENT_HEADER_SIZE > size {
             return Vec::new();
         }
         let read_u64 = |offset: usize| -> u64 {
             unsafe { std::ptr::read_volatile(ptr.add(offset) as *const u64) }
         };
-        let write_seq = read_u64(base);
+        let write_seq = read_u64(0);
         let mut events = Vec::new();
         let capacity = RUNTIME_EVENT_CAPACITY as u64;
         if self.runtime_event_read_seq + capacity < write_seq {
@@ -327,8 +326,7 @@ impl<B: SimBackend> Simulator<B> {
         while self.runtime_event_read_seq < write_seq {
             let seq = self.runtime_event_read_seq;
             let slot = (seq as usize) & (layout.runtime_event_capacity - 1);
-            let slot_base =
-                base + RUNTIME_EVENT_HEADER_SIZE + slot * layout.runtime_event_slot_size;
+            let slot_base = RUNTIME_EVENT_HEADER_SIZE + slot * layout.runtime_event_slot_size;
             let published = read_u64(slot_base + RUNTIME_EVENT_SLOT_SEQ_OFFSET);
             if published == RUNTIME_EVENT_WRITING || published != seq {
                 break;

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -9,6 +9,7 @@ use crate::backend::native::{NativeBackend, SharedNativeCode};
 use crate::{
     IOContext, RuntimeErrorCode,
     backend::{JitBackend, MemoryLayout, SharedJitCode, SimBackend},
+    display_format::{DisplayFormatArg, format_display_arg},
     ir::{InstancePath, Program, RuntimeEventKind, RuntimeEventSite, SignalRef, VariableInfo},
 };
 use num_bigint::BigUint;
@@ -110,22 +111,6 @@ struct RuntimeEventArgValue {
     signed: bool,
 }
 
-fn runtime_event_bit(words: &[u64], bit: usize) -> bool {
-    words
-        .get(bit / 64)
-        .map(|word| ((word >> (bit % 64)) & 1) != 0)
-        .unwrap_or(false)
-}
-
-fn runtime_event_has_mask(arg: &RuntimeEventArgValue) -> bool {
-    for bit in 0..arg.width {
-        if runtime_event_bit(&arg.masks, bit) {
-            return true;
-        }
-    }
-    false
-}
-
 fn runtime_event_words_to_biguint(words: &[u64], width: usize) -> BigUint {
     let mut value = BigUint::from(0u8);
     for (idx, word) in words.iter().enumerate() {
@@ -138,101 +123,26 @@ fn runtime_event_words_to_biguint(words: &[u64], width: usize) -> BigUint {
     }
 }
 
-fn format_runtime_arg_decimal(arg: &RuntimeEventArgValue) -> String {
-    if runtime_event_has_mask(arg) {
-        return "x".to_string();
-    }
+fn runtime_event_format_arg(arg: &RuntimeEventArgValue, spec: Option<char>) -> String {
     let value = runtime_event_words_to_biguint(&arg.values, arg.width);
-    if arg.signed && arg.width > 0 && runtime_event_bit(&arg.values, arg.width - 1) {
-        let modulus = BigUint::from(1u8) << arg.width;
-        format!("-{}", modulus - value)
-    } else {
-        value.to_string()
-    }
-}
-
-fn format_runtime_arg_binary(arg: &RuntimeEventArgValue) -> String {
-    if !runtime_event_has_mask(arg) {
-        return runtime_event_words_to_biguint(&arg.values, arg.width).to_str_radix(2);
-    }
-    let digits = arg.width.max(1);
-    let mut out = String::with_capacity(digits);
-    for bit in (0..digits).rev() {
-        if runtime_event_bit(&arg.masks, bit) {
-            out.push('x');
-        } else if runtime_event_bit(&arg.values, bit) {
-            out.push('1');
-        } else {
-            out.push('0');
-        }
-    }
-    out
-}
-
-fn format_runtime_arg_radix_with_mask(arg: &RuntimeEventArgValue, bits_per_digit: usize) -> String {
-    let digits = arg.width.div_ceil(bits_per_digit).max(1);
-    let mut out = String::with_capacity(digits);
-    for digit_idx in (0..digits).rev() {
-        let start = digit_idx * bits_per_digit;
-        let end = (start + bits_per_digit).min(arg.width);
-        if (start..end).any(|bit| runtime_event_bit(&arg.masks, bit)) {
-            out.push('x');
-            continue;
-        }
-        let mut digit = 0u32;
-        for bit in start..end {
-            if runtime_event_bit(&arg.values, bit) {
-                digit |= 1 << (bit - start);
-            }
-        }
-        out.push(char::from_digit(digit, 1 << bits_per_digit).unwrap());
-    }
-    out
-}
-
-fn format_runtime_arg_hex(arg: &RuntimeEventArgValue, upper: bool) -> String {
-    let mut out = if runtime_event_has_mask(arg) {
-        format_runtime_arg_radix_with_mask(arg, 4)
-    } else {
-        runtime_event_words_to_biguint(&arg.values, arg.width).to_str_radix(16)
-    };
-    if upper {
-        out.make_ascii_uppercase();
-    }
-    out
-}
-
-fn format_runtime_arg_octal(arg: &RuntimeEventArgValue) -> String {
-    if runtime_event_has_mask(arg) {
-        format_runtime_arg_radix_with_mask(arg, 3)
-    } else {
-        runtime_event_words_to_biguint(&arg.values, arg.width).to_str_radix(8)
-    }
-}
-
-fn format_runtime_arg_char(arg: &RuntimeEventArgValue) -> String {
-    if runtime_event_has_mask(arg) {
-        "x".to_string()
-    } else {
-        let value = arg.values.first().copied().unwrap_or(0);
-        let value = if arg.width >= 64 {
-            value
-        } else if arg.width == 0 {
-            0
-        } else {
-            value & ((1u64 << arg.width) - 1)
-        };
-        char::from_u32(value as u32)
-            .unwrap_or('\u{fffd}')
-            .to_string()
-    }
+    let mask = runtime_event_words_to_biguint(&arg.masks, arg.width);
+    format_display_arg(
+        &DisplayFormatArg {
+            value: &value,
+            mask: Some(&mask),
+            width: arg.width,
+            signed: arg.signed,
+            is_string: false,
+        },
+        spec,
+    )
 }
 
 fn render_runtime_event_message(site: &RuntimeEventSite, args: &[RuntimeEventArgValue]) -> String {
     let Some(template) = site.template.as_deref() else {
         return args
             .iter()
-            .map(format_runtime_arg_decimal)
+            .map(|arg| runtime_event_format_arg(arg, Some('d')))
             .collect::<Vec<_>>()
             .join(" ");
     };
@@ -267,12 +177,10 @@ fn render_runtime_event_message(site: &RuntimeEventSite, args: &[RuntimeEventArg
         };
         arg_idx += 1;
         match spec {
-            'x' => out.push_str(&format_runtime_arg_hex(arg, false)),
-            'X' => out.push_str(&format_runtime_arg_hex(arg, true)),
-            'b' | 'B' => out.push_str(&format_runtime_arg_binary(arg)),
-            'o' | 'O' => out.push_str(&format_runtime_arg_octal(arg)),
-            'c' => out.push_str(&format_runtime_arg_char(arg)),
-            _ => out.push_str(&format_runtime_arg_decimal(arg)),
+            'x' | 'h' | 'X' | 'H' | 'b' | 'B' | 'o' | 'O' | 'c' | 'C' | 's' | 'S' => {
+                out.push_str(&runtime_event_format_arg(arg, Some(spec)));
+            }
+            _ => out.push_str(&runtime_event_format_arg(arg, Some('d'))),
         }
     }
     out

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -12,6 +12,7 @@ use crate::{
     display_format::{DisplayFormatArg, format_display_arg},
     ir::{InstancePath, Program, RuntimeEventKind, RuntimeEventSite, SignalRef, VariableInfo},
 };
+#[cfg(not(target_arch = "wasm32"))]
 use num_bigint::BigUint;
 
 mod builder;
@@ -69,6 +70,7 @@ pub struct Simulator<B: SimBackend = crate::DefaultBackend> {
     runtime_event_read_seq: u64,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuntimeEvent {
     Display { message: String },
@@ -104,6 +106,7 @@ impl<B: SimBackend> std::fmt::Debug for Simulator<B> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 struct RuntimeEventArgValue {
     values: Vec<u64>,
     masks: Vec<u64>,
@@ -111,6 +114,7 @@ struct RuntimeEventArgValue {
     signed: bool,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn runtime_event_words_to_biguint(words: &[u64], width: usize) -> BigUint {
     let mut value = BigUint::from(0u8);
     for (idx, word) in words.iter().enumerate() {
@@ -123,6 +127,7 @@ fn runtime_event_words_to_biguint(words: &[u64], width: usize) -> BigUint {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn runtime_event_format_arg(arg: &RuntimeEventArgValue, spec: Option<char>) -> String {
     let value = runtime_event_words_to_biguint(&arg.values, arg.width);
     let mask = runtime_event_words_to_biguint(&arg.masks, arg.width);
@@ -138,6 +143,7 @@ fn runtime_event_format_arg(arg: &RuntimeEventArgValue, spec: Option<char>) -> S
     )
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn render_runtime_event_message(site: &RuntimeEventSite, args: &[RuntimeEventArgValue]) -> String {
     let Some(template) = site.template.as_deref() else {
         return args

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -7,6 +7,7 @@
 
 use crate::backend::get_byte_size;
 use crate::backend::traits::SimBackend;
+use crate::display_format::{DisplayFormatArg, format_display_arg};
 use crate::ir::{AbsoluteAddr, SignalRef};
 use crate::simulator::Simulator;
 use num_bigint::{BigInt, BigUint, Sign};
@@ -435,72 +436,19 @@ fn compile_assert_message<B: SimBackend>(
     }
 }
 
-fn tb_value_to_utf8(value: &TbValue, width: usize) -> Option<String> {
-    if !width.is_multiple_of(8) {
-        return None;
-    }
-    let num_bytes = width / 8;
-    let mut bytes = vec![0u8; num_bytes];
-    match value {
-        TbValue::U64(v) => {
-            let mut payload = *v;
-            for i in (0..num_bytes).rev() {
-                bytes[i] = (payload & 0xff) as u8;
-                payload >>= 8;
-            }
-        }
-        TbValue::Wide(v) => {
-            let mut payload = v.clone();
-            let mask = BigUint::from(0xffu64);
-            for i in (0..num_bytes).rev() {
-                bytes[i] = (&payload & &mask).to_u64().unwrap_or(0) as u8;
-                payload >>= 8;
-            }
-        }
-    }
-    String::from_utf8(bytes).ok()
-}
-
-fn tb_value_to_signed_bigint(value: &TbValue, width: usize) -> BigInt {
-    if width == 0 {
-        return BigInt::from(0);
-    }
-    let unsigned = value.to_biguint();
-    let sign_bit = BigUint::from(1u8) << (width - 1);
-    if (&unsigned & &sign_bit) != BigUint::ZERO {
-        BigInt::from_biguint(Sign::Plus, unsigned) - (BigInt::from(1u8) << width)
-    } else {
-        BigInt::from_biguint(Sign::Plus, unsigned)
-    }
-}
-
 fn format_assert_arg(arg: &CompiledAssertArg, memory: *mut u8, spec: Option<char>) -> String {
     let value = arg.expr.eval_value(memory);
-    if arg.is_string {
-        return tb_value_to_utf8(&value, arg.width).unwrap_or_else(|| format!("{:?}", value));
-    }
-    match spec.unwrap_or('d') {
-        'b' | 'B' => format!("{:b}", value.to_biguint()),
-        'o' | 'O' => format!("{:o}", value.to_biguint()),
-        'x' | 'h' => format!("{:x}", value.to_biguint()),
-        'X' | 'H' => format!("{:X}", value.to_biguint()),
-        'd' | 'D' | 'i' | 'I' => {
-            if arg.signed {
-                tb_value_to_signed_bigint(&value, arg.width).to_string()
-            } else {
-                value.to_biguint().to_string()
-            }
-        }
-        'c' | 'C' => char::from((value.to_u64() & 0xff) as u8).to_string(),
-        's' | 'S' => tb_value_to_utf8(&value, arg.width).unwrap_or_else(|| format!("{:?}", value)),
-        _ => {
-            if arg.signed {
-                tb_value_to_signed_bigint(&value, arg.width).to_string()
-            } else {
-                value.to_biguint().to_string()
-            }
-        }
-    }
+    let value = value.to_biguint();
+    format_display_arg(
+        &DisplayFormatArg {
+            value: &value,
+            mask: None,
+            width: arg.width,
+            signed: arg.signed,
+            is_string: arg.is_string,
+        },
+        spec,
+    )
 }
 
 fn render_assert_message(

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -43,6 +43,63 @@ fn test_ff_nonblocking(sim) {
     assert_eq!(sim.get(q), 0x11111111u32.into());
 }
 
+fn test_ff_runtime_display_and_assert_continue(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @setup { let code = r#"
+        module Top (clk: input clock, a: input logic<8>, q: output logic<8>) {
+            always_ff (clk) {
+                q = a;
+                $display("a=%0d", a);
+                $assert_continue(a != 8'd3, "bad a=%0d", a);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let a = sim.signal("a");
+
+    sim.modify(|io| io.set(a, 3u8)).unwrap();
+    sim.tick(clk).unwrap();
+    let events = sim.drain_runtime_events();
+    assert_eq!(
+        events,
+        vec![
+            celox::RuntimeEvent::Display {
+                message: "a=3".to_string(),
+            },
+            celox::RuntimeEvent::AssertContinue {
+                message: "bad a=3".to_string(),
+            },
+        ],
+    );
+}
+
+fn test_ff_runtime_fatal_assert_records_event(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @setup { let code = r#"
+        module Top (clk: input clock, a: input logic<8>) {
+            always_ff (clk) {
+                $assert(a != 8'd7, "fatal a=%0d", a);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let a = sim.signal("a");
+
+    sim.modify(|io| io.set(a, 7u8)).unwrap();
+    assert!(sim.tick(clk).is_err());
+    let events = sim.drain_runtime_events();
+    assert_eq!(
+        events,
+        vec![celox::RuntimeEvent::AssertFatal {
+            message: "fatal a=7".to_string(),
+        }],
+    );
+}
+
 fn test_ff_runtime_for_bounds(sim) {
     @setup { let code = r#"
         module Top (

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -109,6 +109,79 @@ fn test_ff_runtime_events_preserve_four_state_args(sim) {
     );
 }
 
+fn test_ff_runtime_events_support_design_sized_arg_count(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            a: input logic<8>,
+            b: input logic<8>,
+            c: input logic<8>,
+            d: input logic<8>,
+            e: input logic<8>
+        ) {
+            always_ff (clk) {
+                $display("%0d %0d %0d %0d %0d", a, b, c, d, e);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let a = sim.signal("a");
+    let b = sim.signal("b");
+    let c = sim.signal("c");
+    let d = sim.signal("d");
+    let e = sim.signal("e");
+
+    sim.modify(|io| {
+        io.set(a, 1u8);
+        io.set(b, 2u8);
+        io.set(c, 3u8);
+        io.set(d, 4u8);
+        io.set(e, 5u8);
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "1 2 3 4 5".to_string(),
+        }],
+    );
+}
+
+fn test_ff_runtime_events_support_wide_four_state_args(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @setup { let code = r#"
+        module Top (clk: input clock, a: input logic<80>) {
+            always_ff (clk) {
+                $display("a=%x dec=%0d", a, a);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top").four_state(true);
+    let clk = sim.event("clk");
+    let a = sim.signal("a");
+
+    sim.modify(|io| {
+        io.set_four_state(
+            a,
+            BigUint::parse_bytes(b"123456789abcdef01234", 16).unwrap(),
+            BigUint::from(0x0fu32),
+        )
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "a=123456789abcdef0123x dec=x".to_string(),
+        }],
+    );
+}
+
 fn test_ff_runtime_fatal_assert_records_event(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -75,6 +75,40 @@ fn test_ff_runtime_display_and_assert_continue(sim) {
     );
 }
 
+fn test_ff_runtime_events_preserve_four_state_args(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @setup { let code = r#"
+        module Top (clk: input clock, a: input logic<4>) {
+            always_ff (clk) {
+                $display("a=%b hex=%x dec=%0d", a, a, a);
+                $assert_continue(1'b0, "bad=%b", a);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top").four_state(true);
+    let clk = sim.event("clk");
+    let a = sim.signal("a");
+
+    sim.modify(|io| {
+        io.set_four_state(a, BigUint::from(0b1010u32), BigUint::from(0b0100u32))
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+    let events = sim.drain_runtime_events();
+    assert_eq!(
+        events,
+        vec![
+            celox::RuntimeEvent::Display {
+                message: "a=1x10 hex=x dec=x".to_string(),
+            },
+            celox::RuntimeEvent::AssertContinue {
+                message: "bad=1x10".to_string(),
+            },
+        ],
+    );
+}
+
 fn test_ff_runtime_fatal_assert_records_event(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -75,6 +75,30 @@ fn test_ff_runtime_display_and_assert_continue(sim) {
     );
 }
 
+fn test_ff_runtime_events_format_verilog_radices(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @setup { let code = r#"
+        module Top (clk: input clock, a: input logic<8>) {
+            always_ff (clk) {
+                $display("bin=%b hex=%h HEX=%H", a, a, a);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let a = sim.signal("a");
+
+    sim.modify(|io| io.set(a, 0x2au8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "bin=00101010 hex=2a HEX=2A".to_string(),
+        }],
+    );
+}
+
 fn test_ff_runtime_events_preserve_four_state_args(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -182,6 +182,61 @@ fn test_ff_runtime_events_support_wide_four_state_args(sim) {
     );
 }
 
+fn test_ff_runtime_event_drain_handle_can_run_during_simulation(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @setup { let code = r#"
+        module Top (clk: input clock, a: input logic<16>) {
+            always_ff (clk) {
+                $display("a=%0d", a);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let a = sim.signal("a");
+    let mut drain = sim.runtime_event_drain().expect("runtime event drain handle");
+    let done = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let drained = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let drain_thread = {
+        let done = std::sync::Arc::clone(&done);
+        let drained = std::sync::Arc::clone(&drained);
+        std::thread::spawn(move || {
+            while !done.load(std::sync::atomic::Ordering::Acquire) {
+                let events = drain.drain();
+                if !events.is_empty() {
+                    drained.lock().unwrap().extend(events);
+                }
+                std::thread::yield_now();
+            }
+            drained.lock().unwrap().extend(drain.drain());
+        })
+    };
+
+    for value in 0..128u16 {
+        sim.modify(|io| io.set(a, value)).unwrap();
+        sim.tick(clk).unwrap();
+    }
+    done.store(true, std::sync::atomic::Ordering::Release);
+    drain_thread.join().unwrap();
+
+    let events = std::sync::Arc::try_unwrap(drained)
+        .unwrap()
+        .into_inner()
+        .unwrap();
+    let messages = events
+        .into_iter()
+        .map(|event| match event {
+            celox::RuntimeEvent::Display { message } => message,
+            other => panic!("unexpected runtime event: {other:?}"),
+        })
+        .collect::<Vec<_>>();
+    let expected = (0..128u16)
+        .map(|value| format!("a={value}"))
+        .collect::<Vec<_>>();
+    assert_eq!(messages, expected);
+}
+
 fn test_ff_runtime_fatal_assert_records_event(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -1244,6 +1244,26 @@ fn test_assert_format_args_render_uppercase_aliases_like_lowercase() {
 }
 
 #[test]
+fn test_assert_format_args_preserve_binary_width_and_hex_alias() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            initial {
+                $assert_continue(1'b0, "bin=%b hex=%h", 8'd1, 8'h2a);
+                $finish();
+            }
+        }
+    "#;
+    let detailed = Simulator::builder(code, "t").run_test_detailed().unwrap();
+    assert!(!detailed.passed);
+    assert_eq!(detailed.assertions.len(), 1);
+    assert_eq!(
+        detailed.assertions[0].message.as_deref(),
+        Some("bin=00000001 hex=2a")
+    );
+}
+
+#[test]
 fn test_run_test_detailed_collects_multiple_plain_assert_failures() {
     let code = r#"
         #[test(t)]

--- a/crates/celox/tests/snapshots/native_mir__high_pressure_comb_mir.snap
+++ b/crates/celox/tests/snapshots/native_mir__high_pressure_comb_mir.snap
@@ -1,40 +1,41 @@
 ---
 source: crates/celox/tests/native_mir.rs
+assertion_line: 33
 expression: output
 ---
 === MIR (eval_comb) ===
 Execution Unit 0 (before regalloc):
 bb0:
-  v0 = load.i32 [sim + 0]
-  v10 = load.i32 [sim + 44]
-  v30 = load.i32 [sim + 20]
-  v19 = load.i32 [sim + 64]
-  v8 = load.i32 [sim + 40]
-  v28 = load.i32 [sim + 16]
-  v17 = load.i32 [sim + 60]
-  v6 = load.i32 [sim + 36]
+  v0 = load.i32 [sim + 8]
+  v10 = load.i32 [sim + 52]
+  v30 = load.i32 [sim + 28]
+  v19 = load.i32 [sim + 72]
+  v8 = load.i32 [sim + 48]
+  v28 = load.i32 [sim + 24]
+  v17 = load.i32 [sim + 68]
+  v6 = load.i32 [sim + 44]
   v31 = add v0, v10
   v20 = and v31, 0xffffffff
-  v26 = load.i32 [sim + 12]
-  v15 = load.i32 [sim + 56]
+  v26 = load.i32 [sim + 20]
+  v15 = load.i32 [sim + 64]
   v32 = add v20, v30
   v9 = and v32, 0xffffffff
-  v4 = load.i32 [sim + 32]
+  v4 = load.i32 [sim + 40]
   v33 = add v9, v19
   v29 = and v33, 0xffffffff
-  v24 = load.i32 [sim + 8]
+  v24 = load.i32 [sim + 16]
   v34 = add v29, v8
   v18 = and v34, 0xffffffff
-  v13 = load.i32 [sim + 52]
+  v13 = load.i32 [sim + 60]
   v35 = add v18, v28
   v7 = and v35, 0xffffffff
-  v2 = load.i32 [sim + 28]
+  v2 = load.i32 [sim + 36]
   v36 = add v7, v17
   v27 = and v36, 0xffffffff
-  v22 = load.i32 [sim + 4]
+  v22 = load.i32 [sim + 12]
   v37 = add v27, v6
   v16 = and v37, 0xffffffff
-  v11 = load.i32 [sim + 48]
+  v11 = load.i32 [sim + 56]
   v38 = add v16, v26
   v5 = and v38, 0xffffffff
   v39 = add v5, v15
@@ -51,41 +52,41 @@ bb0:
   v1 = and v44, 0xffffffff
   v45 = add v1, v11
   v21 = and v45, 0xffffffff
-  store.i32 [sim + 24], v21
+  store.i32 [sim + 32], v21
   ret
 
 Execution Unit 0 (after regalloc):
 bb0:
-  v0 = load.i32 [sim + 0]
-  v10 = load.i32 [sim + 44]
-  v30 = load.i32 [sim + 20]
-  v19 = load.i32 [sim + 64]
-  v8 = load.i32 [sim + 40]
-  v28 = load.i32 [sim + 16]
-  v17 = load.i32 [sim + 60]
-  v6 = load.i32 [sim + 36]
+  v0 = load.i32 [sim + 8]
+  v10 = load.i32 [sim + 52]
+  v30 = load.i32 [sim + 28]
+  v19 = load.i32 [sim + 72]
+  v8 = load.i32 [sim + 48]
+  v28 = load.i32 [sim + 24]
+  v17 = load.i32 [sim + 68]
+  v6 = load.i32 [sim + 44]
   v31 = add v0, v10
   v20 = and v31, 0xffffffff
-  v26 = load.i32 [sim + 12]
-  v15 = load.i32 [sim + 56]
+  v26 = load.i32 [sim + 20]
+  v15 = load.i32 [sim + 64]
   v32 = add v20, v30
   v9 = and v32, 0xffffffff
-  v4 = load.i32 [sim + 32]
+  v4 = load.i32 [sim + 40]
   v33 = add v9, v19
   v29 = and v33, 0xffffffff
-  v24 = load.i32 [sim + 8]
+  v24 = load.i32 [sim + 16]
   v34 = add v29, v8
   v18 = and v34, 0xffffffff
-  v13 = load.i32 [sim + 52]
+  v13 = load.i32 [sim + 60]
   v35 = add v18, v28
   v7 = and v35, 0xffffffff
-  v2 = load.i32 [sim + 28]
+  v2 = load.i32 [sim + 36]
   v36 = add v7, v17
   v27 = and v36, 0xffffffff
-  v22 = load.i32 [sim + 4]
+  v22 = load.i32 [sim + 12]
   v37 = add v27, v6
   v16 = and v37, 0xffffffff
-  v11 = load.i32 [sim + 48]
+  v11 = load.i32 [sim + 56]
   v38 = add v16, v26
   v5 = and v38, 0xffffffff
   v39 = add v5, v15
@@ -102,7 +103,7 @@ bb0:
   v1 = and v44, 0xffffffff
   v45 = add v1, v11
   v21 = and v45, 0xffffffff
-  store.i32 [sim + 24], v21
+  store.i32 [sim + 32], v21
   ret
   Register assignment:
     v0 -> rax
@@ -155,55 +156,55 @@ bb0:
   0x00000000  push r15
   0x00000002  sub rsp,8
   0x00000006  mov r15,rdi
-  0x00000009  mov eax,[r15]
-  0x0000000c  mov edx,[r15+2Ch]
-  0x00000010  mov esi,[r15+14h]
-  0x00000014  mov edi,[r15+40h]
-  0x00000018  mov r8d,[r15+28h]
-  0x0000001c  mov r9d,[r15+10h]
-  0x00000020  mov r10d,[r15+3Ch]
-  0x00000024  mov r11d,[r15+24h]
-  0x00000028  add rax,rdx
-  0x0000002b  and eax,0FFFFFFFFh
-  0x00000030  mov edx,[r15+0Ch]
-  0x00000034  mov ecx,[r15+38h]
-  0x00000038  add rax,rsi
-  0x0000003b  and eax,0FFFFFFFFh
-  0x00000040  mov esi,[r15+20h]
-  0x00000044  add rax,rdi
-  0x00000047  and eax,0FFFFFFFFh
-  0x0000004c  mov edi,[r15+8]
-  0x00000050  add rax,r8
-  0x00000053  and eax,0FFFFFFFFh
-  0x00000058  mov r8d,[r15+34h]
-  0x0000005c  add rax,r9
-  0x0000005f  and eax,0FFFFFFFFh
-  0x00000064  mov r9d,[r15+1Ch]
-  0x00000068  add rax,r10
-  0x0000006b  and eax,0FFFFFFFFh
-  0x00000070  mov r10d,[r15+4]
-  0x00000074  add rax,r11
-  0x00000077  and eax,0FFFFFFFFh
-  0x0000007c  mov r11d,[r15+30h]
-  0x00000080  add rax,rdx
-  0x00000083  and eax,0FFFFFFFFh
-  0x00000088  add rax,rcx
-  0x0000008b  and eax,0FFFFFFFFh
-  0x00000090  add rax,rsi
-  0x00000093  and eax,0FFFFFFFFh
-  0x00000098  add rax,rdi
-  0x0000009b  and eax,0FFFFFFFFh
-  0x000000a0  add rax,r8
-  0x000000a3  and eax,0FFFFFFFFh
-  0x000000a8  add rax,r9
-  0x000000ab  and eax,0FFFFFFFFh
-  0x000000b0  add rax,r10
-  0x000000b3  and eax,0FFFFFFFFh
-  0x000000b8  add rax,r11
-  0x000000bb  and eax,0FFFFFFFFh
-  0x000000c0  mov [r15+18h],eax
-  0x000000c4  xor eax,eax
-  0x000000c6  jmp short 00000000000000C8h
-  0x000000c8  add rsp,8
-  0x000000cc  pop r15
-  0x000000ce  ret
+  0x00000009  mov eax,[r15+8]
+  0x0000000d  mov edx,[r15+34h]
+  0x00000011  mov esi,[r15+1Ch]
+  0x00000015  mov edi,[r15+48h]
+  0x00000019  mov r8d,[r15+30h]
+  0x0000001d  mov r9d,[r15+18h]
+  0x00000021  mov r10d,[r15+44h]
+  0x00000025  mov r11d,[r15+2Ch]
+  0x00000029  add rax,rdx
+  0x0000002c  and eax,0FFFFFFFFh
+  0x00000031  mov edx,[r15+14h]
+  0x00000035  mov ecx,[r15+40h]
+  0x00000039  add rax,rsi
+  0x0000003c  and eax,0FFFFFFFFh
+  0x00000041  mov esi,[r15+28h]
+  0x00000045  add rax,rdi
+  0x00000048  and eax,0FFFFFFFFh
+  0x0000004d  mov edi,[r15+10h]
+  0x00000051  add rax,r8
+  0x00000054  and eax,0FFFFFFFFh
+  0x00000059  mov r8d,[r15+3Ch]
+  0x0000005d  add rax,r9
+  0x00000060  and eax,0FFFFFFFFh
+  0x00000065  mov r9d,[r15+24h]
+  0x00000069  add rax,r10
+  0x0000006c  and eax,0FFFFFFFFh
+  0x00000071  mov r10d,[r15+0Ch]
+  0x00000075  add rax,r11
+  0x00000078  and eax,0FFFFFFFFh
+  0x0000007d  mov r11d,[r15+38h]
+  0x00000081  add rax,rdx
+  0x00000084  and eax,0FFFFFFFFh
+  0x00000089  add rax,rcx
+  0x0000008c  and eax,0FFFFFFFFh
+  0x00000091  add rax,rsi
+  0x00000094  and eax,0FFFFFFFFh
+  0x00000099  add rax,rdi
+  0x0000009c  and eax,0FFFFFFFFh
+  0x000000a1  add rax,r8
+  0x000000a4  and eax,0FFFFFFFFh
+  0x000000a9  add rax,r9
+  0x000000ac  and eax,0FFFFFFFFh
+  0x000000b1  add rax,r10
+  0x000000b4  and eax,0FFFFFFFFh
+  0x000000b9  add rax,r11
+  0x000000bc  and eax,0FFFFFFFFh
+  0x000000c1  mov [r15+20h],eax
+  0x000000c5  xor eax,eax
+  0x000000c7  jmp short 00000000000000C9h
+  0x000000c9  add rsp,8
+  0x000000cd  pop r15
+  0x000000cf  ret

--- a/crates/celox/tests/snapshots/native_mir__large_comb_pressure_mir.snap
+++ b/crates/celox/tests/snapshots/native_mir__large_comb_pressure_mir.snap
@@ -1,41 +1,42 @@
 ---
 source: crates/celox/tests/native_mir.rs
+assertion_line: 69
 expression: output
 ---
 === MIR (eval_comb) ===
 Execution Unit 0 (before regalloc):
 bb0:
-  v0 = load.i32 [sim + 0]
-  v10 = load.i32 [sim + 56]
-  v30 = load.i32 [sim + 108]
-  v50 = load.i32 [sim + 160]
-  v9 = load.i32 [sim + 52]
-  v29 = load.i32 [sim + 104]
-  v49 = load.i32 [sim + 156]
-  v8 = load.i32 [sim + 48]
+  v0 = load.i32 [sim + 8]
+  v10 = load.i32 [sim + 64]
+  v30 = load.i32 [sim + 116]
+  v50 = load.i32 [sim + 168]
+  v9 = load.i32 [sim + 60]
+  v29 = load.i32 [sim + 112]
+  v49 = load.i32 [sim + 164]
+  v8 = load.i32 [sim + 56]
   v20 = xor v0, v10
-  v28 = load.i32 [sim + 100]
-  v48 = load.i32 [sim + 152]
+  v28 = load.i32 [sim + 108]
+  v48 = load.i32 [sim + 160]
   v40 = xor v20, v30
-  v7 = load.i32 [sim + 44]
+  v7 = load.i32 [sim + 52]
   v59 = xor v40, v50
-  v27 = load.i32 [sim + 96]
+  v27 = load.i32 [sim + 104]
   v19 = xor v59, v9
-  v47 = load.i32 [sim + 148]
+  v47 = load.i32 [sim + 156]
   v39 = xor v19, v29
-  v6 = load.i32 [sim + 40]
+  v6 = load.i32 [sim + 48]
   v58 = xor v39, v49
-  v26 = load.i32 [sim + 92]
+  v26 = load.i32 [sim + 100]
   v18 = xor v58, v8
-  v46 = load.i32 [sim + 144]
+  v46 = load.i32 [sim + 152]
   v38 = xor v18, v28
-  v5 = load.i32 [sim + 36]
+  v5 = load.i32 [sim + 44]
   v57 = xor v38, v48
-  v25 = load.i32 [sim + 88]
+  v25 = load.i32 [sim + 96]
   v17 = xor v57, v7
-  v45 = load.i32 [sim + 140]
+  v45 = load.i32 [sim + 148]
   v37 = xor v17, v27
-  v4 = load.i32 [sim + 32]
+  v4 = load.i32 [sim + 40]
   v56 = xor v37, v47
   v16 = xor v56, v6
   v36 = xor v16, v26
@@ -44,110 +45,110 @@ bb0:
   v35 = xor v15, v25
   v54 = xor v35, v45
   v14 = xor v54, v4
-  store.i32 [sim + 4], v14
+  store.i32 [sim + 12], v14
   v60 = add v14, v0
   v34 = and v60, 0xffffffff
-  store.i32 [sim + 84], v34
+  store.i32 [sim + 92], v34
   v61 = add v14, v10
   v44 = and v61, 0xffffffff
-  store.i32 [sim + 136], v44
+  store.i32 [sim + 144], v44
   v62 = add v14, v30
   v53 = and v62, 0xffffffff
-  store.i32 [sim + 28], v53
+  store.i32 [sim + 36], v53
   v63 = add v14, v50
   v3 = and v63, 0xffffffff
-  store.i32 [sim + 80], v3
+  store.i32 [sim + 88], v3
   v64 = add v14, v9
   v13 = and v64, 0xffffffff
-  store.i32 [sim + 132], v13
+  store.i32 [sim + 140], v13
   v65 = add v14, v29
   v23 = and v65, 0xffffffff
-  store.i32 [sim + 24], v23
+  store.i32 [sim + 32], v23
   v66 = add v14, v49
   v33 = and v66, 0xffffffff
-  store.i32 [sim + 76], v33
+  store.i32 [sim + 84], v33
   v67 = add v14, v8
   v43 = and v67, 0xffffffff
-  store.i32 [sim + 128], v43
+  store.i32 [sim + 136], v43
   v68 = add v14, v28
   v52 = and v68, 0xffffffff
-  store.i32 [sim + 20], v52
+  store.i32 [sim + 28], v52
   v69 = add v14, v48
   v2 = and v69, 0xffffffff
-  store.i32 [sim + 72], v2
+  store.i32 [sim + 80], v2
   v70 = add v14, v7
   v12 = and v70, 0xffffffff
-  store.i32 [sim + 124], v12
+  store.i32 [sim + 132], v12
   v71 = add v14, v27
   v22 = and v71, 0xffffffff
-  store.i32 [sim + 16], v22
+  store.i32 [sim + 24], v22
   v72 = add v14, v47
   v32 = and v72, 0xffffffff
-  store.i32 [sim + 68], v32
+  store.i32 [sim + 76], v32
   v73 = add v14, v6
   v42 = and v73, 0xffffffff
-  store.i32 [sim + 120], v42
+  store.i32 [sim + 128], v42
   v74 = add v14, v26
   v51 = and v74, 0xffffffff
-  store.i32 [sim + 12], v51
+  store.i32 [sim + 20], v51
   v75 = add v14, v46
   v1 = and v75, 0xffffffff
-  store.i32 [sim + 64], v1
+  store.i32 [sim + 72], v1
   v76 = add v14, v5
   v11 = and v76, 0xffffffff
-  store.i32 [sim + 116], v11
+  store.i32 [sim + 124], v11
   v77 = add v14, v25
   v21 = and v77, 0xffffffff
-  store.i32 [sim + 8], v21
+  store.i32 [sim + 16], v21
   v78 = add v14, v45
   v31 = and v78, 0xffffffff
-  store.i32 [sim + 60], v31
+  store.i32 [sim + 68], v31
   v79 = add v14, v4
   v41 = and v79, 0xffffffff
-  store.i32 [sim + 112], v41
+  store.i32 [sim + 120], v41
   ret
 
 Execution Unit 0 (after regalloc):
 bb0:
-  v0 = load.i32 [sim + 0]
-  v10 = load.i32 [sim + 56]
-  v30 = load.i32 [sim + 108]
-  v50 = load.i32 [sim + 160]
-  v9 = load.i32 [sim + 52]
-  v29 = load.i32 [sim + 104]
-  v49 = load.i32 [sim + 156]
-  v8 = load.i32 [sim + 48]
+  v0 = load.i32 [sim + 8]
+  v10 = load.i32 [sim + 64]
+  v30 = load.i32 [sim + 116]
+  v50 = load.i32 [sim + 168]
+  v9 = load.i32 [sim + 60]
+  v29 = load.i32 [sim + 112]
+  v49 = load.i32 [sim + 164]
+  v8 = load.i32 [sim + 56]
   v20 = xor v0, v10
-  v28 = load.i32 [sim + 100]
-  v48 = load.i32 [sim + 152]
+  v28 = load.i32 [sim + 108]
+  v48 = load.i32 [sim + 160]
   v40 = xor v20, v30
-  v7 = load.i32 [sim + 44]
+  v7 = load.i32 [sim + 52]
   v59 = xor v40, v50
-  v27 = load.i32 [sim + 96]
+  v27 = load.i32 [sim + 104]
   store.i64 [sp + 0], v50
   v19 = xor v59, v9
-  v47 = load.i32 [sim + 148]
+  v47 = load.i32 [sim + 156]
   store.i64 [sp + 8], v9
   v39 = xor v19, v29
-  v6 = load.i32 [sim + 40]
+  v6 = load.i32 [sim + 48]
   store.i64 [sp + 16], v29
   v58 = xor v39, v49
-  v26 = load.i32 [sim + 92]
+  v26 = load.i32 [sim + 100]
   store.i64 [sp + 24], v49
   v18 = xor v58, v8
-  v46 = load.i32 [sim + 144]
+  v46 = load.i32 [sim + 152]
   store.i64 [sp + 32], v8
   v38 = xor v18, v28
-  v5 = load.i32 [sim + 36]
+  v5 = load.i32 [sim + 44]
   store.i64 [sp + 40], v28
   v57 = xor v38, v48
-  v25 = load.i32 [sim + 88]
+  v25 = load.i32 [sim + 96]
   store.i64 [sp + 48], v48
   v17 = xor v57, v7
-  v45 = load.i32 [sim + 140]
+  v45 = load.i32 [sim + 148]
   store.i64 [sp + 56], v7
   v37 = xor v17, v27
-  v4 = load.i32 [sim + 32]
+  v4 = load.i32 [sim + 40]
   store.i64 [sp + 64], v27
   v56 = xor v37, v47
   v16 = xor v56, v6
@@ -157,76 +158,76 @@ bb0:
   v35 = xor v15, v25
   v54 = xor v35, v45
   v14 = xor v54, v4
-  store.i32 [sim + 4], v14
+  store.i32 [sim + 12], v14
   v60 = add v14, v0
   v34 = and v60, 0xffffffff
-  store.i32 [sim + 84], v34
+  store.i32 [sim + 92], v34
   v61 = add v14, v10
   v44 = and v61, 0xffffffff
-  store.i32 [sim + 136], v44
+  store.i32 [sim + 144], v44
   v62 = add v14, v30
   v53 = and v62, 0xffffffff
-  store.i32 [sim + 28], v53
+  store.i32 [sim + 36], v53
   v80 = load.i64 [sp + 0]
   v63 = add v14, v80
   v3 = and v63, 0xffffffff
-  store.i32 [sim + 80], v3
+  store.i32 [sim + 88], v3
   v81 = load.i64 [sp + 8]
   v64 = add v14, v81
   v13 = and v64, 0xffffffff
-  store.i32 [sim + 132], v13
+  store.i32 [sim + 140], v13
   v82 = load.i64 [sp + 16]
   v65 = add v14, v82
   v23 = and v65, 0xffffffff
-  store.i32 [sim + 24], v23
+  store.i32 [sim + 32], v23
   v83 = load.i64 [sp + 24]
   v66 = add v14, v83
   v33 = and v66, 0xffffffff
-  store.i32 [sim + 76], v33
+  store.i32 [sim + 84], v33
   v84 = load.i64 [sp + 32]
   v67 = add v14, v84
   v43 = and v67, 0xffffffff
-  store.i32 [sim + 128], v43
+  store.i32 [sim + 136], v43
   v85 = load.i64 [sp + 40]
   v68 = add v14, v85
   v52 = and v68, 0xffffffff
-  store.i32 [sim + 20], v52
+  store.i32 [sim + 28], v52
   v86 = load.i64 [sp + 48]
   v69 = add v14, v86
   v2 = and v69, 0xffffffff
-  store.i32 [sim + 72], v2
+  store.i32 [sim + 80], v2
   v87 = load.i64 [sp + 56]
   v70 = add v14, v87
   v12 = and v70, 0xffffffff
-  store.i32 [sim + 124], v12
+  store.i32 [sim + 132], v12
   v88 = load.i64 [sp + 64]
   v71 = add v14, v88
   v22 = and v71, 0xffffffff
-  store.i32 [sim + 16], v22
+  store.i32 [sim + 24], v22
   v72 = add v14, v47
   v32 = and v72, 0xffffffff
-  store.i32 [sim + 68], v32
+  store.i32 [sim + 76], v32
   v73 = add v14, v6
   v42 = and v73, 0xffffffff
-  store.i32 [sim + 120], v42
+  store.i32 [sim + 128], v42
   v74 = add v14, v26
   v51 = and v74, 0xffffffff
-  store.i32 [sim + 12], v51
+  store.i32 [sim + 20], v51
   v75 = add v14, v46
   v1 = and v75, 0xffffffff
-  store.i32 [sim + 64], v1
+  store.i32 [sim + 72], v1
   v76 = add v14, v5
   v11 = and v76, 0xffffffff
-  store.i32 [sim + 116], v11
+  store.i32 [sim + 124], v11
   v77 = add v14, v25
   v21 = and v77, 0xffffffff
-  store.i32 [sim + 8], v21
+  store.i32 [sim + 16], v21
   v78 = add v14, v45
   v31 = and v78, 0xffffffff
-  store.i32 [sim + 60], v31
+  store.i32 [sim + 68], v31
   v79 = add v14, v4
   v41 = and v79, 0xffffffff
-  store.i32 [sim + 112], v41
+  store.i32 [sim + 120], v41
   ret
   Register assignment:
     v0 -> rax
@@ -325,140 +326,140 @@ bb0:
   0x00000007  push r15
   0x00000009  sub rsp,48h
   0x0000000d  mov r15,rdi
-  0x00000010  mov eax,[r15]
-  0x00000013  mov edx,[r15+38h]
-  0x00000017  mov esi,[r15+6Ch]
-  0x0000001b  mov edi,[r15+0A0h]
-  0x00000022  mov r8d,[r15+34h]
-  0x00000026  mov r9d,[r15+68h]
-  0x0000002a  mov r10d,[r15+9Ch]
-  0x00000031  mov r11d,[r15+30h]
-  0x00000035  mov ecx,eax
-  0x00000037  xor ecx,edx
-  0x00000039  mov ebx,[r15+64h]
-  0x0000003d  mov r12d,[r15+98h]
-  0x00000044  xor ecx,esi
-  0x00000046  mov r13d,[r15+2Ch]
-  0x0000004a  xor ecx,edi
-  0x0000004c  mov r14d,[r15+60h]
-  0x00000050  mov [rsp],rdi
-  0x00000054  xor ecx,r8d
-  0x00000057  mov edi,[r15+94h]
-  0x0000005e  mov [rsp+8],r8
-  0x00000063  xor ecx,r9d
-  0x00000066  mov r8d,[r15+28h]
-  0x0000006a  mov [rsp+10h],r9
-  0x0000006f  xor ecx,r10d
-  0x00000072  mov r9d,[r15+5Ch]
-  0x00000076  mov [rsp+18h],r10
-  0x0000007b  xor ecx,r11d
-  0x0000007e  mov r10d,[r15+90h]
-  0x00000085  mov [rsp+20h],r11
-  0x0000008a  xor ecx,ebx
-  0x0000008c  mov r11d,[r15+24h]
-  0x00000090  mov [rsp+28h],rbx
-  0x00000095  xor ecx,r12d
-  0x00000098  mov ebx,[r15+58h]
-  0x0000009c  mov [rsp+30h],r12
-  0x000000a1  xor ecx,r13d
-  0x000000a4  mov r12d,[r15+8Ch]
-  0x000000ab  mov [rsp+38h],r13
-  0x000000b0  xor ecx,r14d
-  0x000000b3  mov r13d,[r15+20h]
-  0x000000b7  mov [rsp+40h],r14
-  0x000000bc  xor ecx,edi
-  0x000000be  xor ecx,r8d
-  0x000000c1  xor ecx,r9d
-  0x000000c4  xor ecx,r10d
-  0x000000c7  xor ecx,r11d
-  0x000000ca  xor ecx,ebx
-  0x000000cc  xor ecx,r12d
-  0x000000cf  xor ecx,r13d
-  0x000000d2  mov [r15+4],ecx
-  0x000000d6  add rax,rcx
-  0x000000d9  and eax,0FFFFFFFFh
-  0x000000de  mov [r15+54h],eax
-  0x000000e2  add rdx,rcx
-  0x000000e5  and edx,0FFFFFFFFh
-  0x000000e8  mov [r15+88h],edx
-  0x000000ef  add rsi,rcx
-  0x000000f2  and esi,0FFFFFFFFh
-  0x000000f5  mov [r15+1Ch],esi
-  0x000000f9  mov rax,[rsp]
-  0x000000fd  mov rdx,rcx
-  0x00000100  add rdx,rax
-  0x00000103  and edx,0FFFFFFFFh
-  0x00000106  mov [r15+50h],edx
-  0x0000010a  mov rax,[rsp+8]
-  0x0000010f  mov rdx,rcx
-  0x00000112  add rdx,rax
-  0x00000115  and edx,0FFFFFFFFh
-  0x00000118  mov [r15+84h],edx
-  0x0000011f  mov rax,[rsp+10h]
-  0x00000124  mov rdx,rcx
-  0x00000127  add rdx,rax
-  0x0000012a  and edx,0FFFFFFFFh
-  0x0000012d  mov [r15+18h],edx
-  0x00000131  mov rax,[rsp+18h]
-  0x00000136  mov rdx,rcx
-  0x00000139  add rdx,rax
-  0x0000013c  and edx,0FFFFFFFFh
-  0x0000013f  mov [r15+4Ch],edx
-  0x00000143  mov rax,[rsp+20h]
-  0x00000148  mov rdx,rcx
-  0x0000014b  add rdx,rax
-  0x0000014e  and edx,0FFFFFFFFh
-  0x00000151  mov [r15+80h],edx
-  0x00000158  mov rax,[rsp+28h]
-  0x0000015d  mov rdx,rcx
-  0x00000160  add rdx,rax
-  0x00000163  and edx,0FFFFFFFFh
-  0x00000166  mov [r15+14h],edx
-  0x0000016a  mov rax,[rsp+30h]
-  0x0000016f  mov rdx,rcx
-  0x00000172  add rdx,rax
-  0x00000175  and edx,0FFFFFFFFh
-  0x00000178  mov [r15+48h],edx
-  0x0000017c  mov rax,[rsp+38h]
-  0x00000181  mov rdx,rcx
-  0x00000184  add rdx,rax
-  0x00000187  and edx,0FFFFFFFFh
-  0x0000018a  mov [r15+7Ch],edx
-  0x0000018e  mov rax,[rsp+40h]
-  0x00000193  mov rdx,rcx
-  0x00000196  add rdx,rax
-  0x00000199  and edx,0FFFFFFFFh
-  0x0000019c  mov [r15+10h],edx
-  0x000001a0  add rdi,rcx
-  0x000001a3  and edi,0FFFFFFFFh
-  0x000001a6  mov [r15+44h],edi
-  0x000001aa  add r8,rcx
-  0x000001ad  and r8d,0FFFFFFFFh
-  0x000001b1  mov [r15+78h],r8d
-  0x000001b5  add r9,rcx
-  0x000001b8  and r9d,0FFFFFFFFh
-  0x000001bc  mov [r15+0Ch],r9d
-  0x000001c0  add r10,rcx
-  0x000001c3  and r10d,0FFFFFFFFh
-  0x000001c7  mov [r15+40h],r10d
-  0x000001cb  add r11,rcx
-  0x000001ce  and r11d,0FFFFFFFFh
-  0x000001d2  mov [r15+74h],r11d
-  0x000001d6  add rbx,rcx
-  0x000001d9  and ebx,0FFFFFFFFh
-  0x000001dc  mov [r15+8],ebx
-  0x000001e0  add r12,rcx
-  0x000001e3  and r12d,0FFFFFFFFh
-  0x000001e7  mov [r15+3Ch],r12d
-  0x000001eb  add rcx,r13
-  0x000001ee  and ecx,0FFFFFFFFh
-  0x000001f1  mov [r15+70h],ecx
-  0x000001f5  xor eax,eax
-  0x000001f7  jmp short 00000000000001F9h
-  0x000001f9  add rsp,48h
-  0x000001fd  pop r15
-  0x000001ff  pop r14
-  0x00000201  pop r13
-  0x00000203  pop r12
-  0x00000205  pop rbx
-  0x00000206  ret
+  0x00000010  mov eax,[r15+8]
+  0x00000014  mov edx,[r15+40h]
+  0x00000018  mov esi,[r15+74h]
+  0x0000001c  mov edi,[r15+0A8h]
+  0x00000023  mov r8d,[r15+3Ch]
+  0x00000027  mov r9d,[r15+70h]
+  0x0000002b  mov r10d,[r15+0A4h]
+  0x00000032  mov r11d,[r15+38h]
+  0x00000036  mov ecx,eax
+  0x00000038  xor ecx,edx
+  0x0000003a  mov ebx,[r15+6Ch]
+  0x0000003e  mov r12d,[r15+0A0h]
+  0x00000045  xor ecx,esi
+  0x00000047  mov r13d,[r15+34h]
+  0x0000004b  xor ecx,edi
+  0x0000004d  mov r14d,[r15+68h]
+  0x00000051  mov [rsp],rdi
+  0x00000055  xor ecx,r8d
+  0x00000058  mov edi,[r15+9Ch]
+  0x0000005f  mov [rsp+8],r8
+  0x00000064  xor ecx,r9d
+  0x00000067  mov r8d,[r15+30h]
+  0x0000006b  mov [rsp+10h],r9
+  0x00000070  xor ecx,r10d
+  0x00000073  mov r9d,[r15+64h]
+  0x00000077  mov [rsp+18h],r10
+  0x0000007c  xor ecx,r11d
+  0x0000007f  mov r10d,[r15+98h]
+  0x00000086  mov [rsp+20h],r11
+  0x0000008b  xor ecx,ebx
+  0x0000008d  mov r11d,[r15+2Ch]
+  0x00000091  mov [rsp+28h],rbx
+  0x00000096  xor ecx,r12d
+  0x00000099  mov ebx,[r15+60h]
+  0x0000009d  mov [rsp+30h],r12
+  0x000000a2  xor ecx,r13d
+  0x000000a5  mov r12d,[r15+94h]
+  0x000000ac  mov [rsp+38h],r13
+  0x000000b1  xor ecx,r14d
+  0x000000b4  mov r13d,[r15+28h]
+  0x000000b8  mov [rsp+40h],r14
+  0x000000bd  xor ecx,edi
+  0x000000bf  xor ecx,r8d
+  0x000000c2  xor ecx,r9d
+  0x000000c5  xor ecx,r10d
+  0x000000c8  xor ecx,r11d
+  0x000000cb  xor ecx,ebx
+  0x000000cd  xor ecx,r12d
+  0x000000d0  xor ecx,r13d
+  0x000000d3  mov [r15+0Ch],ecx
+  0x000000d7  add rax,rcx
+  0x000000da  and eax,0FFFFFFFFh
+  0x000000df  mov [r15+5Ch],eax
+  0x000000e3  add rdx,rcx
+  0x000000e6  and edx,0FFFFFFFFh
+  0x000000e9  mov [r15+90h],edx
+  0x000000f0  add rsi,rcx
+  0x000000f3  and esi,0FFFFFFFFh
+  0x000000f6  mov [r15+24h],esi
+  0x000000fa  mov rax,[rsp]
+  0x000000fe  mov rdx,rcx
+  0x00000101  add rdx,rax
+  0x00000104  and edx,0FFFFFFFFh
+  0x00000107  mov [r15+58h],edx
+  0x0000010b  mov rax,[rsp+8]
+  0x00000110  mov rdx,rcx
+  0x00000113  add rdx,rax
+  0x00000116  and edx,0FFFFFFFFh
+  0x00000119  mov [r15+8Ch],edx
+  0x00000120  mov rax,[rsp+10h]
+  0x00000125  mov rdx,rcx
+  0x00000128  add rdx,rax
+  0x0000012b  and edx,0FFFFFFFFh
+  0x0000012e  mov [r15+20h],edx
+  0x00000132  mov rax,[rsp+18h]
+  0x00000137  mov rdx,rcx
+  0x0000013a  add rdx,rax
+  0x0000013d  and edx,0FFFFFFFFh
+  0x00000140  mov [r15+54h],edx
+  0x00000144  mov rax,[rsp+20h]
+  0x00000149  mov rdx,rcx
+  0x0000014c  add rdx,rax
+  0x0000014f  and edx,0FFFFFFFFh
+  0x00000152  mov [r15+88h],edx
+  0x00000159  mov rax,[rsp+28h]
+  0x0000015e  mov rdx,rcx
+  0x00000161  add rdx,rax
+  0x00000164  and edx,0FFFFFFFFh
+  0x00000167  mov [r15+1Ch],edx
+  0x0000016b  mov rax,[rsp+30h]
+  0x00000170  mov rdx,rcx
+  0x00000173  add rdx,rax
+  0x00000176  and edx,0FFFFFFFFh
+  0x00000179  mov [r15+50h],edx
+  0x0000017d  mov rax,[rsp+38h]
+  0x00000182  mov rdx,rcx
+  0x00000185  add rdx,rax
+  0x00000188  and edx,0FFFFFFFFh
+  0x0000018b  mov [r15+84h],edx
+  0x00000192  mov rax,[rsp+40h]
+  0x00000197  mov rdx,rcx
+  0x0000019a  add rdx,rax
+  0x0000019d  and edx,0FFFFFFFFh
+  0x000001a0  mov [r15+18h],edx
+  0x000001a4  add rdi,rcx
+  0x000001a7  and edi,0FFFFFFFFh
+  0x000001aa  mov [r15+4Ch],edi
+  0x000001ae  add r8,rcx
+  0x000001b1  and r8d,0FFFFFFFFh
+  0x000001b5  mov [r15+80h],r8d
+  0x000001bc  add r9,rcx
+  0x000001bf  and r9d,0FFFFFFFFh
+  0x000001c3  mov [r15+14h],r9d
+  0x000001c7  add r10,rcx
+  0x000001ca  and r10d,0FFFFFFFFh
+  0x000001ce  mov [r15+48h],r10d
+  0x000001d2  add r11,rcx
+  0x000001d5  and r11d,0FFFFFFFFh
+  0x000001d9  mov [r15+7Ch],r11d
+  0x000001dd  add rbx,rcx
+  0x000001e0  and ebx,0FFFFFFFFh
+  0x000001e3  mov [r15+10h],ebx
+  0x000001e7  add r12,rcx
+  0x000001ea  and r12d,0FFFFFFFFh
+  0x000001ee  mov [r15+44h],r12d
+  0x000001f2  add rcx,r13
+  0x000001f5  and ecx,0FFFFFFFFh
+  0x000001f8  mov [r15+78h],ecx
+  0x000001fc  xor eax,eax
+  0x000001fe  jmp short 0000000000000200h
+  0x00000200  add rsp,48h
+  0x00000204  pop r15
+  0x00000206  pop r14
+  0x00000208  pop r13
+  0x0000020a  pop r12
+  0x0000020c  pop rbx
+  0x0000020d  ret

--- a/crates/celox/tests/snapshots/native_mir__rle_comb_mir.snap
+++ b/crates/celox/tests/snapshots/native_mir__rle_comb_mir.snap
@@ -6,20 +6,20 @@ expression: output
 === MIR (eval_comb) ===
 Execution Unit 0 (before regalloc):
 bb0:
-  v0 = load.i32 [sim + 0]
-  v1 = load.i32 [sim + 8]
+  v0 = load.i32 [sim + 8]
+  v1 = load.i32 [sim + 16]
   v3 = add v0, v1
   v2 = and v3, 0xffffffff
-  store.i32 [sim + 4], v2
+  store.i32 [sim + 12], v2
   ret
 
 Execution Unit 0 (after regalloc):
 bb0:
-  v0 = load.i32 [sim + 0]
-  v1 = load.i32 [sim + 8]
+  v0 = load.i32 [sim + 8]
+  v1 = load.i32 [sim + 16]
   v3 = add v0, v1
   v2 = and v3, 0xffffffff
-  store.i32 [sim + 4], v2
+  store.i32 [sim + 12], v2
   ret
   Register assignment:
     v0 -> rax
@@ -30,13 +30,13 @@ bb0:
   0x00000000  push r15
   0x00000002  sub rsp,8
   0x00000006  mov r15,rdi
-  0x00000009  mov eax,[r15]
-  0x0000000c  mov edx,[r15+8]
-  0x00000010  add rax,rdx
-  0x00000013  and eax,0FFFFFFFFh
-  0x00000018  mov [r15+4],eax
-  0x0000001c  xor eax,eax
-  0x0000001e  jmp short 0000000000000020h
-  0x00000020  add rsp,8
-  0x00000024  pop r15
-  0x00000026  ret
+  0x00000009  mov eax,[r15+8]
+  0x0000000d  mov edx,[r15+10h]
+  0x00000011  add rax,rdx
+  0x00000014  and eax,0FFFFFFFFh
+  0x00000019  mov [r15+0Ch],eax
+  0x0000001d  xor eax,eax
+  0x0000001f  jmp short 0000000000000021h
+  0x00000021  add rsp,8
+  0x00000025  pop r15
+  0x00000027  ret

--- a/crates/celox/tests/snapshots/native_mir__shared_expression_mir.snap
+++ b/crates/celox/tests/snapshots/native_mir__shared_expression_mir.snap
@@ -1,34 +1,35 @@
 ---
 source: crates/celox/tests/native_mir.rs
+assertion_line: 103
 expression: output
 ---
 === MIR (eval_comb) ===
 Execution Unit 0 (before regalloc):
 bb0:
-  v0 = load.i32 [sim + 0]
-  v4 = load.i32 [sim + 8]
+  v0 = load.i32 [sim + 8]
+  v4 = load.i32 [sim + 16]
   v7 = add v0, v4
   v2 = and v7, 0xffffffff
   v6 = imm 0x1
   v3 = and v2, v6
-  store.i32 [sim + 4], v3
+  store.i32 [sim + 12], v3
   v1 = imm 0x2
   v5 = or v2, v1
-  store.i32 [sim + 12], v5
+  store.i32 [sim + 20], v5
   ret
 
 Execution Unit 0 (after regalloc):
 bb0:
-  v0 = load.i32 [sim + 0]
-  v4 = load.i32 [sim + 8]
+  v0 = load.i32 [sim + 8]
+  v4 = load.i32 [sim + 16]
   v7 = add v0, v4
   v2 = and v7, 0xffffffff
   v6 = imm 0x1
   v3 = and v2, v6
-  store.i32 [sim + 4], v3
+  store.i32 [sim + 12], v3
   v1 = imm 0x2
   v5 = or v2, v1
-  store.i32 [sim + 12], v5
+  store.i32 [sim + 20], v5
   ret
   Register assignment:
     v0 -> rax
@@ -43,18 +44,18 @@ bb0:
   0x00000000  push r15
   0x00000002  sub rsp,8
   0x00000006  mov r15,rdi
-  0x00000009  mov eax,[r15]
-  0x0000000c  mov edx,[r15+8]
-  0x00000010  add rax,rdx
-  0x00000013  and eax,0FFFFFFFFh
-  0x00000018  mov edx,1
-  0x0000001d  and edx,eax
-  0x0000001f  mov [r15+4],edx
-  0x00000023  mov edx,2
-  0x00000028  or eax,edx
-  0x0000002a  mov [r15+0Ch],eax
-  0x0000002e  xor eax,eax
-  0x00000030  jmp short 0000000000000032h
-  0x00000032  add rsp,8
-  0x00000036  pop r15
-  0x00000038  ret
+  0x00000009  mov eax,[r15+8]
+  0x0000000d  mov edx,[r15+10h]
+  0x00000011  add rax,rdx
+  0x00000014  and eax,0FFFFFFFFh
+  0x00000019  mov edx,1
+  0x0000001e  and edx,eax
+  0x00000020  mov [r15+0Ch],edx
+  0x00000024  mov edx,2
+  0x00000029  or eax,edx
+  0x0000002b  mov [r15+14h],eax
+  0x0000002f  xor eax,eax
+  0x00000031  jmp short 0000000000000033h
+  0x00000033  add rsp,8
+  0x00000037  pop r15
+  0x00000039  ret

--- a/crates/celox/tests/system_function.rs
+++ b/crates/celox/tests/system_function.rs
@@ -432,28 +432,38 @@ module Top (
 }
 
 #[test]
-fn test_ff_statement_system_functions_are_reported_as_unsupported() {
+fn test_ff_statement_runtime_event_system_functions_are_supported() {
+    let code = r#"
+module Top (clk: input clock, d: input logic) {
+    always_ff (clk) {
+        $display("display d=%0d", d);
+        $write("write d=%0d", d);
+        $assert(d, "assert d=%0d", d);
+    }
+}
+"#;
+    let mut sim = Simulator::builder(code, "Top").build().unwrap();
+    let clk = sim.event("clk");
+    let d = sim.signal("d");
+
+    sim.modify(|io| io.set(d, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![
+            celox::RuntimeEvent::Display {
+                message: "display d=1".to_string(),
+            },
+            celox::RuntimeEvent::Display {
+                message: "write d=1".to_string(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn test_unsupported_ff_statement_system_functions_are_reported() {
     let cases = [
-        (
-            "display",
-            r#"
-module Top (clk: input clock, d: input logic) {
-    always_ff (clk) {
-        $display("d=%0d", d);
-    }
-}
-"#,
-        ),
-        (
-            "write",
-            r#"
-module Top (clk: input clock, d: input logic) {
-    always_ff (clk) {
-        $write("d=%0d", d);
-    }
-}
-"#,
-        ),
         (
             "readmemh",
             r#"
@@ -461,16 +471,6 @@ module Top (clk: input clock) {
     var mem: logic<8>[4];
     always_ff (clk) {
         $readmemh("mem.hex", mem);
-    }
-}
-"#,
-        ),
-        (
-            "assert",
-            r#"
-module Top (clk: input clock, d: input logic) {
-    always_ff (clk) {
-        $assert(d);
     }
 }
 "#,


### PR DESCRIPTION
## Summary

Adds runtime event support for FF system tasks such as `$display`, `$write`, `$assert_continue`, and fatal `$assert`.

Key changes:
- Lower supported FF system tasks into runtime event records.
- Preserve 4-state event arguments and share display argument formatting with native testbench formatting.
- Size runtime event slots from the compiled design.
- Split runtime event storage from simulator state and expose a concrete `RuntimeEventDrain` handle for concurrent draining.
- Use atomic sequence words for producer/consumer publication and avoid mixed payload reads on ring overwrite.
- Keep wasm compilation gated where runtime event draining is host-only today.

## Validation

Pre-push hook passed:
- submodule check
- `cargo fmt`
- biome check
- `cargo clippy`
- workspace `cargo test`
- package build/test commands

Additional checks run during review fixes:
- `cargo check -p celox`
- `cargo check -p celox --target wasm32-unknown-unknown`
- `cargo test -p celox --test native_mir`
- `cargo test -p celox --test flip_flop`
- `cargo test -p celox --test native_testbench`
- `cargo test -p celox --test system_function`