### PR TITLE
fix(ci): disable benchmark debuginfo

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -19,6 +19,8 @@ jobs:
   # ── Rust benchmarks (Criterion) ──
   bench-rust:
     runs-on: ubuntu-latest
+    env:
+      CARGO_PROFILE_BENCH_DEBUG: "0"
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Summary

- disable Rust debug info only for the `bench-rust` GitHub Actions job
- preserve the benchmark profile's optimization, LTO, and codegen-unit settings
- expose the profile override at job scope so the Rust cache action sees the same environment

## Root cause

Cold `bench-rust` builds repeatedly reached the final `celox` compilation and then lost the hosted runner with exit 143 before `Swatinem/rust-cache` could save the target directory. That left every subsequent run without a cache and repeated the expensive cold build. The benchmark profile generated full debug information in addition to its release optimizations, substantially increasing final compilation resource usage without being needed for published benchmark results.

## Impact

Benchmark runtime optimization settings remain unchanged. The workflow stops generating unnecessary debug information, reducing cold-build time and pressure on the standard hosted runner.

## Validation

- clean `CARGO_PROFILE_BENCH_DEBUG=0 cargo bench --locked -p celox --bench simulation --bench overhead --no-run` completed in 5m08s with `[optimized]`
- YAML parsed successfully
- `git diff --check`
- pre-push hook: submodule check, Biome, cargo fmt, cargo check, clean tree