### PR TITLE
Add docs build check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,25 @@ permissions:
   contents: read
 
 jobs:
+  docs:
+    name: Docs Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build docs
+        run: pnpm docs:build
+
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- add a dedicated docs build job to the PR CI workflow
- use the same Node.js, pnpm, frozen-lockfile install, and `pnpm docs:build` command as the docs deployment workflow

## Why

The docs deployment previously failed only after a change reached `master`, because documentation builds were not validated by pull request CI. This moves that failure detection before merge.

## Validation

- `pnpm docs:build`
- pre-push hook: submodule check, `cargo fmt`, Biome, Cargo Clippy, and the full Rust/JS test suite