### PR TITLE
Extract source-independent elaborated design

### DIFF
--- a/crates/celox-design/src/lib.rs
+++ b/crates/celox-design/src/lib.rs
@@ -115,6 +115,69 @@ impl<A> Default for RuntimeSchema<A> {
     }
 }
 
+/// Source-independent event-domain topology after elaboration.
+///
+/// Addresses are already flattened. Source paths and frontend IDs used only
+/// for diagnostics or lookup deliberately live outside this structure.
+#[derive(Clone, Debug)]
+pub struct EventTopology<A> {
+    /// Alias event address to the canonical event-domain address.
+    pub aliases: HashMap<A, A>,
+    /// Canonical event domains in evaluation order.
+    pub ordered_events: Vec<A>,
+    /// Canonical clocks whose value may be changed by another event domain.
+    pub cascaded_events: BTreeSet<A>,
+    /// Canonical asynchronous/synchronous reset to its canonical clock.
+    pub reset_clocks: HashMap<A, A>,
+}
+
+impl<A> Default for EventTopology<A> {
+    fn default() -> Self {
+        Self {
+            aliases: HashMap::default(),
+            ordered_events: Vec::new(),
+            cascaded_events: BTreeSet::new(),
+            reset_clocks: HashMap::default(),
+        }
+    }
+}
+
+impl<A: Copy + Eq + std::hash::Hash> EventTopology<A> {
+    pub fn canonical(&self, address: A) -> A {
+        self.aliases.get(&address).copied().unwrap_or(address)
+    }
+
+    pub fn len(&self) -> usize {
+        self.ordered_events.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ordered_events.is_empty()
+    }
+}
+
+/// Backend-neutral semantic design data after hierarchy flattening.
+///
+/// This is intentionally not a frontend lookup table: every state object is
+/// keyed by its flattened semantic address, and no source-language AST or path
+/// type is retained.
+#[derive(Clone, Debug)]
+pub struct ElaboratedDesign<A> {
+    pub state_objects: HashMap<A, VariableMetadata>,
+    pub events: EventTopology<A>,
+    pub initial_state: Vec<InitialStateValue<A>>,
+}
+
+impl<A> Default for ElaboratedDesign<A> {
+    fn default() -> Self {
+        Self {
+            state_objects: HashMap::default(),
+            events: EventTopology::default(),
+            initial_state: Vec::new(),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum BinaryOp {
     Add,
@@ -499,5 +562,28 @@ mod tests {
 
         assert_eq!(metadata.width, 32);
         assert_eq!(metadata.array_dims, vec![4]);
+    }
+
+    #[test]
+    fn elaborated_design_uses_flat_addresses_and_canonical_event_topology() {
+        let mut design = ElaboratedDesign::<u32>::default();
+        design.state_objects.insert(
+            10,
+            VariableMetadata {
+                width: 1,
+                is_4state: false,
+                kind: DomainKind::ClockPosedge,
+                type_kind: PortTypeKind::Clock,
+                array_dims: Vec::new(),
+            },
+        );
+        design.events.aliases.insert(11, 10);
+        design.events.ordered_events.push(10);
+
+        assert_eq!(design.events.canonical(11), 10);
+        assert_eq!(design.events.canonical(12), 12);
+        assert_eq!(design.events.len(), 1);
+        assert!(!design.events.is_empty());
+        assert_eq!(design.state_objects[&10].width, 1);
     }
 }

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -27,19 +27,13 @@ impl LayoutSource<AbsoluteAddr> for Program {
             HashMap::default()
         };
         let state_objects = self
-            .instance_module
+            .design
+            .state_objects
             .iter()
-            .flat_map(|(instance_id, module_id)| {
-                self.module_variables[module_id]
-                    .values()
-                    .map(move |info| StateObjectLayout {
-                        address: AbsoluteAddr {
-                            instance_id: *instance_id,
-                            var_id: info.id,
-                        },
-                        width: info.width,
-                        is_4state: info.is_4state,
-                    })
+            .map(|(&address, metadata)| StateObjectLayout {
+                address,
+                width: metadata.width,
+                is_4state: metadata.is_4state,
             })
             .collect();
 
@@ -65,28 +59,23 @@ impl LayoutSource<AbsoluteAddr> for Program {
 
 fn declared_strided_array_layouts(program: &Program) -> HashMap<AbsoluteAddr, UnpackedArrayLayout> {
     let mut layouts = HashMap::default();
-    for (instance_id, module_id) in &program.instance_module {
-        for info in program.module_variables[module_id].values() {
-            let element_count = info.array_dims.iter().copied().product::<usize>();
-            if element_count <= 1 || info.width % element_count != 0 {
-                continue;
-            }
-            let element_width = info.width / element_count;
-            let element_bytes = get_byte_size(element_width);
-            let element_stride = element_bytes;
-            layouts.insert(
-                AbsoluteAddr {
-                    instance_id: *instance_id,
-                    var_id: info.id,
-                },
-                UnpackedArrayLayout {
-                    element_width,
-                    element_count,
-                    element_stride,
-                    plane_size: element_stride * element_count,
-                },
-            );
+    for (&address, metadata) in &program.design.state_objects {
+        let element_count = metadata.array_dims.iter().copied().product::<usize>();
+        if element_count <= 1 || metadata.width % element_count != 0 {
+            continue;
         }
+        let element_width = metadata.width / element_count;
+        let element_bytes = get_byte_size(element_width);
+        let element_stride = element_bytes;
+        layouts.insert(
+            address,
+            UnpackedArrayLayout {
+                element_width,
+                element_count,
+                element_stride,
+                plane_size: element_stride * element_count,
+            },
+        );
     }
     for (&alias, &canonical) in &program.address_aliases {
         layouts.remove(&alias);

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -610,7 +610,7 @@ fn compile_program(
                             id_to_event: &mut Vec<NativeEventRef>|
      -> Result<(), SimulatorError> {
         for addr in ff_map.keys() {
-            let canonical = sir.clock_domains.get(addr).copied().unwrap_or(*addr);
+            let canonical = sir.design.events.canonical(*addr);
             if let Some(&event) = event_map_out.get(&canonical) {
                 event_map_out.insert(*addr, event);
                 continue;

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -542,7 +542,7 @@ impl JitBackend {
         let _ = compile_ffs;
 
         // Insert clock_domains aliases so every event signal resolves
-        for (alias, canonical) in &sir.clock_domains {
+        for (alias, canonical) in &sir.design.events.aliases {
             if let Some(&ev) = event_map.get(canonical) {
                 event_map.insert(*alias, ev);
             }
@@ -575,9 +575,11 @@ impl JitBackend {
         if options.four_state {
             for (addr, &offset) in &engine.translator.layout.offsets {
                 let width = engine.translator.layout.widths[addr];
-                let is_4state = sir.module_variables[&sir.instance_module[&addr.instance_id]]
-                    .get(&addr.var_id)
-                    .map(|v| v.is_4state)
+                let is_4state = sir
+                    .design
+                    .state_objects
+                    .get(addr)
+                    .map(|metadata| metadata.is_4state)
                     .unwrap_or(false);
 
                 if is_4state {
@@ -588,9 +590,11 @@ impl JitBackend {
             for (addr, &rel_offset) in &engine.translator.layout.working_offsets {
                 let offset = engine.translator.layout.working_base_offset + rel_offset;
                 let width = engine.translator.layout.widths[addr];
-                let is_4state = sir.module_variables[&sir.instance_module[&addr.instance_id]]
-                    .get(&addr.var_id)
-                    .map(|v| v.is_4state)
+                let is_4state = sir
+                    .design
+                    .state_objects
+                    .get(addr)
+                    .map(|metadata| metadata.is_4state)
                     .unwrap_or(false);
 
                 if is_4state {

--- a/crates/celox/src/backend/wasm_runtime.rs
+++ b/crates/celox/src/backend/wasm_runtime.rs
@@ -193,7 +193,7 @@ impl WasmBackend {
                            id_to_addr: &mut Vec<AbsoluteAddr>|
          -> Result<(), crate::SimulatorError> {
             for (clock, units) in ff_map {
-                let canonical = sir.clock_domains.get(clock).copied().unwrap_or(*clock);
+                let canonical = sir.design.events.canonical(*clock);
                 let id = *addr_to_id.entry(canonical).or_insert_with(|| {
                     let id = *next_id;
                     *next_id += 1;
@@ -250,7 +250,7 @@ impl WasmBackend {
         )?;
 
         // Insert clock domain aliases
-        for (alias, canonical) in &sir.clock_domains {
+        for (alias, canonical) in &sir.design.events.aliases {
             if let Some(ev) = event_map.get(canonical).cloned() {
                 event_map.insert(*alias, ev);
             }
@@ -267,9 +267,11 @@ impl WasmBackend {
         if options.four_state {
             for (addr, &offset) in &layout.offsets {
                 let width = layout.widths[addr];
-                let is_4state = sir.module_variables[&sir.instance_module[&addr.instance_id]]
-                    .get(&addr.var_id)
-                    .map(|v| v.is_4state)
+                let is_4state = sir
+                    .design
+                    .state_objects
+                    .get(addr)
+                    .map(|metadata| metadata.is_4state)
                     .unwrap_or(false);
                 if is_4state {
                     four_state_inits.push((offset, get_byte_size(width)));
@@ -278,9 +280,11 @@ impl WasmBackend {
             for (addr, &rel_offset) in &layout.working_offsets {
                 let offset = layout.working_base_offset + rel_offset;
                 let width = layout.widths[addr];
-                let is_4state = sir.module_variables[&sir.instance_module[&addr.instance_id]]
-                    .get(&addr.var_id)
-                    .map(|v| v.is_4state)
+                let is_4state = sir
+                    .design
+                    .state_objects
+                    .get(addr)
+                    .map(|metadata| metadata.is_4state)
                     .unwrap_or(false);
                 if is_4state {
                     four_state_inits.push((offset, get_byte_size(width)));

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -18,7 +18,6 @@ pub(crate) use celox_sir::{
     SirMergeProvenance, inline_single_predecessor_jumps, merge_sir_eu_refs_with_provenance,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
 use std::fmt;
 use veryl_analyzer::ir::{VarId, VarPath, Variable};
 
@@ -99,6 +98,7 @@ pub struct CombObserver<A = AbsoluteAddr> {
 #[derive(Clone)]
 pub struct Program {
     pub sir: SirProgram,
+    pub design: celox_design::ElaboratedDesign<AbsoluteAddr>,
     /// Semantic comb process for each exact published range. Physical
     /// ExecutionUnit boundaries deliberately do not define these regions.
     pub comb_semantic_regions: HashMap<VarAtomBase<AbsoluteAddr>, u64>,
@@ -111,18 +111,10 @@ pub struct Program {
     /// `None` marks ambiguous paths (multiple VarIds share the same VarPath).
     pub module_var_path_index: HashMap<ModuleId, HashMap<VarPath, Option<VarId>>>,
     pub module_names: HashMap<ModuleId, StrId>,
-    pub clock_domains: HashMap<AbsoluteAddr, AbsoluteAddr>,
-    pub topological_clocks: Vec<AbsoluteAddr>,
-    pub cascaded_clocks: BTreeSet<AbsoluteAddr>,
     pub arena: SLTNodeArena<AbsoluteAddr>,
-    pub num_events: usize,
-    /// Maps reset AbsoluteAddr → clock AbsoluteAddr (from FfDeclaration).
-    pub reset_clock_map: HashMap<AbsoluteAddr, AbsoluteAddr>,
     /// Memory layout aliases: non-canonical → canonical address.
     /// Variables with identity Store→Load roundtrips share physical memory.
     pub address_aliases: HashMap<AbsoluteAddr, AbsoluteAddr>,
-    /// Initial memory contents loaded from synthesizable initial blocks.
-    pub initial_memory_values: Vec<InitialMemoryValue>,
     /// Initial block statements from the top-level module (for native testbenches).
     pub initial_statements: Option<Vec<veryl_analyzer::ir::Statement>>,
     /// Functions defined in the top-level module (for testbench function calls).
@@ -164,7 +156,7 @@ impl LaidOutProgram {
 impl fmt::Debug for Program {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Program")
-            .field("num_events", &self.num_events)
+            .field("num_events", &self.design.events.len())
             .finish_non_exhaustive()
     }
 }
@@ -311,7 +303,42 @@ impl Program {
     }
 
     pub fn num_events(&self) -> usize {
-        self.num_events
+        self.design.events.len()
+    }
+
+    /// Verify the temporary migration projection from frontend lookup tables
+    /// into the source-independent elaborated design. This can be removed once
+    /// the frontend tables are consumed rather than retained beside `design`.
+    pub(crate) fn verify_design_projection(&self) -> Result<(), String> {
+        let expected_count = self
+            .instance_module
+            .values()
+            .map(|module_id| self.module_variables[module_id].len())
+            .sum::<usize>();
+        if self.design.state_objects.len() != expected_count {
+            return Err(format!(
+                "state object count differs: design={} frontend={expected_count}",
+                self.design.state_objects.len()
+            ));
+        }
+
+        for (&instance_id, module_id) in &self.instance_module {
+            for info in self.module_variables[module_id].values() {
+                let address = AbsoluteAddr {
+                    instance_id,
+                    var_id: info.id,
+                };
+                let Some(metadata) = self.design.state_objects.get(&address) else {
+                    return Err(format!("missing flattened state object {address}"));
+                };
+                if metadata != &info.metadata {
+                    return Err(format!(
+                        "metadata differs for flattened state object {address}"
+                    ));
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Collect the set of `AbsoluteAddr` values that are accessed in the working

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -53,7 +53,7 @@ pub use backend::wasm_runtime::WasmBackend;
 pub use backend::{EventHandle, MemoryLayout, MemoryLayoutMode, get_byte_size};
 #[cfg(not(target_arch = "wasm32"))]
 pub use backend::{JitBackend, SimBackend};
-pub use celox_design::RuntimeSchema;
+pub use celox_design::{ElaboratedDesign, EventTopology, RuntimeSchema};
 pub use celox_macros::veryl_test;
 #[cfg(not(target_arch = "wasm32"))]
 pub use debug::CompilationTraceResult;

--- a/crates/celox/src/optimizer/coalescing/pass_identity_store_bypass.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_identity_store_bypass.rs
@@ -66,12 +66,7 @@ pub(super) fn optimize_program_identity_stores(
             .iter()
             .flat_map(|observer| observer.written_inputs.iter().copied()),
     );
-    blocked_aliases.extend(
-        program
-            .initial_memory_values
-            .iter()
-            .map(|init| init.address),
-    );
+    blocked_aliases.extend(program.design.initial_state.iter().map(|init| init.address));
 
     optimize_eval_comb_identity_stores(
         &mut program.sir.eval_comb,

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -1399,6 +1399,7 @@ pub(crate) fn flatten(
                     apply_ffs: HashMap::default(),
                     eval_comb: Vec::new(),
                 },
+                design: celox_design::ElaboratedDesign::default(),
                 comb_semantic_regions: HashMap::default(),
                 runtime_schema: celox_design::RuntimeSchema::default(),
                 comb_observers: Vec::new(),
@@ -1407,14 +1408,8 @@ pub(crate) fn flatten(
                 module_variables: err_vars,
                 module_var_path_index: err_path_idx,
                 module_names: module_names.clone(),
-                clock_domains: HashMap::default(),
-                topological_clocks: Vec::new(),
-                cascaded_clocks: BTreeSet::new(),
                 arena: SLTNodeArena::new(),
-                num_events: 0,
-                reset_clock_map: HashMap::default(),
                 address_aliases: HashMap::default(),
-                initial_memory_values: Vec::new(),
                 initial_statements: None,
                 tb_functions: fxhash::FxHashMap::default(),
             };
@@ -1562,7 +1557,6 @@ pub(crate) fn flatten(
         if stmts.is_empty() { None } else { Some(stmts) }
     });
 
-    let num_events = topological_clocks.len();
     let (mod_vars, mod_path_idx) = module_variables(module_ir, config)?;
     let initial_memory_values = instance_modules
         .iter()
@@ -1579,6 +1573,20 @@ pub(crate) fn flatten(
                 })
         })
         .collect();
+    let state_objects = instance_modules
+        .iter()
+        .flat_map(|(&instance_id, module_id)| {
+            mod_vars[module_id].values().map(move |info| {
+                (
+                    AbsoluteAddr {
+                        instance_id,
+                        var_id: info.id,
+                    },
+                    info.metadata.clone(),
+                )
+            })
+        })
+        .collect();
     let program = Program {
         sir: crate::ir::SirProgram {
             eval_apply_ffs,
@@ -1586,6 +1594,16 @@ pub(crate) fn flatten(
             eval_only_ffs,
             apply_ffs,
             eval_comb,
+        },
+        design: celox_design::ElaboratedDesign {
+            state_objects,
+            events: celox_design::EventTopology {
+                aliases: clock_domains,
+                ordered_events: topological_clocks,
+                cascaded_events: cascaded_clocks,
+                reset_clocks: reset_clock_map,
+            },
+            initial_state: initial_memory_values,
         },
         comb_semantic_regions,
         runtime_schema: celox_design::RuntimeSchema {
@@ -1598,14 +1616,8 @@ pub(crate) fn flatten(
         module_variables: mod_vars,
         module_var_path_index: mod_path_idx,
         module_names,
-        clock_domains,
-        topological_clocks,
-        cascaded_clocks,
         arena: global_arena,
-        num_events,
-        reset_clock_map,
         address_aliases: HashMap::default(),
-        initial_memory_values,
         initial_statements,
         tb_functions: module_ir
             .get(root_id)
@@ -1616,19 +1628,15 @@ pub(crate) fn flatten(
     // --- Trigger Injection ---
     let mut trigger_map: HashMap<AbsoluteAddr, Vec<crate::ir::TriggerIdWithKind>> =
         HashMap::default();
-    let module_vars = &program.module_variables;
-    for (id, addr) in program.topological_clocks.iter().enumerate() {
-        if let Some(module_id) = program.instance_module.get(&addr.instance_id) {
-            if let Some(vars) = module_vars.get(module_id) {
-                // Find variable info by var_id
-                if let Some(info) = vars.get(&addr.var_id) {
-                    let kind = info.kind;
-                    trigger_map
-                        .entry(*addr)
-                        .or_default()
-                        .push(crate::ir::TriggerIdWithKind { kind, id });
-                }
-            }
+    for (id, addr) in program.design.events.ordered_events.iter().enumerate() {
+        if let Some(metadata) = program.design.state_objects.get(addr) {
+            trigger_map
+                .entry(*addr)
+                .or_default()
+                .push(crate::ir::TriggerIdWithKind {
+                    kind: metadata.kind,
+                    id,
+                });
         }
     }
 
@@ -1645,14 +1653,14 @@ pub(crate) fn flatten(
                     match inst {
                         crate::ir::SIRInstruction::Store(addr, _, _, _, triggers, _) => {
                             let abs = addr.absolute_addr();
-                            let canonical = program.clock_domains.get(&abs).copied().unwrap_or(abs);
+                            let canonical = program.design.events.canonical(abs);
                             if let Some(ts) = trigger_map.get(&canonical) {
                                 *triggers = ts.clone();
                             }
                         }
                         crate::ir::SIRInstruction::Commit(_, dst, .., triggers) => {
                             let abs = dst.absolute_addr();
-                            let canonical = program.clock_domains.get(&abs).copied().unwrap_or(abs);
+                            let canonical = program.design.events.canonical(abs);
                             if let Some(ts) = trigger_map.get(&canonical) {
                                 *triggers = ts.clone();
                             }
@@ -1670,14 +1678,14 @@ pub(crate) fn flatten(
                     match inst {
                         crate::ir::SIRInstruction::Store(addr, _, _, _, triggers, _) => {
                             let abs = addr.absolute_addr();
-                            let canonical = program.clock_domains.get(&abs).copied().unwrap_or(abs);
+                            let canonical = program.design.events.canonical(abs);
                             if let Some(ts) = trigger_map.get(&canonical) {
                                 *triggers = ts.clone();
                             }
                         }
                         crate::ir::SIRInstruction::Commit(_, dst, .., triggers) => {
                             let abs = dst.absolute_addr();
-                            let canonical = program.clock_domains.get(&abs).copied().unwrap_or(abs);
+                            let canonical = program.design.events.canonical(abs);
                             if let Some(ts) = trigger_map.get(&canonical) {
                                 *triggers = ts.clone();
                             }
@@ -1695,7 +1703,7 @@ pub(crate) fn flatten(
                     match inst {
                         crate::ir::SIRInstruction::Store(addr, ..) => {
                             let abs = addr.absolute_addr();
-                            let canonical = program.clock_domains.get(&abs).copied().unwrap_or(abs);
+                            let canonical = program.design.events.canonical(abs);
                             if let Some(ts) = trigger_map.get(&canonical) {
                                 if let crate::ir::SIRInstruction::Store(_, _, _, _, triggers, _) =
                                     inst
@@ -1706,7 +1714,7 @@ pub(crate) fn flatten(
                         }
                         crate::ir::SIRInstruction::Commit(_, dst, ..) => {
                             let abs = dst.absolute_addr();
-                            let canonical = program.clock_domains.get(&abs).copied().unwrap_or(abs);
+                            let canonical = program.design.events.canonical(abs);
                             if let Some(ts) = trigger_map.get(&canonical) {
                                 if let crate::ir::SIRInstruction::Commit(.., triggers) = inst {
                                     *triggers = ts.clone();
@@ -1725,14 +1733,14 @@ pub(crate) fn flatten(
                 match inst {
                     crate::ir::SIRInstruction::Store(addr, _, _, _, triggers, _) => {
                         let abs = addr.absolute_addr();
-                        let canonical = program.clock_domains.get(&abs).copied().unwrap_or(abs);
+                        let canonical = program.design.events.canonical(abs);
                         if let Some(ts) = trigger_map.get(&canonical) {
                             *triggers = ts.clone();
                         }
                     }
                     crate::ir::SIRInstruction::Commit(_, dst, .., triggers) => {
                         let abs = dst.absolute_addr();
-                        let canonical = program.clock_domains.get(&abs).copied().unwrap_or(abs);
+                        let canonical = program.design.events.canonical(abs);
                         if let Some(ts) = trigger_map.get(&canonical) {
                             *triggers = ts.clone();
                         }
@@ -2128,6 +2136,9 @@ fn expand(
 }
 
 fn verify_program_sir(program: &Program, phase: &'static str) -> Result<(), ParserError> {
+    program.verify_design_projection().map_err(|detail| {
+        ParserError::illegal_context("elaborated design projection", detail, None)
+    })?;
     let units = program
         .sir
         .eval_comb

--- a/crates/celox/src/simulation.rs
+++ b/crates/celox/src/simulation.rs
@@ -80,7 +80,9 @@ impl<B: SimBackend> Simulation<B> {
         let num_events = simulator.backend.num_events();
         let topo_signals: Vec<(SignalRef, usize, usize)> = simulator
             .program
-            .topological_clocks
+            .design
+            .events
+            .ordered_events
             .iter()
             .map(|addr| {
                 let signal = simulator.backend.resolve_signal(addr);
@@ -89,12 +91,7 @@ impl<B: SimBackend> Simulation<B> {
                     .resolve_event_opt(addr)
                     .map(|ev| ev.id())
                     .unwrap_or(usize::MAX);
-                let canonical = simulator
-                    .program
-                    .clock_domains
-                    .get(addr)
-                    .copied()
-                    .unwrap_or(*addr);
+                let canonical = simulator.program.design.events.canonical(*addr);
                 let canonical_id = simulator
                     .backend
                     .resolve_event_opt(&canonical)
@@ -136,14 +133,14 @@ impl<B: SimBackend> Simulation<B> {
         ];
         for (id, info) in event_info.iter_mut().enumerate() {
             let addr = simulator.backend.id_to_addr_slice()[id];
-            let canonical = simulator
-                .program
-                .clock_domains
-                .get(&addr)
-                .copied()
-                .unwrap_or(addr);
+            let canonical = simulator.program.design.events.canonical(addr);
 
-            let is_cascaded = simulator.program.cascaded_clocks.contains(&canonical);
+            let is_cascaded = simulator
+                .program
+                .design
+                .events
+                .cascaded_events
+                .contains(&canonical);
 
             let eval_ff_event = simulator.backend.resolve_event_opt(&canonical);
             let eval_only_event = simulator.backend.resolve_eval_only_event(&canonical);

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -569,7 +569,7 @@ impl<B: SimBackend> Simulator<B> {
 
     pub(crate) fn apply_initial_values(&mut self) {
         let mut applied = false;
-        let initial_memory_values = std::mem::take(&mut self.program.initial_memory_values);
+        let initial_memory_values = std::mem::take(&mut self.program.design.initial_state);
         for init in &initial_memory_values {
             applied = true;
             let signal = self.backend.resolve_signal(&init.address);
@@ -602,7 +602,7 @@ impl<B: SimBackend> Simulator<B> {
         if applied {
             self.dirty = true;
         }
-        self.program.initial_memory_values = initial_memory_values;
+        self.program.design.initial_state = initial_memory_values;
     }
 
     fn apply_initial_memory_writes(&mut self, signal: SignalRef, runs: &[InitialMemoryWriteRun]) {
@@ -1281,7 +1281,9 @@ impl<B: SimBackend> Simulator<B> {
             // Resolve associated clock for reset signals
             let associated_clock = self
                 .program
-                .reset_clock_map
+                .design
+                .events
+                .reset_clocks
                 .get(&addr)
                 .map(|clock_addr| self.program.get_path(clock_addr));
 

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -9,10 +9,12 @@ crates already exist.
 Migration note: `celox-state-layout` now owns the generic layout algorithm and the compiler driver
 uses a consuming `Program -> LaidOutProgram` transition. The current facade artifact still wraps
 the mixed `Program`, whose execution-unit groups are now held by `celox-sir::SirProgram` and whose
-runtime diagnostics are held by `celox-design::RuntimeSchema`. Cranelift oversized-function
-planning is now constructed from final SIR at the backend boundary; backend scratch extends only
-the backend's private layout copy. Dissolving the remaining design, symbolic, optimizer, and
-testbench payload into the phase-specific target types below remains part of Milestone 3.
+flattened state metadata, event topology, and initial state are held by
+`celox-design::ElaboratedDesign`. Runtime diagnostics are held by
+`celox-design::RuntimeSchema`. Cranelift oversized-function planning is constructed from final SIR
+at the backend boundary; backend scratch extends only the backend's private layout copy.
+Dissolving the remaining frontend lookup, symbolic, optimizer, and testbench payload into the
+phase-specific target types below remains part of Milestone 3.
 
 The baseline is the compiler pipeline on `perf/native-simulation-throughput` after PR #322. The
 split must preserve RTL semantics, generated-code quality, and the public `celox` API while making
@@ -356,8 +358,10 @@ Cargo features may remove optional dependencies; they must not reverse these edg
 
 ### `ElaboratedDesign`
 
-Contains hierarchy, semantic state objects, clocks/resets, initial values, runtime event schema, and
-source maps required for diagnostics. It contains no SLT/SIR/layout/backend plan.
+Contains semantic hierarchy identities, flattened semantic state objects, clocks/resets, initial
+values, and runtime event schema. Source-language paths and IDs used for diagnostics or public
+lookup stay in a separate frontend/facade lookup artifact. It contains no SLT/SIR/layout/backend
+plan.
 
 ### `SymbolicRtl`
 
@@ -410,7 +414,8 @@ optional testbench bytecode. It has no compiler IR.
 | `eval_comb`, `eval_*_ffs`, `eval_comb_apply_ffs` | `SirProgram` |
 | `comb_semantic_regions` | `ScheduledRtl`, then explicit SIR provenance if still needed |
 | `arena`, `comb_observers` containing `NodeId` | `SymbolicRtl`; consumed before `SirProgram` |
-| hierarchy/module/variable/clock/reset maps | `ElaboratedDesign` |
+| semantic hierarchy/state/clock/reset maps | `ElaboratedDesign` |
+| Veryl module, variable, and path lookup maps | temporary frontend/facade lookup artifact, then compiled diagnostics |
 | runtime errors and event sites | design/runtime schema |
 | `address_aliases` | `LayoutRequirements` with proof identity |
 | `layout: Option<MemoryLayout>` | separate `LaidOutProgram` |


### PR DESCRIPTION
Stacked on #342.

## Summary
- add `celox-design::ElaboratedDesign` with flattened state metadata, event topology, and initial state
- move clock/reset topology and initial state out of the mixed `Program` fields
- make layout and native/Cranelift/WASM runtime consume flattened design metadata rather than Veryl module tables
- verify the temporary frontend-to-design projection at parser phase boundaries
- document the separate frontend lookup boundary

## Validation
- `cargo test -p celox-design --lib`
- `cargo test -p celox --lib`
- `cargo test -p celox --test multi_clock`
- `cargo test -p celox --test initial_readmem`
- `cargo test -p celox --test wasm_regression`
- `cargo test -p celox --test native_testbench`
- `cargo test -p celox backend::memory_layout`
- `cargo test -p celox --test data_access`
- `cargo clippy -p celox-design -p celox --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- pre-push hook