### PR TITLE
refactor(sir): require optimized SIR before state layout

### DIFF
--- a/crates/celox-testbench/src/lib.rs
+++ b/crates/celox-testbench/src/lib.rs
@@ -51,6 +51,7 @@ pub struct SourceLocation {
     pub column: u32,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AssertMessage<Argument> {
     Formatted {
         template: String,
@@ -59,11 +60,13 @@ pub enum AssertMessage<Argument> {
     DynamicArgs(Vec<Argument>),
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ClockCount<Expression> {
     Static(u64),
     Dynamic(Expression),
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LoopBound<Expression> {
     Static(usize),
     Dynamic {
@@ -78,6 +81,7 @@ pub enum LoopBound<Expression> {
 /// Frontends instantiate this with semantic state/event identities and
 /// unbound expressions. Runtime binding instantiates the same contract with
 /// backend event/signal handles and executable expressions.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TestbenchStatement<Event, Signal, Expression, Argument> {
     ClockNext {
         clock_event: Event,
@@ -122,6 +126,54 @@ pub enum TestbenchStatement<Event, Signal, Expression, Argument> {
     },
     Break,
     Finish,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SemanticSignal<A> {
+    pub address: A,
+    pub width: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SemanticArgument<A> {
+    pub expr: ExprBytecode<StateLocation<A>>,
+    pub width: usize,
+    pub signed: bool,
+    pub is_string: bool,
+}
+
+pub type SemanticStatement<A> =
+    TestbenchStatement<A, SemanticSignal<A>, ExprBytecode<StateLocation<A>>, SemanticArgument<A>>;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TestbenchProgram<A> {
+    statements: Vec<SemanticStatement<A>>,
+}
+
+impl<A> Default for TestbenchProgram<A> {
+    fn default() -> Self {
+        Self {
+            statements: Vec::new(),
+        }
+    }
+}
+
+impl<A> TestbenchProgram<A> {
+    pub fn new(statements: Vec<SemanticStatement<A>>) -> Self {
+        Self { statements }
+    }
+
+    pub fn statements(&self) -> &[SemanticStatement<A>] {
+        &self.statements
+    }
+
+    pub fn into_statements(self) -> Vec<SemanticStatement<A>> {
+        self.statements
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.statements.is_empty()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -79,6 +79,39 @@ pub struct Program {
     pub testbench: Option<TestbenchProgram<AbsoluteAddr>>,
 }
 
+/// A pre-layout compiler artifact whose SIR optimization pipeline has
+/// completed successfully.
+///
+/// Construction is restricted to the compiler driver. Physical layout can
+/// only be finalized from this phase, preventing unoptimized SIR from
+/// accidentally entering a backend.
+#[derive(Clone, Debug)]
+pub struct OptimizedSir {
+    program: Program,
+}
+
+impl OptimizedSir {
+    pub(crate) fn new(program: Program) -> Self {
+        Self { program }
+    }
+
+    pub fn program(&self) -> &Program {
+        &self.program
+    }
+
+    pub fn into_program(self) -> Program {
+        self.program
+    }
+}
+
+impl std::ops::Deref for OptimizedSir {
+    type Target = Program;
+
+    fn deref(&self) -> &Self::Target {
+        &self.program
+    }
+}
+
 /// A [`Program`] whose physical state layout has been finalized.
 ///
 /// Backend code generation accepts this artifact instead of a bare `Program`,
@@ -119,8 +152,8 @@ impl fmt::Debug for Program {
     }
 }
 
-impl Program {
-    /// Finalize the physical state layout and consume the pre-layout program.
+impl OptimizedSir {
+    /// Finalize the physical state layout and consume the optimized program.
     pub fn into_laid_out(self, four_state: bool) -> LaidOutProgram {
         self.into_laid_out_with_mode(
             four_state,
@@ -129,32 +162,40 @@ impl Program {
     }
 
     pub fn into_laid_out_with_mode(
-        mut self,
+        self,
         four_state: bool,
         mode: crate::backend::memory_layout::MemoryLayoutMode,
     ) -> LaidOutProgram {
-        if !self.runtime_schema.comb_observers.is_empty() && !self.layout_requirements.is_empty() {
-            let observed_written: crate::HashSet<AbsoluteAddr> = self
+        let mut program = self.program;
+        if !program.runtime_schema.comb_observers.is_empty()
+            && !program.layout_requirements.is_empty()
+        {
+            let observed_written: crate::HashSet<AbsoluteAddr> = program
                 .runtime_schema
                 .comb_observers
                 .iter()
                 .flat_map(|observer| observer.written_inputs.iter().copied())
                 .collect();
-            self.layout_requirements
+            program
+                .layout_requirements
                 .state_aliases_mut()
                 .retain(|alias_addr, _| !observed_written.contains(alias_addr));
-            self.layout_requirements
+            program
+                .layout_requirements
                 .state_aliases_mut()
                 .retain(|alias_addr, _| {
-                    !comb_capture_enable_needs_unaliased_old_value(&self.sir.eval_comb, *alias_addr)
+                    !comb_capture_enable_needs_unaliased_old_value(
+                        &program.sir.eval_comb,
+                        *alias_addr,
+                    )
                 });
         }
-        crate::optimizer::coalescing::retain_final_identity_aliases(&mut self, four_state);
-        let layout = crate::backend::MemoryLayout::build(&self, four_state, mode);
+        crate::optimizer::coalescing::retain_final_identity_aliases(&mut program, four_state);
+        let layout = crate::backend::MemoryLayout::build(&program, four_state, mode);
 
         // Remove identity Stores for aliases validated by the layout
-        if !self.layout_requirements.is_empty() {
-            let aliased: crate::HashMap<AbsoluteAddr, AbsoluteAddr> = self
+        if !program.layout_requirements.is_empty() {
+            let aliased: crate::HashMap<AbsoluteAddr, AbsoluteAddr> = program
                 .layout_requirements
                 .state_aliases()
                 .iter()
@@ -169,18 +210,19 @@ impl Program {
                 .collect();
             if !aliased.is_empty() {
                 crate::optimizer::coalescing::remove_final_identity_alias_stores(
-                    &mut self, &aliased, four_state,
+                    &mut program,
+                    &aliased,
+                    four_state,
                 );
             }
         }
-        self.layout_requirements.clear();
+        program.layout_requirements.clear();
 
-        LaidOutProgram {
-            program: self,
-            layout,
-        }
+        LaidOutProgram { program, layout }
     }
+}
 
+impl Program {
     pub fn get_addr(
         &self,
         instance_path: &[(&str, usize)],

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -9,9 +9,7 @@ pub(crate) use celox_design::{
     RuntimeEventKind, RuntimeEventSite, RuntimeSchema, SPARSE_WORKING_REGION, STABLE_REGION,
     TriggerIdWithKind, TriggerSet, UnaryOp, VarAtomBase, WORKING_REGION,
 };
-pub use celox_frontend_veryl::{
-    InstancePath, VariableInfo, VerylFrontendLookup, VerylTestbenchSource,
-};
+pub use celox_frontend_veryl::{InstancePath, VariableInfo, VerylFrontendLookup};
 pub(crate) use celox_sir::{
     BasicBlock, BlockId, ExecutionUnit, RegisterId, RegisterType, SIRBuilder, SIRInstruction,
     SIROffset, SIRSwitchCase, SIRTerminator, SIRValue, collect_exact_zero_registers, merge_sir_eus,
@@ -20,6 +18,7 @@ pub(crate) use celox_sir::{
 pub(crate) use celox_sir::{
     SirMergeProvenance, inline_single_predecessor_jumps, merge_sir_eu_refs_with_provenance,
 };
+use celox_testbench::TestbenchProgram;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use veryl_analyzer::ir::{VarId, VarPath, Variable};
@@ -77,7 +76,7 @@ pub struct Program {
     pub frontend: VerylFrontendLookup,
     pub runtime_schema: RuntimeSchema<AbsoluteAddr>,
     pub layout_requirements: celox_state_layout::LayoutRequirements<AbsoluteAddr>,
-    pub testbench_source: VerylTestbenchSource,
+    pub testbench: Option<TestbenchProgram<AbsoluteAddr>>,
 }
 
 /// A [`Program`] whose physical state layout has been finalized.

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -61,8 +61,8 @@ pub use debug::{CompilationTrace, NativeProfileBlock, TraceOptions};
 pub(crate) use fxhash::FxHashMap as HashMap;
 pub(crate) use fxhash::FxHashSet as HashSet;
 pub use ir::{
-    AbsoluteAddr, AddrLookupError, InstancePath, LaidOutProgram, PortTypeKind, Program,
-    RuntimeErrorInfo, SignalRef, SirProgram, VariableInfo, VerylFrontendLookup,
+    AbsoluteAddr, AddrLookupError, InstancePath, LaidOutProgram, OptimizedSir, PortTypeKind,
+    Program, RuntimeErrorInfo, SignalRef, SirProgram, VariableInfo, VerylFrontendLookup,
 };
 #[cfg(target_arch = "x86_64")]
 pub mod native_backend {

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -63,7 +63,6 @@ pub(crate) use fxhash::FxHashSet as HashSet;
 pub use ir::{
     AbsoluteAddr, AddrLookupError, InstancePath, LaidOutProgram, PortTypeKind, Program,
     RuntimeErrorInfo, SignalRef, SirProgram, VariableInfo, VerylFrontendLookup,
-    VerylTestbenchSource,
 };
 #[cfg(target_arch = "x86_64")]
 pub mod native_backend {

--- a/crates/celox/src/optimizer/coalescing/pass_identity_store_bypass.rs
+++ b/crates/celox/src/optimizer/coalescing/pass_identity_store_bypass.rs
@@ -48,7 +48,7 @@ struct GlobalIdentityFacts {
 
 /// Analyze all combinational units before selecting any Program-global address
 /// alias or memory-copy replacement. Alias selection has priority; the
-/// returned stores are still present until `Program::into_laid_out` validates
+/// returned stores are still present until `OptimizedSir::into_laid_out` validates
 /// the selected aliases.
 pub(super) fn optimize_program_identity_stores(
     program: &mut Program,

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -1408,7 +1408,7 @@ pub(crate) fn flatten(
                 },
                 runtime_schema: celox_design::RuntimeSchema::default(),
                 layout_requirements: Default::default(),
-                testbench_source: Default::default(),
+                testbench: None,
             };
             let source_locations = scheduler_source_locations(&error, module_ir, &instance_modules);
             let mut target_arena = SLTNodeArena::new();
@@ -1592,6 +1592,13 @@ pub(crate) fn flatten(
             written_inputs: observer.written_inputs.clone(),
         })
         .collect();
+    let testbench_source = celox_frontend_veryl::VerylTestbenchSource {
+        initial_statements,
+        functions: module_ir
+            .get(root_id)
+            .map(|m| m.functions.clone())
+            .unwrap_or_default(),
+    };
     let program = Program {
         sir: crate::ir::SirProgram {
             eval_apply_ffs,
@@ -1624,13 +1631,7 @@ pub(crate) fn flatten(
             testbench_read_roots: Default::default(),
         },
         layout_requirements: Default::default(),
-        testbench_source: crate::ir::VerylTestbenchSource {
-            initial_statements,
-            functions: module_ir
-                .get(root_id)
-                .map(|m| m.functions.clone())
-                .unwrap_or_default(),
-        },
+        testbench: None,
     };
 
     // --- Trigger Injection ---
@@ -1758,6 +1759,9 @@ pub(crate) fn flatten(
             }
         }
     }
+
+    crate::testbench::project_observability(&mut program, &testbench_source);
+    program.testbench = crate::testbench::compile_semantic_testbench(&program, &testbench_source);
 
     dump_addr_map_if_requested(&program);
 
@@ -2558,11 +2562,6 @@ pub fn parse(
             trace.as_deref_mut(),
         )
     )?;
-    timed_phase!(
-        "project_testbench_observability",
-        crate::testbench::project_observability(&mut program)
-    );
-
     if let Some(t) = trace.as_deref_mut()
         && trace_opts.pre_optimized_sir
     {

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -2518,7 +2518,7 @@ pub fn parse(
     mut trace: Option<&mut crate::debug::CompilationTrace>,
     optimize_options: &crate::optimizer::OptimizeOptions,
     preserve_element_storage_layout: bool,
-) -> Result<Program, ParserError> {
+) -> Result<crate::ir::OptimizedSir, ParserError> {
     debug_assert!(
         loop_provenance.is_consistent_with(ir),
         "loop provenance must describe the analyzer IR passed to the parser"
@@ -2598,7 +2598,7 @@ pub fn parse(
         t.post_optimized_sir = Some(program.clone());
     }
 
-    Ok(program)
+    Ok(crate::ir::OptimizedSir::new(program))
 }
 
 fn relocate_executation_unit_with_errors<A, B>(

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -1464,9 +1464,9 @@ impl Simulator<NativeBackend> {
     }
 
     /// Create a simulator from pre-compiled shared native code.
-    pub fn from_shared(shared: Arc<SharedNativeCode>, program: crate::ir::Program) -> Self {
+    pub fn from_shared(shared: Arc<SharedNativeCode>, program: crate::ir::OptimizedSir) -> Self {
         let backend = NativeBackend::from_shared(shared);
-        let mut sim = Self::with_backend_and_program(backend, program, vec![]);
+        let mut sim = Self::with_backend_and_program(backend, program.into_program(), vec![]);
         sim.apply_initial_values();
         sim
     }

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -746,21 +746,14 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
     /// observed before the test finishes or stops on a fatal failure.
     pub fn run_test_detailed(self) -> Result<crate::testbench::TestResultDetailed, SimulatorError> {
         let mut sim = self.build()?;
-        let initial_stmts = sim
-            .program()
-            .testbench_source
-            .initial_statements
-            .clone()
-            .ok_or_else(|| {
-                SimulatorError::new(SimulatorErrorKind::Codegen(
-                    "no initial block found — this module is not a native testbench".into(),
-                ))
-            })?;
-        let mut tb_builder = crate::testbench::TestbenchBuilder::new(&sim);
-        tb_builder.build_event_map(&initial_stmts);
-        let tb_stmts = tb_builder.convert(&initial_stmts);
+        let testbench = crate::testbench::compile_initial_testbench(&sim).ok_or_else(|| {
+            SimulatorError::new(SimulatorErrorKind::Codegen(
+                "no initial block found — this module is not a native testbench".into(),
+            ))
+        })?;
         Ok(crate::testbench::run_testbench_detailed(
-            &mut sim, &tb_stmts,
+            &mut sim,
+            &testbench.stmts,
         ))
     }
 
@@ -842,20 +835,12 @@ fn run_test_with_sim<B: crate::backend::SimBackend>(
 ) -> Result<crate::testbench::TestResult, SimulatorError> {
     let phase_timing = std::env::var_os("CELOX_PHASE_TIMING").is_some();
     let testbench_start = phase_timing.then(crate::timing::now);
-    let initial_stmts = sim
-        .program()
-        .testbench_source
-        .initial_statements
-        .clone()
-        .ok_or_else(|| {
-            SimulatorError::new(SimulatorErrorKind::Codegen(
-                "no initial block found — this module is not a native testbench".into(),
-            ))
-        })?;
-    let mut tb_builder = crate::testbench::TestbenchBuilder::new(&sim);
-    tb_builder.build_event_map(&initial_stmts);
-    let tb_stmts = tb_builder.convert(&initial_stmts);
-    let result = crate::testbench::run_testbench(&mut sim, &tb_stmts);
+    let testbench = crate::testbench::compile_initial_testbench(&sim).ok_or_else(|| {
+        SimulatorError::new(SimulatorErrorKind::Codegen(
+            "no initial block found — this module is not a native testbench".into(),
+        ))
+    })?;
+    let result = crate::testbench::run_testbench(&mut sim, &testbench.stmts);
     if let Some(start) = testbench_start {
         eprintln!("[phase-timing] testbench: {:?}", start.elapsed());
     }

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -8,7 +8,11 @@ use veryl_parser::Parser;
 use veryl_parser::resource_table;
 
 use crate::parser::BuildConfig;
-use crate::{ParserError, SimulatorError, SimulatorErrorKind, ir::Program, parser};
+use crate::{
+    ParserError, SimulatorError, SimulatorErrorKind,
+    ir::{OptimizedSir, Program},
+    parser,
+};
 
 fn analyze(
     sources: &[(&str, &Path)],
@@ -31,7 +35,7 @@ fn analyze(
     param_overrides: &[(String, u64)],
     optimize_options: &crate::optimizer::OptimizeOptions,
     preserve_element_storage_layout: bool,
-) -> (Result<Program, ParserError>, Vec<AnalyzerError>) {
+) -> (Result<OptimizedSir, ParserError>, Vec<AnalyzerError>) {
     symbol_table::clear();
     attribute_table::clear();
 
@@ -109,7 +113,7 @@ fn analyze(
 /// Compile Veryl source code to the SIR (Simulation IR) representation.
 ///
 /// This is the shared compilation pipeline used by all backends.
-/// Returns the compiled Program and any analyzer warnings on success.
+/// Returns verified optimized SIR and any analyzer warnings on success.
 pub fn compile_to_sir(
     sources: &[(&str, &Path)],
     top: &str,
@@ -130,7 +134,7 @@ pub fn compile_to_sir(
     reset_type: Option<ResetType>,
     param_overrides: &[(String, u64)],
     optimize_options: &crate::optimizer::OptimizeOptions,
-) -> Result<(Program, Vec<AnalyzerError>), SimulatorError> {
+) -> Result<(OptimizedSir, Vec<AnalyzerError>), SimulatorError> {
     compile_to_sir_with_layout_mode(
         sources,
         top,
@@ -169,7 +173,7 @@ fn compile_to_sir_with_layout_mode(
     param_overrides: &[(String, u64)],
     optimize_options: &crate::optimizer::OptimizeOptions,
     layout_mode: crate::backend::memory_layout::MemoryLayoutMode,
-) -> Result<(Program, Vec<AnalyzerError>), SimulatorError> {
+) -> Result<(OptimizedSir, Vec<AnalyzerError>), SimulatorError> {
     let (sir, errors) = analyze(
         sources,
         top,

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -18,10 +18,12 @@ use crate::context_width::{
 use crate::display_format::{DisplayFormatArg, format_display_arg};
 use crate::ir::{AbsoluteAddr, Program, RuntimeEventKind, RuntimeEventSite, SignalRef};
 use crate::simulator::{RuntimeEvent, RuntimeFormatContext, Simulator};
+use celox_frontend_veryl::VerylTestbenchSource;
 pub use celox_testbench::SourceLocation;
 use celox_testbench::{
     AssertMessage as GenericAssertMessage, ClockCount as GenericClockCount, ExprBytecode,
-    ExprOpcode as TbOpcode, LoopBound as GenericLoopBound, StateLocation, TestbenchOperator as Op,
+    ExprOpcode as TbOpcode, LoopBound as GenericLoopBound, SemanticArgument, SemanticSignal,
+    SemanticStatement, StateLocation, TestbenchOperator as Op, TestbenchProgram,
     TestbenchStatement as GenericTestbenchStatement,
 };
 use num_bigint::{BigInt, BigUint, Sign};
@@ -66,7 +68,7 @@ pub struct TestResultDetailed {
 
 /// Opaque, precompiled native testbench program for a built simulator.
 pub struct CompiledTestbench<B: SimBackend> {
-    stmts: Vec<TestbenchStatement<B>>,
+    pub(crate) stmts: Vec<TestbenchStatement<B>>,
 }
 
 /// Result of executing a testbench with an optional tick limit.
@@ -387,10 +389,10 @@ fn static_string_expr(expr: &Expression) -> Option<String> {
     byte_value_to_string(value)
 }
 
-fn compile_assert_arg<B: SimBackend>(
+fn compile_assert_arg(
     input: &SystemFunctionInput,
-    ec: &ExprCompiler<'_, B>,
-) -> CompiledAssertArg {
+    ec: &ExprCompiler<'_>,
+) -> SemanticArgument<AbsoluteAddr> {
     let expr = &input.0;
     let width = {
         let ctx_width = expr.comptime().expr_context.width;
@@ -404,7 +406,7 @@ fn compile_assert_arg<B: SimBackend>(
             0
         }
     };
-    CompiledAssertArg {
+    SemanticArgument {
         expr: ec.compile(expr),
         width,
         signed: expression_signed(expr),
@@ -527,21 +529,24 @@ fn count_assert_statements(
     count
 }
 
-pub(crate) fn project_observability(program: &mut Program) {
-    let Some(stmts) = program.testbench_source.initial_statements.as_ref() else {
+pub(crate) fn project_observability(program: &mut Program, source: &VerylTestbenchSource) {
+    let Some(stmts) = source.initial_statements.as_ref() else {
         return;
     };
     let mut sites = Vec::new();
-    collect_runtime_event_sites(stmts, &program.testbench_source.functions, &mut sites);
+    collect_runtime_event_sites(stmts, &source.functions, &mut sites);
     program.runtime_schema.runtime_event_sites.extend(sites);
-    program.runtime_schema.testbench_read_roots = initial_read_addresses(program);
+    program.runtime_schema.testbench_read_roots = initial_read_addresses(program, source);
 }
 
 /// Return top-module signals read by the native testbench. Testbench bytecode
 /// reads these directly from simulator memory, so they are external roots for
 /// dead-store elimination even though no SIR execution unit loads them.
-fn initial_read_addresses(program: &Program) -> crate::HashSet<AbsoluteAddr> {
-    let Some(stmts) = program.testbench_source.initial_statements.as_ref() else {
+fn initial_read_addresses(
+    program: &Program,
+    source: &VerylTestbenchSource,
+) -> crate::HashSet<AbsoluteAddr> {
+    let Some(stmts) = source.initial_statements.as_ref() else {
         return crate::HashSet::default();
     };
     let Some(&root_instance_id) = program
@@ -560,12 +565,7 @@ fn initial_read_addresses(program: &Program) -> crate::HashSet<AbsoluteAddr> {
 
     let mut reads = crate::HashSet::default();
     let mut active_functions = crate::HashSet::default();
-    collect_statement_reads(
-        stmts,
-        &program.testbench_source.functions,
-        &mut active_functions,
-        &mut reads,
-    );
+    collect_statement_reads(stmts, &source.functions, &mut active_functions, &mut reads);
     reads
         .into_iter()
         .filter(|id| root_variables.contains_key(id))
@@ -814,10 +814,10 @@ fn collect_function_call_reads(
     }
 }
 
-fn compile_assert_message<B: SimBackend>(
+fn compile_assert_message(
     args: &[SystemFunctionInput],
-    ec: &ExprCompiler<'_, B>,
-) -> Option<AssertMessage> {
+    ec: &ExprCompiler<'_>,
+) -> Option<GenericAssertMessage<SemanticArgument<AbsoluteAddr>>> {
     if args.is_empty() {
         return None;
     }
@@ -826,12 +826,12 @@ fn compile_assert_message<B: SimBackend>(
             .iter()
             .map(|arg| compile_assert_arg(arg, ec))
             .collect::<Vec<_>>();
-        Some(AssertMessage::Formatted {
+        Some(GenericAssertMessage::Formatted {
             template,
             args: compiled_args,
         })
     } else {
-        Some(AssertMessage::DynamicArgs(
+        Some(GenericAssertMessage::DynamicArgs(
             args.iter().map(|arg| compile_assert_arg(arg, ec)).collect(),
         ))
     }
@@ -1521,23 +1521,26 @@ fn lower_testbench_operator(op: VerylOp) -> Op {
     }
 }
 
-struct ExprCompiler<'a, B: SimBackend> {
-    sim: &'a Simulator<B>,
+struct ExprCompiler<'a> {
+    program: &'a Program,
+    testbench_source: &'a VerylTestbenchSource,
     /// Root module instance ID, cached for repeated lookups.
     root_instance_id: crate::ir::InstanceId,
     root_module_id: crate::ir::ModuleId,
 }
 
-impl<'a, B: SimBackend> ExprCompiler<'a, B> {
-    fn compile(&self, expr: &Expression) -> CompiledExpr {
+impl ExprCompiler<'_> {
+    fn compile(&self, expr: &Expression) -> ExprBytecode<StateLocation<AbsoluteAddr>> {
         let mut ops = Vec::new();
         self.emit(expr, &mut ops);
-        CompiledExpr {
-            bytecode: self.bind(ops),
-        }
+        ExprBytecode::new(ops)
     }
 
-    fn compile_with_width(&self, expr: &Expression, width: usize) -> CompiledExpr {
+    fn compile_with_width(
+        &self,
+        expr: &Expression,
+        width: usize,
+    ) -> ExprBytecode<StateLocation<AbsoluteAddr>> {
         let mut ops = Vec::new();
         self.emit_in_context(
             expr,
@@ -1547,27 +1550,7 @@ impl<'a, B: SimBackend> ExprCompiler<'a, B> {
                 signed: expression_signed(expr),
             }),
         );
-        CompiledExpr {
-            bytecode: self.bind(ops),
-        }
-    }
-
-    fn bind(&self, ops: Vec<UnboundTbOpcode>) -> ExprBytecode {
         ExprBytecode::new(ops)
-            .bind_with(|address| {
-                self.sim
-                    .backend_ref()
-                    .layout()
-                    .offsets
-                    .get(address)
-                    .copied()
-            })
-            .unwrap_or_else(|error| {
-                panic!(
-                    "testbench bytecode references state absent from physical layout: {:?}",
-                    error.address
-                )
-            })
     }
 
     fn natural_width(&self, expr: &Expression) -> usize {
@@ -1771,7 +1754,7 @@ impl<'a, B: SimBackend> ExprCompiler<'a, B> {
                     let part_width = self.natural_width(val_expr);
                     let repeat = repeat_expr
                         .as_ref()
-                        .and_then(|e| Self::try_const_usize(e))
+                        .and_then(Self::try_const_usize)
                         .unwrap_or(1);
                     for _ in 0..repeat {
                         self.emit_in_context(val_expr, ops, None);
@@ -1862,8 +1845,7 @@ impl<'a, B: SimBackend> ExprCompiler<'a, B> {
         fc: &veryl_analyzer::ir::FunctionCall,
         ops: &mut Vec<UnboundTbOpcode>,
     ) {
-        let p = self.sim.program();
-        let func = match p.testbench_source.functions.get(&fc.id) {
+        let func = match self.testbench_source.functions.get(&fc.id) {
             Some(f) => f,
             None => {
                 ops.push(TbOpcode::ConstU64(0));
@@ -1943,12 +1925,12 @@ impl<'a, B: SimBackend> ExprCompiler<'a, B> {
     fn emit_var_access(
         &self,
         var_id: &VarId,
-        sig: SignalRef,
+        sig: SemanticSignal<AbsoluteAddr>,
         index: &veryl_analyzer::ir::VarIndex,
         select: &veryl_analyzer::ir::VarSelect,
         ops: &mut Vec<UnboundTbOpcode>,
     ) {
-        let p = self.sim.program();
+        let p = self.program;
         let info = match p
             .frontend
             .module_variables
@@ -2091,7 +2073,7 @@ impl<'a, B: SimBackend> ExprCompiler<'a, B> {
     ) -> (usize, usize, bool) {
         if let Some((op, range_expr)) = &select.1 {
             let anchor_expr = select.0.last();
-            let anchor = anchor_expr.and_then(|e| Self::try_const_usize(e));
+            let anchor = anchor_expr.and_then(Self::try_const_usize);
             let range_val = Self::try_const_usize(range_expr);
 
             if let (Some(a), Some(v)) = (anchor, range_val) {
@@ -2216,7 +2198,7 @@ impl<'a, B: SimBackend> ExprCompiler<'a, B> {
         if let Expression::Term(f) = expr {
             match f.as_ref() {
                 Factor::Variable(var_id, _, _, _) => {
-                    let p = self.sim.program();
+                    let p = self.program;
                     if let Some(vars) = p.frontend.module_variables.get(&self.root_module_id) {
                         if let Some(info) = vars.get(var_id) {
                             return info.width;
@@ -2244,49 +2226,59 @@ impl<'a, B: SimBackend> ExprCompiler<'a, B> {
         }
     }
 
-    fn resolve_var(&self, var_id: &VarId) -> Option<SignalRef> {
-        let p = self.sim.program();
+    fn resolve_var(&self, var_id: &VarId) -> Option<SemanticSignal<AbsoluteAddr>> {
+        let p = self.program;
         let vars = p.frontend.module_variables.get(&self.root_module_id)?;
-        let _ = vars.get(var_id)?;
-        Some(self.sim.backend_ref().resolve_signal(&AbsoluteAddr {
-            instance_id: self.root_instance_id,
-            var_id: *var_id,
-        }))
+        let info = vars.get(var_id)?;
+        Some(SemanticSignal {
+            address: AbsoluteAddr {
+                instance_id: self.root_instance_id,
+                var_id: *var_id,
+            },
+            width: info.width,
+        })
     }
 }
 
 // ── Builder ────────────────────────────────────────────────────────────
 
-pub struct TestbenchBuilder<'a, B: SimBackend> {
-    sim: &'a Simulator<B>,
-    event_map: std::collections::HashMap<StrId, B::Event>,
-    signal_map: std::collections::HashMap<StrId, SignalRef>,
+struct SemanticTestbenchBuilder<'a> {
+    program: &'a Program,
+    testbench_source: &'a VerylTestbenchSource,
+    event_map: std::collections::HashMap<StrId, AbsoluteAddr>,
+    signal_map: std::collections::HashMap<StrId, SemanticSignal<AbsoluteAddr>>,
     default_reset_duration: u64,
 }
 
-impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
-    pub fn new(sim: &'a Simulator<B>) -> Self {
+impl<'a> SemanticTestbenchBuilder<'a> {
+    fn new(program: &'a Program, testbench_source: &'a VerylTestbenchSource) -> Self {
         Self {
-            sim,
+            program,
+            testbench_source,
             event_map: Default::default(),
             signal_map: Default::default(),
             default_reset_duration: 3,
         }
     }
 
-    pub fn build_event_map(&mut self, stmts: &[Statement]) {
+    fn build_event_map(&mut self, stmts: &[Statement]) {
         let mut clock_insts: Vec<StrId> = Vec::new();
         let mut reset_insts: Vec<StrId> = Vec::new();
         Self::scan_tb_methods(stmts, &mut clock_insts, &mut reset_insts);
-        let program = self.sim.program();
+        let program = self.program;
         for inst in clock_insts.iter().chain(reset_insts.iter()) {
             let name = veryl_parser::resource_table::get_str_value(*inst).unwrap_or_default();
             if let Ok(addr) = program.get_addr(&[], &[&name]) {
-                if let Some(event) = self.sim.backend_ref().resolve_event_opt(&addr) {
-                    self.event_map.insert(*inst, event);
+                self.event_map.insert(*inst, addr);
+                if let Some(info) = program.get_variable_info(&addr) {
+                    self.signal_map.insert(
+                        *inst,
+                        SemanticSignal {
+                            address: addr,
+                            width: info.width,
+                        },
+                    );
                 }
-                self.signal_map
-                    .insert(*inst, self.sim.backend_ref().resolve_signal(&addr));
             }
         }
     }
@@ -2323,8 +2315,8 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
         }
     }
 
-    pub(crate) fn convert(&mut self, stmts: &[Statement]) -> Vec<TestbenchStatement<B>> {
-        let p = self.sim.program();
+    fn convert(&mut self, stmts: &[Statement]) -> Vec<SemanticStatement<AbsoluteAddr>> {
+        let p = self.program;
         let root_instance_id = *p
             .frontend
             .instance_ids
@@ -2332,11 +2324,12 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
             .expect("root instance not found");
         let root_module_id = p.frontend.instance_module[&root_instance_id];
         let ec = ExprCompiler {
-            sim: self.sim,
+            program: self.program,
+            testbench_source: self.testbench_source,
             root_instance_id,
             root_module_id,
         };
-        let site_count = count_assert_statements(stmts, &p.testbench_source.functions) as u32;
+        let site_count = count_assert_statements(stmts, &self.testbench_source.functions) as u32;
         let mut next_assert_site_id = p
             .runtime_schema
             .runtime_event_sites
@@ -2351,16 +2344,16 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
     fn convert_stmt(
         &self,
         stmt: &Statement,
-        ec: &ExprCompiler<'_, B>,
+        ec: &ExprCompiler<'_>,
         next_assert_site_id: &mut u32,
-    ) -> Option<TestbenchStatement<B>> {
-        fn convert_for_bound<B: SimBackend>(
+    ) -> Option<SemanticStatement<AbsoluteAddr>> {
+        fn convert_for_bound(
             bound: &ForBound,
-            ec: &ExprCompiler<'_, B>,
-        ) -> LoopBound {
+            ec: &ExprCompiler<'_>,
+        ) -> GenericLoopBound<ExprBytecode<StateLocation<AbsoluteAddr>>> {
             match bound {
-                ForBound::Const(x) => LoopBound::Static(*x),
-                ForBound::Expression(expr) => LoopBound::Dynamic {
+                ForBound::Const(x) => GenericLoopBound::Static(*x),
+                ForBound::Expression(expr) => GenericLoopBound::Dynamic {
                     expr: ec.compile(expr.as_ref()),
                     width: ec.root_context(expr).width,
                     signed: expression_signed(expr),
@@ -2483,11 +2476,10 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
     fn convert_function_call(
         &self,
         fc: &veryl_analyzer::ir::FunctionCall,
-        ec: &ExprCompiler<'_, B>,
+        ec: &ExprCompiler<'_>,
         next_assert_site_id: &mut u32,
-    ) -> Option<TestbenchStatement<B>> {
-        let program = self.sim.program();
-        let func = program.testbench_source.functions.get(&fc.id)?;
+    ) -> Option<SemanticStatement<AbsoluteAddr>> {
+        let func = self.testbench_source.functions.get(&fc.id)?;
         let func_body = if let Some(idx) = &fc.index {
             func.get_function(idx)?
         } else {
@@ -2495,7 +2487,7 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
         };
 
         // Build a list of statements: argument assignments + body
-        let mut stmts: Vec<TestbenchStatement<B>> = Vec::new();
+        let mut stmts: Vec<SemanticStatement<AbsoluteAddr>> = Vec::new();
 
         // Bind input arguments
         for (arg_path, arg_expr) in &fc.inputs {
@@ -2525,9 +2517,7 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
             // flatten into the parent's statement list.
             // For now, wrap in an always-true If:
             Some(GenericTestbenchStatement::If {
-                expr: CompiledExpr {
-                    bytecode: ExprBytecode::new(vec![TbOpcode::ConstU64(1)]),
-                },
+                expr: ExprBytecode::new(vec![TbOpcode::ConstU64(1)]),
                 then_block: stmts,
                 else_block: Vec::new(),
             })
@@ -2537,20 +2527,20 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
     fn convert_tb_method(
         &self,
         tb: &TbMethodCall,
-        ec: &ExprCompiler<'_, B>,
-    ) -> Option<TestbenchStatement<B>> {
+        ec: &ExprCompiler<'_>,
+    ) -> Option<SemanticStatement<AbsoluteAddr>> {
         match &tb.method {
             TbMethod::ClockNext { count, .. } => {
                 let ev = self.event_map.get(&tb.inst).copied()?;
                 let clock_count = match count {
                     Some(expr) => {
                         if let Some(n) = try_eval_const(expr) {
-                            ClockCount::Static(n)
+                            GenericClockCount::Static(n)
                         } else {
-                            ClockCount::Dynamic(ec.compile(expr))
+                            GenericClockCount::Dynamic(ec.compile(expr))
                         }
                     }
-                    None => ClockCount::Static(1),
+                    None => GenericClockCount::Static(1),
                 };
                 Some(GenericTestbenchStatement::ClockNext {
                     clock_event: ev,
@@ -2586,7 +2576,7 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
     /// unlike DomainKind which maps sync resets to Other.
     fn resolve_reset_polarity(&self, inst: &StrId) -> (u8, u8) {
         let name = veryl_parser::resource_table::get_str_value(*inst).unwrap_or_default();
-        let program = self.sim.program();
+        let program = self.program;
         if let Ok(addr) = program.get_addr(&[], &[&name]) {
             if let Some(info) = program.get_variable_info(&addr) {
                 return match info.type_kind {
@@ -2601,8 +2591,8 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
         (0, 1)
     }
 
-    fn resolve_loop_var(&self, var_id: &VarId) -> Option<(SignalRef, usize)> {
-        let p = self.sim.program();
+    fn resolve_loop_var(&self, var_id: &VarId) -> Option<(SemanticSignal<AbsoluteAddr>, usize)> {
+        let p = self.program;
         let rid = p
             .frontend
             .instance_ids
@@ -2614,7 +2604,13 @@ impl<'a, B: SimBackend> TestbenchBuilder<'a, B> {
             instance_id: *rid,
             var_id: *var_id,
         };
-        Some((self.sim.backend_ref().resolve_signal(&addr), info.width))
+        Some((
+            SemanticSignal {
+                address: addr,
+                width: info.width,
+            },
+            info.width,
+        ))
     }
 }
 
@@ -3185,15 +3181,210 @@ fn run_testbench_limited<B: SimBackend>(
     }
 }
 
+pub(crate) fn compile_semantic_testbench(
+    program: &Program,
+    source: &VerylTestbenchSource,
+) -> Option<TestbenchProgram<AbsoluteAddr>> {
+    let initial_stmts = source.initial_statements.as_ref()?;
+    let mut builder = SemanticTestbenchBuilder::new(program, source);
+    builder.build_event_map(initial_stmts);
+    Some(TestbenchProgram::new(builder.convert(initial_stmts)))
+}
+
+fn bind_expr<B: SimBackend>(
+    sim: &Simulator<B>,
+    expr: ExprBytecode<StateLocation<AbsoluteAddr>>,
+) -> Option<CompiledExpr> {
+    let layout = sim.backend_ref().layout();
+    let bytecode = expr
+        .bind_with(|address| layout.offsets.get(address).copied())
+        .ok()?;
+    Some(CompiledExpr { bytecode })
+}
+
+fn bind_assert_arg<B: SimBackend>(
+    sim: &Simulator<B>,
+    arg: SemanticArgument<AbsoluteAddr>,
+) -> Option<CompiledAssertArg> {
+    Some(CompiledAssertArg {
+        expr: bind_expr(sim, arg.expr)?,
+        width: arg.width,
+        signed: arg.signed,
+        is_string: arg.is_string,
+    })
+}
+
+fn bind_assert_message<B: SimBackend>(
+    sim: &Simulator<B>,
+    message: GenericAssertMessage<SemanticArgument<AbsoluteAddr>>,
+) -> Option<AssertMessage> {
+    match message {
+        GenericAssertMessage::Formatted { template, args } => {
+            let args = args
+                .into_iter()
+                .map(|arg| bind_assert_arg(sim, arg))
+                .collect::<Option<Vec<_>>>()?;
+            Some(GenericAssertMessage::Formatted { template, args })
+        }
+        GenericAssertMessage::DynamicArgs(args) => {
+            let args = args
+                .into_iter()
+                .map(|arg| bind_assert_arg(sim, arg))
+                .collect::<Option<Vec<_>>>()?;
+            Some(GenericAssertMessage::DynamicArgs(args))
+        }
+    }
+}
+
+fn bind_clock_count<B: SimBackend>(
+    sim: &Simulator<B>,
+    count: GenericClockCount<ExprBytecode<StateLocation<AbsoluteAddr>>>,
+) -> Option<ClockCount> {
+    match count {
+        GenericClockCount::Static(count) => Some(GenericClockCount::Static(count)),
+        GenericClockCount::Dynamic(expr) => Some(GenericClockCount::Dynamic(bind_expr(sim, expr)?)),
+    }
+}
+
+fn bind_loop_bound<B: SimBackend>(
+    sim: &Simulator<B>,
+    bound: GenericLoopBound<ExprBytecode<StateLocation<AbsoluteAddr>>>,
+) -> Option<LoopBound> {
+    match bound {
+        GenericLoopBound::Static(bound) => Some(GenericLoopBound::Static(bound)),
+        GenericLoopBound::Dynamic {
+            expr,
+            width,
+            signed,
+        } => Some(GenericLoopBound::Dynamic {
+            expr: bind_expr(sim, expr)?,
+            width,
+            signed,
+        }),
+    }
+}
+
+fn bind_statement<B: SimBackend>(
+    sim: &Simulator<B>,
+    statement: SemanticStatement<AbsoluteAddr>,
+) -> Option<TestbenchStatement<B>> {
+    match statement {
+        GenericTestbenchStatement::ClockNext { clock_event, count } => {
+            Some(GenericTestbenchStatement::ClockNext {
+                clock_event: sim.backend_ref().resolve_event_opt(&clock_event)?,
+                count: bind_clock_count(sim, count)?,
+            })
+        }
+        GenericTestbenchStatement::ResetAssert {
+            reset_signal,
+            clock_event,
+            duration,
+            assert_value,
+            deassert_value,
+        } => Some(GenericTestbenchStatement::ResetAssert {
+            reset_signal: sim.backend_ref().resolve_signal(&reset_signal.address),
+            clock_event: sim.backend_ref().resolve_event_opt(&clock_event)?,
+            duration,
+            assert_value,
+            deassert_value,
+        }),
+        GenericTestbenchStatement::Assert {
+            expr,
+            site_id,
+            continue_on_fail,
+            message,
+            location,
+        } => Some(GenericTestbenchStatement::Assert {
+            expr: bind_expr(sim, expr)?,
+            site_id,
+            continue_on_fail,
+            message: match message {
+                Some(message) => Some(bind_assert_message(sim, message)?),
+                None => None,
+            },
+            location,
+        }),
+        GenericTestbenchStatement::Display { message, newline } => {
+            Some(GenericTestbenchStatement::Display {
+                message: match message {
+                    Some(message) => Some(bind_assert_message(sim, message)?),
+                    None => None,
+                },
+                newline,
+            })
+        }
+        GenericTestbenchStatement::If {
+            expr,
+            then_block,
+            else_block,
+        } => Some(GenericTestbenchStatement::If {
+            expr: bind_expr(sim, expr)?,
+            then_block: then_block
+                .into_iter()
+                .map(|statement| bind_statement(sim, statement))
+                .collect::<Option<Vec<_>>>()?,
+            else_block: else_block
+                .into_iter()
+                .map(|statement| bind_statement(sim, statement))
+                .collect::<Option<Vec<_>>>()?,
+        }),
+        GenericTestbenchStatement::For {
+            loop_var,
+            start,
+            end,
+            inclusive,
+            step,
+            step_op,
+            reverse,
+            body,
+        } => Some(GenericTestbenchStatement::For {
+            loop_var: loop_var.map(|(signal, width, signed)| {
+                (
+                    sim.backend_ref().resolve_signal(&signal.address),
+                    width,
+                    signed,
+                )
+            }),
+            start: bind_loop_bound(sim, start)?,
+            end: bind_loop_bound(sim, end)?,
+            inclusive,
+            step,
+            step_op,
+            reverse,
+            body: body
+                .into_iter()
+                .map(|statement| bind_statement(sim, statement))
+                .collect::<Option<Vec<_>>>()?,
+        }),
+        GenericTestbenchStatement::Assign { dst, expr } => {
+            Some(GenericTestbenchStatement::Assign {
+                dst: sim.backend_ref().resolve_signal(&dst.address),
+                expr: bind_expr(sim, expr)?,
+            })
+        }
+        GenericTestbenchStatement::Break => Some(GenericTestbenchStatement::Break),
+        GenericTestbenchStatement::Finish => Some(GenericTestbenchStatement::Finish),
+    }
+}
+
+fn bind_testbench_program<B: SimBackend>(
+    sim: &Simulator<B>,
+    program: TestbenchProgram<AbsoluteAddr>,
+) -> Option<Vec<TestbenchStatement<B>>> {
+    program
+        .into_statements()
+        .into_iter()
+        .map(|statement| bind_statement(sim, statement))
+        .collect()
+}
+
 /// Compile the root module's initial block into an executable native testbench.
 pub fn compile_initial_testbench<B: SimBackend>(
     sim: &Simulator<B>,
 ) -> Option<CompiledTestbench<B>> {
-    let initial_stmts = sim.program().testbench_source.initial_statements.as_ref()?;
-    let mut tb_builder = TestbenchBuilder::new(sim);
-    tb_builder.build_event_map(initial_stmts);
+    let semantic = sim.program().testbench.clone()?;
     Some(CompiledTestbench {
-        stmts: tb_builder.convert(initial_stmts),
+        stmts: bind_testbench_program(sim, semantic)?,
     })
 }
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -25,7 +25,7 @@ The transformation from Veryl source code to execution consists of the following
     -   **SIR Optimization**: Applies per-pass optimization (store-load forwarding, commit sinking, dead store elimination, instruction scheduling, etc.) controlled by `OptimizeOptions`.
 
 3.  **Backend (Code Generation)**:
-    -   **Memory Layout**: Determines memory offsets for all variables and places them on a single memory buffer with Stable, Working, Triggered-bits, and Scratch regions. Layout finalization consumes a pre-layout `Program` and produces `LaidOutProgram`; every backend accepts only that typed artifact and therefore shares the same immutable layout.
+    -   **Memory Layout**: Determines memory offsets for all variables and places them on a single memory buffer with Stable, Working, Triggered-bits, and Scratch regions. The optimizer wraps verified SIR in `OptimizedSir`; layout finalization consumes that artifact and produces `LaidOutProgram`. Every backend accepts only the laid-out artifact and therefore shares the same immutable layout.
     -   **Code Generation**: Compiles SIR into executable machine code via one of the available backends.
     -   **Runtime**: Manages compiled function pointers as event handles and executes the simulation.
     -   **Testbench VM** (optional): A stack-based bytecode VM that executes Veryl `initial` blocks and testbench functions. Opcodes include `ConstU64`, `ConstWide`, `LoadU64`, `LoadWide`, `BinOp`, `UnaryOp`, `Ternary`, `LoadIndexed`, `LoadBitSelect`, `StoreU64`, supporting both narrow (≤64-bit) and wide signals.

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -7,8 +7,10 @@ current `celox` compiler/runtime monolith. It is a design document, not a claim 
 crates already exist.
 
 Migration note: `celox-state-layout` now owns the generic layout algorithm and the compiler driver
-uses a consuming `Program -> LaidOutProgram` transition. The current facade artifact still wraps
-the mixed `Program`, whose execution-unit groups are now held by `celox-sir::SirProgram` and whose
+uses a consuming `Program -> OptimizedSir -> LaidOutProgram` transition. Only the optimizer driver
+can construct `OptimizedSir`, and physical layout is no longer available on an unoptimized
+`Program`. The transitional facade artifact wraps the mixed `Program`, whose execution-unit groups
+are now held by `celox-sir::SirProgram` and whose
 flattened state metadata, event topology, and initial state are held by
 `celox-design::ElaboratedDesign`. Runtime diagnostics are held by
 `celox-design::RuntimeSchema`; its combinational observation recipes retain only persistent-state
@@ -21,22 +23,19 @@ artifact. The unused semantic-process provenance formerly copied from `LogicPath
 scheduler into `Program` has been removed instead of being assigned to a target crate. Moving the
 optimizer-to-layout state-alias contract is now represented by
 `celox-state-layout::LayoutRequirements` and is cleared after physical layout is finalized. Tests
-and consumers construct each backend from an unlaid-out `Program` rather than attempting to
+and consumers construct each backend from `OptimizedSir` rather than attempting to
 re-layout the finalized program after identity Stores have been removed. Veryl
 testbench runtime-event sites and direct state-read roots are projected into the source-independent
 `RuntimeSchema` before SIR optimization, so optimization and layout no longer traverse testbench
-AST. The remaining Veryl statements/functions are now one explicit
-`celox-frontend-veryl::VerylTestbenchSource` input owned by the frontend. The source-independent
+AST. Veryl statements/functions are an explicit
+`celox-frontend-veryl::VerylTestbenchSource` input consumed during frontend flattening. The source-independent
 expression opcode and operator vocabulary is owned by `celox-testbench`; the current Veryl
 testbench compiler translates source operators at that boundary and emits bytecode with semantic
-state addresses plus relative byte offsets. A separate binding step resolves those locations from
-the finalized physical layout before the VM executes the bound bytecode. Source statements are
-still retained until simulator construction, but the statement/control vocabulary is now also a
-generic `celox-testbench` contract over event identities, signal identities, expressions, and
-formatted arguments. Moving frontend construction of that contract before layout and storing the
-resulting source-independent artifact remains the next step. Moving the remaining parser implementation,
-symbolic, optimizer, and testbench payload into the phase-specific target types below remains part
-of Milestone 3.
+state addresses plus relative byte offsets. The resulting source-independent `TestbenchProgram` is
+stored before optimization; a separate binding step resolves those locations from the finalized
+physical layout before the VM executes the bound bytecode. Native, Cranelift, and WASM execution
+therefore share the same testbench binding path. Moving the remaining parser implementation,
+symbolic, optimizer, and runtime payload into the phase-specific target crates below remains.
 
 The baseline is the compiler pipeline on `perf/native-simulation-throughput` after PR #322. The
 split must preserve RTL semantics, generated-code quality, and the public `celox` API while making


### PR DESCRIPTION
## What changed

- add an `OptimizedSir` phase artifact with a compiler-private constructor
- make the parser/optimizer driver return `OptimizedSir`
- move `into_laid_out*` off unoptimized `Program` and onto `OptimizedSir`
- keep read-only access to the underlying program for diagnostics and existing consumers
- require the optimized artifact when recreating a simulator from shared native code

## Why

The compiler previously used the same `Program` type before and after optimization, so an unoptimized program could enter physical layout and backend code generation. The new type boundary makes the required phase order explicit and enforceable.

## Impact

The normal public compilation flow remains source-compatible for field reads through `Deref`, while layout finalization is restricted to verified optimizer output. Native, Cranelift, WASM, NAPI, and browser-facing crates all compile through the new boundary.

## Validation

- `cargo check --workspace --all-targets`
- `cargo clippy -p celox --all-targets -- -D warnings`
- `cargo test -p celox --test cross_validate` (11 passed)
- `cargo test -p celox --test wasm_regression` (29 passed)
- `cargo test -p celox --test native_testbench` (61 passed, 1 ignored)
- `cargo test -p celox --test initial_readmem test_initial_readmemh_applies_to_shared_native_simulator`
- repository pre-push hook