### PR TITLE
[codex] Group Cranelift Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,19 @@
     },
     {
       "matchManagers": [
+        "cargo"
+      ],
+      "matchPackageNames": [
+        "cranelift",
+        "cranelift-frontend",
+        "cranelift-jit",
+        "cranelift-module",
+        "cranelift-native"
+      ],
+      "groupName": "cranelift crates"
+    },
+    {
+      "matchManagers": [
         "cargo",
         "npm"
       ],


### PR DESCRIPTION
## Summary

Adds a Renovate package rule to group the direct Cranelift Cargo dependencies into one PR.

## Why

Renovate currently opens separate PRs for `cranelift`, `cranelift-frontend`, `cranelift-jit`, `cranelift-module`, and `cranelift-native`. These crates are versioned together and should be reviewed together.

## Validation

- `jq empty renovate.json`
- pre-push hook passed: submodule check, biome, cargo fmt, cargo clippy, and full test suite