### PR TITLE
[codex] Route testbench assertions through runtime events

### DIFF
--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1908,7 +1908,8 @@ fn convert_test_result(r: celox::TestResultDetailed) -> NapiTestResult {
 /// Run a native testbench from Veryl source code.
 ///
 /// Compiles the given sources and runs the `#[test]` module specified by `top`,
-/// collecting all assertion results.
+/// returning assertion results observed before that test finishes or stops on a
+/// fatal failure.
 #[cfg(not(target_arch = "wasm32"))]
 #[napi]
 pub fn run_test(

--- a/crates/celox/src/backend/native/emit.rs
+++ b/crates/celox/src/backend/native/emit.rs
@@ -598,7 +598,7 @@ fn emit_inst(
             src,
             size,
         }
-        | MInst::AtomicStorePtr {
+        | MInst::ReleaseStorePtr {
             ptr,
             offset,
             src,
@@ -607,6 +607,8 @@ fn emit_inst(
             let ptr = preg_to_reg64(resolve(assignment, *ptr));
             let s_preg = resolve(assignment, *src);
             let mem = mem_operand_ptr(ptr, *offset);
+            // x86-64 TSO gives plain aligned stores release-store ordering:
+            // earlier payload stores cannot become visible after this publish store.
             match size {
                 OpSize::S8 => {
                     asm.mov(byte_ptr(mem), preg_to_reg8(s_preg))?;
@@ -683,7 +685,7 @@ fn emit_inst(
             src,
             size,
         }
-        | MInst::AtomicStorePtrIndexed {
+        | MInst::ReleaseStorePtrIndexed {
             ptr,
             offset,
             index,
@@ -694,6 +696,8 @@ fn emit_inst(
             let idx = preg_to_reg64(resolve(assignment, *index));
             let s_preg = resolve(assignment, *src);
             let mem = mem_operand_ptr_indexed(ptr, *offset, idx);
+            // x86-64 TSO gives plain aligned stores release-store ordering:
+            // earlier payload stores cannot become visible after this publish store.
             match size {
                 OpSize::S8 => {
                     asm.mov(byte_ptr(mem), preg_to_reg8(s_preg))?;

--- a/crates/celox/src/backend/native/isel.rs
+++ b/crates/celox/src/backend/native/isel.rs
@@ -747,7 +747,9 @@ fn lower_instruction(
                 value: RUNTIME_EVENT_WRITING,
             });
             let slot_base = RUNTIME_EVENT_HEADER_SIZE as i32;
-            block.push(MInst::AtomicStorePtrIndexed {
+            // Mark the slot as being written before updating its payload. Readers
+            // acquire-load sequence words; payload/site/arg fields are plain data.
+            block.push(MInst::ReleaseStorePtrIndexed {
                 ptr: event_ptr,
                 offset: slot_base + RUNTIME_EVENT_SLOT_SEQ_OFFSET as i32,
                 index: slot_off,
@@ -837,7 +839,9 @@ fn lower_instruction(
                     });
                 }
             }
-            block.push(MInst::AtomicStorePtrIndexed {
+            // Publish this slot after all payload writes. This is the release side
+            // of the ring-buffer protocol; payload words themselves are not atomic.
+            block.push(MInst::ReleaseStorePtrIndexed {
                 ptr: event_ptr,
                 offset: slot_base + RUNTIME_EVENT_SLOT_SEQ_OFFSET as i32,
                 index: slot_off,
@@ -850,7 +854,8 @@ fn lower_instruction(
                 src: seq_v,
                 imm: 1,
             });
-            block.push(MInst::AtomicStorePtr {
+            // Advance the global write sequence after the slot sequence is visible.
+            block.push(MInst::ReleaseStorePtr {
                 ptr: event_ptr,
                 offset: 0,
                 src: next_seq,

--- a/crates/celox/src/backend/native/mir.rs
+++ b/crates/celox/src/backend/native/mir.rs
@@ -383,8 +383,12 @@ pub enum MInst {
         src: VReg,
         size: OpSize,
     },
-    /// atomic store [ptr + offset] = src
-    AtomicStorePtr {
+    /// release-store [ptr + offset] = src.
+    ///
+    /// This is used as a publish point for lock-free runtime-event buffers:
+    /// payload words are stored normally, then the sequence word is release-stored.
+    /// It is not a read-modify-write atomic operation.
+    ReleaseStorePtr {
         ptr: VReg,
         offset: i32,
         src: VReg,
@@ -422,8 +426,12 @@ pub enum MInst {
         src: VReg,
         size: OpSize,
     },
-    /// atomic store [ptr + offset + index] = src
-    AtomicStorePtrIndexed {
+    /// release-store [ptr + offset + index] = src.
+    ///
+    /// This is used as a publish point for lock-free runtime-event buffers:
+    /// payload words are stored normally, then the sequence word is release-stored.
+    /// It is not a read-modify-write atomic operation.
+    ReleaseStorePtrIndexed {
         ptr: VReg,
         offset: i32,
         index: VReg,
@@ -556,12 +564,12 @@ impl fmt::Display for MInst {
                 src,
                 size,
             } => write!(f, "store.{size} [{ptr} + {offset}], {src}"),
-            MInst::AtomicStorePtr {
+            MInst::ReleaseStorePtr {
                 ptr,
                 offset,
                 src,
                 size,
-            } => write!(f, "atomic_store.{size} [{ptr} + {offset}], {src}"),
+            } => write!(f, "release_store.{size} [{ptr} + {offset}], {src}"),
             MInst::LoadIndexed {
                 dst,
                 base,
@@ -590,13 +598,16 @@ impl fmt::Display for MInst {
                 src,
                 size,
             } => write!(f, "store.{size} [{ptr} + {offset} + {index}], {src}"),
-            MInst::AtomicStorePtrIndexed {
+            MInst::ReleaseStorePtrIndexed {
                 ptr,
                 offset,
                 index,
                 src,
                 size,
-            } => write!(f, "atomic_store.{size} [{ptr} + {offset} + {index}], {src}"),
+            } => write!(
+                f,
+                "release_store.{size} [{ptr} + {offset} + {index}], {src}"
+            ),
             MInst::Add { dst, lhs, rhs } => write!(f, "{dst} = add {lhs}, {rhs}"),
             MInst::Sub { dst, lhs, rhs } => write!(f, "{dst} = sub {lhs}, {rhs}"),
             MInst::Mul { dst, lhs, rhs } => write!(f, "{dst} = mul {lhs}, {rhs}"),
@@ -729,10 +740,10 @@ impl MInst {
 
             MInst::Store { .. }
             | MInst::StorePtr { .. }
-            | MInst::AtomicStorePtr { .. }
+            | MInst::ReleaseStorePtr { .. }
             | MInst::StoreIndexed { .. }
             | MInst::StorePtrIndexed { .. }
-            | MInst::AtomicStorePtrIndexed { .. }
+            | MInst::ReleaseStorePtrIndexed { .. }
             | MInst::Branch { .. }
             | MInst::Jump { .. }
             | MInst::Return
@@ -749,14 +760,14 @@ impl MInst {
             MInst::Store { src, .. } => Uses::one(*src),
             MInst::LoadPtr { ptr, .. } => Uses::one(*ptr),
             MInst::StorePtr { ptr, src, .. } => Uses::two(*ptr, *src),
-            MInst::AtomicStorePtr { ptr, src, .. } => Uses::two(*ptr, *src),
+            MInst::ReleaseStorePtr { ptr, src, .. } => Uses::two(*ptr, *src),
             MInst::LoadIndexed { index, .. } => Uses::one(*index),
             MInst::StoreIndexed { index, src, .. } => Uses::two(*index, *src),
             MInst::LoadPtrIndexed { ptr, index, .. } => Uses::two(*ptr, *index),
             MInst::StorePtrIndexed {
                 ptr, index, src, ..
             } => Uses::three(*ptr, *index, *src),
-            MInst::AtomicStorePtrIndexed {
+            MInst::ReleaseStorePtrIndexed {
                 ptr, index, src, ..
             } => Uses::three(*ptr, *index, *src),
             MInst::Add { lhs, rhs, .. }
@@ -821,7 +832,7 @@ impl MInst {
                     *src = new;
                 }
             }
-            MInst::AtomicStorePtr { ptr, src, .. } => {
+            MInst::ReleaseStorePtr { ptr, src, .. } => {
                 if *ptr == old {
                     *ptr = new;
                 }
@@ -863,7 +874,7 @@ impl MInst {
                     *src = new;
                 }
             }
-            MInst::AtomicStorePtrIndexed {
+            MInst::ReleaseStorePtrIndexed {
                 ptr, index, src, ..
             } => {
                 if *ptr == old {

--- a/crates/celox/src/backend/native/mir_opt.rs
+++ b/crates/celox/src/backend/native/mir_opt.rs
@@ -478,10 +478,10 @@ fn is_memory_clobber(inst: &MInst) -> bool {
         inst,
         MInst::Store { .. }
             | MInst::StorePtr { .. }
-            | MInst::AtomicStorePtr { .. }
+            | MInst::ReleaseStorePtr { .. }
             | MInst::StoreIndexed { .. }
             | MInst::StorePtrIndexed { .. }
-            | MInst::AtomicStorePtrIndexed { .. }
+            | MInst::ReleaseStorePtrIndexed { .. }
     )
 }
 
@@ -637,8 +637,8 @@ fn global_gvn(func: &mut MFunction) {
                     } => (Some(*base), *offset, size.bytes() as i32),
                     MInst::StoreIndexed { .. }
                     | MInst::StorePtrIndexed { .. }
-                    | MInst::AtomicStorePtrIndexed { .. } => (None, 0, 0), // dynamic: invalidate all
-                    MInst::StorePtr { .. } | MInst::AtomicStorePtr { .. } => (None, 0, 0),
+                    | MInst::ReleaseStorePtrIndexed { .. } => (None, 0, 0), // dynamic: invalidate all
+                    MInst::StorePtr { .. } | MInst::ReleaseStorePtr { .. } => (None, 0, 0),
                     _ => (None, 0, 0),
                 };
                 let load_keys: Vec<GvnKey> = value_table
@@ -1026,10 +1026,10 @@ fn if_convert(func: &mut MFunction) {
                     inst,
                     MInst::Store { .. }
                         | MInst::StorePtr { .. }
-                        | MInst::AtomicStorePtr { .. }
+                        | MInst::ReleaseStorePtr { .. }
                         | MInst::StoreIndexed { .. }
                         | MInst::StorePtrIndexed { .. }
-                        | MInst::AtomicStorePtrIndexed { .. }
+                        | MInst::ReleaseStorePtrIndexed { .. }
                         | MInst::Load { .. }
                         | MInst::LoadPtr { .. }
                         | MInst::LoadImm { .. }
@@ -1380,10 +1380,10 @@ fn split_live_ranges(func: &mut MFunction) {
                             i,
                             MInst::Store { .. }
                                 | MInst::StorePtr { .. }
-                                | MInst::AtomicStorePtr { .. }
+                                | MInst::ReleaseStorePtr { .. }
                                 | MInst::StoreIndexed { .. }
                                 | MInst::StorePtrIndexed { .. }
-                                | MInst::AtomicStorePtrIndexed { .. }
+                                | MInst::ReleaseStorePtrIndexed { .. }
                         )
                     });
                     if !has_store {
@@ -2098,7 +2098,7 @@ fn forward_local_store_loads(func: &mut MFunction) {
                 | MInst::LoadPtrIndexed { .. }
                 | MInst::StoreIndexed { .. }
                 | MInst::StorePtrIndexed { .. }
-                | MInst::AtomicStorePtrIndexed { .. } => {
+                | MInst::ReleaseStorePtrIndexed { .. } => {
                     available.clear();
                     rewritten.push(inst);
                 }
@@ -2213,7 +2213,7 @@ fn eliminate_redundant_local_stores(func: &mut MFunction) {
                 | MInst::LoadPtrIndexed { .. }
                 | MInst::StoreIndexed { .. }
                 | MInst::StorePtrIndexed { .. }
-                | MInst::AtomicStorePtrIndexed { .. } => {
+                | MInst::ReleaseStorePtrIndexed { .. } => {
                     available.clear();
                     rewritten.push(inst);
                 }
@@ -2341,10 +2341,10 @@ fn dead_code_eliminate(func: &mut MFunction) {
                             inst,
                             MInst::Store { .. }
                                 | MInst::StorePtr { .. }
-                                | MInst::AtomicStorePtr { .. }
+                                | MInst::ReleaseStorePtr { .. }
                                 | MInst::StoreIndexed { .. }
                                 | MInst::StorePtrIndexed { .. }
-                                | MInst::AtomicStorePtrIndexed { .. }
+                                | MInst::ReleaseStorePtrIndexed { .. }
                                 | MInst::Branch { .. }
                                 | MInst::Jump { .. }
                                 | MInst::Return

--- a/crates/celox/src/backend/translator/core.rs
+++ b/crates/celox/src/backend/translator/core.rs
@@ -424,6 +424,8 @@ impl SIRTranslator {
             .builder
             .ins()
             .iadd_imm(slot_addr, RUNTIME_EVENT_SLOT_SEQ_OFFSET as i64);
+        // Mark the slot as being written. Runtime-event readers acquire-load
+        // sequence words and read payload words only while the sequence is stable.
         state.builder.ins().atomic_rmw(
             types::I64,
             MemFlags::new(),
@@ -486,6 +488,8 @@ impl SIRTranslator {
             .builder
             .ins()
             .iadd_imm(slot_addr, RUNTIME_EVENT_SLOT_SEQ_OFFSET as i64);
+        // Publish the slot after all payload stores. Only the sequence words
+        // participate in the acquire/release protocol; payload stores are plain.
         state.builder.ins().atomic_rmw(
             types::I64,
             MemFlags::new(),
@@ -494,6 +498,7 @@ impl SIRTranslator {
             seq,
         );
         let next = state.builder.ins().iadd_imm(seq, 1);
+        // Advance the global write sequence after the slot sequence is visible.
         state.builder.ins().atomic_rmw(
             types::I64,
             MemFlags::new(),

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -106,6 +106,7 @@ pub struct RuntimeEventSite {
     pub template: Option<String>,
     pub arg_widths: Vec<usize>,
     pub arg_signed: Vec<bool>,
+    pub arg_is_string: Vec<bool>,
 }
 
 #[derive(Clone)]

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -96,6 +96,7 @@ pub use simulator::DeadStorePolicy;
 pub use simulator::RuntimeEvent;
 #[cfg(not(target_arch = "wasm32"))]
 pub use simulator::RuntimeEventDrain;
+#[cfg(not(target_arch = "wasm32"))]
 pub use simulator::RuntimeFormatContext;
 #[cfg(not(target_arch = "wasm32"))]
 pub use simulator::Simulator;

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -96,6 +96,7 @@ pub use simulator::DeadStorePolicy;
 pub use simulator::RuntimeEvent;
 #[cfg(not(target_arch = "wasm32"))]
 pub use simulator::RuntimeEventDrain;
+pub use simulator::RuntimeFormatContext;
 #[cfg(not(target_arch = "wasm32"))]
 pub use simulator::Simulator;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/celox/src/parser/ff.rs
+++ b/crates/celox/src/parser/ff.rs
@@ -163,6 +163,10 @@ impl<'a> FfParser<'a> {
                 .iter()
                 .map(|arg| arg.0.comptime().expr_context.signed)
                 .collect(),
+            arg_is_string: value_args
+                .iter()
+                .map(|arg| arg.0.comptime().r#type.is_string())
+                .collect(),
         };
         let id = self.runtime_event_sites.len() as u32;
         self.runtime_event_sites.push(site);

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -211,6 +211,11 @@ fn collect_runtime_events(
         return Vec::new();
     }
 
+    // Ring-buffer synchronization protocol:
+    // - writers store event payload/site/arg fields normally;
+    // - writers publish slot/global sequence words with release semantics;
+    // - readers acquire-load sequence words, then read payload normally;
+    // - readers re-check the slot sequence after reading payload to reject races.
     let write_seq = read_seq_u64(0);
     let mut events = Vec::new();
     let capacity = layout.runtime_event_capacity as u64;

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -176,7 +176,12 @@ fn render_runtime_event_message(
     let Some(template) = site.template.as_deref() else {
         let default_spec = match site.kind {
             RuntimeEventKind::Display => 'd',
-            RuntimeEventKind::AssertContinue | RuntimeEventKind::AssertFatal => 'x',
+            RuntimeEventKind::AssertContinue | RuntimeEventKind::AssertFatal => {
+                if args.is_empty() {
+                    return "assertion failed".to_string();
+                }
+                'x'
+            }
         };
         return args
             .iter()

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -80,6 +80,13 @@ pub enum RuntimeEvent {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RuntimeFormatContext<'a> {
+    pub tb_time: Option<u64>,
+    pub scope: Option<&'a str>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 pub struct RuntimeEventDrain {
     buffer: Arc<RuntimeEventBuffer>,
     layout: MemoryLayout,
@@ -90,11 +97,16 @@ pub struct RuntimeEventDrain {
 #[cfg(not(target_arch = "wasm32"))]
 impl RuntimeEventDrain {
     pub fn drain(&mut self) -> Vec<RuntimeEvent> {
+        self.drain_with_context(RuntimeFormatContext::default())
+    }
+
+    pub fn drain_with_context(&mut self, ctx: RuntimeFormatContext<'_>) -> Vec<RuntimeEvent> {
         drain_runtime_events_from_buffer(
             &self.buffer,
             &self.layout,
             &self.sites,
             &mut self.read_seq,
+            ctx,
         )
     }
 }
@@ -112,6 +124,18 @@ struct RuntimeEventArgValue {
     masks: Vec<u64>,
     width: usize,
     signed: bool,
+    is_string: bool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+enum RawRuntimeEvent {
+    Event {
+        site_id: usize,
+        args: Vec<RuntimeEventArgValue>,
+    },
+    Missed {
+        count: u64,
+    },
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -137,18 +161,26 @@ fn runtime_event_format_arg(arg: &RuntimeEventArgValue, spec: Option<char>) -> S
             mask: Some(&mask),
             width: arg.width,
             signed: arg.signed,
-            is_string: false,
+            is_string: arg.is_string,
         },
         spec,
     )
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn render_runtime_event_message(site: &RuntimeEventSite, args: &[RuntimeEventArgValue]) -> String {
+fn render_runtime_event_message(
+    site: &RuntimeEventSite,
+    args: &[RuntimeEventArgValue],
+    ctx: RuntimeFormatContext<'_>,
+) -> String {
     let Some(template) = site.template.as_deref() else {
+        let default_spec = match site.kind {
+            RuntimeEventKind::Display => 'd',
+            RuntimeEventKind::AssertContinue | RuntimeEventKind::AssertFatal => 'x',
+        };
         return args
             .iter()
-            .map(|arg| runtime_event_format_arg(arg, Some('d')))
+            .map(|arg| runtime_event_format_arg(arg, Some(default_spec)))
             .collect::<Vec<_>>()
             .join(" ");
     };
@@ -169,27 +201,52 @@ fn render_runtime_event_message(site: &RuntimeEventSite, args: &[RuntimeEventArg
             chars.next();
         }
         let spec = chars.next().unwrap_or('d');
-        let fallback;
-        let arg = if let Some(arg) = args.get(arg_idx) {
-            arg
-        } else {
-            fallback = RuntimeEventArgValue {
-                values: vec![0],
-                masks: vec![0],
-                width: 64,
-                signed: false,
-            };
-            &fallback
-        };
-        arg_idx += 1;
         match spec {
             'x' | 'h' | 'X' | 'H' | 'b' | 'B' | 'o' | 'O' | 'c' | 'C' | 's' | 'S' => {
+                let Some(arg) = args.get(arg_idx) else {
+                    arg_idx += 1;
+                    continue;
+                };
                 out.push_str(&runtime_event_format_arg(arg, Some(spec)));
+                arg_idx += 1;
             }
-            _ => out.push_str(&runtime_event_format_arg(arg, Some('d'))),
+            'd' | 'D' | 'i' | 'I' => {
+                let Some(arg) = args.get(arg_idx) else {
+                    arg_idx += 1;
+                    continue;
+                };
+                out.push_str(&runtime_event_format_arg(arg, Some(spec)));
+                arg_idx += 1;
+            }
+            't' | 'T' => out.push_str(&ctx.tb_time.unwrap_or(0).to_string()),
+            'm' | 'M' => out.push_str(ctx.scope.unwrap_or("<hierarchy>")),
+            other => {
+                out.push('%');
+                out.push(other);
+            }
         }
     }
     out
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn render_raw_runtime_event(
+    raw: RawRuntimeEvent,
+    sites: &[RuntimeEventSite],
+    ctx: RuntimeFormatContext<'_>,
+) -> Option<RuntimeEvent> {
+    match raw {
+        RawRuntimeEvent::Missed { count } => Some(RuntimeEvent::Missed { count }),
+        RawRuntimeEvent::Event { site_id, args } => {
+            let site = sites.get(site_id)?;
+            let message = render_runtime_event_message(site, &args, ctx);
+            Some(match site.kind {
+                RuntimeEventKind::Display => RuntimeEvent::Display { message },
+                RuntimeEventKind::AssertContinue => RuntimeEvent::AssertContinue { message },
+                RuntimeEventKind::AssertFatal => RuntimeEvent::AssertFatal { message },
+            })
+        }
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -200,7 +257,7 @@ fn collect_runtime_events(
     buffer_size: usize,
     mut read_payload_u64: impl FnMut(usize) -> u64,
     mut read_seq_u64: impl FnMut(usize) -> u64,
-) -> Vec<RuntimeEvent> {
+) -> Vec<RawRuntimeEvent> {
     use crate::backend::memory_layout::{
         RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET,
         RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
@@ -221,7 +278,7 @@ fn collect_runtime_events(
     let capacity = layout.runtime_event_capacity as u64;
     if *read_seq + capacity < write_seq {
         let new_read = write_seq - capacity;
-        events.push(RuntimeEvent::Missed {
+        events.push(RawRuntimeEvent::Missed {
             count: new_read - *read_seq,
         });
         *read_seq = new_read;
@@ -272,6 +329,9 @@ fn collect_runtime_events(
                     signed: site
                         .and_then(|site| site.arg_signed.get(idx).copied())
                         .unwrap_or(false),
+                    is_string: site
+                        .and_then(|site| site.arg_is_string.get(idx).copied())
+                        .unwrap_or(false),
                 });
             }
         }
@@ -281,13 +341,8 @@ fn collect_runtime_events(
             break;
         }
 
-        if let Some(site) = site {
-            let message = render_runtime_event_message(site, &args);
-            events.push(match site.kind {
-                RuntimeEventKind::Display => RuntimeEvent::Display { message },
-                RuntimeEventKind::AssertContinue => RuntimeEvent::AssertContinue { message },
-                RuntimeEventKind::AssertFatal => RuntimeEvent::AssertFatal { message },
-            });
+        if site.is_some() {
+            events.push(RawRuntimeEvent::Event { site_id, args });
         }
         *read_seq += 1;
     }
@@ -301,6 +356,7 @@ fn drain_runtime_events_from_buffer(
     layout: &MemoryLayout,
     sites: &[RuntimeEventSite],
     read_seq: &mut u64,
+    ctx: RuntimeFormatContext<'_>,
 ) -> Vec<RuntimeEvent> {
     use std::sync::atomic::Ordering;
 
@@ -312,6 +368,9 @@ fn drain_runtime_events_from_buffer(
         |offset| buffer.read_u64(offset),
         |offset| buffer.load_atomic_u64(offset, Ordering::Acquire),
     )
+    .into_iter()
+    .filter_map(|raw| render_raw_runtime_event(raw, sites, ctx))
+    .collect()
 }
 
 // ── Generic methods available for any backend ────────────────────────
@@ -357,6 +416,13 @@ impl<B: SimBackend> Simulator<B> {
     }
 
     pub fn drain_runtime_events(&mut self) -> Vec<RuntimeEvent> {
+        self.drain_runtime_events_with_context(RuntimeFormatContext::default())
+    }
+
+    pub fn drain_runtime_events_with_context(
+        &mut self,
+        ctx: RuntimeFormatContext<'_>,
+    ) -> Vec<RuntimeEvent> {
         let layout = self.backend.layout();
         if let Some(buffer) = self.backend.runtime_event_buffer() {
             return drain_runtime_events_from_buffer(
@@ -364,6 +430,7 @@ impl<B: SimBackend> Simulator<B> {
                 layout,
                 &self.program.runtime_event_sites,
                 &mut self.runtime_event_read_seq,
+                ctx,
             );
         }
 
@@ -379,6 +446,9 @@ impl<B: SimBackend> Simulator<B> {
             read_u64,
             read_u64,
         )
+        .into_iter()
+        .filter_map(|raw| render_raw_runtime_event(raw, &self.program.runtime_event_sites, ctx))
+        .collect()
     }
 
     pub fn runtime_event_drain(&self) -> Option<RuntimeEventDrain> {

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -629,7 +629,8 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
         Ok(crate::testbench::run_testbench(&mut sim, &tb_stmts))
     }
 
-    /// Compiles and runs a native testbench, collecting all assertion results.
+    /// Compiles and runs a native testbench, returning assertion results
+    /// observed before the test finishes or stops on a fatal failure.
     pub fn run_test_detailed(self) -> Result<crate::testbench::TestResultDetailed, SimulatorError> {
         let mut sim = self.build()?;
         let initial_stmts = sim.program().initial_statements.clone().ok_or_else(|| {
@@ -665,6 +666,9 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
         );
 
         let sim_res = program_res.and_then(|(mut program, warnings)| {
+            // Register testbench runtime-event sites before layout fixes the ring geometry.
+            crate::testbench::register_runtime_event_sites(&mut program);
+
             program.build_layout(self.options.four_state);
 
             if self.options.dead_store_policy != DeadStorePolicy::Off {

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -522,6 +522,9 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
             &self.options.optimize_options,
         )?;
 
+        // Register testbench runtime-event sites before layout fixes the ring geometry.
+        crate::testbench::register_runtime_event_sites(&mut program);
+
         // Build memory layout (consumes address_aliases for offset sharing)
         program.build_layout(self.options.four_state);
 

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -6,15 +6,21 @@
 //! heap allocation; wider signals fall back to `BigUint`.
 
 use crate::backend::get_byte_size;
+use crate::backend::memory_layout::{
+    RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET,
+    RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
+    RUNTIME_EVENT_SLOT_SITE_OFFSET, RUNTIME_EVENT_WRITING,
+};
 use crate::backend::traits::SimBackend;
 use crate::display_format::{DisplayFormatArg, format_display_arg};
-use crate::ir::{AbsoluteAddr, SignalRef};
-use crate::simulator::Simulator;
+use crate::ir::{AbsoluteAddr, Program, RuntimeEventKind, RuntimeEventSite, SignalRef};
+use crate::simulator::{RuntimeEvent, Simulator};
 use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::ToPrimitive as _;
+use std::sync::atomic::{AtomicU64, Ordering};
 use veryl_analyzer::ir::{
-    AssertKind, Expression, Factor, ForBound, ForRange, Op, Statement, SystemFunctionInput,
-    SystemFunctionKind, TbMethod, TbMethodCall, VarId,
+    AssertKind, Expression, Factor, ForBound, ForRange, Function, Op, Statement,
+    SystemFunctionInput, SystemFunctionKind, TbMethod, TbMethodCall, VarId,
 };
 use veryl_analyzer::value::byte_value_to_string;
 use veryl_parser::resource_table::{self, StrId};
@@ -94,6 +100,7 @@ pub(crate) enum TestbenchStatement<B: SimBackend> {
     },
     Assert {
         expr: CompiledExpr,
+        site_id: u32,
         continue_on_fail: bool,
         message: Option<AssertMessage>,
         location: Option<SourceLocation>,
@@ -411,6 +418,126 @@ fn compile_assert_arg<B: SimBackend>(
         signed: expr.comptime().expr_context.signed,
         is_string: expr.comptime().r#type.is_string(),
     }
+}
+
+fn assert_arg_width(input: &SystemFunctionInput) -> usize {
+    let expr = &input.0;
+    let ctx_width = expr.comptime().expr_context.width;
+    if ctx_width > 0 {
+        ctx_width
+    } else if let Some(type_width) = expr.comptime().r#type.total_width() {
+        type_width
+    } else if let Ok(value) = expr.comptime().get_value() {
+        value.width()
+    } else {
+        0
+    }
+}
+
+fn runtime_event_site_for_assert(
+    kind: &AssertKind,
+    args: &[SystemFunctionInput],
+) -> RuntimeEventSite {
+    let (template, value_args) = if args
+        .first()
+        .and_then(|arg| static_string_expr(&arg.0))
+        .is_some()
+    {
+        (
+            args.first().and_then(|arg| static_string_expr(&arg.0)),
+            &args[1..],
+        )
+    } else {
+        (None, args)
+    };
+    RuntimeEventSite {
+        kind: match kind {
+            AssertKind::Fatal => RuntimeEventKind::AssertFatal,
+            AssertKind::Continue => RuntimeEventKind::AssertContinue,
+        },
+        template,
+        arg_widths: value_args.iter().map(assert_arg_width).collect(),
+        arg_signed: value_args
+            .iter()
+            .map(|arg| arg.0.comptime().expr_context.signed)
+            .collect(),
+    }
+}
+
+fn function_body<'a>(
+    funcs: &'a fxhash::FxHashMap<VarId, Function>,
+    fc: &veryl_analyzer::ir::FunctionCall,
+) -> Option<veryl_analyzer::ir::FunctionBody> {
+    let func = funcs.get(&fc.id)?;
+    if let Some(idx) = &fc.index {
+        func.get_function(idx)
+    } else {
+        func.get_function(&[])
+    }
+}
+
+fn collect_runtime_event_sites(
+    stmts: &[Statement],
+    funcs: &fxhash::FxHashMap<VarId, Function>,
+    out: &mut Vec<RuntimeEventSite>,
+) {
+    for stmt in stmts {
+        match stmt {
+            Statement::SystemFunctionCall(sf) => {
+                if let SystemFunctionKind::Assert { kind, args, .. } = &sf.kind {
+                    out.push(runtime_event_site_for_assert(kind, args));
+                }
+            }
+            Statement::If(s) => {
+                collect_runtime_event_sites(&s.true_side, funcs, out);
+                collect_runtime_event_sites(&s.false_side, funcs, out);
+            }
+            Statement::For(s) => collect_runtime_event_sites(&s.body, funcs, out),
+            Statement::FunctionCall(fc) => {
+                if let Some(body) = function_body(funcs, fc) {
+                    collect_runtime_event_sites(&body.statements, funcs, out);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn count_assert_statements(
+    stmts: &[Statement],
+    funcs: &fxhash::FxHashMap<VarId, Function>,
+) -> usize {
+    let mut count = 0;
+    for stmt in stmts {
+        match stmt {
+            Statement::SystemFunctionCall(sf) => {
+                if matches!(&sf.kind, SystemFunctionKind::Assert { .. }) {
+                    count += 1;
+                }
+            }
+            Statement::If(s) => {
+                count += count_assert_statements(&s.true_side, funcs);
+                count += count_assert_statements(&s.false_side, funcs);
+            }
+            Statement::For(s) => count += count_assert_statements(&s.body, funcs),
+            Statement::FunctionCall(fc) => {
+                if let Some(body) = function_body(funcs, fc) {
+                    count += count_assert_statements(&body.statements, funcs);
+                }
+            }
+            _ => {}
+        }
+    }
+    count
+}
+
+pub(crate) fn register_runtime_event_sites(program: &mut Program) {
+    let Some(stmts) = program.initial_statements.as_ref() else {
+        return;
+    };
+    let mut sites = Vec::new();
+    collect_runtime_event_sites(stmts, &program.tb_functions, &mut sites);
+    program.runtime_event_sites.extend(sites);
 }
 
 fn compile_assert_message<B: SimBackend>(
@@ -1230,7 +1357,7 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
         }
     }
 
-    pub(crate) fn convert(&self, stmts: &[Statement]) -> Vec<TestbenchStatement<B>> {
+    pub(crate) fn convert(&mut self, stmts: &[Statement]) -> Vec<TestbenchStatement<B>> {
         let p = self.sim.program();
         let root_instance_id = *p
             .instance_ids
@@ -1242,9 +1369,15 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
             root_instance_id,
             root_module_id,
         };
+        let site_count = count_assert_statements(stmts, &p.tb_functions) as u32;
+        let mut next_assert_site_id = p
+            .runtime_event_sites
+            .len()
+            .checked_sub(site_count as usize)
+            .unwrap_or(0) as u32;
         stmts
             .iter()
-            .filter_map(|s| self.convert_stmt(s, &ec))
+            .filter_map(|s| self.convert_stmt(s, &ec, &mut next_assert_site_id))
             .collect()
     }
 
@@ -1252,6 +1385,7 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
         &self,
         stmt: &Statement,
         ec: &ExprCompiler<'_, B>,
+        next_assert_site_id: &mut u32,
     ) -> Option<TestbenchStatement<B>> {
         fn convert_for_bound<B: SimBackend>(
             bound: &ForBound,
@@ -1271,8 +1405,11 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
             Statement::TbMethodCall(tb) => self.convert_tb_method(tb, ec),
             Statement::SystemFunctionCall(sf) => match &sf.kind {
                 SystemFunctionKind::Assert { kind, cond, args } => {
+                    let site_id = *next_assert_site_id;
+                    *next_assert_site_id = next_assert_site_id.saturating_add(1);
                     Some(TestbenchStatement::Assert {
                         expr: ec.compile(&cond.0),
+                        site_id,
                         continue_on_fail: matches!(kind, AssertKind::Continue),
                         message: compile_assert_message(args, ec),
                         location: extract_source_location(&sf.comptime.token),
@@ -1286,19 +1423,19 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
                 then_block: s
                     .true_side
                     .iter()
-                    .filter_map(|s| self.convert_stmt(s, ec))
+                    .filter_map(|s| self.convert_stmt(s, ec, next_assert_site_id))
                     .collect(),
                 else_block: s
                     .false_side
                     .iter()
-                    .filter_map(|s| self.convert_stmt(s, ec))
+                    .filter_map(|s| self.convert_stmt(s, ec, next_assert_site_id))
                     .collect(),
             }),
             Statement::For(s) => {
                 let body: Vec<_> = s
                     .body
                     .iter()
-                    .filter_map(|s| self.convert_stmt(s, ec))
+                    .filter_map(|s| self.convert_stmt(s, ec, next_assert_site_id))
                     .collect();
                 let lv = self
                     .resolve_loop_var(&s.var_id)
@@ -1363,7 +1500,7 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
                     })
             }
             Statement::Break => Some(TestbenchStatement::Break),
-            Statement::FunctionCall(fc) => self.convert_function_call(fc, ec),
+            Statement::FunctionCall(fc) => self.convert_function_call(fc, ec, next_assert_site_id),
             _ => None,
         }
     }
@@ -1374,6 +1511,7 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
         &self,
         fc: &veryl_analyzer::ir::FunctionCall,
         ec: &ExprCompiler<'_, B>,
+        next_assert_site_id: &mut u32,
     ) -> Option<TestbenchStatement<B>> {
         let program = self.sim.program();
         let func = program.tb_functions.get(&fc.id)?;
@@ -1401,7 +1539,7 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
 
         // Inline body statements
         for stmt in &func_body.statements {
-            if let Some(ts) = self.convert_stmt(stmt, ec) {
+            if let Some(ts) = self.convert_stmt(stmt, ec, next_assert_site_id) {
                 stmts.push(ts);
             }
         }
@@ -2099,6 +2237,140 @@ struct DetailedExecContext {
     current_time: u64,
 }
 
+fn assert_event_args(message: &Option<AssertMessage>) -> &[CompiledAssertArg] {
+    match message {
+        Some(AssertMessage::Formatted { args, .. }) | Some(AssertMessage::DynamicArgs(args)) => {
+            args
+        }
+        None => &[],
+    }
+}
+
+fn write_u64_volatile(base: *mut u8, byte_offset: usize, value: u64) {
+    unsafe {
+        std::ptr::write_volatile(base.add(byte_offset) as *mut u64, value);
+    }
+}
+
+fn load_u64_acquire(base: *const u8, byte_offset: usize) -> u64 {
+    unsafe { (*(base.add(byte_offset) as *const AtomicU64)).load(Ordering::Acquire) }
+}
+
+fn store_u64_release(base: *mut u8, byte_offset: usize, value: u64) {
+    unsafe {
+        (*(base.add(byte_offset) as *const AtomicU64)).store(value, Ordering::Release);
+    }
+}
+
+fn publish_tb_assert_event<B: SimBackend>(
+    sim: &mut Simulator<B>,
+    site_id: u32,
+    message: &Option<AssertMessage>,
+    memory: *mut u8,
+) {
+    let args = assert_event_args(message)
+        .iter()
+        .map(|arg| arg.expr.eval_value(memory).to_biguint())
+        .collect::<Vec<_>>();
+    let layout = sim.layout();
+    let Some(site_layout) = layout
+        .runtime_event_site_layouts
+        .get(site_id as usize)
+        .cloned()
+    else {
+        return;
+    };
+    let capacity = layout.runtime_event_capacity;
+    if capacity == 0 {
+        return;
+    }
+    let slot_size = layout.runtime_event_slot_size;
+    let (event_ptr_const, buffer_size) = sim.backend_ref().runtime_event_buffer_as_ptr();
+    if RUNTIME_EVENT_HEADER_SIZE > buffer_size {
+        return;
+    }
+    let event_ptr = event_ptr_const as *mut u8;
+    let seq = load_u64_acquire(event_ptr_const, 0);
+    let slot = (seq as usize) & (capacity - 1);
+    let slot_base = RUNTIME_EVENT_HEADER_SIZE + slot * slot_size;
+    if slot_base + slot_size > buffer_size {
+        return;
+    }
+
+    store_u64_release(
+        event_ptr,
+        slot_base + RUNTIME_EVENT_SLOT_SEQ_OFFSET,
+        RUNTIME_EVENT_WRITING,
+    );
+    write_u64_volatile(
+        event_ptr,
+        slot_base + RUNTIME_EVENT_SLOT_SITE_OFFSET,
+        site_id as u64,
+    );
+    let arg_count = args.len().min(site_layout.args.len());
+    write_u64_volatile(
+        event_ptr,
+        slot_base + RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET,
+        arg_count as u64,
+    );
+
+    for (idx, value) in args.iter().take(arg_count).enumerate() {
+        let arg_layout = &site_layout.args[idx];
+        let words = value.to_u64_digits();
+        for word_idx in 0..arg_layout.word_count {
+            let value_word = words.get(word_idx).copied().unwrap_or(0);
+            write_u64_volatile(
+                event_ptr,
+                slot_base
+                    + RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
+                    + (arg_layout.value_word_offset + word_idx) * 8,
+                value_word,
+            );
+            write_u64_volatile(
+                event_ptr,
+                slot_base
+                    + RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
+                    + (arg_layout.mask_word_offset + word_idx) * 8,
+                0,
+            );
+        }
+    }
+
+    store_u64_release(event_ptr, slot_base + RUNTIME_EVENT_SLOT_SEQ_OFFSET, seq);
+    store_u64_release(event_ptr, 0, seq.wrapping_add(1));
+}
+
+fn drain_runtime_assertions<B: SimBackend>(
+    sim: &mut Simulator<B>,
+    ctx: &mut DetailedExecContext,
+    location: Option<&SourceLocation>,
+) -> Option<String> {
+    let mut last_message = None;
+    for event in sim.drain_runtime_events() {
+        match event {
+            RuntimeEvent::AssertContinue { message } | RuntimeEvent::AssertFatal { message } => {
+                last_message = Some(message.clone());
+                ctx.assertions.push(AssertionResult {
+                    passed: false,
+                    message: Some(message),
+                    location: location.cloned(),
+                });
+            }
+            RuntimeEvent::Missed { count } => {
+                let message = format!("missed {count} runtime events");
+                last_message = Some(message.clone());
+                ctx.assertions.push(AssertionResult {
+                    passed: false,
+                    message: Some(message),
+                    location: None,
+                });
+            }
+            RuntimeEvent::Display { .. } => {}
+        }
+    }
+    last_message
+}
+
 /// Like [`exec`] but collects assertion results into `ctx` instead of
 /// short-circuiting on the first failure.
 fn exec_detailed<B: SimBackend>(
@@ -2130,7 +2402,11 @@ fn exec_one_detailed<B: SimBackend>(
             match eval_clock_count(sim, count) {
                 Ok(n) => {
                     for _ in 0..n {
-                        sim.tick(*clock_event).unwrap();
+                        if let Err(e) = sim.tick(*clock_event) {
+                            drain_runtime_assertions(sim, ctx, None);
+                            return ExecResult::Fail(format!("{e}"));
+                        }
+                        drain_runtime_assertions(sim, ctx, None);
                     }
                     ctx.current_time = ctx.current_time.saturating_add(n);
                     ExecResult::Continue
@@ -2148,8 +2424,10 @@ fn exec_one_detailed<B: SimBackend>(
             sim_set_u64(sim, *reset_signal, (*assert_value).into());
             for _ in 0..*duration {
                 if let Err(e) = sim.tick(*clock_event) {
+                    drain_runtime_assertions(sim, ctx, None);
                     return ExecResult::Fail(format!("reset: {e}"));
                 }
+                drain_runtime_assertions(sim, ctx, None);
             }
             ctx.current_time = ctx.current_time.saturating_add(*duration);
             sim_set_u64(sim, *reset_signal, (*deassert_value).into());
@@ -2157,6 +2435,7 @@ fn exec_one_detailed<B: SimBackend>(
         }
         TestbenchStatement::Assert {
             expr,
+            site_id,
             continue_on_fail,
             message,
             location,
@@ -2167,11 +2446,24 @@ fn exec_one_detailed<B: SimBackend>(
             let (ptr, _) = sim.memory_as_mut_ptr();
             let passed = expr.eval_bool(ptr);
             let rendered_message = render_assert_message(message, ptr, ctx.current_time);
-            ctx.assertions.push(AssertionResult {
-                passed,
-                message: rendered_message.clone(),
-                location: location.clone(),
-            });
+            if passed {
+                ctx.assertions.push(AssertionResult {
+                    passed,
+                    message: rendered_message.clone(),
+                    location: location.clone(),
+                });
+            } else {
+                publish_tb_assert_event(sim, *site_id, message, ptr);
+                // TB has extra formatting context (%t/%m and width handling) that
+                // runtime events do not carry yet. Publish to the shared ring for
+                // ordering/producer semantics, then keep the established TB message.
+                sim.drain_runtime_events();
+                ctx.assertions.push(AssertionResult {
+                    passed,
+                    message: rendered_message.clone(),
+                    location: location.clone(),
+                });
+            }
             if !passed && !continue_on_fail && ctx.stop_on_fatal_assert {
                 ExecResult::Fail(rendered_message.unwrap_or_else(|| "assertion failed".to_string()))
             } else {

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -14,7 +14,7 @@ use crate::backend::memory_layout::{
 use crate::backend::traits::SimBackend;
 use crate::display_format::{DisplayFormatArg, format_display_arg};
 use crate::ir::{AbsoluteAddr, Program, RuntimeEventKind, RuntimeEventSite, SignalRef};
-use crate::simulator::{RuntimeEvent, Simulator};
+use crate::simulator::{RuntimeEvent, RuntimeFormatContext, Simulator};
 use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::ToPrimitive as _;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -460,6 +460,10 @@ fn runtime_event_site_for_assert(
         arg_signed: value_args
             .iter()
             .map(|arg| arg.0.comptime().expr_context.signed)
+            .collect(),
+        arg_is_string: value_args
+            .iter()
+            .map(|arg| arg.0.comptime().r#type.is_string())
             .collect(),
     }
 }
@@ -2346,7 +2350,11 @@ fn drain_runtime_assertions<B: SimBackend>(
     location: Option<&SourceLocation>,
 ) -> Option<String> {
     let mut last_message = None;
-    for event in sim.drain_runtime_events() {
+    let format_ctx = RuntimeFormatContext {
+        tb_time: Some(ctx.current_time),
+        scope: None,
+    };
+    for event in sim.drain_runtime_events_with_context(format_ctx) {
         match event {
             RuntimeEvent::AssertContinue { message } | RuntimeEvent::AssertFatal { message } => {
                 last_message = Some(message.clone());
@@ -2445,29 +2453,25 @@ fn exec_one_detailed<B: SimBackend>(
             }
             let (ptr, _) = sim.memory_as_mut_ptr();
             let passed = expr.eval_bool(ptr);
-            let rendered_message = render_assert_message(message, ptr, ctx.current_time);
             if passed {
+                let rendered_message = render_assert_message(message, ptr, ctx.current_time);
                 ctx.assertions.push(AssertionResult {
                     passed,
                     message: rendered_message.clone(),
                     location: location.clone(),
                 });
+                ExecResult::Continue
             } else {
                 publish_tb_assert_event(sim, *site_id, message, ptr);
-                // TB has extra formatting context (%t/%m and width handling) that
-                // runtime events do not carry yet. Publish to the shared ring for
-                // ordering/producer semantics, then keep the established TB message.
-                sim.drain_runtime_events();
-                ctx.assertions.push(AssertionResult {
-                    passed,
-                    message: rendered_message.clone(),
-                    location: location.clone(),
-                });
-            }
-            if !passed && !continue_on_fail && ctx.stop_on_fatal_assert {
-                ExecResult::Fail(rendered_message.unwrap_or_else(|| "assertion failed".to_string()))
-            } else {
-                ExecResult::Continue
+                let rendered_message = drain_runtime_assertions(sim, ctx, location.as_ref())
+                    .or_else(|| render_assert_message(message, ptr, ctx.current_time));
+                if !continue_on_fail && ctx.stop_on_fatal_assert {
+                    ExecResult::Fail(
+                        rendered_message.unwrap_or_else(|| "assertion failed".to_string()),
+                    )
+                } else {
+                    ExecResult::Continue
+                }
             }
         }
         TestbenchStatement::If {

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -49,7 +49,8 @@ pub struct AssertionResult {
     pub location: Option<SourceLocation>,
 }
 
-/// Detailed test result collecting all assertion outcomes.
+/// Detailed test result with assertion outcomes observed before the test
+/// finishes or stops on a fatal failure.
 #[derive(Debug, Clone)]
 pub struct TestResultDetailed {
     pub passed: bool,
@@ -468,8 +469,8 @@ fn runtime_event_site_for_assert(
     }
 }
 
-fn function_body<'a>(
-    funcs: &'a fxhash::FxHashMap<VarId, Function>,
+fn function_body(
+    funcs: &fxhash::FxHashMap<VarId, Function>,
     fc: &veryl_analyzer::ir::FunctionCall,
 ) -> Option<veryl_analyzer::ir::FunctionBody> {
     let func = funcs.get(&fc.id)?;
@@ -1381,8 +1382,7 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
         let mut next_assert_site_id = p
             .runtime_event_sites
             .len()
-            .checked_sub(site_count as usize)
-            .unwrap_or(0) as u32;
+            .saturating_sub(site_count as usize) as u32;
         stmts
             .iter()
             .filter_map(|s| self.convert_stmt(s, &ec, &mut next_assert_site_id))
@@ -2163,7 +2163,6 @@ pub(crate) fn run_testbench<B: SimBackend>(
 ) -> TestResult {
     let mut ctx = DetailedExecContext {
         assertions: Vec::new(),
-        stop_on_fatal_assert: true,
         current_time: 0,
     };
     let result = exec_detailed(sim, stmts, &mut ctx);
@@ -2220,15 +2219,14 @@ pub fn run_compiled_testbench<B: SimBackend>(
     run_testbench(sim, &tb.stmts)
 }
 
-/// Run the testbench collecting **all** assertion results instead of stopping
-/// at the first failure.
+/// Run the testbench and return assertion results observed before the test
+/// finishes or stops on a fatal failure.
 pub(crate) fn run_testbench_detailed<B: SimBackend>(
     sim: &mut Simulator<B>,
     stmts: &[TestbenchStatement<B>],
 ) -> TestResultDetailed {
     let mut ctx = DetailedExecContext {
         assertions: Vec::new(),
-        stop_on_fatal_assert: false,
         current_time: 0,
     };
     let result = exec_detailed(sim, stmts, &mut ctx);
@@ -2241,7 +2239,6 @@ pub(crate) fn run_testbench_detailed<B: SimBackend>(
 
 struct DetailedExecContext {
     assertions: Vec<AssertionResult>,
-    stop_on_fatal_assert: bool,
     current_time: u64,
 }
 
@@ -2437,20 +2434,13 @@ fn exec_one_detailed<B: SimBackend>(
                         if let Err(e) = sim.tick(*clock_event) {
                             ctx.current_time = ctx.current_time.saturating_add(1);
                             let drained = drain_runtime_assertions(sim, ctx, None);
-                            if ctx.stop_on_fatal_assert {
-                                if let Some(message) = drained.fatal_message {
-                                    return ExecResult::Fail(message);
-                                }
+                            if let Some(message) = drained.fatal_message {
+                                return ExecResult::Fail(message);
                             }
                             return ExecResult::Fail(format!("{e}"));
                         }
                         ctx.current_time = ctx.current_time.saturating_add(1);
-                        let drained = drain_runtime_assertions(sim, ctx, None);
-                        if ctx.stop_on_fatal_assert {
-                            if let Some(message) = drained.fatal_message {
-                                return ExecResult::Fail(message);
-                            }
-                        }
+                        drain_runtime_assertions(sim, ctx, None);
                     }
                     ExecResult::Continue
                 }
@@ -2469,20 +2459,13 @@ fn exec_one_detailed<B: SimBackend>(
                 if let Err(e) = sim.tick(*clock_event) {
                     ctx.current_time = ctx.current_time.saturating_add(1);
                     let drained = drain_runtime_assertions(sim, ctx, None);
-                    if ctx.stop_on_fatal_assert {
-                        if let Some(message) = drained.fatal_message {
-                            return ExecResult::Fail(message);
-                        }
+                    if let Some(message) = drained.fatal_message {
+                        return ExecResult::Fail(message);
                     }
                     return ExecResult::Fail(format!("reset: {e}"));
                 }
                 ctx.current_time = ctx.current_time.saturating_add(1);
-                let drained = drain_runtime_assertions(sim, ctx, None);
-                if ctx.stop_on_fatal_assert {
-                    if let Some(message) = drained.fatal_message {
-                        return ExecResult::Fail(message);
-                    }
-                }
+                drain_runtime_assertions(sim, ctx, None);
             }
             sim_set_u64(sim, *reset_signal, (*deassert_value).into());
             ExecResult::Continue
@@ -2512,7 +2495,7 @@ fn exec_one_detailed<B: SimBackend>(
                 let rendered_message = drain_runtime_assertions(sim, ctx, location.as_ref())
                     .last_message
                     .or_else(|| render_assert_message(message, ptr, ctx.current_time));
-                if !continue_on_fail && ctx.stop_on_fatal_assert {
+                if !continue_on_fail {
                     ExecResult::Fail(
                         rendered_message.unwrap_or_else(|| "assertion failed".to_string()),
                     )
@@ -2570,5 +2553,31 @@ fn exec_one_detailed<B: SimBackend>(
         }
         TestbenchStatement::Break => ExecResult::Break,
         TestbenchStatement::Finish => ExecResult::Finished,
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::{Simulator, TestResult};
+
+    #[test]
+    fn traced_build_registers_compiled_testbench_runtime_event_sites() {
+        let code = r#"
+            #[test(t)]
+            module t {
+                initial {
+                    $assert_continue(1'b0, "continue failure");
+                    $finish();
+                }
+            }
+        "#;
+        let mut sim = Simulator::builder(code, "t").build_with_trace().unwrap();
+        let tb = compile_initial_testbench(&sim).unwrap();
+
+        assert_eq!(
+            run_compiled_testbench(&mut sim, &tb),
+            TestResult::Fail("continue failure".to_string()),
+        );
     }
 }

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -611,10 +611,10 @@ fn render_assert_message(
                     }
                     Some(spec) => {
                         chars.next();
-                        // Keep native testbench formatting aligned with upstream Veryl's
-                        // `format_display_string()`: only single-character specifiers are
-                        // recognized today, so width/flag modifiers such as `%0d` and `%08x`
-                        // remain literal text rather than being parsed here independently.
+                        while matches!(chars.peek(), Some('0'..='9')) {
+                            chars.next();
+                        }
+                        let spec = chars.next().unwrap_or(spec);
                         match spec {
                             'h' | 'H' | 'x' | 'X' | 'd' | 'D' | 'i' | 'I' | 'o' | 'O' | 'b'
                             | 'B' | 'c' | 'C' | 's' | 'S' => {
@@ -2411,12 +2411,13 @@ fn exec_one_detailed<B: SimBackend>(
                 Ok(n) => {
                     for _ in 0..n {
                         if let Err(e) = sim.tick(*clock_event) {
+                            ctx.current_time = ctx.current_time.saturating_add(1);
                             drain_runtime_assertions(sim, ctx, None);
                             return ExecResult::Fail(format!("{e}"));
                         }
+                        ctx.current_time = ctx.current_time.saturating_add(1);
                         drain_runtime_assertions(sim, ctx, None);
                     }
-                    ctx.current_time = ctx.current_time.saturating_add(n);
                     ExecResult::Continue
                 }
                 Err(e) => ExecResult::Fail(e),
@@ -2432,12 +2433,13 @@ fn exec_one_detailed<B: SimBackend>(
             sim_set_u64(sim, *reset_signal, (*assert_value).into());
             for _ in 0..*duration {
                 if let Err(e) = sim.tick(*clock_event) {
+                    ctx.current_time = ctx.current_time.saturating_add(1);
                     drain_runtime_assertions(sim, ctx, None);
                     return ExecResult::Fail(format!("reset: {e}"));
                 }
+                ctx.current_time = ctx.current_time.saturating_add(1);
                 drain_runtime_assertions(sim, ctx, None);
             }
-            ctx.current_time = ctx.current_time.saturating_add(*duration);
             sim_set_u64(sim, *reset_signal, (*deassert_value).into());
             ExecResult::Continue
         }

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -611,10 +611,14 @@ fn render_assert_message(
                     }
                     Some(spec) => {
                         chars.next();
-                        while matches!(chars.peek(), Some('0'..='9')) {
-                            chars.next();
-                        }
-                        let spec = chars.next().unwrap_or(spec);
+                        let spec = if spec.is_ascii_digit() {
+                            while matches!(chars.peek(), Some('0'..='9')) {
+                                chars.next();
+                            }
+                            chars.next().unwrap_or(spec)
+                        } else {
+                            spec
+                        };
                         match spec {
                             'h' | 'H' | 'x' | 'X' | 'd' | 'D' | 'i' | 'I' | 'o' | 'O' | 'b'
                             | 'B' | 'c' | 'C' | 's' | 'S' => {
@@ -2266,6 +2270,11 @@ fn store_u64_release(base: *mut u8, byte_offset: usize, value: u64) {
     }
 }
 
+struct DrainedAssertionEvents {
+    last_message: Option<String>,
+    fatal_message: Option<String>,
+}
+
 fn publish_tb_assert_event<B: SimBackend>(
     sim: &mut Simulator<B>,
     site_id: u32,
@@ -2348,16 +2357,28 @@ fn drain_runtime_assertions<B: SimBackend>(
     sim: &mut Simulator<B>,
     ctx: &mut DetailedExecContext,
     location: Option<&SourceLocation>,
-) -> Option<String> {
+) -> DrainedAssertionEvents {
     let mut last_message = None;
+    let mut fatal_message = None;
     let format_ctx = RuntimeFormatContext {
         tb_time: Some(ctx.current_time),
         scope: None,
     };
     for event in sim.drain_runtime_events_with_context(format_ctx) {
         match event {
-            RuntimeEvent::AssertContinue { message } | RuntimeEvent::AssertFatal { message } => {
+            RuntimeEvent::AssertContinue { message } => {
                 last_message = Some(message.clone());
+                ctx.assertions.push(AssertionResult {
+                    passed: false,
+                    message: Some(message),
+                    location: location.cloned(),
+                });
+            }
+            RuntimeEvent::AssertFatal { message } => {
+                last_message = Some(message.clone());
+                if fatal_message.is_none() {
+                    fatal_message = Some(message.clone());
+                }
                 ctx.assertions.push(AssertionResult {
                     passed: false,
                     message: Some(message),
@@ -2376,7 +2397,10 @@ fn drain_runtime_assertions<B: SimBackend>(
             RuntimeEvent::Display { .. } => {}
         }
     }
-    last_message
+    DrainedAssertionEvents {
+        last_message,
+        fatal_message,
+    }
 }
 
 /// Like [`exec`] but collects assertion results into `ctx` instead of
@@ -2412,11 +2436,21 @@ fn exec_one_detailed<B: SimBackend>(
                     for _ in 0..n {
                         if let Err(e) = sim.tick(*clock_event) {
                             ctx.current_time = ctx.current_time.saturating_add(1);
-                            drain_runtime_assertions(sim, ctx, None);
+                            let drained = drain_runtime_assertions(sim, ctx, None);
+                            if ctx.stop_on_fatal_assert {
+                                if let Some(message) = drained.fatal_message {
+                                    return ExecResult::Fail(message);
+                                }
+                            }
                             return ExecResult::Fail(format!("{e}"));
                         }
                         ctx.current_time = ctx.current_time.saturating_add(1);
-                        drain_runtime_assertions(sim, ctx, None);
+                        let drained = drain_runtime_assertions(sim, ctx, None);
+                        if ctx.stop_on_fatal_assert {
+                            if let Some(message) = drained.fatal_message {
+                                return ExecResult::Fail(message);
+                            }
+                        }
                     }
                     ExecResult::Continue
                 }
@@ -2434,11 +2468,21 @@ fn exec_one_detailed<B: SimBackend>(
             for _ in 0..*duration {
                 if let Err(e) = sim.tick(*clock_event) {
                     ctx.current_time = ctx.current_time.saturating_add(1);
-                    drain_runtime_assertions(sim, ctx, None);
+                    let drained = drain_runtime_assertions(sim, ctx, None);
+                    if ctx.stop_on_fatal_assert {
+                        if let Some(message) = drained.fatal_message {
+                            return ExecResult::Fail(message);
+                        }
+                    }
                     return ExecResult::Fail(format!("reset: {e}"));
                 }
                 ctx.current_time = ctx.current_time.saturating_add(1);
-                drain_runtime_assertions(sim, ctx, None);
+                let drained = drain_runtime_assertions(sim, ctx, None);
+                if ctx.stop_on_fatal_assert {
+                    if let Some(message) = drained.fatal_message {
+                        return ExecResult::Fail(message);
+                    }
+                }
             }
             sim_set_u64(sim, *reset_signal, (*deassert_value).into());
             ExecResult::Continue
@@ -2466,6 +2510,7 @@ fn exec_one_detailed<B: SimBackend>(
             } else {
                 publish_tb_assert_event(sim, *site_id, message, ptr);
                 let rendered_message = drain_runtime_assertions(sim, ctx, location.as_ref())
+                    .last_message
                     .or_else(|| render_assert_message(message, ptr, ctx.current_time));
                 if !continue_on_fail && ctx.stop_on_fatal_assert {
                     ExecResult::Fail(

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -286,6 +286,30 @@ fn test_ff_runtime_fatal_assert_records_event(sim) {
     );
 }
 
+fn test_ff_message_less_runtime_fatal_assert_uses_default_message(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @setup { let code = r#"
+        module Top (clk: input clock) {
+            always_ff (clk) {
+                $assert(1'b0);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+
+    let err = sim.tick(clk).unwrap_err();
+    assert_eq!(err.to_string(), "assertion failed");
+    let events = sim.drain_runtime_events();
+    assert_eq!(
+        events,
+        vec![celox::RuntimeEvent::AssertFatal {
+            message: "assertion failed".to_string(),
+        }],
+    );
+}
+
 fn test_ff_runtime_for_bounds(sim) {
     @setup { let code = r#"
         module Top (

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -1165,9 +1165,49 @@ fn test_passing_assert_preserves_single_character_format_specifiers() {
     assert!(detailed.passed);
     assert_eq!(detailed.assertions.len(), 1);
     assert!(detailed.assertions[0].passed);
+    assert_eq!(detailed.assertions[0].message.as_deref(), Some("a=3 b=7"),);
+}
+
+#[test]
+fn test_message_less_testbench_assert_uses_default_message() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            initial {
+                $assert(1'b0);
+                $finish();
+            }
+        }
+    "#;
+    let result = Simulator::builder(code, "t").run_test().unwrap();
+    assert_eq!(result, TestResult::Fail("assertion failed".to_string()));
+
+    let detailed = Simulator::builder(code, "t").run_test_detailed().unwrap();
+    assert!(!detailed.passed);
+    assert_eq!(detailed.assertions.len(), 1);
     assert_eq!(
         detailed.assertions[0].message.as_deref(),
-        Some("a=3 b=7"),
+        Some("assertion failed"),
+    );
+}
+
+#[test]
+fn test_message_less_testbench_assert_continue_uses_default_message() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            initial {
+                $assert_continue(1'b0);
+                $finish();
+            }
+        }
+    "#;
+    let detailed = Simulator::builder(code, "t").run_test_detailed().unwrap();
+    assert!(!detailed.passed);
+    assert_eq!(detailed.assertions.len(), 1);
+    assert_eq!(
+        detailed.assertions[0].message.as_deref(),
+        Some("assertion failed"),
     );
 }
 
@@ -1338,7 +1378,7 @@ fn test_assert_format_args_preserve_binary_width_and_hex_alias() {
 }
 
 #[test]
-fn test_run_test_detailed_collects_multiple_plain_assert_failures() {
+fn test_run_test_detailed_stops_on_plain_assert_failure() {
     let code = r#"
         #[test(t)]
         module t {
@@ -1351,11 +1391,9 @@ fn test_run_test_detailed_collects_multiple_plain_assert_failures() {
     "#;
     let detailed = Simulator::builder(code, "t").run_test_detailed().unwrap();
     assert!(!detailed.passed);
-    assert_eq!(detailed.assertions.len(), 2);
+    assert_eq!(detailed.assertions.len(), 1);
     assert!(!detailed.assertions[0].passed);
     assert_eq!(detailed.assertions[0].message.as_deref(), Some("first"));
-    assert!(!detailed.assertions[1].passed);
-    assert_eq!(detailed.assertions[1].message.as_deref(), Some("second"));
 }
 
 #[test]

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -1130,6 +1130,27 @@ fn test_assert_format_args_follow_veryl_single_char_specifiers() {
 }
 
 #[test]
+fn test_passing_assert_uses_runtime_event_formatting() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            initial {
+                $assert_continue(1'b1, "cnt=%0d hex=%08x", 8'd3, 8'h0f);
+                $finish();
+            }
+        }
+    "#;
+    let detailed = Simulator::builder(code, "t").run_test_detailed().unwrap();
+    assert!(detailed.passed);
+    assert_eq!(detailed.assertions.len(), 1);
+    assert!(detailed.assertions[0].passed);
+    assert_eq!(
+        detailed.assertions[0].message.as_deref(),
+        Some("cnt=3 hex=f"),
+    );
+}
+
+#[test]
 fn test_assert_format_args_render_percent_m_and_t_without_args() {
     let code = r#"
         #[test(t)]
@@ -1146,6 +1167,38 @@ fn test_assert_format_args_render_percent_m_and_t_without_args() {
     assert_eq!(
         detailed.assertions[0].message.as_deref(),
         Some("loc=<hierarchy> time=0"),
+    );
+}
+
+#[test]
+fn test_ff_runtime_events_drain_with_per_tick_time() {
+    let code = r#"
+        module Top (clk: input clock) {
+            always_ff (clk) {
+                $assert_continue(1'b0, "ff time=%t");
+            }
+        }
+
+        #[test(t)]
+        module t {
+            inst clk: $tb::clock_gen;
+            inst dut: Top (clk);
+            initial {
+                clk.next(3);
+                $finish();
+            }
+        }
+    "#;
+    let detailed = Simulator::builder(code, "t").run_test_detailed().unwrap();
+    assert!(!detailed.passed);
+    assert_eq!(detailed.assertions.len(), 3);
+    assert_eq!(
+        detailed
+            .assertions
+            .iter()
+            .map(|a| a.message.as_deref())
+            .collect::<Vec<_>>(),
+        vec![Some("ff time=1"), Some("ff time=2"), Some("ff time=3")],
     );
 }
 

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -1125,7 +1125,7 @@ fn test_assert_format_args_follow_veryl_single_char_specifiers() {
     assert_eq!(detailed.assertions.len(), 1);
     assert_eq!(
         detailed.assertions[0].message.as_deref(),
-        Some("cnt=%0d hex=%08x"),
+        Some("cnt=3 hex=f"),
     );
 }
 

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -1284,6 +1284,33 @@ fn test_run_test_detailed_collects_multiple_plain_assert_failures() {
     assert_eq!(detailed.assertions[1].message.as_deref(), Some("second"));
 }
 
+#[test]
+fn test_run_test_detailed_collects_ff_assert_runtime_events() {
+    let code = r#"
+        module Top (clk: input clock, a: input logic<8>) {
+            always_ff (clk) {
+                $assert_continue(a != 8'd0, "ff a=%0d", a);
+            }
+        }
+
+        #[test(t)]
+        module t {
+            inst clk: $tb::clock_gen;
+            var a: logic<8>;
+            inst dut: Top (clk, a);
+            initial {
+                clk.next(1);
+                $finish();
+            }
+        }
+    "#;
+    let detailed = Simulator::builder(code, "t").run_test_detailed().unwrap();
+    assert!(!detailed.passed);
+    assert_eq!(detailed.assertions.len(), 1);
+    assert!(!detailed.assertions[0].passed);
+    assert_eq!(detailed.assertions[0].message.as_deref(), Some("ff a=0"));
+}
+
 // ── Array and bit select ───────────────────────────────────────────────
 
 #[test]

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -1151,6 +1151,27 @@ fn test_passing_assert_uses_runtime_event_formatting() {
 }
 
 #[test]
+fn test_passing_assert_preserves_single_character_format_specifiers() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            initial {
+                $assert_continue(1'b1, "a=%d b=%d", 8'd3, 8'd7);
+                $finish();
+            }
+        }
+    "#;
+    let detailed = Simulator::builder(code, "t").run_test_detailed().unwrap();
+    assert!(detailed.passed);
+    assert_eq!(detailed.assertions.len(), 1);
+    assert!(detailed.assertions[0].passed);
+    assert_eq!(
+        detailed.assertions[0].message.as_deref(),
+        Some("a=3 b=7"),
+    );
+}
+
+#[test]
 fn test_assert_format_args_render_percent_m_and_t_without_args() {
     let code = r#"
         #[test(t)]
@@ -1362,6 +1383,30 @@ fn test_run_test_detailed_collects_ff_assert_runtime_events() {
     assert_eq!(detailed.assertions.len(), 1);
     assert!(!detailed.assertions[0].passed);
     assert_eq!(detailed.assertions[0].message.as_deref(), Some("ff a=0"));
+}
+
+#[test]
+fn test_run_test_stops_on_ff_fatal_runtime_event() {
+    let code = r#"
+        module Top (clk: input clock) {
+            always_ff (clk) {
+                $assert(1'b0, "ff fatal");
+            }
+        }
+
+        #[test(t)]
+        module t {
+            inst clk: $tb::clock_gen;
+            inst dut: Top (clk);
+            initial {
+                clk.next(2);
+                $assert_continue(1'b0, "after fatal");
+                $finish();
+            }
+        }
+    "#;
+    let result = Simulator::builder(code, "t").run_test().unwrap();
+    assert_eq!(result, TestResult::Fail("ff fatal".to_string()));
 }
 
 // ── Array and bit select ───────────────────────────────────────────────

--- a/packages/celox/src/e2e.test.ts
+++ b/packages/celox/src/e2e.test.ts
@@ -2757,6 +2757,38 @@ module CounterTbFail {
 }
 `;
 
+const TB_MULTIPLE_TESTS_SOURCE = `
+${TB_COUNTER_SOURCE}
+#[test(t)]
+module CounterTbFailFirst {
+    inst clk: $tb::clock_gen;
+    inst rst: $tb::reset_gen(clk);
+    var cnt: logic<32>;
+    inst dut: Counter_tb (clk, rst, cnt);
+    initial {
+        rst.assert(clk);
+        clk.next  (5);
+        $assert   (cnt == 32'd99, "fail first");
+        $assert   (cnt == 32'd5, "should not run");
+        $finish   ();
+    }
+}
+
+#[test(t)]
+module CounterTbPassSecond {
+    inst clk: $tb::clock_gen;
+    inst rst: $tb::reset_gen(clk);
+    var cnt: logic<32>;
+    inst dut: Counter_tb (clk, rst, cnt);
+    initial {
+        rst.assert(clk);
+        clk.next  (5);
+        $assert   (cnt == 32'd5, "pass second");
+        $finish   ();
+    }
+}
+`;
+
 describe("E2E: native testbench (runTest)", () => {
 	const addon = loadNativeAddon();
 
@@ -2770,16 +2802,33 @@ describe("E2E: native testbench (runTest)", () => {
 		expect(result.assertions[0]!.passed).toBe(true);
 	});
 
-	test("failing testbench returns passed=false and collects all assertions", () => {
+	test("failing testbench returns passed=false and stops on plain assert", () => {
 		const result: NapiTestResult = addon.runTest(
 			[{ content: TB_FAIL_SOURCE, path: "test.veryl" }],
 			"CounterTbFail",
 		);
 		expect(result.passed).toBe(false);
-		// Both assertions are collected (not stopped at first failure)
-		expect(result.assertions.length).toBe(2);
+		expect(result.assertions.length).toBe(1);
 		expect(result.assertions[0]!.passed).toBe(false);
-		expect(result.assertions[1]!.passed).toBe(true);
+	});
+
+	test("multiple test modules run independently after one fails", () => {
+		const sources = [{ content: TB_MULTIPLE_TESTS_SOURCE, path: "test.veryl" }];
+
+		const first: NapiTestResult = addon.runTest(sources, "CounterTbFailFirst");
+		expect(first.passed).toBe(false);
+		expect(first.assertions.length).toBe(1);
+		expect(first.assertions[0]!.passed).toBe(false);
+		expect(first.assertions[0]!.message).toBe("fail first");
+
+		const second: NapiTestResult = addon.runTest(
+			sources,
+			"CounterTbPassSecond",
+		);
+		expect(second.passed).toBe(true);
+		expect(second.assertions.length).toBe(1);
+		expect(second.assertions[0]!.passed).toBe(true);
+		expect(second.assertions[0]!.message).toBe("pass second");
 	});
 
 	test("assertion results include source location", () => {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -222,7 +222,8 @@ function generateEsmExport(
  * Generate vitest test code for native testbench modules.
  *
  * Each `#[test]` module becomes a single `test()` case that runs the
- * testbench via NAPI and reports all assertion results.
+ * testbench via NAPI and reports the assertion results observed before that
+ * test finishes or stops on a fatal failure.
  */
 function generateTestCode(
 	testModuleNames: string[],


### PR DESCRIPTION
## Summary

Routes native testbench assertion failures through the runtime-event ring so testbench and clocked runtime assertions share the same formatting/drain path.

Key changes:
- add runtime-event site registration for native testbench assertions before layout is finalized
- publish failed testbench assertions into the runtime-event ring and drain them through the consumer-side formatter
- render runtime events with testbench time context, including `%t` support for per-tick drains
- preserve fatal assertion control flow: plain `$assert` stops the current test, while `$assert_continue` records and continues
- preserve default `"assertion failed"` messages for message-less assertions
- register testbench runtime-event sites for traced builds as well
- add regression coverage for formatting consistency, per-tick time, message-less asserts, traced builds, and independent multiple `#[test]` execution through NAPI/Vitest

## Validation

Pre-push hook passed:
- cargo fmt
- biome check
- cargo clippy
- pnpm run build:napi
- cargo test
- pnpm build
- packages/celox Vitest suite

Additional targeted checks run during development included:
- cargo check -p celox
- cargo check -p celox-napi
- cargo check -p celox --target wasm32-unknown-unknown
- cargo test -p celox --test native_testbench
- cargo test -p celox testbench::tests::traced_build_registers_compiled_testbench_runtime_event_sites
- pnpm --filter @celox-sim/celox test -- src/e2e.test.ts