### PR TITLE
Extract Veryl frontend lookup artifact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,7 @@ dependencies = [
  "bit-set 0.11.1",
  "celox-analysis",
  "celox-design",
+ "celox-frontend-veryl",
  "celox-macros",
  "celox-sir",
  "celox-state-layout",
@@ -468,6 +469,16 @@ dependencies = [
  "fxhash",
  "num-bigint",
  "serde",
+]
+
+[[package]]
+name = "celox-frontend-veryl"
+version = "0.18.0"
+dependencies = [
+ "celox-design",
+ "fxhash",
+ "veryl-analyzer",
+ "veryl-parser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/celox",
     "crates/celox-analysis",
     "crates/celox-design",
+    "crates/celox-frontend-veryl",
     "crates/celox-sir",
     "crates/celox-state-layout",
     "crates/celox-bench-sv",

--- a/crates/celox-frontend-veryl/Cargo.toml
+++ b/crates/celox-frontend-veryl/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name                  = "celox-frontend-veryl"
+version.workspace     = true
+authors.workspace     = true
+repository.workspace  = true
+license.workspace     = true
+description           = "Veryl frontend artifacts and source lookup for Celox"
+edition.workspace     = true
+
+[dependencies]
+celox-design   = { path = "../celox-design" }
+fxhash         = { workspace = true }
+veryl-analyzer = { workspace = true }
+veryl-parser   = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/celox-frontend-veryl/src/lib.rs
+++ b/crates/celox-frontend-veryl/src/lib.rs
@@ -1,0 +1,80 @@
+//! Veryl-owned frontend artifacts.
+//!
+//! Types in this crate may retain Veryl source identities for diagnostics and
+//! public path lookup. Semantic design and backend phases must not depend on
+//! them.
+
+use celox_design::{InstanceId, ModuleId, VariableMetadata};
+use fxhash::FxHashMap as HashMap;
+use std::fmt;
+use veryl_analyzer::ir::{VarId, VarPath};
+use veryl_parser::resource_table::StrId;
+
+#[derive(Clone)]
+pub struct VariableInfo {
+    pub id: VarId,
+    pub path: VarPath,
+    pub var_kind: veryl_analyzer::ir::VarKind,
+    pub metadata: VariableMetadata,
+}
+
+impl std::ops::Deref for VariableInfo {
+    type Target = VariableMetadata;
+
+    fn deref(&self) -> &Self::Target {
+        &self.metadata
+    }
+}
+
+impl fmt::Debug for VariableInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VariableInfo")
+            .field("width", &self.width)
+            .field("id", &self.id)
+            .field("is_4state", &self.is_4state)
+            .field("kind", &self.kind)
+            .field("type_kind", &self.type_kind)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct InstancePath(pub Vec<(StrId, usize)>);
+
+/// Veryl source identities retained by the facade for diagnostics and public
+/// path lookup. Compiler phases after elaboration should consume flattened
+/// `celox-design` identities instead.
+#[derive(Clone, Default)]
+pub struct VerylFrontendLookup {
+    pub instance_ids: HashMap<InstancePath, InstanceId>,
+    pub instance_module: HashMap<InstanceId, ModuleId>,
+    pub module_variables: HashMap<ModuleId, HashMap<VarId, VariableInfo>>,
+    /// Reverse index from source path to source variable ID. `None` marks a
+    /// path that is ambiguous within the module.
+    pub module_var_path_index: HashMap<ModuleId, HashMap<VarPath, Option<VarId>>>,
+    pub module_names: HashMap<ModuleId, StrId>,
+}
+
+impl fmt::Debug for VerylFrontendLookup {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VerylFrontendLookup")
+            .field("instances", &self.instance_module.len())
+            .field("modules", &self.module_variables.len())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_lookup_has_no_source_identities() {
+        let lookup = VerylFrontendLookup::default();
+        assert!(lookup.instance_ids.is_empty());
+        assert!(lookup.instance_module.is_empty());
+        assert!(lookup.module_variables.is_empty());
+        assert!(lookup.module_var_path_index.is_empty());
+        assert!(lookup.module_names.is_empty());
+    }
+}

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1661,9 +1661,9 @@ impl NativeSimulatorHandle {
 
         let mut layout_map: BTreeMap<String, serde_json::Value> = BTreeMap::new();
 
-        for (instance_id, module_id) in &program.instance_module {
-            let variables = &program.module_variables[module_id];
-            let path_index = &program.module_var_path_index[module_id];
+        for (instance_id, module_id) in &program.frontend.instance_module {
+            let variables = &program.frontend.module_variables[module_id];
+            let path_index = &program.frontend.module_var_path_index[module_id];
 
             for info in variables.values() {
                 if path_index.get(&info.path) == Some(&None) {

--- a/crates/celox-wasm/src/lib.rs
+++ b/crates/celox-wasm/src/lib.rs
@@ -113,9 +113,9 @@ impl SimHandle {
 
         let mut layout_map: BTreeMap<String, serde_json::Value> = BTreeMap::new();
 
-        for (instance_id, module_id) in &self.program().instance_module {
-            let variables = &self.program().module_variables[module_id];
-            let path_index = &self.program().module_var_path_index[module_id];
+        for (instance_id, module_id) in &self.program().frontend.instance_module {
+            let variables = &self.program().frontend.module_variables[module_id];
+            let path_index = &self.program().frontend.module_var_path_index[module_id];
 
             for info in variables.values() {
                 if path_index.get(&info.path) == Some(&None) {

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -16,6 +16,7 @@ veryl-path            = { workspace = true }
 celox-macros          = { path = "../celox-macros" }
 celox-analysis        = { path = "../celox-analysis" }
 celox-design          = { path = "../celox-design" }
+celox-frontend-veryl  = { path = "../celox-frontend-veryl" }
 celox-sir             = { path = "../celox-sir" }
 celox-state-layout    = { path = "../celox-state-layout" }
 fxhash                = { workspace = true }

--- a/crates/celox/src/flatting_tests.rs
+++ b/crates/celox/src/flatting_tests.rs
@@ -410,10 +410,12 @@ fn test_instances_inherit_module_boundaries() {
     let c2_path = InstancePath(vec![(resource_table::insert_str("c2"), 0)]);
 
     let c1_id = program
+        .frontend
         .instance_ids
         .get(&c1_path)
         .expect("c1 instance not found");
     let c2_id = program
+        .frontend
         .instance_ids
         .get(&c2_path)
         .expect("c2 instance not found");
@@ -421,12 +423,13 @@ fn test_instances_inherit_module_boundaries() {
     // Find VarId for 'x' in Child module
     let child_name = resource_table::insert_str("Child");
     let child_module_id = program
+        .frontend
         .module_names
         .iter()
         .find(|(_, name)| **name == child_name)
         .map(|(id, _)| *id)
         .expect("Child module not found");
-    let child_vars = &program.module_variables[&child_module_id];
+    let child_vars = &program.frontend.module_variables[&child_module_id];
     let x_info = child_vars
         .values()
         .find(|info| info.path.0.len() == 1 && info.path.0[0] == resource_table::insert_str("x"))

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -7,8 +7,9 @@ pub(crate) use celox_design::{
     AbsoluteAddrBase, BinaryOp, BitAccess, DomainKind, InitialStateData, InitialStateValue,
     InitialStateWriteRun, InstanceId, ModuleId, RegionedAbsoluteAddrBase, RegionedVarAddrBase,
     RuntimeEventKind, RuntimeEventSite, RuntimeSchema, SPARSE_WORKING_REGION, STABLE_REGION,
-    TriggerIdWithKind, TriggerSet, UnaryOp, VarAtomBase, VariableMetadata, WORKING_REGION,
+    TriggerIdWithKind, TriggerSet, UnaryOp, VarAtomBase, WORKING_REGION,
 };
+pub use celox_frontend_veryl::{InstancePath, VariableInfo, VerylFrontendLookup};
 pub(crate) use celox_sir::{
     BasicBlock, BlockId, ExecutionUnit, RegisterId, RegisterType, SIRBuilder, SIRInstruction,
     SIROffset, SIRSwitchCase, SIRTerminator, SIRValue, collect_exact_zero_registers, merge_sir_eus,
@@ -40,39 +41,11 @@ pub enum AddrLookupError {
     AmbiguousPath { path: String },
 }
 
-#[derive(Clone)]
-pub struct VariableInfo {
-    pub id: VarId,
-    pub path: VarPath,
-    pub var_kind: veryl_analyzer::ir::VarKind,
-    pub metadata: VariableMetadata,
-}
-
 pub type InitialMemoryWriteRun = InitialStateWriteRun;
 pub type InitialMemoryData = InitialStateData;
 pub type InitialMemoryValue = InitialStateValue<AbsoluteAddr>;
 pub type ModuleInitialMemoryValue = InitialStateValue<VarId>;
 pub type RuntimeErrorInfo<Addr = AbsoluteAddr> = celox_design::RuntimeErrorInfo<Addr>;
-
-impl std::ops::Deref for VariableInfo {
-    type Target = VariableMetadata;
-
-    fn deref(&self) -> &Self::Target {
-        &self.metadata
-    }
-}
-
-impl fmt::Debug for VariableInfo {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("VariableInfo")
-            .field("width", &self.width)
-            .field("id", &self.id)
-            .field("is_4state", &self.is_4state)
-            .field("kind", &self.kind)
-            .field("type_kind", &self.type_kind)
-            .finish()
-    }
-}
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct LogicPathId(pub usize);
@@ -99,18 +72,12 @@ pub struct CombObserver<A = AbsoluteAddr> {
 pub struct Program {
     pub sir: SirProgram,
     pub design: celox_design::ElaboratedDesign<AbsoluteAddr>,
+    pub frontend: VerylFrontendLookup,
     /// Semantic comb process for each exact published range. Physical
     /// ExecutionUnit boundaries deliberately do not define these regions.
     pub comb_semantic_regions: HashMap<VarAtomBase<AbsoluteAddr>, u64>,
     pub runtime_schema: RuntimeSchema<AbsoluteAddr>,
     pub comb_observers: Vec<CombObserver<AbsoluteAddr>>,
-    pub instance_ids: HashMap<InstancePath, InstanceId>,
-    pub instance_module: HashMap<InstanceId, ModuleId>,
-    pub module_variables: HashMap<ModuleId, HashMap<VarId, VariableInfo>>,
-    /// Reverse index: VarPath → VarId for path-based lookups.
-    /// `None` marks ambiguous paths (multiple VarIds share the same VarPath).
-    pub module_var_path_index: HashMap<ModuleId, HashMap<VarPath, Option<VarId>>>,
-    pub module_names: HashMap<ModuleId, StrId>,
     pub arena: SLTNodeArena<AbsoluteAddr>,
     /// Memory layout aliases: non-canonical → canonical address.
     /// Variables with identity Store→Load roundtrips share physical memory.
@@ -228,6 +195,7 @@ impl Program {
             instance_path_str_id.push((id, path.1));
         }
         let instance_id = *self
+            .frontend
             .instance_ids
             .get(&InstancePath(instance_path_str_id))
             .ok_or_else(|| AddrLookupError::InstanceNotFound {
@@ -237,7 +205,7 @@ impl Program {
                     .collect::<Vec<_>>()
                     .join("."),
             })?;
-        let module_id = self.instance_module[&instance_id];
+        let module_id = self.frontend.instance_module[&instance_id];
         let mut var_path_str_id = Vec::new();
         for path in var_path {
             let id = veryl_parser::resource_table::insert_str(path);
@@ -246,7 +214,7 @@ impl Program {
 
         let target_path = VarPath(var_path_str_id);
         let path_str = var_path.join(".");
-        let entry = self.module_var_path_index[&module_id]
+        let entry = self.frontend.module_var_path_index[&module_id]
             .get(&target_path)
             .ok_or_else(|| AddrLookupError::VariableNotFound {
                 path: path_str.clone(),
@@ -263,12 +231,13 @@ impl Program {
         let var_id = addr.var_id;
 
         let instance_path = self
+            .frontend
             .instance_ids
             .iter()
             .find(|(_, id)| **id == instance_id)
             .map(|(path, _)| path);
-        let module_id = self.instance_module.get(&instance_id).unwrap();
-        let module_vars = self.module_variables.get(module_id).unwrap();
+        let module_id = self.frontend.instance_module.get(&instance_id).unwrap();
+        let module_vars = self.frontend.module_variables.get(module_id).unwrap();
         let var_path = module_vars
             .values()
             .find(|info| info.id == var_id)
@@ -297,8 +266,8 @@ impl Program {
     }
 
     pub fn get_variable_info(&self, addr: &AbsoluteAddr) -> Option<&VariableInfo> {
-        let module_id = self.instance_module.get(&addr.instance_id)?;
-        let module_vars = self.module_variables.get(module_id)?;
+        let module_id = self.frontend.instance_module.get(&addr.instance_id)?;
+        let module_vars = self.frontend.module_variables.get(module_id)?;
         module_vars.get(&addr.var_id)
     }
 
@@ -311,9 +280,10 @@ impl Program {
     /// the frontend tables are consumed rather than retained beside `design`.
     pub(crate) fn verify_design_projection(&self) -> Result<(), String> {
         let expected_count = self
+            .frontend
             .instance_module
             .values()
-            .map(|module_id| self.module_variables[module_id].len())
+            .map(|module_id| self.frontend.module_variables[module_id].len())
             .sum::<usize>();
         if self.design.state_objects.len() != expected_count {
             return Err(format!(
@@ -322,8 +292,8 @@ impl Program {
             ));
         }
 
-        for (&instance_id, module_id) in &self.instance_module {
-            for info in self.module_variables[module_id].values() {
+        for (&instance_id, module_id) in &self.frontend.instance_module {
+            for info in self.frontend.module_variables[module_id].values() {
                 let address = AbsoluteAddr {
                     instance_id,
                     var_id: info.id,
@@ -478,9 +448,6 @@ pub struct SignalRef {
     pub is_4state: bool,
     pub array_layout: Option<SignalArrayLayout>,
 }
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct InstancePath(pub Vec<(StrId, usize)>);
-
 #[derive(Clone)]
 pub struct RelocationModule {
     #[cfg(test)]

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -61,8 +61,8 @@ pub use debug::{CompilationTrace, NativeProfileBlock, TraceOptions};
 pub(crate) use fxhash::FxHashMap as HashMap;
 pub(crate) use fxhash::FxHashSet as HashSet;
 pub use ir::{
-    AbsoluteAddr, AddrLookupError, LaidOutProgram, PortTypeKind, Program, RuntimeErrorInfo,
-    SignalRef, SirProgram,
+    AbsoluteAddr, AddrLookupError, InstancePath, LaidOutProgram, PortTypeKind, Program,
+    RuntimeErrorInfo, SignalRef, SirProgram, VariableInfo, VerylFrontendLookup,
 };
 #[cfg(target_arch = "x86_64")]
 pub mod native_backend {

--- a/crates/celox/src/optimizer/coalescing.rs
+++ b/crates/celox/src/optimizer/coalescing.rs
@@ -885,27 +885,18 @@ fn optimize_with_options(
     let max_native_memory_width = opt.max_native_memory_width();
     let unpacked_element_widths = Arc::new(
         program
-            .instance_module
+            .design
+            .state_objects
             .iter()
-            .flat_map(|(&instance_id, &module_id)| {
-                program.module_variables[&module_id]
-                    .values()
-                    .filter_map(move |info| {
-                        let element_count = info
-                            .array_dims
-                            .iter()
-                            .try_fold(1usize, |count, &dimension| count.checked_mul(dimension))?;
-                        (!info.array_dims.is_empty()
-                            && element_count != 0
-                            && info.width % element_count == 0)
-                            .then_some((
-                                AbsoluteAddr {
-                                    instance_id,
-                                    var_id: info.id,
-                                },
-                                info.width / element_count,
-                            ))
-                    })
+            .filter_map(|(&address, metadata)| {
+                let element_count = metadata
+                    .array_dims
+                    .iter()
+                    .try_fold(1usize, |count, &dimension| count.checked_mul(dimension))?;
+                (!metadata.array_dims.is_empty()
+                    && element_count != 0
+                    && metadata.width % element_count == 0)
+                    .then_some((address, metadata.width / element_count))
             })
             .collect::<crate::HashMap<_, _>>(),
     );

--- a/crates/celox/src/optimizer/coalescing/pass_circular_priority.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_circular_priority.rs
@@ -169,61 +169,47 @@ impl CircularPriorityPass {
     pub(super) fn for_program(program: &Program) -> Self {
         let mut bit_array_elements = HashMap::default();
         let mut array_shapes = HashMap::default();
-        for (&instance_id, &module_id) in &program.instance_module {
-            for info in program.module_variables[&module_id].values() {
-                let element_count = if info.array_dims.is_empty() {
-                    info.width
-                } else {
-                    let Some(element_count) = info
-                        .array_dims
-                        .iter()
-                        .try_fold(1usize, |count, &dimension| count.checked_mul(dimension))
-                    else {
+        for (&address, info) in &program.design.state_objects {
+            let element_count = if info.array_dims.is_empty() {
+                info.width
+            } else {
+                let Some(element_count) = info
+                    .array_dims
+                    .iter()
+                    .try_fold(1usize, |count, &dimension| count.checked_mul(dimension))
+                else {
+                    continue;
+                };
+                if info.width != element_count {
+                    let Some(element_width) = info.width.checked_div(element_count) else {
                         continue;
                     };
-                    if info.width != element_count {
-                        let Some(element_width) = info.width.checked_div(element_count) else {
-                            continue;
-                        };
-                        if element_width == 0 || element_width * element_count != info.width {
-                            continue;
-                        }
-                        array_shapes.insert(
-                            AbsoluteAddr {
-                                instance_id,
-                                var_id: info.id,
-                            },
-                            ArrayShape {
-                                element_width,
-                                element_count,
-                            },
-                        );
+                    if element_width == 0 || element_width * element_count != info.width {
                         continue;
                     }
-                    element_count
-                };
-                if element_count == 0 {
-                    continue;
-                }
-                bit_array_elements.insert(
-                    AbsoluteAddr {
-                        instance_id,
-                        var_id: info.id,
-                    },
-                    element_count,
-                );
-                if !info.array_dims.is_empty() {
                     array_shapes.insert(
-                        AbsoluteAddr {
-                            instance_id,
-                            var_id: info.id,
-                        },
+                        address,
                         ArrayShape {
-                            element_width: 1,
+                            element_width,
                             element_count,
                         },
                     );
+                    continue;
                 }
+                element_count
+            };
+            if element_count == 0 {
+                continue;
+            }
+            bit_array_elements.insert(address, element_count);
+            if !info.array_dims.is_empty() {
+                array_shapes.insert(
+                    address,
+                    ArrayShape {
+                        element_width: 1,
+                        element_count,
+                    },
+                );
             }
         }
         Self {

--- a/crates/celox/src/optimizer/coalescing/pass_identity_store_bypass.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_identity_store_bypass.rs
@@ -78,24 +78,20 @@ pub(super) fn optimize_program_identity_stores(
 }
 
 fn address_metadata(program: &Program) -> HashMap<AbsoluteAddr, AddressMetadata> {
-    let mut metadata = HashMap::default();
-    for (&instance_id, module_id) in &program.instance_module {
-        if let Some(variables) = program.module_variables.get(module_id) {
-            for variable in variables.values() {
-                metadata.insert(
-                    AbsoluteAddr {
-                        instance_id,
-                        var_id: variable.id,
-                    },
-                    AddressMetadata {
-                        width: variable.width,
-                        is_4state: variable.is_4state,
-                    },
-                );
-            }
-        }
-    }
-    metadata
+    program
+        .design
+        .state_objects
+        .iter()
+        .map(|(&address, metadata)| {
+            (
+                address,
+                AddressMetadata {
+                    width: metadata.width,
+                    is_4state: metadata.is_4state,
+                },
+            )
+        })
+        .collect()
 }
 
 fn optimize_eval_comb_identity_stores(

--- a/crates/celox/src/optimizer/coalescing/pass_indexed_store_recovery.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_indexed_store_recovery.rs
@@ -38,32 +38,27 @@ pub(super) struct IndexedStoreRecoveryPass {
 impl IndexedStoreRecoveryPass {
     pub(super) fn for_program(program: &Program) -> Self {
         let mut arrays = HashMap::default();
-        for (&instance_id, &module_id) in &program.instance_module {
-            for info in program.module_variables[&module_id].values() {
-                if info.array_dims.is_empty() {
-                    continue;
-                }
-                let Some(element_count) = info
-                    .array_dims
-                    .iter()
-                    .try_fold(1usize, |count, &dimension| count.checked_mul(dimension))
-                else {
-                    continue;
-                };
-                if element_count == 0 || info.width % element_count != 0 {
-                    continue;
-                }
-                arrays.insert(
-                    AbsoluteAddr {
-                        instance_id,
-                        var_id: info.id,
-                    },
-                    ArrayShape {
-                        element_width: info.width / element_count,
-                        element_count,
-                    },
-                );
+        for (&address, info) in &program.design.state_objects {
+            if info.array_dims.is_empty() {
+                continue;
             }
+            let Some(element_count) = info
+                .array_dims
+                .iter()
+                .try_fold(1usize, |count, &dimension| count.checked_mul(dimension))
+            else {
+                continue;
+            };
+            if element_count == 0 || info.width % element_count != 0 {
+                continue;
+            }
+            arrays.insert(
+                address,
+                ArrayShape {
+                    element_width: info.width / element_count,
+                    element_count,
+                },
+            );
         }
         Self { arrays }
     }

--- a/crates/celox/src/optimizer/coalescing/pass_masked_array_any.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_masked_array_any.rs
@@ -36,32 +36,27 @@ pub(super) struct MaskedArrayAnyPass {
 impl MaskedArrayAnyPass {
     pub(super) fn for_program(program: &Program) -> Self {
         let mut unpacked_arrays = HashMap::default();
-        for (&instance_id, &module_id) in &program.instance_module {
-            for info in program.module_variables[&module_id].values() {
-                if info.array_dims.is_empty() {
-                    continue;
-                }
-                let Some(element_count) = info
-                    .array_dims
-                    .iter()
-                    .try_fold(1usize, |count, &dimension| count.checked_mul(dimension))
-                else {
-                    continue;
-                };
-                if element_count == 0 || info.width % element_count != 0 {
-                    continue;
-                }
-                unpacked_arrays.insert(
-                    AbsoluteAddr {
-                        instance_id,
-                        var_id: info.id,
-                    },
-                    ArrayShape {
-                        element_width: info.width / element_count,
-                        element_count,
-                    },
-                );
+        for (&address, info) in &program.design.state_objects {
+            if info.array_dims.is_empty() {
+                continue;
             }
+            let Some(element_count) = info
+                .array_dims
+                .iter()
+                .try_fold(1usize, |count, &dimension| count.checked_mul(dimension))
+            else {
+                continue;
+            };
+            if element_count == 0 || info.width % element_count != 0 {
+                continue;
+            }
+            unpacked_arrays.insert(
+                address,
+                ArrayShape {
+                    element_width: info.width / element_count,
+                    element_count,
+                },
+            );
         }
         Self { unpacked_arrays }
     }

--- a/crates/celox/src/optimizer/coalescing/pass_packed_scatter_store.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_packed_scatter_store.rs
@@ -22,29 +22,21 @@ pub(super) struct PackedScatterStorePass {
 impl PackedScatterStorePass {
     pub(super) fn for_program(program: &Program) -> Self {
         let mut unpacked_element_widths = HashMap::default();
-        for (&instance_id, &module_id) in &program.instance_module {
-            for info in program.module_variables[&module_id].values() {
-                if info.array_dims.is_empty() {
-                    continue;
-                }
-                let Some(element_count) = info
-                    .array_dims
-                    .iter()
-                    .try_fold(1usize, |count, &dimension| count.checked_mul(dimension))
-                else {
-                    continue;
-                };
-                if element_count == 0 || info.width % element_count != 0 {
-                    continue;
-                }
-                unpacked_element_widths.insert(
-                    AbsoluteAddr {
-                        instance_id,
-                        var_id: info.id,
-                    },
-                    info.width / element_count,
-                );
+        for (&address, info) in &program.design.state_objects {
+            if info.array_dims.is_empty() {
+                continue;
             }
+            let Some(element_count) = info
+                .array_dims
+                .iter()
+                .try_fold(1usize, |count, &dimension| count.checked_mul(dimension))
+            else {
+                continue;
+            };
+            if element_count == 0 || info.width % element_count != 0 {
+                continue;
+            }
+            unpacked_element_widths.insert(address, info.width / element_count);
         }
         Self {
             unpacked_element_widths,

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -1400,14 +1400,16 @@ pub(crate) fn flatten(
                     eval_comb: Vec::new(),
                 },
                 design: celox_design::ElaboratedDesign::default(),
+                frontend: crate::ir::VerylFrontendLookup {
+                    instance_ids: expanded.clone(),
+                    instance_module: instance_modules.clone(),
+                    module_variables: err_vars,
+                    module_var_path_index: err_path_idx,
+                    module_names: module_names.clone(),
+                },
                 comb_semantic_regions: HashMap::default(),
                 runtime_schema: celox_design::RuntimeSchema::default(),
                 comb_observers: Vec::new(),
-                instance_ids: expanded.clone(),
-                instance_module: instance_modules.clone(),
-                module_variables: err_vars,
-                module_var_path_index: err_path_idx,
-                module_names: module_names.clone(),
                 arena: SLTNodeArena::new(),
                 address_aliases: HashMap::default(),
                 initial_statements: None,
@@ -1605,17 +1607,19 @@ pub(crate) fn flatten(
             },
             initial_state: initial_memory_values,
         },
+        frontend: crate::ir::VerylFrontendLookup {
+            instance_ids: expanded,
+            instance_module: instance_modules,
+            module_variables: mod_vars,
+            module_var_path_index: mod_path_idx,
+            module_names,
+        },
         comb_semantic_regions,
         runtime_schema: celox_design::RuntimeSchema {
             runtime_errors,
             runtime_event_sites,
         },
         comb_observers,
-        instance_ids: expanded,
-        instance_module: instance_modules,
-        module_variables: mod_vars,
-        module_var_path_index: mod_path_idx,
-        module_names,
         arena: global_arena,
         address_aliases: HashMap::default(),
         initial_statements,
@@ -1763,8 +1767,8 @@ fn dump_addr_map_if_requested(program: &Program) {
 
     let filter = parse_addr_map_filter();
     let mut entries = Vec::new();
-    for (&instance_id, &module_id) in &program.instance_module {
-        let Some(vars) = program.module_variables.get(&module_id) else {
+    for (&instance_id, &module_id) in &program.frontend.instance_module {
+        let Some(vars) = program.frontend.module_variables.get(&module_id) else {
             continue;
         };
         for (&var_id, info) in vars {
@@ -1785,6 +1789,7 @@ fn dump_addr_map_if_requested(program: &Program) {
 
     for (instance_id, module_id, var_id, info) in entries {
         let module_name = program
+            .frontend
             .module_names
             .get(&module_id)
             .and_then(|name| resource_table::get_str_value(*name))

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -1171,12 +1171,12 @@ impl<B: SimBackend> Simulator<B> {
     /// paths without the original [`Program`].
     pub fn build_vcd_descs(&self, four_state_mode: bool) -> Vec<crate::vcd::VcdSignalDesc> {
         let mut descs = Vec::new();
-        let mut sorted_instances: Vec<_> = self.program.instance_module.iter().collect();
+        let mut sorted_instances: Vec<_> = self.program.frontend.instance_module.iter().collect();
         sorted_instances.sort_by_key(|(id, _)| *id);
 
         for (instance_id, module_id) in sorted_instances {
-            let variables = &self.program.module_variables[module_id];
-            let path_index = &self.program.module_var_path_index[module_id];
+            let variables = &self.program.frontend.module_variables[module_id];
+            let path_index = &self.program.frontend.module_var_path_index[module_id];
             let scope = format!("{}", instance_id);
 
             let mut sorted_vars: Vec<_> = variables
@@ -1224,6 +1224,7 @@ impl<B: SimBackend> Simulator<B> {
     pub fn named_signals(&self) -> Vec<NamedSignal> {
         let top_instance_id = self
             .program
+            .frontend
             .instance_ids
             .get(&InstancePath(vec![]))
             .expect("top-level instance not found");
@@ -1239,7 +1240,12 @@ impl<B: SimBackend> Simulator<B> {
             .iter()
             .map(|(name, idx)| (veryl_parser::resource_table::insert_str(name), *idx))
             .collect();
-        match self.program.instance_ids.get(&InstancePath(path_str_ids)) {
+        match self
+            .program
+            .frontend
+            .instance_ids
+            .get(&InstancePath(path_str_ids))
+        {
             Some(&instance_id) => self.build_signals_for_instance(instance_id),
             None => Vec::new(),
         }
@@ -1251,9 +1257,9 @@ impl<B: SimBackend> Simulator<B> {
     /// same name) are excluded — they cannot be addressed by path and would
     /// cause silent overwrites in name-keyed maps such as the layout JSON.
     fn build_signals_for_instance(&self, instance_id: crate::ir::InstanceId) -> Vec<NamedSignal> {
-        let module_id = &self.program.instance_module[&instance_id];
-        let module_vars = &self.program.module_variables[module_id];
-        let path_index = &self.program.module_var_path_index[module_id];
+        let module_id = &self.program.frontend.instance_module[&instance_id];
+        let module_vars = &self.program.frontend.module_variables[module_id];
+        let path_index = &self.program.frontend.module_var_path_index[module_id];
 
         let mut result = Vec::new();
         for info in module_vars.values() {
@@ -1356,12 +1362,14 @@ impl<B: SimBackend> Simulator<B> {
     ) -> InstanceHierarchy {
         let instance_id = self
             .program
+            .frontend
             .instance_ids
             .get(&InstancePath(current_path.to_vec()))
             .expect("instance not found");
-        let module_id = &self.program.instance_module[instance_id];
+        let module_id = &self.program.frontend.instance_module[instance_id];
         let module_name = self
             .program
+            .frontend
             .module_names
             .get(module_id)
             .and_then(|name| veryl_parser::resource_table::get_str_value(*name))
@@ -1375,7 +1383,7 @@ impl<B: SimBackend> Simulator<B> {
         let mut children_map: crate::HashMap<String, Vec<(usize, InstanceHierarchy)>> =
             crate::HashMap::default();
 
-        for path in self.program.instance_ids.keys() {
+        for path in self.program.frontend.instance_ids.keys() {
             if path.0.len() == current_len + 1 && path.0.starts_with(current_path) {
                 let (child_name_id, child_index) = path.0[current_len];
                 let child_name = veryl_parser::resource_table::get_str_value(child_name_id)

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -976,9 +976,9 @@ fn run_dead_store_elimination(
 
     // PreserveTopPorts: auto-collect top module port addresses
     if options.dead_store_policy == DeadStorePolicy::PreserveTopPorts {
-        if let Some(&top_instance_id) = program.instance_ids.get(&InstancePath(vec![])) {
-            if let Some(&top_module_id) = program.instance_module.get(&top_instance_id) {
-                if let Some(top_vars) = program.module_variables.get(&top_module_id) {
+        if let Some(&top_instance_id) = program.frontend.instance_ids.get(&InstancePath(vec![])) {
+            if let Some(&top_module_id) = program.frontend.instance_module.get(&top_instance_id) {
+                if let Some(top_vars) = program.frontend.module_variables.get(&top_module_id) {
                     for info in top_vars.values() {
                         if info.var_kind.is_port() {
                             externally_live.insert(AbsoluteAddr {
@@ -994,8 +994,8 @@ fn run_dead_store_elimination(
 
     // PreserveAllPorts: collect port addresses from every instance
     if options.dead_store_policy == DeadStorePolicy::PreserveAllPorts {
-        for (&instance_id, &module_id) in &program.instance_module {
-            if let Some(vars) = program.module_variables.get(&module_id) {
+        for (&instance_id, &module_id) in &program.frontend.instance_module {
+            if let Some(vars) = program.frontend.module_variables.get(&module_id) {
                 for info in vars.values() {
                     if info.var_kind.is_port() {
                         externally_live.insert(AbsoluteAddr {

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -677,13 +677,17 @@ pub(crate) fn initial_read_addresses(program: &Program) -> crate::HashSet<Absolu
     let Some(stmts) = program.initial_statements.as_ref() else {
         return crate::HashSet::default();
     };
-    let Some(&root_instance_id) = program.instance_ids.get(&crate::ir::InstancePath(vec![])) else {
+    let Some(&root_instance_id) = program
+        .frontend
+        .instance_ids
+        .get(&crate::ir::InstancePath(vec![]))
+    else {
         return crate::HashSet::default();
     };
-    let Some(&root_module_id) = program.instance_module.get(&root_instance_id) else {
+    let Some(&root_module_id) = program.frontend.instance_module.get(&root_instance_id) else {
         return crate::HashSet::default();
     };
-    let Some(root_variables) = program.module_variables.get(&root_module_id) else {
+    let Some(root_variables) = program.frontend.module_variables.get(&root_module_id) else {
         return crate::HashSet::default();
     };
 
@@ -2015,6 +2019,7 @@ impl<'a, B: SimBackend> ExprCompiler<'a, B> {
     ) {
         let p = self.sim.program();
         let info = match p
+            .frontend
             .module_variables
             .get(&self.root_module_id)
             .and_then(|v| v.get(var_id))
@@ -2265,7 +2270,7 @@ impl<'a, B: SimBackend> ExprCompiler<'a, B> {
             match f.as_ref() {
                 Factor::Variable(var_id, _, _, _) => {
                     let p = self.sim.program();
-                    if let Some(vars) = p.module_variables.get(&self.root_module_id) {
+                    if let Some(vars) = p.frontend.module_variables.get(&self.root_module_id) {
                         if let Some(info) = vars.get(var_id) {
                             return info.width;
                         }
@@ -2294,7 +2299,7 @@ impl<'a, B: SimBackend> ExprCompiler<'a, B> {
 
     fn resolve_var(&self, var_id: &VarId) -> Option<SignalRef> {
         let p = self.sim.program();
-        let vars = p.module_variables.get(&self.root_module_id)?;
+        let vars = p.frontend.module_variables.get(&self.root_module_id)?;
         let _ = vars.get(var_id)?;
         Some(self.sim.backend_ref().resolve_signal(&AbsoluteAddr {
             instance_id: self.root_instance_id,
@@ -2374,10 +2379,11 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
     pub(crate) fn convert(&mut self, stmts: &[Statement]) -> Vec<TestbenchStatement<B>> {
         let p = self.sim.program();
         let root_instance_id = *p
+            .frontend
             .instance_ids
             .get(&crate::ir::InstancePath(Vec::new()))
             .expect("root instance not found");
-        let root_module_id = p.instance_module[&root_instance_id];
+        let root_module_id = p.frontend.instance_module[&root_instance_id];
         let ec = ExprCompiler {
             sim: self.sim,
             root_instance_id,
@@ -2650,9 +2656,12 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
 
     fn resolve_loop_var(&self, var_id: &VarId) -> Option<(SignalRef, usize)> {
         let p = self.sim.program();
-        let rid = p.instance_ids.get(&crate::ir::InstancePath(Vec::new()))?;
-        let mid = p.instance_module.get(rid)?;
-        let vars = p.module_variables.get(mid)?;
+        let rid = p
+            .frontend
+            .instance_ids
+            .get(&crate::ir::InstancePath(Vec::new()))?;
+        let mid = p.frontend.instance_module.get(rid)?;
+        let vars = p.frontend.module_variables.get(mid)?;
         let info = vars.get(var_id)?;
         let addr = AbsoluteAddr {
             instance_id: *rid,

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -13,8 +13,10 @@ flattened state metadata, event topology, and initial state are held by
 `celox-design::ElaboratedDesign`. Runtime diagnostics are held by
 `celox-design::RuntimeSchema`. Cranelift oversized-function planning is constructed from final SIR
 at the backend boundary; backend scratch extends only the backend's private layout copy.
-Dissolving the remaining frontend lookup, symbolic, optimizer, and testbench payload into the
-phase-specific target types below remains part of Milestone 3.
+Veryl source identities retained for diagnostics and public path lookup are grouped in
+`celox-frontend-veryl::VerylFrontendLookup`; optimizer and backend code no longer inspect that
+artifact. Moving the remaining parser implementation, symbolic, optimizer, and testbench payload
+into the phase-specific target types below remains part of Milestone 3.
 
 The baseline is the compiler pipeline on `perf/native-simulation-throughput` after PR #322. The
 split must preserve RTL semantics, generated-code quality, and the public `celox` API while making


### PR DESCRIPTION
Stacked on #343.

## Summary
- add the first `celox-frontend-veryl` crate and move `VariableInfo`, `InstancePath`, and Veryl source lookup maps into it
- replace five mixed `Program` source-lookup fields with one explicit `VerylFrontendLookup` artifact
- migrate semantic optimizer metadata queries to `ElaboratedDesign::state_objects`
- ensure optimizer, backend, and runtime scheduler have no frontend lookup dependency
- retain source lookup only for hierarchy/path APIs, diagnostics, and the still-unmigrated testbench frontend

## Validation
- `cargo test -p celox-frontend-veryl --lib`
- `cargo test -p celox --lib`
- `cargo test -p celox --test hierarchy`
- `cargo test -p celox --test duplicate_varpath`
- `cargo test -p celox --test native_testbench`
- `cargo test -p celox --test data_access`
- `cargo clippy -p celox-frontend-veryl -p celox --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- pre-push hook