### PR TITLE
Separate design variable metadata from source bindings

### DIFF
--- a/crates/celox-design/src/lib.rs
+++ b/crates/celox-design/src/lib.rs
@@ -31,6 +31,21 @@ pub enum PortTypeKind {
     Other,
 }
 
+/// Source-independent metadata for one elaborated design variable.
+///
+/// Source IDs, source paths, and declaration syntax belong to the frontend and
+/// deliberately are not part of this type.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VariableMetadata {
+    pub width: usize,
+    pub is_4state: bool,
+    pub kind: DomainKind,
+    pub type_kind: PortTypeKind,
+    /// Per-dimension sizes for array ports (for example, `[4]` for `logic<32>[4]`).
+    /// Empty means scalar.
+    pub array_dims: Vec<usize>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct TriggerSet<A> {
     pub clock: A,
@@ -442,5 +457,19 @@ mod tests {
 
         assert_eq!(error.signals, vec![initial.address]);
         assert!(matches!(initial.data, InitialStateData::Writes(_)));
+    }
+
+    #[test]
+    fn variable_metadata_preserves_elaborated_shape_and_domain() {
+        let metadata = VariableMetadata {
+            width: 32,
+            is_4state: true,
+            kind: DomainKind::Other,
+            type_kind: PortTypeKind::Logic,
+            array_dims: vec![4],
+        };
+
+        assert_eq!(metadata.width, 32);
+        assert_eq!(metadata.array_dims, vec![4]);
     }
 }

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -7,7 +7,7 @@ pub(crate) use celox_design::{
     AbsoluteAddrBase, BinaryOp, BitAccess, DomainKind, InitialStateData, InitialStateValue,
     InitialStateWriteRun, InstanceId, ModuleId, RegionedAbsoluteAddrBase, RegionedVarAddrBase,
     RuntimeEventKind, RuntimeEventSite, SPARSE_WORKING_REGION, STABLE_REGION, TriggerIdWithKind,
-    TriggerSet, UnaryOp, VarAtomBase, WORKING_REGION,
+    TriggerSet, UnaryOp, VarAtomBase, VariableMetadata, WORKING_REGION,
 };
 pub(crate) use celox_sir::{
     BasicBlock, BlockId, ExecutionUnit, RegisterId, RegisterType, SIRBuilder, SIRInstruction,
@@ -42,16 +42,10 @@ pub enum AddrLookupError {
 
 #[derive(Clone)]
 pub struct VariableInfo {
-    pub width: usize,
     pub id: VarId,
     pub path: VarPath,
-    pub is_4state: bool,
-    pub kind: DomainKind,
     pub var_kind: veryl_analyzer::ir::VarKind,
-    pub type_kind: PortTypeKind,
-    /// Per-dimension sizes for array ports (e.g. `[4]` for `logic<32>[4]`).
-    /// Empty means scalar.
-    pub array_dims: Vec<usize>,
+    pub metadata: VariableMetadata,
 }
 
 pub type InitialMemoryWriteRun = InitialStateWriteRun;
@@ -59,6 +53,14 @@ pub type InitialMemoryData = InitialStateData;
 pub type InitialMemoryValue = InitialStateValue<AbsoluteAddr>;
 pub type ModuleInitialMemoryValue = InitialStateValue<VarId>;
 pub type RuntimeErrorInfo<Addr = AbsoluteAddr> = celox_design::RuntimeErrorInfo<Addr>;
+
+impl std::ops::Deref for VariableInfo {
+    type Target = VariableMetadata;
+
+    fn deref(&self) -> &Self::Target {
+        &self.metadata
+    }
+}
 
 impl fmt::Debug for VariableInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -1850,14 +1850,16 @@ fn module_variables(
             variables.insert(
                 *id,
                 VariableInfo {
-                    width: resolve_total_width(module, varibale)?,
                     id: *id,
                     path: varibale.path.clone(),
-                    is_4state: is_4state_type(&varibale.r#type.kind),
-                    kind: type_kind_to_domain_kind(&varibale.r#type.kind, config),
                     var_kind: varibale.kind,
-                    type_kind: type_kind_to_port_type_kind(&varibale.r#type.kind, config),
-                    array_dims: varibale.r#type.array.iter().filter_map(|d| *d).collect(),
+                    metadata: celox_design::VariableMetadata {
+                        width: resolve_total_width(module, varibale)?,
+                        is_4state: is_4state_type(&varibale.r#type.kind),
+                        kind: type_kind_to_domain_kind(&varibale.r#type.kind, config),
+                        type_kind: type_kind_to_port_type_kind(&varibale.r#type.kind, config),
+                        array_dims: varibale.r#type.array.iter().filter_map(|d| *d).collect(),
+                    },
                 },
             );
         }


### PR DESCRIPTION
## Summary

- add source-independent `VariableMetadata` to `celox-design`
- keep Veryl `VarId`, `VarPath`, and declaration kind in the frontend-facing `VariableInfo`
- preserve existing read access through a compatibility dereference while making ownership explicit

## Why

Width, four-state classification, clock/reset domain, port kind, and array shape belong to the elaborated design. Veryl identities and source paths do not. Separating them avoids solving the crate boundary with a generic type that merely leaks frontend concepts into `celox-design`.

## Stack

1. `refactor/design-state-schema`
2. **This PR**
3. `refactor/state-layout-contract`

## Validation

- `cargo test -p celox-design`
- `cargo test -p celox --lib` (1,145 tests)
- `RUSTFLAGS=-Dwarnings cargo check -p celox-napi --target aarch64-unknown-linux-gnu`
- lightweight pre-push hook