### PR TITLE
Move state layout construction behind explicit input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,10 @@ dependencies = [
 [[package]]
 name = "celox-state-layout"
 version = "0.18.0"
+dependencies = [
+ "celox-design",
+ "fxhash",
+]
 
 [[package]]
 name = "celox-ts-gen"

--- a/crates/celox-state-layout/Cargo.toml
+++ b/crates/celox-state-layout/Cargo.toml
@@ -7,5 +7,9 @@ license.workspace     = true
 description           = "Physical simulation-state layout contracts for Celox"
 edition.workspace     = true
 
+[dependencies]
+celox-design = { path = "../celox-design" }
+fxhash       = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/celox-state-layout/src/lib.rs
+++ b/crates/celox-state-layout/src/lib.rs
@@ -3,6 +3,13 @@
 //! These types and offsets form the ABI between layout construction, generated
 //! code, and runtime state access. They contain no frontend or backend IR.
 
+use celox_design::{
+    AbsoluteAddrBase, RegionedAbsoluteAddrBase, RuntimeEventSite, SPARSE_WORKING_REGION,
+    STABLE_REGION,
+};
+use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use std::hash::Hash;
+
 pub const RUNTIME_EVENT_CAPACITY: usize = 1024;
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub const RUNTIME_EVENT_WRITING: u64 = u64::MAX;
@@ -63,6 +70,404 @@ pub struct UnpackedArrayLayout {
     pub plane_size: usize,
 }
 
+/// One semantic state object that requires stable storage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StateObjectLayout<A> {
+    pub address: A,
+    pub width: usize,
+    pub is_4state: bool,
+}
+
+/// Complete, backend-independent input to physical layout construction.
+///
+/// The compiler facade adapts its phase artifacts into this value. Layout
+/// construction therefore never needs to inspect frontend IR, optimizer plans,
+/// or a mixed compiler `Program`.
+#[derive(Debug, Clone)]
+pub struct LayoutInput<A> {
+    pub state_objects: Vec<StateObjectLayout<A>>,
+    pub working_addresses: Vec<A>,
+    pub sparse_addresses: Vec<A>,
+    pub unpacked_arrays: HashMap<A, UnpackedArrayLayout>,
+    pub address_aliases: Vec<(A, A)>,
+    pub ff_referenced_addresses: HashSet<A>,
+    pub num_events: usize,
+    pub scratch_bytes: usize,
+    pub runtime_event_sites: Vec<RuntimeEventSite>,
+}
+
+/// Adapter implemented by the phase artifact that precedes physical layout.
+pub trait LayoutSource<A> {
+    fn layout_input(&self, mode: MemoryLayoutMode) -> LayoutInput<A>;
+}
+
+#[derive(Debug, Clone)]
+pub struct MemoryLayout<A> {
+    pub four_state: bool,
+    pub mode: MemoryLayoutMode,
+    /// Stable region offsets. Includes all declared state objects.
+    pub offsets: HashMap<A, usize>,
+    pub widths: HashMap<A, usize>,
+    /// Whether each state object has a four-state source type.
+    pub is_4states: HashMap<A, bool>,
+    pub unpacked_arrays: HashMap<A, UnpackedArrayLayout>,
+    /// Stable region size in bytes.
+    pub total_size: usize,
+
+    /// Working region offsets. Includes only actually-used state objects.
+    pub working_offsets: HashMap<A, usize>,
+    pub working_base_offset: usize,
+    /// Copy-on-write next-state data for dynamically addressed FF targets.
+    pub sparse_offsets: HashMap<A, usize>,
+    pub sparse_base_offset: usize,
+    pub sparse_layouts: HashMap<A, SparseWorkingLayout>,
+    pub sparse_active_bits_offset: usize,
+    pub sparse_active_capacity: usize,
+    pub merged_total_size: usize,
+
+    pub triggered_bits_offset: usize,
+    pub triggered_bits_total_size: usize,
+
+    pub scratch_base_offset: usize,
+    pub scratch_size: usize,
+
+    pub runtime_event_capacity: usize,
+    pub runtime_event_slot_size: usize,
+    pub runtime_event_buffer_size: usize,
+    pub runtime_event_site_layouts: Vec<RuntimeEventSiteLayout>,
+}
+
+type PhysicalLayoutObject<A> = (A, usize, bool, usize, usize);
+
+fn sort_layout_objects<A: Copy + Ord>(objects: &mut [PhysicalLayoutObject<A>]) {
+    // Packing by decreasing alignment avoids padding. Equal-alignment objects
+    // use semantic-address order so randomized input maps cannot perturb every
+    // physical offset and the generated machine code that embeds it.
+    objects.sort_unstable_by_key(|(address, _, _, _, alignment)| {
+        (std::cmp::Reverse(*alignment), *address)
+    });
+}
+
+impl<A> MemoryLayout<A>
+where
+    A: Copy + Eq + Hash + Ord,
+{
+    pub fn build<S>(source: &S, four_state: bool, mode: MemoryLayoutMode) -> Self
+    where
+        S: LayoutSource<A>,
+    {
+        let input = source.layout_input(mode);
+        let LayoutInput {
+            state_objects,
+            working_addresses,
+            sparse_addresses,
+            unpacked_arrays,
+            mut address_aliases,
+            ff_referenced_addresses,
+            num_events,
+            scratch_bytes,
+            runtime_event_sites,
+        } = input;
+
+        let mut stable_objects = state_objects
+            .into_iter()
+            .map(|object| {
+                let size = unpacked_arrays
+                    .get(&object.address)
+                    .map(|layout| layout.plane_size)
+                    .unwrap_or_else(|| get_byte_size(object.width));
+                let alignment = unpacked_arrays
+                    .get(&object.address)
+                    .map(|layout| layout.element_stride.min(8))
+                    .unwrap_or_else(|| get_alignment(object.width));
+                (
+                    object.address,
+                    object.width,
+                    object.is_4state,
+                    size,
+                    alignment,
+                )
+            })
+            .collect::<Vec<_>>();
+        sort_layout_objects(&mut stable_objects);
+
+        let mut offsets = HashMap::default();
+        let mut widths = HashMap::default();
+        let mut is_4states = HashMap::default();
+        let runtime_event_site_layouts = build_runtime_event_site_layouts(&runtime_event_sites);
+        let runtime_event_slot_size = RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
+            + runtime_event_site_layouts
+                .iter()
+                .map(|site| site.payload_words)
+                .max()
+                .unwrap_or(0)
+                * 8;
+
+        let mut current_offset = STATE_HEADER_SIZE;
+        for (address, width, is_4state, size, alignment) in stable_objects {
+            current_offset = align_up(current_offset, alignment);
+            offsets.insert(address, current_offset);
+            widths.insert(address, width);
+            is_4states.insert(address, is_4state);
+            current_offset += size;
+            if four_state {
+                current_offset += size;
+            }
+        }
+
+        let mut working_objects = working_addresses
+            .iter()
+            .map(|address| {
+                let width = widths[address];
+                let size = unpacked_arrays
+                    .get(address)
+                    .map(|layout| layout.plane_size)
+                    .unwrap_or_else(|| get_byte_size(width));
+                let alignment = unpacked_arrays
+                    .get(address)
+                    .map(|layout| layout.element_stride.min(8))
+                    .unwrap_or_else(|| get_alignment(width));
+                (*address, width, is_4states[address], size, alignment)
+            })
+            .collect::<Vec<_>>();
+        sort_layout_objects(&mut working_objects);
+
+        let mut working_offsets = HashMap::default();
+        let mut working_size = 0;
+        for (address, _, _, size, alignment) in working_objects {
+            working_size = align_up(working_size, alignment);
+            working_offsets.insert(address, working_size);
+            working_size += size;
+            if four_state {
+                working_size += size;
+            }
+        }
+
+        let mut sparse_objects = sparse_addresses
+            .iter()
+            .map(|address| {
+                let width = widths[address];
+                let size = unpacked_arrays
+                    .get(address)
+                    .map(|layout| layout.plane_size)
+                    .unwrap_or_else(|| get_byte_size(width));
+                let alignment = unpacked_arrays
+                    .get(address)
+                    .map(|layout| layout.element_stride.min(8))
+                    .unwrap_or_else(|| get_alignment(width));
+                (*address, width, is_4states[address], size, alignment)
+            })
+            .collect::<Vec<_>>();
+        sort_layout_objects(&mut sparse_objects);
+
+        let mut sparse_offsets = HashMap::default();
+        let mut sparse_size = 0usize;
+        for (address, _, _, size, alignment) in sparse_objects {
+            sparse_size = align_up(sparse_size, alignment);
+            sparse_offsets.insert(address, sparse_size);
+            let plane_count = if four_state { 2 } else { 1 };
+            let final_chunk_size = align_up(size, 8);
+            let physical_extent = (plane_count - 1) * size + final_chunk_size;
+            sparse_size += align_up(physical_extent, 8);
+        }
+
+        let working_base_offset = align_up(current_offset, 8);
+        let sparse_base_offset = align_up(working_base_offset + working_size, 8);
+        let mut sparse_metadata_offset = align_up(sparse_base_offset + sparse_size, 8);
+        let mut sparse_layouts = HashMap::default();
+        let mut sparse_order = sparse_addresses;
+        sparse_order.sort_unstable();
+        let sparse_active_capacity = sparse_order.len();
+        for (active_index, address) in sparse_order.into_iter().enumerate() {
+            let chunk_count = unpacked_arrays
+                .get(&address)
+                .map(|layout| layout.plane_size.div_ceil(8))
+                .unwrap_or_else(|| widths[&address].div_ceil(64));
+            let dirty_word_count = chunk_count.div_ceil(64);
+            let summary_word_count = dirty_word_count.div_ceil(64);
+            let dirty_words_offset = sparse_metadata_offset;
+            sparse_metadata_offset += dirty_word_count * 8;
+            let summary_words_offset = sparse_metadata_offset;
+            sparse_metadata_offset += summary_word_count * 8;
+            sparse_layouts.insert(
+                address,
+                SparseWorkingLayout {
+                    active_index,
+                    chunk_count,
+                    dirty_words_offset,
+                    dirty_word_count,
+                    summary_words_offset,
+                    summary_word_count,
+                },
+            );
+        }
+
+        let sparse_active_bits_offset = align_up(sparse_metadata_offset, 8);
+        sparse_metadata_offset =
+            sparse_active_bits_offset + sparse_active_capacity.div_ceil(64) * 8;
+        let triggered_bits_offset = align_up(sparse_metadata_offset, 8);
+        let triggered_bits_total_size = num_events.div_ceil(8);
+        let scratch_base_offset = align_up(triggered_bits_offset + triggered_bits_total_size, 8);
+        let runtime_event_buffer_size =
+            RUNTIME_EVENT_HEADER_SIZE + RUNTIME_EVENT_CAPACITY * runtime_event_slot_size;
+        let merged_total_size = align_up(scratch_base_offset + scratch_bytes, 8);
+
+        address_aliases.sort_unstable();
+        for (alias, canonical) in address_aliases {
+            let fourstate_ok = !four_state
+                || (is_4states.get(&alias) == Some(&false)
+                    && is_4states.get(&canonical) == Some(&false));
+            let alias_fits = widths
+                .get(&alias)
+                .zip(widths.get(&canonical))
+                .is_some_and(|(&alias_width, &canonical_width)| alias_width <= canonical_width);
+            if fourstate_ok
+                && alias_fits
+                && !ff_referenced_addresses.contains(&alias)
+                && let Some(&canonical_offset) = offsets.get(&canonical)
+            {
+                offsets.insert(alias, canonical_offset);
+            }
+        }
+
+        Self {
+            four_state,
+            mode,
+            offsets,
+            widths,
+            is_4states,
+            unpacked_arrays,
+            total_size: current_offset,
+            working_offsets,
+            working_base_offset,
+            sparse_offsets,
+            sparse_base_offset,
+            sparse_layouts,
+            sparse_active_bits_offset,
+            sparse_active_capacity,
+            merged_total_size,
+            triggered_bits_offset,
+            triggered_bits_total_size,
+            scratch_base_offset,
+            scratch_size: scratch_bytes,
+            runtime_event_capacity: RUNTIME_EVENT_CAPACITY,
+            runtime_event_slot_size,
+            runtime_event_buffer_size,
+            runtime_event_site_layouts,
+        }
+    }
+
+    pub fn plane_size(&self, address: &A) -> usize {
+        self.unpacked_arrays
+            .get(address)
+            .map(|layout| layout.plane_size)
+            .unwrap_or_else(|| get_byte_size(self.widths[address]))
+    }
+
+    pub fn region_base_offset<R>(&self, address: &R) -> usize
+    where
+        R: RegionedAddress<A>,
+    {
+        let absolute = address.absolute_address();
+        match address.region() {
+            STABLE_REGION => self.offsets[&absolute],
+            SPARSE_WORKING_REGION => self.sparse_base_offset + self.sparse_offsets[&absolute],
+            _ => self.working_base_offset + self.working_offsets[&absolute],
+        }
+    }
+
+    pub fn map_static_bit_offset(&self, address: &A, bit_offset: usize) -> (usize, usize) {
+        let Some(array) = self.unpacked_arrays.get(address) else {
+            return (bit_offset / 8, bit_offset % 8);
+        };
+        let element = bit_offset / array.element_width;
+        let intra_element = bit_offset % array.element_width;
+        (
+            element * array.element_stride + intra_element / 8,
+            intra_element % 8,
+        )
+    }
+
+    pub fn regioned_static_byte_and_intra<R>(
+        &self,
+        address: &R,
+        bit_offset: usize,
+    ) -> Option<(i32, usize)>
+    where
+        R: RegionedAddress<A>,
+    {
+        let absolute = address.absolute_address();
+        let base = match address.region() {
+            STABLE_REGION => *self.offsets.get(&absolute).unwrap_or(&0),
+            SPARSE_WORKING_REGION => {
+                self.sparse_base_offset + *self.sparse_offsets.get(&absolute).unwrap_or(&0)
+            }
+            _ => self.working_base_offset + *self.working_offsets.get(&absolute).unwrap_or(&0),
+        };
+        let (byte, intra) = self.map_static_bit_offset(&absolute, bit_offset);
+        Some((i32::try_from(base.checked_add(byte)?).ok()?, intra))
+    }
+}
+
+pub trait RegionedAddress<A> {
+    fn region(&self) -> u32;
+    fn absolute_address(&self) -> A;
+}
+
+impl<V: Copy> RegionedAddress<AbsoluteAddrBase<V>> for RegionedAbsoluteAddrBase<V> {
+    fn region(&self) -> u32 {
+        self.region
+    }
+
+    fn absolute_address(&self) -> AbsoluteAddrBase<V> {
+        self.absolute_addr()
+    }
+}
+
+fn build_runtime_event_site_layouts(sites: &[RuntimeEventSite]) -> Vec<RuntimeEventSiteLayout> {
+    sites
+        .iter()
+        .map(|site| {
+            let mut payload_words = 0;
+            let args = site
+                .arg_widths
+                .iter()
+                .map(|width| {
+                    let word_count = (*width).div_ceil(64).max(1);
+                    let value_word_offset = payload_words;
+                    payload_words += word_count;
+                    let mask_word_offset = payload_words;
+                    payload_words += word_count;
+                    RuntimeEventArgLayout {
+                        value_word_offset,
+                        mask_word_offset,
+                        word_count,
+                    }
+                })
+                .collect();
+            RuntimeEventSiteLayout {
+                args,
+                payload_words,
+            }
+        })
+        .collect()
+}
+
+const fn align_up(offset: usize, alignment: usize) -> usize {
+    (offset + alignment - 1) & !(alignment - 1)
+}
+
+fn get_alignment(width: usize) -> usize {
+    let size = get_byte_size(width);
+    if size == 0 {
+        1
+    } else if size <= 8 {
+        size.next_power_of_two()
+    } else {
+        8
+    }
+}
+
 pub const fn get_byte_size(width: usize) -> usize {
     width.div_ceil(8)
 }
