### PR TITLE
refactor(veryl): add an explicit SymbolicRtl scheduling boundary

### DIFF
--- a/crates/celox-frontend-veryl/src/hierarchy.rs
+++ b/crates/celox-frontend-veryl/src/hierarchy.rs
@@ -12,18 +12,21 @@ use crate::{
 /// This artifact may retain analyzer references while frontend construction is
 /// in progress. It is consumed before source-independent design and SIR
 /// artifacts leave the frontend boundary.
-pub struct ParseIrResult<'a> {
+pub struct SymbolicRtl<'a> {
     pub modules: HashMap<ModuleId, SimModule>,
     pub module_ir: HashMap<ModuleId, &'a Module>,
     pub module_names: HashMap<ModuleId, StrId>,
     pub root_id: ModuleId,
 }
 
+/// Compatibility name retained while callers migrate to the phase artifact.
+pub type ParseIrResult<'a> = SymbolicRtl<'a>;
+
 pub fn parse_ir<'a>(
     ir: &'a veryl_analyzer::ir::Ir,
     config: &BuildConfig,
     top: &StrId,
-) -> Result<ParseIrResult<'a>, ParserError> {
+) -> Result<SymbolicRtl<'a>, ParserError> {
     parse_ir_with_loop_provenance(ir, &LoopProvenance::default(), config, top)
 }
 
@@ -32,7 +35,7 @@ pub fn parse_ir_with_loop_provenance<'a>(
     loop_provenance: &LoopProvenance,
     config: &BuildConfig,
     top: &StrId,
-) -> Result<ParseIrResult<'a>, ParserError> {
+) -> Result<SymbolicRtl<'a>, ParserError> {
     let mut name_to_ir: HashMap<StrId, &'a Module> = HashMap::default();
     let mut generic_names: HashSet<StrId> = HashSet::default();
     for component in &ir.components {
@@ -149,7 +152,7 @@ pub fn parse_ir_with_loop_provenance<'a>(
         modules.insert(*module_id, sim_module);
     }
 
