### PR TITLE
Extract shared state layout contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,7 @@ dependencies = [
  "celox-design",
  "celox-macros",
  "celox-sir",
+ "celox-state-layout",
  "chrono",
  "clap",
  "cranelift",
@@ -514,6 +515,10 @@ dependencies = [
  "num-traits",
  "serde",
 ]
+
+[[package]]
+name = "celox-state-layout"
+version = "0.18.0"
 
 [[package]]
 name = "celox-ts-gen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/celox-analysis",
     "crates/celox-design",
     "crates/celox-sir",
+    "crates/celox-state-layout",
     "crates/celox-bench-sv",
     "crates/celox-macros",
     "crates/celox-napi",

--- a/crates/celox-state-layout/Cargo.toml
+++ b/crates/celox-state-layout/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name                  = "celox-state-layout"
+version.workspace     = true
+authors.workspace     = true
+repository.workspace  = true
+license.workspace     = true
+description           = "Physical simulation-state layout contracts for Celox"
+edition.workspace     = true
+
+[lints]
+workspace = true

--- a/crates/celox-state-layout/src/lib.rs
+++ b/crates/celox-state-layout/src/lib.rs
@@ -1,0 +1,98 @@
+//! Shared physical simulation-state layout contracts.
+//!
+//! These types and offsets form the ABI between layout construction, generated
+//! code, and runtime state access. They contain no frontend or backend IR.
+
+pub const RUNTIME_EVENT_CAPACITY: usize = 1024;
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+pub const RUNTIME_EVENT_WRITING: u64 = u64::MAX;
+pub const STATE_HEADER_SIZE: usize = 32;
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+pub const STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET: usize = 0;
+/// Remaining iterations for an in-function native tick loop.
+#[cfg(target_arch = "x86_64")]
+pub const STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET: usize = 8;
+#[cfg(target_arch = "x86_64")]
+pub const STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET: usize = 24;
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+pub const STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET: usize = 16;
+/// Runtime-event write sequence observed when a native tick batch starts.
+pub const RUNTIME_EVENT_HEADER_SIZE: usize = 8;
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+pub const RUNTIME_EVENT_SLOT_SEQ_OFFSET: usize = 0;
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+pub const RUNTIME_EVENT_SLOT_SITE_OFFSET: usize = 8;
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+pub const RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET: usize = 16;
+pub const RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET: usize = 24;
+
+#[derive(Debug, Clone)]
+pub struct RuntimeEventArgLayout {
+    pub value_word_offset: usize,
+    pub mask_word_offset: usize,
+    pub word_count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeEventSiteLayout {
+    pub args: Vec<RuntimeEventArgLayout>,
+    pub payload_words: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct SparseWorkingLayout {
+    pub active_index: usize,
+    pub chunk_count: usize,
+    pub dirty_words_offset: usize,
+    pub dirty_word_count: usize,
+    pub summary_words_offset: usize,
+    pub summary_word_count: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryLayoutMode {
+    Packed,
+    ElementStrided,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnpackedArrayLayout {
+    pub element_width: usize,
+    pub element_count: usize,
+    pub element_stride: usize,
+    pub plane_size: usize,
+}
+
+pub const fn get_byte_size(width: usize) -> usize {
+    width.div_ceil(8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn byte_size_rounds_up_partial_bytes() {
+        assert_eq!(get_byte_size(0), 0);
+        assert_eq!(get_byte_size(1), 1);
+        assert_eq!(get_byte_size(8), 1);
+        assert_eq!(get_byte_size(9), 2);
+    }
+
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn state_header_fields_do_not_overlap() {
+        assert!(
+            STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET + 8 <= STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET
+        );
+        assert!(
+            STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET + 8
+                <= STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET
+        );
+        assert!(
+            STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET + 8
+                <= STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET
+        );
+        assert!(STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET + 8 <= STATE_HEADER_SIZE);
+    }
+}

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -17,6 +17,7 @@ celox-macros          = { path = "../celox-macros" }
 celox-analysis        = { path = "../celox-analysis" }
 celox-design          = { path = "../celox-design" }
 celox-sir             = { path = "../celox-sir" }
+celox-state-layout    = { path = "../celox-state-layout" }
 fxhash                = { workspace = true }
 thiserror             = { workspace = true }
 clap                  = { workspace = true }

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -3,6 +3,18 @@ use crate::ir::{
     AbsoluteAddr, Program, RegionedAbsoluteAddr, RegisterId, SIRInstruction, SIROffset,
     STABLE_REGION, collect_exact_zero_registers,
 };
+pub use celox_state_layout::{
+    MemoryLayoutMode, RUNTIME_EVENT_CAPACITY, RUNTIME_EVENT_HEADER_SIZE,
+    RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET, RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET,
+    RUNTIME_EVENT_SLOT_SEQ_OFFSET, RUNTIME_EVENT_SLOT_SITE_OFFSET, RUNTIME_EVENT_WRITING,
+    RuntimeEventArgLayout, RuntimeEventSiteLayout, STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET,
+    STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET, STATE_HEADER_SIZE, SparseWorkingLayout,
+    UnpackedArrayLayout, get_byte_size,
+};
+#[cfg(target_arch = "x86_64")]
+pub use celox_state_layout::{
+    STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET, STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET,
+};
 
 type LayoutVariable = (AbsoluteAddr, usize, bool, usize, usize);
 
@@ -14,66 +26,6 @@ fn sort_layout_variables(variables: &mut [LayoutVariable]) {
     variables.sort_unstable_by_key(|(address, _, _, _, alignment)| {
         (std::cmp::Reverse(*alignment), *address)
     });
-}
-
-pub const RUNTIME_EVENT_CAPACITY: usize = 1024;
-#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
-pub const RUNTIME_EVENT_WRITING: u64 = u64::MAX;
-pub const STATE_HEADER_SIZE: usize = 32;
-#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
-pub const STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET: usize = 0;
-/// Remaining iterations for an in-function native tick loop.
-#[cfg(target_arch = "x86_64")]
-pub const STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET: usize = 8;
-#[cfg(target_arch = "x86_64")]
-pub const STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET: usize = 24;
-#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
-pub const STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET: usize = 16;
-/// Runtime-event write sequence observed when a native tick batch starts.
-pub const RUNTIME_EVENT_HEADER_SIZE: usize = 8;
-#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
-pub const RUNTIME_EVENT_SLOT_SEQ_OFFSET: usize = 0;
-#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
-pub const RUNTIME_EVENT_SLOT_SITE_OFFSET: usize = 8;
-#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
-pub const RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET: usize = 16;
-pub const RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET: usize = 24;
-
-#[derive(Debug, Clone)]
-pub struct RuntimeEventArgLayout {
-    pub value_word_offset: usize,
-    pub mask_word_offset: usize,
-    pub word_count: usize,
-}
-
-#[derive(Debug, Clone)]
-pub struct RuntimeEventSiteLayout {
-    pub args: Vec<RuntimeEventArgLayout>,
-    pub payload_words: usize,
-}
-
-#[derive(Debug, Clone)]
-pub struct SparseWorkingLayout {
-    pub active_index: usize,
-    pub chunk_count: usize,
-    pub dirty_words_offset: usize,
-    pub dirty_word_count: usize,
-    pub summary_words_offset: usize,
-    pub summary_word_count: usize,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MemoryLayoutMode {
-    Packed,
-    ElementStrided,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct UnpackedArrayLayout {
-    pub element_width: usize,
-    pub element_count: usize,
-    pub element_stride: usize,
-    pub plane_size: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -614,10 +566,6 @@ fn collect_ff_referenced_addresses(program: &Program) -> crate::HashSet<Absolute
         }
     }
     addrs
-}
-
-pub fn get_byte_size(width: usize) -> usize {
-    (width + 7) >> 3
 }
 
 fn get_alignment(width: usize) -> usize {


### PR DESCRIPTION
## Summary

- add the `celox-state-layout` crate
- move the shared state-header and runtime-event ABI constants into it
- move physical array, sparse-working, event-site, and layout-mode descriptors into it
- retain compatibility re-exports from the existing backend module while the `Program`-dependent builder is migrated separately

## Why

Generated code and runtimes share one physical state ABI, but that contract was owned by the monolithic backend module. This gives the ABI a backend- and frontend-independent owner without prematurely moving the builder while it still depends on the mixed `Program`.

## Stack

1. `refactor/design-state-schema`
2. `refactor/design-variable-metadata`
3. **This PR**

## Validation

- `cargo test -p celox-state-layout`
- `cargo test -p celox --lib` (1,145 tests)
- `cargo check -p celox-state-layout --tests --target aarch64-unknown-linux-gnu`
- `RUSTFLAGS=-Dwarnings cargo check -p celox-napi --target aarch64-unknown-linux-gnu`
- lightweight pre-push hook