### PR TITLE
Introduce typed laid-out program artifact

### DIFF
--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1450,7 +1450,7 @@ impl NativeSimulatorHandle {
             .collect();
 
         let trace_opts = celox::TraceOptions::default();
-        let (mut program, warnings) = celox::compile_to_sir(
+        let (program, warnings) = celox::compile_to_sir(
             &source_refs,
             &top,
             &opts
@@ -1474,8 +1474,9 @@ impl NativeSimulatorHandle {
         )
         .map_err(|e| Error::from_reason(format!("{}", e)))?;
 
-        program.build_layout(opts.four_state);
-        let layout = program.layout.as_ref().unwrap();
+        let laid_out = program.into_laid_out(opts.four_state);
+        let program = laid_out.program();
+        let layout = laid_out.layout();
 
         let layout_json = Self::build_layout_json(&program, layout, opts.four_state);
         let events_json = Self::build_events_json(&program);
@@ -1484,7 +1485,7 @@ impl NativeSimulatorHandle {
 
         let stable_size = layout.total_size as u32;
         let total_size = layout.merged_total_size as u32;
-        let layout = layout.clone();
+        let (program, layout) = laid_out.into_parts();
 
         Ok(Self {
             program,
@@ -1516,7 +1517,7 @@ impl NativeSimulatorHandle {
             .collect();
 
         let trace_opts = celox::TraceOptions::default();
-        let (mut program, warnings) = celox::compile_to_sir(
+        let (program, warnings) = celox::compile_to_sir(
             &source_refs,
             &top,
             &opts
@@ -1540,8 +1541,9 @@ impl NativeSimulatorHandle {
         )
         .map_err(|e| Error::from_reason(format!("{}", e)))?;
 
-        program.build_layout(opts.four_state);
-        let layout = program.layout.as_ref().unwrap();
+        let laid_out = program.into_laid_out(opts.four_state);
+        let program = laid_out.program();
+        let layout = laid_out.layout();
 
         let layout_json = Self::build_layout_json(&program, layout, opts.four_state);
         let events_json = Self::build_events_json(&program);
@@ -1550,7 +1552,7 @@ impl NativeSimulatorHandle {
 
         let stable_size = layout.total_size as u32;
         let total_size = layout.merged_total_size as u32;
-        let layout = layout.clone();
+        let (program, layout) = laid_out.into_parts();
 
         Ok(Self {
             program,

--- a/crates/celox-wasm/src/lib.rs
+++ b/crates/celox-wasm/src/lib.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use celox::wasm_codegen;
-use celox::{MemoryLayout, OptimizeOptions, Program};
+use celox::{LaidOutProgram, MemoryLayout, OptimizeOptions, Program};
 // MemoryLayout imported for SimHandle::layout() return type
 
 /// Initialize panic hook for better error messages in the browser console.
@@ -16,13 +16,17 @@ pub fn init() {
 /// hierarchy) so the JS side can instantiate and drive the simulation.
 #[wasm_bindgen]
 pub struct SimHandle {
-    program: Program,
+    program: LaidOutProgram,
     four_state: bool,
 }
 
 impl SimHandle {
+    fn program(&self) -> &Program {
+        self.program.program()
+    }
+
     fn layout(&self) -> &MemoryLayout {
-        self.program.layout.as_ref().unwrap()
+        self.program.layout()
     }
 }
 
@@ -36,7 +40,7 @@ impl SimHandle {
         let trace_opts = celox::TraceOptions::default();
         let optimize_options = OptimizeOptions::default();
 
-        let (mut program, _warnings) = celox::compile_to_sir(
+        let (program, _warnings) = celox::compile_to_sir(
             &[(source, std::path::Path::new("input.veryl"))],
             top,
             &[],
@@ -52,7 +56,7 @@ impl SimHandle {
         )
         .map_err(|e| JsError::new(&e.to_string()))?;
 
-        program.build_layout(false);
+        let program = program.into_laid_out(false);
 
         Ok(SimHandle {
             program,
@@ -64,7 +68,7 @@ impl SimHandle {
     #[wasm_bindgen(js_name = "combWasmBytes")]
     pub fn comb_wasm_bytes(&self) -> Vec<u8> {
         let wasm = wasm_codegen::compile_units(
-            &self.program.eval_comb,
+            &self.program().eval_comb,
             self.layout(),
             self.four_state,
             false,
@@ -78,8 +82,8 @@ impl SimHandle {
     #[wasm_bindgen(js_name = "eventWasmBytes")]
     pub fn event_wasm_bytes(&self, event_name: &str) -> Result<Vec<u8>, JsError> {
         // Search through eval_apply_ffs to find matching event
-        for (addr, units) in &self.program.eval_apply_ffs {
-            let event_path = self.program.get_path(addr);
+        for (addr, units) in &self.program().eval_apply_ffs {
+            let event_path = self.program().get_path(addr);
             if event_path == event_name {
                 let wasm =
                     wasm_codegen::compile_units(units, self.layout(), self.four_state, false);
@@ -90,10 +94,10 @@ impl SimHandle {
         Err(JsError::new(&format!(
             "Event '{}' not found. Available events: {}",
             event_name,
-            self.program
+            self.program()
                 .eval_apply_ffs
                 .keys()
-                .map(|addr| self.program.get_path(addr))
+                .map(|addr| self.program().get_path(addr))
                 .collect::<Vec<_>>()
                 .join(", ")
         )))
@@ -108,9 +112,9 @@ impl SimHandle {
 
         let mut layout_map: BTreeMap<String, serde_json::Value> = BTreeMap::new();
 
-        for (instance_id, module_id) in &self.program.instance_module {
-            let variables = &self.program.module_variables[module_id];
-            let path_index = &self.program.module_var_path_index[module_id];
+        for (instance_id, module_id) in &self.program().instance_module {
+            let variables = &self.program().module_variables[module_id];
+            let path_index = &self.program().module_var_path_index[module_id];
 
             for info in variables.values() {
                 if path_index.get(&info.path) == Some(&None) {
@@ -157,12 +161,10 @@ impl SimHandle {
         use std::collections::BTreeMap;
 
         let mut events: BTreeMap<String, usize> = BTreeMap::new();
-        let mut next_id = 0usize;
 
-        for addr in self.program.eval_apply_ffs.keys() {
-            let name = self.program.get_path(addr);
+        for (next_id, addr) in self.program().eval_apply_ffs.keys().enumerate() {
+            let name = self.program().get_path(addr);
             events.insert(name, next_id);
-            next_id += 1;
         }
 
         serde_json::to_string(&events).unwrap_or_else(|_| "{}".to_string())

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use bit_set::BitSet;
 use num_bigint::BigUint;
 
-use crate::ir::{AbsoluteAddr, Program, SignalArrayLayout, SignalRef};
+use crate::ir::{AbsoluteAddr, LaidOutProgram, Program, SignalArrayLayout, SignalRef};
 use crate::{HashMap, SimulatorError, SimulatorOptions};
 
 use super::super::RuntimeEventBuffer;
@@ -502,16 +502,14 @@ fn format_native_codegen_trace(
 }
 
 fn compile_program(
-    sir: &Program,
+    laid_out: &LaidOutProgram,
     options: &SimulatorOptions,
     capture_trace: bool,
 ) -> Result<(SharedNativeCode, Option<NativeCodegenTrace>), SimulatorError> {
     const MAX_PARALLEL_NATIVE_FUNCTIONS: usize = 4;
 
-    let layout = sir
-        .layout
-        .as_ref()
-        .expect("layout must be built before backend");
+    let sir = laid_out.program();
+    let layout = laid_out.layout();
     let (compile_tasks, task_bindings) = collect_ff_compile_tasks(sir);
     let next_task = AtomicUsize::new(0);
     let (comb_jit, mut compiled_ff_codes) = std::thread::scope(|scope| {
@@ -747,18 +745,21 @@ pub struct NativeBackend {
 }
 
 impl NativeBackend {
-    pub fn new(sir: &Program, options: &SimulatorOptions) -> Result<Self, SimulatorError> {
-        let (shared, trace) = compile_program(sir, options, false)?;
+    pub fn new(
+        laid_out: &LaidOutProgram,
+        options: &SimulatorOptions,
+    ) -> Result<Self, SimulatorError> {
+        let (shared, trace) = compile_program(laid_out, options, false)?;
         debug_assert!(trace.is_none());
         let shared = Arc::new(shared);
         Ok(Self::from_shared(shared))
     }
 
     pub(crate) fn new_with_codegen_trace(
-        sir: &Program,
+        laid_out: &LaidOutProgram,
         options: &SimulatorOptions,
     ) -> Result<(Self, NativeCodegenTrace), SimulatorError> {
-        let (shared, trace) = compile_program(sir, options, true)?;
+        let (shared, trace) = compile_program(laid_out, options, true)?;
         let backend = Self::from_shared(Arc::new(shared));
         Ok((
             backend,

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -162,25 +162,22 @@ pub struct JitBackend {
 
 impl JitBackend {
     pub fn new(
-        sir: &crate::ir::Program,
+        laid_out: &crate::ir::LaidOutProgram,
         options: &SimulatorOptions,
         trace: Option<&mut crate::debug::CompilationTrace>,
     ) -> Result<Self, crate::SimulatorError> {
-        let shared = Arc::new(Self::compile(sir, options, trace)?);
+        let shared = Arc::new(Self::compile(laid_out, options, trace)?);
         Ok(Self::from_shared(shared))
     }
 
     /// Build the shared JIT code from a Program.
     fn compile(
-        sir: &crate::ir::Program,
+        laid_out: &crate::ir::LaidOutProgram,
         options: &SimulatorOptions,
         mut trace: Option<&mut crate::debug::CompilationTrace>,
     ) -> Result<SharedJitCode, crate::SimulatorError> {
-        let layout = sir
-            .layout
-            .as_ref()
-            .expect("layout must be built before backend")
-            .clone();
+        let sir = laid_out.program();
+        let layout = laid_out.layout().clone();
 
         // Auto-select SinglePass RA for large designs where Backtracking RA's
         // superlinear compile time would dominate. The threshold is half the

--- a/crates/celox/src/backend/wasm_runtime.rs
+++ b/crates/celox/src/backend/wasm_runtime.rs
@@ -15,7 +15,7 @@ use crate::{
             STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET, STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET,
         },
     },
-    ir::{AbsoluteAddr, Program, SignalRef},
+    ir::{AbsoluteAddr, SignalRef},
 };
 
 use super::wasm_codegen;
@@ -152,13 +152,13 @@ pub struct WasmBackend {
 }
 
 impl WasmBackend {
-    pub fn new(sir: &Program, options: &SimulatorOptions) -> Result<Self, crate::SimulatorError> {
+    pub fn new(
+        laid_out: &crate::ir::LaidOutProgram,
+        options: &SimulatorOptions,
+    ) -> Result<Self, crate::SimulatorError> {
         let engine = Engine::default();
-        let layout = sir
-            .layout
-            .as_ref()
-            .expect("layout must be built before backend")
-            .clone();
+        let sir = laid_out.program();
+        let layout = laid_out.layout().clone();
 
         // Compile eval_comb
         let comb_wasm = wasm_codegen::compile_units(

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -140,14 +140,44 @@ pub struct Program {
     /// Memory layout aliases: non-canonical → canonical address.
     /// Variables with identity Store→Load roundtrips share physical memory.
     pub address_aliases: HashMap<AbsoluteAddr, AbsoluteAddr>,
-    /// Pre-computed memory layout. Built after optimization, before backend codegen.
-    pub layout: Option<crate::backend::MemoryLayout>,
     /// Initial memory contents loaded from synthesizable initial blocks.
     pub initial_memory_values: Vec<InitialMemoryValue>,
     /// Initial block statements from the top-level module (for native testbenches).
     pub initial_statements: Option<Vec<veryl_analyzer::ir::Statement>>,
     /// Functions defined in the top-level module (for testbench function calls).
     pub tb_functions: fxhash::FxHashMap<veryl_analyzer::ir::VarId, veryl_analyzer::ir::Function>,
+}
+
+/// A [`Program`] whose physical state layout has been finalized.
+///
+/// Backend code generation accepts this artifact instead of a bare `Program`,
+/// making it impossible to enter code generation before layout construction.
+#[derive(Clone, Debug)]
+pub struct LaidOutProgram {
+    program: Program,
+    layout: crate::backend::MemoryLayout,
+}
+
+impl LaidOutProgram {
+    pub fn program(&self) -> &Program {
+        &self.program
+    }
+
+    pub fn layout(&self) -> &crate::backend::MemoryLayout {
+        &self.layout
+    }
+
+    pub(crate) fn program_mut(&mut self) -> &mut Program {
+        &mut self.program
+    }
+
+    pub fn into_program(self) -> Program {
+        self.program
+    }
+
+    pub fn into_parts(self) -> (Program, crate::backend::MemoryLayout) {
+        (self.program, self.layout)
+    }
 }
 
 impl fmt::Debug for Program {
@@ -159,20 +189,19 @@ impl fmt::Debug for Program {
 }
 
 impl Program {
-    /// Build and store the memory layout. Also removes identity Stores for
-    /// validated aliases and runs DCE to clean up dead instruction chains.
-    pub fn build_layout(&mut self, four_state: bool) {
-        self.build_layout_with_mode(
+    /// Finalize the physical state layout and consume the pre-layout program.
+    pub fn into_laid_out(self, four_state: bool) -> LaidOutProgram {
+        self.into_laid_out_with_mode(
             four_state,
             crate::backend::memory_layout::MemoryLayoutMode::Packed,
-        );
+        )
     }
 
-    pub fn build_layout_with_mode(
-        &mut self,
+    pub fn into_laid_out_with_mode(
+        mut self,
         four_state: bool,
         mode: crate::backend::memory_layout::MemoryLayoutMode,
-    ) {
+    ) -> LaidOutProgram {
         if !self.comb_observers.is_empty() && !self.address_aliases.is_empty() {
             let observed_written: crate::HashSet<AbsoluteAddr> = self
                 .comb_observers
@@ -185,8 +214,8 @@ impl Program {
                 !comb_capture_enable_needs_unaliased_old_value(&self.eval_comb, *alias_addr)
             });
         }
-        crate::optimizer::coalescing::retain_final_identity_aliases(self, four_state);
-        let layout = crate::backend::MemoryLayout::build(self, four_state, mode);
+        crate::optimizer::coalescing::retain_final_identity_aliases(&mut self, four_state);
+        let layout = crate::backend::MemoryLayout::build(&self, four_state, mode);
 
         // Remove identity Stores for aliases validated by the layout
         if !self.address_aliases.is_empty() {
@@ -204,12 +233,15 @@ impl Program {
                 .collect();
             if !aliased.is_empty() {
                 crate::optimizer::coalescing::remove_final_identity_alias_stores(
-                    self, &aliased, four_state,
+                    &mut self, &aliased, four_state,
                 );
             }
         }
 
-        self.layout = Some(layout);
+        LaidOutProgram {
+            program: self,
+            layout,
+        }
     }
 
     pub fn get_addr(

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -59,7 +59,10 @@ pub use debug::CompilationTraceResult;
 pub use debug::{CompilationTrace, NativeProfileBlock, TraceOptions};
 pub(crate) use fxhash::FxHashMap as HashMap;
 pub(crate) use fxhash::FxHashSet as HashSet;
-pub use ir::{AbsoluteAddr, AddrLookupError, PortTypeKind, Program, RuntimeErrorInfo, SignalRef};
+pub use ir::{
+    AbsoluteAddr, AddrLookupError, LaidOutProgram, PortTypeKind, Program, RuntimeErrorInfo,
+    SignalRef,
+};
 #[cfg(target_arch = "x86_64")]
 pub mod native_backend {
     //! Re-exports for the native x86-64 backend (for testing/integration).

--- a/crates/celox/src/optimizer/coalescing/pass_identity_store_bypass.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_identity_store_bypass.rs
@@ -48,7 +48,7 @@ struct GlobalIdentityFacts {
 
 /// Analyze all combinational units before selecting any Program-global address
 /// alias or memory-copy replacement. Alias selection has priority; the
-/// returned stores are still present until `Program::build_layout` validates
+/// returned stores are still present until `Program::into_laid_out` validates
 /// the selected aliases.
 pub(super) fn optimize_program_identity_stores(
     program: &mut Program,

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -1414,7 +1414,6 @@ pub(crate) fn flatten(
                 num_events: 0,
                 reset_clock_map: HashMap::default(),
                 address_aliases: HashMap::default(),
-                layout: None,
                 initial_memory_values: Vec::new(),
                 initial_statements: None,
                 tb_functions: fxhash::FxHashMap::default(),
@@ -1603,7 +1602,6 @@ pub(crate) fn flatten(
         num_events,
         reset_clock_map,
         address_aliases: HashMap::default(),
-        layout: None,
         initial_memory_values,
         initial_statements,
         tb_functions: module_ir

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -560,14 +560,15 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
         }
     }
 
-    /// Compile SIR and return it along with the remaining builder state.
+    /// Compile SIR, finalize its state layout, and return the typed artifact
+    /// along with the remaining builder state.
     /// Consumes self.
-    fn into_sir(
+    fn into_laid_out_program(
         self,
         layout_mode: crate::backend::memory_layout::MemoryLayoutMode,
     ) -> Result<
         (
-            crate::ir::Program,
+            crate::ir::LaidOutProgram,
             Vec<veryl_analyzer::AnalyzerError>,
             SimulatorOptions,
             Option<std::path::PathBuf>,
@@ -609,14 +610,14 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
 
         // Build memory layout (consumes address_aliases for offset sharing)
         let layout_start = phase_timing.then(crate::timing::now);
-        program.build_layout_with_mode(self.options.four_state, layout_mode);
+        let mut laid_out = program.into_laid_out_with_mode(self.options.four_state, layout_mode);
         if let Some(start) = layout_start {
             eprintln!("[phase-timing] build_layout: {:?}", start.elapsed());
         }
 
         if self.options.dead_store_policy != DeadStorePolicy::Off {
             let dse_start = phase_timing.then(crate::timing::now);
-            run_dead_store_elimination(&mut program, &self.live_signals, &self.options);
+            run_dead_store_elimination(laid_out.program_mut(), &self.live_signals, &self.options);
             if let Some(start) = dse_start {
                 eprintln!(
                     "[phase-timing] dead_store_elimination: {:?}",
@@ -625,7 +626,7 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
             }
         }
 
-        Ok((program, warnings, self.options, self.vcd_path))
+        Ok((laid_out, warnings, self.options, self.vcd_path))
     }
 
     /// Compiles the Veryl source and constructs the simulator.
@@ -646,20 +647,24 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
         let phase_timing = std::env::var("CELOX_PHASE_TIMING").is_ok();
         let phase_start = phase_timing.then(crate::timing::now);
 
-        let (program, warnings, options, vcd_path) =
-            self.into_sir(crate::backend::memory_layout::MemoryLayoutMode::Packed)?;
+        let (laid_out, warnings, options, vcd_path) =
+            self.into_laid_out_program(crate::backend::memory_layout::MemoryLayoutMode::Packed)?;
 
         if let Some(s) = phase_start {
-            eprintln!("[phase-timing] compile_to_sir (total): {:?}", s.elapsed());
+            eprintln!(
+                "[phase-timing] compile_and_layout (total): {:?}",
+                s.elapsed()
+            );
         }
 
         let jit_start = phase_timing.then(crate::timing::now);
-        let backend = JitBackend::new(&program, &options, None)?;
+        let backend = JitBackend::new(&laid_out, &options, None)?;
         if let Some(s) = jit_start {
             eprintln!("[phase-timing] jit_backend: {:?}", s.elapsed());
         }
 
-        let mut sim = Simulator::with_backend_and_program(backend, program, warnings);
+        let mut sim =
+            Simulator::with_backend_and_program(backend, laid_out.into_program(), warnings);
         if let Some(path) = vcd_path {
             let descs = sim.build_vcd_descs(options.four_state);
             let vcd_writer = crate::vcd::VcdWriter::new(path, &descs)
@@ -678,17 +683,22 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
     ) -> Result<Simulator<crate::backend::native::NativeBackend>, SimulatorError> {
         let phase_timing = std::env::var_os("CELOX_PHASE_TIMING").is_some();
         let sir_start = phase_timing.then(crate::timing::now);
-        let (program, warnings, options, vcd_path) =
-            self.into_sir(crate::backend::memory_layout::MemoryLayoutMode::ElementStrided)?;
+        let (laid_out, warnings, options, vcd_path) = self.into_laid_out_program(
+            crate::backend::memory_layout::MemoryLayoutMode::ElementStrided,
+        )?;
         if let Some(start) = sir_start {
-            eprintln!("[phase-timing] into_sir total: {:?}", start.elapsed());
+            eprintln!(
+                "[phase-timing] into_laid_out_program total: {:?}",
+                start.elapsed()
+            );
         }
         let backend_start = phase_timing.then(crate::timing::now);
-        let backend = crate::backend::native::NativeBackend::new(&program, &options)?;
+        let backend = crate::backend::native::NativeBackend::new(&laid_out, &options)?;
         if let Some(start) = backend_start {
             eprintln!("[phase-timing] native_backend: {:?}", start.elapsed());
         }
-        let mut sim = Simulator::with_backend_and_program(backend, program, warnings);
+        let mut sim =
+            Simulator::with_backend_and_program(backend, laid_out.into_program(), warnings);
         if let Some(path) = vcd_path {
             let descs = sim.build_vcd_descs(options.four_state);
             let vcd_writer = crate::vcd::VcdWriter::new(path, &descs)
@@ -712,10 +722,11 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
     pub fn build_wasm(
         self,
     ) -> Result<Simulator<crate::backend::wasm_runtime::WasmBackend>, SimulatorError> {
-        let (program, warnings, options, vcd_path) =
-            self.into_sir(crate::backend::memory_layout::MemoryLayoutMode::Packed)?;
-        let backend = crate::backend::wasm_runtime::WasmBackend::new(&program, &options)?;
-        let mut sim = Simulator::with_backend_and_program(backend, program, warnings);
+        let (laid_out, warnings, options, vcd_path) =
+            self.into_laid_out_program(crate::backend::memory_layout::MemoryLayoutMode::Packed)?;
+        let backend = crate::backend::wasm_runtime::WasmBackend::new(&laid_out, &options)?;
+        let mut sim =
+            Simulator::with_backend_and_program(backend, laid_out.into_program(), warnings);
         if let Some(path) = vcd_path {
             let descs = sim.build_vcd_descs(options.four_state);
             let vcd_writer = crate::vcd::VcdWriter::new(path, &descs)
@@ -788,10 +799,15 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
             // Register testbench runtime-event sites before layout fixes the ring geometry.
             crate::testbench::register_runtime_event_sites(&mut program);
 
-            program.build_layout_with_mode(self.options.four_state, layout_mode);
+            let mut laid_out =
+                program.into_laid_out_with_mode(self.options.four_state, layout_mode);
 
             if self.options.dead_store_policy != DeadStorePolicy::Off {
-                run_dead_store_elimination(&mut program, &self.live_signals, &self.options);
+                run_dead_store_elimination(
+                    laid_out.program_mut(),
+                    &self.live_signals,
+                    &self.options,
+                );
             }
 
             #[cfg(target_arch = "x86_64")]
@@ -799,7 +815,7 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
                 if self.options.trace.mir || !self.options.trace.native_profile_blocks.is_empty() {
                     let (backend, native_trace) =
                         crate::backend::native::NativeBackend::new_with_codegen_trace(
-                            &program,
+                            &laid_out,
                             &self.options,
                         )?;
                     trace.native_optimized_sir = Some(native_trace.optimized_sir);
@@ -808,12 +824,13 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
                     trace.native_state_layout = Some(native_trace.state_layout);
                     backend
                 } else {
-                    crate::backend::native::NativeBackend::new(&program, &self.options)?
+                    crate::backend::native::NativeBackend::new(&laid_out, &self.options)?
                 };
             #[cfg(not(target_arch = "x86_64"))]
-            let backend = JitBackend::new(&program, &self.options, None)?;
+            let backend = JitBackend::new(&laid_out, &self.options, None)?;
 
-            let mut sim = Simulator::with_backend_and_program(backend, program, warnings);
+            let mut sim =
+                Simulator::with_backend_and_program(backend, laid_out.into_program(), warnings);
             sim.apply_initial_values();
             sim.modify(|_| {}).map_err(SimulatorError::from)?;
             Ok(sim)
@@ -893,7 +910,7 @@ impl<'a> SimulatorBuilder<'a, crate::Simulation> {
         let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::ElementStrided;
         #[cfg(not(target_arch = "x86_64"))]
         let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::Packed;
-        let (mut program, warnings) = compile_to_sir_with_layout_mode(
+        let (program, warnings) = compile_to_sir_with_layout_mode(
             &self.sources,
             self.top,
             &self.ignored_loops,
@@ -908,17 +925,18 @@ impl<'a> SimulatorBuilder<'a, crate::Simulation> {
             &self.options.optimize_options,
             layout_mode,
         )?;
-        program.build_layout_with_mode(self.options.four_state, layout_mode);
+        let mut laid_out = program.into_laid_out_with_mode(self.options.four_state, layout_mode);
 
         if self.options.dead_store_policy != DeadStorePolicy::Off {
-            run_dead_store_elimination(&mut program, &self.live_signals, &self.options);
+            run_dead_store_elimination(laid_out.program_mut(), &self.live_signals, &self.options);
         }
         #[cfg(target_arch = "x86_64")]
-        let backend = crate::backend::native::NativeBackend::new(&program, &self.options)?;
+        let backend = crate::backend::native::NativeBackend::new(&laid_out, &self.options)?;
         #[cfg(not(target_arch = "x86_64"))]
-        let backend = crate::backend::JitBackend::new(&program, &self.options, None)?;
+        let backend = crate::backend::JitBackend::new(&laid_out, &self.options, None)?;
 
-        let mut sim = Simulator::with_backend_and_program(backend, program, warnings);
+        let mut sim =
+            Simulator::with_backend_and_program(backend, laid_out.into_program(), warnings);
         if let Some(path) = self.vcd_path {
             let descs = sim.build_vcd_descs(self.options.four_state);
             let vcd_writer = crate::vcd::VcdWriter::new(path, &descs)

--- a/crates/celox/tests/wasm_backend.rs
+++ b/crates/celox/tests/wasm_backend.rs
@@ -2,8 +2,8 @@ use celox::{BigUint, SimulatorOptions, WasmBackend};
 
 fn build_wasm(code: &str, top: &str) -> (WasmBackend, celox::Simulator) {
     let sim = celox::Simulator::builder(code, top).build().unwrap();
-    let program = sim.program().clone();
     let opts = SimulatorOptions::default();
+    let program = sim.program().clone().into_laid_out(opts.four_state);
     let backend = WasmBackend::new(&program, &opts).expect("WasmBackend::new failed");
     (backend, sim)
 }

--- a/crates/celox/tests/wasm_regression.rs
+++ b/crates/celox/tests/wasm_regression.rs
@@ -7,8 +7,8 @@ use celox::{BigUint, SimulatorOptions, WasmBackend};
 /// Returns (jit_simulator, wasm_backend).
 fn build_both(code: &str, top: &str) -> (celox::Simulator, WasmBackend) {
     let sim = celox::Simulator::builder(code, top).build().unwrap();
-    let program = sim.program().clone();
     let opts = SimulatorOptions::default();
+    let program = sim.program().clone().into_laid_out(opts.four_state);
     let wasm = WasmBackend::new(&program, &opts).expect("WasmBackend::new failed");
     (sim, wasm)
 }

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -25,7 +25,7 @@ The transformation from Veryl source code to execution consists of the following
     -   **SIR Optimization**: Applies per-pass optimization (store-load forwarding, commit sinking, dead store elimination, instruction scheduling, etc.) controlled by `OptimizeOptions`.
 
 3.  **Backend (Code Generation)**:
-    -   **Memory Layout**: Determines memory offsets for all variables and places them on a single memory buffer with Stable, Working, Triggered-bits, and Scratch regions. Layout is pre-computed in `Program` after optimization, before backend codegen, so all backends share the same layout.
+    -   **Memory Layout**: Determines memory offsets for all variables and places them on a single memory buffer with Stable, Working, Triggered-bits, and Scratch regions. Layout finalization consumes a pre-layout `Program` and produces `LaidOutProgram`; every backend accepts only that typed artifact and therefore shares the same immutable layout.
     -   **Code Generation**: Compiles SIR into executable machine code via one of the available backends.
     -   **Runtime**: Manages compiled function pointers as event handles and executes the simulation.
     -   **Testbench VM** (optional): A stack-based bytecode VM that executes Veryl `initial` blocks and testbench functions. Opcodes include `ConstU64`, `ConstWide`, `LoadU64`, `LoadWide`, `BinOp`, `UnaryOp`, `Ternary`, `LoadIndexed`, `LoadBitSelect`, `StoreU64`, supporting both narrow (≤64-bit) and wide signals.

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -6,6 +6,11 @@ This document defines the target crate architecture and the migration contract f
 current `celox` compiler/runtime monolith. It is a design document, not a claim that the described
 crates already exist.
 
+Migration note: `celox-state-layout` now owns the generic layout algorithm and the compiler driver
+uses a consuming `Program -> LaidOutProgram` transition. The current facade artifact still wraps
+the mixed `Program`; dissolving that payload into the phase-specific target types below remains
+part of Milestone 3.
+
 The baseline is the compiler pipeline on `perf/native-simulation-throughput` after PR #322. The
 split must preserve RTL semantics, generated-code quality, and the public `celox` API while making
 phase ownership explicit.


### PR DESCRIPTION
## Summary

- replace the phase-dependent optional layout field with a consuming Program to LaidOutProgram transition
- require native, Cranelift, and Wasmtime backends to receive the typed laid-out artifact
- update WASM and NAPI consumers and document the transitional Milestone 3 boundary

## Why

Backend constructors previously accepted a bare Program and failed at runtime when layout had not been built. The explicit artifact makes the pre-layout and post-layout phases distinct at the type boundary while preserving the current layout and optimization order.

## Validation

- cargo test -p celox --lib
- cargo test -p celox --test native_exec --test wasm_backend --test wasm_regression
- cargo test -p celox --test data_access --test four_state --test initial_readmem --test native_testbench
- cargo test -p celox-state-layout
- cargo clippy -p celox -p celox-wasm -p celox-napi --all-targets -- -D warnings
- cargo check -p celox-napi --target aarch64-unknown-linux-gnu
- cargo check --workspace --locked
- cargo fmt --all -- --check
- pnpm run lint

The wasm32 target check could not run in this container because clang is not installed; host-side WASM backend tests passed.