### PR TITLE
Keep syn ecosystem updates in one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,7 +46,8 @@
         "syn",
         "prettyplease"
       ],
-      "groupName": "syn ecosystem"
+      "groupName": "syn ecosystem",
+      "separateMajorMinor": false
     },
     {
       "matchManagers": [


### PR DESCRIPTION
## Summary

- disable Renovate's major/minor split for the `syn` and `prettyplease` dependency group

## Why

Renovate's default `separateMajorMinor: true` takes precedence over `groupName`, which caused `prettyplease` and `syn` to be recreated as separate PRs #325 and #326. These upgrades must be tested together because `prettyplease` exposes Syn types in its API.

## Validation

- Renovate 44.3.2 `renovate-config-validator renovate.json`
- pre-push hook: submodule check, Biome, `cargo fmt`, Cargo Clippy, and the full Rust/JS test suite