-    Ok(ParseIrResult {
+    Ok(SymbolicRtl {
         modules,
         module_ir,
         module_names,

--- a/crates/celox-frontend-veryl/src/lib.rs
+++ b/crates/celox-frontend-veryl/src/lib.rs
@@ -22,7 +22,7 @@ mod types;
 
 pub use config::BuildConfig;
 pub use error::{LoweringPhase, ParserError, SourceLocation};
-pub use hierarchy::{ParseIrResult, parse_ir, parse_ir_with_loop_provenance};
+pub use hierarchy::{ParseIrResult, SymbolicRtl, parse_ir, parse_ir_with_loop_provenance};
 pub use module_artifact::{RelocationModule, ScheduledRtl, SimModule};
 pub use types::{resolve_dims, resolve_total_width};
 

--- a/crates/celox-frontend-veryl/src/lib.rs
+++ b/crates/celox-frontend-veryl/src/lib.rs
@@ -23,7 +23,7 @@ mod types;
 pub use config::BuildConfig;
 pub use error::{LoweringPhase, ParserError, SourceLocation};
 pub use hierarchy::{ParseIrResult, parse_ir, parse_ir_with_loop_provenance};
-pub use module_artifact::{RelocationModule, SimModule};
+pub use module_artifact::{RelocationModule, ScheduledRtl, SimModule};
 pub use types::{resolve_dims, resolve_total_width};
 
 use celox_design::{InstanceId, ModuleId, VariableMetadata};
@@ -90,6 +90,43 @@ impl fmt::Debug for VerylFrontendLookup {
             .field("instances", &self.instance_module.len())
             .field("modules", &self.module_variables.len())
             .finish_non_exhaustive()
+    }
+}
+
+impl VerylFrontendLookup {
+    pub fn get_path(&self, address: &AbsoluteAddr) -> String {
+        let instance_path = self
+            .instance_ids
+            .iter()
+            .find(|(_, id)| **id == address.instance_id)
+            .map(|(path, _)| path);
+        let module_id = self.instance_module.get(&address.instance_id).unwrap();
+        let module_vars = self.module_variables.get(module_id).unwrap();
+        let variable_path = module_vars
+            .values()
+            .find(|info| info.id == address.var_id)
+            .map(|info| &info.path);
+
+        let mut result = Vec::new();
+        if let Some(instance_path) = instance_path {
+            for part in &instance_path.0 {
+                result.push(format!(
+                    "{}[{}]",
+                    veryl_parser::resource_table::get_str_value(part.0).unwrap(),
+                    part.1
+                ));
+            }
+        }
+        if let Some(variable_path) = variable_path {
+            for part in &variable_path.0 {
+                result.push(
+                    veryl_parser::resource_table::get_str_value(*part)
+                        .unwrap()
+                        .to_string(),
+                );
+            }
+        }
+        result.join(".")
     }
 }
 

--- a/crates/celox-frontend-veryl/src/module_artifact.rs
+++ b/crates/celox-frontend-veryl/src/module_artifact.rs
@@ -1,17 +1,17 @@
 use std::{collections::BTreeSet, fmt};
 
 use celox_design::{
-    AbsoluteAddrBase, InitialStateValue, RegionedAbsoluteAddrBase, RegionedVarAddrBase,
-    RuntimeErrorInfo, RuntimeEventSite, TriggerSet,
+    AbsoluteAddrBase, ElaboratedDesign, InitialStateValue, RegionedAbsoluteAddrBase,
+    RegionedVarAddrBase, RuntimeErrorInfo, RuntimeEventSite, RuntimeSchema, TriggerSet,
 };
-use celox_sir::ExecutionUnit;
+use celox_sir::{ExecutionUnit, SirProgram};
 use celox_slt::{
     CombObserver, FfAccessSummary, GlueBlockBase, LogicPath, NodeId, SLTNodeArena, SymbolicStore,
 };
 use veryl_analyzer::ir::{VarId, VarPath, Variable};
 use veryl_parser::resource_table::StrId;
 
-use crate::HashMap;
+use crate::{HashMap, VerylFrontendLookup, VerylTestbenchSource};
 
 type RegionedVarAddr = RegionedVarAddrBase<VarId>;
 type GlueBlock = GlueBlockBase<VarId>;
@@ -88,6 +88,32 @@ impl fmt::Debug for RelocationModule {
             .field("apply_ff_blocks", &self.apply_ff_blocks)
             .field("comb_blocks", &self.comb_blocks)
             .field("comb_observers", &self.comb_observers)
+            .finish()
+    }
+}
+
+/// Source-independent SIR and design data produced after all SLT nodes have
+/// been scheduled and lowered.
+///
+/// No `NodeId` or SLT arena may cross this boundary. Veryl identities retained
+/// for diagnostics and public path lookup live only in `frontend_lookup`.
+#[derive(Clone)]
+pub struct ScheduledRtl {
+    pub sir: SirProgram<AbsoluteAddr, RegionedAbsoluteAddr>,
+    pub design: ElaboratedDesign<AbsoluteAddr>,
+    pub frontend_lookup: VerylFrontendLookup,
+    pub runtime_schema: RuntimeSchema<AbsoluteAddr>,
+    pub testbench_source: VerylTestbenchSource,
+}
+
+impl fmt::Debug for ScheduledRtl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ScheduledRtl")
+            .field("sir", &self.sir)
+            .field("design", &self.design)
+            .field("frontend_lookup", &self.frontend_lookup)
+            .field("runtime_schema", &self.runtime_schema)
+            .field("testbench_source", &self.testbench_source)
             .finish()
     }
 }

