### PR TITLE
[codex] fix native unaligned wide stores

### DIFF
--- a/crates/celox/src/backend/native/emit.rs
+++ b/crates/celox/src/backend/native/emit.rs
@@ -1311,7 +1311,8 @@ pub fn emit_chained_eus(
         let (mut merged, boundaries) = crate::ir::merge_sir_eus(units);
         // Cross-EU SIR optimization
         crate::optimizer::coalescing::pass_eliminate_working_round_trip::eliminate_working_round_trip(
-            &mut merged, &boundaries,
+            &mut merged,
+            &boundaries,
         );
         crate::optimizer::coalescing::commit_ops::inline_commit_forwarding(&mut merged);
         (merged, boundaries)

--- a/crates/celox/src/backend/native/isel.rs
+++ b/crates/celox/src/backend/native/isel.rs
@@ -1981,46 +1981,64 @@ fn lower_instruction(
                                 // Wide store: emit chunk-by-chunk stores
                                 let mut bit_pos = 0usize;
                                 for (chunk_vreg, chunk_width) in &chunks {
-                                    let chunk_bit_off = *bit_off + bit_pos;
-                                    let chunk_byte_off = ctx.byte_offset(addr, chunk_bit_off);
-                                    let intra = chunk_bit_off % 8;
+                                    let mut consumed = 0usize;
+                                    while consumed < *chunk_width {
+                                        let part_bit_off = *bit_off + bit_pos + consumed;
+                                        let intra = part_bit_off % 8;
+                                        let remaining = *chunk_width - consumed;
+                                        let part_width = remaining.min(64 - intra);
+                                        let part_byte_off = ctx.byte_offset(addr, part_bit_off);
 
-                                    if intra == 0 && OpSize::from_bits(*chunk_width).is_some() {
-                                        block.push(MInst::Store {
-                                            base: BaseReg::SimState,
-                                            offset: chunk_byte_off,
-                                            src: *chunk_vreg,
-                                            size: OpSize::from_bits(*chunk_width).unwrap(),
-                                        });
-                                    } else if *chunk_width <= 64 {
-                                        // Non-aligned chunk: RMW via BitFieldInsert
-                                        let containing_off =
-                                            ctx.byte_offset(addr, 0) + (chunk_bit_off / 8) as i32;
-                                        let load_size =
-                                            ISelContext::op_size_for_width(*chunk_width + intra);
-                                        let old = ctx.alloc_vreg(SpillDesc::transient());
-                                        block.push(MInst::Load {
-                                            dst: old,
-                                            base: BaseReg::SimState,
-                                            offset: containing_off,
-                                            size: load_size,
-                                        });
-                                        let mask = mask_for_width(*chunk_width);
-                                        let new = ctx.alloc_vreg(SpillDesc::transient());
-                                        ctx.emit_bfi(
-                                            block,
-                                            new,
-                                            old,
-                                            *chunk_vreg,
-                                            intra as u8,
-                                            mask,
-                                        );
-                                        block.push(MInst::Store {
-                                            base: BaseReg::SimState,
-                                            offset: containing_off,
-                                            src: new,
-                                            size: load_size,
-                                        });
+                                        let part_src = if consumed == 0 {
+                                            *chunk_vreg
+                                        } else {
+                                            let shifted = ctx.alloc_vreg(SpillDesc::transient());
+                                            block.push(MInst::ShrImm {
+                                                dst: shifted,
+                                                src: *chunk_vreg,
+                                                imm: consumed as u8,
+                                            });
+                                            shifted
+                                        };
+
+                                        if intra == 0 && OpSize::from_bits(part_width).is_some() {
+                                            block.push(MInst::Store {
+                                                base: BaseReg::SimState,
+                                                offset: part_byte_off,
+                                                src: part_src,
+                                                size: OpSize::from_bits(part_width).unwrap(),
+                                            });
+                                        } else {
+                                            // Non-aligned chunk part: RMW via BitFieldInsert.
+                                            let containing_off = ctx.byte_offset(addr, 0)
+                                                + (part_bit_off / 8) as i32;
+                                            let load_size =
+                                                ISelContext::op_size_for_width(part_width + intra);
+                                            let old = ctx.alloc_vreg(SpillDesc::transient());
+                                            block.push(MInst::Load {
+                                                dst: old,
+                                                base: BaseReg::SimState,
+                                                offset: containing_off,
+                                                size: load_size,
+                                            });
+                                            let mask = mask_for_width(part_width);
+                                            let new = ctx.alloc_vreg(SpillDesc::transient());
+                                            ctx.emit_bfi(
+                                                block,
+                                                new,
+                                                old,
+                                                part_src,
+                                                intra as u8,
+                                                mask,
+                                            );
+                                            block.push(MInst::Store {
+                                                base: BaseReg::SimState,
+                                                offset: containing_off,
+                                                src: new,
+                                                size: load_size,
+                                            });
+                                        }
+                                        consumed += part_width;
                                     }
                                     bit_pos += chunk_width;
                                 }
@@ -2531,19 +2549,81 @@ fn lower_instruction(
 
                     // For wide commits (> 64 bits), emit chunk-by-chunk
                     if *width_bits <= 64 {
-                        let tmp = ctx.alloc_vreg(SpillDesc::transient());
-                        block.push(MInst::Load {
-                            dst: tmp,
-                            base: BaseReg::SimState,
-                            offset: src_byte_off,
-                            size: op_size,
-                        });
-                        block.push(MInst::Store {
-                            base: BaseReg::SimState,
-                            offset: dst_byte_off,
-                            src: tmp,
-                            size: op_size,
-                        });
+                        let intra_byte = bit_off % 8;
+                        if intra_byte == 0 && OpSize::from_bits(*width_bits).is_some() {
+                            let tmp = ctx.alloc_vreg(SpillDesc::transient());
+                            block.push(MInst::Load {
+                                dst: tmp,
+                                base: BaseReg::SimState,
+                                offset: src_byte_off,
+                                size: op_size,
+                            });
+                            block.push(MInst::Store {
+                                base: BaseReg::SimState,
+                                offset: dst_byte_off,
+                                src: tmp,
+                                size: op_size,
+                            });
+                        } else {
+                            let containing_src =
+                                ctx.byte_offset(src_addr, 0) + (bit_off / 8) as i32;
+                            let containing_dst =
+                                ctx.byte_offset(dst_addr, 0) + (bit_off / 8) as i32;
+                            let load_size =
+                                ISelContext::op_size_for_width(*width_bits + intra_byte);
+
+                            let raw = ctx.alloc_vreg(SpillDesc::transient());
+                            block.push(MInst::Load {
+                                dst: raw,
+                                base: BaseReg::SimState,
+                                offset: containing_src,
+                                size: load_size,
+                            });
+
+                            let value = if intra_byte > 0 {
+                                let shifted = ctx.alloc_vreg(SpillDesc::transient());
+                                block.push(MInst::ShrImm {
+                                    dst: shifted,
+                                    src: raw,
+                                    imm: intra_byte as u8,
+                                });
+                                let masked = ctx.alloc_vreg(SpillDesc::transient());
+                                ctx.emit_and_imm(
+                                    block,
+                                    masked,
+                                    shifted,
+                                    mask_for_width(*width_bits),
+                                );
+                                masked
+                            } else {
+                                let masked = ctx.alloc_vreg(SpillDesc::transient());
+                                ctx.emit_and_imm(block, masked, raw, mask_for_width(*width_bits));
+                                masked
+                            };
+
+                            let old = ctx.alloc_vreg(SpillDesc::transient());
+                            block.push(MInst::Load {
+                                dst: old,
+                                base: BaseReg::SimState,
+                                offset: containing_dst,
+                                size: load_size,
+                            });
+                            let new = ctx.alloc_vreg(SpillDesc::transient());
+                            ctx.emit_bfi(
+                                block,
+                                new,
+                                old,
+                                value,
+                                intra_byte as u8,
+                                mask_for_width(*width_bits),
+                            );
+                            block.push(MInst::Store {
+                                base: BaseReg::SimState,
+                                offset: containing_dst,
+                                src: new,
+                                size: load_size,
+                            });
+                        }
                     } else {
                         // Chunk-by-chunk copy (64 bits at a time)
                         let mut remaining = *width_bits;
@@ -2628,20 +2708,86 @@ fn lower_instruction(
                         let src_mask_off = ctx.mask_byte_offset(src_addr, *bit_off);
                         let dst_mask_off = ctx.mask_byte_offset(dst_addr, *bit_off);
                         if *width_bits <= 64 {
-                            let op_size = ISelContext::op_size_for_width(*width_bits);
-                            let tmp = ctx.alloc_vreg(SpillDesc::transient());
-                            block.push(MInst::Load {
-                                dst: tmp,
-                                base: BaseReg::SimState,
-                                offset: src_mask_off,
-                                size: op_size,
-                            });
-                            block.push(MInst::Store {
-                                base: BaseReg::SimState,
-                                offset: dst_mask_off,
-                                src: tmp,
-                                size: op_size,
-                            });
+                            let intra_byte = bit_off % 8;
+                            if intra_byte == 0 && OpSize::from_bits(*width_bits).is_some() {
+                                let op_size = ISelContext::op_size_for_width(*width_bits);
+                                let tmp = ctx.alloc_vreg(SpillDesc::transient());
+                                block.push(MInst::Load {
+                                    dst: tmp,
+                                    base: BaseReg::SimState,
+                                    offset: src_mask_off,
+                                    size: op_size,
+                                });
+                                block.push(MInst::Store {
+                                    base: BaseReg::SimState,
+                                    offset: dst_mask_off,
+                                    src: tmp,
+                                    size: op_size,
+                                });
+                            } else {
+                                let containing_src =
+                                    ctx.mask_byte_offset(src_addr, 0) + (bit_off / 8) as i32;
+                                let containing_dst =
+                                    ctx.mask_byte_offset(dst_addr, 0) + (bit_off / 8) as i32;
+                                let load_size =
+                                    ISelContext::op_size_for_width(*width_bits + intra_byte);
+
+                                let raw = ctx.alloc_vreg(SpillDesc::transient());
+                                block.push(MInst::Load {
+                                    dst: raw,
+                                    base: BaseReg::SimState,
+                                    offset: containing_src,
+                                    size: load_size,
+                                });
+                                let value = if intra_byte > 0 {
+                                    let shifted = ctx.alloc_vreg(SpillDesc::transient());
+                                    block.push(MInst::ShrImm {
+                                        dst: shifted,
+                                        src: raw,
+                                        imm: intra_byte as u8,
+                                    });
+                                    let masked = ctx.alloc_vreg(SpillDesc::transient());
+                                    ctx.emit_and_imm(
+                                        block,
+                                        masked,
+                                        shifted,
+                                        mask_for_width(*width_bits),
+                                    );
+                                    masked
+                                } else {
+                                    let masked = ctx.alloc_vreg(SpillDesc::transient());
+                                    ctx.emit_and_imm(
+                                        block,
+                                        masked,
+                                        raw,
+                                        mask_for_width(*width_bits),
+                                    );
+                                    masked
+                                };
+
+                                let old = ctx.alloc_vreg(SpillDesc::transient());
+                                block.push(MInst::Load {
+                                    dst: old,
+                                    base: BaseReg::SimState,
+                                    offset: containing_dst,
+                                    size: load_size,
+                                });
+                                let new = ctx.alloc_vreg(SpillDesc::transient());
+                                ctx.emit_bfi(
+                                    block,
+                                    new,
+                                    old,
+                                    value,
+                                    intra_byte as u8,
+                                    mask_for_width(*width_bits),
+                                );
+                                block.push(MInst::Store {
+                                    base: BaseReg::SimState,
+                                    offset: containing_dst,
+                                    src: new,
+                                    size: load_size,
+                                });
+                            }
                         } else {
                             let mut remaining = *width_bits;
                             let mut s_off = src_mask_off;

--- a/crates/celox/src/backend/native/regalloc/unified.rs
+++ b/crates/celox/src/backend/native/regalloc/unified.rs
@@ -206,7 +206,7 @@ fn compute_entry_regfile(
             let src = phi
                 .sources
                 .iter()
-                .find_map(|(pred_id, src)| (*pred_id == BlockId(pred_idx as u32)).then_some(*src));
+                .find_map(|(pred_id, src)| (*pred_id == func.blocks[pred_idx].id).then_some(*src));
             let preferred = src.and_then(|src_vreg| {
                 let preg = rf.get_preg(src_vreg)?;
                 if analysis.entry_distances[block_idx].contains_key(&src_vreg) {

--- a/crates/celox/tests/fixtures/linear_sorter_pull_mre.veryl
+++ b/crates/celox/tests/fixtures/linear_sorter_pull_mre.veryl
@@ -1,0 +1,92 @@
+module SorterCellPullMreU16 (
+    clk     : input  clock    ,
+    rst     : input  reset    ,
+    clear   : input  logic    ,
+    push    : input  logic    ,
+    pop     : input  logic    ,
+    d_in    : input  logic<16>,
+    prev_val: input  logic<16>,
+    next_val: input  logic<16>,
+    lt_prev : input  logic    ,
+    lt_next : input  logic    ,
+    pp_lt   : input  logic    ,
+    o_reg   : output logic<16>,
+    lt      : output logic    ,
+) {
+    var r_val: logic<16>;
+
+    assign lt    = d_in <: r_val;
+    assign o_reg = r_val;
+
+    always_ff {
+        if_reset {
+            r_val = -1;
+        } else if clear {
+            r_val = -1;
+        } else if push && !pop {
+            if lt && !lt_prev {
+                r_val = d_in;
+            } else if lt {
+                r_val = prev_val;
+            }
+        } else if pop && !push {
+            r_val = next_val;
+        } else if push && pop {
+            if lt_next && !pp_lt {
+                r_val = d_in;
+            } else if !lt_next {
+                r_val = next_val;
+            }
+        }
+    }
+}
+
+pub module LinearSorterPullMreU16 #(
+    param DEPTH: u32 = 100,
+) (
+    clk  : input  clock    ,
+    rst  : input  reset    ,
+    clear: input  logic    ,
+    push : input  logic    ,
+    pop  : input  logic    ,
+    d_in : input  logic<16>,
+    d_out: output logic<16>,
+    empty: output logic    ,
+    full : output logic    ,
+) {
+    var cell_lt  : logic     [DEPTH + 2];
+    var cell_reg : logic<16> [DEPTH + 2];
+    var pp_lt_sig: logic     [DEPTH]    ;
+
+    assign cell_lt[0]          = 0;
+    assign cell_reg[0]         = 0;
+    assign cell_lt[DEPTH + 1]  = 1;
+    assign cell_reg[DEPTH + 1] = -1;
+
+    assign pp_lt_sig[0] = 0;
+    for i in 1..DEPTH :g_pp {
+        assign pp_lt_sig[i] = cell_lt[i + 1];
+    }
+
+    for i in 0..DEPTH :g_cell {
+        inst u_cell: SorterCellPullMreU16 (
+            clk                      ,
+            rst                      ,
+            clear                    ,
+            push                     ,
+            pop                      ,
+            d_in                     ,
+            prev_val: cell_reg[i]    ,
+            next_val: cell_reg[i + 2],
+            lt_prev : cell_lt[i]     ,
+            lt_next : cell_lt[i + 2] ,
+            pp_lt   : pp_lt_sig[i]   ,
+            o_reg   : cell_reg[i + 1],
+            lt      : cell_lt[i + 1] ,
+        );
+    }
+
+    assign d_out = cell_reg[1];
+    assign empty = cell_reg[1][15];
+    assign full  = !cell_reg[DEPTH][15];
+}

--- a/crates/celox/tests/linear_sorter_pull_mre.rs
+++ b/crates/celox/tests/linear_sorter_pull_mre.rs
@@ -1,0 +1,185 @@
+use celox::Simulator;
+
+#[path = "test_utils/mod.rs"]
+#[macro_use]
+#[allow(unused_macros)]
+mod test_utils;
+
+const DEPTH: usize = 100;
+const SOURCE: &str = include_str!("fixtures/linear_sorter_pull_mre.veryl");
+
+fn push_values<B: celox::SimBackend>(sim: &mut celox::Simulator<B>, clk: B::Event, values: &[u16]) {
+    let push = sim.signal("push");
+    let pop = sim.signal("pop");
+    let d_in = sim.signal("d_in");
+
+    sim.modify(|io| {
+        io.set(pop, 0u8);
+        io.set(push, 1u8);
+    })
+    .unwrap();
+    for &value in values {
+        sim.modify(|io| io.set(d_in, value)).unwrap();
+        sim.tick(clk).unwrap();
+    }
+    sim.modify(|io| io.set(push, 0u8)).unwrap();
+    sim.tick(clk).unwrap();
+}
+
+fn pull_until_empty<B: celox::SimBackend>(
+    sim: &mut celox::Simulator<B>,
+    clk: B::Event,
+    max_cycles: usize,
+) -> Vec<u16> {
+    let pop = sim.signal("pop");
+    let empty = sim.signal("empty");
+    let d_out = sim.signal("d_out");
+    let mut out = Vec::new();
+
+    for _ in 0..max_cycles {
+        if sim.get_as::<u8>(empty) != 0 {
+            break;
+        }
+        out.push(sim.get_as::<u16>(d_out));
+        sim.modify(|io| io.set(pop, 1u8)).unwrap();
+        sim.tick(clk).unwrap();
+        sim.modify(|io| io.set(pop, 0u8)).unwrap();
+        sim.tick(clk).unwrap();
+    }
+
+    out
+}
+
+all_backends! {
+fn bit_array_index_64_ff_roundtrips(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module BitArrayIndex64 (
+    clk: input clock,
+    rst: input reset,
+    d: input logic,
+    q: output logic,
+) {
+    var bits: logic [65];
+
+    always_ff {
+        if_reset {
+            bits[0] = 0;
+            bits[64] = 0;
+        } else {
+            bits[0] = d;
+            bits[64] = bits[0];
+        }
+    }
+
+    assign q = bits[64];
+}
+"#, "BitArrayIndex64").reset_type(celox::ResetType::AsyncLow);
+
+    let clk = sim.event("clk");
+    let rst = sim.signal("rst");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+
+    sim.modify(|io| {
+        io.set(rst, 0u8);
+        io.set(d, 0u8);
+    }).unwrap();
+    sim.tick(clk).unwrap();
+    sim.modify(|io| io.set(rst, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get_as::<u8>(q), 0);
+
+    sim.modify(|io| io.set(d, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get_as::<u8>(q), 0);
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get_as::<u8>(q), 1);
+}
+
+fn word_array_index_64_ff_roundtrips(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module WordArrayIndex64 (
+    clk: input clock,
+    rst: input reset,
+    d: input logic<16>,
+    q: output logic<16>,
+) {
+    var words: logic<16> [65];
+
+    always_ff {
+        if_reset {
+            words[0] = 0;
+            words[64] = 0;
+        } else {
+            words[0] = d;
+            words[64] = words[0];
+        }
+    }
+
+    assign q = words[64];
+}
+"#, "WordArrayIndex64").reset_type(celox::ResetType::AsyncLow);
+
+    let clk = sim.event("clk");
+    let rst = sim.signal("rst");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+
+    sim.modify(|io| {
+        io.set(rst, 0u8);
+        io.set(d, 0u16);
+    }).unwrap();
+    sim.tick(clk).unwrap();
+    sim.modify(|io| io.set(rst, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get_as::<u16>(q), 0);
+
+    sim.modify(|io| io.set(d, 0x1234u16)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get_as::<u16>(q), 0);
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get_as::<u16>(q), 0x1234);
+}
+
+fn linear_sorter_pull_late_minima_drain_once_in_sorted_order(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(SOURCE, "LinearSorterPullMreU16")
+        .param("DEPTH", DEPTH as u64)
+        .reset_type(celox::ResetType::AsyncLow);
+
+    let rst = sim.signal("rst");
+    let clk = sim.event("clk");
+    let clear = sim.signal("clear");
+    let push = sim.signal("push");
+    let pop = sim.signal("pop");
+    let d_in = sim.signal("d_in");
+
+    sim.modify(|io| {
+        io.set(rst, 0u8);
+        io.set(clear, 0u8);
+        io.set(push, 0u8);
+        io.set(pop, 0u8);
+        io.set(d_in, 0u16);
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+    sim.tick(clk).unwrap();
+    sim.modify(|io| io.set(rst, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+
+    let mut input: Vec<u16> = (0..DEPTH - 4).map(|i| 1000 + i as u16).collect();
+    input.extend([1, 2, 3, 4]);
+    let mut expected = input.clone();
+    expected.sort();
+
+    push_values(&mut sim, clk, &input);
+    let got = pull_until_empty(&mut sim, clk, DEPTH + 8);
+
+    assert_eq!(got, expected);
+}
+}


### PR DESCRIPTION
## Summary

Fix native backend lowering for unaligned wide stores that cross a 64-bit boundary. The tgz MRE reproduced as a native-only sorter corruption: an optimized 65-bit store starting at bit offset 1 could update one bit outside the intended RMW window and corrupt `cell_lt[64]`.

This PR splits unaligned wide store chunks into pieces that fit within the current 64-bit RMW window, makes narrow unaligned commits bit-exact, fixes phi predecessor matching to use actual block ids, and adds regression coverage from the linear sorter MRE.

## Validation

- `cargo test -p celox --test linear_sorter_pull_mre`
- `pnpm run build:napi`
- tgz MRE via Vitest against rebuilt NAPI addon
- `pnpm run build`
- pre-push hook: submodule-check, cargo-fmt, biome, cargo-clippy, full `cargo test`, package build/test
