### PR TITLE
fix(renovate): group emnapi package updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,17 @@
   "packageRules": [
     {
       "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "emnapi",
+        "@emnapi/core",
+        "@emnapi/runtime"
+      ],
+      "groupName": "emnapi packages"
+    },
+    {
+      "matchManagers": [
         "cargo"
       ],
       "matchPackageNames": [


### PR DESCRIPTION
## What changed

Group `emnapi`, `@emnapi/core`, and `@emnapi/runtime` into one Renovate update.

## Why

Renovate updated these packages independently, leaving `emnapi@1.11.2` alongside `@emnapi/core@1.11.3` and `@emnapi/runtime@1.11.3`. The napi-rs WASM build requires matching emnapi versions and failed with a version mismatch.

Keeping the three packages in one Renovate PR makes their lockfile updates atomic and prevents the transient incompatible state.

## Validation

- `renovate-config-validator renovate.json`
- `git diff --check`
- pre-push hook: submodule check, `cargo fmt`, Biome, `cargo check`, clean-tree