### PR TITLE
Extract grouped SIR program artifact

### DIFF
--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1607,7 +1607,7 @@ impl NativeSimulatorHandle {
     #[napi]
     pub fn comb_wasm_bytes(&self) -> Vec<u8> {
         let wasm = celox::wasm_codegen::compile_units(
-            &self.program.eval_comb,
+            &self.program.sir.eval_comb,
             &self.layout,
             self.four_state,
             false,
@@ -1620,7 +1620,7 @@ impl NativeSimulatorHandle {
     /// `event_name` should match a clock or reset port name (e.g. "clk", "rst").
     #[napi]
     pub fn event_wasm_bytes(&self, event_name: String) -> Result<Vec<u8>> {
-        for (addr, units) in &self.program.eval_apply_ffs {
+        for (addr, units) in &self.program.sir.eval_apply_ffs {
             let event_path = self.program.get_path(addr);
             if event_path == event_name {
                 let wasm =
@@ -1633,6 +1633,7 @@ impl NativeSimulatorHandle {
             "Event '{}' not found. Available events: {}",
             event_name,
             self.program
+                .sir
                 .eval_apply_ffs
                 .keys()
                 .map(|addr| self.program.get_path(addr))
@@ -1712,7 +1713,7 @@ impl NativeSimulatorHandle {
         let mut events: BTreeMap<String, usize> = BTreeMap::new();
         let mut next_id = 0usize;
 
-        for addr in program.eval_apply_ffs.keys() {
+        for addr in program.sir.eval_apply_ffs.keys() {
             let name = program.get_path(addr);
             events.insert(name, next_id);
             next_id += 1;

--- a/crates/celox-sir/src/lib.rs
+++ b/crates/celox-sir/src/lib.rs
@@ -20,6 +20,21 @@ pub use transform::{
     merge_sir_eu_refs_with_provenance, merge_sir_eus,
 };
 
+/// Backend-independent executable SIR grouped by simulation phase and event.
+///
+/// This type deliberately contains no frontend arena, optimizer plan, physical
+/// layout, or backend artifact.
+#[derive(Debug, Clone)]
+pub struct SirProgram<EventAddr, StateAddr> {
+    pub eval_comb: Vec<ExecutionUnit<StateAddr>>,
+    pub eval_apply_ffs: HashMap<EventAddr, Vec<ExecutionUnit<StateAddr>>>,
+    /// Native fast path in which required comb values and one FF event were
+    /// scheduled and lowered through the same SIR builder.
+    pub eval_comb_apply_ffs: HashMap<EventAddr, Vec<ExecutionUnit<StateAddr>>>,
+    pub eval_only_ffs: HashMap<EventAddr, Vec<ExecutionUnit<StateAddr>>>,
+    pub apply_ffs: HashMap<EventAddr, Vec<ExecutionUnit<StateAddr>>>,
+}
+
 /// Block identifier
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct BlockId(pub usize);

--- a/crates/celox-wasm/src/lib.rs
+++ b/crates/celox-wasm/src/lib.rs
@@ -68,7 +68,7 @@ impl SimHandle {
     #[wasm_bindgen(js_name = "combWasmBytes")]
     pub fn comb_wasm_bytes(&self) -> Vec<u8> {
         let wasm = wasm_codegen::compile_units(
-            &self.program().eval_comb,
+            &self.program().sir.eval_comb,
             self.layout(),
             self.four_state,
             false,
@@ -82,7 +82,7 @@ impl SimHandle {
     #[wasm_bindgen(js_name = "eventWasmBytes")]
     pub fn event_wasm_bytes(&self, event_name: &str) -> Result<Vec<u8>, JsError> {
         // Search through eval_apply_ffs to find matching event
-        for (addr, units) in &self.program().eval_apply_ffs {
+        for (addr, units) in &self.program().sir.eval_apply_ffs {
             let event_path = self.program().get_path(addr);
             if event_path == event_name {
                 let wasm =
@@ -95,6 +95,7 @@ impl SimHandle {
             "Event '{}' not found. Available events: {}",
             event_name,
             self.program()
+                .sir
                 .eval_apply_ffs
                 .keys()
                 .map(|addr| self.program().get_path(addr))
@@ -162,7 +163,7 @@ impl SimHandle {
 
         let mut events: BTreeMap<String, usize> = BTreeMap::new();
 
-        for (next_id, addr) in self.program().eval_apply_ffs.keys().enumerate() {
+        for (next_id, addr) in self.program().sir.eval_apply_ffs.keys().enumerate() {
             let name = self.program().get_path(addr);
             events.insert(name, next_id);
         }

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -181,12 +181,13 @@ pub(crate) fn collect_strided_array_layouts(
         }
     };
     for eu in program
+        .sir
         .eval_comb
         .iter()
-        .chain(program.eval_apply_ffs.values().flatten())
-        .chain(program.eval_comb_apply_ffs.values().flatten())
-        .chain(program.eval_only_ffs.values().flatten())
-        .chain(program.apply_ffs.values().flatten())
+        .chain(program.sir.eval_apply_ffs.values().flatten())
+        .chain(program.sir.eval_comb_apply_ffs.values().flatten())
+        .chain(program.sir.eval_only_ffs.values().flatten())
+        .chain(program.sir.apply_ffs.values().flatten())
     {
         let mut zero_roots = eu
             .blocks
@@ -228,11 +229,12 @@ fn collect_ff_referenced_addresses(program: &Program) -> crate::HashSet<Absolute
     // scanning the fused form would conservatively reject every useful comb
     // identity alias.
     let ff_eus = program
+        .sir
         .eval_apply_ffs
         .values()
         .flat_map(|v| v.iter())
-        .chain(program.eval_only_ffs.values().flat_map(|v| v.iter()))
-        .chain(program.apply_ffs.values().flat_map(|v| v.iter()));
+        .chain(program.sir.eval_only_ffs.values().flat_map(|v| v.iter()))
+        .chain(program.sir.apply_ffs.values().flat_map(|v| v.iter()));
     for eu in ff_eus {
         for block in eu.blocks.values() {
             for inst in &block.instructions {

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -259,21 +259,21 @@ fn collect_ff_compile_tasks(sir: &Program) -> (Vec<NativeCompileTask<'_>>, Nativ
     let mut task_bindings = HashMap::default();
     collect_ff_compile_tasks_from(
         sir,
-        &sir.eval_apply_ffs,
+        &sir.sir.eval_apply_ffs,
         "eval_apply_ff",
         &mut tasks,
         &mut task_bindings,
     );
     collect_ff_compile_tasks_from(
         sir,
-        &sir.eval_only_ffs,
+        &sir.sir.eval_only_ffs,
         "eval_only_ff",
         &mut tasks,
         &mut task_bindings,
     );
     collect_ff_compile_tasks_from(
         sir,
-        &sir.apply_ffs,
+        &sir.sir.apply_ffs,
         "apply_ff",
         &mut tasks,
         &mut task_bindings,
@@ -288,12 +288,12 @@ fn collect_comb_apply_compile_tasks<'a>(
     task_bindings: &mut NativeTaskBindings,
 ) {
     const LABEL: &str = "eval_comb_apply_ff";
-    for (addr, ff_units) in &sir.eval_apply_ffs {
-        let fused_units = sir.eval_comb_apply_ffs.get(addr);
+    for (addr, ff_units) in &sir.sir.eval_apply_ffs {
+        let fused_units = sir.sir.eval_comb_apply_ffs.get(addr);
         let (unit_refs, first_ff_unit) = if let Some(fused_units) = fused_units {
             (fused_units.iter().collect::<Vec<_>>(), None)
         } else {
-            let mut unit_refs = sir.eval_comb.iter().collect::<Vec<_>>();
+            let mut unit_refs = sir.sir.eval_comb.iter().collect::<Vec<_>>();
             let first_ff_unit =
                 (!unit_refs.is_empty() && !ff_units.is_empty()).then_some(unit_refs.len());
             unit_refs.extend(ff_units);
@@ -517,7 +517,7 @@ fn compile_program(
         let enable_x86_slp = options.optimize_options.x86_slp_enabled();
         let comb_handle = scope.spawn(move || {
             compile_units(
-                &sir.eval_comb,
+                &sir.sir.eval_comb,
                 layout,
                 four_state,
                 "eval_comb",
@@ -653,7 +653,7 @@ fn compile_program(
     };
 
     compile_ff_group(
-        &sir.eval_apply_ffs,
+        &sir.sir.eval_apply_ffs,
         "eval_apply_ff",
         &mut event_map,
         &mut addr_to_id,
@@ -664,7 +664,7 @@ fn compile_program(
         &mut id_to_event,
     )?;
     compile_ff_group(
-        &sir.eval_only_ffs,
+        &sir.sir.eval_only_ffs,
         "eval_only_ff",
         &mut eval_only_event_map,
         &mut addr_to_id,
@@ -675,7 +675,7 @@ fn compile_program(
         &mut id_to_event,
     )?;
     compile_ff_group(
-        &sir.apply_ffs,
+        &sir.sir.apply_ffs,
         "apply_ff",
         &mut apply_event_map,
         &mut addr_to_id,

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -187,11 +187,13 @@ impl JitBackend {
         {
             use crate::optimizer::coalescing::cost_model::*;
             let _comb_cost: usize = sir
+                .sir
                 .eval_comb
                 .iter()
                 .map(|eu| estimate_eu_cost(eu, options.four_state))
                 .sum();
             let comb_vregs: usize = sir
+                .sir
                 .eval_comb
                 .iter()
                 .map(|eu| estimate_eu_value_count(eu, options.four_state))
@@ -247,7 +249,9 @@ impl JitBackend {
             Some(crate::ir::EvalCombPlan::TailCallChunks(chunks)) => {
                 engine.compile_chunks(chunks, pre_clif_ptr, post_clif_ptr, native_ptr)
             }
-            None => engine.compile_units(&sir.eval_comb, pre_clif_ptr, post_clif_ptr, native_ptr),
+            None => {
+                engine.compile_units(&sir.sir.eval_comb, pre_clif_ptr, post_clif_ptr, native_ptr)
+            }
         };
 
         if let Some(t) = trace.as_deref_mut() {
@@ -285,7 +289,7 @@ impl JitBackend {
                 let layout_ref = layout_for_mir.as_ref().unwrap();
 
                 mir_output.push_str("=== MIR (eval_comb) ===\n");
-                for (idx, eu) in sir.eval_comb.iter().enumerate() {
+                for (idx, eu) in sir.sir.eval_comb.iter().enumerate() {
                     let mut mfunc = lower_execution_unit(eu, layout_ref, options.four_state);
                     mir_legalize::legalize(&mut mfunc);
                     mir_opt::optimize(&mut mfunc);
@@ -319,7 +323,7 @@ impl JitBackend {
                     }
                     mir_output.push('\n');
                 }
-                for (addr, units) in &sir.eval_apply_ffs {
+                for (addr, units) in &sir.sir.eval_apply_ffs {
                     mir_output.push_str(&format!(
                         "=== MIR (eval_apply_ffs) Trigger: {} ===\n",
                         sir.get_path(addr)
@@ -432,19 +436,19 @@ impl JitBackend {
         };
 
         let mut event_map = compile_ffs(
-            &sir.eval_apply_ffs,
+            &sir.sir.eval_apply_ffs,
             &mut addr_to_id,
             &mut next_id,
             &mut id_to_addr,
         )?;
         let mut eval_only_event_map = compile_ffs(
-            &sir.eval_only_ffs,
+            &sir.sir.eval_only_ffs,
             &mut addr_to_id,
             &mut next_id,
             &mut id_to_addr,
         )?;
         let mut apply_event_map = compile_ffs(
-            &sir.apply_ffs,
+            &sir.sir.apply_ffs,
             &mut addr_to_id,
             &mut next_id,
             &mut id_to_addr,

--- a/crates/celox/src/backend/wasm_runtime.rs
+++ b/crates/celox/src/backend/wasm_runtime.rs
@@ -162,7 +162,7 @@ impl WasmBackend {
 
         // Compile eval_comb
         let comb_wasm = wasm_codegen::compile_units(
-            &sir.eval_comb,
+            &sir.sir.eval_comb,
             &layout,
             options.four_state,
             options.emit_triggers,
@@ -225,7 +225,7 @@ impl WasmBackend {
         };
 
         compile_ffs(
-            &sir.eval_apply_ffs,
+            &sir.sir.eval_apply_ffs,
             &mut event_modules,
             &mut event_map,
             &mut addr_to_id,
@@ -233,7 +233,7 @@ impl WasmBackend {
             &mut id_to_addr,
         )?;
         compile_ffs(
-            &sir.eval_only_ffs,
+            &sir.sir.eval_only_ffs,
             &mut eval_only_modules,
             &mut eval_only_event_map,
             &mut addr_to_id,
@@ -241,7 +241,7 @@ impl WasmBackend {
             &mut id_to_addr,
         )?;
         compile_ffs(
-            &sir.apply_ffs,
+            &sir.sir.apply_ffs,
             &mut apply_modules,
             &mut apply_event_map,
             &mut addr_to_id,

--- a/crates/celox/src/debug/output.rs
+++ b/crates/celox/src/debug/output.rs
@@ -75,7 +75,7 @@ pub fn format_program(program: &Program) -> String {
     let mut output = String::new();
 
     output.push_str("=== Evaluation Flip-Flops (eval_apply_ffs) ===\n");
-    for (addr, execution_units) in &program.eval_apply_ffs {
+    for (addr, execution_units) in &program.sir.eval_apply_ffs {
         output.push_str(&format!(
             "Trigger Group: {} ({})\n",
             program.get_path(addr),
@@ -112,7 +112,7 @@ pub fn format_program(program: &Program) -> String {
     }
 
     output.push_str("\n=== Evaluation Flip-Flops (eval_only_ffs) ===\n");
-    for (addr, execution_units) in &program.eval_only_ffs {
+    for (addr, execution_units) in &program.sir.eval_only_ffs {
         output.push_str(&format!(
             "Trigger Group: {} ({})\n",
             program.get_path(addr),
@@ -149,7 +149,7 @@ pub fn format_program(program: &Program) -> String {
     }
 
     output.push_str("\n=== Application Flip-Flops (apply_ffs) ===\n");
-    for (addr, execution_units) in &program.apply_ffs {
+    for (addr, execution_units) in &program.sir.apply_ffs {
         output.push_str(&format!(
             "Trigger Group: {} ({})\n",
             program.get_path(addr),
@@ -186,7 +186,7 @@ pub fn format_program(program: &Program) -> String {
     }
 
     output.push_str("\n=== Evaluation Combinational Logic (eval_comb) ===\n");
-    for (idx, eu) in program.eval_comb.iter().enumerate() {
+    for (idx, eu) in program.sir.eval_comb.iter().enumerate() {
         output.push_str(&format!("Execution Unit {}:\n", idx));
         output.push_str(&format!("  Entry Block: {}\n", eu.entry_block_id.0));
         output.push_str("  Registers:\n");

--- a/crates/celox/src/flatting_tests.rs
+++ b/crates/celox/src/flatting_tests.rs
@@ -549,7 +549,7 @@ fn find_stores_to_var(
     var_id: VarId,
 ) -> Vec<StoreInfo> {
     let mut stores = Vec::new();
-    for unit in &program.eval_comb {
+    for unit in &program.sir.eval_comb {
         for block in unit.blocks.values() {
             for inst in &block.instructions {
                 if let crate::ir::SIRInstruction::Store(addr, _, bits, _, _, _) = inst {
@@ -582,5 +582,5 @@ fn test_assign_partial_no_cycle() {
 
     let program = setup_and_parse(code, "Top");
 
-    assert!(!program.eval_comb.is_empty());
+    assert!(!program.sir.eval_comb.is_empty());
 }

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -28,6 +28,7 @@ pub type AbsoluteAddr = AbsoluteAddrBase<VarId>;
 pub type RegionedVarAddr = RegionedVarAddrBase<VarId>;
 /// Concrete regioned address using the Veryl analyzer's `VarId`.
 pub type RegionedAbsoluteAddr = RegionedAbsoluteAddrBase<VarId>;
+pub type SirProgram = celox_sir::SirProgram<AbsoluteAddr, RegionedAbsoluteAddr>;
 
 /// Error returned by [`Program::get_addr`] when a path-based variable lookup fails.
 #[derive(Debug, Clone, thiserror::Error)]
@@ -107,13 +108,7 @@ pub struct CombObserver<A = AbsoluteAddr> {
 
 #[derive(Clone)]
 pub struct Program {
-    pub eval_apply_ffs: HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
-    /// Native fast path in which the required comb LogicPaths and one FF
-    /// domain were scheduled and lowered through the same SIRBuilder.
-    pub eval_comb_apply_ffs: HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
-    pub eval_only_ffs: HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
-    pub apply_ffs: HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
-    pub eval_comb: Vec<ExecutionUnit<RegionedAbsoluteAddr>>,
+    pub sir: SirProgram,
     /// Semantic comb process for each exact published range. Physical
     /// ExecutionUnit boundaries deliberately do not define these regions.
     pub comb_semantic_regions: HashMap<VarAtomBase<AbsoluteAddr>, u64>,
@@ -211,7 +206,7 @@ impl Program {
             self.address_aliases
                 .retain(|alias_addr, _| !observed_written.contains(alias_addr));
             self.address_aliases.retain(|alias_addr, _| {
-                !comb_capture_enable_needs_unaliased_old_value(&self.eval_comb, *alias_addr)
+                !comb_capture_enable_needs_unaliased_old_value(&self.sir.eval_comb, *alias_addr)
             });
         }
         crate::optimizer::coalescing::retain_final_identity_aliases(&mut self, four_state);
@@ -368,10 +363,10 @@ impl Program {
                 }
             };
 
-        scan_units(&self.eval_apply_ffs, &mut addrs);
-        scan_units(&self.eval_comb_apply_ffs, &mut addrs);
-        scan_units(&self.eval_only_ffs, &mut addrs);
-        scan_units(&self.apply_ffs, &mut addrs);
+        scan_units(&self.sir.eval_apply_ffs, &mut addrs);
+        scan_units(&self.sir.eval_comb_apply_ffs, &mut addrs);
+        scan_units(&self.sir.eval_only_ffs, &mut addrs);
+        scan_units(&self.sir.apply_ffs, &mut addrs);
 
         addrs
     }
@@ -379,10 +374,11 @@ impl Program {
     pub fn collect_sparse_working_region_addrs(&self) -> std::collections::HashSet<AbsoluteAddr> {
         let mut addrs = std::collections::HashSet::new();
         for units in self
+            .sir
             .eval_apply_ffs
             .values()
-            .chain(self.eval_comb_apply_ffs.values())
-            .chain(self.eval_only_ffs.values())
+            .chain(self.sir.eval_comb_apply_ffs.values())
+            .chain(self.sir.eval_only_ffs.values())
         {
             for eu in units {
                 for block in eu.blocks.values() {

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -61,7 +61,7 @@ pub(crate) use fxhash::FxHashMap as HashMap;
 pub(crate) use fxhash::FxHashSet as HashSet;
 pub use ir::{
     AbsoluteAddr, AddrLookupError, LaidOutProgram, PortTypeKind, Program, RuntimeErrorInfo,
-    SignalRef,
+    SignalRef, SirProgram,
 };
 #[cfg(target_arch = "x86_64")]
 pub mod native_backend {

--- a/crates/celox/src/optimizer/coalescing.rs
+++ b/crates/celox/src/optimizer/coalescing.rs
@@ -294,7 +294,7 @@ pub(crate) fn optimize_rooted_comb_memory(
         four_state,
         ..PassOptions::default()
     };
-    for eu in &mut program.eval_comb {
+    for eu in &mut program.sir.eval_comb {
         pass_vectorize_concat::remove_dead_definitions(eu);
         pass_guarded_region_sinking::eliminate_dead_control_regions(eu);
         pass_manager::ExecutionUnitPass::run(&ControlFlowSimplifyPass, eu, &options);
@@ -309,11 +309,12 @@ pub(crate) fn optimize_rooted_comb_memory(
     // transformed function instead of compiling stale chunks.
     program.eval_comb_plan = None;
     if enable_tail_split {
-        if let Some(chunks) = pass_tail_call_split::split_if_needed(&program.eval_comb, four_state)
+        if let Some(chunks) =
+            pass_tail_call_split::split_if_needed(&program.sir.eval_comb, four_state)
         {
             program.eval_comb_plan = Some(EvalCombPlan::TailCallChunks(chunks));
         } else if let Some(plan) =
-            pass_tail_call_split::split_if_needed_spilled(&program.eval_comb, four_state)
+            pass_tail_call_split::split_if_needed_spilled(&program.sir.eval_comb, four_state)
         {
             program.eval_comb_plan = Some(EvalCombPlan::MemorySpilled(plan));
         }
@@ -746,7 +747,7 @@ fn optimize_late_comb(
         if std::env::var_os("CELOX_SIR_VERIFY_PASSES").is_none() {
             return;
         }
-        for (unit, eu) in program.eval_comb.iter().enumerate() {
+        for (unit, eu) in program.sir.eval_comb.iter().enumerate() {
             if let Err(error) = crate::parser::verify_memory_offset_contract(program, eu) {
                 panic!("after late comb stage {stage} in unit {unit}: {error}");
             }
@@ -766,6 +767,7 @@ fn optimize_late_comb(
         };
     }
     let branchify_watermarks = program
+        .sir
         .eval_comb
         .iter()
         .map(|eu| eu.blocks.keys().map(|block| block.0).max().unwrap_or(0))
@@ -790,7 +792,7 @@ fn optimize_late_comb(
 
     // Identity-store bypass can make an entire expression DAG dead.
     if opt.opt_level() != crate::optimizer::OptLevel::O0 {
-        for eu in &mut program.eval_comb {
+        for eu in &mut program.sir.eval_comb {
             pass_manager::ExecutionUnitPass::run(&LoopIdiomPass, eu, options);
         }
     }
@@ -801,7 +803,7 @@ fn optimize_late_comb(
     }
     if opt.opt_level() != crate::optimizer::OptLevel::O0 {
         let packed_scatter_store = PackedScatterStorePass::for_program(program);
-        for eu in &mut program.eval_comb {
+        for eu in &mut program.sir.eval_comb {
             pass_manager::ExecutionUnitPass::run(&packed_scatter_store, eu, options);
         }
     }
@@ -812,7 +814,7 @@ fn optimize_late_comb(
     }
     if on(SirPass::IndexedStoreRecovery) {
         let indexed_store_recovery = IndexedStoreRecoveryPass::for_program(program);
-        for eu in &mut program.eval_comb {
+        for eu in &mut program.sir.eval_comb {
             pass_manager::ExecutionUnitPass::run(&indexed_store_recovery, eu, options);
         }
     }
@@ -822,7 +824,7 @@ fn optimize_late_comb(
         eprintln!("[branchify-stats] late indexed");
     }
     if opt.opt_level() != crate::optimizer::OptLevel::O0 {
-        for eu in &mut program.eval_comb {
+        for eu in &mut program.sir.eval_comb {
             pass_manager::ExecutionUnitPass::run(&GuardedRegionSinkingPass, eu, options);
         }
     }
@@ -836,7 +838,7 @@ fn optimize_late_comb(
         if trace {
             eprintln!("[branchify-stats] late sparse constructed");
         }
-        for eu in &mut program.eval_comb {
+        for eu in &mut program.sir.eval_comb {
             pass_manager::ExecutionUnitPass::run(&sparse_case_pass, eu, options);
         }
     }
@@ -849,10 +851,10 @@ fn optimize_late_comb(
     // Recover control dependence created by the program-wide transforms, then
     // repair value placement and correlated merge state on that final CFG.
     if on(SirPass::BranchifyMux) {
-        for (eu, watermark) in program.eval_comb.iter_mut().zip(branchify_watermarks) {
+        for (eu, watermark) in program.sir.eval_comb.iter_mut().zip(branchify_watermarks) {
             pass_branchify_mux::run_late_branchify_mux(eu, options, watermark);
         }
-        for eu in &mut program.eval_comb {
+        for eu in &mut program.sir.eval_comb {
             pass_guarded_region_sinking::sink_pure_values_with_predicate_repair(eu);
             pass_manager::ExecutionUnitPass::run(&PhiOutcomeCompressionPass, eu, options);
         }
@@ -863,14 +865,14 @@ fn optimize_late_comb(
     // Final canonicalization must precede native lowering, which fixes live
     // ranges and spill slots.
     if on(SirPass::Gvn) {
-        for eu in &mut program.eval_comb {
+        for eu in &mut program.sir.eval_comb {
             pass_manager::ExecutionUnitPass::run(&GvnPass, eu, options);
         }
     }
     verify_stage(program, "final GVN");
     checkpoint!("final GVN");
     if on(SirPass::ControlFlowSimplify) {
-        for eu in &mut program.eval_comb {
+        for eu in &mut program.sir.eval_comb {
             pass_manager::ExecutionUnitPass::run(&ControlFlowSimplifyPass, eu, options);
         }
     }
@@ -946,13 +948,13 @@ fn optimize_with_options(
     // Sparse next-state data must stay invisible until every evaluator for the
     // event has sampled STABLE.  Keep the commit in the same unified generated
     // function, but place it in a final EU after all evaluator EUs.
-    move_sparse_commits_to_event_tail(&mut program.eval_apply_ffs);
-    move_sparse_commits_to_event_tail(&mut program.eval_comb_apply_ffs);
+    move_sparse_commits_to_event_tail(&mut program.sir.eval_apply_ffs);
+    move_sparse_commits_to_event_tail(&mut program.sir.eval_comb_apply_ffs);
 
     // 1. Unified Case (Fast Path): Full optimizations are safe.
     let phase_start = timing.then(crate::timing::now);
     if timing {
-        for (trigger, units) in &program.eval_apply_ffs {
+        for (trigger, units) in &program.sir.eval_apply_ffs {
             for (index, eu) in units.iter().enumerate() {
                 let instruction_count: usize = eu
                     .blocks
@@ -1100,11 +1102,15 @@ fn optimize_with_options(
         comb_ff_passes.add_pass(CircularPriorityPass::for_program(program));
     }
 
-    let ff_eu_count: usize = program.eval_apply_ffs.values().map(Vec::len).sum();
-    let comb_ff_eu_count: usize = program.eval_comb_apply_ffs.values().map(Vec::len).sum();
+    let ff_eu_count: usize = program.sir.eval_apply_ffs.values().map(Vec::len).sum();
+    let comb_ff_eu_count: usize = program.sir.eval_comb_apply_ffs.values().map(Vec::len).sum();
     let eu_count = ff_eu_count + comb_ff_eu_count;
-    optimize_unit_groups_cached(&mut program.eval_apply_ffs, &ff_passes, &options);
-    optimize_unit_groups_cached(&mut program.eval_comb_apply_ffs, &comb_ff_passes, &options);
+    optimize_unit_groups_cached(&mut program.sir.eval_apply_ffs, &ff_passes, &options);
+    optimize_unit_groups_cached(
+        &mut program.sir.eval_comb_apply_ffs,
+        &comb_ff_passes,
+        &options,
+    );
 
     // The late comb pipeline must start from the CFG produced by the complete
     // initial pipeline. Keep it in the same exact-equivalence cache: clock
@@ -1122,18 +1128,18 @@ fn optimize_with_options(
         comb_ff_late_passes.add_pass(SplitWideCommitsPass);
     }
     optimize_unit_groups_cached(
-        &mut program.eval_comb_apply_ffs,
+        &mut program.sir.eval_comb_apply_ffs,
         &comb_ff_late_passes,
         &options,
     );
 
     optimize_unified_commit_groups(
-        &mut program.eval_apply_ffs,
+        &mut program.sir.eval_apply_ffs,
         on(SirPass::CommitSinking),
         on(SirPass::InlineCommitForwarding),
     );
     optimize_unified_commit_groups(
-        &mut program.eval_comb_apply_ffs,
+        &mut program.sir.eval_comb_apply_ffs,
         on(SirPass::CommitSinking),
         on(SirPass::InlineCommitForwarding),
     );
@@ -1165,9 +1171,9 @@ fn optimize_with_options(
             max_store_width: max_native_memory_width,
         });
     }
-    optimize_unit_groups_cached(&mut program.eval_apply_ffs, &ff_post_passes, &options);
+    optimize_unit_groups_cached(&mut program.sir.eval_apply_ffs, &ff_post_passes, &options);
     optimize_unit_groups_cached(
-        &mut program.eval_comb_apply_ffs,
+        &mut program.sir.eval_comb_apply_ffs,
         &comb_ff_post_passes,
         &options,
     );
@@ -1226,8 +1232,8 @@ fn optimize_with_options(
         eval_only_passes.add_pass(ReschedulePass);
     }
 
-    let eu_count: usize = program.eval_only_ffs.values().map(|v| v.len()).sum();
-    optimize_unit_groups_cached(&mut program.eval_only_ffs, &eval_only_passes, &options);
+    let eu_count: usize = program.sir.eval_only_ffs.values().map(|v| v.len()).sum();
+    optimize_unit_groups_cached(&mut program.sir.eval_only_ffs, &eval_only_passes, &options);
     if let Some(s) = phase_start {
         eprintln!("[phase] eval_only_ffs ({eu_count} EUs): {:?}", s.elapsed());
     }
@@ -1270,8 +1276,8 @@ fn optimize_with_options(
         apply_passes.add_pass(ReschedulePass);
     }
 
-    let eu_count: usize = program.apply_ffs.values().map(|v| v.len()).sum();
-    for units in program.apply_ffs.values_mut() {
+    let eu_count: usize = program.sir.apply_ffs.values().map(|v| v.len()).sum();
+    for units in program.sir.apply_ffs.values_mut() {
         for eu in units {
             apply_passes.run(eu, &options);
         }
@@ -1369,8 +1375,8 @@ fn optimize_with_options(
         comb_passes.add_pass(DeadCodeEliminationPass);
     }
 
-    let eu_count = program.eval_comb.len();
-    for (i, eu) in program.eval_comb.iter_mut().enumerate() {
+    let eu_count = program.sir.eval_comb.len();
+    for (i, eu) in program.sir.eval_comb.iter_mut().enumerate() {
         if timing {
             let inst_count: usize = eu.blocks.values().map(|b| b.instructions.len()).sum();
             let block_count = eu.blocks.len();
@@ -1384,7 +1390,7 @@ fn optimize_with_options(
 
     optimize_late_comb(program, opt, &options, &unpacked_element_widths);
     if std::env::var_os("CELOX_MUX_CHAIN_STATS").is_some() {
-        dump_mux_chain_stats(&program.eval_comb);
+        dump_mux_chain_stats(&program.sir.eval_comb);
     }
 
     // 5. Tail-call chain splitting for eval_comb.
@@ -1395,7 +1401,7 @@ fn optimize_with_options(
     // Fall back to memory-spilled multi-block splitting if needed.
     if on(SirPass::TailCallSplit) {
         if timing {
-            for (i, eu) in program.eval_comb.iter().enumerate() {
+            for (i, eu) in program.sir.eval_comb.iter().enumerate() {
                 let inst_cost = cost_model::estimate_eu_cost(eu, four_state);
                 let value_count = cost_model::estimate_eu_value_count(eu, four_state);
                 eprintln!(
@@ -1411,7 +1417,8 @@ fn optimize_with_options(
             }
         }
         let split_start = timing.then(crate::timing::now);
-        if let Some(chunks) = pass_tail_call_split::split_if_needed(&program.eval_comb, four_state)
+        if let Some(chunks) =
+            pass_tail_call_split::split_if_needed(&program.sir.eval_comb, four_state)
         {
             if timing {
                 eprintln!(
@@ -1422,7 +1429,7 @@ fn optimize_with_options(
             }
             program.eval_comb_plan = Some(crate::ir::EvalCombPlan::TailCallChunks(chunks));
         } else if let Some(plan) =
-            pass_tail_call_split::split_if_needed_spilled(&program.eval_comb, four_state)
+            pass_tail_call_split::split_if_needed_spilled(&program.sir.eval_comb, four_state)
         {
             if timing {
                 eprintln!(

--- a/crates/celox/src/optimizer/coalescing/pass_dead_store_elimination.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_dead_store_elimination.rs
@@ -19,27 +19,37 @@ pub(crate) fn eliminate_dead_stores(
     let mut dynamic_addrs: HashSet<AbsoluteAddr> = HashSet::default();
 
     let all_eus = program
+        .sir
         .eval_comb
         .iter()
         .chain(
             program
+                .sir
                 .eval_apply_ffs
                 .values()
                 .flat_map(|units| units.iter()),
         )
         .chain(
             program
+                .sir
                 .eval_comb_apply_ffs
                 .values()
                 .flat_map(|units| units.iter()),
         )
         .chain(
             program
+                .sir
                 .eval_only_ffs
                 .values()
                 .flat_map(|units| units.iter()),
         )
-        .chain(program.apply_ffs.values().flat_map(|units| units.iter()));
+        .chain(
+            program
+                .sir
+                .apply_ffs
+                .values()
+                .flat_map(|units| units.iter()),
+        );
 
     for eu in all_eus {
         for block in eu.blocks.values() {
@@ -83,7 +93,7 @@ pub(crate) fn eliminate_dead_stores(
     }
 
     // 2. Remove dead stores from eval_comb.
-    for eu in program.eval_comb.iter_mut() {
+    for eu in program.sir.eval_comb.iter_mut() {
         for block in eu.blocks.values_mut() {
             block.instructions.retain(|inst| {
                 match inst {

--- a/crates/celox/src/optimizer/coalescing/pass_identity_store_bypass.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_identity_store_bypass.rs
@@ -74,7 +74,7 @@ pub(super) fn optimize_program_identity_stores(
     );
 
     optimize_eval_comb_identity_stores(
-        &mut program.eval_comb,
+        &mut program.sir.eval_comb,
         &metadata,
         &blocked_aliases,
         &program.address_aliases,
@@ -138,13 +138,13 @@ pub(crate) fn retain_final_identity_aliases(program: &mut Program, four_state: b
     let mut valid = aliases.keys().copied().collect::<HashSet<_>>();
 
     retain_aliases_valid_for_units(
-        &program.eval_comb,
+        &program.sir.eval_comb,
         &aliases,
         &metadata,
         four_state,
         &mut valid,
     );
-    for units in program.eval_comb_apply_ffs.values() {
+    for units in program.sir.eval_comb_apply_ffs.values() {
         retain_aliases_valid_for_units(units, &aliases, &metadata, four_state, &mut valid);
     }
     program
@@ -164,12 +164,12 @@ pub(crate) fn remove_final_identity_alias_stores(
     }
     let metadata = address_metadata(program);
     remove_proven_alias_stores(
-        &mut program.eval_comb,
+        &mut program.sir.eval_comb,
         validated_aliases,
         &metadata,
         four_state,
     );
-    for units in program.eval_comb_apply_ffs.values_mut() {
+    for units in program.sir.eval_comb_apply_ffs.values_mut() {
         remove_proven_alias_stores(units, validated_aliases, &metadata, four_state);
     }
 }
@@ -811,16 +811,24 @@ fn ff_referenced_addresses(program: &Program) -> HashSet<AbsoluteAddr> {
     // The split FF forms below are retained even when the native fused form is
     // selected and therefore remain the authoritative FF-state inventory.
     let units = program
+        .sir
         .eval_apply_ffs
         .values()
         .flat_map(|units| units.iter())
         .chain(
             program
+                .sir
                 .eval_only_ffs
                 .values()
                 .flat_map(|units| units.iter()),
         )
-        .chain(program.apply_ffs.values().flat_map(|units| units.iter()));
+        .chain(
+            program
+                .sir
+                .apply_ffs
+                .values()
+                .flat_map(|units| units.iter()),
+        );
     for eu in units {
         for block in eu.blocks.values() {
             for inst in &block.instructions {

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -1392,11 +1392,13 @@ pub(crate) fn flatten(
         Err(error) => {
             let (err_vars, err_path_idx) = module_variables(module_ir, config).unwrap_or_default();
             let program = Program {
-                eval_apply_ffs: HashMap::default(),
-                eval_comb_apply_ffs: HashMap::default(),
-                eval_only_ffs: HashMap::default(),
-                apply_ffs: HashMap::default(),
-                eval_comb: Vec::new(),
+                sir: crate::ir::SirProgram {
+                    eval_apply_ffs: HashMap::default(),
+                    eval_comb_apply_ffs: HashMap::default(),
+                    eval_only_ffs: HashMap::default(),
+                    apply_ffs: HashMap::default(),
+                    eval_comb: Vec::new(),
+                },
                 comb_semantic_regions: HashMap::default(),
                 runtime_errors: HashMap::default(),
                 runtime_event_sites: Vec::new(),
@@ -1580,11 +1582,13 @@ pub(crate) fn flatten(
         })
         .collect();
     let program = Program {
-        eval_apply_ffs,
-        eval_comb_apply_ffs,
-        eval_only_ffs,
-        apply_ffs,
-        eval_comb,
+        sir: crate::ir::SirProgram {
+            eval_apply_ffs,
+            eval_comb_apply_ffs,
+            eval_only_ffs,
+            apply_ffs,
+            eval_comb,
+        },
         comb_semantic_regions,
         runtime_errors,
         runtime_event_sites,
@@ -1631,9 +1635,10 @@ pub(crate) fn flatten(
 
     let mut program = program;
     for units in program
+        .sir
         .eval_apply_ffs
         .values_mut()
-        .chain(program.eval_comb_apply_ffs.values_mut())
+        .chain(program.sir.eval_comb_apply_ffs.values_mut())
     {
         for eu in units {
             for bb in eu.blocks.values_mut() {
@@ -1659,7 +1664,7 @@ pub(crate) fn flatten(
             }
         }
     }
-    for units in program.eval_only_ffs.values_mut() {
+    for units in program.sir.eval_only_ffs.values_mut() {
         for eu in units {
             for bb in eu.blocks.values_mut() {
                 for inst in &mut bb.instructions {
@@ -1684,7 +1689,7 @@ pub(crate) fn flatten(
             }
         }
     }
-    for units in program.apply_ffs.values_mut() {
+    for units in program.sir.apply_ffs.values_mut() {
         for eu in units {
             for bb in eu.blocks.values_mut() {
                 for inst in &mut bb.instructions {
@@ -1715,7 +1720,7 @@ pub(crate) fn flatten(
             }
         }
     }
-    for eu in &mut program.eval_comb {
+    for eu in &mut program.sir.eval_comb {
         for bb in eu.blocks.values_mut() {
             for inst in &mut bb.instructions {
                 match inst {
@@ -2125,12 +2130,14 @@ fn expand(
 
 fn verify_program_sir(program: &Program, phase: &'static str) -> Result<(), ParserError> {
     let units = program
+        .sir
         .eval_comb
         .iter()
         .enumerate()
         .map(|(unit, eu)| ("eval_comb", unit, eu))
         .chain(
             program
+                .sir
                 .eval_apply_ffs
                 .values()
                 .flatten()
@@ -2139,6 +2146,7 @@ fn verify_program_sir(program: &Program, phase: &'static str) -> Result<(), Pars
         )
         .chain(
             program
+                .sir
                 .eval_comb_apply_ffs
                 .values()
                 .flatten()
@@ -2147,6 +2155,7 @@ fn verify_program_sir(program: &Program, phase: &'static str) -> Result<(), Pars
         )
         .chain(
             program
+                .sir
                 .eval_only_ffs
                 .values()
                 .flatten()
@@ -2155,6 +2164,7 @@ fn verify_program_sir(program: &Program, phase: &'static str) -> Result<(), Pars
         )
         .chain(
             program
+                .sir
                 .apply_ffs
                 .values()
                 .flatten()

--- a/crates/celox/tests/cost_directed_mux.rs
+++ b/crates/celox/tests/cost_directed_mux.rs
@@ -27,6 +27,7 @@ module Top (
         .build_with_trace();
     let sir = result.trace.pre_optimized_sir.as_ref().unwrap();
     let rendered_sir = sir
+        .sir
         .eval_comb
         .iter()
         .map(|eu| format!("{eu}"))

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -1810,8 +1810,8 @@ fn test_single_clock_optimization() {
     "#;
     let trace = setup_and_trace(code, "Top");
     let program = trace.post_optimized_sir.unwrap();
-    assert!(program.eval_only_ffs.is_empty());
-    assert!(program.apply_ffs.is_empty());
+    assert!(program.sir.eval_only_ffs.is_empty());
+    assert!(program.sir.apply_ffs.is_empty());
 }
 
 #[test]
@@ -1824,8 +1824,8 @@ fn test_multi_clock_no_optimization() {
     "#;
     let trace = setup_and_trace(code, "Top");
     let program = trace.post_optimized_sir.unwrap();
-    assert!(!program.eval_only_ffs.is_empty());
-    assert!(!program.apply_ffs.is_empty());
+    assert!(!program.sir.eval_only_ffs.is_empty());
+    assert!(!program.sir.apply_ffs.is_empty());
 }
 
 #[test]

--- a/crates/celox/tests/native_exec.rs
+++ b/crates/celox/tests/native_exec.rs
@@ -58,7 +58,7 @@ fn compile_and_run_inner(
 
     use celox::native_backend::{emit, isel, jit_mem, regalloc};
 
-    let eu = &sir.eval_comb[0];
+    let eu = &sir.sir.eval_comb[0];
     let mut mfunc = isel::lower_execution_unit(eu, &layout, false);
 
     if debug {
@@ -463,7 +463,7 @@ fn test_debug_let_bitslice_write() {
     use celox::native_backend::{emit, isel, regalloc};
     let layout = celox::MemoryLayout::build(&sir, false, MemoryLayoutMode::ElementStrided);
 
-    for (eu_idx, eu) in sir.eval_comb.iter().enumerate() {
+    for (eu_idx, eu) in sir.sir.eval_comb.iter().enumerate() {
         let mut mfunc = isel::lower_execution_unit(eu, &layout, false);
         eprintln!("=== EU {eu_idx} MIR ===\n{mfunc}");
         let ra = regalloc::run_regalloc(&mut mfunc).unwrap();

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -8,8 +8,9 @@ crates already exist.
 
 Migration note: `celox-state-layout` now owns the generic layout algorithm and the compiler driver
 uses a consuming `Program -> LaidOutProgram` transition. The current facade artifact still wraps
-the mixed `Program`; dissolving that payload into the phase-specific target types below remains
-part of Milestone 3.
+the mixed `Program`, whose execution-unit groups are now held by `celox-sir::SirProgram`.
+Dissolving the remaining design, symbolic, optimizer, and testbench payload into the phase-specific
+target types below remains part of Milestone 3.
 
 The baseline is the compiler pipeline on `perf/native-simulation-throughput` after PR #322. The
 split must preserve RTL semantics, generated-code quality, and the public `celox` API while making


### PR DESCRIPTION
## Summary

- add a generic SirProgram artifact to celox-sir for the five backend-independent execution-unit groups
- move those groups out of the mixed facade Program and make all parser, optimizer, layout, trace, and backend accesses explicit through Program.sir
- keep optimizer plans, SLT state, design metadata, physical layout, and testbench data outside SirProgram

## Why

The mixed Program still owned executable SIR beside unrelated compiler phases. This extraction gives the SIR crate ownership of the executable unit groups without recreating the entire mixed Program under another name.

## Validation

- cargo test -p celox-sir
- cargo test -p celox --lib
- cargo test -p celox --test native_exec --test wasm_backend --test wasm_regression --test cost_directed_mux
- cargo test -p celox --test data_access --test four_state --test initial_readmem --test native_testbench
- cargo clippy -p celox-sir -p celox -p celox-wasm -p celox-napi --all-targets -- -D warnings
- cargo check -p celox-napi --target aarch64-unknown-linux-gnu
- cargo check --workspace --locked
- cargo fmt --all -- --check
- pnpm run lint