### PR TITLE
refactor(testbench): project observability before optimization

### DIFF
--- a/crates/celox-design/src/lib.rs
+++ b/crates/celox-design/src/lib.rs
@@ -1,6 +1,6 @@
 //! Source-language-independent design identities and semantic vocabulary.
 
-use fxhash::FxHashMap as HashMap;
+use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, fmt};
@@ -118,6 +118,9 @@ pub struct RuntimeSchema<A> {
     pub runtime_errors: HashMap<i64, RuntimeErrorInfo<A>>,
     pub runtime_event_sites: Vec<RuntimeEventSite>,
     pub comb_observers: Vec<RuntimeCombObserver<A>>,
+    /// Persistent state read directly by host-side testbench execution. These
+    /// are optimization roots even when no SIR instruction loads them.
+    pub testbench_read_roots: HashSet<A>,
 }
 
 impl<A> Default for RuntimeSchema<A> {
@@ -126,6 +129,7 @@ impl<A> Default for RuntimeSchema<A> {
             runtime_errors: HashMap::default(),
             runtime_event_sites: Vec::new(),
             comb_observers: Vec::new(),
+            testbench_read_roots: HashSet::default(),
         }
     }
 }
@@ -567,12 +571,14 @@ mod tests {
             }],
             written_inputs: vec![initial.address],
         });
+        runtime.testbench_read_roots.insert(initial.address);
 
         assert_eq!(error.signals, vec![initial.address]);
         assert!(matches!(initial.data, InitialStateData::Writes(_)));
         assert_eq!(runtime.runtime_errors[&1], error);
         assert_eq!(runtime.runtime_event_sites.len(), 1);
         assert_eq!(runtime.comb_observers[0].sensitivity[0].id, initial.address);
+        assert!(runtime.testbench_read_roots.contains(&initial.address));
     }
 
     #[test]

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -1622,6 +1622,7 @@ pub(crate) fn flatten(
             runtime_errors,
             runtime_event_sites,
             comb_observers: runtime_comb_observers,
+            testbench_read_roots: Default::default(),
         },
         layout_requirements: Default::default(),
         initial_statements,
@@ -2556,6 +2557,10 @@ pub fn parse(
             trace.as_deref_mut(),
         )
     )?;
