### PR TITLE
refactor(slt): introduce source-independent state core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "celox-frontend-veryl",
  "celox-macros",
  "celox-sir",
+ "celox-slt",
  "celox-state-layout",
  "celox-testbench",
  "chrono",
@@ -526,6 +527,15 @@ dependencies = [
  "fxhash",
  "num-bigint",
  "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "celox-slt"
+version = "0.18.0"
+dependencies = [
+ "celox-design",
+ "fxhash",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/celox-design",
     "crates/celox-frontend-veryl",
     "crates/celox-sir",
+    "crates/celox-slt",
     "crates/celox-state-layout",
     "crates/celox-testbench",
     "crates/celox-bench-sv",

--- a/crates/celox-slt/Cargo.toml
+++ b/crates/celox-slt/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name                  = "celox-slt"
+version.workspace     = true
+authors.workspace     = true
+repository.workspace  = true
+license.workspace     = true
+description           = "Source-independent symbolic logic tree core for Celox"
+edition.workspace     = true
+
+[dependencies]
+celox-design = { path = "../celox-design" }
+fxhash       = { workspace = true }
+serde        = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/celox-slt/src/lib.rs
+++ b/crates/celox-slt/src/lib.rs
@@ -1,0 +1,38 @@
+//! Source-independent symbolic logic tree primitives.
+//!
+//! This crate owns semantic bit-range state independently of any HDL
+//! frontend. Frontends provide their own address identity and SLT node type.
+
+use std::collections::BTreeSet;
+
+use celox_design::VarAtomBase;
+use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
+
+pub mod range_store;
+
+pub use range_store::{RangeStore, RangeStoreError};
+
+/// Symbolic state keyed by a frontend-independent semantic address.
+///
+/// `N` is the symbolic expression identity. It remains generic until the SLT
+/// arena itself moves into this crate.
+pub type SymbolicStore<A, N> = HashMap<A, RangeStore<Option<(N, HashSet<VarAtomBase<A>>)>>>;
+
+/// Bit boundaries discovered while constructing symbolic state.
+pub type BoundaryMap<A> = HashMap<A, BTreeSet<usize>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn symbolic_store_key_is_a_semantic_address_not_a_frontend_id() {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+        struct DesignAddress(u32);
+
+        let mut store = SymbolicStore::<DesignAddress, u32>::default();
+        store.insert(DesignAddress(7), RangeStore::new(None, 8));
+
+        assert!(store.contains_key(&DesignAddress(7)));
+    }
+}

--- a/crates/celox-slt/src/range_store.rs
+++ b/crates/celox-slt/src/range_store.rs
@@ -1,4 +1,4 @@
-use crate::ir::BitAccess;
+use celox_design::BitAccess;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt;

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -18,6 +18,7 @@ celox-analysis        = { path = "../celox-analysis" }
 celox-design          = { path = "../celox-design" }
 celox-frontend-veryl  = { path = "../celox-frontend-veryl" }
 celox-sir             = { path = "../celox-sir" }
+celox-slt             = { path = "../celox-slt" }
 celox-state-layout    = { path = "../celox-state-layout" }
 celox-testbench       = { path = "../celox-testbench" }
 fxhash                = { workspace = true }

--- a/crates/celox/src/logic_tree.rs
+++ b/crates/celox/src/logic_tree.rs
@@ -1,7 +1,7 @@
 mod comb;
 pub mod const_inline;
 mod lower;
-pub mod range_store;
+pub use celox_slt::range_store;
 pub use comb::SLTLoopBound;
 pub use comb::SLTNode;
 pub(crate) use comb::SLTNodeArenaEditError;

--- a/crates/celox/src/logic_tree/comb/state.rs
+++ b/crates/celox/src/logic_tree/comb/state.rs
@@ -1,15 +1,12 @@
-use std::collections::BTreeSet;
-
 use veryl_analyzer::ir::VarId;
 
-use crate::{HashMap, HashSet, ir::VarAtomBase, logic_tree::range_store::RangeStore};
+use crate::{HashSet, ir::VarAtomBase};
 
 use super::NodeId;
 
-// SymbolicStore: Maps variable IDs to their current symbolic representation.
-// Each variable is managed by a RangeStore, which tracks bit-ranges and their associated SLT nodes.
-pub type SymbolicStore<A> = HashMap<VarId, RangeStore<Option<(NodeId, HashSet<VarAtomBase<A>>)>>>;
-pub type BoundaryMap<A> = HashMap<A, BTreeSet<usize>>;
+// Frontend specialization of the source-independent symbolic state contract.
+pub type SymbolicStore<A> = celox_slt::SymbolicStore<A, NodeId>;
+pub type BoundaryMap<A> = celox_slt::BoundaryMap<A>;
 
 #[derive(Clone)]
 pub(super) struct LoopControlState {

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -36,6 +36,9 @@ stored before optimization; a separate binding step resolves those locations fro
 physical layout before the VM executes the bound bytecode. Native, Cranelift, and WASM execution
 therefore share the same testbench binding path. Moving the remaining parser implementation,
 symbolic, optimizer, and runtime payload into the phase-specific target crates below remains.
+`celox-slt` now owns the frontend-independent bit-range store and a symbolic-state contract generic
+over both semantic addresses and node identities; the arena, facts, scheduler, and lowerer remain
+in the facade until their Veryl construction dependencies are separated.
 
 The baseline is the compiler pipeline on `perf/native-simulation-throughput` after PR #322. The
 split must preserve RTL semantics, generated-code quality, and the public `celox` API while making


### PR DESCRIPTION
## What changed

- add the `celox-slt` crate
- move checked bit-range symbolic storage into that crate
- define symbolic state generically over semantic address and node identity
- adapt the existing Veryl construction path through a compatibility type alias

## Why

The old `SymbolicStore<A>` looked generic but was hard-coded to Veryl `VarId` as its map key. Moving that implementation unchanged would only create a cosmetic crate boundary. The new contract is genuinely frontend-independent and provides the base for moving the SLT arena, facts, scheduler, and lowerer.

## Impact

Existing frontend behavior is unchanged. `celox-slt` depends only on `celox-design`, `fxhash`, and `serde`; it has no Veryl dependency.

## Validation

- `cargo test -p celox-slt` (3 passed)
- `cargo clippy -p celox-slt -p celox --all-targets -- -D warnings`
- `cargo tree -p celox-slt` (no Veryl dependencies)
- repository pre-push hook