### PR TITLE
[codex] Group Veryl Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,15 @@
         "cargo"
       ],
       "matchPackageNames": [
+        "/^veryl-/"
+      ],
+      "groupName": "veryl crates"
+    },
+    {
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchPackageNames": [
         "napi",
         "napi-derive"
       ],


### PR DESCRIPTION
## Summary

- Add a Renovate package rule that groups Cargo packages matching `veryl-*`.
- Keep future Veryl crate version bumps in one dependency PR instead of splitting them by crate.

## Why

Veryl crates are versioned and consumed together in the workspace. When Renovate opens separate PRs for each `veryl-*` crate, updating them becomes noisy and harder to review. Grouping them keeps the dependency update workflow aligned with how the project uses Veryl.

## Validation

- `jq . renovate.json`
- pre-push hook:
  - submodule check
  - cargo fmt
  - biome check
  - cargo clippy
  - pnpm run test