### PR TITLE
refactor(testbench): isolate Veryl source artifact

### DIFF
--- a/crates/celox-frontend-veryl/src/lib.rs
+++ b/crates/celox-frontend-veryl/src/lib.rs
@@ -7,7 +7,7 @@
 use celox_design::{InstanceId, ModuleId, VariableMetadata};
 use fxhash::FxHashMap as HashMap;
 use std::fmt;
-use veryl_analyzer::ir::{VarId, VarPath};
+use veryl_analyzer::ir::{Function, Statement, VarId, VarPath};
 use veryl_parser::resource_table::StrId;
 
 #[derive(Clone)]
@@ -64,6 +64,29 @@ impl fmt::Debug for VerylFrontendLookup {
     }
 }
 
+/// Veryl-owned source input for frontend testbench lowering.
+///
+/// This artifact is intentionally separate from semantic design/runtime
+/// schemas.  It is consumed by the testbench compiler and must not be
+/// inspected by SIR optimization, layout, or backend code generation.
+#[derive(Clone, Default)]
+pub struct VerylTestbenchSource {
+    pub initial_statements: Option<Vec<Statement>>,
+    pub functions: HashMap<VarId, Function>,
+}
+
+impl fmt::Debug for VerylTestbenchSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VerylTestbenchSource")
+            .field(
+                "initial_statements",
+                &self.initial_statements.as_ref().map(Vec::len),
+            )
+            .field("functions", &self.functions.len())
+            .finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,5 +99,12 @@ mod tests {
         assert!(lookup.module_variables.is_empty());
         assert!(lookup.module_var_path_index.is_empty());
         assert!(lookup.module_names.is_empty());
+    }
+
+    #[test]
+    fn default_testbench_source_is_empty() {
+        let source = VerylTestbenchSource::default();
+        assert!(source.initial_statements.is_none());
+        assert!(source.functions.is_empty());
     }
 }

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -9,7 +9,9 @@ pub(crate) use celox_design::{
     RuntimeEventKind, RuntimeEventSite, RuntimeSchema, SPARSE_WORKING_REGION, STABLE_REGION,
     TriggerIdWithKind, TriggerSet, UnaryOp, VarAtomBase, WORKING_REGION,
 };