+    timed_phase!(
+        "project_testbench_observability",
+        crate::testbench::project_observability(&mut program)
+    );
 
     if let Some(t) = trace.as_deref_mut()
         && trace_opts.pre_optimized_sir

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -577,7 +577,7 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
     > {
         let phase_timing = std::env::var_os("CELOX_PHASE_TIMING").is_some();
         let compile_start = phase_timing.then(crate::timing::now);
-        let (mut program, warnings) = compile_to_sir_with_layout_mode(
+        let (program, warnings) = compile_to_sir_with_layout_mode(
             &self.sources,
             self.top,
             &self.ignored_loops,
@@ -594,18 +594,6 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
         )?;
         if let Some(start) = compile_start {
             eprintln!("[phase-timing] compile_to_sir: {:?}", start.elapsed());
-        }
-
-        // Register testbench runtime-event sites before layout fixes the ring geometry.
-        let runtime_sites_start = phase_timing.then(crate::timing::now);
-        crate::testbench::register_runtime_event_sites(&mut program);
-        if let Some(start) = runtime_sites_start {
-            eprintln!(
-                "[phase-timing] register_runtime_event_sites: {:?} runtime_event_sites={} comb_observers={}",
-                start.elapsed(),
-                program.runtime_schema.runtime_event_sites.len(),
-                program.runtime_schema.comb_observers.len()
-            );
         }
 
         // Build memory layout (consumes semantic layout requirements).
@@ -795,10 +783,7 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
             layout_mode,
         );
 
-        let sim_res = program_res.and_then(|(mut program, warnings)| {
-            // Register testbench runtime-event sites before layout fixes the ring geometry.
-            crate::testbench::register_runtime_event_sites(&mut program);
-
+        let sim_res = program_res.and_then(|(program, warnings)| {
             let mut laid_out =
                 program.into_laid_out_with_mode(self.options.four_state, layout_mode);
 
@@ -963,7 +948,7 @@ fn run_dead_store_elimination(
     // Native testbench expressions bypass SIR and read simulator memory
     // directly. Their inputs are therefore external DSE roots just like
     // signals named with `live_signal()`.
-    externally_live.extend(crate::testbench::initial_read_addresses(program));
+    externally_live.extend(program.runtime_schema.testbench_read_roots.iter().copied());
 
     // User-specified live signals
     for (inst_path, var_path) in live_signals {

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -661,19 +661,20 @@ fn count_assert_statements(
     count
 }
 
-pub(crate) fn register_runtime_event_sites(program: &mut Program) {
+pub(crate) fn project_observability(program: &mut Program) {
     let Some(stmts) = program.initial_statements.as_ref() else {
         return;
     };
     let mut sites = Vec::new();
     collect_runtime_event_sites(stmts, &program.tb_functions, &mut sites);
     program.runtime_schema.runtime_event_sites.extend(sites);
+    program.runtime_schema.testbench_read_roots = initial_read_addresses(program);
 }
 
 /// Return top-module signals read by the native testbench. Testbench bytecode
 /// reads these directly from simulator memory, so they are external roots for
 /// dead-store elimination even though no SIR execution unit loads them.
-pub(crate) fn initial_read_addresses(program: &Program) -> crate::HashSet<AbsoluteAddr> {
+fn initial_read_addresses(program: &Program) -> crate::HashSet<AbsoluteAddr> {
     let Some(stmts) = program.initial_statements.as_ref() else {
         return crate::HashSet::default();
     };

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -1,4 +1,4 @@
-use celox::{ResetType, Simulator, TestResult};
+use celox::{DeadStorePolicy, ResetType, Simulator, TestResult};
 
 #[path = "test_utils/mod.rs"]
 #[macro_use]
@@ -87,6 +87,33 @@ fn test_counter_fail() {
         Simulator::builder(&code, "t").run_test().unwrap(),
         TestResult::Fail(_),
     ));
+}
+
+#[test]
+fn test_testbench_direct_reads_are_dead_store_roots() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            var hidden: logic<8>;
+
+            always_comb {
+                hidden = 8'd7;
+            }
+
+            initial {
+                $assert(hidden == 8'd7);
+                $finish();
+            }
+        }
+    "#;
+
+    assert_eq!(
+        Simulator::builder(code, "t")
+            .dead_store_policy(DeadStorePolicy::PreserveListedSignals)
+            .run_test()
+            .unwrap(),
+        TestResult::Pass,
+    );
 }
 
 // ── Wide signal (>64 bit) ──────────────────────────────────────────────

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -22,8 +22,10 @@ scheduler into `Program` has been removed instead of being assigned to a target 
 optimizer-to-layout state-alias contract is now represented by
 `celox-state-layout::LayoutRequirements` and is cleared after physical layout is finalized. Tests
 and consumers construct each backend from an unlaid-out `Program` rather than attempting to
-re-layout the finalized program after identity Stores have been removed. Moving the remaining
-parser implementation, symbolic, optimizer, and testbench payload
+re-layout the finalized program after identity Stores have been removed. Veryl
+testbench runtime-event sites and direct state-read roots are projected into the source-independent
+`RuntimeSchema` before SIR optimization, so optimization and layout no longer traverse testbench
+AST. Moving the remaining parser implementation, symbolic, optimizer, and testbench payload
 into the phase-specific target types below remains part of Milestone 3.
 
 The baseline is the compiler pipeline on `perf/native-simulation-throughput` after PR #322. The


### PR DESCRIPTION
## Summary
- project testbench runtime-event sites and direct state-read roots immediately after frontend flattening
- store read roots in source-independent `RuntimeSchema`
- stop builder/layout/DSE paths from traversing Veryl testbench AST
- preserve internal testbench reads under dead-store elimination

## Validation
- `cargo test -p celox-design --lib`
- `cargo test -p celox testbench::tests --lib`
- `cargo test -p celox --test native_testbench`
- `cargo test -p celox --lib`
- focused clippy and workspace all-target check
- pre-push hook