### PR TITLE
fix: migrate pnpm settings to workspace config

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,16 +18,6 @@
     "docs:build": "pnpm run docs:api && vitepress build docs",
     "docs:preview": "vitepress preview docs"
   },
-  "pnpm": {
-    "overrides": {
-      "@celox-sim/celox": "workspace:*",
-      "@celox-sim/celox-napi": "workspace:*",
-      "@celox-sim/vite-plugin": "workspace:*"
-    },
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
-  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.5",
     "@emnapi/core": "^1.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@celox-sim/celox': workspace:*
+  '@celox-sim/celox-napi': workspace:*
+  '@celox-sim/vite-plugin': workspace:*
+
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,10 @@
 packages:
   - "packages/*"
   - "crates/celox-napi"
+overrides:
+  "@celox-sim/celox": "workspace:*"
+  "@celox-sim/celox-napi": "workspace:*"
+  "@celox-sim/vite-plugin": "workspace:*"
 allowBuilds:
   esbuild: true
   lefthook: true


### PR DESCRIPTION
## Summary

- Move the workspace dependency overrides from `package.json` to `pnpm-workspace.yaml`.
- Remove the deprecated `pnpm.onlyBuiltDependencies` configuration from `package.json`; the existing `allowBuilds` setting remains the pnpm v11 replacement.
- Update `pnpm-lock.yaml` to record the workspace overrides.

This removes the pnpm v11 warning reported in #279.

## Validation

- `pnpm install --lockfile-only --ignore-scripts`
- `pnpm install --frozen-lockfile`
- Pre-push checks: submodule check, Biome, Cargo clippy, and `pnpm test`

Fixes #279