### PR TITLE
ci: skip unrelated validation jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,32 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.classify.outputs.docs }}
+      javascript: ${{ steps.classify.outputs.javascript }}
+      napi: ${{ steps.classify.outputs.napi }}
+      napi_arm64: ${{ steps.classify.outputs.napi_arm64 }}
+      rust: ${{ steps.classify.outputs.rust }}
+      scripts: ${{ steps.classify.outputs.scripts }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed files
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+        run: node scripts/ci-changes.mjs "$BASE_SHA" "$HEAD_SHA"
+
   docs:
     name: Docs Build
+    needs: changes
+    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.docs == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -38,6 +62,8 @@ jobs:
 
   lint:
     name: Lint & Format
+    needs: changes
+    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.javascript == 'true' || needs.changes.outputs.scripts == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -45,33 +71,48 @@ jobs:
           submodules: recursive
 
       - uses: ./.github/actions/setup-rust
+        if: needs.changes.result != 'success' || needs.changes.outputs.rust == 'true'
 
       - uses: Swatinem/rust-cache@v2
+        if: needs.changes.result != 'success' || needs.changes.outputs.rust == 'true'
 
       - name: cargo fmt
+        if: needs.changes.result != 'success' || needs.changes.outputs.rust == 'true'
         run: cargo fmt --all -- --check
 
       - name: Verify vendored Veryl metadata
+        if: needs.changes.result != 'success' || needs.changes.outputs.rust == 'true'
         run: node scripts/veryl-vendor.mjs check
 
       - name: cargo clippy
+        if: needs.changes.result != 'success' || needs.changes.outputs.rust == 'true'
         run: cargo clippy --locked -p celox -p celox-macros -p celox-napi -p celox-ts-gen --all-targets --no-deps
 
       - uses: pnpm/action-setup@v6
+        if: needs.changes.result != 'success' || needs.changes.outputs.javascript == 'true'
 
       - uses: actions/setup-node@v7
+        if: needs.changes.result != 'success' || needs.changes.outputs.javascript == 'true'
         with:
           node-version: 24
           cache: pnpm
 
       - name: Install dependencies
+        if: needs.changes.result != 'success' || needs.changes.outputs.javascript == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Biome check
+        if: needs.changes.result != 'success' || needs.changes.outputs.javascript == 'true'
         run: pnpm run lint
+
+      - name: Test repository scripts
+        if: needs.changes.result != 'success' || needs.changes.outputs.scripts == 'true'
+        run: node --test scripts/*.test.mjs
 
   rust:
     name: Rust Test & NAPI Build
+    needs: changes
+    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.napi == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -83,6 +124,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run tests
+        if: needs.changes.result != 'success' || needs.changes.outputs.rust == 'true'
         run: cargo test --locked
 
       - uses: pnpm/action-setup@v6
@@ -109,6 +151,8 @@ jobs:
 
   napi-windows:
     name: NAPI Build (Windows)
+    needs: changes
+    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.napi == 'true')
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v7
@@ -143,6 +187,8 @@ jobs:
 
   napi-linux-arm64:
     name: NAPI Build (Linux ARM64 GNU)
+    needs: changes
+    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.napi_arm64 == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -182,7 +228,8 @@ jobs:
 
   js-ubuntu:
     name: JS Test (Ubuntu)
-    needs: rust
+    needs: [changes, rust]
+    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.javascript == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -224,7 +271,8 @@ jobs:
 
   js-windows:
     name: JS Test (Windows)
-    needs: napi-windows
+    needs: [changes, napi-windows]
+    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.javascript == 'true')
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v7

--- a/scripts/ci-changes.mjs
+++ b/scripts/ci-changes.mjs
@@ -1,0 +1,156 @@
+import { execFileSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const ALL_AFFECTED = Object.freeze({
+  docs: true,
+  javascript: true,
+  napi: true,
+  napi_arm64: true,
+  rust: true,
+  scripts: true,
+});
+
+const NEUTRAL_FILES = new Set([
+  ".gitignore",
+  ".release-please-manifest.json",
+  "AGENTS.md",
+  "CHANGELOG.md",
+  "CLAUDE.md",
+  "LICENSE-APACHE",
+  "LICENSE-MIT",
+  "VERSION",
+  "release-please-config.json",
+  "renovate.json",
+]);
+
+function startsWithAny(path, prefixes) {
+  return prefixes.some((prefix) => path.startsWith(prefix));
+}
+
+export function classifyFiles(files) {
+  const affected = {
+    docs: false,
+    javascript: false,
+    napi: false,
+    napi_arm64: false,
+    rust: false,
+    scripts: false,
+  };
+
+  for (const rawPath of files) {
+    const path = rawPath.replace(/^\.\//, "");
+
+    if (
+      path === ".github/workflows/ci.yml" ||
+      startsWithAny(path, [".github/actions/", "scripts/ci-changes."])
+    ) {
+      return { ...ALL_AFFECTED };
+    }
+
+    if (
+      startsWithAny(path, ["docs/", "adr/"]) ||
+      path === "README.md"
+    ) {
+      affected.docs = true;
+      continue;
+    }
+
+    if (
+      startsWithAny(path, ["crates/celox-napi/"]) &&
+      /\.(?:js|json|ts)$/.test(path)
+    ) {
+      affected.javascript = true;
+      affected.napi = true;
+      continue;
+    }
+
+    if (
+      startsWithAny(path, ["crates/", "vendor/", ".cargo/"]) ||
+      ["Cargo.lock", "Cargo.toml", "rust-toolchain.toml", ".gitmodules"].includes(
+        path,
+      )
+    ) {
+      affected.rust = true;
+      affected.napi = true;
+      affected.napi_arm64 = true;
+      affected.javascript = true;
+      continue;
+    }
+
+    if (
+      startsWithAny(path, ["packages/", "examples/"]) ||
+      [
+        "biome.json",
+        "package.json",
+        "pnpm-lock.yaml",
+        "pnpm-workspace.yaml",
+        "typedoc.json",
+      ].includes(path)
+    ) {
+      affected.javascript = true;
+      affected.napi = true;
+      if (startsWithAny(path, ["packages/"]) || path === "typedoc.json") {
+        affected.docs = true;
+      }
+      continue;
+    }
+
+    if (startsWithAny(path, ["scripts/"])) {
+      affected.scripts = true;
+      continue;
+    }
+
+    if (
+      NEUTRAL_FILES.has(path) ||
+      startsWithAny(path, [".github/ISSUE_TEMPLATE/", ".github/workflows/"]) ||
+      path === ".github/pull_request_template.md"
+    ) {
+      continue;
+    }
+
+    // Unknown paths fail open so a new source/configuration area cannot
+    // accidentally bypass validation.
+    return { ...ALL_AFFECTED };
+  }
+
+  return affected;
+}
+
+function changedFiles(base, head) {
+  const sha = /^[0-9a-f]{40,64}$/i;
+  if (!sha.test(base) || !sha.test(head) || /^0+$/.test(base)) {
+    return null;
+  }
+
+  try {
+    const output = execFileSync(
+      "git",
+      ["diff", "--name-only", "-z", base, head],
+      { encoding: "utf8" },
+    );
+    return output.split("\0").filter(Boolean);
+  } catch (error) {
+    console.warn(`Unable to determine changed files: ${error.message}`);
+    return null;
+  }
+}
+
+function writeOutputs(affected) {
+  const lines = Object.entries(affected)
+    .map(([name, value]) => `${name}=${value}`)
+    .join("\n");
+  console.log(lines);
+
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `${lines}\n`);
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  const files = changedFiles(process.argv[2] ?? "", process.argv[3] ?? "");
+  writeOutputs(files === null ? ALL_AFFECTED : classifyFiles(files));
+}

--- a/scripts/ci-changes.test.mjs
+++ b/scripts/ci-changes.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { classifyFiles } from "./ci-changes.mjs";
+
+const none = {
+  docs: false,
+  javascript: false,
+  napi: false,
+  napi_arm64: false,
+  rust: false,
+  scripts: false,
+};
+
+const all = {
+  docs: true,
+  javascript: true,
+  napi: true,
+  napi_arm64: true,
+  rust: true,
+  scripts: true,
+};
+
+test("documentation changes only build documentation", () => {
+  assert.deepEqual(classifyFiles(["docs/index.md", "adr/README.md"]), {
+    ...none,
+    docs: true,
+  });
+});
+
+test("Rust changes exercise native builds and JavaScript bindings", () => {
+  assert.deepEqual(
+    classifyFiles(["crates/celox/src/lib.rs"]),
+    { ...all, docs: false, scripts: false },
+  );
+});
+
+test("JavaScript changes skip Rust tests and the ARM64 native build", () => {
+  assert.deepEqual(classifyFiles(["packages/celox/src/index.ts"]), {
+    ...none,
+    docs: true,
+    javascript: true,
+    napi: true,
+  });
+});
+
+test("release and repository metadata do not run product tests", () => {
+  assert.deepEqual(
+    classifyFiles(["CHANGELOG.md", "VERSION", ".release-please-manifest.json"]),
+    none,
+  );
+});
+
+test("release package versions skip Rust tests and ARM64 builds", () => {
+  assert.deepEqual(
+    classifyFiles([
+      ".release-please-manifest.json",
+      "CHANGELOG.md",
+      "VERSION",
+      "crates/celox-napi/package.json",
+      "packages/celox/package.json",
+      "packages/vite-plugin/package.json",
+    ]),
+    {
+      ...none,
+      docs: true,
+      javascript: true,
+      napi: true,
+    },
+  );
+});
+
+test("CI classifier changes exercise every path", () => {
+  assert.deepEqual(classifyFiles(["scripts/ci-changes.mjs"]), all);
+});
+
+test("repository script changes only run script tests", () => {
+  assert.deepEqual(classifyFiles(["scripts/check-pr-title.mjs"]), {
+    ...none,
+    scripts: true,
+  });
+});
+
+test("unknown paths fail open", () => {
+  assert.deepEqual(classifyFiles(["new-source-area/input.xyz"]), all);
+});


### PR DESCRIPTION
## Summary

- classify changed paths once per CI run without adding a third-party action
- skip unrelated required jobs while preserving their existing check names
- run only relevant Rust or JavaScript lint steps inside the combined lint job
- fail open to the full suite when a path or commit range cannot be classified

## Impact

Documentation-only and repository-metadata changes no longer spend time on Rust, NAPI, or JavaScript validation. JavaScript-only changes skip `cargo test` and the Linux ARM64 NAPI build. Rust changes retain the native cross-platform and JavaScript binding coverage.

Because the workflow itself still runs, conditionally skipped required jobs report success and remain compatible with the master merge queue.

## Validation

- `node --test scripts/*.test.mjs`
- `actionlint .github/workflows/*.yml`
- `pnpm run lint`
- real-range classification from `origin/master` to the feature commit
- pre-push: submodule check, `cargo fmt`, Biome, `cargo check`, clean tree