--- a/crates/celox/src/flatting_tests.rs
+++ b/crates/celox/src/flatting_tests.rs
@@ -367,10 +367,7 @@ fn setup_and_parse(code: &str, top_name: &str) -> crate::ir::Program {
     let build_config = crate::parser::BuildConfig::default();
     let result = crate::parser::parse_ir(&ir, &build_config, &top_id).expect("Failed to parse IR");
     let scheduled = crate::parser::flatten(
-        &result.root_id,
-        &result.module_ir,
-        result.modules,
-        result.module_names,
+        result,
         &build_config,
         &[],
         &[],

--- a/crates/celox/src/flatting_tests.rs
+++ b/crates/celox/src/flatting_tests.rs
@@ -366,7 +366,7 @@ fn setup_and_parse(code: &str, top_name: &str) -> crate::ir::Program {
     // crate::parser::parse(&top_id, &ir).expect("Failed to parse program")
     let build_config = crate::parser::BuildConfig::default();
     let result = crate::parser::parse_ir(&ir, &build_config, &top_id).expect("Failed to parse IR");
-    crate::parser::flatten(
+    let scheduled = crate::parser::flatten(
         &result.root_id,
         &result.module_ir,
         result.modules,
@@ -378,7 +378,8 @@ fn setup_and_parse(code: &str, top_name: &str) -> crate::ir::Program {
         &crate::debug::TraceOptions::default(),
         None,
     )
-    .expect("Failed to flatten")
+    .expect("Failed to flatten");
+    crate::ir::Program::from_scheduled(scheduled).0
 }
 
 #[test]

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -201,6 +201,22 @@ impl OptimizedSir {
 }
 
 impl Program {
+    pub(crate) fn from_scheduled(
+        scheduled: celox_frontend_veryl::ScheduledRtl,
+    ) -> (Self, celox_frontend_veryl::VerylTestbenchSource) {
+        (
+            Self {
+                sir: scheduled.sir,
+                design: scheduled.design,
+                frontend: scheduled.frontend_lookup,
+                runtime_schema: scheduled.runtime_schema,
+                layout_requirements: Default::default(),
+                testbench: None,
+            },
+            scheduled.testbench_source,
+        )
+    }
+
     pub fn get_addr(
         &self,
         instance_path: &[(&str, usize)],
@@ -244,42 +260,7 @@ impl Program {
     }
 
     pub fn get_path(&self, addr: &AbsoluteAddr) -> String {
-        let instance_id = addr.instance_id;
-        let var_id = addr.var_id;
-
-        let instance_path = self
-            .frontend
-            .instance_ids
-            .iter()
-            .find(|(_, id)| **id == instance_id)
-            .map(|(path, _)| path);
-        let module_id = self.frontend.instance_module.get(&instance_id).unwrap();
-        let module_vars = self.frontend.module_variables.get(module_id).unwrap();
-        let var_path = module_vars
-            .values()
-            .find(|info| info.id == var_id)
-            .map(|info| &info.path);
-
-        let mut res = Vec::new();
-        if let Some(ip) = instance_path {
-            for part in &ip.0 {
-                res.push(format!(
-                    "{}[{}]",
-                    veryl_parser::resource_table::get_str_value(part.0).unwrap(),
-                    part.1
-                ));
-            }
-        }
-        if let Some(vp) = var_path {
-            for part in &vp.0 {
-                res.push(
-                    veryl_parser::resource_table::get_str_value(*part)
-                        .unwrap()
-                        .to_string(),
-                );
-            }
-        }
-        res.join(".")
+        self.frontend.get_path(addr)
     }
 
     pub fn get_variable_info(&self, addr: &AbsoluteAddr) -> Option<&VariableInfo> {

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -192,7 +192,7 @@ pub(crate) fn flatten(
     four_state: bool,
     trace_opts: &crate::debug::TraceOptions,
     mut trace: Option<&mut crate::debug::CompilationTrace>,
-) -> Result<Program, ParserError> {
+) -> Result<celox_frontend_veryl::ScheduledRtl, ParserError> {
     let flatten_timing = std::env::var("CELOX_PHASE_TIMING").is_ok();
     macro_rules! timed_sub {
         ($label:expr, $body:expr) => {{
@@ -473,30 +473,17 @@ pub(crate) fn flatten(
         Ok(schedule) => schedule,
         Err(error) => {
             let (err_vars, err_path_idx) = module_variables(module_ir, config).unwrap_or_default();
-            let program = Program {
-                sir: crate::ir::SirProgram {
-                    eval_apply_ffs: HashMap::default(),
-                    eval_comb_apply_ffs: HashMap::default(),
-                    eval_only_ffs: HashMap::default(),
-                    apply_ffs: HashMap::default(),
-                    eval_comb: Vec::new(),
-                },
-                design: celox_design::ElaboratedDesign::default(),
-                frontend: crate::ir::VerylFrontendLookup {
-                    instance_ids: expanded.clone(),
-                    instance_module: instance_modules.clone(),
-                    module_variables: err_vars,
-                    module_var_path_index: err_path_idx,
-                    module_names: module_names.clone(),
-                },
-                runtime_schema: celox_design::RuntimeSchema::default(),
-                layout_requirements: Default::default(),
-                testbench: None,
+            let frontend_lookup = crate::ir::VerylFrontendLookup {
+                instance_ids: expanded.clone(),
+                instance_module: instance_modules.clone(),
+                module_variables: err_vars,
+                module_var_path_index: err_path_idx,
+                module_names: module_names.clone(),
             };
             let source_locations = scheduler_source_locations(&error, module_ir, &instance_modules);
             let mut target_arena = SLTNodeArena::new();
             let error = error.map_addr(&global_arena, &mut target_arena, &|addr| {
-                program.get_path(addr)
+                frontend_lookup.get_path(addr)
             })?;
             return Err(if source_locations.is_empty() {
                 ParserError::Scheduler(error)
@@ -682,7 +669,7 @@ pub(crate) fn flatten(
             .map(|m| m.functions.clone())
             .unwrap_or_default(),
     };
-    let program = Program {
+    let mut scheduled = celox_frontend_veryl::ScheduledRtl {
         sir: crate::ir::SirProgram {
             eval_apply_ffs,
             eval_comb_apply_ffs,
@@ -700,7 +687,7 @@ pub(crate) fn flatten(
             },
             initial_state: initial_memory_values,
         },
-        frontend: crate::ir::VerylFrontendLookup {
+        frontend_lookup: crate::ir::VerylFrontendLookup {
             instance_ids: expanded,
             instance_module: instance_modules,
             module_variables: mod_vars,
@@ -713,15 +700,14 @@ pub(crate) fn flatten(
             comb_observers: runtime_comb_observers,
             testbench_read_roots: Default::default(),
         },
-        layout_requirements: Default::default(),
-        testbench: None,
+        testbench_source,
     };
 
     // --- Trigger Injection ---
     let mut trigger_map: HashMap<AbsoluteAddr, Vec<crate::ir::TriggerIdWithKind>> =
         HashMap::default();
-    for (id, addr) in program.design.events.ordered_events.iter().enumerate() {
-        if let Some(metadata) = program.design.state_objects.get(addr) {
+    for (id, addr) in scheduled.design.events.ordered_events.iter().enumerate() {
+        if let Some(metadata) = scheduled.design.state_objects.get(addr) {
             trigger_map
                 .entry(*addr)
                 .or_default()
@@ -732,12 +718,11 @@ pub(crate) fn flatten(
         }
     }
 
-    let mut program = program;
-    for units in program
+    for units in scheduled
         .sir
         .eval_apply_ffs
         .values_mut()
-        .chain(program.sir.eval_comb_apply_ffs.values_mut())
+        .chain(scheduled.sir.eval_comb_apply_ffs.values_mut())
     {
         for eu in units {
             for bb in eu.blocks.values_mut() {
@@ -745,14 +730,14 @@ pub(crate) fn flatten(
                     match inst {
                         crate::ir::SIRInstruction::Store(addr, _, _, _, triggers, _) => {
                             let abs = addr.absolute_addr();
-                            let canonical = program.design.events.canonical(abs);
+                            let canonical = scheduled.design.events.canonical(abs);
                             if let Some(ts) = trigger_map.get(&canonical) {
                                 *triggers = ts.clone();
                             }
                         }
                         crate::ir::SIRInstruction::Commit(_, dst, .., triggers) => {
                             let abs = dst.absolute_addr();
-                            let canonical = program.design.events.canonical(abs);
+                            let canonical = scheduled.design.events.canonical(abs);
                             if let Some(ts) = trigger_map.get(&canonical) {
                                 *triggers = ts.clone();
                             }
@@ -763,21 +748,21 @@ pub(crate) fn flatten(
             }
         }
     }
-    for units in program.sir.eval_only_ffs.values_mut() {
+    for units in scheduled.sir.eval_only_ffs.values_mut() {
         for eu in units {
             for bb in eu.blocks.values_mut() {
                 for inst in &mut bb.instructions {
                     match inst {
                         crate::ir::SIRInstruction::Store(addr, _, _, _, triggers, _) => {
                             let abs = addr.absolute_addr();
-                            let canonical = program.design.events.canonical(abs);
+                            let canonical = scheduled.design.events.canonical(abs);
                             if let Some(ts) = trigger_map.get(&canonical) {
                                 *triggers = ts.clone();
                             }
                         }
                         crate::ir::SIRInstruction::Commit(_, dst, .., triggers) => {
                             let abs = dst.absolute_addr();
-                            let canonical = program.design.events.canonical(abs);
+                            let canonical = scheduled.design.events.canonical(abs);
                             if let Some(ts) = trigger_map.get(&canonical) {
                                 *triggers = ts.clone();
                             }
@@ -788,14 +773,14 @@ pub(crate) fn flatten(
             }
         }
     }
-    for units in program.sir.apply_ffs.values_mut() {
+    for units in scheduled.sir.apply_ffs.values_mut() {
         for eu in units {
             for bb in eu.blocks.values_mut() {
                 for inst in &mut bb.instructions {
                     match inst {
                         crate::ir::SIRInstruction::Store(addr, ..) => {
                             let abs = addr.absolute_addr();
-                            let canonical = program.design.events.canonical(abs);
+                            let canonical = scheduled.design.events.canonical(abs);
                             if let Some(ts) = trigger_map.get(&canonical) {
                                 if let crate::ir::SIRInstruction::Store(_, _, _, _, triggers, _) =
                                     inst
@@ -806,7 +791,7 @@ pub(crate) fn flatten(
                         }
                         crate::ir::SIRInstruction::Commit(_, dst, ..) => {
                             let abs = dst.absolute_addr();
-                            let canonical = program.design.events.canonical(abs);
+                            let canonical = scheduled.design.events.canonical(abs);
                             if let Some(ts) = trigger_map.get(&canonical) {
                                 if let crate::ir::SIRInstruction::Commit(.., triggers) = inst {
                                     *triggers = ts.clone();
@@ -819,20 +804,20 @@ pub(crate) fn flatten(
             }
         }
     }
-    for eu in &mut program.sir.eval_comb {
+    for eu in &mut scheduled.sir.eval_comb {
         for bb in eu.blocks.values_mut() {
             for inst in &mut bb.instructions {
                 match inst {
                     crate::ir::SIRInstruction::Store(addr, _, _, _, triggers, _) => {
                         let abs = addr.absolute_addr();
-                        let canonical = program.design.events.canonical(abs);
+                        let canonical = scheduled.design.events.canonical(abs);
                         if let Some(ts) = trigger_map.get(&canonical) {
                             *triggers = ts.clone();
                         }
                     }
                     crate::ir::SIRInstruction::Commit(_, dst, .., triggers) => {
                         let abs = dst.absolute_addr();
-                        let canonical = program.design.events.canonical(abs);
+                        let canonical = scheduled.design.events.canonical(abs);
                         if let Some(ts) = trigger_map.get(&canonical) {
                             *triggers = ts.clone();
                         }
@@ -843,12 +828,7 @@ pub(crate) fn flatten(
         }
     }
 
-    crate::testbench::project_observability(&mut program, &testbench_source);
-    program.testbench = crate::testbench::compile_semantic_testbench(&program, &testbench_source);
-
-    dump_addr_map_if_requested(&program);
-
-    Ok(program)
+    Ok(scheduled)
 }
 
 fn dump_addr_map_if_requested(program: &Program) {
@@ -1630,7 +1610,7 @@ pub fn parse(
     {
         t.analyzer_ir = Some(ir.to_string());
     }
-    let mut program = timed_phase!(
+    let scheduled = timed_phase!(
         "flatten",
         flatten(
             &result.root_id,
@@ -1645,6 +1625,10 @@ pub fn parse(
             trace.as_deref_mut(),
         )
     )?;
+    let (mut program, testbench_source) = Program::from_scheduled(scheduled);
+    crate::testbench::project_observability(&mut program, &testbench_source);
+    program.testbench = crate::testbench::compile_semantic_testbench(&program, &testbench_source);
+    dump_addr_map_if_requested(&program);
     if let Some(t) = trace.as_deref_mut()
         && trace_opts.pre_optimized_sir
     {

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -175,10 +175,7 @@ fn scheduler_source_locations(
 }
 
 pub(crate) fn flatten(
-    root_id: &ModuleId,
-    module_ir: &HashMap<ModuleId, &Module>,
-    modules: HashMap<ModuleId, SimModule>,
-    module_names: HashMap<ModuleId, StrId>,
+    symbolic: celox_frontend_veryl::SymbolicRtl<'_>,
     config: &BuildConfig,
     ignored_loops: &[(
         (Vec<(String, usize)>, Vec<String>),
@@ -193,6 +190,12 @@ pub(crate) fn flatten(
     trace_opts: &crate::debug::TraceOptions,
     mut trace: Option<&mut crate::debug::CompilationTrace>,
 ) -> Result<celox_frontend_veryl::ScheduledRtl, ParserError> {
+    let celox_frontend_veryl::SymbolicRtl {
+        modules,
+        module_ir,
+        module_names,
+        root_id,
+    } = symbolic;
     let flatten_timing = std::env::var("CELOX_PHASE_TIMING").is_ok();
     macro_rules! timed_sub {
         ($label:expr, $body:expr) => {{
@@ -214,7 +217,7 @@ pub(crate) fn flatten(
     }
 
     let (expanded, instance_modules) =
-        timed_sub!("expand_hierarchy", expand_hierarchy(root_id, &modules));
+        timed_sub!("expand_hierarchy", expand_hierarchy(&root_id, &modules));
     let global_boundaries = timed_sub!(
         "propagate_boundaries",
         propagate_boundaries(&expanded, &instance_modules, &modules)
@@ -399,7 +402,7 @@ pub(crate) fn flatten(
     })?;
 
     let ff_clock_recipes = build_ff_clock_recipes(
-        module_ir,
+        &module_ir,
         &modules,
         &instance_modules,
         &clock_domains,
@@ -472,7 +475,7 @@ pub(crate) fn flatten(
     ) {
         Ok(schedule) => schedule,
         Err(error) => {
-            let (err_vars, err_path_idx) = module_variables(module_ir, config).unwrap_or_default();
+            let (err_vars, err_path_idx) = module_variables(&module_ir, config).unwrap_or_default();
             let frontend_lookup = crate::ir::VerylFrontendLookup {
                 instance_ids: expanded.clone(),
                 instance_module: instance_modules.clone(),
@@ -480,7 +483,8 @@ pub(crate) fn flatten(
                 module_var_path_index: err_path_idx,
                 module_names: module_names.clone(),
             };
-            let source_locations = scheduler_source_locations(&error, module_ir, &instance_modules);
+            let source_locations =
+                scheduler_source_locations(&error, &module_ir, &instance_modules);
             let mut target_arena = SLTNodeArena::new();
             let error = error.map_addr(&global_arena, &mut target_arena, &|addr| {
                 frontend_lookup.get_path(addr)
@@ -613,7 +617,7 @@ pub(crate) fn flatten(
     };
 
     // Extract initial block statements from root module (for native testbenches)
-    let initial_statements = module_ir.get(root_id).and_then(|root_module| {
+    let initial_statements = module_ir.get(&root_id).and_then(|root_module| {
         let mut stmts = Vec::new();
         for decl in &root_module.declarations {
             if let Declaration::Initial(init_decl) = decl {
@@ -623,7 +627,7 @@ pub(crate) fn flatten(
         if stmts.is_empty() { None } else { Some(stmts) }
     });
 
-    let (mod_vars, mod_path_idx) = module_variables(module_ir, config)?;
+    let (mod_vars, mod_path_idx) = module_variables(&module_ir, config)?;
     let initial_memory_values = instance_modules
         .iter()
         .flat_map(|(&instance_id, module_id)| {
@@ -665,7 +669,7 @@ pub(crate) fn flatten(
     let testbench_source = celox_frontend_veryl::VerylTestbenchSource {
         initial_statements,
         functions: module_ir
-            .get(root_id)
+            .get(&root_id)
             .map(|m| m.functions.clone())
             .unwrap_or_default(),
     };
@@ -1613,10 +1617,7 @@ pub fn parse(
     let scheduled = timed_phase!(
         "flatten",
         flatten(
-            &result.root_id,
-            &result.module_ir,
-            result.modules,
-            result.module_names,
+            result,
             config,
             ignored_loops,
             true_loops,

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -46,7 +46,12 @@ It also owns Veryl module discovery, per-instance hierarchy flattening/atomizati
 frontend-only relocation artifact. Global instance relocation, design assembly, trigger injection,
 and compiler-driver orchestration remain in the facade and are the remaining Milestone 4 ownership
 boundary. The facade's flattening compatibility wrapper owns diagnostic trace collection so the
-frontend crate does not depend on compiler-driver debug types.
+frontend crate does not depend on compiler-driver debug types. Module discovery now produces an
+explicit `celox-frontend-veryl::SymbolicRtl`, which is consumed exactly once by scheduling and
+lowering. That transition returns `celox-frontend-veryl::ScheduledRtl`; this artifact contains SIR,
+the elaborated design, runtime schema, frontend lookup, and testbench source, but cannot contain an
+SLT arena or `NodeId`. The facade converts it into the transitional `Program` before testbench
+compilation and SIR optimization.
 
 The baseline is the compiler pipeline on `perf/native-simulation-throughput` after PR #322. The
 split must preserve RTL semantics, generated-code quality, and the public `celox` API while making


### PR DESCRIPTION
## Summary

- define the frontend `SymbolicRtl` artifact for module-level SLT arenas and analyzer references
- consume `SymbolicRtl` as a whole at the global scheduling boundary
- define `ScheduledRtl` as the post-SLT output containing SIR, design, runtime schema, source lookup, and testbench source
- move source-path formatting onto the frontend lookup artifact
- assemble the transitional facade `Program` only after `ScheduledRtl` is returned

## Why

Milestone 4 requires phase artifacts that make it impossible for `NodeId` or an SLT arena to leak into optimization and backend phases. Passing four independent maps did not express that transition. The new input/output types do.

## Validation

- `cargo test -p celox-frontend-veryl`
- `cargo test -p celox flatting`
- `cargo test -p celox --test hierarchy`
- `cargo test -p celox --test flip_flop`
- `cargo test -p celox --test native_testbench`
- `cargo clippy -p celox-frontend-veryl -p celox --all-targets -- -D warnings`
- pre-push format and workspace checks