### PR TITLE
Extract source-independent design vocabulary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,7 @@ version = "0.18.0"
 dependencies = [
  "bit-set 0.11.1",
  "celox-analysis",
+ "celox-design",
  "celox-macros",
  "celox-sir",
  "chrono",
@@ -460,6 +461,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "celox-design"
+version = "0.18.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "celox-macros"
 version = "0.18.0"
 dependencies = [
@@ -499,6 +507,7 @@ name = "celox-sir"
 version = "0.18.0"
 dependencies = [
  "celox-analysis",
+ "celox-design",
  "fxhash",
  "num-bigint",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/celox",
     "crates/celox-analysis",
+    "crates/celox-design",
     "crates/celox-sir",
     "crates/celox-bench-sv",
     "crates/celox-macros",

--- a/crates/celox-design/Cargo.toml
+++ b/crates/celox-design/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name                  = "celox-design"
+version.workspace     = true
+authors.workspace     = true
+repository.workspace  = true
+license.workspace     = true
+description           = "Source-independent elaborated design model for Celox"
+edition.workspace     = true
+
+[dependencies]
+serde = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/celox-design/src/lib.rs
+++ b/crates/celox-design/src/lib.rs
@@ -1,0 +1,392 @@
+//! Source-language-independent design identities and semantic vocabulary.
+
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeSet, fmt};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum DomainKind {
+    ClockPosedge,
+    ClockNegedge,
+    ResetAsyncHigh,
+    ResetAsyncLow,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TriggerIdWithKind {
+    pub kind: DomainKind,
+    pub id: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PortTypeKind {
+    Clock,
+    ResetAsyncHigh,
+    ResetAsyncLow,
+    ResetSyncHigh,
+    ResetSyncLow,
+    Logic,
+    Bit,
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct TriggerSet<A> {
+    pub clock: A,
+    pub resets: Vec<A>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum RuntimeEventKind {
+    Display,
+    AssertContinue,
+    AssertFatal,
+}
+
+#[derive(Clone, Debug)]
+pub struct RuntimeEventSite {
+    pub kind: RuntimeEventKind,
+    pub template: Option<String>,
+    pub arg_widths: Vec<usize>,
+    pub arg_signed: Vec<bool>,
+    pub arg_is_string: Vec<bool>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum BinaryOp {
+    Add,
+    Sub,
+    Mul,
+    DivU,
+    DivS,
+    RemU,
+    RemS,
+    And,
+    Or,
+    Xor,
+    Shl, // Logical Shift Left (<<)
+    Shr, // Logical Shift Right (>>)
+    Sar, // Arithmetic Shift Right (>>>)
+    Eq,
+    Ne,
+    LtU,
+    LtS, // Less Than (Unsigned / Signed)
+    LeU,
+    LeS, // Less Equal
+    GtU,
+    GtS, // Greater Than
+    GeU,
+    GeS, // Greater Equal
+    LogicAnd,
+    LogicOr,
+    EqWildcard,
+    NeWildcard,
+}
+
+impl BinaryOp {
+    /// Whether the operation is commutative (a op b == b op a).
+    pub fn is_commutative(&self) -> bool {
+        matches!(
+            self,
+            BinaryOp::Add
+                | BinaryOp::Mul
+                | BinaryOp::And
+                | BinaryOp::Or
+                | BinaryOp::Xor
+                | BinaryOp::Eq
+                | BinaryOp::Ne
+                | BinaryOp::LogicAnd
+                | BinaryOp::LogicOr
+        )
+    }
+}
+
+impl fmt::Display for BinaryOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let op_str = match self {
+            BinaryOp::Add => "Add",
+            BinaryOp::Sub => "Sub",
+            BinaryOp::Mul => "Mul",
+            BinaryOp::DivU => "DivU",
+            BinaryOp::DivS => "DivS",
+            BinaryOp::RemU => "RemU",
+            BinaryOp::RemS => "RemS",
+            BinaryOp::And => "And",
+            BinaryOp::Or => "Or",
+            BinaryOp::Xor => "Xor",
+            BinaryOp::Shl => "Shl",
+            BinaryOp::Shr => "Shr",
+            BinaryOp::Sar => "Sar",
+            BinaryOp::Eq => "Eq",
+            BinaryOp::Ne => "Ne",
+            BinaryOp::LtU => "LtU",
+            BinaryOp::LtS => "LtS",
+            BinaryOp::LeU => "LeU",
+            BinaryOp::LeS => "LeS",
+            BinaryOp::GtU => "GtU",
+            BinaryOp::GtS => "GtS",
+            BinaryOp::GeU => "GeU",
+            BinaryOp::GeS => "GeS",
+            BinaryOp::LogicAnd => "LogicAnd",
+            BinaryOp::LogicOr => "LogicOr",
+            BinaryOp::EqWildcard => "EqWildcard",
+            BinaryOp::NeWildcard => "NeWildcard",
+        };
+        write!(f, "{}", op_str)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum UnaryOp {
+    Ident,
+    /// Convert a four-state value to two-state form. Unknown bits become zero:
+    /// `(value, mask) -> (value & !mask, 0)`.
+    ToTwoState,
+    Minus,
+    BitNot,
+    LogicNot,
+    And,
+    Or,
+    Xor,
+    PopCount,
+    CountLeadingZeros,
+    CountTrailingZeros,
+}
+
+impl UnaryOp {
+    /// Return the canonical result width for an operand of `operand_width` bits.
+    ///
+    /// Bit-count operations return a value in `0..=operand_width`, which needs
+    /// `ceil(log2(operand_width + 1))` bits.  Computing that as the bit length
+    /// of `operand_width` avoids overflowing when the operand width is
+    /// `usize::MAX`.
+    pub fn result_width(self, operand_width: usize) -> usize {
+        match self {
+            UnaryOp::LogicNot | UnaryOp::And | UnaryOp::Or | UnaryOp::Xor => 1,
+            UnaryOp::Ident | UnaryOp::ToTwoState | UnaryOp::Minus | UnaryOp::BitNot => {
+                operand_width
+            }
+            UnaryOp::PopCount | UnaryOp::CountLeadingZeros | UnaryOp::CountTrailingZeros => {
+                usize::BITS as usize - operand_width.leading_zeros() as usize
+            }
+        }
+    }
+}
+
+impl fmt::Display for UnaryOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let op_str = match self {
+            UnaryOp::Ident => "Ident",
+            UnaryOp::ToTwoState => "ToTwoState",
+            UnaryOp::Minus => "Minus",
+            UnaryOp::BitNot => "BitNot",
+            UnaryOp::LogicNot => "LogicNot",
+            UnaryOp::And => "And",
+            UnaryOp::Or => "Or",
+            UnaryOp::Xor => "Xor",
+            UnaryOp::PopCount => "PopCount",
+            UnaryOp::CountLeadingZeros => "CountLeadingZeros",
+            UnaryOp::CountTrailingZeros => "CountTrailingZeros",
+        };
+        write!(f, "{}", op_str)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Serialize, Deserialize)]
+pub struct BitAccess {
+    pub lsb: usize,
+    pub msb: usize,
+}
+impl BitAccess {
+    pub fn new(lsb: usize, msb: usize) -> Self {
+        debug_assert!(lsb <= msb, "lsb must be less than or equal to msb");
+        Self { lsb, msb }
+    }
+    pub fn overlaps(&self, other: &Self) -> bool {
+        !(self.msb < other.lsb || other.msb < self.lsb)
+    }
+
+    /// Calculates the atomic bit ranges for a given access range and a set of boundaries.
+    pub fn calculate_atoms(&self, bounds: &BTreeSet<usize>) -> Vec<Self> {
+        use std::ops::Bound::*;
+        let mut atoms = Vec::new();
+        let mut current_lsb = self.lsb;
+
+        // Iterate through the boundaries that are within the access range
+        // Excluded(lsb) to Included(msb) handles lsb == msb case naturally (returns empty iterator)
+        for &bound in bounds.range((Excluded(self.lsb), Included(self.msb))) {
+            atoms.push(Self::new(current_lsb, bound - 1));
+            current_lsb = bound;
+        }
+
+        // Add the last atom
+        if current_lsb <= self.msb {
+            atoms.push(Self::new(current_lsb, self.msb));
+        }
+
+        atoms
+    }
+}
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Serialize, Deserialize)]
+pub struct VarAtomBase<A> {
+    pub id: A,
+    pub access: BitAccess,
+}
+impl<A> VarAtomBase<A> {
+    pub fn new(id: A, lsb: usize, msb: usize) -> Self {
+        Self {
+            id,
+            access: BitAccess { lsb, msb },
+        }
+    }
+}
+impl fmt::Display for BitAccess {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.lsb == self.msb {
+            write!(f, "[{}]", self.lsb)
+        } else {
+            write!(f, "[{}:{}]", self.msb, self.lsb)
+        }
+    }
+}
+
+impl<A> fmt::Display for VarAtomBase<A>
+where
+    A: fmt::Display + std::hash::Hash + Eq,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}{}", self.id, self.access)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ModuleId(pub usize);
+
+impl fmt::Display for ModuleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "mod{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct InstanceId(pub usize);
+
+impl fmt::Display for InstanceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "inst{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct AbsoluteAddrBase<V> {
+    pub instance_id: InstanceId,
+    pub var_id: V,
+}
+
+impl<V: fmt::Display> fmt::Display for AbsoluteAddrBase<V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "AbsoluteAddr({}, {})", self.instance_id, self.var_id)
+    }
+}
+
+pub const STABLE_REGION: u32 = 0;
+pub const WORKING_REGION: u32 = 1;
+pub const SPARSE_WORKING_REGION: u32 = 2;
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct RegionedVarAddrBase<V> {
+    pub region: u32,
+    pub var_id: V,
+}
+
+impl<V: fmt::Display> fmt::Display for RegionedVarAddrBase<V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "RegionedVarAddr(region={}, {})",
+            self.region, self.var_id
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct RegionedAbsoluteAddrBase<V> {
+    pub region: u32,
+    pub instance_id: InstanceId,
+    pub var_id: V,
+}
+
+impl<V: Copy> RegionedAbsoluteAddrBase<V> {
+    pub fn from_absolute_addr(region: u32, addr: AbsoluteAddrBase<V>) -> Self {
+        Self {
+            region,
+            instance_id: addr.instance_id,
+            var_id: addr.var_id,
+        }
+    }
+
+    pub fn absolute_addr(&self) -> AbsoluteAddrBase<V> {
+        AbsoluteAddrBase {
+            instance_id: self.instance_id,
+            var_id: self.var_id,
+        }
+    }
+}
+
+impl<V: fmt::Display> fmt::Display for RegionedAbsoluteAddrBase<V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "RegionedAbsoluteAddr(region={}, {}, {})",
+            self.region, self.instance_id, self.var_id
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bit_access_splits_only_at_internal_boundaries() {
+        let access = BitAccess::new(4, 11);
+        let bounds = [0, 4, 7, 12, 20].into_iter().collect();
+
+        assert_eq!(
+            access.calculate_atoms(&bounds),
+            vec![BitAccess::new(4, 6), BitAccess::new(7, 11)]
+        );
+    }
+
+    #[test]
+    fn design_ids_and_addresses_have_stable_display() {
+        let address = AbsoluteAddrBase {
+            instance_id: InstanceId(42),
+            var_id: 7,
+        };
+
+        assert_eq!(ModuleId(3).to_string(), "mod3");
+        assert_eq!(InstanceId(42).to_string(), "inst42");
+        assert_eq!(address.to_string(), "AbsoluteAddr(inst42, 7)");
+    }
+
+    #[test]
+    fn regioned_address_round_trips_semantic_identity() {
+        let address = AbsoluteAddrBase {
+            instance_id: InstanceId(2),
+            var_id: 9,
+        };
+        let regioned = RegionedAbsoluteAddrBase::from_absolute_addr(WORKING_REGION, address);
+
+        assert_eq!(regioned.absolute_addr(), address);
+        assert_eq!(regioned.region, WORKING_REGION);
+    }
+
+    #[test]
+    fn semantic_operator_contracts_are_source_independent() {
+        assert!(BinaryOp::Add.is_commutative());
+        assert!(!BinaryOp::Sub.is_commutative());
+        assert_eq!(UnaryOp::LogicNot.result_width(128), 1);
+        assert_eq!(UnaryOp::PopCount.result_width(128), 8);
+    }
+}

