### PR TITLE
Move SLT arena and verifier into celox-slt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,7 +536,9 @@ version = "0.18.0"
 dependencies = [
  "celox-design",
  "fxhash",
+ "num-bigint",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/celox-slt/Cargo.toml
+++ b/crates/celox-slt/Cargo.toml
@@ -10,7 +10,11 @@ edition.workspace     = true
 [dependencies]
 celox-design = { path = "../celox-design" }
 fxhash       = { workspace = true }
+num-bigint   = { workspace = true }
 serde        = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/celox-slt/src/lib.rs
+++ b/crates/celox-slt/src/lib.rs
@@ -8,9 +8,24 @@ use std::collections::BTreeSet;
 use celox_design::VarAtomBase;
 use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
+mod node;
+mod node_facts;
+mod node_rules;
 pub mod range_store;
 
+pub use node::{
+    NodeId, SLTForEffect, SLTForFoldGroupState, SLTForUpdate, SLTIndex, SLTIndexKind, SLTLoopBound,
+    SLTNode, SLTNodeArena, SLTNodeArenaEditError, SLTStepOp,
+};
+pub use node_facts::{SLTNodeFacts, SLTNodeFactsError};
 pub use range_store::{RangeStore, RangeStoreError};
+
+/// Return the construction-time width cached when a node was interned.
+pub fn get_width<A: std::hash::Hash + Eq + Clone>(node: NodeId, arena: &SLTNodeArena<A>) -> usize {
+    arena
+        .width(node)
+        .unwrap_or_else(|| panic!("SLT node id n{} is outside the arena", node.0))
+}
 
 /// Symbolic state keyed by a frontend-independent semantic address.
 ///

--- a/crates/celox-slt/src/node.rs
+++ b/crates/celox-slt/src/node.rs
@@ -5,17 +5,15 @@ use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
 
 use super::node_facts::{SLTNodeFactsError, verify_append, verify_raw_nodes};
 
-use crate::{
-    HashMap,
-    ir::{BinaryOp, BitAccess, UnaryOp, VarAtomBase},
-};
+use crate::HashMap;
+use celox_design::{BinaryOp, BitAccess, UnaryOp, VarAtomBase};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct NodeId(pub usize);
 
 /// Failure from a narrowly scoped mutation of a construction arena.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum SLTNodeArenaEditError {
+pub enum SLTNodeArenaEditError {
     RangeOutOfBounds {
         start: usize,
         end: usize,
@@ -137,7 +135,7 @@ impl<A: Hash + Eq + Clone> SLTNodeArena<A> {
     }
 
     /// Return a construction-time width computed once when `id` was interned.
-    pub(super) fn width(&self, id: NodeId) -> Option<usize> {
+    pub(crate) fn width(&self, id: NodeId) -> Option<usize> {
         self.widths.get(id.0).copied()
     }
 
@@ -174,7 +172,7 @@ impl<A: Hash + Eq + Clone> SLTNodeArena<A> {
     /// The semantic interning cache is rebuilt internally whenever the rewrite
     /// changes a node, so callers cannot leave node storage and cache identity
     /// out of sync. `None` leaves an effect unchanged.
-    pub(crate) fn remap_for_fold_effect_sites(
+    pub fn remap_for_fold_effect_sites(
         &mut self,
         range: std::ops::Range<usize>,
         mut remap: impl FnMut(
@@ -349,27 +347,27 @@ impl<A: Hash + Eq + Clone> SLTNode<A> {
                 write!(f, "n{}:", lhs.0)?;
                 arena.get(*lhs).fmt_expression(f, arena)?;
                 let op_str = match op {
-                    crate::ir::BinaryOp::Add => "+",
-                    crate::ir::BinaryOp::Sub => "-",
-                    crate::ir::BinaryOp::Mul => "*",
-                    crate::ir::BinaryOp::DivU | crate::ir::BinaryOp::DivS => "/",
-                    crate::ir::BinaryOp::RemU | crate::ir::BinaryOp::RemS => "%",
-                    crate::ir::BinaryOp::And => "&",
-                    crate::ir::BinaryOp::Or => "|",
-                    crate::ir::BinaryOp::Xor => "^",
-                    crate::ir::BinaryOp::Shl => "<<",
-                    crate::ir::BinaryOp::Shr => ">>",
-                    crate::ir::BinaryOp::Sar => ">>>",
-                    crate::ir::BinaryOp::Eq => "==",
-                    crate::ir::BinaryOp::Ne => "!=",
-                    crate::ir::BinaryOp::LtU | crate::ir::BinaryOp::LtS => "<",
-                    crate::ir::BinaryOp::LeU | crate::ir::BinaryOp::LeS => "<=",
-                    crate::ir::BinaryOp::GtU | crate::ir::BinaryOp::GtS => ">",
-                    crate::ir::BinaryOp::GeU | crate::ir::BinaryOp::GeS => ">=",
-                    crate::ir::BinaryOp::LogicAnd => "&&",
-                    crate::ir::BinaryOp::LogicOr => "||",
-                    crate::ir::BinaryOp::EqWildcard => "==?",
-                    crate::ir::BinaryOp::NeWildcard => "!=?",
+                    celox_design::BinaryOp::Add => "+",
+                    celox_design::BinaryOp::Sub => "-",
+                    celox_design::BinaryOp::Mul => "*",
+                    celox_design::BinaryOp::DivU | celox_design::BinaryOp::DivS => "/",
+                    celox_design::BinaryOp::RemU | celox_design::BinaryOp::RemS => "%",
+                    celox_design::BinaryOp::And => "&",
+                    celox_design::BinaryOp::Or => "|",
+                    celox_design::BinaryOp::Xor => "^",
+                    celox_design::BinaryOp::Shl => "<<",
+                    celox_design::BinaryOp::Shr => ">>",
+                    celox_design::BinaryOp::Sar => ">>>",
+                    celox_design::BinaryOp::Eq => "==",
+                    celox_design::BinaryOp::Ne => "!=",
+                    celox_design::BinaryOp::LtU | celox_design::BinaryOp::LtS => "<",
+                    celox_design::BinaryOp::LeU | celox_design::BinaryOp::LeS => "<=",
+                    celox_design::BinaryOp::GtU | celox_design::BinaryOp::GtS => ">",
+                    celox_design::BinaryOp::GeU | celox_design::BinaryOp::GeS => ">=",
+                    celox_design::BinaryOp::LogicAnd => "&&",
+                    celox_design::BinaryOp::LogicOr => "||",
+                    celox_design::BinaryOp::EqWildcard => "==?",
+                    celox_design::BinaryOp::NeWildcard => "!=?",
                 };
                 write!(f, " {} ", op_str)?;
                 write!(f, "n{}:", rhs.0)?;
@@ -378,17 +376,17 @@ impl<A: Hash + Eq + Clone> SLTNode<A> {
             }
             SLTNode::Unary(op, inner) => {
                 let op_str = match op {
-                    crate::ir::UnaryOp::Ident => "",
-                    crate::ir::UnaryOp::ToTwoState => "2state",
-                    crate::ir::UnaryOp::Minus => "-",
-                    crate::ir::UnaryOp::BitNot => "~",
-                    crate::ir::UnaryOp::LogicNot => "!",
-                    crate::ir::UnaryOp::And => "&", // reduction
-                    crate::ir::UnaryOp::Or => "|",
-                    crate::ir::UnaryOp::Xor => "^",
-                    crate::ir::UnaryOp::PopCount => "popcount",
-                    crate::ir::UnaryOp::CountLeadingZeros => "clz",
-                    crate::ir::UnaryOp::CountTrailingZeros => "ctz",
+                    celox_design::UnaryOp::Ident => "",
+                    celox_design::UnaryOp::ToTwoState => "2state",
+                    celox_design::UnaryOp::Minus => "-",
+                    celox_design::UnaryOp::BitNot => "~",
+                    celox_design::UnaryOp::LogicNot => "!",
+                    celox_design::UnaryOp::And => "&", // reduction
+                    celox_design::UnaryOp::Or => "|",
+                    celox_design::UnaryOp::Xor => "^",
+                    celox_design::UnaryOp::PopCount => "popcount",
+                    celox_design::UnaryOp::CountLeadingZeros => "clz",
+                    celox_design::UnaryOp::CountTrailingZeros => "ctz",
                 };
                 write!(f, "{}(", op_str)?;
                 write!(f, "n{}:", inner.0)?;
@@ -1405,10 +1403,8 @@ mod tests {
         NodeId, SLTForEffect, SLTForFoldGroupState, SLTIndex, SLTLoopBound, SLTNode, SLTNodeArena,
         SLTNodeArenaEditError, SLTNodeArenaWire, SLTStepOp,
     };
-    use crate::{
-        ir::{BinaryOp, BitAccess, UnaryOp, VarAtomBase},
-        logic_tree::comb::{expr::get_width, node_facts::SLTNodeFacts},
-    };
+    use crate::{SLTNodeFacts, get_width};
+    use celox_design::{BinaryOp, BitAccess, UnaryOp, VarAtomBase};
     use num_bigint::{BigInt, BigUint};
 
     fn constant(value: u8) -> SLTNode<u32> {
@@ -1685,33 +1681,6 @@ mod tests {
         assert_eq!(
             SLTNodeFacts::verify(&arena).unwrap_err().invariant,
             "FACTS.CACHED_WIDTH_MATCHES"
-        );
-    }
-
-    #[test]
-    fn zero_width_coercion_is_a_structured_error() {
-        let mut arena = SLTNodeArena::<u32>::new();
-        let zero = arena
-            .alloc(SLTNode::Constant(
-                BigUint::from(0u8),
-                BigUint::from(0u8),
-                0,
-                false,
-            ))
-            .unwrap();
-        let nonzero = arena.alloc(constant(1)).unwrap();
-
-        assert_eq!(
-            crate::logic_tree::coerce_node_width(&mut arena, zero, Some(8), true)
-                .unwrap_err()
-                .invariant,
-            "WIDTH.COERCE_SOURCE_NON_ZERO"
-        );
-        assert_eq!(
-            crate::logic_tree::coerce_node_width(&mut arena, nonzero, Some(0), false)
-                .unwrap_err()
-                .invariant,
-            "WIDTH.COERCE_TARGET_NON_ZERO"
         );
     }
 

--- a/crates/celox-slt/src/node_facts.rs
+++ b/crates/celox-slt/src/node_facts.rs
@@ -1,6 +1,6 @@
 use std::{fmt, hash::Hash};
 
-use crate::ir::BitAccess;
+use celox_design::BitAccess;
 
 use super::node::{NodeId, SLTLoopBound, SLTNode, SLTNodeArena, SLTStepOp};
 use super::node_rules;
@@ -372,7 +372,7 @@ pub struct SLTNodeFactsError {
 }
 
 impl SLTNodeFactsError {
-    pub(crate) fn new(invariant: &'static str, node: NodeId, message: impl Into<String>) -> Self {
+    pub fn new(invariant: &'static str, node: NodeId, message: impl Into<String>) -> Self {
         Self {
             invariant,
             node,
@@ -847,12 +847,10 @@ where
 mod tests {
     use num_bigint::{BigInt, BigUint};
 
-    use crate::ir::{BinaryOp, UnaryOp, VarAtomBase};
+    use celox_design::{BinaryOp, UnaryOp, VarAtomBase};
 
     use super::*;
-    use crate::logic_tree::comb::node::{
-        SLTForEffect, SLTForFoldGroupState, SLTForUpdate, SLTStepOp,
-    };
+    use crate::node::{SLTForEffect, SLTForFoldGroupState, SLTForUpdate, SLTStepOp};
 
     fn arena(nodes: Vec<SLTNode<u32>>) -> SLTNodeArena<u32> {
         SLTNodeArena::try_from_nodes(nodes).expect("test node graph must verify")

--- a/crates/celox-slt/src/node_rules.rs
+++ b/crates/celox-slt/src/node_rules.rs
@@ -5,7 +5,7 @@
 
 use num_bigint::BigUint;
 
-use crate::ir::{BinaryOp, BitAccess, UnaryOp};
+use celox_design::{BinaryOp, BitAccess, UnaryOp};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct NodeRuleError {

--- a/crates/celox/src/logic_tree/comb.rs
+++ b/crates/celox/src/logic_tree/comb.rs
@@ -1,11 +1,19 @@
 mod effect;
 mod expr;
-mod node;
-mod node_facts;
-mod node_rules;
 mod path;
 mod recover_unrolled;
 mod state;
+
+pub(crate) mod node {
+    pub use celox_slt::{
+        NodeId, SLTForEffect, SLTForFoldGroupState, SLTForUpdate, SLTIndex, SLTIndexKind,
+        SLTLoopBound, SLTNode, SLTNodeArena, SLTNodeArenaEditError, SLTStepOp,
+    };
+}
+
+pub(crate) mod node_facts {
+    pub use celox_slt::{SLTNodeFacts, SLTNodeFactsError};
+}
 
 pub use path::{LogicPath, LogicPathTarget};
 pub use state::{BoundaryMap, SymbolicStore};

--- a/crates/celox/src/logic_tree/comb/expr.rs
+++ b/crates/celox/src/logic_tree/comb/expr.rs
@@ -2670,9 +2670,7 @@ fn eval_factor(
     }
 }
 pub fn get_width<A: Hash + Eq + Clone>(expr: NodeId, arena: &SLTNodeArena<A>) -> usize {
-    arena
-        .width(expr)
-        .unwrap_or_else(|| panic!("SLT node id n{} is outside the arena", expr.0))
+    celox_slt::get_width(expr, arena)
 }
 
 pub(super) fn merge_boundaries(
@@ -3038,5 +3036,46 @@ pub fn convert_unary_op(op: &Op) -> UnaryOp {
         Op::Condition => unreachable!("condition node must not be lowered by convert_unary_op"),
         Op::Repeat => unreachable!("repeat node must be lowered by repeat-specific path"),
         Op::As => unreachable!("As is binary and must not be lowered by convert_unary_op"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::coerce_node_width;
+    use celox_slt::{SLTNode, SLTNodeArena};
+    use num_bigint::BigUint;
+
+    #[test]
+    fn zero_width_coercion_is_a_structured_error() {
+        let mut arena = SLTNodeArena::<u32>::new();
+        let zero = arena
+            .alloc(SLTNode::Constant(
+                BigUint::from(0u8),
+                BigUint::from(0u8),
+                0,
+                false,
+            ))
+            .unwrap();
+        let nonzero = arena
+            .alloc(SLTNode::Constant(
+                BigUint::from(1u8),
+                BigUint::from(0u8),
+                8,
+                false,
+            ))
+            .unwrap();
+
+        assert_eq!(
+            coerce_node_width(&mut arena, zero, Some(8), true)
+                .unwrap_err()
+                .invariant,
+            "WIDTH.COERCE_SOURCE_NON_ZERO"
+        );
+        assert_eq!(
+            coerce_node_width(&mut arena, nonzero, Some(0), false)
+                .unwrap_err()
+                .invariant,
+            "WIDTH.COERCE_TARGET_NON_ZERO"
+        );
     }
 }

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -36,9 +36,9 @@ stored before optimization; a separate binding step resolves those locations fro
 physical layout before the VM executes the bound bytecode. Native, Cranelift, and WASM execution
 therefore share the same testbench binding path. Moving the remaining parser implementation,
 symbolic, optimizer, and runtime payload into the phase-specific target crates below remains.
-`celox-slt` now owns the frontend-independent bit-range store and a symbolic-state contract generic
-over both semantic addresses and node identities; the arena, facts, scheduler, and lowerer remain
-in the facade until their Veryl construction dependencies are separated.
+`celox-slt` now owns the frontend-independent bit-range store, symbolic-state contract, SLT node
+arena, and iterative facts/verifier. Veryl AST traversal remains in the facade as an arena builder;
+the source-independent path graph, scheduler, and lowerer are the remaining SLT moves.
 
 The baseline is the compiler pipeline on `perf/native-simulation-throughput` after PR #322. The
 split must preserve RTL semantics, generated-code quality, and the public `celox` API while making


### PR DESCRIPTION
## What changed

- move `SLTNode`, `SLTNodeArena`, node rules, and iterative `SLTNodeFacts` verification into `celox-slt`
- expose the semantic arena contract through the existing facade compatibility module
- keep Veryl AST expression construction in the frontend-facing module
- move the width-coercion regression test to the frontend expression owner

## Why

Arena storage and graph verification are source-independent. Keeping them beside Veryl traversal obscured the boundary and prevented the scheduler/lowerer from depending on a clean SLT crate.

## Impact

No SLT construction or scheduling semantics change. Arena serialization, canonicalization, deep-DAG verification, ForFold contracts, and scheduler behavior retain their existing tests.

## Validation

- `cargo test -p celox-slt` (39 passed)
- `cargo test -p celox --lib zero_width_coercion_is_a_structured_error`
- `cargo test -p celox --lib parser::scheduler::tests` (19 passed)
- `cargo clippy -p celox-slt -p celox --all-targets -- -D warnings`
- repository pre-push hook