### PR TITLE
[codex] fetch Rust deps before TS benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Fetch Rust dependencies
+        run: cargo fetch --locked
+
       - name: Build NAPI (release)
         run: pnpm run build:napi:release
 


### PR DESCRIPTION
## Summary

- Adds an explicit `cargo fetch --locked` step before the TypeScript benchmark job builds and runs.
- Ensures `veryl-std 0.20.0` is present under Cargo's registry source tree before `packages/celox/src/e2e.bench.ts` reads it directly.

## Root Cause

The failing `bench-ts` job reached `pnpm --filter @celox-sim/celox bench --outputJson ts-output.json`, then failed in `resolveVerylStd` with:

```text
veryl-std 0.20.0 source not found; run cargo fetch first
```

Building NAPI does not reliably leave the crate source tree available for the TypeScript benchmark's file-based stdlib reads, so the job needs to fetch Rust dependencies explicitly.

## Validation

- Inspected failing job `82320093817` from run `27816851917`
- `cargo fetch --locked`
- Verified the benchmark resolver path exists locally for `veryl-std-0.20.0/veryl/src`
- pre-push hook: `cargo-fmt`, `biome`, `cargo-clippy`, full `cargo test`, package build, package tests