--- a/crates/celox-sir/Cargo.toml
+++ b/crates/celox-sir/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace     = true
 
 [dependencies]
 celox-analysis = { path = "../celox-analysis" }
+celox-design   = { path = "../celox-design" }
 fxhash         = { workspace = true }
 num-bigint     = { workspace = true }
 num-traits     = { workspace = true }

--- a/crates/celox-sir/src/lib.rs
+++ b/crates/celox-sir/src/lib.rs
@@ -6,6 +6,8 @@ use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use std::{fmt, fmt::Display};
 
+pub use celox_design::{BinaryOp, DomainKind, TriggerIdWithKind, UnaryOp};
+
 pub mod builder;
 pub mod cfg;
 mod serde_helpers;
@@ -17,21 +19,6 @@ pub use transform::{
     SirMergeProvenance, inline_single_predecessor_jumps, merge_sir_eu_refs,
     merge_sir_eu_refs_with_provenance, merge_sir_eus,
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum DomainKind {
-    ClockPosedge,
-    ClockNegedge,
-    ResetAsyncHigh,
-    ResetAsyncLow,
-    Other,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct TriggerIdWithKind {
-    pub kind: DomainKind,
-    pub id: usize,
-}
 
 /// Block identifier
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -244,145 +231,6 @@ impl fmt::Display for RegisterId {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum BinaryOp {
-    Add,
-    Sub,
-    Mul,
-    DivU,
-    DivS,
-    RemU,
-    RemS,
-    And,
-    Or,
-    Xor,
-    Shl, // Logical Shift Left (<<)
-    Shr, // Logical Shift Right (>>)
-    Sar, // Arithmetic Shift Right (>>>)
-    Eq,
-    Ne,
-    LtU,
-    LtS, // Less Than (Unsigned / Signed)
-    LeU,
-    LeS, // Less Equal
-    GtU,
-    GtS, // Greater Than
-    GeU,
-    GeS, // Greater Equal
-    LogicAnd,
-    LogicOr,
-    EqWildcard,
-    NeWildcard,
-}
-
-impl BinaryOp {
-    /// Whether the operation is commutative (a op b == b op a).
-    pub fn is_commutative(&self) -> bool {
-        matches!(
-            self,
-            BinaryOp::Add
-                | BinaryOp::Mul
-                | BinaryOp::And
-                | BinaryOp::Or
-                | BinaryOp::Xor
-                | BinaryOp::Eq
-                | BinaryOp::Ne
-                | BinaryOp::LogicAnd
-                | BinaryOp::LogicOr
-        )
-    }
-}
-
-impl fmt::Display for BinaryOp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let op_str = match self {
-            BinaryOp::Add => "Add",
-            BinaryOp::Sub => "Sub",
-            BinaryOp::Mul => "Mul",
-            BinaryOp::DivU => "DivU",
-            BinaryOp::DivS => "DivS",
-            BinaryOp::RemU => "RemU",
-            BinaryOp::RemS => "RemS",
-            BinaryOp::And => "And",
-            BinaryOp::Or => "Or",
-            BinaryOp::Xor => "Xor",
-            BinaryOp::Shl => "Shl",
-            BinaryOp::Shr => "Shr",
-            BinaryOp::Sar => "Sar",
-            BinaryOp::Eq => "Eq",
-            BinaryOp::Ne => "Ne",
-            BinaryOp::LtU => "LtU",
-            BinaryOp::LtS => "LtS",
-            BinaryOp::LeU => "LeU",
-            BinaryOp::LeS => "LeS",
-            BinaryOp::GtU => "GtU",
-            BinaryOp::GtS => "GtS",
-            BinaryOp::GeU => "GeU",
-            BinaryOp::GeS => "GeS",
-            BinaryOp::LogicAnd => "LogicAnd",
-            BinaryOp::LogicOr => "LogicOr",
-            BinaryOp::EqWildcard => "EqWildcard",
-            BinaryOp::NeWildcard => "NeWildcard",
-        };
-        write!(f, "{}", op_str)
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum UnaryOp {
-    Ident,
-    /// Convert a four-state value to two-state form. Unknown bits become zero:
-    /// `(value, mask) -> (value & !mask, 0)`.
-    ToTwoState,
-    Minus,
-    BitNot,
-    LogicNot,
-    And,
-    Or,
-    Xor,
-    PopCount,
-    CountLeadingZeros,
-    CountTrailingZeros,
-}
-
-impl UnaryOp {
-    /// Return the canonical result width for an operand of `operand_width` bits.
-    ///
-    /// Bit-count operations return a value in `0..=operand_width`, which needs
-    /// `ceil(log2(operand_width + 1))` bits.  Computing that as the bit length
-    /// of `operand_width` avoids overflowing when the operand width is
-    /// `usize::MAX`.
-    pub fn result_width(self, operand_width: usize) -> usize {
-        match self {
-            UnaryOp::LogicNot | UnaryOp::And | UnaryOp::Or | UnaryOp::Xor => 1,
-            UnaryOp::Ident | UnaryOp::ToTwoState | UnaryOp::Minus | UnaryOp::BitNot => {
-                operand_width
-            }
-            UnaryOp::PopCount | UnaryOp::CountLeadingZeros | UnaryOp::CountTrailingZeros => {
-                usize::BITS as usize - operand_width.leading_zeros() as usize
-            }
-        }
-    }
-}
-
-impl fmt::Display for UnaryOp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let op_str = match self {
-            UnaryOp::Ident => "Ident",
-            UnaryOp::ToTwoState => "ToTwoState",
-            UnaryOp::Minus => "Minus",
-            UnaryOp::BitNot => "BitNot",
-            UnaryOp::LogicNot => "LogicNot",
-            UnaryOp::And => "And",
-            UnaryOp::Or => "Or",
-            UnaryOp::Xor => "Xor",
-            UnaryOp::PopCount => "PopCount",
-            UnaryOp::CountLeadingZeros => "CountLeadingZeros",
-            UnaryOp::CountTrailingZeros => "CountTrailingZeros",
-        };
-        write!(f, "{}", op_str)
-    }
-}
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 
 pub struct SIRValue {

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -15,6 +15,7 @@ veryl-parser          = { workspace = true }
 veryl-path            = { workspace = true }
 celox-macros          = { path = "../celox-macros" }
 celox-analysis        = { path = "../celox-analysis" }
+celox-design          = { path = "../celox-design" }
 celox-sir             = { path = "../celox-sir" }
 fxhash                = { workspace = true }
 thiserror             = { workspace = true }

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -2,10 +2,16 @@ use crate::{
     HashMap, HashSet,
     logic_tree::{LogicPath, SLTNodeArena, SymbolicStore},
 };
+pub use celox_design::PortTypeKind;
+pub(crate) use celox_design::{
+    AbsoluteAddrBase, BinaryOp, BitAccess, DomainKind, InstanceId, ModuleId,
+    RegionedAbsoluteAddrBase, RegionedVarAddrBase, RuntimeEventKind, RuntimeEventSite,
+    SPARSE_WORKING_REGION, STABLE_REGION, TriggerIdWithKind, TriggerSet, UnaryOp, VarAtomBase,
+    WORKING_REGION,
+};
 pub(crate) use celox_sir::{
-    BasicBlock, BinaryOp, BlockId, DomainKind, ExecutionUnit, RegisterId, RegisterType, SIRBuilder,
-    SIRInstruction, SIROffset, SIRSwitchCase, SIRTerminator, SIRValue, TriggerIdWithKind, UnaryOp,
-    collect_exact_zero_registers, merge_sir_eus,
+    BasicBlock, BlockId, ExecutionUnit, RegisterId, RegisterType, SIRBuilder, SIRInstruction,
+    SIROffset, SIRSwitchCase, SIRTerminator, SIRValue, collect_exact_zero_registers, merge_sir_eus,
 };
 #[cfg(any(target_arch = "x86_64", test))]
 pub(crate) use celox_sir::{
@@ -17,6 +23,13 @@ use std::collections::BTreeSet;
 use std::fmt;
 use veryl_analyzer::ir::{VarId, VarPath, Variable};
 
+/// Concrete address type using the Veryl analyzer's `VarId` during frontend migration.
+pub type AbsoluteAddr = AbsoluteAddrBase<VarId>;
+/// Concrete regioned variable address using the Veryl analyzer's `VarId`.
+pub type RegionedVarAddr = RegionedVarAddrBase<VarId>;
+/// Concrete regioned address using the Veryl analyzer's `VarId`.
+pub type RegionedAbsoluteAddr = RegionedAbsoluteAddrBase<VarId>;
+
 /// Error returned by [`Program::get_addr`] when a path-based variable lookup fails.
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum AddrLookupError {
@@ -26,18 +39,6 @@ pub enum AddrLookupError {
     VariableNotFound { path: String },
     #[error("Ambiguous variable path: {path} — multiple variables share this path")]
     AmbiguousPath { path: String },
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum PortTypeKind {
-    Clock,
-    ResetAsyncHigh,
-    ResetAsyncLow,
-    ResetSyncHigh,
-    ResetSyncLow,
-    Logic,
-    Bit,
-    Other,
 }
 
 #[derive(Clone)]
@@ -96,11 +97,6 @@ impl fmt::Debug for VariableInfo {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct TriggerSet<A> {
-    pub clock: A,
-    pub resets: Vec<A>,
-}
 /// Compilation plan for eval_comb when the CLIF instruction count exceeds
 /// Cranelift's limit. Mutually exclusive strategies.
 #[derive(Debug, Clone)]
@@ -115,22 +111,6 @@ pub enum EvalCombPlan {
 pub struct RuntimeErrorInfo<Addr = AbsoluteAddr> {
     pub message: String,
     pub signals: Vec<Addr>,
-}
-
-#[derive(Clone, Copy, Debug)]
-pub enum RuntimeEventKind {
-    Display,
-    AssertContinue,
-    AssertFatal,
-}
-
-#[derive(Clone, Debug)]
-pub struct RuntimeEventSite {
-    pub kind: RuntimeEventKind,
-    pub template: Option<String>,
-    pub arg_widths: Vec<usize>,
-    pub arg_signed: Vec<bool>,
-    pub arg_is_string: Vec<bool>,
 }
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -449,72 +429,6 @@ fn comb_capture_enable_needs_unaliased_old_value(
     false
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Serialize, Deserialize)]
-pub struct BitAccess {
-    pub lsb: usize,
-    pub msb: usize,
-}
-impl BitAccess {
-    pub fn new(lsb: usize, msb: usize) -> Self {
-        debug_assert!(lsb <= msb, "lsb must be less than or equal to msb");
-        Self { lsb, msb }
-    }
-    pub fn overlaps(&self, other: &Self) -> bool {
-        !(self.msb < other.lsb || other.msb < self.lsb)
-    }
-
-    /// Calculates the atomic bit ranges for a given access range and a set of boundaries.
-    pub fn calculate_atoms(&self, bounds: &BTreeSet<usize>) -> Vec<crate::ir::BitAccess> {
-        use std::ops::Bound::*;
-        let mut atoms = Vec::new();
-        let mut current_lsb = self.lsb;
-
-        // Iterate through the boundaries that are within the access range
-        // Excluded(lsb) to Included(msb) handles lsb == msb case naturally (returns empty iterator)
-        for &bound in bounds.range((Excluded(self.lsb), Included(self.msb))) {
-            atoms.push(crate::ir::BitAccess::new(current_lsb, bound - 1));
-            current_lsb = bound;
-        }
-
-        // Add the last atom
-        if current_lsb <= self.msb {
-            atoms.push(crate::ir::BitAccess::new(current_lsb, self.msb));
-        }
-
-        atoms
-    }
-}
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Serialize, Deserialize)]
-pub struct VarAtomBase<A> {
-    pub id: A,
-    pub access: BitAccess,
-}
-impl<A> VarAtomBase<A> {
-    pub fn new(id: A, lsb: usize, msb: usize) -> Self {
-        Self {
-            id,
-            access: BitAccess { lsb, msb },
-        }
-    }
-}
-impl fmt::Display for BitAccess {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.lsb == self.msb {
-            write!(f, "[{}]", self.lsb)
-        } else {
-            write!(f, "[{}:{}]", self.msb, self.lsb)
-        }
-    }
-}
-
-impl<A> fmt::Display for VarAtomBase<A>
-where
-    A: fmt::Display + std::hash::Hash + Eq,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}{}", self.id, self.access)
-    }
-}
 pub type VarAtom = VarAtomBase<VarId>;
 pub(crate) mod cfg {
     pub(crate) use celox_sir::cfg::*;
@@ -537,44 +451,6 @@ pub struct GlueBlockBase<V: std::hash::Hash + Eq + Clone> {
 
 /// Concrete glue block using the Veryl analyzer's `VarId`.
 pub type GlueBlock = GlueBlockBase<VarId>;
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct ModuleId(pub usize);
-
-impl fmt::Display for ModuleId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "mod{}", self.0)
-    }
-}
-
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct InstanceId(pub usize);
-
-impl fmt::Display for InstanceId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "inst{}", self.0)
-    }
-}
-
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct AbsoluteAddrBase<V> {
-    pub instance_id: InstanceId,
-    pub var_id: V,
-}
-
-/// Concrete address type using the Veryl analyzer's `VarId`.
-pub type AbsoluteAddr = AbsoluteAddrBase<VarId>;
-
-impl<V: fmt::Display> fmt::Display for AbsoluteAddrBase<V> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "AbsoluteAddr({}, {})", self.instance_id, self.var_id)
-    }
-}
-
-/// A high-performance handle to a signal's physical memory.
-///
-/// Unlike [`AbsoluteAddr`], which requires a [`HashMap`] lookup for every access,
-/// a [`SignalRef`] stores the pre-resolved memory offset and metadata, allowing
-/// for essentially zero-cost reads and writes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SignalArrayLayout {
     pub element_width: usize,
