### PR TITLE
[codex] Split invalid context parser errors

### DIFF
--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -3849,9 +3849,7 @@ fn eval_function_call_expression(
     };
 
     let Some(ret_id) = function_body.ret else {
-        return Err(ParserError::unsupported(
-            63,
-            LoweringPhase::CombLowering,
+        return Err(ParserError::illegal_context(
             "void function call in comb expression",
             format!("{call}"),
             Some(&call.comptime.token),

--- a/crates/celox/src/parser/ff/expression.rs
+++ b/crates/celox/src/parser/ff/expression.rs
@@ -1276,10 +1276,12 @@ impl<'a> FfParser<'a> {
                 self.stack.push_back(casted);
                 Ok(())
             }
-            _ => Err(ParserError::unsupported(
-                66,
-                LoweringPhase::FfLowering,
-                "system function call",
+            SystemFunctionKind::Readmemh(_, _)
+            | SystemFunctionKind::Display(_)
+            | SystemFunctionKind::Write(_)
+            | SystemFunctionKind::Assert { .. }
+            | SystemFunctionKind::Finish => Err(ParserError::illegal_context(
+                "system task in FF expression",
                 format!("{call}"),
                 Some(&call.comptime.token),
             )),

--- a/crates/celox/src/parser/ff/function_call.rs
+++ b/crates/celox/src/parser/ff/function_call.rs
@@ -690,9 +690,7 @@ impl<'a> FfParser<'a> {
         }
 
         let Some(ret_id) = function_body.ret else {
-            return Err(ParserError::unsupported(
-                63,
-                LoweringPhase::FfLowering,
+            return Err(ParserError::illegal_context(
                 "void function call in expression",
                 format!("{call}"),
                 Some(&call.comptime.token),

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -872,6 +872,50 @@ fn test_ff_function_call_rejects_mismatched_unpacked_array_shape() {
 }
 
 #[test]
+fn test_comb_void_function_call_in_expression_is_illegal_context() {
+    let code = r#"
+        module Top (q: output logic) {
+            function f () {
+            }
+            always_comb {
+                q = f();
+            }
+        }
+    "#;
+
+    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| {
+        match e.kind() {
+            SimulatorErrorKind::SIRParser(ParserError::IllegalContext { feature, .. }) => {
+                assert_eq!(*feature, "void function call in comb expression");
+            }
+            k => panic!("expected IllegalContext for void comb function expression, got {k:?}"),
+        }
+    });
+}
+
+#[test]
+fn test_ff_void_function_call_in_expression_is_illegal_context() {
+    let code = r#"
+        module Top (clk: input clock, q: output logic) {
+            function f () {
+            }
+            always_ff (clk) {
+                q = f();
+            }
+        }
+    "#;
+
+    assert_analyzer_or_sir(Simulator::builder(code, "Top").build(), |e| {
+        match e.kind() {
+            SimulatorErrorKind::SIRParser(ParserError::IllegalContext { feature, .. }) => {
+                assert_eq!(*feature, "void function call in expression");
+            }
+            k => panic!("expected IllegalContext for void FF function expression, got {k:?}"),
+        }
+    });
+}
+
+#[test]
 fn test_ff_array_literal_multiple_default_is_illegal_context() {
     let code = r#"
         module Top (


### PR DESCRIPTION
## Summary

- classify void-return function calls used in expression position as `IllegalContext` instead of unsupported lowering
- classify statement-only system tasks encountered in FF expression lowering as `IllegalContext`
- add regression coverage for comb and FF void function calls used as expressions

## Rationale

These cases are not missing simulator lowering features in the same sense as the remaining tracked `unsupported` gaps. A void function used where a value is required is an invalid expression context, so it should use the existing `IllegalContext` diagnostic path instead of consuming a tracking issue bucket.

The procedural system-task cases inside FF statements and function bodies remain unsupported where they may be semantically valid but not implemented.

## Validation

- `cargo fmt --check`
- `cargo test -p celox --test error_detection void_function_call_in_expression -- --nocapture`
- `cargo test -p celox --test system_function test_unsupported_ff_statement_system_functions_are_reported -- --nocapture`
- pre-push hook: submodule-check, cargo-fmt, biome, cargo-clippy, full test, clean-tree