### PR TITLE
fix(ci): let benchmark runs finish

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,7 +13,7 @@ env:
 
 concurrency:
   group: bench
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # ── Rust benchmarks (Criterion) ──
@@ -28,7 +28,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run Rust benchmarks
-        run: cargo bench --locked -p celox --bench simulation --bench overhead -- --output-format bencher | tee rust-output.txt
+        shell: bash
+        run: set -o pipefail && cargo bench --locked -p celox --bench simulation --bench overhead -- --output-format bencher | tee rust-output.txt
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary

- keep the currently running Benchmark workflow alive when a newer `master` push arrives
- retain the default single pending run so only the newest waiting commit is benchmarked
- enable `pipefail` for Rust benchmark output capture

## Root cause

The workflow used `cancel-in-progress: true`. Frequent merges to `master` terminated the running cold Rust build with SIGTERM (exit 143), before the cache post-step could save its build cache. Each subsequent run repeated the same failure pattern.

## Validation

- `actionlint` (all workflows)
- `git diff --check`
- repository pre-push hook: submodule check, Biome, cargo fmt, cargo check, clean tree