@@ -77,6 +482,21 @@ mod tests {
         assert_eq!(get_byte_size(1), 1);
         assert_eq!(get_byte_size(8), 1);
         assert_eq!(get_byte_size(9), 2);
+    }
+
+    #[test]
+    fn layout_order_is_independent_of_input_iteration_order() {
+        let high_address = (3u32, 64, false, 8, 8);
+        let low_address = (1u32, 64, false, 8, 8);
+        let less_aligned = (0u32, 32, false, 4, 4);
+        let mut forward = vec![high_address, less_aligned, low_address];
+        let mut reverse = forward.iter().copied().rev().collect::<Vec<_>>();
+
+        sort_layout_objects(&mut forward);
+        sort_layout_objects(&mut reverse);
+
+        assert_eq!(forward, reverse);
+        assert_eq!(forward, vec![low_address, high_address, less_aligned]);
     }
 
     #[test]

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -1,355 +1,70 @@
 use crate::HashMap;
 use crate::ir::{
-    AbsoluteAddr, Program, RegionedAbsoluteAddr, RegisterId, SIRInstruction, SIROffset,
-    STABLE_REGION, collect_exact_zero_registers,
+    AbsoluteAddr, Program, RegisterId, SIRInstruction, SIROffset, STABLE_REGION,
+    collect_exact_zero_registers,
 };
