### PR TITLE
[codex] Allow Renovate to create pending PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "prCreation": "not-pending",
   "internalChecksFilter": "strict",
   "cloneSubmodules": true,
   "extends": [


### PR DESCRIPTION
## Summary

- Remove `prCreation: "not-pending"` from Renovate config.

## Why

Renovate was leaving updates in the Dependency Dashboard under `Pending Status Checks` because PR creation was gated on branch status checks. The repository CI runs on `pull_request` and `master` pushes, so Renovate branches do not get the normal CI checks before a PR exists. Removing the setting lets Renovate create PRs first, then CI can run through the normal pull request flow.

## Validation

- `jq empty renovate.json`
- pre-push hook: `submodule-check`, `cargo-fmt`, `biome`, `cargo-clippy`, `pnpm test`