### PR TITLE
[codex] Classify invalid initial statements as illegal context

### DIFF
--- a/crates/celox/src/parser/module.rs
+++ b/crates/celox/src/parser/module.rs
@@ -313,11 +313,9 @@ impl<'a> ModuleParser<'a> {
                 Ok(())
             }
             Statement::Null => Ok(()),
-            Statement::Unsupported(token) => Err(ParserError::unsupported(
-                111,
-                LoweringPhase::SimulatorParser,
+            Statement::Unsupported(token) => Err(ParserError::illegal_context(
                 "initial statement",
-                "unsupported initial statement; only direct $readmemh calls are currently lowered",
+                "only direct $readmemh calls are valid in simulator-lowered initial blocks",
                 Some(token),
             )),
             _ => Ok(()),

--- a/crates/celox/tests/initial_readmem.rs
+++ b/crates/celox/tests/initial_readmem.rs
@@ -1,4 +1,4 @@
-use celox::{BigUint, LoweringPhase, ParserError, Simulator, SimulatorErrorKind};
+use celox::{BigUint, ParserError, Simulator, SimulatorErrorKind};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 #[path = "test_utils/mod.rs"]
@@ -189,7 +189,7 @@ fn test_initial_readmemh_multiple_files_merge_in_order(sim) {
 }
 
 #[test]
-fn test_initial_readmemb_reports_unsupported() {
+fn test_initial_readmemb_reports_illegal_context() {
     let mem_path = temp_mem_file("readmemb", "00010010\n00110100\n01010110\n01111000\n");
     let code = format!(
         r#"
@@ -208,19 +208,13 @@ fn test_initial_readmemb_reports_unsupported() {
         .build()
         .expect_err("$readmemb should not be silently ignored");
     match err.kind() {
-        SimulatorErrorKind::SIRParser(ParserError::Unsupported {
-            issue,
-            phase,
-            feature,
-            detail,
-            ..
+        SimulatorErrorKind::SIRParser(ParserError::IllegalContext {
+            feature, detail, ..
         }) => {
-            assert_eq!(*issue, 111);
-            assert_eq!(*phase, LoweringPhase::SimulatorParser);
             assert_eq!(*feature, "initial statement");
             assert!(detail.contains("only direct $readmemh"));
         }
-        other => panic!("expected unsupported initial statement error, got {other:?}"),
+        other => panic!("expected illegal initial statement context error, got {other:?}"),
     }
 }
 


### PR DESCRIPTION
## Summary

- Classify simulator-lowered `initial` block statements outside the direct `$readmemh` path as `IllegalContext` instead of `Unsupported`.
- Update the `$readmemb` regression test to assert the new diagnostic category and remove the tracking-issue-specific expectations.

## Why

This path is not a simulator support gap that needs an unsupported-feature tracking issue. It is an invalid statement for the currently supported simulator-lowered `initial` block context, so `IllegalContext` better describes the failure.

## Validation

- `cargo test -p celox test_initial_readmemb_reports_illegal_context -- --nocapture`
- pre-push hook: `cargo fmt`, `biome check`, `cargo clippy`, full `pnpm run build:napi && cargo test && pnpm run build && pnpm --filter="!@celox-sim/celox-napi" --filter="!@celox-sim/playground" -r test`