### PR TITLE
[codex] Support initial readmem memory loading

### DIFF
--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -60,6 +60,22 @@ pub struct VariableInfo {
     pub array_dims: Vec<usize>,
 }
 
+#[derive(Clone, Debug)]
+pub struct InitialMemoryValue {
+    pub addr: AbsoluteAddr,
+    pub value: BigUint,
+    pub mask: BigUint,
+    pub written_mask: BigUint,
+}
+
+#[derive(Clone, Debug)]
+pub struct ModuleInitialMemoryValue {
+    pub var_id: VarId,
+    pub value: BigUint,
+    pub mask: BigUint,
+    pub written_mask: BigUint,
+}
+
 impl fmt::Debug for VariableInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("VariableInfo")
@@ -139,6 +155,8 @@ pub struct Program {
     pub address_aliases: HashMap<AbsoluteAddr, AbsoluteAddr>,
     /// Pre-computed memory layout. Built after optimization, before backend codegen.
     pub layout: Option<crate::backend::MemoryLayout>,
+    /// Initial memory contents loaded from synthesizable initial blocks.
+    pub initial_memory_values: Vec<InitialMemoryValue>,
     /// Initial block statements from the top-level module (for native testbenches).
     pub initial_statements: Option<Vec<veryl_analyzer::ir::Statement>>,
     /// Functions defined in the top-level module (for testbench function calls).
@@ -597,6 +615,7 @@ pub struct SimModule {
     pub comb_blocks: Vec<LogicPath<VarId>>,
     pub runtime_errors: HashMap<i64, RuntimeErrorInfo<VarId>>,
     pub runtime_event_sites: Vec<RuntimeEventSite>,
+    pub initial_memory_values: Vec<ModuleInitialMemoryValue>,
     pub comb_boundaries: HashMap<VarId, std::collections::BTreeSet<usize>>,
     pub arena: SLTNodeArena<VarId>,
     pub store: SymbolicStore<VarId>,

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -742,6 +742,7 @@ pub(crate) fn flatten(
             reset_clock_map: HashMap::default(),
             address_aliases: HashMap::default(),
             layout: None,
+            initial_memory_values: Vec::new(),
             initial_statements: None,
             tb_functions: fxhash::FxHashMap::default(),
         };
@@ -829,6 +830,23 @@ pub(crate) fn flatten(
 
     let num_events = topological_clocks.len();
     let (mod_vars, mod_path_idx) = module_variables(module_ir, config)?;
+    let initial_memory_values = instance_modules
+        .iter()
+        .flat_map(|(&instance_id, module_id)| {
+            modules[module_id]
+                .initial_memory_values
+                .iter()
+                .map(move |init| crate::ir::InitialMemoryValue {
+                    addr: AbsoluteAddr {
+                        instance_id,
+                        var_id: init.var_id,
+                    },
+                    value: init.value.clone(),
+                    mask: init.mask.clone(),
+                    written_mask: init.written_mask.clone(),
+                })
+        })
+        .collect();
     let program = Program {
         eval_apply_ffs,
         eval_only_ffs,
@@ -850,6 +868,7 @@ pub(crate) fn flatten(
         reset_clock_map,
         address_aliases: HashMap::default(),
         layout: None,
+        initial_memory_values,
         initial_statements,
         tb_functions: module_ir
             .get(root_id)

--- a/crates/celox/src/parser/module.rs
+++ b/crates/celox/src/parser/module.rs
@@ -19,6 +19,7 @@ use veryl_analyzer::ir::{
     AssignDestination, Component, Declaration, Expression, InstDeclaration, Module, Statement,
     SystemFunctionInput, SystemFunctionKind, VarId,
 };
+use veryl_analyzer::value::Value;
 use veryl_analyzer::value::byte_value_to_string;
 use veryl_parser::resource_table::StrId;
 
@@ -253,18 +254,72 @@ impl<'a> ModuleParser<'a> {
         &mut self,
         decl: &veryl_analyzer::ir::InitialDeclaration,
     ) -> Result<(), ParserError> {
+        let mut context = veryl_analyzer::Context::default();
+        context.variables = self.module.variables.clone();
         for stmt in &decl.statements {
-            self.parse_initial_statement(stmt)?;
+            self.parse_initial_statement(stmt, &mut context)?;
         }
         Ok(())
     }
 
-    fn parse_initial_statement(&mut self, stmt: &Statement) -> Result<(), ParserError> {
+    fn parse_initial_statement(
+        &mut self,
+        stmt: &Statement,
+        context: &mut veryl_analyzer::Context,
+    ) -> Result<(), ParserError> {
         match stmt {
             Statement::SystemFunctionCall(call) => {
                 if let SystemFunctionKind::Readmemh(filename, output) = &call.kind {
                     let value = self.parse_readmem_file(filename, output.0.as_slice(), 16)?;
                     self.initial_memory_values.push(value);
+                }
+                Ok(())
+            }
+            Statement::If(if_stmt) => {
+                let cond = if_stmt
+                    .cond
+                    .clone()
+                    .eval_value(context)
+                    .and_then(|value| value.to_usize());
+                let Some(cond) = cond else {
+                    return Err(ParserError::unsupported(
+                        111,
+                        LoweringPhase::SimulatorParser,
+                        "initial if condition",
+                        "condition must be compile-time constant",
+                        Some(&if_stmt.token),
+                    ));
+                };
+                let branch = if cond != 0 {
+                    &if_stmt.true_side
+                } else {
+                    &if_stmt.false_side
+                };
+                for stmt in branch {
+                    self.parse_initial_statement(stmt, context)?;
+                }
+                Ok(())
+            }
+            Statement::For(for_stmt) => {
+                let Some(iter) = for_stmt.range.eval_iter(context) else {
+                    return Err(ParserError::unsupported(
+                        111,
+                        LoweringPhase::SimulatorParser,
+                        "initial for range",
+                        "range bounds and step must be compile-time constant",
+                        Some(&for_stmt.token),
+                    ));
+                };
+                for i in iter {
+                    if let Some(var) = context.variables.get_mut(&for_stmt.var_id)
+                        && let Some(total_width) = for_stmt.var_type.total_width()
+                    {
+                        let val = Value::new(i as u64, total_width, for_stmt.var_type.signed);
+                        var.set_value(&[], val, None);
+                    }
+                    for stmt in &for_stmt.body {
+                        self.parse_initial_statement(stmt, context)?;
+                    }
                 }
                 Ok(())
             }

--- a/crates/celox/src/parser/module.rs
+++ b/crates/celox/src/parser/module.rs
@@ -283,13 +283,7 @@ impl<'a> ModuleParser<'a> {
                     .eval_value(context)
                     .and_then(|value| value.to_usize());
                 let Some(cond) = cond else {
-                    return Err(ParserError::unsupported(
-                        111,
-                        LoweringPhase::SimulatorParser,
-                        "initial if condition",
-                        "condition must be compile-time constant",
-                        Some(&if_stmt.token),
-                    ));
+                    return Ok(());
                 };
                 let branch = if cond != 0 {
                     &if_stmt.true_side
@@ -303,13 +297,7 @@ impl<'a> ModuleParser<'a> {
             }
             Statement::For(for_stmt) => {
                 let Some(iter) = for_stmt.range.eval_iter(context) else {
-                    return Err(ParserError::unsupported(
-                        111,
-                        LoweringPhase::SimulatorParser,
-                        "initial for range",
-                        "range bounds and step must be compile-time constant",
-                        Some(&for_stmt.token),
-                    ));
+                    return Ok(());
                 };
                 for i in iter {
                     if let Some(var) = context.variables.get_mut(&for_stmt.var_id)

--- a/crates/celox/src/parser/module.rs
+++ b/crates/celox/src/parser/module.rs
@@ -270,7 +270,8 @@ impl<'a> ModuleParser<'a> {
         match stmt {
             Statement::SystemFunctionCall(call) => {
                 if let SystemFunctionKind::Readmemh(filename, output) = &call.kind {
-                    let value = self.parse_readmem_file(filename, output.0.as_slice(), 16)?;
+                    let value =
+                        self.parse_readmem_file(filename, output.0.as_slice(), 16, context)?;
                     self.initial_memory_values.push(value);
                 }
                 Ok(())
@@ -340,6 +341,7 @@ impl<'a> ModuleParser<'a> {
         filename_arg: &SystemFunctionInput,
         output: &[AssignDestination],
         radix: u32,
+        context: &mut veryl_analyzer::Context,
     ) -> Result<ModuleInitialMemoryValue, ParserError> {
         let Some(filename) = Self::static_string_expr(&filename_arg.0) else {
             return Err(ParserError::unsupported(
@@ -351,9 +353,7 @@ impl<'a> ModuleParser<'a> {
             ));
         };
         let dst = match output {
-            [dst] if dst.index.0.is_empty() && dst.select.is_empty() && dst.select.1.is_none() => {
-                dst
-            }
+            [dst] if dst.select.is_empty() && dst.select.1.is_none() => dst,
             [dst] => {
                 return Err(ParserError::unsupported(
                     111,
@@ -378,6 +378,29 @@ impl<'a> ModuleParser<'a> {
         let depth = var.r#type.total_array().ok_or_else(|| {
             ParserError::unresolved_width(self.module, var, var.r#type.to_string())
         })?;
+        let start_addr = if dst.index.0.is_empty() {
+            0
+        } else {
+            let Some(indices) = dst.index.eval_value(context) else {
+                return Err(ParserError::unsupported(
+                    111,
+                    LoweringPhase::SimulatorParser,
+                    "$readmemh destination index",
+                    "destination index must be compile-time constant",
+                    Some(&dst.token),
+                ));
+            };
+            let Some(index) = var.r#type.array.calc_index(&indices) else {
+                return Err(ParserError::unsupported(
+                    111,
+                    LoweringPhase::SimulatorParser,
+                    "$readmemh destination index",
+                    format!("destination index {indices:?} is out of range"),
+                    Some(&dst.token),
+                ));
+            };
+            index
+        };
         if depth <= 1 {
             return Err(ParserError::unsupported(
                 111,
@@ -415,6 +438,15 @@ impl<'a> ModuleParser<'a> {
         let element_bits = (BigUint::from(1u8) << element_width) - BigUint::from(1u8);
 
         for (addr, word_value, word_mask) in words {
+            let Some(addr) = start_addr.checked_add(addr) else {
+                return Err(ParserError::unsupported(
+                    111,
+                    LoweringPhase::SimulatorParser,
+                    "$readmemh address",
+                    "address exceeds destination depth",
+                    Some(&dst.token),
+                ));
+            };
             if addr >= depth {
                 return Err(ParserError::unsupported(
                     111,

--- a/crates/celox/src/parser/module.rs
+++ b/crates/celox/src/parser/module.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeSet;
 
 use crate::ir::{
-    BitAccess, BlockId, ExecutionUnit, GlueAddr, GlueBlock, ModuleId, SIRBuilder, SIRTerminator,
-    SimModule, TriggerSet, VarAtomBase,
+    BitAccess, BlockId, ExecutionUnit, GlueAddr, GlueBlock, ModuleId, ModuleInitialMemoryValue,
+    SIRBuilder, SIRTerminator, SimModule, TriggerSet, VarAtomBase,
 };
 
 use crate::logic_tree::{
@@ -14,7 +14,12 @@ use crate::parser::{
     ff::FfParser, registry::get_port_type, resolve_total_width,
 };
 use crate::{HashMap, HashSet};
-use veryl_analyzer::ir::{Component, Declaration, InstDeclaration, Module, VarId};
+use num_bigint::BigUint;
+use veryl_analyzer::ir::{
+    AssignDestination, Component, Declaration, Expression, InstDeclaration, Module, Statement,
+    SystemFunctionInput, SystemFunctionKind, VarId,
+};
+use veryl_analyzer::value::byte_value_to_string;
 use veryl_parser::resource_table::StrId;
 
 pub struct ModuleParser<'a> {
@@ -26,6 +31,7 @@ pub struct ModuleParser<'a> {
     comb_blocks: Vec<LogicPath<VarId>>,
     comb_boundaries: HashMap<VarId, BTreeSet<usize>>,
     glue_blocks: HashMap<StrId, Vec<GlueBlock>>,
+    initial_memory_values: Vec<ModuleInitialMemoryValue>,
     ff_parser: FfParser<'a>,
     arena: SLTNodeArena<VarId>,
     reset_clock_map: HashMap<VarId, VarId>,
@@ -55,6 +61,7 @@ impl<'a> ModuleParser<'a> {
             comb_blocks: Vec::new(),
             comb_boundaries: HashMap::default(),
             glue_blocks: HashMap::default(),
+            initial_memory_values: Vec::new(),
             ff_parser: FfParser::new(module, *config),
             arena: SLTNodeArena::new(),
             reset_clock_map: HashMap::default(),
@@ -234,6 +241,161 @@ impl<'a> ModuleParser<'a> {
         Ok(())
     }
 
+    fn static_string_expr(expr: &Expression) -> Option<String> {
+        if !expr.comptime().r#type.is_string() {
+            return None;
+        }
+        let value = expr.comptime().get_value().ok()?;
+        byte_value_to_string(value)
+    }
+
+    fn parse_initial_declaration(
+        &mut self,
+        decl: &veryl_analyzer::ir::InitialDeclaration,
+    ) -> Result<(), ParserError> {
+        for stmt in &decl.statements {
+            self.parse_initial_statement(stmt)?;
+        }
+        Ok(())
+    }
+
+    fn parse_initial_statement(&mut self, stmt: &Statement) -> Result<(), ParserError> {
+        match stmt {
+            Statement::SystemFunctionCall(call) => {
+                if let SystemFunctionKind::Readmemh(filename, output) = &call.kind {
+                    let value = self.parse_readmem_file(filename, output.0.as_slice(), 16)?;
+                    self.initial_memory_values.push(value);
+                }
+                Ok(())
+            }
+            Statement::Null => Ok(()),
+            _ => Ok(()),
+        }
+    }
+
+    fn parse_readmem_file(
+        &self,
+        filename_arg: &SystemFunctionInput,
+        output: &[AssignDestination],
+        radix: u32,
+    ) -> Result<ModuleInitialMemoryValue, ParserError> {
+        let Some(filename) = Self::static_string_expr(&filename_arg.0) else {
+            return Err(ParserError::unsupported(
+                111,
+                LoweringPhase::SimulatorParser,
+                "$readmemh filename expression",
+                "filename must be a compile-time string",
+                Some(&filename_arg.0.comptime().token),
+            ));
+        };
+        let dst = match output {
+            [dst] if dst.index.0.is_empty() && dst.select.is_empty() && dst.select.1.is_none() => {
+                dst
+            }
+            [dst] => {
+                return Err(ParserError::unsupported(
+                    111,
+                    LoweringPhase::SimulatorParser,
+                    "$readmemh destination",
+                    "destination must be a whole unpacked array variable",
+                    Some(&dst.token),
+                ));
+            }
+            _ => {
+                return Err(ParserError::unsupported(
+                    111,
+                    LoweringPhase::SimulatorParser,
+                    "$readmemh destination",
+                    "concatenated destinations are not supported",
+                    None,
+                ));
+            }
+        };
+
+        let var = &self.module.variables[&dst.id];
+        let depth = var.r#type.total_array().ok_or_else(|| {
+            ParserError::unresolved_width(self.module, var, var.r#type.to_string())
+        })?;
+        if depth <= 1 {
+            return Err(ParserError::unsupported(
+                111,
+                LoweringPhase::SimulatorParser,
+                "$readmemh destination",
+                "destination must be an unpacked array",
+                Some(&dst.token),
+            ));
+        }
+
+        let total_width = resolve_total_width(self.module, var)?;
+        let element_width = total_width / depth;
+        if element_width == 0 || element_width * depth != total_width {
+            return Err(ParserError::unresolved_width(
+                self.module,
+                var,
+                var.r#type.to_string(),
+            ));
+        }
+
+        let path = self.resolve_readmem_path(&filename, &filename_arg.0.comptime().token);
+        let content = std::fs::read_to_string(&path).map_err(|err| {
+            ParserError::unsupported(
+                111,
+                LoweringPhase::SimulatorParser,
+                "$readmemh file",
+                format!("failed to read {}: {err}", path.display()),
+                Some(&filename_arg.0.comptime().token),
+            )
+        })?;
+        let words = parse_memory_content(&content, radix, element_width)?;
+        let mut value = BigUint::default();
+        let mut mask = BigUint::default();
+        let mut written_mask = BigUint::default();
+        let element_bits = (BigUint::from(1u8) << element_width) - BigUint::from(1u8);
+
+        for (addr, word_value, word_mask) in words {
+            if addr >= depth {
+                return Err(ParserError::unsupported(
+                    111,
+                    LoweringPhase::SimulatorParser,
+                    "$readmemh address",
+                    format!("address {addr} exceeds destination depth {depth}"),
+                    Some(&dst.token),
+                ));
+            }
+            let shift = addr * element_width;
+            value |= word_value << shift;
+            mask |= word_mask << shift;
+            written_mask |= &element_bits << shift;
+        }
+
+        Ok(ModuleInitialMemoryValue {
+            var_id: dst.id,
+            value,
+            mask,
+            written_mask,
+        })
+    }
+
+    fn resolve_readmem_path(
+        &self,
+        filename: &str,
+        token: &veryl_parser::token_range::TokenRange,
+    ) -> std::path::PathBuf {
+        let path = std::path::PathBuf::from(filename);
+        if path.is_absolute() {
+            return path;
+        }
+
+        let source_path = token.beg.source.to_string();
+        if source_path.is_empty() {
+            return path;
+        }
+        std::path::Path::new(&source_path)
+            .parent()
+            .map(|parent| parent.join(&path))
+            .unwrap_or(path)
+    }
+
     fn parse_inner(mut self) -> Result<SimModule, ParserError> {
         let mut ff_groups: HashMap<TriggerSet<VarId>, Vec<&veryl_analyzer::ir::FfDeclaration>> =
             HashMap::default();
@@ -256,6 +418,9 @@ impl<'a> ModuleParser<'a> {
                     let mid = self.inst_ids[self.inst_idx];
                     self.inst_idx += 1;
                     self.parse_inst_declaration(inst_decl, mid)?;
+                }
+                Declaration::Initial(init_decl) => {
+                    self.parse_initial_declaration(init_decl)?;
                 }
                 _ => {}
             }
@@ -392,6 +557,7 @@ impl<'a> ModuleParser<'a> {
             comb_blocks: self.comb_blocks,
             runtime_errors: self.ff_parser.runtime_errors().clone(),
             runtime_event_sites: self.ff_parser.runtime_event_sites().clone(),
+            initial_memory_values: self.initial_memory_values,
             comb_boundaries,
             arena: self.arena,
             store: self.store,
@@ -491,4 +657,118 @@ fn collect_glue_sources_with_window(
         }
         SLTNode::Constant(_, _, _, _) => {}
     }
+}
+
+fn parse_memory_content(
+    content: &str,
+    radix: u32,
+    width: usize,
+) -> Result<Vec<(usize, BigUint, BigUint)>, ParserError> {
+    let mut result = Vec::new();
+    let mut addr = 0usize;
+    for token in memory_tokens(content) {
+        if let Some(address) = token.strip_prefix('@') {
+            addr = usize::from_str_radix(address, 16).map_err(|err| {
+                ParserError::unsupported(
+                    111,
+                    LoweringPhase::SimulatorParser,
+                    "$readmemh address",
+                    format!("invalid address directive {token}: {err}"),
+                    None,
+                )
+            })?;
+            continue;
+        }
+        let (value, mask) = parse_memory_word(&token, radix, width)?;
+        result.push((addr, value, mask));
+        addr += 1;
+    }
+    Ok(result)
+}
+
+fn memory_tokens(content: &str) -> Vec<String> {
+    let mut out = String::with_capacity(content.len());
+    let bytes = content.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'/' && i + 1 < bytes.len() {
+            match bytes[i + 1] {
+                b'/' => {
+                    i += 2;
+                    while i < bytes.len() && bytes[i] != b'\n' {
+                        i += 1;
+                    }
+                    out.push(' ');
+                    continue;
+                }
+                b'*' => {
+                    i += 2;
+                    while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                        i += 1;
+                    }
+                    i = (i + 2).min(bytes.len());
+                    out.push(' ');
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out.split_whitespace()
+        .map(|token| token.replace('_', ""))
+        .filter(|token| !token.is_empty())
+        .collect()
+}
+
+fn parse_memory_word(
+    token: &str,
+    radix: u32,
+    width: usize,
+) -> Result<(BigUint, BigUint), ParserError> {
+    let bits_per_digit = match radix {
+        2 => 1,
+        16 => 4,
+        _ => unreachable!(),
+    };
+    let mut value = BigUint::default();
+    let mut mask = BigUint::default();
+    for ch in token.chars() {
+        value <<= bits_per_digit;
+        mask <<= bits_per_digit;
+        match ch {
+            '0'..='9' | 'a'..='f' | 'A'..='F' => {
+                let Some(digit) = ch.to_digit(radix) else {
+                    return Err(invalid_memory_word(token));
+                };
+                value |= BigUint::from(digit);
+            }
+            'x' | 'X' | '?' => {
+                mask |= (BigUint::from(1u8) << bits_per_digit) - BigUint::from(1u8);
+            }
+            'z' | 'Z' => {
+                let unknown = (BigUint::from(1u8) << bits_per_digit) - BigUint::from(1u8);
+                value |= &unknown;
+                mask |= unknown;
+            }
+            _ => return Err(invalid_memory_word(token)),
+        }
+    }
+
+    if width == 0 {
+        return Ok((BigUint::default(), BigUint::default()));
+    }
+    let keep = (BigUint::from(1u8) << width) - BigUint::from(1u8);
+    Ok((value & &keep, mask & keep))
+}
+
+fn invalid_memory_word(token: &str) -> ParserError {
+    ParserError::unsupported(
+        111,
+        LoweringPhase::SimulatorParser,
+        "$readmemh data",
+        format!("invalid data token {token}"),
+        None,
+    )
 }

--- a/crates/celox/src/parser/module.rs
+++ b/crates/celox/src/parser/module.rs
@@ -269,6 +269,13 @@ impl<'a> ModuleParser<'a> {
                 Ok(())
             }
             Statement::Null => Ok(()),
+            Statement::Unsupported(token) => Err(ParserError::unsupported(
+                111,
+                LoweringPhase::SimulatorParser,
+                "initial statement",
+                "unsupported initial statement; only direct $readmemh calls are currently lowered",
+                Some(token),
+            )),
             _ => Ok(()),
         }
     }

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -421,7 +421,9 @@ impl<B: SimBackend> Simulator<B> {
     }
 
     pub(crate) fn apply_initial_values(&mut self) {
+        let mut applied = false;
         for init in &self.program.initial_memory_values {
+            applied = true;
             let signal = self.backend.resolve_signal(&init.addr);
             let width_mask = if signal.width == 0 {
                 BigUint::default()
@@ -437,6 +439,9 @@ impl<B: SimBackend> Simulator<B> {
             } else {
                 self.backend.set_wide(signal, value);
             }
+        }
+        if applied {
+            self.dirty = true;
         }
     }
 
@@ -952,7 +957,9 @@ impl Simulator<NativeBackend> {
     /// Create a simulator from pre-compiled shared native code.
     pub fn from_shared(shared: Arc<SharedNativeCode>, program: crate::ir::Program) -> Self {
         let backend = NativeBackend::from_shared(shared);
-        Self::with_backend_and_program(backend, program, vec![])
+        let mut sim = Self::with_backend_and_program(backend, program, vec![]);
+        sim.apply_initial_values();
+        sim
     }
 
     /// Consume the simulator and return the inner native backend.

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -420,6 +420,26 @@ impl<B: SimBackend> Simulator<B> {
         }
     }
 
+    pub(crate) fn apply_initial_values(&mut self) {
+        for init in &self.program.initial_memory_values {
+            let signal = self.backend.resolve_signal(&init.addr);
+            let width_mask = if signal.width == 0 {
+                BigUint::default()
+            } else {
+                (BigUint::from(1u8) << signal.width) - BigUint::from(1u8)
+            };
+            let preserve_mask = &width_mask ^ (&init.written_mask & &width_mask);
+            let (current_value, current_mask) = self.backend.get_four_state(signal);
+            let value = (current_value & &preserve_mask) | (&init.value & &init.written_mask);
+            let mask = (current_mask & &preserve_mask) | (&init.mask & &init.written_mask);
+            if signal.is_4state {
+                self.backend.set_four_state(signal, value, mask);
+            } else {
+                self.backend.set_wide(signal, value);
+            }
+        }
+    }
+
     pub fn drain_runtime_events(&mut self) -> Vec<RuntimeEvent> {
         self.drain_runtime_events_with_context(RuntimeFormatContext::default())
     }

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -576,6 +576,7 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
                 .map_err(|_| SimulatorError::from(crate::RuntimeErrorCode::InternalError))?;
             sim.vcd_writer = Some(vcd_writer);
         }
+        sim.apply_initial_values();
         sim.modify(|_| {}).map_err(SimulatorError::from)?;
         Ok(sim)
     }
@@ -594,6 +595,7 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
                 .map_err(|_| SimulatorError::from(crate::RuntimeErrorCode::InternalError))?;
             sim.vcd_writer = Some(vcd_writer);
         }
+        sim.apply_initial_values();
         sim.modify(|_| {}).map_err(SimulatorError::from)?;
         Ok(sim)
     }
@@ -611,6 +613,7 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
                 .map_err(|_| SimulatorError::from(crate::RuntimeErrorCode::InternalError))?;
             sim.vcd_writer = Some(vcd_writer);
         }
+        sim.apply_initial_values();
         sim.modify(|_| {}).map_err(SimulatorError::from)?;
         Ok(sim)
     }
@@ -718,6 +721,7 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
             let backend = JitBackend::new(&program, &self.options, None)?;
 
             let mut sim = Simulator::with_backend_and_program(backend, program, warnings);
+            sim.apply_initial_values();
             sim.modify(|_| {}).map_err(SimulatorError::from)?;
             Ok(sim)
         });
@@ -807,6 +811,7 @@ impl<'a> SimulatorBuilder<'a, crate::Simulation> {
                 .map_err(|_| SimulatorError::from(crate::RuntimeErrorCode::InternalError))?;
             sim.vcd_writer = Some(vcd_writer);
         }
+        sim.apply_initial_values();
         sim.modify(|_| {}).map_err(SimulatorError::from)?;
         Ok(crate::Simulation::new(sim))
     }

--- a/crates/celox/tests/initial_readmem.rs
+++ b/crates/celox/tests/initial_readmem.rs
@@ -74,6 +74,55 @@ fn test_initial_readmemh_supports_comments_address_and_xz(sim) {
     assert_eq!(sim.get_four_state(sim.signal("out3")), (BigUint::from(0xf0u32), BigUint::from(0xf0u32)));
 }
 
+fn test_initial_readmemh_supports_const_if(sim) {
+    @omit_veryl;
+    @setup {
+        let hex_path = temp_mem_file("readmemh_if", "21\n43\n65\n87\n");
+        let other_path = temp_mem_file("readmemh_if_dead", "00\n00\n00\n00\n");
+        let code = format!(r#"
+            module Top (out0: output logic<8>, out3: output logic<8>) {{
+                var mem: logic<8>[4];
+                initial {{
+                    if 1'd1 {{
+                        $readmemh("{}", mem);
+                    }} else {{
+                        $readmemh("{}", mem);
+                    }}
+                }}
+                assign out0 = mem[0];
+                assign out3 = mem[3];
+            }}
+        "#, hex_path, other_path);
+    }
+    @build Simulator::builder(&code, "Top");
+    assert_eq!(sim.get(sim.signal("out0")), BigUint::from(0x21u32));
+    assert_eq!(sim.get(sim.signal("out3")), BigUint::from(0x87u32));
+}
+
+fn test_initial_readmemh_supports_const_for(sim) {
+    @omit_veryl;
+    @setup {
+        let mem_path = temp_mem_file("readmemh_for", "11\n22\n33\n44\n");
+        let code = format!(r#"
+            module Top (out0: output logic<8>, out2: output logic<8>) {{
+                var mem: logic<8>[4];
+                initial {{
+                    for i in 0..2 {{
+                        if i == 1 {{
+                            $readmemh("{}", mem);
+                        }}
+                    }}
+                }}
+                assign out0 = mem[0];
+                assign out2 = mem[2];
+            }}
+        "#, mem_path);
+    }
+    @build Simulator::builder(&code, "Top");
+    assert_eq!(sim.get(sim.signal("out0")), BigUint::from(0x11u32));
+    assert_eq!(sim.get(sim.signal("out2")), BigUint::from(0x33u32));
+}
+
 }
 
 #[test]

--- a/crates/celox/tests/initial_readmem.rs
+++ b/crates/celox/tests/initial_readmem.rs
@@ -123,6 +123,66 @@ fn test_initial_readmemh_supports_const_for(sim) {
     assert_eq!(sim.get(sim.signal("out2")), BigUint::from(0x33u32));
 }
 
+fn test_initial_readmemh_supports_indexed_destination(sim) {
+    @omit_veryl;
+    @setup {
+        let mem_path = temp_mem_file("readmemh_indexed", "aa\nbb\n");
+        let code = format!(r#"
+            module Top (
+                out0: output logic<8>,
+                out1: output logic<8>,
+                out2: output logic<8>,
+                out3: output logic<8>,
+            ) {{
+                var mem: logic<8>[4];
+                initial {{
+                    $readmemh("{}", mem[1]);
+                }}
+                assign out0 = mem[0];
+                assign out1 = mem[1];
+                assign out2 = mem[2];
+                assign out3 = mem[3];
+            }}
+        "#, mem_path);
+    }
+    @build Simulator::builder(&code, "Top").four_state(true);
+    assert_eq!(sim.get_four_state(sim.signal("out0")).1, BigUint::from(0xffu32));
+    assert_eq!(sim.get_four_state(sim.signal("out1")), (BigUint::from(0xaau32), BigUint::from(0u32)));
+    assert_eq!(sim.get_four_state(sim.signal("out2")), (BigUint::from(0xbbu32), BigUint::from(0u32)));
+    assert_eq!(sim.get_four_state(sim.signal("out3")).1, BigUint::from(0xffu32));
+}
+
+fn test_initial_readmemh_multiple_files_merge_in_order(sim) {
+    @omit_veryl;
+    @setup {
+        let first_path = temp_mem_file("readmemh_multi_first", "11\n22\n33\n44\n");
+        let second_path = temp_mem_file("readmemh_multi_second", "aa\nbb\n");
+        let code = format!(r#"
+            module Top (
+                out0: output logic<8>,
+                out1: output logic<8>,
+                out2: output logic<8>,
+                out3: output logic<8>,
+            ) {{
+                var mem: logic<8>[4];
+                initial {{
+                    $readmemh("{}", mem);
+                    $readmemh("{}", mem[1]);
+                }}
+                assign out0 = mem[0];
+                assign out1 = mem[1];
+                assign out2 = mem[2];
+                assign out3 = mem[3];
+            }}
+        "#, first_path, second_path);
+    }
+    @build Simulator::builder(&code, "Top");
+    assert_eq!(sim.get(sim.signal("out0")), BigUint::from(0x11u32));
+    assert_eq!(sim.get(sim.signal("out1")), BigUint::from(0xaau32));
+    assert_eq!(sim.get(sim.signal("out2")), BigUint::from(0xbbu32));
+    assert_eq!(sim.get(sim.signal("out3")), BigUint::from(0x44u32));
+}
+
 }
 
 #[test]

--- a/crates/celox/tests/initial_readmem.rs
+++ b/crates/celox/tests/initial_readmem.rs
@@ -1,0 +1,77 @@
+use celox::{BigUint, Simulator};
+
+#[path = "test_utils/mod.rs"]
+#[macro_use]
+#[allow(unused_macros)]
+mod test_utils;
+
+fn temp_mem_file(name: &str, content: &str) -> String {
+    let path = std::env::temp_dir().join(format!("celox_{name}_{}.mem", std::process::id()));
+    std::fs::write(&path, content).unwrap();
+    path.to_string_lossy().replace('\\', "\\\\")
+}
+
+all_backends! {
+
+fn test_initial_readmemh_loads_unpacked_array(sim) {
+    @omit_veryl;
+    @setup {
+        let mem_path = temp_mem_file("readmemh", "12\n34\n56\n78\n");
+        let code = format!(r#"
+            module Top (
+                out0: output logic<8>,
+                out1: output logic<8>,
+                out2: output logic<8>,
+                out3: output logic<8>,
+            ) {{
+                var mem: logic<8>[4];
+                initial {{
+                    $readmemh("{}", mem);
+                }}
+                assign out0 = mem[0];
+                assign out1 = mem[1];
+                assign out2 = mem[2];
+                assign out3 = mem[3];
+            }}
+        "#, mem_path);
+    }
+    @build Simulator::builder(&code, "Top");
+    assert_eq!(sim.get(sim.signal("out0")), BigUint::from(0x12u32));
+    assert_eq!(sim.get(sim.signal("out1")), BigUint::from(0x34u32));
+    assert_eq!(sim.get(sim.signal("out2")), BigUint::from(0x56u32));
+    assert_eq!(sim.get(sim.signal("out3")), BigUint::from(0x78u32));
+}
+
+fn test_initial_readmemh_supports_comments_address_and_xz(sim) {
+    @omit_veryl;
+    @setup {
+        let mem_path = temp_mem_file(
+            "readmemh_xz",
+            "aa\n// skip to address 2\n@2\nx5\nz0\n",
+        );
+        let code = format!(r#"
+            module Top (
+                out0: output logic<8>,
+                out1: output logic<8>,
+                out2: output logic<8>,
+                out3: output logic<8>,
+            ) {{
+                var mem: logic<8>[4];
+                initial {{
+                    $readmemh("{}", mem);
+                }}
+                assign out0 = mem[0];
+                assign out1 = mem[1];
+                assign out2 = mem[2];
+                assign out3 = mem[3];
+            }}
+        "#, mem_path);
+    }
+    @build Simulator::builder(&code, "Top").four_state(true);
+    assert_eq!(sim.get_four_state(sim.signal("out0")), (BigUint::from(0xaau32), BigUint::from(0u32)));
+    assert_eq!(sim.get_four_state(sim.signal("out1")).1, BigUint::from(0xffu32));
+    assert_eq!(sim.get_four_state(sim.signal("out2")), (BigUint::from(0x05u32), BigUint::from(0xf0u32)));
+    assert_eq!(sim.get_four_state(sim.signal("out3")), (BigUint::from(0xf0u32), BigUint::from(0xf0u32)));
+}
+
+}

--- a/crates/celox/tests/initial_readmem.rs
+++ b/crates/celox/tests/initial_readmem.rs
@@ -220,3 +220,44 @@ fn test_initial_readmemb_reports_unsupported() {
         other => panic!("expected unsupported initial statement error, got {other:?}"),
     }
 }
+
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn test_initial_readmemh_applies_to_shared_native_simulator() {
+    let mem_path = temp_mem_file("readmemh_shared_native", "ca\nfe\n");
+    let code = format!(
+        r#"
+            module Top (out0: output logic<8>, out1: output logic<8>) {{
+                var mem: logic<8>[2];
+                initial {{
+                    $readmemh("{}", mem);
+                }}
+                assign out0 = mem[0];
+                assign out1 = mem[1];
+            }}
+        "#,
+        mem_path
+    );
+
+    let sim = Simulator::builder(&code, "Top").build_native().unwrap();
+    let shared = sim.shared_code();
+    let (program, _) = celox::compile_to_sir(
+        &[(&code, std::path::Path::new(""))],
+        "Top",
+        &[],
+        &[],
+        false,
+        &celox::TraceOptions::default(),
+        None,
+        None,
+        None,
+        None,
+        &[],
+        &celox::OptimizeOptions::default(),
+    )
+    .unwrap();
+    let mut sim = Simulator::from_shared(shared, program);
+
+    assert_eq!(sim.get(sim.signal("out0")), BigUint::from(0xcau32));
+    assert_eq!(sim.get(sim.signal("out1")), BigUint::from(0xfeu32));
+}

--- a/crates/celox/tests/initial_readmem.rs
+++ b/crates/celox/tests/initial_readmem.rs
@@ -1,4 +1,4 @@
-use celox::{BigUint, Simulator};
+use celox::{BigUint, LoweringPhase, ParserError, Simulator, SimulatorErrorKind};
 
 #[path = "test_utils/mod.rs"]
 #[macro_use]
@@ -74,4 +74,40 @@ fn test_initial_readmemh_supports_comments_address_and_xz(sim) {
     assert_eq!(sim.get_four_state(sim.signal("out3")), (BigUint::from(0xf0u32), BigUint::from(0xf0u32)));
 }
 
+}
+
+#[test]
+fn test_initial_readmemb_reports_unsupported() {
+    let mem_path = temp_mem_file("readmemb", "00010010\n00110100\n01010110\n01111000\n");
+    let code = format!(
+        r#"
+            module Top (out0: output logic<8>) {{
+                var mem: logic<8>[4];
+                initial {{
+                    $readmemb("{}", mem);
+                }}
+                assign out0 = mem[0];
+            }}
+        "#,
+        mem_path
+    );
+
+    let err = Simulator::builder(&code, "Top")
+        .build()
+        .expect_err("$readmemb should not be silently ignored");
+    match err.kind() {
+        SimulatorErrorKind::SIRParser(ParserError::Unsupported {
+            issue,
+            phase,
+            feature,
+            detail,
+            ..
+        }) => {
+            assert_eq!(*issue, 111);
+            assert_eq!(*phase, LoweringPhase::SimulatorParser);
+            assert_eq!(*feature, "initial statement");
+            assert!(detail.contains("only direct $readmemh"));
+        }
+        other => panic!("expected unsupported initial statement error, got {other:?}"),
+    }
 }

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -1655,3 +1655,23 @@ fn test_arithmetic_in_assert() {
         TestResult::Pass,
     );
 }
+
+#[test]
+fn test_runtime_if_in_initial_is_left_for_testbench_runner() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            var done: logic;
+            initial {
+                done = 1;
+                if done {
+                    $finish();
+                }
+            }
+        }
+    "#;
+    assert_eq!(
+        Simulator::builder(code, "t").run_test().unwrap(),
+        TestResult::Pass,
+    );
+}


### PR DESCRIPTION
## Summary

Adds synthesizable `initial` `$readmemh` support for memory initialization in Celox.

- lowers direct `$readmemh("file", mem)` calls from normal module `initial` blocks
- supports compile-time `if` and `for` around readmem calls without taking over native testbench runtime control flow
- supports indexed destinations such as `mem[1]` as a start offset
- merges multiple readmem loads in source order, with later overlapping writes winning
- rejects unsupported initial statements instead of silently ignoring them when they are selected for lowering
- applies initial memory values across normal builder paths and `NativeBackend` shared-code construction

## Notes

General assignment inside `initial` is intentionally not implemented in Celox. Unsupported `$readmemb` currently errors because Veryl analyzer does not expose it as a Celox-visible readmem IR kind.

## Validation

- `cargo fmt --check`
- `cargo check -p celox`
- `cargo test -p celox --test initial_readmem`
- `cargo test -p celox --test native_testbench test_runtime_if_in_initial_is_left_for_testbench_runner -- --exact`
- `cargo test -p celox --test native_testbench test_for_loop_dynamic_signed_bound_preserves_negative_value -- --exact`
- pre-push hook: submodule check, cargo fmt, Biome, cargo clippy, full `cargo test`, package build/test