### PR TITLE
Drop symbolic arena from compiled program

### DIFF
--- a/crates/celox-design/src/lib.rs
+++ b/crates/celox-design/src/lib.rs
@@ -69,6 +69,19 @@ pub struct RuntimeEventSite {
     pub arg_is_string: Vec<bool>,
 }
 
+/// Runtime activation recipe for one combinational event site.
+///
+/// Expression trees used to emit the event have already been lowered into
+/// SIR.  The runtime only retains the persistent-state ranges needed to detect
+/// whether the corresponding combinational process must be observed again.
+#[derive(Clone, Debug)]
+pub struct RuntimeCombObserver<A> {
+    pub site_id: u32,
+    pub activation_group: u32,
+    pub sensitivity: Vec<VarAtomBase<A>>,
+    pub written_inputs: Vec<A>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InitialStateWriteRun {
     pub bit_offset: usize,
@@ -104,6 +117,7 @@ pub struct RuntimeErrorInfo<A> {
 pub struct RuntimeSchema<A> {
     pub runtime_errors: HashMap<i64, RuntimeErrorInfo<A>>,
     pub runtime_event_sites: Vec<RuntimeEventSite>,
+    pub comb_observers: Vec<RuntimeCombObserver<A>>,
 }
 
 impl<A> Default for RuntimeSchema<A> {
@@ -111,6 +125,7 @@ impl<A> Default for RuntimeSchema<A> {
         Self {
             runtime_errors: HashMap::default(),
             runtime_event_sites: Vec::new(),
+            comb_observers: Vec::new(),
         }
     }
 }
@@ -543,11 +558,21 @@ mod tests {
             arg_signed: Vec::new(),
             arg_is_string: Vec::new(),
         });
+        runtime.comb_observers.push(RuntimeCombObserver {
+            site_id: 0,
+            activation_group: 0,
+            sensitivity: vec![VarAtomBase {
+                id: initial.address,
+                access: BitAccess { lsb: 3, msb: 7 },
+            }],
+            written_inputs: vec![initial.address],
+        });
 
         assert_eq!(error.signals, vec![initial.address]);
         assert!(matches!(initial.data, InitialStateData::Writes(_)));
         assert_eq!(runtime.runtime_errors[&1], error);
         assert_eq!(runtime.runtime_event_sites.len(), 1);
+        assert_eq!(runtime.comb_observers[0].sensitivity[0].id, initial.address);
     }
 
     #[test]

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -77,8 +77,6 @@ pub struct Program {
     /// ExecutionUnit boundaries deliberately do not define these regions.
     pub comb_semantic_regions: HashMap<VarAtomBase<AbsoluteAddr>, u64>,
     pub runtime_schema: RuntimeSchema<AbsoluteAddr>,
-    pub comb_observers: Vec<CombObserver<AbsoluteAddr>>,
-    pub arena: SLTNodeArena<AbsoluteAddr>,
     /// Memory layout aliases: non-canonical → canonical address.
     /// Variables with identity Store→Load roundtrips share physical memory.
     pub address_aliases: HashMap<AbsoluteAddr, AbsoluteAddr>,
@@ -142,8 +140,9 @@ impl Program {
         four_state: bool,
         mode: crate::backend::memory_layout::MemoryLayoutMode,
     ) -> LaidOutProgram {
-        if !self.comb_observers.is_empty() && !self.address_aliases.is_empty() {
+        if !self.runtime_schema.comb_observers.is_empty() && !self.address_aliases.is_empty() {
             let observed_written: crate::HashSet<AbsoluteAddr> = self
+                .runtime_schema
                 .comb_observers
                 .iter()
                 .flat_map(|observer| observer.written_inputs.iter().copied())

--- a/crates/celox/src/optimizer/coalescing/pass_identity_store_bypass.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_identity_store_bypass.rs
@@ -62,6 +62,7 @@ pub(super) fn optimize_program_identity_stores(
     let mut blocked_aliases = ff_referenced_addresses(program);
     blocked_aliases.extend(
         program
+            .runtime_schema
             .comb_observers
             .iter()
             .flat_map(|observer| observer.written_inputs.iter().copied()),

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -1409,8 +1409,6 @@ pub(crate) fn flatten(
                 },
                 comb_semantic_regions: HashMap::default(),
                 runtime_schema: celox_design::RuntimeSchema::default(),
-                comb_observers: Vec::new(),
-                arena: SLTNodeArena::new(),
                 address_aliases: HashMap::default(),
                 initial_statements: None,
                 tb_functions: fxhash::FxHashMap::default(),
@@ -1589,6 +1587,15 @@ pub(crate) fn flatten(
             })
         })
         .collect();
+    let runtime_comb_observers = comb_observers
+        .iter()
+        .map(|observer| celox_design::RuntimeCombObserver {
+            site_id: observer.site_id,
+            activation_group: observer.activation_group,
+            sensitivity: observer.sensitivity.clone(),
+            written_inputs: observer.written_inputs.clone(),
+        })
+        .collect();
     let program = Program {
         sir: crate::ir::SirProgram {
             eval_apply_ffs,
@@ -1618,9 +1625,8 @@ pub(crate) fn flatten(
         runtime_schema: celox_design::RuntimeSchema {
             runtime_errors,
             runtime_event_sites,
+            comb_observers: runtime_comb_observers,
         },
-        comb_observers,
-        arena: global_arena,
         address_aliases: HashMap::default(),
         initial_statements,
         tb_functions: module_ir

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -680,7 +680,7 @@ impl<B: SimBackend> Simulator<B> {
             !self.runtime_event_drain_active.load(Ordering::Acquire),
             "cannot use Simulator::drain_runtime_events while a RuntimeEventDrain is active",
         );
-        if !self.program.comb_observers.is_empty() && self.dirty {
+        if !self.program.runtime_schema.comb_observers.is_empty() && self.dirty {
             self.eval_comb_checked().unwrap();
             self.dirty = false;
         }
@@ -868,7 +868,7 @@ impl<B: SimBackend> Simulator<B> {
                 .eval_comb()
                 .map_err(|e| self.decorate_runtime_error(e));
         }
-        if self.program.comb_observers.is_empty() {
+        if self.program.runtime_schema.comb_observers.is_empty() {
             let runtime_event_start_seq = self.runtime_event_write_seq();
             let eval_result = self
                 .backend
@@ -890,13 +890,14 @@ impl<B: SimBackend> Simulator<B> {
         let mut active_sites = vec![false; self.program.runtime_schema.runtime_event_sites.len()];
         for (observer, is_active) in self
             .program
+            .runtime_schema
             .comb_observers
             .iter()
             .zip(active_before.iter().copied())
         {
             if is_active || self.comb_observer_initial_eval {
                 let group = observer.activation_group;
-                for group_observer in &self.program.comb_observers {
+                for group_observer in &self.program.runtime_schema.comb_observers {
                     if group_observer.activation_group == group {
                         active_sites[group_observer.site_id as usize] = true;
                     }
@@ -929,6 +930,7 @@ impl<B: SimBackend> Simulator<B> {
 
     fn snapshot_all_comb_observers(&self) -> Vec<Vec<(BigUint, BigUint)>> {
         self.program
+            .runtime_schema
             .comb_observers
             .iter()
             .map(|observer| {
@@ -1048,7 +1050,7 @@ impl<B: SimBackend> Simulator<B> {
     /// Native testbenches use this between observable expressions so the
     /// preceding comb phase and this FF phase can share one compiled function.
     pub(crate) fn tick_deferred_comb(&mut self, event: B::Event) -> Result<(), RuntimeErrorCode> {
-        if !self.program.comb_observers.is_empty() {
+        if !self.program.runtime_schema.comb_observers.is_empty() {
             return self.tick(event);
         }
         if self.dirty {
@@ -1071,7 +1073,7 @@ impl<B: SimBackend> Simulator<B> {
         if count == 0 {
             return (0, Ok(()));
         }
-        if !self.program.comb_observers.is_empty() || !self.dirty {
+        if !self.program.runtime_schema.comb_observers.is_empty() || !self.dirty {
             return (1, self.tick_deferred_comb(event));
         }
         let (completed, result) = self.backend.eval_comb_apply_ff_many_at(event, count);

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -604,7 +604,7 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
                 "[phase-timing] register_runtime_event_sites: {:?} runtime_event_sites={} comb_observers={}",
                 start.elapsed(),
                 program.runtime_schema.runtime_event_sites.len(),
-                program.comb_observers.len()
+                program.runtime_schema.comb_observers.len()
             );
         }
 

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -3169,7 +3169,7 @@ module Top (
     .unwrap();
 
     let tmp_addr = sim.program().get_addr(&[], &["tmp"]).unwrap();
-    let observer = &sim.program().comb_observers[0];
+    let observer = &sim.program().runtime_schema.comb_observers[0];
     assert!(
         observer.sensitivity.iter().all(|atom| atom.id != tmp_addr),
         "written LHS must be excluded from always_comb sensitivity: {:?}",
@@ -3202,7 +3202,7 @@ module Top (
 
     let tmp_addr = sim.program().get_addr(&[], &["tmp"]).unwrap();
     let idx_addr = sim.program().get_addr(&[], &["idx"]).unwrap();
-    let observer = &sim.program().comb_observers[0];
+    let observer = &sim.program().runtime_schema.comb_observers[0];
 
     // IEEE 1800-2023 9.2.2.2.1 uses expansions of the longest static prefix.
     // For tmp[idx], the dynamic select falls back to tmp's expansion, but the
@@ -3256,7 +3256,7 @@ module Top (
     .unwrap();
 
     let mem_addr = sim.program().get_addr(&[], &["mem"]).unwrap();
-    let observer = &sim.program().comb_observers[0];
+    let observer = &sim.program().runtime_schema.comb_observers[0];
 
     // IEEE 1800-2023 9.2.2.2.1 refers to the expansion of the longest static
     // prefix. For mem[1][idx], the longest static prefix is mem[1], not mem.
@@ -3307,7 +3307,7 @@ module Top (
     .unwrap();
 
     let mem_addr = sim.program().get_addr(&[], &["mem"]).unwrap();
-    let observer = &sim.program().comb_observers[0];
+    let observer = &sim.program().runtime_schema.comb_observers[0];
 
     // The written expression is mem[1][idx], whose longest static prefix is
     // mem[1]. Excluding written expressions must not remove mem[2].
@@ -3351,7 +3351,7 @@ module Top (
     .unwrap();
 
     let mem_addr = sim.program().get_addr(&[], &["mem"]).unwrap();
-    let observer = &sim.program().comb_observers[0];
+    let observer = &sim.program().runtime_schema.comb_observers[0];
 
     // The indexed part-select anchor is dynamic, so the longest static prefix
     // is mem[1], not the bits selected when idx is treated as zero.
@@ -3401,7 +3401,7 @@ module Top (
     .unwrap();
 
     let mem_addr = sim.program().get_addr(&[], &["mem"]).unwrap();
-    let observer = &sim.program().comb_observers[0];
+    let observer = &sim.program().runtime_schema.comb_observers[0];
 
     assert!(
         observer
@@ -3449,7 +3449,7 @@ module Top (
     .unwrap();
 
     let tmp_addr = sim.program().get_addr(&[], &["tmp"]).unwrap();
-    let observer = &sim.program().comb_observers[0];
+    let observer = &sim.program().runtime_schema.comb_observers[0];
 
     assert!(
         observer.sensitivity.iter().all(|atom| atom.id != tmp_addr),
@@ -3487,7 +3487,7 @@ module Top (
     .unwrap();
 
     let mem_addr = sim.program().get_addr(&[], &["mem"]).unwrap();
-    let observer = &sim.program().comb_observers[0];
+    let observer = &sim.program().runtime_schema.comb_observers[0];
 
     assert!(
         observer
@@ -3539,6 +3539,7 @@ module Top (
     let mem_addr = sim.program().get_addr(&[], &["mem"]).unwrap();
     let mut observed_ranges: Vec<_> = sim
         .program()
+        .runtime_schema
         .comb_observers
         .iter()
         .map(|observer| {
@@ -3603,6 +3604,7 @@ module Top (
     let mem_addr = sim.program().get_addr(&[], &["mem"]).unwrap();
     let observer =
         sim.program()
+            .runtime_schema
             .comb_observers
             .iter()
             .find(|observer| {

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -11,7 +11,9 @@ uses a consuming `Program -> LaidOutProgram` transition. The current facade arti
 the mixed `Program`, whose execution-unit groups are now held by `celox-sir::SirProgram` and whose
 flattened state metadata, event topology, and initial state are held by
 `celox-design::ElaboratedDesign`. Runtime diagnostics are held by
-`celox-design::RuntimeSchema`. Cranelift oversized-function planning is constructed from final SIR
+`celox-design::RuntimeSchema`; its combinational observation recipes retain only persistent-state
+ranges, so the final `Program` no longer owns an SLT arena or observer `NodeId`s. Cranelift
+oversized-function planning is constructed from final SIR
 at the backend boundary; backend scratch extends only the backend's private layout copy.
 Veryl source identities retained for diagnostics and public path lookup are grouped in
 `celox-frontend-veryl::VerylFrontendLookup`; optimizer and backend code no longer inspect that


### PR DESCRIPTION
## Summary
- project combinational observers into source-independent runtime recipes after SLT-to-SIR lowering
- remove `SLTNodeArena` and observer `NodeId` payload from the compiled `Program`
- keep runtime sensitivity/activation and alias-safety behavior in `RuntimeSchema`

## Validation
- `cargo test -p celox-design --lib`
- `cargo test -p celox --lib`
- `cargo test -p celox --test comb_observer`
- `cargo test -p celox --test native_testbench`
- `cargo clippy -p celox-design -p celox --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- pre-push hook