+#[cfg(any(target_arch = "x86_64", test))]
+pub use celox_state_layout::SparseWorkingLayout;
 pub use celox_state_layout::{
-    MemoryLayoutMode, RUNTIME_EVENT_CAPACITY, RUNTIME_EVENT_HEADER_SIZE,
+    LayoutInput, LayoutSource, MemoryLayoutMode, RUNTIME_EVENT_HEADER_SIZE,
     RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET, RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET,
     RUNTIME_EVENT_SLOT_SEQ_OFFSET, RUNTIME_EVENT_SLOT_SITE_OFFSET, RUNTIME_EVENT_WRITING,
-    RuntimeEventArgLayout, RuntimeEventSiteLayout, STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET,
-    STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET, STATE_HEADER_SIZE, SparseWorkingLayout,
-    UnpackedArrayLayout, get_byte_size,
+    STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET, STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET,
+    StateObjectLayout, UnpackedArrayLayout, get_byte_size,
 };
 #[cfg(target_arch = "x86_64")]
 pub use celox_state_layout::{
     STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET, STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET,
 };
 
-type LayoutVariable = (AbsoluteAddr, usize, bool, usize, usize);
+pub type MemoryLayout = celox_state_layout::MemoryLayout<AbsoluteAddr>;
 
