### PR TITLE
Group napi-rs Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,16 @@
   "packageRules": [
     {
       "matchManagers": [
+        "cargo"
+      ],
+      "matchPackageNames": [
+        "napi",
+        "napi-derive"
+      ],
+      "groupName": "napi-rs crates"
+    },
+    {
+      "matchManagers": [
         "cargo",
         "npm"
       ],


### PR DESCRIPTION
## Summary

- Group `napi` and `napi-derive` Cargo updates in Renovate.
- Keep future napi-rs lockfile updates in one PR so runtime and derive macro crates are resolved together.

## Context

Renovate PR #104 updated only `napi` to 3.8.6. That lockfile shape fails `cargo check -p celox-napi` because the existing `napi-derive` generates code for the older `napi` API. Grouping the direct napi-rs dependencies lets Renovate update them together and avoids creating an incompatible lockfile-only PR.

## Checks

- pre-push hook
  - submodule-check
  - cargo fmt
  - Biome
  - cargo clippy
  - full test suite