### PR TITLE
fix(ci): mint release tokens from GitHub App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,30 +12,46 @@ concurrency:
   group: release-management
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release-please:
     name: Update release pull request
     runs-on: ubuntu-latest
     steps:
-      # A token other than GITHUB_TOKEN is required so that checks run on the
-      # generated pull request and the manifest push starts the publisher.
+      # Resources created with GITHUB_TOKEN do not start follow-up workflows.
+      # Mint a short-lived installation token so release PR checks and the
+      # manifest-triggered publisher run normally.
+      - name: Create release app token
+        id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.release-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # The release app intentionally has no Issues permission. The weekly
+          # queue locates the deterministic Release Please branch instead.
+          skip-labeling: true
 
   queue-release:
     name: Queue weekly release
     needs: release-please
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
-      GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+      # Enqueuing an existing PR does not need to trigger another workflow, so
+      # the job-scoped token is sufficient and avoids minting a second app token.
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Enable auto-merge for the release pull request
         shell: bash
@@ -44,9 +60,10 @@ jobs:
             gh pr list \
               --repo "$GITHUB_REPOSITORY" \
               --state open \
-              --label "autorelease: pending" \
-              --json number,labels \
-              --jq '[.[] | select((.labels | map(.name) | index("release:hold")) | not)][0].number // empty'
+              --base master \
+              --limit 1000 \
+              --json number,headRefName,isCrossRepository,labels \
+              --jq '[.[] | select(.isCrossRepository == false) | select(.headRefName == "release-please--branches--master--components--celox") | select((.labels | map(.name) | index("release:hold")) | not)][0].number // empty'
           )"
 
           if [ -z "$release_pr" ]; then

--- a/.github/workflows/sync-veryl-vendor.yml
+++ b/.github/workflows/sync-veryl-vendor.yml
@@ -19,6 +19,14 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'renovate/')
     runs-on: ubuntu-latest
     steps:
+      - name: Create release app token
+        id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       # Only scripts from the trusted base revision run on the host. The PR
       # checkout is treated as data, and Cargo processes it in a disposable
       # container with no Actions secrets.
@@ -34,7 +42,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: target
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.release-token.outputs.token }}
 
       - name: Refresh vendored metadata and lockfile
         env:

--- a/.github/workflows/veryl-head.yml
+++ b/.github/workflows/veryl-head.yml
@@ -25,11 +25,19 @@ jobs:
     name: Update integration/veryl-head
     runs-on: ubuntu-latest
     steps:
+      - name: Create release app token
+        id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+
       - uses: actions/checkout@v7
         with:
           ref: master
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.release-token.outputs.token }}
 
       - uses: ./.github/actions/setup-rust
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -64,12 +64,21 @@ separate pull request or git worktree.
 
 ## Repository configuration
 
-The release workflow requires a `RELEASE_PLEASE_TOKEN` Actions secret containing
-a fine-grained token or GitHub App token with repository contents and pull request
-write access. The Veryl HEAD and vendored-metadata workflows use the same token
-to make their generated branch pushes start normal CI. Using the default
-`GITHUB_TOKEN` would prevent workflows from running on bot-created pull request
-updates.
+Release automation uses the `celox-release-please` GitHub App, installed for this
+repository with repository contents and pull request write access. Store its
+Client ID as the `RELEASE_APP_CLIENT_ID` Actions variable and its complete PEM
+private key as the `RELEASE_APP_PRIVATE_KEY` Actions secret. Each job mints a
+short-lived, repository-scoped installation token; never store an installation
+token itself because it expires. The Veryl HEAD and vendored-metadata workflows
+use the same mechanism so generated branch pushes start normal CI. Using the
+default `GITHUB_TOKEN` to create or update those branches would prevent their
+follow-up workflows from running.
+
+The App deliberately has no Issues permission, so Release Please does not add
+its normal status labels. The weekly workflow instead requires the exact
+`release-please--branches--master--components--celox` branch from this repository
+and still honors a manually applied `release:hold` label before enabling
+auto-merge.
 
 Configure merge commits to use the pull request title as the merge commit title.
 This preserves the Conventional Commit title consumed by Release Please. Protect


### PR DESCRIPTION
## Summary

- mint short-lived `celox-release-please` installation tokens in Release Please, Veryl HEAD, and vendored-metadata workflows
- use the job-scoped `GITHUB_TOKEN` only to enqueue an existing release PR
- identify the deterministic Release Please branch without requiring Issues write permission or Release Please status labels
- document the Client ID variable and PEM private-key secret configuration

## Why

GitHub App installation tokens expire after one hour and cannot be stored as a long-lived repository secret. The installed App credentials must instead mint a repository-scoped token in each job. The App intentionally has only Contents and Pull requests write permissions, so Release Please labeling is disabled while the manually applied `release:hold` label remains honored by the weekly queue.

## Repository configuration

`RELEASE_APP_CLIENT_ID=Iv23li6QjsMh7IjrkvMW` is already registered as an Actions variable. `RELEASE_APP_PRIVATE_KEY` must contain the App's complete PEM private key before the release workflows can run.

## Validation

- actionlint 1.7.12 across all workflows; ignored only its stale `create-github-app-token@v3` metadata errors for the officially recommended `client-id` input
- `pnpm run lint`
- `node --test scripts/*.test.mjs`
- release-branch and `release:hold` selection fixture through `jq`
- `git diff --check`
- pre-push submodule, cargo fmt, Biome, workspace cargo check, and clean-tree checks