### PR TITLE
Model optimizer layout requirements explicitly

### DIFF
--- a/crates/celox-state-layout/src/lib.rs
+++ b/crates/celox-state-layout/src/lib.rs
@@ -109,6 +109,10 @@ impl<A> LayoutRequirements<A> {
     pub fn is_empty(&self) -> bool {
         self.state_aliases.is_empty()
     }
+
+    pub fn clear(&mut self) {
+        self.state_aliases.clear();
+    }
 }
 
 /// Complete, backend-independent input to physical layout construction.
@@ -547,6 +551,9 @@ mod tests {
 
         assert_eq!(requirements.state_aliases().get(&2), Some(&1));
         assert!(!requirements.is_empty());
+
+        requirements.clear();
+        assert!(requirements.is_empty());
     }
 
     #[test]

--- a/crates/celox-state-layout/src/lib.rs
+++ b/crates/celox-state-layout/src/lib.rs
@@ -78,6 +78,43 @@ pub struct StateObjectLayout<A> {
     pub is_4state: bool,
 }
 
+/// Semantic constraints produced by optimization and consumed when physical
+/// state layout is finalized.
+///
+/// This deliberately contains no physical offsets.  Alias pairs state that
+/// two semantic objects may share one stable-state home; layout construction
+/// still validates representation compatibility before applying the pair.
+#[derive(Debug, Clone)]
+pub struct LayoutRequirements<A> {
+    state_aliases: HashMap<A, A>,
+}
+
+impl<A> Default for LayoutRequirements<A> {
+    fn default() -> Self {
+        Self {
+            state_aliases: HashMap::default(),
+        }
+    }
+}
+
+impl<A> LayoutRequirements<A> {
+    pub fn state_aliases(&self) -> &HashMap<A, A> {
+        &self.state_aliases
+    }
+
+    pub fn state_aliases_mut(&mut self) -> &mut HashMap<A, A> {
+        &mut self.state_aliases
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.state_aliases.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.state_aliases.clear();
+    }
+}
+
 /// Complete, backend-independent input to physical layout construction.
 ///
 /// The compiler facade adapts its phase artifacts into this value. Layout
