### PR TITLE
Move Cranelift planning behind backend boundary

### DIFF
--- a/crates/celox-state-layout/src/lib.rs
+++ b/crates/celox-state-layout/src/lib.rs
@@ -92,7 +92,6 @@ pub struct LayoutInput<A> {
     pub address_aliases: Vec<(A, A)>,
     pub ff_referenced_addresses: HashSet<A>,
     pub num_events: usize,
-    pub scratch_bytes: usize,
     pub runtime_event_sites: Vec<RuntimeEventSite>,
 }
 
@@ -165,7 +164,6 @@ where
             mut address_aliases,
             ff_referenced_addresses,
             num_events,
-            scratch_bytes,
             runtime_event_sites,
         } = input;
 
@@ -310,7 +308,7 @@ where
         let scratch_base_offset = align_up(triggered_bits_offset + triggered_bits_total_size, 8);
         let runtime_event_buffer_size =
             RUNTIME_EVENT_HEADER_SIZE + RUNTIME_EVENT_CAPACITY * runtime_event_slot_size;
-        let merged_total_size = align_up(scratch_base_offset + scratch_bytes, 8);
+        let merged_total_size = scratch_base_offset;
 
         address_aliases.sort_unstable();
         for (alias, canonical) in address_aliases {
@@ -349,12 +347,21 @@ where
             triggered_bits_offset,
             triggered_bits_total_size,
             scratch_base_offset,
-            scratch_size: scratch_bytes,
+            scratch_size: 0,
             runtime_event_capacity: RUNTIME_EVENT_CAPACITY,
             runtime_event_slot_size,
             runtime_event_buffer_size,
             runtime_event_site_layouts,
         }