-pub use celox_frontend_veryl::{InstancePath, VariableInfo, VerylFrontendLookup};
+pub use celox_frontend_veryl::{
+    InstancePath, VariableInfo, VerylFrontendLookup, VerylTestbenchSource,
+};
 pub(crate) use celox_sir::{
     BasicBlock, BlockId, ExecutionUnit, RegisterId, RegisterType, SIRBuilder, SIRInstruction,
     SIROffset, SIRSwitchCase, SIRTerminator, SIRValue, collect_exact_zero_registers, merge_sir_eus,
@@ -75,10 +77,7 @@ pub struct Program {
     pub frontend: VerylFrontendLookup,
     pub runtime_schema: RuntimeSchema<AbsoluteAddr>,
     pub layout_requirements: celox_state_layout::LayoutRequirements<AbsoluteAddr>,
-    /// Initial block statements from the top-level module (for native testbenches).
-    pub initial_statements: Option<Vec<veryl_analyzer::ir::Statement>>,
-    /// Functions defined in the top-level module (for testbench function calls).
-    pub tb_functions: fxhash::FxHashMap<veryl_analyzer::ir::VarId, veryl_analyzer::ir::Function>,
+    pub testbench_source: VerylTestbenchSource,
 }
 
 /// A [`Program`] whose physical state layout has been finalized.

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -63,6 +63,7 @@ pub(crate) use fxhash::FxHashSet as HashSet;
 pub use ir::{
     AbsoluteAddr, AddrLookupError, InstancePath, LaidOutProgram, PortTypeKind, Program,
     RuntimeErrorInfo, SignalRef, SirProgram, VariableInfo, VerylFrontendLookup,
+    VerylTestbenchSource,
 };
 #[cfg(target_arch = "x86_64")]
 pub mod native_backend {

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -1408,8 +1408,7 @@ pub(crate) fn flatten(
                 },
                 runtime_schema: celox_design::RuntimeSchema::default(),
                 layout_requirements: Default::default(),
-                initial_statements: None,
-                tb_functions: fxhash::FxHashMap::default(),
+                testbench_source: Default::default(),
             };
             let source_locations = scheduler_source_locations(&error, module_ir, &instance_modules);
             let mut target_arena = SLTNodeArena::new();
@@ -1625,11 +1624,13 @@ pub(crate) fn flatten(
             testbench_read_roots: Default::default(),
         },
         layout_requirements: Default::default(),
-        initial_statements,
-        tb_functions: module_ir
-            .get(root_id)
-            .map(|m| m.functions.clone())
-            .unwrap_or_default(),
+        testbench_source: crate::ir::VerylTestbenchSource {
+            initial_statements,
+            functions: module_ir
+                .get(root_id)
+                .map(|m| m.functions.clone())
+                .unwrap_or_default(),
+        },
     };
 
     // --- Trigger Injection ---

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -746,11 +746,16 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
     /// observed before the test finishes or stops on a fatal failure.
     pub fn run_test_detailed(self) -> Result<crate::testbench::TestResultDetailed, SimulatorError> {
         let mut sim = self.build()?;
-        let initial_stmts = sim.program().initial_statements.clone().ok_or_else(|| {
-            SimulatorError::new(SimulatorErrorKind::Codegen(
-                "no initial block found — this module is not a native testbench".into(),
-            ))
-        })?;
+        let initial_stmts = sim
+            .program()
+            .testbench_source
+            .initial_statements
+            .clone()
+            .ok_or_else(|| {
+                SimulatorError::new(SimulatorErrorKind::Codegen(
+                    "no initial block found — this module is not a native testbench".into(),
+                ))
+            })?;
         let mut tb_builder = crate::testbench::TestbenchBuilder::new(&sim);
         tb_builder.build_event_map(&initial_stmts);
         let tb_stmts = tb_builder.convert(&initial_stmts);
@@ -837,11 +842,16 @@ fn run_test_with_sim<B: crate::backend::SimBackend>(
 ) -> Result<crate::testbench::TestResult, SimulatorError> {
     let phase_timing = std::env::var_os("CELOX_PHASE_TIMING").is_some();
     let testbench_start = phase_timing.then(crate::timing::now);
-    let initial_stmts = sim.program().initial_statements.clone().ok_or_else(|| {
-        SimulatorError::new(SimulatorErrorKind::Codegen(
-            "no initial block found — this module is not a native testbench".into(),
-        ))
-    })?;
+    let initial_stmts = sim
+        .program()
+        .testbench_source
+        .initial_statements
+        .clone()
+        .ok_or_else(|| {
+            SimulatorError::new(SimulatorErrorKind::Codegen(
+                "no initial block found — this module is not a native testbench".into(),
+            ))
+        })?;
     let mut tb_builder = crate::testbench::TestbenchBuilder::new(&sim);
     tb_builder.build_event_map(&initial_stmts);
     let tb_stmts = tb_builder.convert(&initial_stmts);

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -662,11 +662,11 @@ fn count_assert_statements(
 }
 
 pub(crate) fn project_observability(program: &mut Program) {
-    let Some(stmts) = program.initial_statements.as_ref() else {
+    let Some(stmts) = program.testbench_source.initial_statements.as_ref() else {
         return;
     };
     let mut sites = Vec::new();
-    collect_runtime_event_sites(stmts, &program.tb_functions, &mut sites);
+    collect_runtime_event_sites(stmts, &program.testbench_source.functions, &mut sites);
     program.runtime_schema.runtime_event_sites.extend(sites);
     program.runtime_schema.testbench_read_roots = initial_read_addresses(program);
 }
@@ -675,7 +675,7 @@ pub(crate) fn project_observability(program: &mut Program) {
 /// reads these directly from simulator memory, so they are external roots for
 /// dead-store elimination even though no SIR execution unit loads them.
 fn initial_read_addresses(program: &Program) -> crate::HashSet<AbsoluteAddr> {
-    let Some(stmts) = program.initial_statements.as_ref() else {
+    let Some(stmts) = program.testbench_source.initial_statements.as_ref() else {
         return crate::HashSet::default();
     };
     let Some(&root_instance_id) = program
@@ -696,7 +696,7 @@ fn initial_read_addresses(program: &Program) -> crate::HashSet<AbsoluteAddr> {
     let mut active_functions = crate::HashSet::default();
     collect_statement_reads(
         stmts,
-        &program.tb_functions,
+        &program.testbench_source.functions,
         &mut active_functions,
         &mut reads,
     );
@@ -1933,7 +1933,7 @@ impl<'a, B: SimBackend> ExprCompiler<'a, B> {
     /// Inline-expands: store args → emit body assigns → load return value.
     fn emit_function_call(&self, fc: &veryl_analyzer::ir::FunctionCall, ops: &mut Vec<TbOpcode>) {
         let p = self.sim.program();
-        let func = match p.tb_functions.get(&fc.id) {
+        let func = match p.testbench_source.functions.get(&fc.id) {
             Some(f) => f,
             None => {
                 ops.push(TbOpcode::ConstU64(0));
@@ -2390,7 +2390,7 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
             root_instance_id,
             root_module_id,
         };
-        let site_count = count_assert_statements(stmts, &p.tb_functions) as u32;
+        let site_count = count_assert_statements(stmts, &p.testbench_source.functions) as u32;
         let mut next_assert_site_id = p
             .runtime_schema
             .runtime_event_sites
@@ -2541,7 +2541,7 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
         next_assert_site_id: &mut u32,
     ) -> Option<TestbenchStatement<B>> {
         let program = self.sim.program();
-        let func = program.tb_functions.get(&fc.id)?;
+        let func = program.testbench_source.functions.get(&fc.id)?;
         let func_body = if let Some(idx) = &fc.index {
             func.get_function(idx)?
         } else {
@@ -3243,7 +3243,7 @@ fn run_testbench_limited<B: SimBackend>(
 pub fn compile_initial_testbench<B: SimBackend>(
     sim: &Simulator<B>,
 ) -> Option<CompiledTestbench<B>> {
-    let initial_stmts = sim.program().initial_statements.as_ref()?;
+    let initial_stmts = sim.program().testbench_source.initial_statements.as_ref()?;
     let mut tb_builder = TestbenchBuilder::new(sim);
     tb_builder.build_event_map(initial_stmts);
     Some(CompiledTestbench {

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -25,7 +25,10 @@ and consumers construct each backend from an unlaid-out `Program` rather than at
 re-layout the finalized program after identity Stores have been removed. Veryl
 testbench runtime-event sites and direct state-read roots are projected into the source-independent
 `RuntimeSchema` before SIR optimization, so optimization and layout no longer traverse testbench
-AST. Moving the remaining parser implementation, symbolic, optimizer, and testbench payload
+AST. The remaining Veryl statements/functions are now one explicit
+`celox-frontend-veryl::VerylTestbenchSource` input owned by the frontend; the next testbench
+milestone consumes that artifact into source-independent bytecode instead of retaining two loose
+AST fields. Moving the remaining parser implementation, symbolic, optimizer, and testbench payload
 into the phase-specific target types below remains part of Milestone 3.
 
 The baseline is the compiler pipeline on `perf/native-simulation-throughput` after PR #322. The


### PR DESCRIPTION
## Summary
- replace loose `Program.initial_statements`/`tb_functions` fields with one frontend-owned `VerylTestbenchSource`
- make the remaining source-language dependency an explicit input to testbench lowering
- keep optimizer, layout, and backend access confined to source-independent observability metadata

## Validation
- `cargo test -p celox-frontend-veryl --lib`
- `cargo test -p celox --test native_testbench`
- `cargo test -p celox --lib`
- focused clippy and workspace all-target check
- pre-push hook