### PR TITLE
Remove unused comb semantic regions

### DIFF
--- a/crates/celox/src/flatting.rs
+++ b/crates/celox/src/flatting.rs
@@ -216,7 +216,6 @@ fn atomize_logic_paths(
 
                 let target = VarAtomBase::new(target_var.id, merged_lsb, merged_msb);
                 atomized_paths.push(LogicPath {
-                    semantic_region: path.semantic_region,
                     target: LogicPathTarget::Var(target),
                     sources: filtered_sources,
                     previous_sources: filtered_previous_sources,
@@ -786,7 +785,6 @@ mod tests {
         let mut sources = crate::HashSet::default();
         sources.insert(VarAtomBase::new(source, 0, 23));
         let path = LogicPath {
-            semantic_region: None,
             target: LogicPathTarget::Var(VarAtomBase::new(address, 0, 23)),
             sources,
             previous_sources: crate::HashSet::default(),

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -73,9 +73,6 @@ pub struct Program {
     pub sir: SirProgram,
     pub design: celox_design::ElaboratedDesign<AbsoluteAddr>,
     pub frontend: VerylFrontendLookup,
-    /// Semantic comb process for each exact published range. Physical
-    /// ExecutionUnit boundaries deliberately do not define these regions.
-    pub comb_semantic_regions: HashMap<VarAtomBase<AbsoluteAddr>, u64>,
     pub runtime_schema: RuntimeSchema<AbsoluteAddr>,
     /// Memory layout aliases: non-canonical → canonical address.
     /// Variables with identity Store→Load roundtrips share physical memory.

--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -162,7 +162,6 @@ pub(crate) fn parse_comb_with_loop_recovery(
                 };
 
                 paths.push(LogicPath::<VarId> {
-                    semantic_region: None,
                     target: LogicPathTarget::Var(VarAtomBase::new(*id, lsb, msb)),
                     sources: sources.clone(),
                     previous_sources: sources

--- a/crates/celox/src/logic_tree/comb/path.rs
+++ b/crates/celox/src/logic_tree/comb/path.rs
@@ -55,10 +55,6 @@ impl<A: fmt::Display + Hash + Eq + Clone> fmt::Display for LogicPathTarget<A> {
 pub struct LogicPath<A: Hash + Eq + Clone> {
     /// Semantic combinational process which produced this range definition.
     ///
-    /// This is placement provenance, not an execution-order constraint.
-    /// Flattening makes populated IDs globally unique before scheduling.
-    #[serde(default)]
-    pub semantic_region: Option<u64>,
     pub target: LogicPathTarget<A>,
     pub sources: HashSet<VarAtomBase<A>>,
     pub previous_sources: HashSet<VarAtomBase<A>>,
@@ -157,7 +153,6 @@ impl<A: fmt::Debug + fmt::Display + Hash + Eq + Clone> LogicPath<A> {
             .map_addr(self.expr, arena, target_arena, cache, f)?;
 
         Ok(LogicPath {
-            semantic_region: self.semantic_region,
             target,
             sources: self
                 .sources

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -372,7 +372,6 @@ mod slt_root_verify_tests {
 
     fn path(expr: crate::logic_tree::NodeId) -> LogicPath<u32> {
         LogicPath {
-            semantic_region: None,
             target: LogicPathTarget::Var(VarAtomBase::new(2, 0, 7)),
             sources: crate::HashSet::default(),
             previous_sources: crate::HashSet::default(),
@@ -1407,7 +1406,6 @@ pub(crate) fn flatten(
                     module_var_path_index: err_path_idx,
                     module_names: module_names.clone(),
                 },
-                comb_semantic_regions: HashMap::default(),
                 runtime_schema: celox_design::RuntimeSchema::default(),
                 address_aliases: HashMap::default(),
                 initial_statements: None,
@@ -1432,7 +1430,6 @@ pub(crate) fn flatten(
         eprintln!("[flatten] scheduler::sort: {:?}", s.elapsed());
     }
     runtime_errors.extend(schedule.runtime_errors);
-    let comb_semantic_regions = schedule.semantic_regions;
     let schduled: Vec<crate::ir::ExecutionUnit<RegionedAbsoluteAddr>> = schedule
         .execution_units
         .into_iter()
@@ -1621,7 +1618,6 @@ pub(crate) fn flatten(
             module_var_path_index: mod_path_idx,
             module_names,
         },
-        comb_semantic_regions,
         runtime_schema: celox_design::RuntimeSchema {
             runtime_errors,
             runtime_event_sites,
@@ -3315,29 +3311,6 @@ fn relocate_units(
             observer.site_id = runtime_event_site_map[&observer.site_id];
             observer.activation_group = runtime_event_site_map[&observer.activation_group];
         }
-        let instance_region =
-            u64::try_from(id.0).expect("instance identifier exceeds semantic-region domain");
-        for (path_index, logic_path) in relocated_module.comb_blocks.iter_mut().enumerate() {
-            let local_region = match logic_path.semantic_region {
-                Some(process) => {
-                    assert!(
-                        process < (1u64 << 31),
-                        "comb process identifier exceeds semantic-region domain"
-                    );
-                    process
-                }
-                None => {
-                    let path = u64::try_from(path_index)
-                        .expect("logic-path index exceeds semantic-region domain");
-                    assert!(
-                        path < (1u64 << 31),
-                        "logic-path index exceeds semantic-region domain"
-                    );
-                    (1u64 << 31) | path
-                }
-            };
-            logic_path.semantic_region = Some((instance_region << 32) | local_region);
-        }
         comb_blocks.extend(relocated_module.comb_blocks);
         comb_observers.extend(relocated_module.comb_observers);
 
@@ -3548,7 +3521,6 @@ fn build_comb_observer_capture_paths(
                 comb_blocks[idx.0].order_before.insert(path_id);
             }
             comb_blocks.push(LogicPath {
-                semantic_region: None,
                 target: LogicPathTarget::CombCaptureEvent {
                     site_id: observer.site_id,
                     guard: None,
@@ -3580,7 +3552,6 @@ fn build_comb_observer_capture_paths(
                 }
                 comb_blocks[trigger_idx.0].order_before.insert(path_id);
                 comb_blocks.push(LogicPath {
-                    semantic_region: None,
                     target: LogicPathTarget::CombCaptureEvent {
                         site_id: observer.site_id,
                         guard: None,
@@ -3661,7 +3632,6 @@ fn build_comb_observer_capture_paths(
             comb_blocks[idx.0].order_before.insert(path_id);
         }
         comb_blocks.push(LogicPath {
-            semantic_region: None,
             target: LogicPathTarget::CombCaptureEvent {
                 site_id: observer.site_id,
                 guard: observer.guard,
@@ -3719,7 +3689,6 @@ fn build_comb_observer_capture_paths(
                 }
                 comb_blocks[trigger_idx.0].order_before.insert(path_id);
                 comb_blocks.push(LogicPath {
-                    semantic_region: None,
                     target: LogicPathTarget::CombCaptureEvent {
                         site_id: member.site_id,
                         guard: member.guard,

--- a/crates/celox/src/parser/module.rs
+++ b/crates/celox/src/parser/module.rs
@@ -43,7 +43,6 @@ pub struct ModuleParser<'a> {
     comb_blocks: Vec<LogicPath<VarId>>,
     comb_observers: Vec<CombObserver<VarId>>,
     comb_runtime_event_sites: Vec<RuntimeEventSite>,
-    next_comb_semantic_region: u64,
     comb_boundaries: HashMap<VarId, BTreeSet<usize>>,
     glue_blocks: HashMap<StrId, Vec<GlueBlock>>,
     initial_memory_values: Vec<ModuleInitialMemoryValue>,
@@ -463,7 +462,6 @@ impl<'a> ModuleParser<'a> {
             comb_blocks: Vec::new(),
             comb_observers: Vec::new(),
             comb_runtime_event_sites: Vec::new(),
-            next_comb_semantic_region: 0,
             comb_boundaries: HashMap::default(),
             glue_blocks: HashMap::default(),
             initial_memory_values: Vec::new(),
@@ -479,17 +477,12 @@ impl<'a> ModuleParser<'a> {
         decl: &veryl_analyzer::ir::CombDeclaration,
     ) -> Result<(), ParserError> {
         let arena_start = self.arena.len();
-        let (mut paths, store, boundaries, mut observers, sites) = parse_comb_with_loop_recovery(
+        let (paths, store, boundaries, mut observers, sites) = parse_comb_with_loop_recovery(
             self.module,
             decl,
             &mut self.arena,
             &self.loop_candidates,
         )?;
-        let semantic_region = self.next_comb_semantic_region;
-        self.next_comb_semantic_region += 1;
-        for path in &mut paths {
-            path.semantic_region = Some(semantic_region);
-        }
         let site_offset = self.comb_runtime_event_sites.len();
         for observer in &mut observers {
             observer.site_id += site_offset as u32;
@@ -580,7 +573,6 @@ impl<'a> ModuleParser<'a> {
             )?;
 
             let path = LogicPath {
-                semantic_region: None,
                 target: LogicPathTarget::Var(VarAtomBase::new(
                     GlueAddr::Child(child_port_id),
                     0,
@@ -703,7 +695,6 @@ impl<'a> ModuleParser<'a> {
                     };
 
                 let path = LogicPath {
-                    semantic_region: None,
                     target: LogicPathTarget::Var(VarAtomBase::new(
                         GlueAddr::Parent(dst.id),
                         access.lsb,

--- a/crates/celox/src/parser/scheduler.rs
+++ b/crates/celox/src/parser/scheduler.rs
@@ -2184,9 +2184,6 @@ impl<A: Display + Debug + Eq + Hash + Clone> SchedulerError<A> {
 pub struct ScheduleResult<Addr> {
     pub execution_units: Vec<ExecutionUnit<Addr>>,
     pub runtime_errors: HashMap<i64, RuntimeErrorInfo<Addr>>,
-    /// Exact comb range definitions grouped by their source semantic process.
-    /// This survives physical EU coalescing and is not an ordering constraint.
-    pub semantic_regions: HashMap<VarAtomBase<Addr>, u64>,
     /// Persistent-state ranges published directly by FF actions in the shared
     /// comb/FF schedule. These Stores are semantic state updates rather than
     /// disposable comb publications.
@@ -2708,10 +2705,6 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display>(
     let n = input.len();
     let (mut materialization_tokens, token_weights) =
         logic_path_materialization_tokens(&input, arena);
-    let semantic_regions = input
-        .iter()
-        .filter_map(|path| Some((*path.target.var()?, path.semantic_region?)))
-        .collect();
     let LogicPathMemorySsa {
         successors: mut adj,
         mut value_users,
@@ -3278,7 +3271,6 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display>(
     Ok(ScheduleResult {
         execution_units: result_eus,
         runtime_errors,
-        semantic_regions,
         direct_ff_writes,
     })
 }
@@ -3440,7 +3432,6 @@ mod tests {
                 .unwrap()
         };
         LogicPath {
-            semantic_region: None,
             target: LogicPathTarget::Var(VarAtomBase::new(target, 0, 7)),
             sources: source
                 .map(|source| [VarAtomBase::new(source, 0, 7)].into_iter().collect())
@@ -3535,30 +3526,6 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(stores, vec![10, 11, 12, 20, 21, 22]);
-    }
-
-    #[test]
-    fn physical_comb_unit_preserves_independent_semantic_regions() {
-        let mut arena = SLTNodeArena::new();
-        let mut first = simple_path(&mut arena, 10, None);
-        first.semantic_region = Some(7);
-        let mut second = simple_path(&mut arena, 20, None);
-        second.semantic_region = Some(9);
-
-        let result = sort(
-            vec![first, second],
-            &arena,
-            &crate::HashSet::default(),
-            &crate::HashMap::default(),
-            false,
-            &crate::HashMap::default(),
-            1,
-        )
-        .unwrap();
-
-        assert_eq!(result.execution_units.len(), 1);
-        assert_eq!(result.semantic_regions[&VarAtomBase::new(10, 0, 7)], 7);
-        assert_eq!(result.semantic_regions[&VarAtomBase::new(20, 0, 7)], 9);
     }
 
     #[test]
@@ -3709,7 +3676,6 @@ mod tests {
             })
             .unwrap();
         LogicPath {
-            semantic_region: None,
             target: LogicPathTarget::Var(target),
             sources: [VarAtomBase::new(external, 0, 63)].into_iter().collect(),
             previous_sources: crate::HashSet::default(),
@@ -4189,7 +4155,6 @@ mod tests {
             })
             .unwrap();
         let path = |target, expr| LogicPath {
-            semantic_region: None,
             target: LogicPathTarget::Var(VarAtomBase::new(target, 0, 7)),
             // Keep the scheduling graph acyclic in this focused cache test;
             // dependency memoization still sees both initial reads.

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -17,7 +17,9 @@ oversized-function planning is constructed from final SIR
 at the backend boundary; backend scratch extends only the backend's private layout copy.
 Veryl source identities retained for diagnostics and public path lookup are grouped in
 `celox-frontend-veryl::VerylFrontendLookup`; optimizer and backend code no longer inspect that
-artifact. Moving the remaining parser implementation, symbolic, optimizer, and testbench payload
+artifact. The unused semantic-process provenance formerly copied from `LogicPath` through the
+scheduler into `Program` has been removed instead of being assigned to a target crate. Moving the
+remaining parser implementation, symbolic, optimizer, and testbench payload
 into the phase-specific target types below remains part of Milestone 3.
 
 The baseline is the compiler pipeline on `perf/native-simulation-throughput` after PR #322. The


### PR DESCRIPTION
## Summary
- remove unused semantic-process provenance from `LogicPath`, scheduler output, and compiled `Program`
- delete per-instance semantic-region numbering and its dead preservation test
- leave scheduling and lowering behavior unchanged

## Validation
- `cargo test -p celox parser::scheduler::tests --lib`
- `cargo test -p celox flatting --lib`
- `cargo test -p celox --test comb_observer`
- `cargo clippy -p celox --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- pre-push hook