### PR TITLE
[codex] Fix false comb loop from local let in for

### DIFF
--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -91,6 +91,9 @@ pub fn parse_comb(
     // Each LogicPath represents a modified bit-range and the logic required to compute it.
     let mut paths = Vec::new();
     for (id, range_store) in &final_store {
+        if module.variables[id].affiliation == veryl_analyzer::symbol::Affiliation::AlwaysComb {
+            continue;
+        }
         for (&lsb, (val_opt, width, origin)) in &range_store.ranges {
             if let Some((expr, sources)) = val_opt {
                 let msb = lsb + width - 1;
@@ -1008,6 +1011,7 @@ fn eval_for_with_effects(
                 .into_iter()
                 .filter(|src| src.id != for_stmt.var_id && !loop_updated_vars.contains(&src.id)),
         );
+        all_sources.retain(|src| src.id != target.id);
 
         let folded_expr = arena.alloc(SLTNode::ForFold {
             loop_var: for_stmt.var_id,

--- a/crates/celox/src/logic_tree/comb/expr.rs
+++ b/crates/celox/src/logic_tree/comb/expr.rs
@@ -952,6 +952,7 @@ pub(super) fn eval_function_body_return(
                     src.id != for_stmt.var_id && !loop_updated_vars.contains(&src.id)
                 }),
             );
+            all_sources.retain(|src| src.id != target.id);
 
             let folded_expr = arena.alloc(SLTNode::ForFold {
                 loop_var: for_stmt.var_id,

--- a/crates/celox/tests/false_loop.rs
+++ b/crates/celox/tests/false_loop.rs
@@ -194,6 +194,34 @@ fn test_struct_member_dynamic_access_false_loop() {
     assert!(result.is_ok());
 }
 
+#[test]
+fn test_local_let_in_conditional_for_is_not_scheduled_as_comb_output() {
+    let code = r#"
+module Top (
+    sel: input logic,
+    a  : input logic [1],
+    o  : output logic,
+) {
+    var y: logic;
+
+    always_comb {
+        y = 0;
+        if sel {
+            for b in 0..1 {
+                let idx: u32 = b;
+                y = y | a[idx];
+            }
+        }
+    }
+
+    assign o = y;
+}
+    "#;
+
+    let result = SimulatorBuilder::new(code, "Top").build();
+    assert!(result.is_ok(), "{result:?}");
+}
+
 all_backends! {
 
 fn test_large_scc_dynamic_loop_convergence(sim) {


### PR DESCRIPTION
## Summary

Fixes a false combinational-loop diagnostic caused by `always_comb` local variables inside runtime `for` lowering.

`ForFold` can represent a conditional loop body by preserving the previous value on non-executed paths. For block-local `let` variables, that produced a dead self-dependency such as `idx -> idx`, and the scheduler treated the local temporary as a real combinational output.

## Changes

- Skip `AlwaysComb`-scoped local variables when extracting final combinational `LogicPath`s.
- Remove a `ForFold` target itself from the outer scheduler dependency set.
- Add a reduced regression test for a conditional runtime `for` with a local `let` index.

## Validation

- `cargo test -p celox --test false_loop`
- `cargo test -p celox`
- Pre-push hook: submodule check, cargo fmt, biome, cargo clippy, full test/build flow