### PR TITLE
[codex] Fix pnpm action v6 CI install

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -69,7 +69,7 @@ jobs:
 
       - uses: ./.github/actions/setup-rust
       - uses: Swatinem/rust-cache@v2
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/.github/workflows/ci-napi.yml
+++ b/.github/workflows/ci-napi.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           node-version: 24
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - name: Install Rust toolchain
         uses: ./.github/actions/setup-rust
@@ -115,7 +115,7 @@ jobs:
         with:
           node-version: 24
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - name: Download binding artifact
         uses: actions/download-artifact@v8
@@ -149,7 +149,7 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -242,7 +242,7 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --locked -p celox -p celox-macros -p celox-napi -p celox-ts-gen --all-targets --no-deps
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -63,7 +63,7 @@ jobs:
       - name: Run tests
         run: cargo test --locked
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -97,7 +97,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -133,7 +133,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -165,7 +165,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:
@@ -187,7 +187,7 @@ jobs:
       - name: Prepare template for local package validation
         working-directory: examples/template
         run: |
-          node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('package.json','utf8')); pkg.devDependencies['@celox-sim/celox']='link:../../packages/celox'; pkg.devDependencies['@celox-sim/vite-plugin']='link:../../packages/vite-plugin'; fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');"
+          node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('package.json','utf8')); pkg.devDependencies['@celox-sim/celox']='link:../../packages/celox'; pkg.devDependencies['@celox-sim/vite-plugin']='link:../../packages/vite-plugin'; pkg.pnpm={...(pkg.pnpm||{}), onlyBuiltDependencies:['esbuild']}; fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');"
           pnpm install --ignore-workspace --no-frozen-lockfile
 
       - name: Run template tests
@@ -206,7 +206,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary

- update CI workflows from `pnpm/action-setup@v4` to `pnpm/action-setup@v6`
- allow `esbuild` build scripts in the generated `examples/template` package used by the JS Ubuntu validation job

## Root Cause

PR #126 installs dependencies inside `examples/template` as a standalone package. With `pnpm/action-setup@v6`, pnpm 10.33.2 enforces build-script approval there, and the template package does not inherit the root `pnpm.onlyBuiltDependencies` setting. That caused `pnpm install --ignore-workspace --no-frozen-lockfile` to fail with `ERR_PNPM_IGNORED_BUILDS` for `esbuild@0.27.7`.

## Validation

Pre-push hook completed successfully:

- submodule check
- `cargo fmt`
- `pnpm run lint`
- `cargo clippy`
- `pnpm run test`
- clean-tree check