-fn sort_layout_variables(variables: &mut [LayoutVariable]) {
-    // Packing by decreasing alignment avoids padding.  Equal-alignment values
-    // must also have a stable order: both Program maps use randomized hashers,
-    // and preserving their iteration order makes every physical offset (and
-    // consequently native MIR/code shape) vary between identical builds.
-    variables.sort_unstable_by_key(|(address, _, _, _, alignment)| {
-        (std::cmp::Reverse(*alignment), *address)
-    });
-}
-
-#[derive(Debug, Clone)]
-pub struct MemoryLayout {
-    pub four_state: bool,
-    pub mode: MemoryLayoutMode,
-    /// Stable region (region = 0) offsets. Includes all declared variables.
-    pub offsets: HashMap<AbsoluteAddr, usize>,
-    pub widths: HashMap<AbsoluteAddr, usize>,
-    /// Whether the variable is a 4-state type.
-    pub is_4states: HashMap<AbsoluteAddr, bool>,
-    pub unpacked_arrays: HashMap<AbsoluteAddr, UnpackedArrayLayout>,
-    /// Stable region size in bytes.
-    pub total_size: usize,
-
-    /// Working region (region != 0) offsets. Includes only actually-used variables.
-    pub working_offsets: HashMap<AbsoluteAddr, usize>,
-    /// Base offset (bytes) of the working region inside the unified memory buffer.
-    pub working_base_offset: usize,
-    /// Copy-on-write next-state data for dynamically addressed FF targets.
-    pub sparse_offsets: HashMap<AbsoluteAddr, usize>,
-    pub sparse_base_offset: usize,
-    pub sparse_layouts: HashMap<AbsoluteAddr, SparseWorkingLayout>,
-    /// Event-local bitmap of sparse regions touched by the current FF
-    /// evaluation. One bit per descriptor makes repeated marks idempotent.
-    pub sparse_active_bits_offset: usize,
-    pub sparse_active_capacity: usize,
-    /// Unified memory buffer size in bytes (stable + working).
-    pub merged_total_size: usize,
-
-    /// Bitset of triggered domain IDs.
-    pub triggered_bits_offset: usize,
-    pub triggered_bits_total_size: usize,
-
-    /// Scratch region for spilling inter-chunk registers.
-    /// Located after triggered bits. Zero if no spilling needed.
-    pub scratch_base_offset: usize,
-    pub scratch_size: usize,
-
-    /// Runtime event ring geometry. The ring storage itself is backend-owned;
-    /// generated code finds it through the state header.
-    pub runtime_event_capacity: usize,
-    pub runtime_event_slot_size: usize,
-    pub runtime_event_buffer_size: usize,
-    pub runtime_event_site_layouts: Vec<RuntimeEventSiteLayout>,
-}
-
-impl MemoryLayout {
-    pub fn build(program: &Program, four_state: bool, mode: MemoryLayoutMode) -> Self {
-        let scratch_bytes = match &program.eval_comb_plan {
+impl LayoutSource<AbsoluteAddr> for Program {
+    fn layout_input(&self, mode: MemoryLayoutMode) -> LayoutInput<AbsoluteAddr> {
+        let scratch_bytes = match &self.eval_comb_plan {
             Some(crate::ir::EvalCombPlan::MemorySpilled(plan)) => plan.scratch_bytes,
             _ => 0,
         };
         let unpacked_arrays = if mode == MemoryLayoutMode::ElementStrided {
-            collect_strided_array_layouts(program)
+            collect_strided_array_layouts(self)
         } else {
             HashMap::default()
         };
-        let mut stable_vars_to_layout = Vec::new();
-
-        for (instance_id, module_id) in &program.instance_module {
-            let variables = &program.module_variables[module_id];
-            for info in variables.values() {
-                let addr = AbsoluteAddr {
-                    instance_id: *instance_id,
-                    var_id: info.id,
-                };
-                let size = unpacked_arrays
-                    .get(&addr)
-                    .map(|layout| layout.plane_size)
-                    .unwrap_or_else(|| get_byte_size(info.width));
-                let align = unpacked_arrays
-                    .get(&addr)
-                    .map(|layout| layout.element_stride.min(8))
-                    .unwrap_or_else(|| get_alignment(info.width));
-                stable_vars_to_layout.push((addr, info.width, info.is_4state, size, align));
-            }
-        }
-
-        sort_layout_variables(&mut stable_vars_to_layout);
-
-        let mut offsets = HashMap::default();
-        let mut widths = HashMap::default();
-        let mut is_4states = HashMap::default();
-        let runtime_event_site_layouts = build_runtime_event_site_layouts(program);
-        let runtime_event_slot_size = RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
-            + runtime_event_site_layouts
-                .iter()
-                .map(|site| site.payload_words)
-                .max()
-                .unwrap_or(0)
-                * 8;
-
-        let mut current_offset = STATE_HEADER_SIZE;
-
-        // 3. Execute packing
-        for (addr, width, is_4state, size, align) in stable_vars_to_layout {
-            current_offset = (current_offset + align - 1) & !(align - 1);
-
-            offsets.insert(addr, current_offset);
-            widths.insert(addr, width);
-            is_4states.insert(addr, is_4state);
-
-            current_offset += size;
-            if four_state {
-                current_offset += size;
-            }
-        }
-
-        // Compact working region: only variables actually written in WORKING region.
-        let working_addrs = program.collect_working_region_addrs();
-        let mut working_vars_to_layout: Vec<LayoutVariable> = working_addrs
+        let state_objects = self
+            .instance_module
             .iter()
-            .map(|addr| {
-                let width = widths[addr];
-                let is_4state = is_4states[addr];
-                let size = unpacked_arrays
-                    .get(addr)
-                    .map(|layout| layout.plane_size)
-                    .unwrap_or_else(|| get_byte_size(width));
-                let align = unpacked_arrays
-                    .get(addr)
-                    .map(|layout| layout.element_stride.min(8))
-                    .unwrap_or_else(|| get_alignment(width));
-                (*addr, width, is_4state, size, align)
+            .flat_map(|(instance_id, module_id)| {
+                self.module_variables[module_id]
+                    .values()
+                    .map(move |info| StateObjectLayout {
+                        address: AbsoluteAddr {
+                            instance_id: *instance_id,
+                            var_id: info.id,
+                        },
+                        width: info.width,
+                        is_4state: info.is_4state,
+                    })
             })
             .collect();
 
-        sort_layout_variables(&mut working_vars_to_layout);
-
-        let mut working_offsets = HashMap::default();
-        let mut working_current_offset = 0;
-        for (addr, _width, _is_4state, size, align) in working_vars_to_layout {
-            working_current_offset = (working_current_offset + align - 1) & !(align - 1);
-
-            working_offsets.insert(addr, working_current_offset);
-
-            working_current_offset += size;
-            if four_state {
-                working_current_offset += size;
-            }
-        }
-
-        let sparse_addrs = program.collect_sparse_working_region_addrs();
-        let mut sparse_vars_to_layout: Vec<LayoutVariable> = sparse_addrs
-            .iter()
-            .map(|addr| {
-                let width = widths[addr];
-                let size = unpacked_arrays
-                    .get(addr)
-                    .map(|layout| layout.plane_size)
-                    .unwrap_or_else(|| get_byte_size(width));
-                let align = unpacked_arrays
-                    .get(addr)
-                    .map(|layout| layout.element_stride.min(8))
-                    .unwrap_or_else(|| get_alignment(width));
-                (*addr, width, is_4states[addr], size, align)
-            })
-            .collect();
-        sort_layout_variables(&mut sparse_vars_to_layout);
-        let mut sparse_offsets = HashMap::default();
-        let mut sparse_current_offset = 0usize;
-        for (addr, _width, _is_4state, size, align) in sparse_vars_to_layout {
-            sparse_current_offset = (sparse_current_offset + align - 1) & !(align - 1);
-            sparse_offsets.insert(addr, sparse_current_offset);
-            // First-write initialization accesses the final logical chunk as
-            // a u64. Keep its tail inside this variable's slot so it cannot
-            // overwrite the next sparse value or the dirty metadata.
-            let plane_count = if four_state { 2 } else { 1 };
-            let final_chunk_size = (size + 7) & !7;
-            let physical_extent = (plane_count - 1) * size + final_chunk_size;
-            sparse_current_offset += (physical_extent + 7) & !7;
-        }
-
-        // Keep working region properly aligned when appended to the stable region.
-        let working_base_offset = (current_offset + 7) & !7;
-        let sparse_base_offset = (working_base_offset + working_current_offset + 7) & !7;
-        let mut sparse_metadata_offset = (sparse_base_offset + sparse_current_offset + 7) & !7;
-        let mut sparse_layouts = HashMap::default();
-        let mut sparse_order: Vec<_> = sparse_addrs.into_iter().collect();
-        sparse_order.sort();
-        let sparse_active_capacity = sparse_order.len();
-        for (active_index, addr) in sparse_order.into_iter().enumerate() {
-            let chunk_count = unpacked_arrays
-                .get(&addr)
-                .map(|layout| layout.plane_size.div_ceil(8))
-                .unwrap_or_else(|| widths[&addr].div_ceil(64));
-            let dirty_word_count = chunk_count.div_ceil(64);
-            let summary_word_count = dirty_word_count.div_ceil(64);
-            let dirty_words_offset = sparse_metadata_offset;
-            sparse_metadata_offset += dirty_word_count * 8;
-            let summary_words_offset = sparse_metadata_offset;
-            sparse_metadata_offset += summary_word_count * 8;
-            sparse_layouts.insert(
-                addr,
-                SparseWorkingLayout {
-                    active_index,
-                    chunk_count,
-                    dirty_words_offset,
-                    dirty_word_count,
-                    summary_words_offset,
-                    summary_word_count,
-                },
-            );
-        }
-
-        let sparse_active_bits_offset = (sparse_metadata_offset + 7) & !7;
-        sparse_metadata_offset =
-            sparse_active_bits_offset + sparse_active_capacity.div_ceil(64) * 8;
-
-        // Triggered bits region (1 bit per event canonical ID)
-        let num_potential_triggers = program.num_events();
-        let triggered_bits_offset = (sparse_metadata_offset + 7) & !7;
-        let triggered_bits_total_size = num_potential_triggers.div_ceil(8);
-
-        let scratch_base_offset = (triggered_bits_offset + triggered_bits_total_size + 7) & !7;
-        let runtime_event_buffer_size =
-            RUNTIME_EVENT_HEADER_SIZE + RUNTIME_EVENT_CAPACITY * runtime_event_slot_size;
-        let merged_total_size = (scratch_base_offset + scratch_bytes + 7) & !7;
-
-        // Apply address aliases: aliased variables share the canonical's offset.
-        // Only alias when:
-        // - Both variables have the same 4-state mode
-        // - Alias width fits within canonical width
-        // - Neither address is used in FF execution units (FF timing requires separate storage)
-        let ff_addrs = collect_ff_referenced_addresses(program);
-        let mut address_aliases = program.address_aliases.iter().collect::<Vec<_>>();
-        address_aliases
-            .sort_unstable_by_key(|(alias_addr, canonical_addr)| (**alias_addr, **canonical_addr));
-        for (alias_addr, canonical_addr) in address_aliases {
-            // In 4-state mode, skip 4-state variables: aliasing only shares
-            // the value offset, but 4-state also needs mask offset sharing.
-            // In 2-state mode (four_state=false), masks are not allocated so all types are safe.
-            let fourstate_ok = !four_state
-                || (is_4states.get(alias_addr) == Some(&false)
-                    && is_4states.get(canonical_addr) == Some(&false));
-            let alias_fits = widths
-                .get(alias_addr)
-                .zip(widths.get(canonical_addr))
-                .is_some_and(|(&aw, &cw)| aw <= cw);
-            // Only the alias (non-canonical) side must not be in FF.
-            // The canonical side can be in FF — aliasing only shares the STABLE
-            // region offset, and WORKING offsets are allocated independently.
-            let not_in_ff = !ff_addrs.contains(alias_addr);
-            if fourstate_ok && alias_fits && not_in_ff {
-                if let Some(&canonical_offset) = offsets.get(canonical_addr) {
-                    offsets.insert(*alias_addr, canonical_offset);
-                }
-            }
-        }
-
-        Self {
-            four_state,
-            mode,
-            offsets,
-            widths,
-            is_4states,
+        LayoutInput {
+            state_objects,
+            working_addresses: self.collect_working_region_addrs().into_iter().collect(),
+            sparse_addresses: self
+                .collect_sparse_working_region_addrs()
+                .into_iter()
+                .collect(),
             unpacked_arrays,
-            total_size: current_offset,
-            working_offsets,
-            working_base_offset,
-            sparse_offsets,
-            sparse_base_offset,
-            sparse_layouts,
-            sparse_active_bits_offset,
-            sparse_active_capacity,
-            merged_total_size,
-            triggered_bits_offset,
-            triggered_bits_total_size,
-            scratch_base_offset,
-            scratch_size: scratch_bytes,
-            runtime_event_capacity: RUNTIME_EVENT_CAPACITY,
-            runtime_event_slot_size,
-            runtime_event_buffer_size,
-            runtime_event_site_layouts,
+            address_aliases: self
+                .address_aliases
+                .iter()
+                .map(|(&alias, &canonical)| (alias, canonical))
+                .collect(),
+            ff_referenced_addresses: collect_ff_referenced_addresses(self),
+            num_events: self.num_events(),
+            scratch_bytes,
+            runtime_event_sites: self.runtime_event_sites.clone(),
         }
-    }
-
-    pub fn plane_size(&self, addr: &AbsoluteAddr) -> usize {
-        self.unpacked_arrays
-            .get(addr)
-            .map(|layout| layout.plane_size)
-            .unwrap_or_else(|| get_byte_size(self.widths[addr]))
-    }
-
-    pub(crate) fn region_base_offset(&self, addr: &RegionedAbsoluteAddr) -> usize {
-        let absolute = addr.absolute_addr();
-        match addr.region {
-            STABLE_REGION => self.offsets[&absolute],
-            crate::ir::SPARSE_WORKING_REGION => {
-                self.sparse_base_offset + self.sparse_offsets[&absolute]
-            }
-            _ => self.working_base_offset + self.working_offsets[&absolute],
-        }
-    }
-
-    pub fn map_static_bit_offset(&self, addr: &AbsoluteAddr, bit_offset: usize) -> (usize, usize) {
-        let Some(array) = self.unpacked_arrays.get(addr) else {
-            return (bit_offset / 8, bit_offset % 8);
-        };
-        let element = bit_offset / array.element_width;
-        let intra_element = bit_offset % array.element_width;
-        (
-            element * array.element_stride + intra_element / 8,
-            intra_element % 8,
-        )
-    }
-
-    #[cfg(any(target_arch = "x86_64", test))]
-    pub(crate) fn regioned_static_byte_and_intra(
-        &self,
-        addr: &RegionedAbsoluteAddr,
-        bit_offset: usize,
-    ) -> Option<(i32, usize)> {
-        let absolute = addr.absolute_addr();
-        let base = match addr.region {
-            STABLE_REGION => *self.offsets.get(&absolute).unwrap_or(&0),
-            crate::ir::SPARSE_WORKING_REGION => {
-                self.sparse_base_offset + *self.sparse_offsets.get(&absolute).unwrap_or(&0)
-            }
-            _ => self.working_base_offset + *self.working_offsets.get(&absolute).unwrap_or(&0),
-        };
-        let (byte, intra) = self.map_static_bit_offset(&absolute, bit_offset);
-        Some((i32::try_from(base.checked_add(byte)?).ok()?, intra))
     }
 }
 
@@ -502,36 +217,6 @@ pub(crate) fn collect_strided_array_layouts(
     candidates
 }
 
-fn build_runtime_event_site_layouts(program: &Program) -> Vec<RuntimeEventSiteLayout> {
-    program
-        .runtime_event_sites
-        .iter()
-        .map(|site| {
-            let mut payload_words = 0;
-            let args = site
-                .arg_widths
-                .iter()
-                .map(|width| {
-                    let word_count = (*width).div_ceil(64).max(1);
-                    let value_word_offset = payload_words;
-                    payload_words += word_count;
-                    let mask_word_offset = payload_words;
-                    payload_words += word_count;
-                    RuntimeEventArgLayout {
-                        value_word_offset,
-                        mask_word_offset,
-                        word_count,
-                    }
-                })
-                .collect();
-            RuntimeEventSiteLayout {
-                args,
-                payload_words,
-            }
-        })
-        .collect()
-}
-
 /// Collect whole objects referenced by FF.
 ///
 /// FF reads cannot share a persistent home without a phase-correct StateSSA
@@ -568,50 +253,9 @@ fn collect_ff_referenced_addresses(program: &Program) -> crate::HashSet<Absolute
     addrs
 }
 
-fn get_alignment(width: usize) -> usize {
-    let size = get_byte_size(width);
-    if size == 0 {
-        1
-    } else if size <= 8 {
-        size.next_power_of_two()
-    } else {
-        8
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ir::InstanceId;
-    use veryl_analyzer::ir::VarId;
-
-    fn variable(instance: usize, variable: u32, alignment: usize) -> LayoutVariable {
-        (
-            AbsoluteAddr {
-                instance_id: InstanceId(instance),
-                var_id: VarId::from_raw(variable),
-            },
-            alignment * 8,
-            false,
-            alignment,
-            alignment,
-        )
-    }
-
-    #[test]
-    fn layout_order_is_independent_of_hash_iteration_order() {
-        let high_address = variable(3, 9, 8);
-        let low_address = variable(1, 2, 8);
-        let less_aligned = variable(0, 0, 4);
-        let mut forward = vec![high_address, less_aligned, low_address];
-        let mut reverse = forward.iter().copied().rev().collect::<Vec<_>>();
-
-        sort_layout_variables(&mut forward);
-        sort_layout_variables(&mut reverse);
-
-        assert_eq!(forward, reverse);
-        assert_eq!(forward, vec![low_address, high_address, less_aligned]);
-    }
 
     #[test]
     fn padded_array_accepts_only_semantic_whole_object_transfers() {


### PR DESCRIPTION
## Summary

- move `MemoryLayout` and the physical packing algorithm into `celox-state-layout`
- add an explicit `LayoutInput` contract for state objects, working/sparse requirements, aliases, runtime events, scratch, and FF alias exclusions
- keep SIR/optimizer inspection in a `Program -> LayoutInput` adapter inside `celox`
- remove the old layout implementation instead of retaining a fallback path

## Why

The layout crate cannot be independent while its builder receives the mixed compiler `Program` and inspects backend planning enums directly. The new boundary makes all physical-layout requirements explicit and leaves `celox-state-layout` dependent only on design vocabulary and collection types.

## Stack

1. #334
2. #335
3. #336
4. **This PR**

## Validation

- `cargo test -p celox-state-layout`
- `cargo test -p celox --lib` (1,144 tests; the deterministic layout-order test moved to the layout crate)
- `cargo test -p celox --test native_exec`
- `cargo test -p celox --test initial_readmem --test data_access --test four_state --test wasm_backend --test native_testbench`
- `RUSTFLAGS=-Dwarnings cargo check -p celox-napi --target aarch64-unknown-linux-gnu`
- `cargo check -p celox-state-layout --tests --target aarch64-unknown-linux-gnu`
- lightweight pre-push hook