### PR TITLE
[codex] support comb function system functions

### DIFF
--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -2625,7 +2625,10 @@ fn eval_function_body_return(
         call: &SystemFunctionCall,
     ) -> Result<(), ParserError> {
         match &call.kind {
-            SystemFunctionKind::Onehot(input) => {
+            SystemFunctionKind::Bits(input)
+            | SystemFunctionKind::Size(input)
+            | SystemFunctionKind::Clog2(input)
+            | SystemFunctionKind::Onehot(input) => {
                 validate_function_body_expression(module, &input.0)
             }
             _ => Err(ParserError::unsupported(
@@ -4729,6 +4732,37 @@ fn eval_system_function_call(
                 false,
             ));
             Ok(((result, HashSet::default()), HashMap::default()))
+        }
+        SystemFunctionKind::Clog2(input) => {
+            let ((arg, sources), bounds) = eval_expression(module, store, &input.0, arena, None)?;
+            let width = get_width(arg, arena);
+            let mut result = arena.alloc(SLTNode::Constant(
+                BigUint::from(0u8),
+                BigUint::from(0u8),
+                32,
+                false,
+            ));
+            for k in 1..=width {
+                let threshold = arena.alloc(SLTNode::Constant(
+                    BigUint::from(1u8) << (k - 1),
+                    BigUint::from(0u8),
+                    width,
+                    false,
+                ));
+                let cond = arena.alloc(SLTNode::Binary(arg, BinaryOp::GtU, threshold));
+                let value = arena.alloc(SLTNode::Constant(
+                    BigUint::from(k),
+                    BigUint::from(0u8),
+                    32,
+                    false,
+                ));
+                result = arena.alloc(SLTNode::Mux {
+                    cond,
+                    then_expr: value,
+                    else_expr: result,
+                });
+            }
+            Ok(((result, sources), bounds))
         }
         SystemFunctionKind::Onehot(input) => {
             let ((arg, sources), bounds) = eval_expression(module, store, &input.0, arena, None)?;

--- a/crates/celox/tests/system_function.rs
+++ b/crates/celox/tests/system_function.rs
@@ -98,6 +98,101 @@ module Top (
         assert_eq!(sim.get_as::<u32>(q), 4);
     }
 
+    #[ignore = "direct $clog2 in always_comb is folded from X payload by Veryl analyzer before Celox comb lowering"]
+    fn test_direct_comb_clog2_system_function(sim) {
+        @build Simulator::builder(r#"
+module Top (
+    d: input logic<8>,
+    q: output logic<32>,
+) {
+    always_comb {
+        q = $clog2(d);
+    }
+}
+"#, "Top");
+
+        let d = sim.signal("d");
+        let q = sim.signal("q");
+
+        for value in 0u16..256 {
+            let value = value as u8;
+            sim.modify(|io| io.set(d, value)).unwrap();
+            let expected = if value == 0 {
+                0
+            } else {
+                u32::BITS - (u32::from(value) - 1).leading_zeros()
+            };
+            assert_eq!(sim.get_as::<u32>(q), expected, "value={value}");
+        }
+    }
+
+    fn test_comb_function_body_clog2_system_function(sim) {
+        @ignore_on(veryl);
+        @build Simulator::builder(r#"
+module Top (
+    d: input logic<8>,
+    q: output logic<32>,
+) {
+    function clog2_value (
+        x: input logic<8>,
+    ) -> logic<32> {
+        return $clog2(x);
+    }
+
+    always_comb {
+        q = clog2_value(d);
+    }
+}
+"#, "Top");
+
+        let d = sim.signal("d");
+        let q = sim.signal("q");
+
+        for value in 0u16..256 {
+            let value = value as u8;
+            sim.modify(|io| io.set(d, value)).unwrap();
+            let expected = if value == 0 {
+                0
+            } else {
+                u32::BITS - (u32::from(value) - 1).leading_zeros()
+            };
+            assert_eq!(sim.get_as::<u32>(q), expected, "value={value}");
+        }
+    }
+
+    fn test_comb_function_body_bits_size_system_functions(sim) {
+        @ignore_on(veryl);
+        @build Simulator::builder(r#"
+module Top (
+    d: input logic<8>[4],
+    bits_q: output logic<32>,
+    size_q: output logic<32>,
+) {
+    function bits_value (
+        x: input logic<8>[4],
+    ) -> logic<32> {
+        return $bits(x);
+    }
+
+    function size_value (
+        x: input logic<8>[4],
+    ) -> logic<32> {
+        return $size(x);
+    }
+
+    always_comb {
+        bits_q = bits_value(d);
+        size_q = size_value(d);
+    }
+}
+"#, "Top");
+
+        let bits_q = sim.signal("bits_q");
+        let size_q = sim.signal("size_q");
+        assert_eq!(sim.get_as::<u32>(bits_q), 32);
+        assert_eq!(sim.get_as::<u32>(size_q), 4);
+    }
+
     fn test_direct_comb_bits_type_system_function(sim) {
         @build Simulator::builder(r#"
 module Top (


### PR DESCRIPTION
## Summary

- Allow `$bits`, `$size`, `$clog2`, and `$onehot` in combinational function bodies when validating comb function expressions.
- Add symbolic comb lowering for `$clog2`, matching the existing FF lowering behavior.
- Add regression coverage for comb function body `$clog2` and `$bits`/`$size` system functions.

## Why

Comb expression lowering already handled some system functions directly, but comb function body validation still rejected most of them as unsupported. This meant helper functions could not use system functions that the lowering path can otherwise represent.

Direct `$clog2` in `always_comb` is still ignored in tests because the Veryl analyzer folds that form from an X payload before Celox lowering receives the input-dependent expression.

## Validation

- `cargo fmt`
- `cargo test -p celox --test system_function -- --nocapture`
- `cargo test -p celox`
- pre-push hook: `submodule-check`, `cargo-fmt`, `biome`, `cargo-clippy`, full `test`, `clean-tree`