@@ -89,7 +126,7 @@ pub struct LayoutInput<A> {
     pub working_addresses: Vec<A>,
     pub sparse_addresses: Vec<A>,
     pub unpacked_arrays: HashMap<A, UnpackedArrayLayout>,
-    pub address_aliases: Vec<(A, A)>,
+    pub requirements: LayoutRequirements<A>,
     pub ff_referenced_addresses: HashSet<A>,
     pub num_events: usize,
     pub runtime_event_sites: Vec<RuntimeEventSite>,
@@ -161,7 +198,7 @@ where
             working_addresses,
             sparse_addresses,
             unpacked_arrays,
-            mut address_aliases,
+            requirements,
             ff_referenced_addresses,
             num_events,
             runtime_event_sites,
@@ -310,6 +347,7 @@ where
             RUNTIME_EVENT_HEADER_SIZE + RUNTIME_EVENT_CAPACITY * runtime_event_slot_size;
         let merged_total_size = scratch_base_offset;
 
+        let mut address_aliases = requirements.state_aliases.into_iter().collect::<Vec<_>>();
         address_aliases.sort_unstable();
         for (alias, canonical) in address_aliases {
             let fourstate_ok = !four_state
@@ -507,6 +545,54 @@ mod tests {
     }
 
     #[test]
+    fn layout_requirements_own_semantic_aliases_until_layout() {
+        let mut requirements = LayoutRequirements::default();
+        requirements.state_aliases_mut().insert(2u32, 1u32);
+
+        assert_eq!(requirements.state_aliases().get(&2), Some(&1));
+        assert!(!requirements.is_empty());
+
+        requirements.clear();
+        assert!(requirements.is_empty());
+    }
+
+    #[test]
+    fn layout_applies_aliases_from_requirements() {
+        struct AliasLayoutSource;
+
+        impl LayoutSource<u32> for AliasLayoutSource {
+            fn layout_input(&self, _mode: MemoryLayoutMode) -> LayoutInput<u32> {
+                let mut requirements = LayoutRequirements::default();
+                requirements.state_aliases_mut().insert(2, 1);
+                LayoutInput {
+                    state_objects: vec![
+                        StateObjectLayout {
+                            address: 1,
+                            width: 8,
+                            is_4state: false,
+                        },
+                        StateObjectLayout {
+                            address: 2,
+                            width: 8,
+                            is_4state: false,
+                        },
+                    ],
+                    working_addresses: Vec::new(),
+                    sparse_addresses: Vec::new(),
+                    unpacked_arrays: HashMap::default(),
+                    requirements,
+                    ff_referenced_addresses: HashSet::default(),
+                    num_events: 0,
+                    runtime_event_sites: Vec::new(),
+                }
+            }
+        }
+
+        let layout = MemoryLayout::build(&AliasLayoutSource, false, MemoryLayoutMode::Packed);
+        assert_eq!(layout.offsets[&1], layout.offsets[&2]);
+    }
+
+    #[test]
     fn backend_scratch_only_extends_the_final_layout_region() {
         struct EmptyLayoutSource;
 
@@ -517,7 +603,7 @@ mod tests {
                     working_addresses: Vec::new(),
                     sparse_addresses: Vec::new(),
                     unpacked_arrays: HashMap::default(),
-                    address_aliases: Vec::new(),
+                    requirements: LayoutRequirements::default(),
                     ff_referenced_addresses: HashSet::default(),
                     num_events: 3,
                     runtime_event_sites: Vec::new(),

--- a/crates/celox-state-layout/src/lib.rs
+++ b/crates/celox-state-layout/src/lib.rs
@@ -109,10 +109,6 @@ impl<A> LayoutRequirements<A> {
     pub fn is_empty(&self) -> bool {
         self.state_aliases.is_empty()
     }
-
-    pub fn clear(&mut self) {
-        self.state_aliases.clear();
-    }
 }
 
 /// Complete, backend-independent input to physical layout construction.
@@ -551,9 +547,6 @@ mod tests {
 
         assert_eq!(requirements.state_aliases().get(&2), Some(&1));
         assert!(!requirements.is_empty());
-
-        requirements.clear();
-        assert!(requirements.is_empty());
     }
 
     #[test]

--- a/crates/celox/src/backend.rs
+++ b/crates/celox/src/backend.rs
@@ -19,7 +19,7 @@ mod wide_ops;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) use jit_engine::JitEngine;
-pub use memory_layout::{MemoryLayout, MemoryLayoutMode, get_byte_size};
+pub use memory_layout::{LayoutRequirements, MemoryLayout, MemoryLayoutMode, get_byte_size};
 #[cfg(not(target_arch = "wasm32"))]
 pub use runtime::SharedJitCode;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -6,7 +6,7 @@ use crate::ir::{
 #[cfg(any(target_arch = "x86_64", test))]
 pub use celox_state_layout::SparseWorkingLayout;
 pub use celox_state_layout::{
-    LayoutInput, LayoutSource, MemoryLayoutMode, RUNTIME_EVENT_HEADER_SIZE,
+    LayoutInput, LayoutRequirements, LayoutSource, MemoryLayoutMode, RUNTIME_EVENT_HEADER_SIZE,
     RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET, RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET,
     RUNTIME_EVENT_SLOT_SEQ_OFFSET, RUNTIME_EVENT_SLOT_SITE_OFFSET, RUNTIME_EVENT_WRITING,
     STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET, STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET,
@@ -45,11 +45,7 @@ impl LayoutSource<AbsoluteAddr> for Program {
                 .into_iter()
                 .collect(),
             unpacked_arrays,
-            address_aliases: self
-                .address_aliases
-                .iter()
-                .map(|(&alias, &canonical)| (alias, canonical))
-                .collect(),
+            requirements: self.layout_requirements.clone(),
             ff_referenced_addresses: collect_ff_referenced_addresses(self),
             num_events: self.num_events(),
             runtime_event_sites: self.runtime_schema.runtime_event_sites.clone(),
@@ -77,7 +73,7 @@ fn declared_strided_array_layouts(program: &Program) -> HashMap<AbsoluteAddr, Un
             },
         );
     }
-    for (&alias, &canonical) in &program.address_aliases {
+    for (&alias, &canonical) in program.layout_requirements.state_aliases() {
         layouts.remove(&alias);
         layouts.remove(&canonical);
     }

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -74,9 +74,7 @@ pub struct Program {
     pub design: celox_design::ElaboratedDesign<AbsoluteAddr>,
     pub frontend: VerylFrontendLookup,
     pub runtime_schema: RuntimeSchema<AbsoluteAddr>,
-    /// Memory layout aliases: non-canonical → canonical address.
-    /// Variables with identity Store→Load roundtrips share physical memory.
-    pub address_aliases: HashMap<AbsoluteAddr, AbsoluteAddr>,
+    pub layout_requirements: celox_state_layout::LayoutRequirements<AbsoluteAddr>,
     /// Initial block statements from the top-level module (for native testbenches).
     pub initial_statements: Option<Vec<veryl_analyzer::ir::Statement>>,
     /// Functions defined in the top-level module (for testbench function calls).
@@ -137,26 +135,30 @@ impl Program {
         four_state: bool,
         mode: crate::backend::memory_layout::MemoryLayoutMode,
     ) -> LaidOutProgram {
-        if !self.runtime_schema.comb_observers.is_empty() && !self.address_aliases.is_empty() {
+        if !self.runtime_schema.comb_observers.is_empty() && !self.layout_requirements.is_empty() {
             let observed_written: crate::HashSet<AbsoluteAddr> = self
                 .runtime_schema
                 .comb_observers
                 .iter()
                 .flat_map(|observer| observer.written_inputs.iter().copied())
                 .collect();
-            self.address_aliases
+            self.layout_requirements
+                .state_aliases_mut()
                 .retain(|alias_addr, _| !observed_written.contains(alias_addr));
-            self.address_aliases.retain(|alias_addr, _| {
-                !comb_capture_enable_needs_unaliased_old_value(&self.sir.eval_comb, *alias_addr)
-            });
+            self.layout_requirements
+                .state_aliases_mut()
+                .retain(|alias_addr, _| {
+                    !comb_capture_enable_needs_unaliased_old_value(&self.sir.eval_comb, *alias_addr)
+                });
         }
         crate::optimizer::coalescing::retain_final_identity_aliases(&mut self, four_state);
         let layout = crate::backend::MemoryLayout::build(&self, four_state, mode);
 
         // Remove identity Stores for aliases validated by the layout
-        if !self.address_aliases.is_empty() {
+        if !self.layout_requirements.is_empty() {
             let aliased: crate::HashMap<AbsoluteAddr, AbsoluteAddr> = self
-                .address_aliases
+                .layout_requirements
+                .state_aliases()
                 .iter()
                 .filter(|(alias_addr, canonical_addr)| {
                     layout
@@ -173,6 +175,7 @@ impl Program {
                 );
             }
         }
+        self.layout_requirements.clear();
 
         LaidOutProgram {
             program: self,

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -175,6 +175,8 @@ impl Program {
                 );
             }
         }
+        self.layout_requirements.clear();
+
         LaidOutProgram {
             program: self,
             layout,

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -175,8 +175,6 @@ impl Program {
                 );
             }
         }
-        self.layout_requirements.clear();
-
         LaidOutProgram {
             program: self,
             layout,

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -50,7 +50,7 @@ pub use backend::EventRef;
 pub use backend::SharedJitCode;
 #[cfg(not(target_arch = "wasm32"))]
 pub use backend::wasm_runtime::WasmBackend;
-pub use backend::{EventHandle, MemoryLayout, MemoryLayoutMode, get_byte_size};
+pub use backend::{EventHandle, LayoutRequirements, MemoryLayout, MemoryLayoutMode, get_byte_size};
 #[cfg(not(target_arch = "wasm32"))]
 pub use backend::{JitBackend, SimBackend};
 pub use celox_design::{ElaboratedDesign, EventTopology, RuntimeSchema};

--- a/crates/celox/src/optimizer/coalescing.rs
+++ b/crates/celox/src/optimizer/coalescing.rs
@@ -765,7 +765,10 @@ fn optimize_late_comb(
             options.four_state,
         );
         if !identity_aliases.is_empty() {
-            program.address_aliases.extend(identity_aliases);
+            program
+                .layout_requirements
+                .state_aliases_mut()
+                .extend(identity_aliases);
         }
     }
     verify_stage(program, "identity-store bypass");
@@ -818,7 +821,8 @@ fn optimize_late_comb(
         eprintln!("[branchify-stats] late guarded");
     }
     if opt.opt_level() != crate::optimizer::OptLevel::O0 {
-        let sparse_case_pass = SparseCaseDispatchPass::new(&program.address_aliases);
+        let sparse_case_pass =
+            SparseCaseDispatchPass::new(program.layout_requirements.state_aliases());
         if trace {
             eprintln!("[branchify-stats] late sparse constructed");
         }
@@ -1094,7 +1098,9 @@ fn optimize_with_options(
         .with_unpacked_element_widths(Arc::clone(&unpacked_element_widths));
     if opt.opt_level() != crate::optimizer::OptLevel::O0 {
         comb_ff_late_passes.add_pass(GuardedRegionSinkingPass);
-        comb_ff_late_passes.add_pass(SparseCaseDispatchPass::new(&program.address_aliases));
+        comb_ff_late_passes.add_pass(SparseCaseDispatchPass::new(
+            program.layout_requirements.state_aliases(),
+        ));
     }
     if on(SirPass::Gvn) {
         comb_ff_late_passes.add_pass(DeadCodeEliminationPass);

--- a/crates/celox/src/optimizer/coalescing/pass_identity_store_bypass.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_identity_store_bypass.rs
@@ -73,7 +73,7 @@ pub(super) fn optimize_program_identity_stores(
         &mut program.sir.eval_comb,
         &metadata,
         &blocked_aliases,
-        &program.address_aliases,
+        program.layout_requirements.state_aliases(),
         four_state,
     )
 }
@@ -122,11 +122,11 @@ fn optimize_eval_comb_identity_stores(
 /// every remaining write to the removable side must still be the exact
 /// full-width identity recipe that justified sharing its home.
 pub(crate) fn retain_final_identity_aliases(program: &mut Program, four_state: bool) {
-    if program.address_aliases.is_empty() {
+    if program.layout_requirements.is_empty() {
         return;
     }
     let metadata = address_metadata(program);
-    let aliases = program.address_aliases.clone();
+    let aliases = program.layout_requirements.state_aliases().clone();
     let mut valid = aliases.keys().copied().collect::<HashSet<_>>();
 
     retain_aliases_valid_for_units(
@@ -140,7 +140,8 @@ pub(crate) fn retain_final_identity_aliases(program: &mut Program, four_state: b
         retain_aliases_valid_for_units(units, &aliases, &metadata, four_state, &mut valid);
     }
     program
-        .address_aliases
+        .layout_requirements
+        .state_aliases_mut()
         .retain(|alias, _| valid.contains(alias));
 }
 

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -1407,7 +1407,7 @@ pub(crate) fn flatten(
                     module_names: module_names.clone(),
                 },
                 runtime_schema: celox_design::RuntimeSchema::default(),
-                address_aliases: HashMap::default(),
+                layout_requirements: Default::default(),
                 initial_statements: None,
                 tb_functions: fxhash::FxHashMap::default(),
             };
@@ -1623,7 +1623,7 @@ pub(crate) fn flatten(
             runtime_event_sites,
             comb_observers: runtime_comb_observers,
         },
-        address_aliases: HashMap::default(),
+        layout_requirements: Default::default(),
         initial_statements,
         tb_functions: module_ir
             .get(root_id)

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -1447,6 +1447,14 @@ impl Simulator<JitBackend> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+impl Simulator<crate::backend::wasm_runtime::WasmBackend> {
+    /// Consume the simulator and return the inner Wasmtime backend.
+    pub fn into_backend(self) -> crate::backend::wasm_runtime::WasmBackend {
+        self.backend
+    }
+}
+
 #[cfg(target_arch = "x86_64")]
 impl Simulator<NativeBackend> {
     /// Returns the shared compiled native code, allowing it to be reused

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -608,7 +608,7 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
             );
         }
 
-        // Build memory layout (consumes address_aliases for offset sharing)
+        // Build memory layout (consumes semantic layout requirements).
         let layout_start = phase_timing.then(crate::timing::now);
         let mut laid_out = program.into_laid_out_with_mode(self.options.four_state, layout_mode);
         if let Some(start) = layout_start {

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -3651,11 +3651,11 @@ module Top (
     .build()
     .unwrap();
 
-    let y_addr = sim.program().get_addr(&[], &["y"]).unwrap();
+    let x = sim.signal("x");
+    let y = sim.signal("y");
     assert!(
-        !sim.program().address_aliases.contains_key(&y_addr),
-        "capture-enabled duplicate store must not be removed as an alias: {:?}",
-        sim.program().address_aliases,
+        x.offset != y.offset,
+        "capture-enabled duplicate store must retain a distinct state home",
     );
 }
 

--- a/crates/celox/tests/wasm_backend.rs
+++ b/crates/celox/tests/wasm_backend.rs
@@ -1,11 +1,9 @@
-use celox::{BigUint, SimulatorOptions, WasmBackend};
+use celox::{BigUint, Program, WasmBackend};
 
-fn build_wasm(code: &str, top: &str) -> (WasmBackend, celox::Simulator) {
-    let sim = celox::Simulator::builder(code, top).build().unwrap();
-    let opts = SimulatorOptions::default();
-    let program = sim.program().clone().into_laid_out(opts.four_state);
-    let backend = WasmBackend::new(&program, &opts).expect("WasmBackend::new failed");
-    (backend, sim)
+fn build_wasm(code: &str, top: &str) -> (WasmBackend, Program) {
+    let sim = celox::Simulator::builder(code, top).build_wasm().unwrap();
+    let program = sim.program().clone();
+    (sim.into_backend(), program)
 }
 
 #[test]
@@ -184,11 +182,11 @@ fn test_wasm_adder_combinational() {
             assign s = a + b;
         }
     "#;
-    let (mut backend, sim) = build_wasm(code, "Top");
+    let (mut backend, program) = build_wasm(code, "Top");
 
-    let a_addr = sim.program().get_addr(&[], &["a"]).unwrap();
-    let b_addr = sim.program().get_addr(&[], &["b"]).unwrap();
-    let s_addr = sim.program().get_addr(&[], &["s"]).unwrap();
+    let a_addr = program.get_addr(&[], &["a"]).unwrap();
+    let b_addr = program.get_addr(&[], &["b"]).unwrap();
+    let s_addr = program.get_addr(&[], &["s"]).unwrap();
 
     let a_sig = backend.resolve_signal(&a_addr);
     let b_sig = backend.resolve_signal(&b_addr);
@@ -220,12 +218,12 @@ fn test_wasm_mux_branching() {
             }
         }
     "#;
-    let (mut backend, sim) = build_wasm(code, "Top");
+    let (mut backend, program) = build_wasm(code, "Top");
 
-    let sel_addr = sim.program().get_addr(&[], &["sel"]).unwrap();
-    let a_addr = sim.program().get_addr(&[], &["a"]).unwrap();
-    let b_addr = sim.program().get_addr(&[], &["b"]).unwrap();
-    let y_addr = sim.program().get_addr(&[], &["y"]).unwrap();
+    let sel_addr = program.get_addr(&[], &["sel"]).unwrap();
+    let a_addr = program.get_addr(&[], &["a"]).unwrap();
+    let b_addr = program.get_addr(&[], &["b"]).unwrap();
+    let y_addr = program.get_addr(&[], &["y"]).unwrap();
 
     let sel = backend.resolve_signal(&sel_addr);
     let a = backend.resolve_signal(&a_addr);
@@ -263,12 +261,12 @@ fn test_wasm_counter_sequential() {
             }
         }
     "#;
-    let (mut backend, sim) = build_wasm(code, "Top");
+    let (mut backend, program) = build_wasm(code, "Top");
 
-    let clk_addr = sim.program().get_addr(&[], &["clk"]).unwrap();
-    let rst_addr = sim.program().get_addr(&[], &["rst"]).unwrap();
-    let en_addr = sim.program().get_addr(&[], &["en"]).unwrap();
-    let cnt_addr = sim.program().get_addr(&[], &["cnt"]).unwrap();
+    let clk_addr = program.get_addr(&[], &["clk"]).unwrap();
+    let rst_addr = program.get_addr(&[], &["rst"]).unwrap();
+    let en_addr = program.get_addr(&[], &["en"]).unwrap();
+    let cnt_addr = program.get_addr(&[], &["cnt"]).unwrap();
 
     let rst_sig = backend.resolve_signal(&rst_addr);
     let en_sig = backend.resolve_signal(&en_addr);
@@ -303,11 +301,11 @@ fn test_wasm_wide_value_128bit() {
             assign s = a + b;
         }
     "#;
-    let (mut backend, sim) = build_wasm(code, "Top");
+    let (mut backend, program) = build_wasm(code, "Top");
 
-    let a_addr = sim.program().get_addr(&[], &["a"]).unwrap();
-    let b_addr = sim.program().get_addr(&[], &["b"]).unwrap();
-    let s_addr = sim.program().get_addr(&[], &["s"]).unwrap();
+    let a_addr = program.get_addr(&[], &["a"]).unwrap();
+    let b_addr = program.get_addr(&[], &["b"]).unwrap();
+    let s_addr = program.get_addr(&[], &["s"]).unwrap();
 
     let a_sig = backend.resolve_signal(&a_addr);
     let b_sig = backend.resolve_signal(&b_addr);

--- a/crates/celox/tests/wasm_regression.rs
+++ b/crates/celox/tests/wasm_regression.rs
@@ -1,15 +1,16 @@
 //! Regression tests: run Veryl designs through both JitBackend and WasmBackend,
 //! comparing results to ensure they match.
 
-use celox::{BigUint, SimulatorOptions, WasmBackend};
+use celox::{BigUint, WasmBackend};
 
 /// Build a Simulator (JIT) and a WasmBackend from the same Veryl code.
 /// Returns (jit_simulator, wasm_backend).
 fn build_both(code: &str, top: &str) -> (celox::Simulator, WasmBackend) {
     let sim = celox::Simulator::builder(code, top).build().unwrap();
-    let opts = SimulatorOptions::default();
-    let program = sim.program().clone().into_laid_out(opts.four_state);
-    let wasm = WasmBackend::new(&program, &opts).expect("WasmBackend::new failed");
+    let wasm = celox::Simulator::builder(code, top)
+        .build_wasm()
+        .expect("WASM simulator build failed")
+        .into_backend();
     (sim, wasm)
 }
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -84,7 +84,7 @@ The simulator employs a **multi-region model on a single memory buffer**.
 -   **Triggered-bits region**: One bit per event, used for cascade/gated clock trigger detection. After a `Store` instruction, the backend compares old and new values and sets the corresponding trigger bit if changed.
 -   **Scratch region**: Used by the tail-call splitting pass for inter-chunk register value spilling.
 -   **SignalRef**: A handle that caches offsets and metadata, enabling direct memory access without going through a `HashMap`.
--   **Layout Requirements**: The `IdentityStoreBypass` optimization detects variables that are identity copies (Store→Load roundtrips) and records non-canonical → canonical state-home aliases in `Program::layout_requirements`. Physical layout validates compatible representations before sharing memory. The contract remains available while the transitional `Program` can be laid out again.
+-   **Layout Requirements**: The `IdentityStoreBypass` optimization detects variables that are identity copies (Store→Load roundtrips) and records non-canonical → canonical state-home aliases in `Program::layout_requirements`. Physical layout validates compatible representations before sharing memory, then consumes the requirements when producing `LaidOutProgram`.
 
 For 4-state variables, each variable occupies `2 × ceil(width/8)` bytes (value + mask pair).
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -84,7 +84,7 @@ The simulator employs a **multi-region model on a single memory buffer**.
 -   **Triggered-bits region**: One bit per event, used for cascade/gated clock trigger detection. After a `Store` instruction, the backend compares old and new values and sets the corresponding trigger bit if changed.
 -   **Scratch region**: Used by the tail-call splitting pass for inter-chunk register value spilling.
 -   **SignalRef**: A handle that caches offsets and metadata, enabling direct memory access without going through a `HashMap`.
--   **Address Aliases**: The `IdentityStoreBypass` optimization detects variables that are identity copies (Store→Load roundtrips) and registers them as aliases in `Program::address_aliases`. Aliased variables share physical memory, eliminating redundant copies.
+-   **Layout Requirements**: The `IdentityStoreBypass` optimization detects variables that are identity copies (Store→Load roundtrips) and records non-canonical → canonical state-home aliases in `Program::layout_requirements`. Physical layout validates compatible representations before sharing memory. The contract remains available while the transitional `Program` can be laid out again.
 
 For 4-state variables, each variable occupies `2 × ceil(width/8)` bytes (value + mask pair).
 

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -19,7 +19,9 @@ Veryl source identities retained for diagnostics and public path lookup are grou
 `celox-frontend-veryl::VerylFrontendLookup`; optimizer and backend code no longer inspect that
 artifact. The unused semantic-process provenance formerly copied from `LogicPath` through the
 scheduler into `Program` has been removed instead of being assigned to a target crate. Moving the
-remaining parser implementation, symbolic, optimizer, and testbench payload
+optimizer-to-layout state-alias contract is now represented by
+`celox-state-layout::LayoutRequirements` and is cleared after physical layout is finalized. Moving
+the remaining parser implementation, symbolic, optimizer, and testbench payload
 into the phase-specific target types below remains part of Milestone 3.
 
 The baseline is the compiler pipeline on `perf/native-simulation-throughput` after PR #322. The

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -20,8 +20,10 @@ Veryl source identities retained for diagnostics and public path lookup are grou
 artifact. The unused semantic-process provenance formerly copied from `LogicPath` through the
 scheduler into `Program` has been removed instead of being assigned to a target crate. Moving the
 optimizer-to-layout state-alias contract is now represented by
-`celox-state-layout::LayoutRequirements` and is cleared after physical layout is finalized. Moving
-the remaining parser implementation, symbolic, optimizer, and testbench payload
+`celox-state-layout::LayoutRequirements`. It remains attached to the transitional, publicly
+re-layoutable `Program`; clearing it after removing identity Stores would make a second layout
+semantically invalid. A later phase-artifact split will consume it together with `Program` instead.
+Moving the remaining parser implementation, symbolic, optimizer, and testbench payload
 into the phase-specific target types below remains part of Milestone 3.
 
 The baseline is the compiler pipeline on `perf/native-simulation-throughput` after PR #322. The

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -20,10 +20,10 @@ Veryl source identities retained for diagnostics and public path lookup are grou
 artifact. The unused semantic-process provenance formerly copied from `LogicPath` through the
 scheduler into `Program` has been removed instead of being assigned to a target crate. Moving the
 optimizer-to-layout state-alias contract is now represented by
-`celox-state-layout::LayoutRequirements`. It remains attached to the transitional, publicly
-re-layoutable `Program`; clearing it after removing identity Stores would make a second layout
-semantically invalid. A later phase-artifact split will consume it together with `Program` instead.
-Moving the remaining parser implementation, symbolic, optimizer, and testbench payload
+`celox-state-layout::LayoutRequirements` and is cleared after physical layout is finalized. Tests
+and consumers construct each backend from an unlaid-out `Program` rather than attempting to
+re-layout the finalized program after identity Stores have been removed. Moving the remaining
+parser implementation, symbolic, optimizer, and testbench payload
 into the phase-specific target types below remains part of Milestone 3.
 
 The baseline is the compiler pipeline on `perf/native-simulation-throughput` after PR #322. The

--- a/docs/internals/ir-reference.md
+++ b/docs/internals/ir-reference.md
@@ -33,7 +33,7 @@ pub struct Program {
     pub eval_comb_plan: Option<EvalCombPlan>,
     // ... instance maps, clock domains, arena, etc.
     pub reset_clock_map: HashMap<AbsoluteAddr, AbsoluteAddr>,
-    pub address_aliases: HashMap<AbsoluteAddr, AbsoluteAddr>,
+    pub layout_requirements: LayoutRequirements<AbsoluteAddr>,
     pub layout: Option<MemoryLayout>,
     pub initial_statements: Option<Vec<Statement>>,
     pub tb_functions: FxHashMap<VarId, Function>,
@@ -45,7 +45,7 @@ pub struct Program {
 -   **`apply_ffs`**: Phase that commits values from the Working region to the Stable region.
 -   **`eval_comb_plan`**: Compilation plan for `eval_comb` when the estimated CLIF instruction count exceeds the safety threshold used to stay below Cranelift's instruction/value limits. See [Tail-Call Splitting](./optimizations.md#214-tail-call-splitting) for details.
 -   **`reset_clock_map`**: Maps each reset `AbsoluteAddr` to its associated clock `AbsoluteAddr` (derived from `FfDeclaration`).
--   **`address_aliases`**: Memory layout aliases mapping non-canonical → canonical addresses. Variables with identity `Store→Load` roundtrips share physical memory (populated by `IdentityStoreBypass`).
+-   **`layout_requirements`**: Semantic physical-layout constraints, including validated candidates mapping non-canonical → canonical state homes. `IdentityStoreBypass` populates these aliases; layout verifies representation compatibility before sharing memory. The requirements are retained while `Program` remains publicly re-layoutable.
 -   **`layout`**: Pre-computed `MemoryLayout`. Built after optimization, before backend codegen. Centralizes offset calculation so all backends share the same layout.
 -   **`initial_statements`**: Initial block statements from the top-level module (for native testbenches).
 -   **`tb_functions`**: Functions defined in the top-level module (for testbench function calls via the bytecode VM).

--- a/docs/internals/ir-reference.md
+++ b/docs/internals/ir-reference.md
@@ -45,7 +45,7 @@ pub struct Program {
 -   **`apply_ffs`**: Phase that commits values from the Working region to the Stable region.
 -   **`eval_comb_plan`**: Compilation plan for `eval_comb` when the estimated CLIF instruction count exceeds the safety threshold used to stay below Cranelift's instruction/value limits. See [Tail-Call Splitting](./optimizations.md#214-tail-call-splitting) for details.
 -   **`reset_clock_map`**: Maps each reset `AbsoluteAddr` to its associated clock `AbsoluteAddr` (derived from `FfDeclaration`).
--   **`layout_requirements`**: Semantic physical-layout constraints, including validated candidates mapping non-canonical → canonical state homes. `IdentityStoreBypass` populates these aliases; layout verifies representation compatibility before sharing memory. The requirements are retained while `Program` remains publicly re-layoutable.
+-   **`layout_requirements`**: Semantic physical-layout constraints, including validated candidates mapping non-canonical → canonical state homes. `IdentityStoreBypass` populates these aliases; layout verifies representation compatibility before sharing memory and consumes the requirements when producing `LaidOutProgram`.
 -   **`layout`**: Pre-computed `MemoryLayout`. Built after optimization, before backend codegen. Centralizes offset calculation so all backends share the same layout.
 -   **`initial_statements`**: Initial block statements from the top-level module (for native testbenches).
 -   **`tb_functions`**: Functions defined in the top-level module (for testbench function calls via the bytecode VM).

--- a/docs/internals/optimizations.md
+++ b/docs/internals/optimizations.md
@@ -64,7 +64,7 @@ Splits wide coalesced stores back into narrower ones after the reschedule pass, 
 Partial store-load forwarding in combinational blocks. When a store covers part of a subsequent load's range, forwards the known portion and narrows the load. Controlled by `SirPass::PartialForward`.
 
 ### 2.14 Identity Store Bypass
-Detects identity copies (Store→Load roundtrips where the value is unchanged) and registers the source and destination as address aliases in `Program::address_aliases`. Aliased variables share physical memory, eliminating redundant copies. Controlled by `SirPass::IdentityStoreBypass`.
+Detects identity copies (Store→Load roundtrips where the value is unchanged) and records the source and destination as semantic state-home aliases in `Program::layout_requirements`. Physical layout validates compatible representations before sharing memory and eliminating redundant copies. Controlled by `SirPass::IdentityStoreBypass`.
 
 ### 2.15 Branch-Aware Mux Lowering
 


### PR DESCRIPTION
## Summary
- add `celox_state_layout::LayoutRequirements` as the optimizer-to-layout semantic contract
- route state-home aliases through that contract instead of a loose `Program` map
- consume and clear requirements after physical layout and identity-store finalization
- validate that aliases supplied by requirements share physical offsets
- make Wasmtime simulators expose the same consuming backend accessor as other backends
- build WASM tests through the normal one-layout builder path instead of re-laying out a finalized `Program`
- update remaining internal documentation from `address_aliases` to the new contract

## Correctness note

Layout finalization removes proven identity Stores after merging their state homes, so a finalized `Program` must not be laid out again after its requirements have been consumed. The previous WASM test helpers did exactly that. They now construct the WASM simulator from source through `build_wasm()` and consume its backend, preserving the phase boundary instead of extending the lifetime of layout requirements.

## Validation
- `cargo test -p celox-state-layout --lib`
- `cargo test -p celox --test wasm_backend`
- `cargo test -p celox --test wasm_regression`
- `cargo clippy -p celox-state-layout -p celox --all-targets -- -D warnings`
- pre-push hook