### PR TITLE
[codex] support comb bits and size system functions

### DIFF
--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -17,7 +17,7 @@ use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::ToPrimitive as _;
 use veryl_analyzer::ir::{
     ArrayLiteralItem, AssignStatement, CombDeclaration, Expression, Factor, ForBound, ForRange,
-    ForStatement, IfStatement, Module, Op, Statement, SystemFunctionCall, SystemFunctionKind,
+    ForStatement, IfStatement, Module, Op, Statement, SystemFunctionCall, SystemFunctionKind, Type,
     ValueVariant, VarId, VarSelectOp,
 };
 use veryl_analyzer::value::Value;
@@ -4710,6 +4710,26 @@ fn eval_system_function_call(
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
     match &call.kind {
+        SystemFunctionKind::Bits(input) => {
+            let width = system_function_input_bits_width(module, store, &input.0, arena);
+            let result = arena.alloc(SLTNode::Constant(
+                BigUint::from(width),
+                BigUint::from(0u8),
+                32,
+                false,
+            ));
+            Ok(((result, HashSet::default()), HashMap::default()))
+        }
+        SystemFunctionKind::Size(input) => {
+            let size = system_function_input_size(module, store, &input.0, arena);
+            let result = arena.alloc(SLTNode::Constant(
+                BigUint::from(size),
+                BigUint::from(0u8),
+                32,
+                false,
+            ));
+            Ok(((result, HashSet::default()), HashMap::default()))
+        }
         SystemFunctionKind::Onehot(input) => {
             let ((arg, sources), bounds) = eval_expression(module, store, &input.0, arena, None)?;
             let width = get_width(arg, arena);
@@ -4739,6 +4759,57 @@ fn eval_system_function_call(
             format!("module `{}`: {call}", module.name),
             Some(&call.comptime.token),
         )),
+    }
+}
+
+fn system_function_type_bits_width(ty: &Type) -> Option<usize> {
+    ty.total_width()
+        .map(|width| width * ty.total_array().unwrap_or(1))
+}
+
+fn system_function_type_size(ty: &Type) -> Option<usize> {
+    if let Some(size) = ty.array.first() {
+        *size
+    } else if let Some(size) = ty.width_expr().first().and_then(|expr| expr.numeric()) {
+        Some(size)
+    } else if let Some(size) = ty.width().first() {
+        *size
+    } else {
+        ty.total_width()
+    }
+}
+
+fn system_function_input_bits_width(
+    module: &Module,
+    store: &SymbolicStore<VarId>,
+    expr: &Expression,
+    arena: &mut SLTNodeArena<VarId>,
+) -> usize {
+    let comptime = expr.comptime();
+    match &comptime.value {
+        ValueVariant::Type(ty) => system_function_type_bits_width(ty).unwrap_or(0),
+        _ => system_function_type_bits_width(&comptime.r#type).unwrap_or_else(|| {
+            eval_expression(module, store, expr, arena, None)
+                .map(|((node, _), _)| get_width(node, arena))
+                .unwrap_or(0)
+        }),
+    }
+}
+
+fn system_function_input_size(
+    module: &Module,
+    store: &SymbolicStore<VarId>,
+    expr: &Expression,
+    arena: &mut SLTNodeArena<VarId>,
+) -> usize {
+    let comptime = expr.comptime();
+    match &comptime.value {
+        ValueVariant::Type(ty) => system_function_type_size(ty).unwrap_or(0),
+        _ => system_function_type_size(&comptime.r#type).unwrap_or_else(|| {
+            eval_expression(module, store, expr, arena, None)
+                .map(|((node, _), _)| get_width(node, arena))
+                .unwrap_or(0)
+        }),
     }
 }
 

--- a/crates/celox/tests/system_function.rs
+++ b/crates/celox/tests/system_function.rs
@@ -65,6 +65,54 @@ module Top (
         }
     }
 
+    fn test_direct_comb_bits_system_function(sim) {
+        @build Simulator::builder(r#"
+module Top (
+    d: input logic<8>,
+    q: output logic<32>,
+) {
+    always_comb {
+        q = $bits(d);
+    }
+}
+"#, "Top");
+
+        let q = sim.signal("q");
+        assert_eq!(sim.get_as::<u32>(q), 8);
+    }
+
+    fn test_direct_comb_size_system_function(sim) {
+        @ignore_on(veryl);
+        @build Simulator::builder(r#"
+module Top (
+    d: input logic<8>[4],
+    q: output logic<32>,
+) {
+    always_comb {
+        q = $size(d);
+    }
+}
+"#, "Top");
+
+        let q = sim.signal("q");
+        assert_eq!(sim.get_as::<u32>(q), 4);
+    }
+
+    fn test_direct_comb_bits_type_system_function(sim) {
+        @build Simulator::builder(r#"
+module Top (
+    q: output logic<32>,
+) {
+    always_comb {
+        q = $bits(logic<8>);
+    }
+}
+"#, "Top");
+
+        let q = sim.signal("q");
+        assert_eq!(sim.get_as::<u32>(q), 8);
+    }
+
     fn test_direct_ff_bits_system_function(sim) {
         @build Simulator::builder(r#"
 module Top (


### PR DESCRIPTION
## Summary

Adds direct `always_comb` lowering support for `$bits(...)` and `$size(...)` system functions. The comb lowering now evaluates these calls to 32-bit constants using the same type and input-width rules already used by FF lowering.

## Impact

This removes an unsupported path for common compile-time system functions in combinational expressions. It covers signal arguments, type arguments, and unpacked array size queries where the analyzer preserves the required shape.

## Validation

- `cargo test -p celox --test system_function`
- `cargo test -p celox`
- pre-push hook: `submodule-check`, `cargo-fmt`, `biome`, `cargo-clippy`, full `test`, `clean-tree`