### PR TITLE
Group syn and prettyplease Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,6 +43,16 @@
         "cargo"
       ],
       "matchPackageNames": [
+        "syn",
+        "prettyplease"
+      ],
+      "groupName": "syn ecosystem"
+    },
+    {
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchPackageNames": [
         "/^veryl-/"
       ],
       "groupName": "veryl crates"


### PR DESCRIPTION
## Summary

- group the `syn` and `prettyplease` Cargo dependencies into one Renovate branch and pull request

## Why

`prettyplease` exposes `syn::File` in its API, so upgrading either dependency independently creates a cross-version type mismatch in `celox-macros` tests. Grouping them lets Renovate validate and merge their compatible releases together.

## Validation

- `renovate-config-validator renovate.json`
- pre-push hook: submodule check, Biome, `cargo fmt`, Cargo Clippy, and the full Rust/JS test suite