### PR TITLE
Handle Statement::Case natively

### DIFF
--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -11,7 +11,7 @@ use std::{collections::BTreeSet, hash::Hash};
 
 use crate::ParserError;
 use crate::logic_tree::range_store::RangeStore;
-use crate::parser::{LoweringPhase, resolve_total_width};
+use crate::parser::{LoweringPhase, case::case_arm_condition_expr, resolve_total_width};
 use crate::{
     HashMap, HashSet,
     ir::{
@@ -22,9 +22,9 @@ use crate::{
 use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::ToPrimitive as _;
 use veryl_analyzer::ir::{
-    ArrayLiteralItem, AssignStatement, CombDeclaration, Expression, Factor, ForBound, ForRange,
-    ForStatement, IfStatement, Module, Op, Statement, SystemFunctionCall, SystemFunctionInput,
-    SystemFunctionKind, VarId, VarSelectOp,
+    ArrayLiteralItem, AssignStatement, CaseStatement, CombDeclaration, Expression, Factor,
+    ForBound, ForRange, ForStatement, IfStatement, Module, Op, Statement, SystemFunctionCall,
+    SystemFunctionInput, SystemFunctionKind, VarId, VarSelectOp,
 };
 use veryl_analyzer::value::{Value, byte_value_to_string};
 
@@ -188,12 +188,7 @@ fn eval_statement(
     match stmt {
         Statement::Assign(assign) => eval_assign(module, store, boundaries, assign, arena),
         Statement::If(if_stmt) => eval_if(module, store, boundaries, if_stmt, arena),
-        Statement::Case(case_stmt) => case_stmt
-            .lower_to_nested_if()
-            .iter()
-            .try_fold((store, boundaries), |(store, boundaries), stmt| {
-                eval_statement(module, store, boundaries, stmt, arena)
-            }),
+        Statement::Case(case_stmt) => eval_case(module, store, boundaries, case_stmt, arena),
         Statement::For(for_stmt) => eval_for(module, store, boundaries, for_stmt, arena),
         Statement::IfReset(ir) => Err(ParserError::illegal_context(
             "statement in always_comb",
@@ -230,6 +225,73 @@ fn eval_statement(
             None,
         )),
     }
+}
+
+fn eval_statements(
+    module: &Module,
+    store: SymbolicStore<VarId>,
+    boundaries: BoundaryMap<VarId>,
+    statements: &[Statement],
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<(SymbolicStore<VarId>, BoundaryMap<VarId>), ParserError> {
+    statements
+        .iter()
+        .try_fold((store, boundaries), |(store, boundaries), stmt| {
+            eval_statement(module, store, boundaries, stmt, arena)
+        })
+}
+
+fn eval_case(
+    module: &Module,
+    store: SymbolicStore<VarId>,
+    boundaries: BoundaryMap<VarId>,
+    case_stmt: &CaseStatement,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<(SymbolicStore<VarId>, BoundaryMap<VarId>), ParserError> {
+    fn eval_from_arm(
+        module: &Module,
+        store: SymbolicStore<VarId>,
+        boundaries: BoundaryMap<VarId>,
+        case_stmt: &CaseStatement,
+        arm_index: usize,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<(SymbolicStore<VarId>, BoundaryMap<VarId>), ParserError> {
+        let Some(arm) = case_stmt.arms.get(arm_index) else {
+            return eval_statements(module, store, boundaries, &case_stmt.default, arena);
+        };
+
+        let cond = case_arm_condition_expr(&case_stmt.case_target, &arm.patterns);
+        let ((cond_expr, cond_sources), cond_bounds) =
+            eval_expression(module, &store, &cond, arena, None)?;
+        let boundaries = merge_boundaries(boundaries, cond_bounds);
+
+        if let Some(cond_val) = constant_bool(arena, cond_expr) {
+            return if cond_val {
+                eval_statements(module, store, boundaries, &arm.body, arena)
+            } else {
+                eval_from_arm(module, store, boundaries, case_stmt, arm_index + 1, arena)
+            };
+        }
+
+        let (then_store, then_boundaries) =
+            eval_statements(module, store.clone(), boundaries.clone(), &arm.body, arena)?;
+        let (else_store, else_boundaries) =
+            eval_from_arm(module, store, boundaries, case_stmt, arm_index + 1, arena)?;
+
+        Ok((
+            merge_symbolic_stores(
+                module,
+                &then_store,
+                &else_store,
+                cond_expr,
+                &cond_sources,
+                arena,
+            )?,
+            merge_boundaries(then_boundaries, else_boundaries),
+        ))
+    }
+
+    eval_from_arm(module, store, boundaries, case_stmt, 0, arena)
 }
 
 fn bool_node(arena: &mut SLTNodeArena<VarId>, value: bool) -> NodeId {
@@ -433,12 +495,7 @@ fn eval_loop_statement(
                 apply_loop_continue_guard(module, guard_state, next_store, next_boundaries, arena)
             }
         }
-        Statement::Case(case_stmt) => case_stmt
-            .lower_to_nested_if()
-            .iter()
-            .try_fold(state, |state, stmt| {
-                eval_loop_statement(module, state, stmt, arena)
-            }),
+        Statement::Case(case_stmt) => eval_loop_case(module, state, case_stmt, arena),
         Statement::For(for_stmt) => {
             let guard_state = state.clone();
             let (next_store, next_boundaries) =
@@ -484,6 +541,98 @@ fn eval_loop_statement(
             None,
         )),
     }
+}
+
+fn eval_loop_case(
+    module: &Module,
+    state: LoopControlState,
+    case_stmt: &CaseStatement,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<LoopControlState, ParserError> {
+    fn eval_from_arm(
+        module: &Module,
+        state: LoopControlState,
+        case_stmt: &CaseStatement,
+        arm_index: usize,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<LoopControlState, ParserError> {
+        let Some(arm) = case_stmt.arms.get(arm_index) else {
+            return case_stmt
+                .default
+                .iter()
+                .try_fold(state, |s, step| eval_loop_statement(module, s, step, arena));
+        };
+
+        let ((cond_expr, cond_sources), cond_bounds) = eval_expression(
+            module,
+            &state.store,
+            &case_arm_condition_expr(&case_stmt.case_target, &arm.patterns),
+            arena,
+            None,
+        )?;
+        let boundaries = merge_boundaries(state.boundaries, cond_bounds);
+
+        if let Some(cond_val) = constant_bool(arena, cond_expr) {
+            let state = LoopControlState {
+                boundaries,
+                ..state
+            };
+            return if cond_val {
+                arm.body
+                    .iter()
+                    .try_fold(state, |s, step| eval_loop_statement(module, s, step, arena))
+            } else {
+                eval_from_arm(module, state, case_stmt, arm_index + 1, arena)
+            };
+        }
+
+        let then_state = arm.body.iter().try_fold(
+            LoopControlState {
+                store: state.store.clone(),
+                boundaries: boundaries.clone(),
+                continue_expr: state.continue_expr,
+                continue_sources: state.continue_sources.clone(),
+            },
+            |s, step| eval_loop_statement(module, s, step, arena),
+        )?;
+        let else_state = eval_from_arm(
+            module,
+            LoopControlState {
+                store: state.store,
+                boundaries,
+                continue_expr: state.continue_expr,
+                continue_sources: state.continue_sources,
+            },
+            case_stmt,
+            arm_index + 1,
+            arena,
+        )?;
+
+        let mut merged_sources = cond_sources;
+        merged_sources.extend(then_state.continue_sources);
+        merged_sources.extend(else_state.continue_sources);
+
+        Ok(LoopControlState {
+            store: merge_symbolic_stores(
+                module,
+                &then_state.store,
+                &else_state.store,
+                cond_expr,
+                &merged_sources,
+                arena,
+            )?,
+            boundaries: merge_boundaries(then_state.boundaries, else_state.boundaries),
+            continue_expr: merge_control_expr(
+                cond_expr,
+                then_state.continue_expr,
+                else_state.continue_expr,
+                arena,
+            ),
+            continue_sources: merged_sources,
+        })
+    }
+
+    eval_from_arm(module, state, case_stmt, 0, arena)
 }
 
 fn eval_loop_if(

--- a/crates/celox/src/logic_tree/comb/effect.rs
+++ b/crates/celox/src/logic_tree/comb/effect.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::parser::case::case_arm_condition_expr;
 
 pub(super) fn subtract_written_sensitivity<A: Copy + Eq + std::hash::Hash>(
     atoms: impl IntoIterator<Item = VarAtomBase<A>>,
@@ -523,6 +524,135 @@ fn collect_function_body_effects(
         Ok(state)
     }
 
+    fn collect_case_from_arm(
+        module: &Module,
+        state: FunctionControlState,
+        case_stmt: &CaseStatement,
+        arm_index: usize,
+        ret_id: VarId,
+        arena: &mut SLTNodeArena<VarId>,
+        collector: &mut CombEffectCollector,
+    ) -> Result<FunctionControlState, ParserError> {
+        let Some(arm) = case_stmt.arms.get(arm_index) else {
+            return collect_statements(module, state, &case_stmt.default, ret_id, arena, collector);
+        };
+
+        let cond = case_arm_condition_expr(&case_stmt.case_target, &arm.patterns);
+        let store = state.store.clone();
+        let live = state.live_expr;
+        let live_sources = state.live_sources.clone();
+        with_collector_guard(collector, arena, live, live_sources, |collector, arena| {
+            collect_expression_effects(module, &store, &cond, arena, collector)
+        })?;
+
+        let ((cond_node, cond_sources), cond_bounds) =
+            eval_expression(module, &state.store, &cond, arena, None)?;
+        let boundaries = merge_boundaries(state.boundaries, cond_bounds);
+
+        if let Some(cond_val) = constant_bool(arena, cond_node) {
+            let state = FunctionControlState {
+                boundaries,
+                ..state
+            };
+            return if cond_val {
+                collect_statements(module, state, &arm.body, ret_id, arena, collector)
+            } else {
+                collect_case_from_arm(
+                    module,
+                    state,
+                    case_stmt,
+                    arm_index + 1,
+                    ret_id,
+                    arena,
+                    collector,
+                )
+            };
+        }
+
+        let true_guard = arena.alloc(SLTNode::Binary(
+            state.live_expr,
+            BinaryOp::LogicAnd,
+            cond_node,
+        ));
+        let mut true_sources = state.live_sources.clone();
+        true_sources.extend(cond_sources.iter().copied());
+        let then_state = with_collector_guard(
+            collector,
+            arena,
+            true_guard,
+            true_sources,
+            |collector, arena| {
+                collect_statements(
+                    module,
+                    FunctionControlState {
+                        store: state.store.clone(),
+                        boundaries: boundaries.clone(),
+                        live_expr: state.live_expr,
+                        live_sources: state.live_sources.clone(),
+                    },
+                    &arm.body,
+                    ret_id,
+                    arena,
+                    collector,
+                )
+            },
+        )?;
+
+        let false_cond = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, cond_node));
+        let false_guard = arena.alloc(SLTNode::Binary(
+            state.live_expr,
+            BinaryOp::LogicAnd,
+            false_cond,
+        ));
+        let mut false_sources = state.live_sources.clone();
+        false_sources.extend(cond_sources.iter().copied());
+        let else_state = with_collector_guard(
+            collector,
+            arena,
+            false_guard,
+            false_sources,
+            |collector, arena| {
+                collect_case_from_arm(
+                    module,
+                    FunctionControlState {
+                        store: state.store,
+                        boundaries,
+                        live_expr: state.live_expr,
+                        live_sources: state.live_sources,
+                    },
+                    case_stmt,
+                    arm_index + 1,
+                    ret_id,
+                    arena,
+                    collector,
+                )
+            },
+        )?;
+
+        let mut live_sources = cond_sources;
+        live_sources.extend(then_state.live_sources);
+        live_sources.extend(else_state.live_sources);
+
+        Ok(FunctionControlState {
+            store: merge_symbolic_stores(
+                module,
+                &then_state.store,
+                &else_state.store,
+                cond_node,
+                &live_sources,
+                arena,
+            )?,
+            boundaries: merge_boundaries(then_state.boundaries, else_state.boundaries),
+            live_expr: merge_control_expr(
+                cond_node,
+                then_state.live_expr,
+                else_state.live_expr,
+                arena,
+            ),
+            live_sources,
+        })
+    }
+
     fn collect_statement(
         module: &Module,
         state: FunctionControlState,
@@ -657,12 +787,9 @@ fn collect_function_body_effects(
                     live_sources: HashSet::default(),
                 })
             }
-            Statement::Case(case_stmt) => case_stmt
-                .lower_to_nested_if()
-                .iter()
-                .try_fold(state, |state, stmt| {
-                    collect_statement(module, state, stmt, ret_id, arena, collector)
-                }),
+            Statement::Case(case_stmt) => {
+                collect_case_from_arm(module, state, case_stmt, 0, ret_id, arena, collector)
+            }
             Statement::For(for_stmt) => {
                 let store = state.store.clone();
                 let live = state.live_expr;
@@ -878,13 +1005,7 @@ pub(super) fn collect_comb_effects_statements(
                 )?;
             }
             Statement::Case(case_stmt) => {
-                store = collect_comb_effects_statements(
-                    module,
-                    store,
-                    &case_stmt.lower_to_nested_if(),
-                    arena,
-                    collector,
-                )?;
+                store = collect_comb_effects_case(module, store, case_stmt, arena, collector)?;
             }
             Statement::IfReset(_)
             | Statement::TbMethodCall(_)
@@ -894,6 +1015,78 @@ pub(super) fn collect_comb_effects_statements(
         }
     }
     Ok(store)
+}
+
+fn collect_comb_effects_case(
+    module: &Module,
+    store: SymbolicStore<VarId>,
+    case_stmt: &CaseStatement,
+    arena: &mut SLTNodeArena<VarId>,
+    collector: &mut CombEffectCollector,
+) -> Result<SymbolicStore<VarId>, ParserError> {
+    fn collect_from_arm(
+        module: &Module,
+        store: SymbolicStore<VarId>,
+        case_stmt: &CaseStatement,
+        arm_index: usize,
+        arena: &mut SLTNodeArena<VarId>,
+        collector: &mut CombEffectCollector,
+    ) -> Result<SymbolicStore<VarId>, ParserError> {
+        let Some(arm) = case_stmt.arms.get(arm_index) else {
+            return collect_comb_effects_statements(
+                module,
+                store,
+                &case_stmt.default,
+                arena,
+                collector,
+            );
+        };
+
+        let cond = case_arm_condition_expr(&case_stmt.case_target, &arm.patterns);
+        collect_expression_effects(module, &store, &cond, arena, collector)?;
+        let ((cond_node, sources), _) = eval_expression(module, &store, &cond, arena, None)?;
+        collector.sensitivity.extend(sources.iter().copied());
+
+        let saved_guard = collector.active_guard;
+        let saved_guard_sources = collector.active_guard_sources.clone();
+        let true_guard = if let Some(active) = saved_guard {
+            arena.alloc(SLTNode::Binary(active, BinaryOp::LogicAnd, cond_node))
+        } else {
+            cond_node
+        };
+        let mut true_sources = saved_guard_sources.clone();
+        true_sources.extend(sources.iter().copied());
+        collector.active_guard = Some(true_guard);
+        collector.active_guard_sources = true_sources;
+        let side_store =
+            collect_comb_effects_statements(module, store.clone(), &arm.body, arena, collector)?;
+
+        let false_cond = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, cond_node));
+        let false_guard = if let Some(active) = saved_guard {
+            arena.alloc(SLTNode::Binary(active, BinaryOp::LogicAnd, false_cond))
+        } else {
+            false_cond
+        };
+        let mut false_sources = saved_guard_sources.clone();
+        false_sources.extend(sources.iter().copied());
+        collector.active_guard = Some(false_guard);
+        collector.active_guard_sources = false_sources;
+        let else_store =
+            collect_from_arm(module, store, case_stmt, arm_index + 1, arena, collector)?;
+
+        collector.active_guard = saved_guard;
+        collector.active_guard_sources = saved_guard_sources;
+        merge_symbolic_stores(
+            module,
+            &side_store,
+            &else_store,
+            bool_node(arena, true),
+            &HashSet::default(),
+            arena,
+        )
+    }
+
+    collect_from_arm(module, store, case_stmt, 0, arena, collector)
 }
 
 fn collect_comb_effects_for(

--- a/crates/celox/src/logic_tree/comb/expr.rs
+++ b/crates/celox/src/logic_tree/comb/expr.rs
@@ -1,8 +1,11 @@
 use super::*;
 
-use crate::{context_width::get_context_width, parser::bitaccess::celox_value_from_comptime};
+use crate::{
+    context_width::get_context_width,
+    parser::{bitaccess::celox_value_from_comptime, case::case_arm_condition_expr},
+};
 use num_traits::ToPrimitive as _;
-use veryl_analyzer::ir::{Type, ValueVariant};
+use veryl_analyzer::ir::{CasePattern, Type, ValueVariant};
 
 use super::state::{FunctionControlState, FunctionLoopControlState};
 
@@ -322,8 +325,25 @@ pub(super) fn eval_function_body_return(
                 Ok(())
             }
             Statement::Case(case_stmt) => {
-                for stmt in case_stmt.lower_to_nested_if() {
-                    validate_function_body_statement(module, &stmt)?;
+                validate_function_body_expression(module, &case_stmt.case_target)?;
+                for arm in &case_stmt.arms {
+                    for pattern in &arm.patterns {
+                        match pattern {
+                            CasePattern::Eq(expr) => {
+                                validate_function_body_expression(module, expr)?
+                            }
+                            CasePattern::Range { lo, hi, .. } => {
+                                validate_function_body_expression(module, lo)?;
+                                validate_function_body_expression(module, hi)?;
+                            }
+                        }
+                    }
+                    for stmt in &arm.body {
+                        validate_function_body_statement(module, stmt)?;
+                    }
+                }
+                for stmt in &case_stmt.default {
+                    validate_function_body_statement(module, stmt)?;
                 }
                 Ok(())
             }
@@ -683,6 +703,126 @@ pub(super) fn eval_function_body_return(
             })
         }
 
+        fn eval_function_loop_case(
+            module: &Module,
+            state: FunctionLoopControlState,
+            case_stmt: &CaseStatement,
+            ret_id: VarId,
+            arena: &mut SLTNodeArena<VarId>,
+        ) -> Result<FunctionLoopControlState, ParserError> {
+            fn eval_from_arm(
+                module: &Module,
+                state: FunctionLoopControlState,
+                case_stmt: &CaseStatement,
+                arm_index: usize,
+                ret_id: VarId,
+                arena: &mut SLTNodeArena<VarId>,
+            ) -> Result<FunctionLoopControlState, ParserError> {
+                let Some(arm) = case_stmt.arms.get(arm_index) else {
+                    return case_stmt.default.iter().try_fold(state, |s, step| {
+                        eval_function_loop_statement(module, s, step, ret_id, arena)
+                    });
+                };
+
+                let ((cond_expr, cond_sources), cond_bounds) = eval_expression(
+                    module,
+                    &state.function.store,
+                    &case_arm_condition_expr(&case_stmt.case_target, &arm.patterns),
+                    arena,
+                    Some(1),
+                )?;
+                let boundaries = merge_boundaries(state.function.boundaries, cond_bounds);
+
+                if let Some(cond_val) = constant_bool(arena, cond_expr) {
+                    let state = FunctionLoopControlState {
+                        function: FunctionControlState {
+                            boundaries,
+                            ..state.function
+                        },
+                        ..state
+                    };
+                    return if cond_val {
+                        arm.body.iter().try_fold(state, |s, step| {
+                            eval_function_loop_statement(module, s, step, ret_id, arena)
+                        })
+                    } else {
+                        eval_from_arm(module, state, case_stmt, arm_index + 1, ret_id, arena)
+                    };
+                }
+
+                let then_state = arm.body.iter().try_fold(
+                    FunctionLoopControlState {
+                        function: FunctionControlState {
+                            store: state.function.store.clone(),
+                            boundaries: boundaries.clone(),
+                            live_expr: state.function.live_expr,
+                            live_sources: state.function.live_sources.clone(),
+                        },
+                        continue_expr: state.continue_expr,
+                        continue_sources: state.continue_sources.clone(),
+                    },
+                    |s, step| eval_function_loop_statement(module, s, step, ret_id, arena),
+                )?;
+                let else_state = eval_from_arm(
+                    module,
+                    FunctionLoopControlState {
+                        function: FunctionControlState {
+                            store: state.function.store,
+                            boundaries,
+                            live_expr: state.function.live_expr,
+                            live_sources: state.function.live_sources,
+                        },
+                        continue_expr: state.continue_expr,
+                        continue_sources: state.continue_sources,
+                    },
+                    case_stmt,
+                    arm_index + 1,
+                    ret_id,
+                    arena,
+                )?;
+
+                let mut merged_sources = cond_sources;
+                merged_sources.extend(then_state.continue_sources);
+                merged_sources.extend(else_state.continue_sources);
+                let mut live_sources = merged_sources.clone();
+                live_sources.extend(then_state.function.live_sources);
+                live_sources.extend(else_state.function.live_sources);
+
+                Ok(FunctionLoopControlState {
+                    function: FunctionControlState {
+                        store: merge_symbolic_stores(
+                            module,
+                            &then_state.function.store,
+                            &else_state.function.store,
+                            cond_expr,
+                            &live_sources,
+                            arena,
+                        )?,
+                        boundaries: merge_boundaries(
+                            then_state.function.boundaries,
+                            else_state.function.boundaries,
+                        ),
+                        live_expr: merge_control_expr(
+                            cond_expr,
+                            then_state.function.live_expr,
+                            else_state.function.live_expr,
+                            arena,
+                        ),
+                        live_sources,
+                    },
+                    continue_expr: merge_control_expr(
+                        cond_expr,
+                        then_state.continue_expr,
+                        else_state.continue_expr,
+                        arena,
+                    ),
+                    continue_sources: merged_sources,
+                })
+            }
+
+            eval_from_arm(module, state, case_stmt, 0, ret_id, arena)
+        }
+
         fn eval_function_loop_statement(
             module: &Module,
             state: FunctionLoopControlState,
@@ -700,12 +840,9 @@ pub(super) fn eval_function_body_return(
                 Statement::If(if_stmt) => {
                     eval_function_loop_if(module, state, if_stmt, ret_id, arena)
                 }
-                Statement::Case(case_stmt) => case_stmt
-                    .lower_to_nested_if()
-                    .iter()
-                    .try_fold(state, |state, stmt| {
-                        eval_function_loop_statement(module, state, stmt, ret_id, arena)
-                    }),
+                Statement::Case(case_stmt) => {
+                    eval_function_loop_case(module, state, case_stmt, ret_id, arena)
+                }
                 Statement::Assign(_)
                 | Statement::For(_)
                 | Statement::FunctionCall(_)
@@ -1222,6 +1359,154 @@ pub(super) fn eval_function_body_return(
         })
     }
 
+    fn eval_function_break_case(
+        module: &Module,
+        state: FunctionLoopControlState,
+        case_stmt: &CaseStatement,
+        ret_id: VarId,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<FunctionLoopControlState, ParserError> {
+        fn eval_from_arm(
+            module: &Module,
+            state: FunctionLoopControlState,
+            case_stmt: &CaseStatement,
+            arm_index: usize,
+            ret_id: VarId,
+            arena: &mut SLTNodeArena<VarId>,
+        ) -> Result<FunctionLoopControlState, ParserError> {
+            let Some(arm) = case_stmt.arms.get(arm_index) else {
+                return case_stmt.default.iter().try_fold(state, |s, step| {
+                    eval_function_break_statement(module, s, step, ret_id, arena)
+                });
+            };
+
+            let ((cond_expr, cond_sources), cond_bounds) = eval_expression(
+                module,
+                &state.function.store,
+                &case_arm_condition_expr(&case_stmt.case_target, &arm.patterns),
+                arena,
+                Some(1),
+            )?;
+            let boundaries = merge_boundaries(state.function.boundaries, cond_bounds);
+
+            if let Some(cond_val) = constant_bool(arena, cond_expr) {
+                let state = FunctionLoopControlState {
+                    function: FunctionControlState {
+                        boundaries,
+                        ..state.function
+                    },
+                    ..state
+                };
+                return if cond_val {
+                    arm.body.iter().try_fold(state, |s, step| {
+                        eval_function_break_statement(module, s, step, ret_id, arena)
+                    })
+                } else {
+                    eval_from_arm(module, state, case_stmt, arm_index + 1, ret_id, arena)
+                };
+            }
+
+            let then_state = arm.body.iter().try_fold(
+                FunctionLoopControlState {
+                    function: FunctionControlState {
+                        store: state.function.store.clone(),
+                        boundaries: boundaries.clone(),
+                        live_expr: state.function.live_expr,
+                        live_sources: state.function.live_sources.clone(),
+                    },
+                    continue_expr: state.continue_expr,
+                    continue_sources: state.continue_sources.clone(),
+                },
+                |s, step| eval_function_break_statement(module, s, step, ret_id, arena),
+            )?;
+            let else_state = eval_from_arm(
+                module,
+                FunctionLoopControlState {
+                    function: FunctionControlState {
+                        store: state.function.store,
+                        boundaries,
+                        live_expr: state.function.live_expr,
+                        live_sources: state.function.live_sources,
+                    },
+                    continue_expr: state.continue_expr,
+                    continue_sources: state.continue_sources,
+                },
+                case_stmt,
+                arm_index + 1,
+                ret_id,
+                arena,
+            )?;
+
+            let mut merged_sources = cond_sources;
+            merged_sources.extend(then_state.continue_sources);
+            merged_sources.extend(else_state.continue_sources);
+            let mut live_sources = merged_sources.clone();
+            live_sources.extend(then_state.function.live_sources);
+            live_sources.extend(else_state.function.live_sources);
+
+            Ok(FunctionLoopControlState {
+                function: FunctionControlState {
+                    store: merge_symbolic_stores(
+                        module,
+                        &then_state.function.store,
+                        &else_state.function.store,
+                        cond_expr,
+                        &live_sources,
+                        arena,
+                    )?,
+                    boundaries: merge_boundaries(
+                        then_state.function.boundaries,
+                        else_state.function.boundaries,
+                    ),
+                    live_expr: merge_control_expr(
+                        cond_expr,
+                        then_state.function.live_expr,
+                        else_state.function.live_expr,
+                        arena,
+                    ),
+                    live_sources,
+                },
+                continue_expr: merge_control_expr(
+                    cond_expr,
+                    then_state.continue_expr,
+                    else_state.continue_expr,
+                    arena,
+                ),
+                continue_sources: merged_sources,
+            })
+        }
+
+        let outer_state = state.clone();
+        let executed_state = eval_from_arm(module, state, case_stmt, 0, ret_id, arena)?;
+
+        if matches!(constant_bool(arena, outer_state.continue_expr), Some(true)) {
+            return Ok(executed_state);
+        }
+
+        let guarded = apply_function_break_guard(
+            module,
+            outer_state.clone(),
+            executed_state.function,
+            arena,
+        )?;
+        let continue_expr = match constant_bool(arena, executed_state.continue_expr) {
+            Some(true) => outer_state.continue_expr,
+            Some(false) => bool_node(arena, false),
+            None => arena.alloc(SLTNode::Binary(
+                outer_state.continue_expr,
+                BinaryOp::And,
+                executed_state.continue_expr,
+            )),
+        };
+        let mut continue_sources = outer_state.continue_sources;
+        continue_sources.extend(executed_state.continue_sources);
+        Ok(FunctionLoopControlState {
+            function: guarded.function,
+            continue_expr,
+            continue_sources,
+        })
+    }
+
     fn eval_function_break_statement(
         module: &Module,
         state: FunctionLoopControlState,
@@ -1237,12 +1522,9 @@ pub(super) fn eval_function_body_return(
 
         match stmt {
             Statement::If(if_stmt) => eval_function_break_if(module, state, if_stmt, ret_id, arena),
-            Statement::Case(case_stmt) => case_stmt
-                .lower_to_nested_if()
-                .iter()
-                .try_fold(state, |state, stmt| {
-                    eval_function_break_statement(module, state, stmt, ret_id, arena)
-                }),
+            Statement::Case(case_stmt) => {
+                eval_function_break_case(module, state, case_stmt, ret_id, arena)
+            }
             Statement::Assign(_)
             | Statement::For(_)
             | Statement::FunctionCall(_)
@@ -1328,6 +1610,99 @@ pub(super) fn eval_function_body_return(
         Ok(state)
     }
 
+    fn eval_function_case(
+        module: &Module,
+        state: FunctionControlState,
+        case_stmt: &CaseStatement,
+        ret_id: VarId,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<FunctionControlState, ParserError> {
+        fn eval_from_arm(
+            module: &Module,
+            state: FunctionControlState,
+            case_stmt: &CaseStatement,
+            arm_index: usize,
+            ret_id: VarId,
+            arena: &mut SLTNodeArena<VarId>,
+        ) -> Result<FunctionControlState, ParserError> {
+            let Some(arm) = case_stmt.arms.get(arm_index) else {
+                return eval_function_statements(module, state, &case_stmt.default, ret_id, arena);
+            };
+
+            let ((cond_expr, cond_sources), cond_bounds) = eval_expression(
+                module,
+                &state.store,
+                &case_arm_condition_expr(&case_stmt.case_target, &arm.patterns),
+                arena,
+                Some(1),
+            )?;
+            let boundaries = merge_boundaries(state.boundaries, cond_bounds);
+
+            if let Some(cond_val) = constant_bool(arena, cond_expr) {
+                let state = FunctionControlState {
+                    boundaries,
+                    ..state
+                };
+                return if cond_val {
+                    eval_function_statements(module, state, &arm.body, ret_id, arena)
+                } else {
+                    eval_from_arm(module, state, case_stmt, arm_index + 1, ret_id, arena)
+                };
+            }
+
+            let then_state = eval_function_statements(
+                module,
+                FunctionControlState {
+                    store: state.store.clone(),
+                    boundaries: boundaries.clone(),
+                    live_expr: state.live_expr,
+                    live_sources: state.live_sources.clone(),
+                },
+                &arm.body,
+                ret_id,
+                arena,
+            )?;
+            let else_state = eval_from_arm(
+                module,
+                FunctionControlState {
+                    store: state.store,
+                    boundaries,
+                    live_expr: state.live_expr,
+                    live_sources: state.live_sources,
+                },
+                case_stmt,
+                arm_index + 1,
+                ret_id,
+                arena,
+            )?;
+
+            let mut live_sources = cond_sources;
+            live_sources.extend(then_state.live_sources);
+            live_sources.extend(else_state.live_sources);
+
+            Ok(FunctionControlState {
+                store: merge_symbolic_stores(
+                    module,
+                    &then_state.store,
+                    &else_state.store,
+                    cond_expr,
+                    &live_sources,
+                    arena,
+                )?,
+                boundaries: merge_boundaries(then_state.boundaries, else_state.boundaries),
+                live_expr: merge_control_expr(
+                    cond_expr,
+                    then_state.live_expr,
+                    else_state.live_expr,
+                    arena,
+                ),
+                live_sources,
+            })
+        }
+
+        eval_from_arm(module, state, case_stmt, 0, ret_id, arena)
+    }
+
     fn eval_function_statement(
         module: &Module,
         state: FunctionControlState,
@@ -1360,12 +1735,9 @@ pub(super) fn eval_function_body_return(
                 )
             }
             Statement::If(if_stmt) => eval_function_if(module, state, if_stmt, ret_id, arena),
-            Statement::Case(case_stmt) => case_stmt
-                .lower_to_nested_if()
-                .iter()
-                .try_fold(state, |state, stmt| {
-                    eval_function_statement(module, state, stmt, ret_id, arena)
-                }),
+            Statement::Case(case_stmt) => {
+                eval_function_case(module, state, case_stmt, ret_id, arena)
+            }
             Statement::For(for_stmt) => eval_function_for(module, state, for_stmt, ret_id, arena),
             Statement::FunctionCall(call) => {
                 let guard_state = state.clone();

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -65,6 +65,7 @@ impl From<&veryl_metadata::Build> for BuildConfig {
 }
 pub mod bitaccess;
 mod bitslicer;
+pub(crate) mod case;
 pub mod ff;
 pub mod module;
 pub mod registry;

--- a/crates/celox/src/parser/case.rs
+++ b/crates/celox/src/parser/case.rs
@@ -1,0 +1,51 @@
+use veryl_analyzer::ir::{CasePattern, Comptime, Expression, Op};
+use veryl_parser::token_range::TokenRange;
+
+fn unknown_comptime() -> Box<Comptime> {
+    Box::new(Comptime::create_unknown(TokenRange::default()))
+}
+
+fn case_pattern_condition(target: &Expression, pattern: &CasePattern) -> Expression {
+    match pattern {
+        CasePattern::Eq(value) => Expression::Binary(
+            Box::new(target.clone()),
+            Op::EqWildcard,
+            value.clone(),
+            unknown_comptime(),
+        ),
+        CasePattern::Range { lo, hi, inclusive } => {
+            let lo_cond = Expression::Binary(
+                lo.clone(),
+                Op::LessEq,
+                Box::new(target.clone()),
+                unknown_comptime(),
+            );
+            let hi_op = if *inclusive { Op::LessEq } else { Op::Less };
+            let hi_cond = Expression::Binary(
+                Box::new(target.clone()),
+                hi_op,
+                hi.clone(),
+                unknown_comptime(),
+            );
+            Expression::Binary(
+                Box::new(lo_cond),
+                Op::LogicAnd,
+                Box::new(hi_cond),
+                unknown_comptime(),
+            )
+        }
+    }
+}
+
+pub(crate) fn case_arm_condition_expr(target: &Expression, patterns: &[CasePattern]) -> Expression {
+    let mut iter = patterns.iter();
+    let first = iter.next().expect("CaseArm must have at least one pattern");
+    iter.fold(case_pattern_condition(target, first), |acc, pattern| {
+        Expression::Binary(
+            Box::new(acc),
+            Op::LogicOr,
+            Box::new(case_pattern_condition(target, pattern)),
+            unknown_comptime(),
+        )
+    })
+}

--- a/crates/celox/src/parser/ff.rs
+++ b/crates/celox/src/parser/ff.rs
@@ -9,6 +9,7 @@ use crate::{
     parser::{
         BuildConfig, LoweringPhase, ParserError,
         bitaccess::{eval_constexpr, get_access_width},
+        case::case_arm_condition_expr,
     },
 };
 use bit_set::BitSet;
@@ -16,9 +17,9 @@ use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::ToPrimitive;
 
 use veryl_analyzer::ir::{
-    AssertKind, Expression, Factor, FfDeclaration, FfReset, ForBound, ForRange, ForStatement,
-    IfResetStatement, IfStatement, Module, Op, Statement, SystemFunctionCall, SystemFunctionInput,
-    SystemFunctionKind, TypeKind, ValueVariant, VarId,
+    AssertKind, CaseStatement, Expression, Factor, FfDeclaration, FfReset, ForBound, ForRange,
+    ForStatement, IfResetStatement, IfStatement, Module, Op, Statement, SystemFunctionCall,
+    SystemFunctionInput, SystemFunctionKind, TypeKind, ValueVariant, VarId,
 };
 use veryl_analyzer::value::Value;
 use veryl_analyzer::value::byte_value_to_string;
@@ -563,6 +564,120 @@ impl<'a> FfParser<'a> {
         }
     }
 
+    fn parse_case_statement<A>(
+        &mut self,
+        stmt: &CaseStatement,
+        targets: &mut Vec<VarAtomBase<A>>,
+        domain: &Domain,
+        convert: &impl Fn(VarId, u32) -> A,
+        sources: &mut Vec<VarAtomBase<A>>,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<ControlFlow, ParserError> {
+        self.parse_case_arm(stmt, 0, targets, domain, convert, sources, ir_builder)
+    }
+
+    fn parse_case_arm<A>(
+        &mut self,
+        stmt: &CaseStatement,
+        arm_index: usize,
+        targets: &mut Vec<VarAtomBase<A>>,
+        domain: &Domain,
+        convert: &impl Fn(VarId, u32) -> A,
+        sources: &mut Vec<VarAtomBase<A>>,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<ControlFlow, ParserError> {
+        let Some(arm) = stmt.arms.get(arm_index) else {
+            return self.parse_statement_list(
+                &stmt.default,
+                targets,
+                domain,
+                convert,
+                sources,
+                ir_builder,
+            );
+        };
+
+        let cond = case_arm_condition_expr(&stmt.case_target, &arm.patterns);
+        if let Some(const_val) = self.get_constant_value(&cond) {
+            return if const_val != 0 {
+                self.parse_statement_list(&arm.body, targets, domain, convert, sources, ir_builder)
+            } else {
+                self.parse_case_arm(
+                    stmt,
+                    arm_index + 1,
+                    targets,
+                    domain,
+                    convert,
+                    sources,
+                    ir_builder,
+                )
+            };
+        }
+
+        self.parse_expression(&cond, targets, domain, convert, sources, ir_builder, None)?;
+        let cond_reg = self.stack.pop_back().unwrap();
+
+        let then_bb = ir_builder.new_block();
+        let else_bb = ir_builder.new_block();
+        let merge_bb = ir_builder.new_block();
+
+        let pre_case_defined = self.defined_ranges.clone();
+        let pre_case_dynamic = self.dynamic_defined_vars.clone();
+
+        ir_builder.seal_block(SIRTerminator::Branch {
+            cond: cond_reg,
+            true_block: (then_bb, vec![]),
+            false_block: (else_bb, vec![]),
+        });
+
+        ir_builder.switch_to_block(then_bb);
+        let then_flow =
+            self.parse_statement_list(&arm.body, targets, domain, convert, sources, ir_builder)?;
+        let then_defined = std::mem::replace(&mut self.defined_ranges, pre_case_defined.clone());
+        let then_dynamic = std::mem::replace(&mut self.dynamic_defined_vars, pre_case_dynamic);
+        if matches!(then_flow, ControlFlow::Continue) {
+            ir_builder.seal_block(SIRTerminator::Jump(merge_bb, vec![]));
+        }
+
+        ir_builder.switch_to_block(else_bb);
+        let else_flow = self.parse_case_arm(
+            stmt,
+            arm_index + 1,
+            targets,
+            domain,
+            convert,
+            sources,
+            ir_builder,
+        )?;
+        let else_defined = std::mem::take(&mut self.defined_ranges);
+        let else_dynamic = std::mem::take(&mut self.dynamic_defined_vars);
+        if matches!(else_flow, ControlFlow::Continue) {
+            ir_builder.seal_block(SIRTerminator::Jump(merge_bb, vec![]));
+        }
+
+        match (then_flow, else_flow) {
+            (ControlFlow::Continue, ControlFlow::Continue) => {
+                self.defined_ranges = self.intersect_defined_states(then_defined, else_defined);
+                self.dynamic_defined_vars = self.intersect_dynamic_vars(then_dynamic, else_dynamic);
+                ir_builder.switch_to_block(merge_bb);
+                Ok(ControlFlow::Continue)
+            }
+            (ControlFlow::Continue, ControlFlow::Break) => {
+                self.defined_ranges = then_defined;
+                self.dynamic_defined_vars = then_dynamic;
+                ir_builder.switch_to_block(merge_bb);
+                Ok(ControlFlow::Continue)
+            }
+            (ControlFlow::Break, ControlFlow::Continue) => {
+                self.defined_ranges = else_defined;
+                self.dynamic_defined_vars = else_dynamic;
+                ir_builder.switch_to_block(merge_bb);
+                Ok(ControlFlow::Continue)
+            }
+            (ControlFlow::Break, ControlFlow::Break) => Ok(ControlFlow::Break),
+        }
+    }
+
     /// Helper to take intersection of dynamic defined variables
     fn intersect_dynamic_vars(
         &self,
@@ -617,14 +732,8 @@ impl<'a> FfParser<'a> {
                     .parse_if_statement(stmt, targets, domain, convert, sources, ir_builder);
             }
             Statement::Case(stmt) => {
-                for lowered in stmt.lower_to_nested_if() {
-                    if self
-                        .parse_statement(&lowered, targets, domain, convert, sources, ir_builder)?
-                        == ControlFlow::Break
-                    {
-                        return Ok(ControlFlow::Break);
-                    }
-                }
+                return self
+                    .parse_case_statement(stmt, targets, domain, convert, sources, ir_builder);
             }
             Statement::IfReset(stmt) => {
                 return self

--- a/crates/celox/src/parser/ff/function_call.rs
+++ b/crates/celox/src/parser/ff/function_call.rs
@@ -5,11 +5,13 @@ use crate::{
     parser::{
         LoweringPhase, ParserError,
         bitaccess::{build_partial_assign_expr, is_static_access},
+        case::case_arm_condition_expr,
     },
 };
 use num_traits::ToPrimitive;
 use veryl_analyzer::ir::{
-    ArrayLiteralItem, Comptime, Expression, Factor, Statement, VarId, VarIndex, VarSelect,
+    ArrayLiteralItem, CaseStatement, Comptime, Expression, Factor, Statement, VarId, VarIndex,
+    VarSelect,
 };
 use veryl_parser::token_range::TokenRange;
 
@@ -408,12 +410,9 @@ impl<'a> FfParser<'a> {
                     let cond = substitute(&if_stmt.cond, state);
                     Ok(merge_branch_state(&cond, then_state, else_state))
                 }
-                Statement::Case(case_stmt) => build_state_from_statements(
-                    parser,
-                    &case_stmt.lower_to_nested_if(),
-                    state,
-                    substitute,
-                ),
+                Statement::Case(case_stmt) => {
+                    build_state_from_case(parser, case_stmt, 0, state, substitute)
+                }
                 Statement::Null => Ok(state.clone()),
                 Statement::IfReset(ir) => Err(ParserError::unsupported(
                     43,
@@ -447,6 +446,27 @@ impl<'a> FfParser<'a> {
                     ))
                 }
             }
+        }
+
+        fn build_state_from_case(
+            parser: &FfParser,
+            case_stmt: &CaseStatement,
+            arm_index: usize,
+            state: &HashMap<VarId, Expression>,
+            substitute: &impl Fn(&Expression, &HashMap<VarId, Expression>) -> Expression,
+        ) -> Result<HashMap<VarId, Expression>, ParserError> {
+            let Some(arm) = case_stmt.arms.get(arm_index) else {
+                return build_state_from_statements(parser, &case_stmt.default, state, substitute);
+            };
+
+            let then_state = build_state_from_statements(parser, &arm.body, state, substitute)?;
+            let else_state =
+                build_state_from_case(parser, case_stmt, arm_index + 1, state, substitute)?;
+            let cond = substitute(
+                &case_arm_condition_expr(&case_stmt.case_target, &arm.patterns),
+                state,
+            );
+            Ok(merge_branch_state(&cond, then_state, else_state))
         }
 
         fn build_state_from_statements(
@@ -573,9 +593,7 @@ impl<'a> FfParser<'a> {
                     }
                 }
                 Statement::Case(case_stmt) => {
-                    let mut lowered = case_stmt.lower_to_nested_if();
-                    lowered.extend_from_slice(rest);
-                    resolve_return_expr(parser, &lowered, ret_id, defs, substitute)
+                    resolve_return_expr_case(parser, case_stmt, rest, ret_id, defs, substitute)
                 }
                 Statement::Null => resolve_return_expr(parser, rest, ret_id, defs, substitute),
                 Statement::IfReset(ir) => Err(ParserError::unsupported(
@@ -613,6 +631,61 @@ impl<'a> FfParser<'a> {
                     ))
                 }
             }
+        }
+
+        fn resolve_return_expr_case(
+            parser: &FfParser,
+            case_stmt: &CaseStatement,
+            rest: &[Statement],
+            ret_id: VarId,
+            defs: &HashMap<VarId, Expression>,
+            substitute: &impl Fn(&Expression, &HashMap<VarId, Expression>) -> Expression,
+        ) -> Result<Option<Expression>, ParserError> {
+            fn resolve_from_arm(
+                parser: &FfParser,
+                case_stmt: &CaseStatement,
+                arm_index: usize,
+                rest: &[Statement],
+                ret_id: VarId,
+                defs: &HashMap<VarId, Expression>,
+                substitute: &impl Fn(&Expression, &HashMap<VarId, Expression>) -> Expression,
+            ) -> Result<Option<Expression>, ParserError> {
+                let Some(arm) = case_stmt.arms.get(arm_index) else {
+                    let mut default_stmts = case_stmt.default.clone();
+                    default_stmts.extend_from_slice(rest);
+                    return resolve_return_expr(parser, &default_stmts, ret_id, defs, substitute);
+                };
+
+                let cond = substitute(
+                    &case_arm_condition_expr(&case_stmt.case_target, &arm.patterns),
+                    defs,
+                );
+
+                let mut then_stmts = arm.body.clone();
+                then_stmts.extend_from_slice(rest);
+                let then_expr = resolve_return_expr(parser, &then_stmts, ret_id, defs, substitute)?;
+                let else_expr = resolve_from_arm(
+                    parser,
+                    case_stmt,
+                    arm_index + 1,
+                    rest,
+                    ret_id,
+                    defs,
+                    substitute,
+                )?;
+
+                match (then_expr, else_expr) {
+                    (Some(then_expr), Some(else_expr)) => Ok(Some(Expression::Ternary(
+                        Box::new(cond),
+                        Box::new(then_expr),
+                        Box::new(else_expr),
+                        Box::new(Comptime::create_unknown(TokenRange::default())),
+                    ))),
+                    _ => Ok(None),
+                }
+            }
+
+            resolve_from_arm(parser, case_stmt, 0, rest, ret_id, defs, substitute)
         }
 
         resolve_return_expr(

--- a/crates/celox/tests/case_switch.rs
+++ b/crates/celox/tests/case_switch.rs
@@ -228,4 +228,120 @@ o2 = 8'h00;
         sim.tick(clk).unwrap();
         assert_eq!(sim.get(o), 0xFFu8.into());
     }
+
+    fn test_case_in_comb_function_return(sim) {
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    sel: input logic<2>,
+    q: output logic<8>,
+) {
+    function f (
+        x: input logic<2>,
+    ) -> logic<8> {
+        case x {
+            2'd0: return 8'h11;
+            2'd1: return 8'h22;
+            default: return 8'h33;
+        }
+    }
+
+    always_comb {
+        q = f(sel);
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+
+        let sel = sim.signal("sel");
+        let q = sim.signal("q");
+
+        sim.modify(|io| io.set(sel, 0u8)).unwrap();
+        assert_eq!(sim.get(q), 0x11u8.into());
+
+        sim.modify(|io| io.set(sel, 1u8)).unwrap();
+        assert_eq!(sim.get(q), 0x22u8.into());
+
+        sim.modify(|io| io.set(sel, 3u8)).unwrap();
+        assert_eq!(sim.get(q), 0x33u8.into());
+    }
+
+    fn test_case_in_comb_function_output_argument(sim) {
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    sel: input logic<2>,
+    q: output logic<8>,
+) {
+    function f (
+        x: input logic<2>,
+        y: output logic<8>,
+    ) {
+        case x {
+            2'd0: y = 8'h44;
+            2'd1: y = 8'h55;
+            default: y = 8'h66;
+        }
+    }
+
+    always_comb {
+        f(sel, q);
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+
+        let sel = sim.signal("sel");
+        let q = sim.signal("q");
+
+        sim.modify(|io| io.set(sel, 0u8)).unwrap();
+        assert_eq!(sim.get(q), 0x44u8.into());
+
+        sim.modify(|io| io.set(sel, 1u8)).unwrap();
+        assert_eq!(sim.get(q), 0x55u8.into());
+
+        sim.modify(|io| io.set(sel, 2u8)).unwrap();
+        assert_eq!(sim.get(q), 0x66u8.into());
+    }
+
+    fn test_case_break_inside_comb_function_for(sim) {
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    d: input logic<4>,
+    q: output logic<8>,
+) {
+    function f (
+        x: input logic<4>,
+    ) -> logic<8> {
+        var tmp: logic<8>;
+        tmp = 8'd0;
+        for i in 0..4 {
+            case x[i] {
+                1'b1: {
+                    tmp = i + 8'd1;
+                    break;
+                }
+                default: {}
+            }
+        }
+        return tmp;
+    }
+
+    always_comb {
+        q = f(d);
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+
+        let d = sim.signal("d");
+        let q = sim.signal("q");
+
+        sim.modify(|io| io.set(d, 0b0000u8)).unwrap();
+        assert_eq!(sim.get(q), 0u8.into());
+
+        sim.modify(|io| io.set(d, 0b1010u8)).unwrap();
+        assert_eq!(sim.get(q), 2u8.into());
+    }
 }


### PR DESCRIPTION
## Summary
- add shared CasePattern-to-condition lowering for Celox-native case handling
- evaluate Statement::Case directly in comb symbolic execution, FF lowering, function return/output handling, and effect collection
- add focused case statement tests for comb functions, output args, and loop break handling

## Verification
- pre-push hook passed: submodule-check, cargo-fmt, biome, cargo-clippy, full test command, clean-tree
- cargo test -p celox
- cargo clippy -p celox --all-targets -- -D warnings