+    }
+
+    /// Append backend-private scratch storage without changing any semantic
+    /// state offset. Backend planning happens after the backend-neutral state
+    /// layout has been finalized, so scratch is always the final region.
+    pub fn with_backend_scratch(mut self, scratch_size: usize) -> Self {
+        self.scratch_size = scratch_size;
+        self.merged_total_size = align_up(self.scratch_base_offset + scratch_size, 8);
+        self
     }
 
     pub fn plane_size(&self, address: &A) -> usize {
@@ -500,19 +507,53 @@ mod tests {
     }
 
     #[test]
+    fn backend_scratch_only_extends_the_final_layout_region() {
+        struct EmptyLayoutSource;
+
+        impl LayoutSource<u32> for EmptyLayoutSource {
+            fn layout_input(&self, _mode: MemoryLayoutMode) -> LayoutInput<u32> {
+                LayoutInput {
+                    state_objects: Vec::new(),
+                    working_addresses: Vec::new(),
+                    sparse_addresses: Vec::new(),
+                    unpacked_arrays: HashMap::default(),
+                    address_aliases: Vec::new(),
+                    ff_referenced_addresses: HashSet::default(),
+                    num_events: 3,
+                    runtime_event_sites: Vec::new(),
+                }
+            }
+        }
+
+        let base = MemoryLayout::build(&EmptyLayoutSource, false, MemoryLayoutMode::Packed);
+        let expanded = base.clone().with_backend_scratch(13);
+
+        assert_eq!(base.scratch_size, 0);
+        assert_eq!(expanded.scratch_base_offset, base.scratch_base_offset);
+        assert_eq!(expanded.scratch_size, 13);
+        assert_eq!(expanded.merged_total_size, base.scratch_base_offset + 16);
+        assert_eq!(expanded.offsets, base.offsets);
+        assert_eq!(expanded.working_offsets, base.working_offsets);
+        assert_eq!(expanded.triggered_bits_offset, base.triggered_bits_offset);
+    }
+
+    #[test]
     #[cfg(target_arch = "x86_64")]
     fn state_header_fields_do_not_overlap() {
-        assert!(
-            STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET + 8 <= STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET
-        );
-        assert!(
-            STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET + 8
-                <= STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET
-        );
-        assert!(
-            STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET + 8
-                <= STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET
-        );
-        assert!(STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET + 8 <= STATE_HEADER_SIZE);
+        const {
+            assert!(
+                STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET + 8
+                    <= STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET
+            );
+            assert!(
+                STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET + 8
+                    <= STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET
+            );
+            assert!(
+                STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET + 8
+                    <= STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET
+            );
+            assert!(STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET + 8 <= STATE_HEADER_SIZE);
+        }
     }
 }

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -21,10 +21,6 @@ pub type MemoryLayout = celox_state_layout::MemoryLayout<AbsoluteAddr>;
 
 impl LayoutSource<AbsoluteAddr> for Program {
     fn layout_input(&self, mode: MemoryLayoutMode) -> LayoutInput<AbsoluteAddr> {
-        let scratch_bytes = match &self.eval_comb_plan {
-            Some(crate::ir::EvalCombPlan::MemorySpilled(plan)) => plan.scratch_bytes,
-            _ => 0,
-        };
         let unpacked_arrays = if mode == MemoryLayoutMode::ElementStrided {
             collect_strided_array_layouts(self)
         } else {
@@ -62,7 +58,6 @@ impl LayoutSource<AbsoluteAddr> for Program {
                 .collect(),
             ff_referenced_addresses: collect_ff_referenced_addresses(self),
             num_events: self.num_events(),
-            scratch_bytes,
             runtime_event_sites: self.runtime_schema.runtime_event_sites.clone(),
         }
     }

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -160,6 +160,84 @@ pub struct JitBackend {
     comb_func: SimFunc,
 }
 
+/// Cranelift-only lowering plan for an oversized `eval_comb` function.
+///
+/// This is deliberately constructed at the backend boundary: it contains
+/// concrete CLIF chunking decisions and must never become part of SIR or the
+/// backend-neutral state layout.
+enum CraneliftEvalCombPlan {
+    Unsplit,
+    TailCallChunks(Vec<crate::optimizer::coalescing::TailCallChunk>),
+    MemorySpilled(crate::optimizer::coalescing::pass_tail_call_split::MemorySpilledPlan),
+}
+
+impl CraneliftEvalCombPlan {
+    fn build(sir: &crate::ir::Program, options: &SimulatorOptions) -> Self {
+        if !options
+            .optimize_options
+            .is_enabled(crate::optimizer::SirPass::TailCallSplit)
+        {
+            return Self::Unsplit;
+        }
+
+        let timing = std::env::var_os("CELOX_OPT_TIMING").is_some();
+        if timing {
+            use crate::optimizer::coalescing::cost_model::{
+                CLIF_INST_THRESHOLD, VREG_VALUE_THRESHOLD, estimate_eu_cost,
+                estimate_eu_value_count,
+            };
+            for (i, eu) in sir.sir.eval_comb.iter().enumerate() {
+                let inst_cost = estimate_eu_cost(eu, options.four_state);
+                let value_count = estimate_eu_value_count(eu, options.four_state);
+                eprintln!(
+                    "[split-check] eval_comb eu[{i}]: blocks={} insts={} clif_cost={inst_cost}/{CLIF_INST_THRESHOLD} values={value_count}/{VREG_VALUE_THRESHOLD}",
+                    eu.blocks.len(),
+                    eu.blocks
+                        .values()
+                        .map(|block| block.instructions.len())
+                        .sum::<usize>(),
+                );
+            }
+        }
+
+        let split_start = timing.then(crate::timing::now);
+        use crate::optimizer::coalescing::pass_tail_call_split;
+        if let Some(chunks) =
+            pass_tail_call_split::split_if_needed(&sir.sir.eval_comb, options.four_state)
+        {
+            if let Some(start) = split_start {
+                eprintln!(
+                    "[split] TailCallChunks: {} chunks, took {:?}",
+                    chunks.len(),
+                    start.elapsed()
+                );
+            }
+            Self::TailCallChunks(chunks)
+        } else if let Some(plan) =
+            pass_tail_call_split::split_if_needed_spilled(&sir.sir.eval_comb, options.four_state)
+        {
+            if let Some(start) = split_start {
+                eprintln!(
+                    "[split] MemorySpilled: {} chunks, scratch={}B, took {:?}",
+                    plan.chunks.len(),
+                    plan.scratch_bytes,
+                    start.elapsed()
+                );
+            }
+            Self::MemorySpilled(plan)
+        } else {
+            Self::Unsplit
+        }
+    }
+
+    fn scratch_size(&self) -> usize {
+        match self {
+            Self::MemorySpilled(plan) => plan.scratch_bytes,
+            Self::Unsplit | Self::TailCallChunks(_) => 0,
+        }
+    }
+}
+
 impl JitBackend {
     pub fn new(
         laid_out: &crate::ir::LaidOutProgram,
@@ -177,7 +255,6 @@ impl JitBackend {
         mut trace: Option<&mut crate::debug::CompilationTrace>,
     ) -> Result<SharedJitCode, crate::SimulatorError> {
         let sir = laid_out.program();
-        let layout = laid_out.layout().clone();
 
         // Auto-select SinglePass RA for large designs where Backtracking RA's
         // superlinear compile time would dominate. The threshold is half the
@@ -212,6 +289,12 @@ impl JitBackend {
             }
         }
 
+        let eval_comb_plan = CraneliftEvalCombPlan::build(sir, &options);
+        let layout = laid_out
+            .layout()
+            .clone()
+            .with_backend_scratch(eval_comb_plan.scratch_size());
+
         #[cfg(target_arch = "x86_64")]
         let layout_for_mir = if options.trace.mir {
             Some(layout.clone())
@@ -240,16 +323,16 @@ impl JitBackend {
             (None, None, None)
         };
 
-        // Batch compile eval_comb — use chunked compilation if the optimizer
-        // determined that the combined CLIF would exceed Cranelift's instruction limit.
-        let res = match &sir.eval_comb_plan {
-            Some(crate::ir::EvalCombPlan::MemorySpilled(plan)) => {
+        // Batch compile eval_comb, using the backend-local chunking plan when
+        // the combined CLIF would exceed Cranelift's instruction limit.
+        let res = match &eval_comb_plan {
+            CraneliftEvalCombPlan::MemorySpilled(plan) => {
                 engine.compile_spilled_chunks(plan, pre_clif_ptr, post_clif_ptr, native_ptr)
             }
-            Some(crate::ir::EvalCombPlan::TailCallChunks(chunks)) => {
+            CraneliftEvalCombPlan::TailCallChunks(chunks) => {
                 engine.compile_chunks(chunks, pre_clif_ptr, post_clif_ptr, native_ptr)
             }
-            None => {
+            CraneliftEvalCombPlan::Unsplit => {
                 engine.compile_units(&sir.sir.eval_comb, pre_clif_ptr, post_clif_ptr, native_ptr)
             }
         };

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -75,16 +75,6 @@ impl fmt::Debug for VariableInfo {
     }
 }
 
-/// Compilation plan for eval_comb when the CLIF instruction count exceeds
-/// Cranelift's limit. Mutually exclusive strategies.
-#[derive(Debug, Clone)]
-pub enum EvalCombPlan {
-    /// EU-boundary / single-block splitting with live regs in tail-call args.
-    TailCallChunks(Vec<crate::optimizer::coalescing::TailCallChunk>),
-    /// Memory-spilled multi-block splitting with scratch memory.
-    MemorySpilled(crate::optimizer::coalescing::pass_tail_call_split::MemorySpilledPlan),
-}
-
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct LogicPathId(pub usize);
 
@@ -114,9 +104,6 @@ pub struct Program {
     pub comb_semantic_regions: HashMap<VarAtomBase<AbsoluteAddr>, u64>,
     pub runtime_schema: RuntimeSchema<AbsoluteAddr>,
     pub comb_observers: Vec<CombObserver<AbsoluteAddr>>,
-    /// Tail-call chain compilation plan, populated by the optimizer when the
-    /// estimated CLIF instruction count exceeds Cranelift's limit.
-    pub eval_comb_plan: Option<EvalCombPlan>,
     pub instance_ids: HashMap<InstancePath, InstanceId>,
     pub instance_module: HashMap<InstanceId, ModuleId>,
     pub module_variables: HashMap<ModuleId, HashMap<VarId, VariableInfo>>,

--- a/crates/celox/src/optimizer.rs
+++ b/crates/celox/src/optimizer.rs
@@ -101,7 +101,8 @@ impl CraneliftOptions {
 /// via [`OptimizeOptions::enable`] / [`OptimizeOptions::disable`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum OptLevel {
-    /// No SIR optimizations except [`SirPass::TailCallSplit`].
+    /// No semantic SIR optimizations. The compatibility
+    /// [`SirPass::TailCallSplit`] selector is consumed only by Cranelift.
     /// Cranelift: `fast_compile()`. DSE: Off.
     O0,
     /// Production-default SIR optimizations enabled, including conservative
@@ -179,6 +180,8 @@ pub enum SirPass {
     SplitCoalescedStores,
     PartialForward,
     IdentityStoreBypass,
+    /// Compatibility selector for Cranelift oversized-function planning.
+    /// This is not a SIR transform and is consumed at the backend boundary.
     TailCallSplit,
 }
 

--- a/crates/celox/src/optimizer/coalescing.rs
+++ b/crates/celox/src/optimizer/coalescing.rs
@@ -287,7 +287,6 @@ pub(crate) fn optimize_rooted_comb_memory(
     program: &mut Program,
     externally_live: &crate::HashSet<AbsoluteAddr>,
     four_state: bool,
-    enable_tail_split: bool,
 ) {
     pass_dead_store_elimination::eliminate_dead_stores(program, externally_live);
     let options = PassOptions {
@@ -303,21 +302,6 @@ pub(crate) fn optimize_rooted_comb_memory(
         pass_guarded_region_sinking::eliminate_dead_control_regions(eu);
         pass_manager::ExecutionUnitPass::run(&ControlFlowSimplifyPass, eu, &options);
         pass_vectorize_concat::remove_dead_definitions(eu);
-    }
-
-    // The old plan refers to the pre-DSE EUs. Rebuild it from the
-    // transformed function instead of compiling stale chunks.
-    program.eval_comb_plan = None;
-    if enable_tail_split {
-        if let Some(chunks) =
-            pass_tail_call_split::split_if_needed(&program.sir.eval_comb, four_state)
-        {
-            program.eval_comb_plan = Some(EvalCombPlan::TailCallChunks(chunks));
-        } else if let Some(plan) =
-            pass_tail_call_split::split_if_needed_spilled(&program.sir.eval_comb, four_state)
-        {
-            program.eval_comb_plan = Some(EvalCombPlan::MemorySpilled(plan));
-        }
     }
 }
 
@@ -1391,65 +1375,5 @@ fn optimize_with_options(
     optimize_late_comb(program, opt, &options, &unpacked_element_widths);
     if std::env::var_os("CELOX_MUX_CHAIN_STATS").is_some() {
         dump_mux_chain_stats(&program.sir.eval_comb);
-    }
-
-    // 5. Tail-call chain splitting for eval_comb.
-    // When the estimated CLIF instruction count exceeds Cranelift's limit,
-    // split into a chain of smaller functions connected by tail calls.
-    //
-    // Try EU-boundary / single-block splitting first (zero live-reg cost).
-    // Fall back to memory-spilled multi-block splitting if needed.
-    if on(SirPass::TailCallSplit) {
-        if timing {
-            for (i, eu) in program.sir.eval_comb.iter().enumerate() {
-                let inst_cost = cost_model::estimate_eu_cost(eu, four_state);
-                let value_count = cost_model::estimate_eu_value_count(eu, four_state);
-                eprintln!(
-                    "[split-check] eval_comb eu[{i}]: blocks={} insts={} clif_cost={inst_cost}/{} values={value_count}/{}",
-                    eu.blocks.len(),
-                    eu.blocks
-                        .values()
-                        .map(|b| b.instructions.len())
-                        .sum::<usize>(),
-                    cost_model::CLIF_INST_THRESHOLD,
-                    cost_model::VREG_VALUE_THRESHOLD,
-                );
-            }
-        }
-        let split_start = timing.then(crate::timing::now);
-        if let Some(chunks) =
-            pass_tail_call_split::split_if_needed(&program.sir.eval_comb, four_state)
-        {
-            if timing {
-                eprintln!(
-                    "[split] TailCallChunks: {} chunks, took {:?}",
-                    chunks.len(),
-                    split_start.unwrap().elapsed()
-                );
-            }
-            program.eval_comb_plan = Some(crate::ir::EvalCombPlan::TailCallChunks(chunks));
-        } else if let Some(plan) =
-            pass_tail_call_split::split_if_needed_spilled(&program.sir.eval_comb, four_state)
-        {
-            if timing {
-                eprintln!(
-                    "[split] MemorySpilled: {} chunks, scratch={}B, took {:?}",
-                    plan.chunks.len(),
-                    plan.scratch_bytes,
-                    split_start.unwrap().elapsed()
-                );
-                for (i, chunk) in plan.chunks.iter().enumerate() {
-                    let blocks = chunk.eu.blocks.len();
-                    let insts: usize = chunk.eu.blocks.values().map(|b| b.instructions.len()).sum();
-                    eprintln!(
-                        "[split]   chunk[{i}]: blocks={blocks} insts={insts} in_spills={} out_spills={} cross_edges={}",
-                        chunk.incoming_spills.len(),
-                        chunk.outgoing_spills.len(),
-                        chunk.cross_chunk_edges.len()
-                    );
-                }
-            }
-            program.eval_comb_plan = Some(crate::ir::EvalCombPlan::MemorySpilled(plan));
-        }
     }
 }

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -1402,7 +1402,6 @@ pub(crate) fn flatten(
                 comb_semantic_regions: HashMap::default(),
                 runtime_schema: celox_design::RuntimeSchema::default(),
                 comb_observers: Vec::new(),
-                eval_comb_plan: None,
                 instance_ids: expanded.clone(),
                 instance_module: instance_modules.clone(),
                 module_variables: err_vars,
@@ -1594,7 +1593,6 @@ pub(crate) fn flatten(
             runtime_event_sites,
         },
         comb_observers,
-        eval_comb_plan: None,
         instance_ids: expanded,
         instance_module: instance_modules,
         module_variables: mod_vars,
@@ -2552,8 +2550,9 @@ pub fn parse(
         verify_program_sir(&program, "before optimization")
     )?;
 
-    // Always run the optimizer — even at O0, individual passes (e.g. TailCallSplit)
-    // may be enabled and need to execute.
+    // Always run the SIR pipeline so required canonicalization and explicit
+    // per-pass overrides are applied consistently. Concrete backend planning
+    // (including Cranelift function splitting) happens after this phase.
     timed_phase!("optimize", {
         if preserve_element_storage_layout {
             crate::optimizer::optimize_preserving_element_storage(

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -1012,8 +1012,5 @@ fn run_dead_store_elimination(
         program,
         &externally_live,
         options.four_state,
-        options
-            .optimize_options
-            .is_enabled(crate::optimizer::SirPass::TailCallSplit),
     );
 }

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -9,9 +9,10 @@ crates already exist.
 Migration note: `celox-state-layout` now owns the generic layout algorithm and the compiler driver
 uses a consuming `Program -> LaidOutProgram` transition. The current facade artifact still wraps
 the mixed `Program`, whose execution-unit groups are now held by `celox-sir::SirProgram` and whose
-runtime diagnostics are held by `celox-design::RuntimeSchema`. Dissolving the remaining design,
-symbolic, optimizer, and testbench payload into the phase-specific target types below remains part
-of Milestone 3.
+runtime diagnostics are held by `celox-design::RuntimeSchema`. Cranelift oversized-function
+planning is now constructed from final SIR at the backend boundary; backend scratch extends only
+the backend's private layout copy. Dissolving the remaining design, symbolic, optimizer, and
+testbench payload into the phase-specific target types below remains part of Milestone 3.
 
 The baseline is the compiler pipeline on `perf/native-simulation-throughput` after PR #322. The
 split must preserve RTL semantics, generated-code quality, and the public `celox` API while making
@@ -22,7 +23,7 @@ phase ownership explicit.
 The problem is not merely that several source files are large. The current ownership graph has
 cycles hidden by Rust modules inside one crate.
 
-`ir::Program` currently owns all of the following at once:
+At the start of this migration, `ir::Program` owned all of the following at once:
 
 - scheduled and lowered SIR execution units;
 - the SLT arena and combinational observers that still refer to `NodeId`;
@@ -35,14 +36,14 @@ cycles hidden by Rust modules inside one crate.
 This creates concrete reverse dependencies:
 
 - `ir` refers to `logic_tree`, `optimizer`, and `backend::MemoryLayout`;
-- `optimizer` accepts `Program`, calls parser verification, and writes optimizer-specific plans
+- `optimizer` accepted `Program`, called parser verification, and wrote optimizer-specific plans
   back into `Program`;
-- `backend::memory_layout` accepts `Program` and inspects optimizer plans;
+- `backend::memory_layout` accepted `Program` and inspected optimizer plans;
 - SLT construction imports parser and Veryl expression helpers, while SLT lowering emits SIR;
 - the facade, compiler driver, backend selection, runtime, and testbench VM all live in `celox`.
 
 The result is one mutable object whose valid fields depend on which phase happened to run. An
-`Option<MemoryLayout>` and an `Option<EvalCombPlan>` encode pipeline state implicitly, and a backend
+`Option<MemoryLayout>` and the former `Option<EvalCombPlan>` encoded pipeline state implicitly, and a backend
 can see frontend structures that should have ceased to exist before code generation.
 
 The split must therefore dissolve `Program`; moving directories into crates without changing that
@@ -413,7 +414,7 @@ optional testbench bytecode. It has no compiler IR.
 | runtime errors and event sites | design/runtime schema |
 | `address_aliases` | `LayoutRequirements` with proof identity |
 | `layout: Option<MemoryLayout>` | separate `LaidOutProgram` |
-| `eval_comb_plan` | concrete backend planning result |
+| former `eval_comb_plan` | Cranelift-private planning result, constructed from final SIR at the backend boundary |
 | initial memory values | design initial state, then laid-out memory image |
 | Veryl `initial_statements` and `tb_functions` | compiled by frontend into `celox-testbench` bytecode |
 


### PR DESCRIPTION
Follows #341.

## Summary
- remove `EvalCombPlan` from the mixed `Program` and generic SIR optimization pipeline
- construct oversized-function chunking from final SIR at the Cranelift backend boundary
- keep backend scratch out of semantic layout input and append it only to Cranelift's private layout copy
- cover the scratch-extension invariant and update the crate architecture migration contract

## Validation
- `cargo test -p celox-state-layout --lib`
- `cargo test -p celox --lib`
- `cargo test -p celox --test issue3_repro test_multi_bit_mux_condition_four_state_cranelift`
- `cargo test -p celox --test fuzz_cross_validate`
- `cargo test -p celox --test data_access`
- `cargo test -p celox --test four_state`
- `cargo clippy -p celox-state-layout -p celox --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- pre-push hook