@@ -593,65 +469,6 @@ pub struct SignalRef {
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct InstancePath(pub Vec<(StrId, usize)>);
 
-pub const STABLE_REGION: u32 = 0;
-pub const WORKING_REGION: u32 = 1;
-pub const SPARSE_WORKING_REGION: u32 = 2;
-
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct RegionedVarAddrBase<V> {
-    pub region: u32,
-    pub var_id: V,
-}
-
-/// Concrete regioned variable address using the Veryl analyzer's `VarId`.
-pub type RegionedVarAddr = RegionedVarAddrBase<VarId>;
-
-impl<V: fmt::Display> fmt::Display for RegionedVarAddrBase<V> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "RegionedVarAddr(region={}, {})",
-            self.region, self.var_id
-        )
-    }
-}
-
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct RegionedAbsoluteAddrBase<V> {
-    pub region: u32,
-    pub instance_id: InstanceId,
-    pub var_id: V,
-}
-
-/// Concrete regioned address type using the Veryl analyzer's `VarId`.
-pub type RegionedAbsoluteAddr = RegionedAbsoluteAddrBase<VarId>;
-
-impl<V: Copy> RegionedAbsoluteAddrBase<V> {
-    pub fn from_absolute_addr(region: u32, addr: AbsoluteAddrBase<V>) -> Self {
-        Self {
-            region,
-            instance_id: addr.instance_id,
-            var_id: addr.var_id,
-        }
-    }
-
-    pub fn absolute_addr(&self) -> AbsoluteAddrBase<V> {
-        AbsoluteAddrBase {
-            instance_id: self.instance_id,
-            var_id: self.var_id,
-        }
-    }
-}
-
-impl<V: fmt::Display> fmt::Display for RegionedAbsoluteAddrBase<V> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "RegionedAbsoluteAddr(region={}, {}, {})",
-            self.region, self.instance_id, self.var_id
-        )
-    }
-}
 #[derive(Clone)]
 pub struct RelocationModule {
     #[cfg(test)]


### PR DESCRIPTION
## Stack

- #329 — lightweight pre-push validation
- #330 — compiler crate architecture
- #331 — backend-independent SIR crate
- This PR — source-independent design vocabulary

## Summary

- introduce `celox-design` for source-independent design identifiers, addresses, bit ranges, and semantic operators
- make `celox-sir` consume the shared design vocabulary instead of owning duplicate definitions
- rewire `celox` to use and re-export the extracted types

This completes the initial crate-boundary stack by separating source-language concepts from the backend-independent SIR representation.

## Validation

- `cargo test -p celox-design` (4 passed)
- `cargo test -p celox-sir` (27 passed)
- `pnpm exec lefthook run pre-push`

## GitHub stacked PR preview

The branches are tracked locally with the official `gh stack` extension. GitHub currently reports that Stacked PRs are not enabled for this repository, so the PRs retain the same base-branch chain and can be linked with `gh stack submit` as soon as the rollout reaches the repository.
