### PR TITLE
Move initial state schema into celox-design

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
 name = "celox-design"
 version = "0.18.0"
 dependencies = [
+ "num-bigint",
  "serde",
 ]
 

--- a/crates/celox-design/Cargo.toml
+++ b/crates/celox-design/Cargo.toml
@@ -8,6 +8,7 @@ description           = "Source-independent elaborated design model for Celox"
 edition.workspace     = true
 
 [dependencies]
+num-bigint = { workspace = true }
 serde = { workspace = true }
 
 [lints]

--- a/crates/celox-design/src/lib.rs
+++ b/crates/celox-design/src/lib.rs
@@ -1,5 +1,6 @@
 //! Source-language-independent design identities and semantic vocabulary.
 
+use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, fmt};
 
@@ -50,6 +51,36 @@ pub struct RuntimeEventSite {
     pub arg_widths: Vec<usize>,
     pub arg_signed: Vec<bool>,
     pub arg_is_string: Vec<bool>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InitialStateWriteRun {
+    pub bit_offset: usize,
+    pub bit_width: usize,
+    pub value_bytes: Vec<u8>,
+    pub mask_bytes: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InitialStateData {
+    Packed {
+        value: BigUint,
+        mask: BigUint,
+        written_mask: BigUint,
+    },
+    Writes(Vec<InitialStateWriteRun>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InitialStateValue<A> {
+    pub address: A,
+    pub data: InitialStateData,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuntimeErrorInfo<A> {
+    pub message: String,
+    pub signals: Vec<A>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -388,5 +419,28 @@ mod tests {
         assert!(!BinaryOp::Sub.is_commutative());
         assert_eq!(UnaryOp::LogicNot.result_width(128), 1);
         assert_eq!(UnaryOp::PopCount.result_width(128), 8);
+    }
+
+    #[test]
+    fn initial_state_and_runtime_error_schemas_accept_design_owned_ids() {
+        let initial = InitialStateValue {
+            address: AbsoluteAddrBase {
+                instance_id: InstanceId(1),
+                var_id: 7u32,
+            },
+            data: InitialStateData::Writes(vec![InitialStateWriteRun {
+                bit_offset: 3,
+                bit_width: 5,
+                value_bytes: vec![0x15],
+                mask_bytes: vec![0],
+            }]),
+        };
+        let error = RuntimeErrorInfo {
+            message: "failed".to_string(),
+            signals: vec![initial.address],
+        };
+
+        assert_eq!(error.signals, vec![initial.address]);
+        assert!(matches!(initial.data, InitialStateData::Writes(_)));
     }
 }

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -4,10 +4,10 @@ use crate::{
 };
 pub use celox_design::PortTypeKind;
 pub(crate) use celox_design::{
-    AbsoluteAddrBase, BinaryOp, BitAccess, DomainKind, InstanceId, ModuleId,
-    RegionedAbsoluteAddrBase, RegionedVarAddrBase, RuntimeEventKind, RuntimeEventSite,
-    SPARSE_WORKING_REGION, STABLE_REGION, TriggerIdWithKind, TriggerSet, UnaryOp, VarAtomBase,
-    WORKING_REGION,
+    AbsoluteAddrBase, BinaryOp, BitAccess, DomainKind, InitialStateData, InitialStateValue,
+    InitialStateWriteRun, InstanceId, ModuleId, RegionedAbsoluteAddrBase, RegionedVarAddrBase,
+    RuntimeEventKind, RuntimeEventSite, SPARSE_WORKING_REGION, STABLE_REGION, TriggerIdWithKind,
+    TriggerSet, UnaryOp, VarAtomBase, WORKING_REGION,
 };
 pub(crate) use celox_sir::{
     BasicBlock, BlockId, ExecutionUnit, RegisterId, RegisterType, SIRBuilder, SIRInstruction,
@@ -17,7 +17,6 @@ pub(crate) use celox_sir::{
 pub(crate) use celox_sir::{
     SirMergeProvenance, inline_single_predecessor_jumps, merge_sir_eu_refs_with_provenance,
 };
-use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::fmt;
@@ -55,35 +54,11 @@ pub struct VariableInfo {
     pub array_dims: Vec<usize>,
 }
 
-#[derive(Clone, Debug)]
-pub struct InitialMemoryWriteRun {
-    pub bit_offset: usize,
-    pub bit_width: usize,
-    pub value_bytes: Vec<u8>,
-    pub mask_bytes: Vec<u8>,
-}
-
-#[derive(Clone, Debug)]
-pub enum InitialMemoryData {
-    Packed {
-        value: BigUint,
-        mask: BigUint,
-        written_mask: BigUint,
-    },
-    Writes(Vec<InitialMemoryWriteRun>),
-}
-
-#[derive(Clone, Debug)]
-pub struct InitialMemoryValue {
-    pub addr: AbsoluteAddr,
-    pub data: InitialMemoryData,
-}
-
-#[derive(Clone, Debug)]
-pub struct ModuleInitialMemoryValue {
-    pub var_id: VarId,
-    pub data: InitialMemoryData,
-}
+pub type InitialMemoryWriteRun = InitialStateWriteRun;
+pub type InitialMemoryData = InitialStateData;
+pub type InitialMemoryValue = InitialStateValue<AbsoluteAddr>;
+pub type ModuleInitialMemoryValue = InitialStateValue<VarId>;
+pub type RuntimeErrorInfo<Addr = AbsoluteAddr> = celox_design::RuntimeErrorInfo<Addr>;
 
 impl fmt::Debug for VariableInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -105,12 +80,6 @@ pub enum EvalCombPlan {
     TailCallChunks(Vec<crate::optimizer::coalescing::TailCallChunk>),
     /// Memory-spilled multi-block splitting with scratch memory.
     MemorySpilled(crate::optimizer::coalescing::pass_tail_call_split::MemorySpilledPlan),
-}
-
-#[derive(Clone)]
-pub struct RuntimeErrorInfo<Addr = AbsoluteAddr> {
-    pub message: String,
-    pub signals: Vec<Addr>,
 }
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]

--- a/crates/celox/src/optimizer/coalescing/pass_identity_store_bypass.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_identity_store_bypass.rs
@@ -66,7 +66,12 @@ pub(super) fn optimize_program_identity_stores(
             .iter()
             .flat_map(|observer| observer.written_inputs.iter().copied()),
     );
-    blocked_aliases.extend(program.initial_memory_values.iter().map(|init| init.addr));
+    blocked_aliases.extend(
+        program
+            .initial_memory_values
+            .iter()
+            .map(|init| init.address),
+    );
 
     optimize_eval_comb_identity_stores(
         &mut program.eval_comb,

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -1572,9 +1572,9 @@ pub(crate) fn flatten(
                 .initial_memory_values
                 .iter()
                 .map(move |init| crate::ir::InitialMemoryValue {
-                    addr: AbsoluteAddr {
+                    address: AbsoluteAddr {
                         instance_id,
-                        var_id: init.var_id,
+                        var_id: init.address,
                     },
                     data: init.data.clone(),
                 })

--- a/crates/celox/src/parser/module.rs
+++ b/crates/celox/src/parser/module.rs
@@ -985,7 +985,7 @@ impl<'a> ModuleParser<'a> {
         }
 
         Ok(ModuleInitialMemoryValue {
-            var_id: dst.id,
+            address: dst.id,
             data: InitialMemoryData::Writes(writes.runs),
         })
     }

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -572,7 +572,7 @@ impl<B: SimBackend> Simulator<B> {
         let initial_memory_values = std::mem::take(&mut self.program.initial_memory_values);
         for init in &initial_memory_values {
             applied = true;
-            let signal = self.backend.resolve_signal(&init.addr);
+            let signal = self.backend.resolve_signal(&init.address);
             match &init.data {
                 InitialMemoryData::Packed {
                     value,


### PR DESCRIPTION
## Summary

- move initial-state write/data/value schemas into `celox-design`
- move the generic runtime-error schema into `celox-design`
- preserve the existing `celox` names and default address type through compatibility aliases

## Why

Initial-state contents and runtime-error signal references are source-independent design contracts. Keeping their concrete definitions in the mixed `celox::ir` module made later phase separation depend on frontend-owned wrappers.

## Stack

1. **This PR**
2. `refactor/design-variable-metadata`
3. `refactor/state-layout-contract`

## Validation

- `cargo test -p celox-design`
- `cargo test -p celox --lib` (1,145 tests)
- `RUSTFLAGS=-Dwarnings cargo check -p celox-napi --target aarch64-unknown-linux-gnu`
- lightweight pre-push hook