### PR TITLE
Keep pre-push validation lightweight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# Agent Instructions
+
+## Validate before pushing
+
+The pre-push hook is only a fast minimum safety net. Before pushing, inspect the
+actual change and autonomously run the formatting, checks, and tests needed to
+validate it. Do not treat passing the hook as sufficient validation, and do not
+defer tests to CI merely because the hook does not run them.
+
+Choose focused tests that exercise the changed behavior, then broaden validation
+in proportion to the change's scope and risk. If a required test cannot be run,
+state that explicitly in the handoff instead of silently omitting it.
+
+When a task has a clear requested outcome, pursue it without waiting for
+step-by-step instructions. Inspect the repository, make reasonable assumptions,
+implement the change, and continue while a safe, in-scope next step remains.
+
+Do not stop after proposing a plan or making a partial change when the remaining
+work can be discovered and completed locally. If a check fails, investigate and
+fix failures caused by the change before reporting completion. Report assumptions,
+validation performed, and any unresolved limitation in the final handoff.
+
+Ask for direction only when a missing choice would materially change the result,
+or when the next action needs additional authority, is destructive, or affects
+systems outside the requested scope. Autonomy does not permit broadening the task,
+bypassing safety checks, or committing, pushing, or publishing unless requested.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md
 
+The repository-wide agent workflow requirements in `AGENTS.md` also apply.
+
 ## Project Overview
 
 Celox is a JIT simulator for Veryl HDL. It compiles Veryl designs with Cranelift for high-speed simulation. Future plans include SystemVerilog/Verilog support.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,9 +14,8 @@ pre-push:
     biome:
       priority: 2
       run: pnpm run lint
-    cargo-clippy:
+    # Keep the local gate bounded. Full clippy, tests, NAPI builds, frontend
+    # builds, and documentation builds remain required in GitHub Actions.
+    cargo-check:
       priority: 3
-      run: cargo clippy -p celox -p celox-macros -p celox-napi -p celox-ts-gen --all-targets
-    test:
-      priority: 4
-      run: pnpm test
+      run: cargo check --workspace --locked


### PR DESCRIPTION
## Stack

- This PR — lightweight pre-push validation
- Child: #330

## Summary

- replace the full pre-push Clippy and test suite with `cargo check --workspace --locked`
- keep clean-tree, submodule, Rust formatting, and Biome checks as the fast local safety net
- document that coding agents must choose and run change-appropriate tests before pushing instead of treating the hook or CI as validation

The full Clippy, Rust/TypeScript tests, NAPI builds, frontend builds, and documentation builds remain enforced by GitHub Actions.

## Validation

- `bash scripts/check-submodules.sh`
- `cargo fmt --all -- --check`
- `pnpm run lint`
- `cargo check --workspace --locked`
- `pnpm exec lefthook run pre-push` (3.0 seconds with a warm build cache)
- real `git push` invocation ran and passed the installed pre-push hook (2.6 seconds reported by lefthook)
