### PR TITLE
feat(bench): add a dedicated Heliodor benchmark harness

### DIFF
--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -1,0 +1,112 @@
+name: Heliodor Benchmark
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    paths:
+      - ".github/actions/setup-rust/**"
+      - ".github/workflows/heliodor-bench.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**"
+      - "scripts/convert-heliodor-bench.mjs"
+      - "scripts/run-heliodor-bench.sh"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_INCREMENTAL: "0"
+
+# This shares the gh-pages benchmark data with bench.yml. Serialize both
+# workflows so their independent benchmark-action pushes cannot race.
+concurrency:
+  group: bench
+  cancel-in-progress: false
+
+jobs:
+  heliodor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/setup-rust
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run fixed Heliodor correctness and performance gate
+        id: gate
+        shell: bash
+        run: |
+          set +e
+          set -o pipefail
+          output="$RUNNER_TEMP/heliodor-output.txt"
+          bash scripts/run-heliodor-bench.sh gate 2>&1 | tee "$output"
+          status=${PIPESTATUS[0]}
+          set -e
+          cp "$output" heliodor-output.txt
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
+          result_file="$(find target/heliodor/results -path '*/gate_*/results.tsv' -type f -print -quit)"
+          if [ -z "$result_file" ]; then
+            echo "The Heliodor gate did not produce results.tsv" >&2
+            exit 1
+          fi
+          echo "result_file=$result_file" >> "$GITHUB_OUTPUT"
+
+      - name: Convert dashboard metrics
+        run: |
+          node scripts/convert-heliodor-bench.mjs "${{ steps.gate.outputs.result_file }}" heliodor-converted.json
+          node scripts/convert-heliodor-bench.mjs "${{ steps.gate.outputs.result_file }}" heliodor-jit.json --jit-only
+
+      - name: Store Heliodor benchmark history
+        if: github.event_name != 'pull_request'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Heliodor Benchmarks
+          tool: customSmallerIsBetter
+          output-file-path: heliodor-converted.json
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          alert-threshold: "110%"
+          fail-on-alert: false
+          comment-on-alert: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check generated-JIT regression
+        if: github.event_name == 'pull_request'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Heliodor Benchmarks
+          tool: customSmallerIsBetter
+          output-file-path: heliodor-jit.json
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: false
+          alert-threshold: "110%"
+          fail-on-alert: true
+          comment-on-alert: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Heliodor results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: heliodor-benchmark
+          path: |
+            heliodor-output.txt
+            heliodor-converted.json
+            heliodor-jit.json
+            target/heliodor/results/gate_*/results.tsv
+            target/heliodor/results/gate_*/*.log
+            target/heliodor/results/gate_*/*.before
+            target/heliodor/results/gate_*/*.after
+
+      - name: Enforce fixed gate result
+        if: always() && steps.gate.outputs.status != '0'
+        run: exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "celox-bench"
+version = "0.0.0"
+dependencies = [
+ "celox",
+ "clap",
+ "libc",
+ "veryl-analyzer",
+ "veryl-metadata",
+ "veryl-parser",
+ "veryl-simulator",
+]
+
+[[package]]
 name = "celox-bench-sv"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/celox-backend-cranelift",
     "crates/celox-backend-wasm",
     "crates/celox-backend-x86",
+    "crates/celox-bench",
     "crates/celox-design",
     "crates/celox-frontend-veryl",
     "crates/celox-sir",

--- a/crates/celox-bench/Cargo.toml
+++ b/crates/celox-bench/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name                  = "celox-bench"
+version.workspace     = true
+publish               = false
+authors.workspace     = true
+repository.workspace  = true
+license.workspace     = true
+description           = "Macro-benchmark runners for Celox"
+edition.workspace     = true
+
+[dependencies]
+celox           = { path = "../celox" }
+clap            = { workspace = true }
+libc            = { workspace = true }
+veryl-analyzer  = { workspace = true }
+veryl-metadata  = { workspace = true }
+veryl-parser    = { workspace = true }
+veryl-simulator = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/celox-bench/src/bin/celox-heliodor.rs
+++ b/crates/celox-bench/src/bin/celox-heliodor.rs
@@ -1,5 +1,4 @@
 use std::{
-    env,
     error::Error,
     fs,
     path::{Path, PathBuf},
@@ -10,7 +9,41 @@ use celox::testbench::{
     compile_initial_testbench, run_compiled_testbench, run_compiled_testbench_with_tick_limit,
 };
 use celox::{OptLevel, OptimizeOptions, Simulator, SirPass, TestResult};
+use clap::{Parser, ValueEnum};
 use veryl_metadata::Metadata;
+
+#[derive(Parser)]
+#[command(about = "Run a Heliodor test with Celox and report split benchmark timing")]
+struct Cli {
+    #[arg(long)]
+    project: PathBuf,
+    #[arg(long)]
+    test: String,
+    #[arg(long = "source-file")]
+    source_files: Vec<PathBuf>,
+    #[arg(long, value_enum, default_value = "o2")]
+    opt_level: OptimizationLevel,
+    #[arg(long, value_enum, default_value = "native")]
+    backend: Backend,
+    #[arg(long)]
+    four_state: bool,
+    #[arg(long)]
+    compile_only: bool,
+    #[arg(long, value_parser = parse_positive_u64)]
+    tick_limit: Option<u64>,
+    #[arg(long)]
+    dump_ir_dir: Option<PathBuf>,
+    #[arg(long)]
+    dump_ir_and_run: bool,
+    #[arg(long = "native-profile-block", value_parser = parse_native_profile_block)]
+    native_profile_blocks: Vec<celox::NativeProfileBlock>,
+    #[arg(long = "sir-pass", value_parser = parse_pass_override)]
+    pass_overrides: Vec<(bool, SirPass)>,
+    #[arg(long, value_parser = parse_native_memory_width)]
+    native_memory_width: Option<usize>,
+    #[arg(long, value_enum)]
+    x86_slp: Option<OnOff>,
+}
 
 struct Options {
     project: PathBuf,
@@ -29,10 +62,33 @@ struct Options {
     x86_slp: bool,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, ValueEnum)]
 enum Backend {
     Native,
     Cranelift,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum OptimizationLevel {
+    O0,
+    O1,
+    O2,
+}
+
+impl From<OptimizationLevel> for OptLevel {
+    fn from(value: OptimizationLevel) -> Self {
+        match value {
+            OptimizationLevel::O0 => Self::O0,
+            OptimizationLevel::O1 => Self::O1,
+            OptimizationLevel::O2 => Self::O2,
+        }
+    }
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum OnOff {
+    On,
+    Off,
 }
 
 impl Backend {
@@ -52,7 +108,32 @@ fn main() {
 }
 
 fn run() -> Result<(), Box<dyn Error>> {
-    let opts = parse_args().map_err(|e| format!("{e}\n\n{}", usage()))?;
+    let cli = Cli::parse();
+    let opts = Options {
+        project: cli.project,
+        test: cli.test,
+        source_files: cli.source_files,
+        opt_level: cli.opt_level.into(),
+        backend: cli.backend,
+        four_state: cli.four_state,
+        compile_only: cli.compile_only,
+        tick_limit: cli.tick_limit,
+        dump_ir_dir: cli.dump_ir_dir,
+        dump_ir_and_run: cli.dump_ir_and_run,
+        native_profile_blocks: cli.native_profile_blocks,
+        pass_overrides: cli.pass_overrides,
+        native_memory_width: cli.native_memory_width.unwrap_or({
+            if cfg!(target_arch = "x86_64") {
+                128
+            } else {
+                64
+            }
+        }),
+        x86_slp: cli
+            .x86_slp
+            .map(|value| matches!(value, OnOff::On))
+            .unwrap_or(cfg!(target_arch = "x86_64")),
+    };
     if !opts.native_profile_blocks.is_empty() && opts.dump_ir_dir.is_none() {
         return Err("--native-profile-block requires --dump-ir-dir".into());
     }
@@ -184,6 +265,7 @@ fn run() -> Result<(), Box<dyn Error>> {
         if opts.dump_ir_and_run {
             let testbench = compile_initial_testbench(&sim)
                 .ok_or("no initial block found — this module is not a native testbench")?;
+            sim.start_native_execution_timing();
             let execute_cpu_start = process_cpu_time();
             let execute_start = Instant::now();
             let (result, ticks, tick_limit_reached) = if let Some(limit) = opts.tick_limit {
@@ -192,26 +274,21 @@ fn run() -> Result<(), Box<dyn Error>> {
             } else {
                 (run_compiled_testbench(&mut sim, &testbench), 0, false)
             };
+            let jit_execute_elapsed = sim
+                .finish_native_execution_timing()
+                .expect("native execution timing was started")
+                .elapsed();
             let execute_elapsed = execute_start.elapsed();
             let execute_cpu_elapsed = process_cpu_time()
                 .zip(execute_cpu_start)
                 .map(|(end, start)| end.saturating_sub(start));
-            if let Some(execute_cpu_elapsed) = execute_cpu_elapsed {
-                println!(
-                    "CELOX_TEST_TIMING test={} compile_ns={} execute_ns={} execute_cpu_ns={}",
-                    opts.test,
-                    compile_elapsed.as_nanos(),
-                    execute_elapsed.as_nanos(),
-                    execute_cpu_elapsed.as_nanos()
-                );
-            } else {
-                println!(
-                    "CELOX_TEST_TIMING test={} compile_ns={} execute_ns={}",
-                    opts.test,
-                    compile_elapsed.as_nanos(),
-                    execute_elapsed.as_nanos()
-                );
-            }
+            print_celox_timing(
+                &opts.test,
+                compile_elapsed,
+                execute_elapsed,
+                Some(jit_execute_elapsed),
+                execute_cpu_elapsed,
+            );
             if opts.tick_limit.is_some() {
                 println!(
                     "CELOX_TEST_TICK_LIMIT test={} ticks={} reached={}",
@@ -265,10 +342,12 @@ fn run() -> Result<(), Box<dyn Error>> {
         }
         let compile_elapsed = compile_start.elapsed();
         let elapsed = total_start.elapsed();
-        println!(
-            "CELOX_TEST_TIMING test={} compile_ns={} execute_ns=0",
-            opts.test,
-            compile_elapsed.as_nanos()
+        print_celox_timing(
+            &opts.test,
+            compile_elapsed,
+            Duration::ZERO,
+            matches!(opts.backend, Backend::Native).then_some(Duration::ZERO),
+            None,
         );
         println!(
             "CELOX_TEST_RESULT test={} status=compile-only elapsed_ns={}",
@@ -279,76 +358,79 @@ fn run() -> Result<(), Box<dyn Error>> {
     }
 
     let compile_start = Instant::now();
-    let (result, ticks, tick_limit_reached, compile_elapsed, execute_elapsed, execute_cpu_elapsed) =
-        match opts.backend {
-            Backend::Native => {
-                let mut sim = builder.build_native()?;
-                let testbench = compile_initial_testbench(&sim)
-                    .ok_or("no initial block found — this module is not a native testbench")?;
-                let compile_elapsed = compile_start.elapsed();
-                let execute_cpu_start = process_cpu_time();
-                let execute_start = Instant::now();
-                let (result, ticks, tick_limit_reached) = if let Some(limit) = opts.tick_limit {
-                    let limited =
-                        run_compiled_testbench_with_tick_limit(&mut sim, &testbench, limit);
-                    (limited.result, limited.ticks, limited.tick_limit_reached)
-                } else {
-                    (run_compiled_testbench(&mut sim, &testbench), 0, false)
-                };
-                (
-                    result,
-                    ticks,
-                    tick_limit_reached,
-                    compile_elapsed,
-                    execute_start.elapsed(),
-                    process_cpu_time()
-                        .zip(execute_cpu_start)
-                        .map(|(end, start)| end.saturating_sub(start)),
-                )
-            }
-            Backend::Cranelift => {
-                let mut sim = builder.build_cranelift()?;
-                let testbench = compile_initial_testbench(&sim)
-                    .ok_or("no initial block found — this module is not a native testbench")?;
-                let compile_elapsed = compile_start.elapsed();
-                let execute_cpu_start = process_cpu_time();
-                let execute_start = Instant::now();
-                let (result, ticks, tick_limit_reached) = if let Some(limit) = opts.tick_limit {
-                    let limited =
-                        run_compiled_testbench_with_tick_limit(&mut sim, &testbench, limit);
-                    (limited.result, limited.ticks, limited.tick_limit_reached)
-                } else {
-                    (run_compiled_testbench(&mut sim, &testbench), 0, false)
-                };
-                (
-                    result,
-                    ticks,
-                    tick_limit_reached,
-                    compile_elapsed,
-                    execute_start.elapsed(),
-                    process_cpu_time()
-                        .zip(execute_cpu_start)
-                        .map(|(end, start)| end.saturating_sub(start)),
-                )
-            }
-        };
+    let (
+        result,
+        ticks,
+        tick_limit_reached,
+        compile_elapsed,
+        execute_elapsed,
+        jit_execute_elapsed,
+        execute_cpu_elapsed,
+    ) = match opts.backend {
+        Backend::Native => {
+            let mut sim = builder.build_native()?;
+            let testbench = compile_initial_testbench(&sim)
+                .ok_or("no initial block found — this module is not a native testbench")?;
+            let compile_elapsed = compile_start.elapsed();
+            sim.start_native_execution_timing();
+            let execute_cpu_start = process_cpu_time();
+            let execute_start = Instant::now();
+            let (result, ticks, tick_limit_reached) = if let Some(limit) = opts.tick_limit {
+                let limited = run_compiled_testbench_with_tick_limit(&mut sim, &testbench, limit);
+                (limited.result, limited.ticks, limited.tick_limit_reached)
+            } else {
+                (run_compiled_testbench(&mut sim, &testbench), 0, false)
+            };
+            let jit_execute_elapsed = sim
+                .finish_native_execution_timing()
+                .expect("native execution timing was started")
+                .elapsed();
+            (
+                result,
+                ticks,
+                tick_limit_reached,
+                compile_elapsed,
+                execute_start.elapsed(),
+                Some(jit_execute_elapsed),
+                process_cpu_time()
+                    .zip(execute_cpu_start)
+                    .map(|(end, start)| end.saturating_sub(start)),
+            )
+        }
+        Backend::Cranelift => {
+            let mut sim = builder.build_cranelift()?;
+            let testbench = compile_initial_testbench(&sim)
+                .ok_or("no initial block found — this module is not a native testbench")?;
+            let compile_elapsed = compile_start.elapsed();
+            let execute_cpu_start = process_cpu_time();
+            let execute_start = Instant::now();
+            let (result, ticks, tick_limit_reached) = if let Some(limit) = opts.tick_limit {
+                let limited = run_compiled_testbench_with_tick_limit(&mut sim, &testbench, limit);
+                (limited.result, limited.ticks, limited.tick_limit_reached)
+            } else {
+                (run_compiled_testbench(&mut sim, &testbench), 0, false)
+            };
+            (
+                result,
+                ticks,
+                tick_limit_reached,
+                compile_elapsed,
+                execute_start.elapsed(),
+                None,
+                process_cpu_time()
+                    .zip(execute_cpu_start)
+                    .map(|(end, start)| end.saturating_sub(start)),
+            )
+        }
+    };
     let elapsed = total_start.elapsed();
-    if let Some(execute_cpu_elapsed) = execute_cpu_elapsed {
-        println!(
-            "CELOX_TEST_TIMING test={} compile_ns={} execute_ns={} execute_cpu_ns={}",
-            opts.test,
-            compile_elapsed.as_nanos(),
-            execute_elapsed.as_nanos(),
-            execute_cpu_elapsed.as_nanos()
-        );
-    } else {
-        println!(
-            "CELOX_TEST_TIMING test={} compile_ns={} execute_ns={}",
-            opts.test,
-            compile_elapsed.as_nanos(),
-            execute_elapsed.as_nanos()
-        );
-    }
+    print_celox_timing(
+        &opts.test,
+        compile_elapsed,
+        execute_elapsed,
+        jit_execute_elapsed,
+        execute_cpu_elapsed,
+    );
     if opts.tick_limit.is_some() {
         println!(
             "CELOX_TEST_TICK_LIMIT test={} ticks={} reached={}",
@@ -384,6 +466,32 @@ fn run() -> Result<(), Box<dyn Error>> {
     }
 }
 
+fn print_celox_timing(
+    test: &str,
+    compile_elapsed: Duration,
+    execute_elapsed: Duration,
+    jit_execute_elapsed: Option<Duration>,
+    execute_cpu_elapsed: Option<Duration>,
+) {
+    let jit_execute_ns = jit_execute_elapsed
+        .map(|elapsed| elapsed.as_nanos().to_string())
+        .unwrap_or_else(|| "NA".to_string());
+    if let Some(execute_cpu_elapsed) = execute_cpu_elapsed {
+        println!(
+            "CELOX_TEST_TIMING test={test} compile_ns={} execute_ns={} jit_execute_ns={jit_execute_ns} execute_cpu_ns={}",
+            compile_elapsed.as_nanos(),
+            execute_elapsed.as_nanos(),
+            execute_cpu_elapsed.as_nanos()
+        );
+    } else {
+        println!(
+            "CELOX_TEST_TIMING test={test} compile_ns={} execute_ns={} jit_execute_ns={jit_execute_ns}",
+            compile_elapsed.as_nanos(),
+            execute_elapsed.as_nanos()
+        );
+    }
+}
+
 #[cfg(unix)]
 fn process_cpu_time() -> Option<Duration> {
     let mut time = libc::timespec {
@@ -404,151 +512,22 @@ fn process_cpu_time() -> Option<Duration> {
     None
 }
 
-fn parse_args() -> Result<Options, String> {
-    let mut project = None;
-    let mut test = None;
-    let mut source_files = Vec::new();
-    let mut opt_level = OptLevel::O2;
-    let mut backend = Backend::Native;
-    let mut four_state = false;
-    let mut compile_only = false;
-    let mut tick_limit = None;
-    let mut dump_ir_dir = None;
-    let mut dump_ir_and_run = false;
-    let mut native_profile_blocks = Vec::new();
-    let mut pass_overrides = Vec::new();
-    let mut native_memory_width = if cfg!(target_arch = "x86_64") {
-        128
+fn parse_positive_u64(value: &str) -> Result<u64, String> {
+    let parsed = value
+        .parse::<u64>()
+        .map_err(|_| format!("invalid positive integer: {value}"))?;
+    if parsed == 0 {
+        Err("value must be greater than zero".to_string())
     } else {
-        64
-    };
-    let mut x86_slp = cfg!(target_arch = "x86_64");
-    let mut args = env::args().skip(1);
-
-    while let Some(arg) = args.next() {
-        match arg.as_str() {
-            "-h" | "--help" => return Err(String::new()),
-            "--project" => {
-                project = Some(PathBuf::from(
-                    args.next()
-                        .ok_or_else(|| "--project requires a path".to_string())?,
-                ));
-            }
-            "--test" => {
-                test = Some(
-                    args.next()
-                        .ok_or_else(|| "--test requires a module name".to_string())?,
-                );
-            }
-            "--opt-level" => {
-                let value = args
-                    .next()
-                    .ok_or_else(|| "--opt-level requires O0, O1, or O2".to_string())?;
-                opt_level = parse_opt_level(&value)?;
-            }
-            "--backend" => {
-                let value = args
-                    .next()
-                    .ok_or_else(|| "--backend requires native or cranelift".to_string())?;
-                backend = parse_backend(&value)?;
-            }
-            "--source-file" => {
-                source_files.push(PathBuf::from(
-                    args.next()
-                        .ok_or_else(|| "--source-file requires a path".to_string())?,
-                ));
-            }
-            "--sir-pass" => {
-                let value = args
-                    .next()
-                    .ok_or_else(|| "--sir-pass requires +name or -name".to_string())?;
-                pass_overrides.push(parse_pass_override(&value)?);
-            }
-            "--four-state" => four_state = true,
-            "--compile-only" => compile_only = true,
-            "--tick-limit" => {
-                let value = args
-                    .next()
-                    .ok_or_else(|| "--tick-limit requires a positive integer".to_string())?;
-                let value = value
-                    .parse::<u64>()
-                    .map_err(|_| format!("invalid tick limit: {value}"))?;
-                if value == 0 {
-                    return Err("--tick-limit must be greater than zero".to_string());
-                }
-                tick_limit = Some(value);
-            }
-            "--dump-ir-dir" => {
-                dump_ir_dir =
-                    Some(PathBuf::from(args.next().ok_or_else(|| {
-                        "--dump-ir-dir requires a directory".to_string()
-                    })?));
-            }
-            "--dump-ir-and-run" => dump_ir_and_run = true,
-            "--native-profile-block" => {
-                let value = args.next().ok_or_else(|| {
-                    "--native-profile-block requires FUNCTION:BLOCK:SAMPLES".to_string()
-                })?;
-                native_profile_blocks.push(parse_native_profile_block(&value)?);
-            }
-            "--native-memory-width" => {
-                let value = args
-                    .next()
-                    .ok_or_else(|| "--native-memory-width requires 64 or 128".to_string())?;
-                native_memory_width = match value.as_str() {
-                    "64" => 64,
-                    "128" => 128,
-                    _ => return Err(format!("invalid native memory width: {value}")),
-                };
-            }
-            "--x86-slp" => {
-                let value = args
-                    .next()
-                    .ok_or_else(|| "--x86-slp requires on or off".to_string())?;
-                x86_slp = match value.as_str() {
-                    "on" => true,
-                    "off" => false,
-                    _ => return Err(format!("invalid x86 SLP setting: {value}")),
-                };
-            }
-            other if project.is_none() => project = Some(PathBuf::from(other)),
-            other if test.is_none() => test = Some(other.to_string()),
-            other => return Err(format!("unexpected argument: {other}")),
-        }
-    }
-
-    Ok(Options {
-        project: project.ok_or_else(|| "missing project path".to_string())?,
-        test: test.ok_or_else(|| "missing test module".to_string())?,
-        source_files,
-        opt_level,
-        backend,
-        four_state,
-        compile_only,
-        tick_limit,
-        dump_ir_dir,
-        dump_ir_and_run,
-        native_profile_blocks,
-        pass_overrides,
-        native_memory_width,
-        x86_slp,
-    })
-}
-
-fn parse_opt_level(value: &str) -> Result<OptLevel, String> {
-    match value {
-        "O0" | "o0" | "0" => Ok(OptLevel::O0),
-        "O1" | "o1" | "1" => Ok(OptLevel::O1),
-        "O2" | "o2" | "2" => Ok(OptLevel::O2),
-        _ => Err(format!("invalid opt level: {value}")),
+        Ok(parsed)
     }
 }
 
-fn parse_backend(value: &str) -> Result<Backend, String> {
+fn parse_native_memory_width(value: &str) -> Result<usize, String> {
     match value {
-        "native" => Ok(Backend::Native),
-        "cranelift" => Ok(Backend::Cranelift),
-        _ => Err(format!("invalid backend: {value}")),
+        "64" => Ok(64),
+        "128" => Ok(128),
+        _ => Err(format!("invalid native memory width: {value}")),
     }
 }
 
@@ -586,10 +565,6 @@ fn parse_pass_override(value: &str) -> Result<(bool, SirPass), String> {
     };
     let pass = SirPass::parse(name).ok_or_else(|| format!("unknown SIR pass: {name}"))?;
     Ok((enable, pass))
-}
-
-fn usage() -> &'static str {
-    "usage: cargo run -p celox --example run_veryl_project_test -- --project <dir> --test <module> [--source-file <path> ...] [--backend native|cranelift] [--opt-level O2] [--sir-pass +/-name ...] [--native-memory-width 64|128] [--x86-slp on|off] [--four-state] [--compile-only] [--tick-limit N] [--dump-ir-dir <dir>] [--dump-ir-and-run] [--native-profile-block FUNCTION:BLOCK:SAMPLES ...]"
 }
 
 fn load_sources(

--- a/crates/celox-bench/src/bin/veryl-heliodor.rs
+++ b/crates/celox-bench/src/bin/veryl-heliodor.rs
@@ -1,5 +1,6 @@
-use std::{env, error::Error, fs, path::PathBuf, time::Instant};
+use std::{error::Error, fs, path::PathBuf, time::Instant};
 
+use clap::Parser as ClapParser;
 use veryl_analyzer::ir as air;
 use veryl_analyzer::{Analyzer, AnalyzerError, Context};
 use veryl_metadata::Metadata;
@@ -10,9 +11,14 @@ use veryl_simulator::testbench::{
     TestResult, build_clock_periods, build_event_map, convert_initial_to_testbench, run_testbench,
 };
 
+#[derive(ClapParser)]
+#[command(about = "Run a Heliodor test with synchronous Veryl AOT-C")]
 struct Options {
+    #[arg(long)]
     project: PathBuf,
+    #[arg(long)]
     test: String,
+    #[arg(long = "source-file")]
     source_files: Vec<PathBuf>,
 }
 
@@ -24,7 +30,7 @@ fn main() {
 }
 
 fn run() -> Result<(), Box<dyn Error>> {
-    let options = parse_args().map_err(|error| format!("{error}\n\n{}", usage()))?;
+    let options = Options::parse();
     let metadata_path = Metadata::search_from(&options.project)?;
     let mut metadata = Metadata::load(&metadata_path)?;
     let paths = metadata.paths(&options.source_files, false, true)?;
@@ -139,46 +145,4 @@ fn ensure_no_errors(stage: &str, diagnostics: Vec<AnalyzerError>) -> Result<(), 
     } else {
         Err(format!("{stage}: {errors:?}").into())
     }
-}
-
-fn parse_args() -> Result<Options, String> {
-    let mut project = None;
-    let mut test = None;
-    let mut source_files = Vec::new();
-    let mut args = env::args().skip(1);
-    while let Some(argument) = args.next() {
-        match argument.as_str() {
-            "-h" | "--help" => return Err(String::new()),
-            "--project" => {
-                project = Some(PathBuf::from(
-                    args.next()
-                        .ok_or_else(|| "--project requires a path".to_string())?,
-                ));
-            }
-            "--test" => {
-                test = Some(
-                    args.next()
-                        .ok_or_else(|| "--test requires a module name".to_string())?,
-                );
-            }
-            "--source-file" => {
-                source_files.push(PathBuf::from(
-                    args.next()
-                        .ok_or_else(|| "--source-file requires a path".to_string())?,
-                ));
-            }
-            other if project.is_none() => project = Some(PathBuf::from(other)),
-            other if test.is_none() => test = Some(other.to_string()),
-            other => return Err(format!("unexpected argument: {other}")),
-        }
-    }
-    Ok(Options {
-        project: project.ok_or_else(|| "missing project path".to_string())?,
-        test: test.ok_or_else(|| "missing test module".to_string())?,
-        source_files,
-    })
-}
-
-fn usage() -> &'static str {
-    "usage: cargo run -p celox --example run_veryl_project_test_timed -- --project <dir> --test <module> [--source-file <path> ...]"
 }

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 
 use bit_set::BitSet;
 use num_bigint::BigUint;
@@ -23,6 +24,26 @@ use super::{emit, jit_mem, regalloc};
 
 /// JIT function type: `fn(state: *mut u8) -> i64`
 pub type NativeSimFunc = unsafe extern "sysv64" fn(*mut u8) -> i64;
+
+/// Time spent inside generated native simulator functions.
+///
+/// Timing is opt-in so normal simulation does not pay for host clock reads.
+/// A call may execute many ticks when the native tick loop is enabled.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct NativeExecutionTiming {
+    elapsed: Duration,
+    calls: u64,
+}
+
+impl NativeExecutionTiming {
+    pub fn elapsed(self) -> Duration {
+        self.elapsed
+    }
+
+    pub fn calls(self) -> u64 {
+        self.calls
+    }
+}
 
 /// Compiled event handle for native backend.
 /// Holds the function pointer directly — no indirection at call time.
@@ -810,6 +831,7 @@ pub struct NativeBackend {
     memory: Vec<u64>,
     runtime_event_buffer: Arc<RuntimeEventBuffer>,
     comb_capture_enabled: Vec<u8>,
+    execution_timing: Option<NativeExecutionTiming>,
 }
 
 impl NativeBackend {
@@ -860,9 +882,20 @@ impl NativeBackend {
             memory,
             runtime_event_buffer,
             comb_capture_enabled,
+            execution_timing: None,
         };
         backend.install_event_buffers();
         backend
+    }
+
+    /// Start a fresh opt-in measurement of generated native function calls.
+    pub fn start_execution_timing(&mut self) {
+        self.execution_timing = Some(NativeExecutionTiming::default());
+    }
+
+    /// Stop timing and return the accumulated generated-code interval.
+    pub fn finish_execution_timing(&mut self) -> Option<NativeExecutionTiming> {
+        self.execution_timing.take()
     }
 
     fn install_event_buffers(&mut self) {
@@ -977,6 +1010,22 @@ impl NativeBackend {
         }
     }
 
+    fn call_func_timed(&mut self, func: NativeSimFunc) -> Result<(), SimulatorErrorCode> {
+        let Some(_) = self.execution_timing else {
+            return Self::call_func(&mut self.memory, func);
+        };
+        let start = Instant::now();
+        let result = Self::call_func(&mut self.memory, func);
+        let elapsed = start.elapsed();
+        let timing = self
+            .execution_timing
+            .as_mut()
+            .expect("native execution timing was enabled before the call");
+        timing.elapsed = timing.elapsed.saturating_add(elapsed);
+        timing.calls = timing.calls.saturating_add(1);
+        result
+    }
+
     fn call_func_many(
         memory: &mut [u64],
         func: NativeSimFunc,
@@ -999,21 +1048,42 @@ impl NativeBackend {
         };
         (completed, result)
     }
+
+    fn call_func_many_timed(
+        &mut self,
+        func: NativeSimFunc,
+        count: u64,
+    ) -> (u64, Result<(), SimulatorErrorCode>) {
+        if self.execution_timing.is_none() || count == 0 {
+            return Self::call_func_many(&mut self.memory, func, count);
+        }
+        let start = Instant::now();
+        let result = Self::call_func_many(&mut self.memory, func, count);
+        let elapsed = start.elapsed();
+        let timing = self
+            .execution_timing
+            .as_mut()
+            .expect("native execution timing was enabled before the call");
+        timing.elapsed = timing.elapsed.saturating_add(elapsed);
+        timing.calls = timing.calls.saturating_add(1);
+        result
+    }
 }
 
 impl super::super::SimBackend for NativeBackend {
     type Event = NativeEventRef;
 
     fn eval_comb(&mut self) -> Result<(), SimulatorErrorCode> {
-        Self::call_func(&mut self.memory, self.compiled.comb_func)
+        let func = self.compiled.comb_func;
+        self.call_func_timed(func)
     }
 
     fn eval_apply_ff_at(&mut self, event: NativeEventRef) -> Result<(), SimulatorErrorCode> {
-        Self::call_func(&mut self.memory, event.func)
+        self.call_func_timed(event.func)
     }
 
     fn eval_comb_apply_ff_at(&mut self, event: NativeEventRef) -> Result<(), SimulatorErrorCode> {
-        Self::call_func(&mut self.memory, event.comb_apply_func)
+        self.call_func_timed(event.comb_apply_func)
     }
 
     fn eval_comb_apply_ff_many_at(
@@ -1022,20 +1092,20 @@ impl super::super::SimBackend for NativeBackend {
         count: u64,
     ) -> (u64, Result<(), SimulatorErrorCode>) {
         if super::native_tick_loop_enabled() {
-            Self::call_func_many(&mut self.memory, event.comb_apply_func, count)
+            self.call_func_many_timed(event.comb_apply_func, count)
         } else if count == 0 {
             (0, Ok(()))
         } else {
-            (1, Self::call_func(&mut self.memory, event.comb_apply_func))
+            (1, self.call_func_timed(event.comb_apply_func))
         }
     }
 
     fn eval_only_ff_at(&mut self, event: NativeEventRef) -> Result<(), SimulatorErrorCode> {
-        Self::call_func(&mut self.memory, event.func)
+        self.call_func_timed(event.func)
     }
 
     fn apply_ff_at(&mut self, event: NativeEventRef) -> Result<(), SimulatorErrorCode> {
-        Self::call_func(&mut self.memory, event.func)
+        self.call_func_timed(event.func)
     }
 
     fn resolve_signal(&self, addr: &AbsoluteAddr) -> SignalRef {

--- a/crates/celox/src/backend/native/mod.rs
+++ b/crates/celox/src/backend/native/mod.rs
@@ -1,3 +1,3 @@
 pub mod backend;
-pub use backend::{NativeBackend, SharedNativeCode};
+pub use backend::{NativeBackend, NativeExecutionTiming, SharedNativeCode};
 pub use celox_backend_x86::native::*;

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -1464,6 +1464,22 @@ impl Simulator<NativeBackend> {
         self.backend.shared_code()
     }
 
+    /// Start measuring time spent inside generated native simulator functions.
+    ///
+    /// The measurement is disabled by default, so ordinary simulation does not
+    /// read the host clock. Native tick loops are measured once per host-side
+    /// batch rather than once per simulated tick.
+    pub fn start_native_execution_timing(&mut self) {
+        self.backend.start_execution_timing();
+    }
+
+    /// Stop native execution timing and return the accumulated measurement.
+    pub fn finish_native_execution_timing(
+        &mut self,
+    ) -> Option<crate::native_backend::NativeExecutionTiming> {
+        self.backend.finish_execution_timing()
+    }
+
     /// Create a simulator from pre-compiled shared native code.
     pub fn from_shared(shared: Arc<SharedNativeCode>, program: crate::ir::OptimizedSir) -> Self {
         let backend = NativeBackend::from_shared(shared);

--- a/crates/celox/tests/native_exec.rs
+++ b/crates/celox/tests/native_exec.rs
@@ -370,6 +370,24 @@ fn test_simulator_native_simple_assignment() {
 }
 
 #[test]
+fn test_native_execution_timing_is_opt_in_and_counts_host_calls() {
+    let code = r#"
+        module Top (a: input logic<32>, b: output logic<32>) {
+            assign b = a;
+        }
+    "#;
+    let mut sim = Simulator::builder(code, "Top").build_native().unwrap();
+    assert_eq!(sim.finish_native_execution_timing(), None);
+
+    sim.start_native_execution_timing();
+    sim.eval_comb().unwrap();
+    let timing = sim
+        .finish_native_execution_timing()
+        .expect("timing must be available after it is started");
+    assert_eq!(timing.calls(), 1);
+}
+
+#[test]
 fn test_simulator_native_add() {
     let code = r#"
         module Top (

--- a/docs/.vitepress/components/BenchmarkDashboard.vue
+++ b/docs/.vitepress/components/BenchmarkDashboard.vue
@@ -51,7 +51,18 @@ interface SeriesPoint {
 interface Series {
   key: string;
   benchName: string;
-  runtime: "rust" | "rust-dse" | "native-tb" | "ts" | "verilator" | "unknown";
+  runtime:
+    | "rust"
+    | "rust-dse"
+    | "native-tb"
+    | "ts"
+    | "verilator"
+    | "heliodor-celox-jit"
+    | "heliodor-celox-total"
+    | "heliodor-celox-compile"
+    | "heliodor-veryl"
+    | "heliodor-veryl-compile"
+    | "unknown";
   points: SeriesPoint[];
 }
 
@@ -138,6 +149,12 @@ const overviewTabs: TabDef[] = [
     match: (n) => /linear_sec|countones|std_counter|fifo|onehot/.test(n),
     sections: stdlibSections,
   },
+  {
+    key: "heliodor",
+    label: "Heliodor Linux",
+    match: (n) => n.startsWith("heliodor_linux_boot_"),
+    sections: singleSection,
+  },
 ];
 
 function apiSections(cards: ChartCard[]): TabSection[] {
@@ -182,11 +199,7 @@ const diagnosticTabs: TabDef[] = [
 const tabs = computed(() => (props.mode === "diagnostic" ? diagnosticTabs : overviewTabs));
 
 function classifySeries(benchName: string): string {
-  const orderedTabs = tabs.value.length > 2
-    ? [tabs.value[2], tabs.value[3], tabs.value[1], tabs.value[0]]
-    : [tabs.value[1], tabs.value[0]];
-
-  for (const tab of orderedTabs) {
+  for (const tab of [...tabs.value].reverse()) {
     if (tab.match(benchName)) return tab.key;
   }
   return "hidden";
@@ -201,6 +214,11 @@ const RUNTIME_COLORS: Record<string, string> = {
   ts: "#22c55e",
   verilator: "#f97316",
   unknown: "#9ca3af",
+  "heliodor-celox-jit": "#3b82f6",
+  "heliodor-celox-total": "#a855f7",
+  "heliodor-celox-compile": "#06b6d4",
+  "heliodor-veryl": "#f97316",
+  "heliodor-veryl-compile": "#eab308",
 };
 
 const RUNTIME_LABELS: Record<string, string> = {
@@ -210,6 +228,11 @@ const RUNTIME_LABELS: Record<string, string> = {
   ts: "Celox (ts)",
   verilator: "Verilator",
   unknown: "Unknown",
+  "heliodor-celox-jit": "Celox JIT code",
+  "heliodor-celox-total": "Celox post-compile total",
+  "heliodor-celox-compile": "Celox compile",
+  "heliodor-veryl": "Veryl-CC execution",
+  "heliodor-veryl-compile": "Veryl-CC compile",
 };
 
 // --- State ---
@@ -222,7 +245,10 @@ const activeTab = ref("counter");
 // --- Helpers ---
 
 function stripPrefix(name: string): string {
-  return name.replace(/^(rust-dse|rust|ts|verilator)\//, "");
+  return name.replace(
+    /^(rust-dse|rust|ts|verilator|heliodor-celox-jit|heliodor-celox-total|heliodor-celox-compile|heliodor-veryl|heliodor-veryl-compile)\//,
+    "",
+  );
 }
 
 /** Normalize variant-specific benchmark names so they merge into the same chart cards */
@@ -246,7 +272,12 @@ function normalizeBenchName(benchName: string): string {
   return benchName;
 }
 
-function runtime(name: string): "rust" | "rust-dse" | "native-tb" | "ts" | "verilator" | "unknown" {
+function runtime(name: string): Series["runtime"] {
+  if (name.startsWith("heliodor-celox-jit/")) return "heliodor-celox-jit";
+  if (name.startsWith("heliodor-celox-total/")) return "heliodor-celox-total";
+  if (name.startsWith("heliodor-celox-compile/")) return "heliodor-celox-compile";
+  if (name.startsWith("heliodor-veryl-compile/")) return "heliodor-veryl-compile";
+  if (name.startsWith("heliodor-veryl/")) return "heliodor-veryl";
   if (name.startsWith("rust-dse/")) return "rust-dse";
   if (name.startsWith("rust/") && stripPrefix(name).startsWith("native_tb_")) return "native-tb";
   if (name.startsWith("rust/")) return "rust";
@@ -292,6 +323,8 @@ function formatChartTitle(benchName: string): string {
   s = s.replace(/_top_n1000/, "");
   // Strip optimize prefix patterns
   s = s.replace(/^optimize_/, "");
+  s = s.replace(/^heliodor_linux_boot_execution$/, "Linux boot execution");
+  s = s.replace(/^heliodor_linux_boot_compilation$/, "Linux boot compilation");
 
   // Replace operation names (longer prefixes first to avoid partial matches)
   s = s.replace(/^native_tb_run/, "Native TB run");
@@ -363,7 +396,9 @@ const allSeries = computed<Series[]>(() => {
 });
 
 function isPrimaryBench(benchName: string): boolean {
-  return PRIMARY_COUNTER_BENCHES.has(benchName) || PRIMARY_STDLIB_BENCHES.has(benchName);
+  return PRIMARY_COUNTER_BENCHES.has(benchName)
+    || PRIMARY_STDLIB_BENCHES.has(benchName)
+    || benchName.startsWith("heliodor_linux_boot_");
 }
 
 // --- Computed: tabs with chart cards ---

--- a/docs/benchmarks/heliodor.md
+++ b/docs/benchmarks/heliodor.md
@@ -2,7 +2,13 @@
 
 Heliodor is a large Veryl RISC-V processor project with ignored Linux boot tests. It is useful as a macro benchmark because it stresses project loading, large memories initialized by `$readmemh`, native testbench scheduling, and long-running sequential simulation.
 
-This benchmark is not part of normal CI. It checks out Heliodor under
+The benchmark executables are owned by the workspace's `celox-bench` crate.
+They are deliberately not examples of the public `celox` API: `celox-heliodor`
+is the Celox measurement subject and `veryl-heliodor` is its synchronous Veryl
+reference. The shell driver prepares pinned external inputs, invokes those
+executables, and validates their machine-readable terminal records.
+
+The dedicated Heliodor CI workflow checks out Heliodor under
 `target/heliodor/source`, builds the timed Veryl and Celox runners before
 timing, runs the Veryl baseline before Celox by default, and writes a TSV
 summary plus full logs under `target/heliodor/results`.
@@ -41,7 +47,12 @@ HELIODOR_TIMEOUT_SEC=300 \
 scripts/run-heliodor-bench.sh run
 ```
 
-Both runners report build/prepare separately from testbench execution. The
+Both runners report build/prepare separately from testbench execution. Celox
+also reports `jit_execute_elapsed_ns`, the accumulated wall time spent inside
+generated native functions. Its timer is read once per host-side native batch,
+not once per simulated tick. `execute_elapsed_ns` remains the enclosing
+post-codegen interval and therefore includes testbench scheduling and runtime
+event handling. The
 compile interval includes frontend analysis, optimization, native code
 generation, simulator initialization, and initial-testbench lowering; it ends
 immediately before the already-built testbench is executed. The Veryl runner
@@ -106,10 +117,12 @@ contain exactly one architectural completion marker equal to
 `cy=9ae070 x3=aa pass=1`; leading hexadecimal zeroes are ignored.
 
 Each runner measures `compile_elapsed_ns` through simulator and initial
-testbench construction, then measures `execute_elapsed_ns` only around execution
-of that already-compiled testbench. The gate exits successfully only if both
-semantic checks pass and the Celox execution interval is no greater than the
-Veryl execution interval. It records and reports code-generation latency
+testbench construction, then measures `execute_elapsed_ns` around execution of
+that already-compiled testbench. Celox additionally measures generated native
+function calls as `jit_execute_elapsed_ns`. The gate exits successfully only if
+both semantic checks pass and the Celox JIT interval is no greater than the
+Veryl execution interval. It records the enclosing Celox execution interval and
+code-generation latency
 separately; compile latency is not folded into the execution-throughput
 decision. Subprocess time remains an end-to-end diagnostic. Compile-only
 completion, a partial window, or process exit zero without the exact markers is
@@ -154,7 +167,7 @@ Useful long tests include:
 
 | Runner | Command |
 |---|---|
-| `celox` | `target/<profile>/examples/run_veryl_project_test --project ... --test ...` |
+| `celox` | `target/<profile>/celox-heliodor --project ... --test ...` |
 | `veryl-cc-sync` | Direct Veryl 0.20.2 synchronous AOT-C runner with split timing |
 | `veryl-cc` | `veryl test --ignored --test ... --backend cc` |
 | `veryl-cranelift` | `veryl test --ignored --test ... --backend cranelift` |
@@ -184,12 +197,14 @@ from the simulated test result. Its columns are:
 | `reported_elapsed_ns` | Runner's internal total elapsed value, or `NA` when unavailable |
 | `compile_elapsed_ns` | Internal build/prepare time through simulator and testbench construction, or `NA` when unavailable |
 | `execute_elapsed_ns` | Internal testbench execution time after code generation, or `NA` when unavailable |
+| `jit_execute_elapsed_ns` | Celox time inside generated native functions; `NA` for backends/runners without this measurement |
 
 The original `runner`, `test`, `status`, `elapsed_ns`, and `log` columns remain
 in their original positions. A valid end-to-end process result exists only when
 `semantic_status=pass`, `exit_status=0`, and `elapsed_ns` is numeric. That legacy
-column is not a generated-code execution result: use `execute_elapsed_ns` for
-throughput and `compile_elapsed_ns` for compiler latency. `process_elapsed_ns`
+column is not a generated-code execution result: use `jit_execute_elapsed_ns`
+for native code quality, `execute_elapsed_ns` for post-codegen simulator
+throughput, and `compile_elapsed_ns` for compiler latency. `process_elapsed_ns`
 and `reported_elapsed_ns` are diagnostics and must not be used to claim
 full-test performance for `compile-only`, `fail`, `unreported`, or `invalid`
 rows.
@@ -197,7 +212,7 @@ rows.
 For Celox, the script requires exactly one timing line and one result line:
 
 ```text
-CELOX_TEST_TIMING test=<requested-test> compile_ns=<integer> execute_ns=<integer>
+CELOX_TEST_TIMING test=<requested-test> compile_ns=<integer> execute_ns=<integer> jit_execute_ns=<integer-or-NA>
 CELOX_TEST_RESULT test=<requested-test> status=pass|fail|compile-only elapsed_ns=<integer>
 ```
 
@@ -210,11 +225,22 @@ exit-status-inconsistent records cannot become a pass. An intentional
 `HELIODOR_CELOX_COMPILE_ONLY=1` run may finish successfully, but its
 `semantic_status` is `compile-only` and its `elapsed_ns` is `NA`.
 
-Existing five- and nine-column TSV files are migrated atomically on the next
+Existing five-, nine-, and eleven-column TSV files are migrated atomically on the next
 run. The script keeps the first copy as `results.tsv.v1.bak` or
-`results.tsv.v2.bak`, recovers split timing from referenced logs where possible,
+`results.tsv.v2.bak`/`results.tsv.v3.bak`, recovers split timing from referenced logs where possible,
 and marks unavailable timing as `NA`. Migration never promotes process exit
 zero alone to a Celox full pass.
+
+## CI and dashboard
+
+`.github/workflows/heliodor-bench.yml` runs the pinned full Linux workload on
+every relevant pull request, every push to `master`, and manual dispatches. The
+fixed semantic/Veryl gate remains mandatory. On pull requests,
+`github-action-benchmark` also fails when generated-JIT execution exceeds the
+published baseline by more than 10%. On `master`, Celox JIT execution, enclosing
+post-codegen execution, compile time, and the corresponding Veryl measurements
+are published to the **Heliodor Linux** tab on the [benchmark dashboard](/benchmarks/).
+Raw logs and the exact TSV are retained as workflow artifacts.
 
 The parser/migration and acceptance-gate fixtures run without checking out or
 executing Heliodor or either compiler:

--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -1,6 +1,10 @@
 # Benchmarks
 
-Celox includes benchmark suites for the Rust core, the TypeScript runtime, and Verilator as a reference baseline. CI runs benchmarks on every push to `master` and publishes an interactive trend dashboard.
+Celox includes benchmark suites for the Rust core, the TypeScript runtime,
+Verilator as a reference baseline, and the Heliodor Linux workload for native
+JIT code quality. CI publishes their history to the interactive dashboard;
+Heliodor pull requests additionally reject generated-JIT regressions above the
+configured tolerance.
 
 ## Dashboard
 

--- a/docs/ja/benchmarks/heliodor.md
+++ b/docs/ja/benchmarks/heliodor.md
@@ -2,7 +2,12 @@
 
 Heliodor は Veryl で書かれた大規模な RISC-V プロセッサで、Linux boot の ignored test を持っています。プロジェクト読み込み、`$readmemh` による大きなメモリ初期化、native testbench scheduling、長時間の順序回路シミュレーションをまとめて踏むので、Celox を Veryl native simulator として見るためのマクロベンチに向いています。
 
-このベンチは通常 CI には含めません。Heliodor を
+ベンチマーク実行ファイルはworkspaceの`celox-bench` crateが所有します。
+これらは公開`celox` APIのexampleではありません。`celox-heliodor`がCeloxの
+計測対象、`veryl-heliodor`が同期Veryl referenceです。shell driverは固定された
+外部入力を準備し、これらを実行してmachine-readableな終了recordを検証します。
+
+専用の Heliodor CI workflow は Heliodor を
 `target/heliodor/source` に checkout し、計測前に時間分離版 Veryl runner と
 Celox runner を build します。デフォルトでは Veryl baseline を先に測ってから
 Celox を走らせ、TSV サマリとフルログを `target/heliodor/results` に出します。
@@ -40,7 +45,11 @@ HELIODOR_TIMEOUT_SEC=300 \
 scripts/run-heliodor-bench.sh run
 ```
 
-両 runner は build/prepare と testbench 実行を別々に報告します。compile 区間には
+両 runner は build/prepare と testbench 実行を別々に報告します。Celox はさらに、
+生成native関数内で消費したwall timeを`jit_execute_elapsed_ns`として報告します。
+時計を読むのはsimulated tickごとではなくhost側native batchごとです。
+`execute_elapsed_ns`はその外側の区間であり、testbench schedulingとruntime event処理も
+含みます。compile 区間には
 frontend 解析、最適化、native コード生成、Simulator 初期化、initial testbench
 lowering を含み、構築済みtestbenchを実行する直前で終了します。
 Veryl 側は Veryl 0.20.2 の Heliodor benchmark と同じ同期 AOT-C 設定
@@ -100,9 +109,10 @@ checkout identity、runner executable hash も検査します。
 16 進数の先頭 0 を除いて `cy=9ae070 x3=aa pass=1` と一致することを要求します。
 
 両 runner は Simulator と initial testbench の構築完了までを
-`compile_elapsed_ns`、構築済みtestbenchの実行だけを `execute_elapsed_ns` として
-測ります。両方の semantic check が成功し、Celox の実行区間が Veryl 以下の場合に
-だけ gate は 0 で終了します。コード生成 latency は別に記録・表示し、実行
+`compile_elapsed_ns`、構築済みtestbenchの実行を `execute_elapsed_ns` として
+測ります。Celoxは生成native関数の呼出しだけを`jit_execute_elapsed_ns`にも集計します。
+両方の semantic check が成功し、Celox のJIT実行区間が Veryl の実行区間以下の場合に
+だけ gate は 0 で終了します。Celoxの外側の実行区間とコード生成 latency は別に記録・表示し、実行
 throughput の判定には混ぜません。subprocess 時間は end-to-end の診断値です。
 compile-only、partial window、または正確な marker を伴わない process exit 0 は
 失敗です。`--kill-after` を持つ GNU `timeout` と Python 3 が必要です。
@@ -143,7 +153,7 @@ scripts/run-heliodor-bench.sh list
 
 | Runner | Command |
 |---|---|
-| `celox` | `target/<profile>/examples/run_veryl_project_test --project ... --test ...` |
+| `celox` | `target/<profile>/celox-heliodor --project ... --test ...` |
 | `veryl-cc-sync` | 分離計測を行う Veryl 0.20.2 同期 AOT-C runner |
 | `veryl-cc` | `veryl test --ignored --test ... --backend cc` |
 | `veryl-cranelift` | `veryl test --ignored --test ... --backend cranelift` |
@@ -173,12 +183,14 @@ Celox runner は Celox の default backend を使います。x86-64 host では 
 | `reported_elapsed_ns` | runner 内部の総 elapsed。取得できない場合は `NA` |
 | `compile_elapsed_ns` | Simulator・testbench 構築までを含む build/prepare 内部時間。取得できない場合は `NA` |
 | `execute_elapsed_ns` | コード生成完了後の testbench 実行時間。取得できない場合は `NA` |
+| `jit_execute_elapsed_ns` | Celox生成native関数内の実行時間。未対応backend/runnerは`NA` |
 
 従来の `runner`、`test`、`status`、`elapsed_ns`、`log` は同じ順序で
 残ります。end-to-end process 結果として扱えるのは `semantic_status=pass`、
 `exit_status=0` かつ `elapsed_ns` が数値の行だけです。この旧列は生成コードの
-実行性能ではありません。throughput には `execute_elapsed_ns`、compiler latency
-には `compile_elapsed_ns` を使います。`process_elapsed_ns` と
+実行性能ではありません。生成コード品質には`jit_execute_elapsed_ns`、コード生成後の
+simulator全体には`execute_elapsed_ns`、compiler latencyには
+`compile_elapsed_ns` を使います。`process_elapsed_ns` と
 `reported_elapsed_ns` は診断値であり、
 `compile-only`、`fail`、`unreported`、`invalid` の full-test 性能として
 扱ってはいけません。
@@ -186,7 +198,7 @@ Celox runner は Celox の default backend を使います。x86-64 host では 
 Celox については、ログ中に timing 行と result 行がそれぞれちょうど 1 個必要です。
 
 ```text
-CELOX_TEST_TIMING test=<requested-test> compile_ns=<integer> execute_ns=<integer>
+CELOX_TEST_TIMING test=<requested-test> compile_ns=<integer> execute_ns=<integer> jit_execute_ns=<integer-or-NA>
 CELOX_TEST_RESULT test=<requested-test> status=pass|fail|compile-only elapsed_ns=<integer>
 ```
 
@@ -199,8 +211,8 @@ process 終了 status との不一致は pass になりません。
 `HELIODOR_CELOX_COMPILE_ONLY=1` が正常終了しても、`semantic_status` は
 `compile-only`、`elapsed_ns` は `NA` です。
 
-既存の 5 列・9 列 TSV は次回実行時に atomic に移行します。最初の内容を
-`results.tsv.v1.bak` または `results.tsv.v2.bak` に保存し、参照先 log から
+既存の5列・9列・11列TSVは次回実行時にatomicに移行します。最初の内容を
+`results.tsv.v1.bak`、`results.tsv.v2.bak`、または`results.tsv.v3.bak`に保存し、参照先 log から
 分離時間を復元できる場合は復元し、取得できない値は `NA` にします。process の
 終了 status が 0 という事実だけで Celox full pass に昇格させることはありません。
 
@@ -211,6 +223,16 @@ checkout・実行せずにテストできます。
 bash scripts/tests/run-heliodor-bench-results.sh
 bash scripts/tests/run-heliodor-bench-gate.sh
 ```
+
+## CIとdashboard
+
+`.github/workflows/heliodor-bench.yml`は、関連するpull request、`master`へのpush、
+manual dispatchで固定Linux workloadを実行します。semantic checkとVeryl比較は常に
+必須です。pull requestでは、生成JIT実行時間が公開済みbaselineより10%を超えて悪化すると
+`github-action-benchmark`がjobを失敗させます。`master`ではCeloxのJIT実行、外側の
+post-codegen実行、compile時間、およびVerylの対応値を
+[benchmark dashboard](/ja/benchmarks/)の**Heliodor Linux** tabへ公開します。
+正確なTSVとlogはworkflow artifactにも保存します。
 
 ## Architectural completion marker
 

--- a/docs/ja/benchmarks/index.md
+++ b/docs/ja/benchmarks/index.md
@@ -1,6 +1,9 @@
 # ベンチマーク
 
-Celox には Rust コア、TypeScript ランタイム、および参照ベースラインとしての Verilator のベンチマークスイートが含まれています。CI は `master` への push ごとにベンチマークを自動実行し、インタラクティブなトレンドダッシュボードを公開します。
+CeloxにはRustコア、TypeScriptランタイム、参照baselineのVerilator、およびnative
+JITコード品質を測るHeliodor Linux workloadのベンチマークがあります。CIは履歴を
+interactive dashboardへ公開し、Heliodorに関係するpull requestでは許容値を超える
+生成JIT性能の退行も拒否します。
 
 ## ダッシュボード
 

--- a/scripts/convert-heliodor-bench.mjs
+++ b/scripts/convert-heliodor-bench.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/** Convert a Heliodor results.tsv file to github-action-benchmark data. */
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const [inputPath, outputPath, mode] = process.argv.slice(2);
+if (!inputPath || !outputPath) {
+  console.error(
+    "Usage: node convert-heliodor-bench.mjs <results.tsv> <output.json> [--jit-only]",
+  );
+  process.exit(1);
+}
+if (mode && mode !== "--jit-only") {
+  throw new Error(`unknown conversion mode: ${mode}`);
+}
+
+const lines = readFileSync(inputPath, "utf8").trim().split("\n");
+const expectedHeader = [
+  "runner",
+  "test",
+  "status",
+  "elapsed_ns",
+  "log",
+  "semantic_status",
+  "exit_status",
+  "process_elapsed_ns",
+  "reported_elapsed_ns",
+  "compile_elapsed_ns",
+  "execute_elapsed_ns",
+  "jit_execute_elapsed_ns",
+];
+const header = lines.shift()?.split("\t") ?? [];
+if (header.join("\t") !== expectedHeader.join("\t")) {
+  throw new Error(`unsupported Heliodor result schema: ${header.join("\t")}`);
+}
+
+const rows = lines.filter(Boolean).map((line) => {
+  const fields = line.split("\t");
+  if (fields.length !== expectedHeader.length) {
+    throw new Error(`expected 12 fields, found ${fields.length}: ${line}`);
+  }
+  return Object.fromEntries(expectedHeader.map((name, index) => [name, fields[index]]));
+});
+
+function requirePassedRunner(name) {
+  const matches = rows.filter((row) => row.runner === name);
+  if (matches.length !== 1) {
+    throw new Error(`expected exactly one ${name} row, found ${matches.length}`);
+  }
+  const row = matches[0];
+  if (row.semantic_status !== "pass" || row.exit_status !== "0") {
+    throw new Error(`${name} did not complete successfully`);
+  }
+  return row;
+}
+
+function ns(row, field) {
+  const value = row[field];
+  if (!/^\d+$/.test(value) || value === "0") {
+    throw new Error(`${row.runner}.${field} is not a positive integer: ${value}`);
+  }
+  return Number(value);
+}
+
+function milliseconds(name, nanoseconds) {
+  return {
+    name,
+    unit: "ms",
+    value: nanoseconds / 1_000_000,
+  };
+}
+
+const celox = requirePassedRunner("celox");
+const veryl = requirePassedRunner("veryl-cc-sync");
+if (celox.test !== veryl.test) {
+  throw new Error(`runner tests differ: Celox=${celox.test}, Veryl=${veryl.test}`);
+}
+
+const results = [
+  milliseconds(
+    "heliodor-celox-jit/heliodor_linux_boot_execution",
+    ns(celox, "jit_execute_elapsed_ns"),
+  ),
+  milliseconds(
+    "heliodor-celox-total/heliodor_linux_boot_execution",
+    ns(celox, "execute_elapsed_ns"),
+  ),
+  milliseconds(
+    "heliodor-veryl/heliodor_linux_boot_execution",
+    ns(veryl, "execute_elapsed_ns"),
+  ),
+  milliseconds(
+    "heliodor-celox-compile/heliodor_linux_boot_compilation",
+    ns(celox, "compile_elapsed_ns"),
+  ),
+  milliseconds(
+    "heliodor-veryl-compile/heliodor_linux_boot_compilation",
+    ns(veryl, "compile_elapsed_ns"),
+  ),
+];
+
+const selectedResults = mode === "--jit-only" ? results.slice(0, 1) : results;
+
+writeFileSync(outputPath, JSON.stringify(selectedResults, null, 2));
+console.log(`Converted ${selectedResults.length} Heliodor metrics → ${outputPath}`);

--- a/scripts/run-heliodor-bench.sh
+++ b/scripts/run-heliodor-bench.sh
@@ -15,8 +15,8 @@ HELIODOR_RUNNERS="${HELIODOR_RUNNERS:-veryl-cc-sync celox}"
 CELOX_OPT_LEVEL="${CELOX_OPT_LEVEL:-O2}"
 CELOX_SIR_PASS_OVERRIDES="${CELOX_SIR_PASS_OVERRIDES:-}"
 HELIODOR_CELOX_CARGO_PROFILE="${HELIODOR_CELOX_CARGO_PROFILE:-heliodor-dev}"
-CELOX_RUNNER_BIN="${CELOX_RUNNER_BIN:-$CELOX_ROOT/target/$HELIODOR_CELOX_CARGO_PROFILE/examples/run_veryl_project_test}"
-VERYL_TIMED_RUNNER_BIN="${VERYL_TIMED_RUNNER_BIN:-$CELOX_ROOT/target/$HELIODOR_CELOX_CARGO_PROFILE/examples/run_veryl_project_test_timed}"
+CELOX_RUNNER_BIN="${CELOX_RUNNER_BIN:-$CELOX_ROOT/target/$HELIODOR_CELOX_CARGO_PROFILE/celox-heliodor}"
+VERYL_TIMED_RUNNER_BIN="${VERYL_TIMED_RUNNER_BIN:-$CELOX_ROOT/target/$HELIODOR_CELOX_CARGO_PROFILE/veryl-heliodor}"
 HELIODOR_BUILD_CELOX_RUNNER="${HELIODOR_BUILD_CELOX_RUNNER:-1}"
 HELIODOR_CELOX_TARGET_DIR="${HELIODOR_CELOX_TARGET_DIR:-}"
 HELIODOR_CELOX_COMPILE_ONLY="${HELIODOR_CELOX_COMPILE_ONLY:-0}"
@@ -42,6 +42,7 @@ declare -A BASELINE_ELAPSED_NS=()
 RESULTS_HEADER_V1=$'runner\ttest\tstatus\telapsed_ns\tlog'
 RESULTS_HEADER_V2=$'runner\ttest\tstatus\telapsed_ns\tlog\tsemantic_status\texit_status\tprocess_elapsed_ns\treported_elapsed_ns'
 RESULTS_HEADER_V3=$'runner\ttest\tstatus\telapsed_ns\tlog\tsemantic_status\texit_status\tprocess_elapsed_ns\treported_elapsed_ns\tcompile_elapsed_ns\texecute_elapsed_ns'
+RESULTS_HEADER_V4=$'runner\ttest\tstatus\telapsed_ns\tlog\tsemantic_status\texit_status\tprocess_elapsed_ns\treported_elapsed_ns\tcompile_elapsed_ns\texecute_elapsed_ns\tjit_execute_elapsed_ns'
 
 # Outputs from classify_celox_result. Keep these as globals so callers retain
 # the function's structured result without parsing diagnostic text.
@@ -49,6 +50,7 @@ CELOX_SEMANTIC_STATUS="unreported"
 CELOX_REPORTED_ELAPSED_NS="NA"
 CELOX_COMPILE_ELAPSED_NS="NA"
 CELOX_EXECUTE_ELAPSED_NS="NA"
+CELOX_JIT_EXECUTE_ELAPSED_NS="NA"
 CELOX_RESULT_DIAGNOSTIC=""
 VERYL_TIMED_SEMANTIC_STATUS="unreported"
 VERYL_TIMED_REPORTED_ELAPSED_NS="NA"
@@ -165,6 +167,7 @@ validate_result_fields() {
     local reported_elapsed_ns="$9"
     local compile_elapsed_ns="${10}"
     local execute_elapsed_ns="${11}"
+    local jit_execute_elapsed_ns="${12}"
 
     if [[ -z "$runner" || -z "$test" || -z "$log" ]]; then
         echo "result row has an empty runner, test, or log field" >&2
@@ -193,6 +196,15 @@ validate_result_fields() {
         echo "result row has invalid split elapsed values: compile=$compile_elapsed_ns execute=$execute_elapsed_ns" >&2
         return 1
     fi
+    if [[ "$jit_execute_elapsed_ns" != NA ]] && ! is_uint "$jit_execute_elapsed_ns"; then
+        echo "result row has invalid jit_execute_elapsed_ns: $jit_execute_elapsed_ns" >&2
+        return 1
+    fi
+    if is_uint "$jit_execute_elapsed_ns" && is_uint "$execute_elapsed_ns" \
+        && ((jit_execute_elapsed_ns > execute_elapsed_ns)); then
+        echo "result row JIT execution exceeds its complete execution interval" >&2
+        return 1
+    fi
     if is_uint "$reported_elapsed_ns" && is_uint "$compile_elapsed_ns" \
         && ((compile_elapsed_ns + execute_elapsed_ns > reported_elapsed_ns)); then
         echo "result row split elapsed values exceed its runner-reported total" >&2
@@ -214,6 +226,10 @@ validate_result_fields() {
             fi
             if is_uint "$execute_elapsed_ns" && ((execute_elapsed_ns != 0)); then
                 echo "compile-only result must have execute_elapsed_ns=0" >&2
+                return 1
+            fi
+            if is_uint "$jit_execute_elapsed_ns" && ((jit_execute_elapsed_ns != 0)); then
+                echo "compile-only result must have jit_execute_elapsed_ns=0" >&2
                 return 1
             fi
             ;;
@@ -248,6 +264,7 @@ parse_celox_result_marker() {
     CELOX_REPORTED_ELAPSED_NS="NA"
     CELOX_COMPILE_ELAPSED_NS="NA"
     CELOX_EXECUTE_ELAPSED_NS="NA"
+    CELOX_JIT_EXECUTE_ELAPSED_NS="NA"
     CELOX_RESULT_DIAGNOSTIC=""
     if [[ ! -f "$log" ]]; then
         CELOX_RESULT_DIAGNOSTIC="Celox log does not exist: $log"
@@ -287,11 +304,12 @@ parse_celox_timing_marker() {
     local log="$1"
     local expected_test="$2"
     local required="$3"
-    local line marker_count=0 marker_valid=0 marker_test="" compile_elapsed="" execute_elapsed=""
-    local pattern='^CELOX_TEST_TIMING test=([^[:space:]]+) compile_ns=([0-9]+) execute_ns=([0-9]+)( execute_cpu_ns=[0-9]+)?$'
+    local line marker_count=0 marker_valid=0 marker_test="" compile_elapsed="" execute_elapsed="" jit_execute_elapsed="NA"
+    local pattern='^CELOX_TEST_TIMING test=([^[:space:]]+) compile_ns=([0-9]+) execute_ns=([0-9]+)( jit_execute_ns=(NA|[0-9]+))?( execute_cpu_ns=[0-9]+)?$'
 
     CELOX_COMPILE_ELAPSED_NS="NA"
     CELOX_EXECUTE_ELAPSED_NS="NA"
+    CELOX_JIT_EXECUTE_ELAPSED_NS="NA"
     while IFS= read -r line || [[ -n "$line" ]]; do
         if [[ "$line" != CELOX_TEST_TIMING* ]]; then
             continue
@@ -302,6 +320,7 @@ parse_celox_timing_marker() {
             marker_test="${BASH_REMATCH[1]}"
             compile_elapsed="${BASH_REMATCH[2]}"
             execute_elapsed="${BASH_REMATCH[3]}"
+            jit_execute_elapsed="${BASH_REMATCH[5]:-NA}"
         fi
     done <"$log"
     if ((marker_count == 0)) && [[ "$required" == 0 ]]; then
@@ -317,6 +336,7 @@ parse_celox_timing_marker() {
     fi
     CELOX_COMPILE_ELAPSED_NS="$compile_elapsed"
     CELOX_EXECUTE_ELAPSED_NS="$execute_elapsed"
+    CELOX_JIT_EXECUTE_ELAPSED_NS="$jit_execute_elapsed"
 }
 
 # Check the marker independently against the process exit status and requested
@@ -595,15 +615,16 @@ append_result_row() {
     local reported_elapsed_ns="$9"
     local compile_elapsed_ns="${10}"
     local execute_elapsed_ns="${11}"
+    local jit_execute_elapsed_ns="${12}"
     validate_result_fields \
         "$runner" "$test" "$exit_status" "$elapsed_ns" "$log" \
         "$semantic_status" "$exit_status" "$process_elapsed_ns" "$reported_elapsed_ns" \
-        "$compile_elapsed_ns" "$execute_elapsed_ns" \
+        "$compile_elapsed_ns" "$execute_elapsed_ns" "$jit_execute_elapsed_ns" \
         || return 1
-    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
         "$runner" "$test" "$exit_status" "$elapsed_ns" "$log" \
         "$semantic_status" "$exit_status" "$process_elapsed_ns" "$reported_elapsed_ns" \
-        "$compile_elapsed_ns" "$execute_elapsed_ns" \
+        "$compile_elapsed_ns" "$execute_elapsed_ns" "$jit_execute_elapsed_ns" \
         | tee -a "$results_file"
 }
 
@@ -612,10 +633,10 @@ migrate_results_v1() {
     local backup_file="${results_file}.v1.bak"
     local temporary_file
     temporary_file="$(mktemp "${results_file}.migrate.XXXXXX")"
-    printf '%s\n' "$RESULTS_HEADER_V3" >"$temporary_file"
+    printf '%s\n' "$RESULTS_HEADER_V4" >"$temporary_file"
 
     local runner test legacy_status legacy_elapsed log extra
-    local semantic_status process_elapsed reported_elapsed compile_elapsed execute_elapsed full_elapsed
+    local semantic_status process_elapsed reported_elapsed compile_elapsed execute_elapsed jit_execute_elapsed full_elapsed
     while IFS=$'\t' read -r runner test legacy_status legacy_elapsed log extra; do
         if [[ -z "$runner$test$legacy_status$legacy_elapsed$log$extra" ]]; then
             continue
@@ -631,6 +652,7 @@ migrate_results_v1() {
         reported_elapsed="NA"
         compile_elapsed="NA"
         execute_elapsed="NA"
+        jit_execute_elapsed="NA"
         case "$runner" in
             celox*)
                 classify_legacy_celox_result "$log" "$test" "$legacy_status" || true
@@ -639,6 +661,7 @@ migrate_results_v1() {
                 if parse_celox_timing_marker "$log" "$test" 0; then
                     compile_elapsed="$CELOX_COMPILE_ELAPSED_NS"
                     execute_elapsed="$CELOX_EXECUTE_ELAPSED_NS"
+                    jit_execute_elapsed="$CELOX_JIT_EXECUTE_ELAPSED_NS"
                 fi
                 ;;
             veryl-*)
@@ -654,15 +677,15 @@ migrate_results_v1() {
         if ! validate_result_fields \
             "$runner" "$test" "$legacy_status" "$full_elapsed" "$log" \
             "$semantic_status" "$legacy_status" "$process_elapsed" "$reported_elapsed" \
-            "$compile_elapsed" "$execute_elapsed"; then
+            "$compile_elapsed" "$execute_elapsed" "$jit_execute_elapsed"; then
             rm -f "$temporary_file"
             echo "error: cannot migrate inconsistent v1 results row for runner=$runner test=$test" >&2
             return 1
         fi
-        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
             "$runner" "$test" "$legacy_status" "$full_elapsed" "$log" \
             "$semantic_status" "$legacy_status" "$process_elapsed" "$reported_elapsed" \
-            "$compile_elapsed" "$execute_elapsed" \
+            "$compile_elapsed" "$execute_elapsed" "$jit_execute_elapsed" \
             >>"$temporary_file"
     done < <(tail -n +2 "$results_file")
 
@@ -684,11 +707,11 @@ migrate_results_v2() {
     local backup_file="${results_file}.v2.bak"
     local temporary_file
     temporary_file="$(mktemp "${results_file}.migrate.XXXXXX")"
-    printf '%s\n' "$RESULTS_HEADER_V3" >"$temporary_file"
+    printf '%s\n' "$RESULTS_HEADER_V4" >"$temporary_file"
 
     local line_number=1
     local line normalized
-    local runner test legacy_status elapsed log semantic_status exit_status process_elapsed reported_elapsed compile_elapsed execute_elapsed extra
+    local runner test legacy_status elapsed log semantic_status exit_status process_elapsed reported_elapsed compile_elapsed execute_elapsed jit_execute_elapsed extra
     while IFS= read -r line || [[ -n "$line" ]]; do
         line_number=$((line_number + 1))
         if ! tsv_has_exact_field_count "$line" 9; then
@@ -700,11 +723,13 @@ migrate_results_v2() {
             <<<"$normalized"
         compile_elapsed=NA
         execute_elapsed=NA
+        jit_execute_elapsed=NA
         case "$runner" in
             celox*)
                 if parse_celox_timing_marker "$log" "$test" 0; then
                     compile_elapsed="$CELOX_COMPILE_ELAPSED_NS"
                     execute_elapsed="$CELOX_EXECUTE_ELAPSED_NS"
+                    jit_execute_elapsed="$CELOX_JIT_EXECUTE_ELAPSED_NS"
                 fi
                 ;;
             veryl-cc-sync)
@@ -717,15 +742,15 @@ migrate_results_v2() {
         if [[ -n "$extra" ]] || ! validate_result_fields \
             "$runner" "$test" "$legacy_status" "$elapsed" "$log" \
             "$semantic_status" "$exit_status" "$process_elapsed" "$reported_elapsed" \
-            "$compile_elapsed" "$execute_elapsed"; then
+            "$compile_elapsed" "$execute_elapsed" "$jit_execute_elapsed"; then
             echo "error: invalid v2 result row at $results_file:$line_number" >&2
             rm -f "$temporary_file"
             return 1
         fi
-        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
             "$runner" "$test" "$legacy_status" "$elapsed" "$log" \
             "$semantic_status" "$exit_status" "$process_elapsed" "$reported_elapsed" \
-            "$compile_elapsed" "$execute_elapsed" >>"$temporary_file"
+            "$compile_elapsed" "$execute_elapsed" "$jit_execute_elapsed" >>"$temporary_file"
     done < <(tail -n +2 "$results_file")
 
     if [[ ! -e "$backup_file" ]]; then
@@ -741,11 +766,16 @@ migrate_results_v2() {
     fi
 }
 
-validate_results_v3() {
+migrate_results_v3() {
     local results_file="$1"
+    local backup_file="${results_file}.v3.bak"
+    local temporary_file
+    temporary_file="$(mktemp "${results_file}.migrate.XXXXXX")"
+    printf '%s\n' "$RESULTS_HEADER_V4" >"$temporary_file"
+
     local line_number=1
     local line normalized
-    local runner test legacy_status elapsed log semantic_status exit_status process_elapsed reported_elapsed compile_elapsed execute_elapsed extra
+    local runner test legacy_status elapsed log semantic_status exit_status process_elapsed reported_elapsed compile_elapsed execute_elapsed jit_execute_elapsed extra
     while IFS= read -r line || [[ -n "$line" ]]; do
         line_number=$((line_number + 1))
         if ! tsv_has_exact_field_count "$line" 11; then
@@ -755,11 +785,53 @@ validate_results_v3() {
         normalized="${line//$'\t'/$'\x1f'}"
         IFS=$'\x1f' read -r runner test legacy_status elapsed log semantic_status exit_status process_elapsed reported_elapsed compile_elapsed execute_elapsed extra \
             <<<"$normalized"
+        jit_execute_elapsed=NA
+        if [[ "$runner" == celox* ]] && parse_celox_timing_marker "$log" "$test" 0; then
+            jit_execute_elapsed="$CELOX_JIT_EXECUTE_ELAPSED_NS"
+        fi
         if [[ -n "$extra" ]] || ! validate_result_fields \
             "$runner" "$test" "$legacy_status" "$elapsed" "$log" \
             "$semantic_status" "$exit_status" "$process_elapsed" "$reported_elapsed" \
-            "$compile_elapsed" "$execute_elapsed"; then
+            "$compile_elapsed" "$execute_elapsed" "$jit_execute_elapsed"; then
             echo "error: invalid v3 result row at $results_file:$line_number" >&2
+            rm -f "$temporary_file"
+            return 1
+        fi
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$runner" "$test" "$legacy_status" "$elapsed" "$log" \
+            "$semantic_status" "$exit_status" "$process_elapsed" "$reported_elapsed" \
+            "$compile_elapsed" "$execute_elapsed" "$jit_execute_elapsed" >>"$temporary_file"
+    done < <(tail -n +2 "$results_file")
+
+    if [[ ! -e "$backup_file" ]]; then
+        cp "$results_file" "$backup_file" || {
+            rm -f "$temporary_file"
+            return 1
+        }
+    fi
+    chmod --reference="$results_file" "$temporary_file" 2>/dev/null || true
+    mv "$temporary_file" "$results_file"
+}
+
+validate_results_v4() {
+    local results_file="$1"
+    local line_number=1
+    local line normalized
+    local runner test legacy_status elapsed log semantic_status exit_status process_elapsed reported_elapsed compile_elapsed execute_elapsed jit_execute_elapsed extra
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line_number=$((line_number + 1))
+        if ! tsv_has_exact_field_count "$line" 12; then
+            echo "error: invalid v4 field count at $results_file:$line_number" >&2
+            return 1
+        fi
+        normalized="${line//$'\t'/$'\x1f'}"
+        IFS=$'\x1f' read -r runner test legacy_status elapsed log semantic_status exit_status process_elapsed reported_elapsed compile_elapsed execute_elapsed jit_execute_elapsed extra \
+            <<<"$normalized"
+        if [[ -n "$extra" ]] || ! validate_result_fields \
+            "$runner" "$test" "$legacy_status" "$elapsed" "$log" \
+            "$semantic_status" "$exit_status" "$process_elapsed" "$reported_elapsed" \
+            "$compile_elapsed" "$execute_elapsed" "$jit_execute_elapsed"; then
+            echo "error: invalid v4 result row at $results_file:$line_number" >&2
             return 1
         fi
     done < <(tail -n +2 "$results_file")
@@ -768,16 +840,17 @@ validate_results_v3() {
 ensure_results_schema() {
     local results_file="$1"
     if [[ ! -e "$results_file" || ! -s "$results_file" ]]; then
-        printf '%s\n' "$RESULTS_HEADER_V3" >"$results_file"
+        printf '%s\n' "$RESULTS_HEADER_V4" >"$results_file"
         return
     fi
 
     local header
     IFS= read -r header <"$results_file" || true
     case "$header" in
-        "$RESULTS_HEADER_V3")
-            validate_results_v3 "$results_file"
+        "$RESULTS_HEADER_V4")
+            validate_results_v4 "$results_file"
             ;;
+        "$RESULTS_HEADER_V3") migrate_results_v3 "$results_file" ;;
         "$RESULTS_HEADER_V2") migrate_results_v2 "$results_file" ;;
         "$RESULTS_HEADER_V1") migrate_results_v1 "$results_file" ;;
         *)
@@ -928,8 +1001,8 @@ build_celox_runner() {
         target_dir_args=(--target-dir "$HELIODOR_CELOX_TARGET_DIR")
     fi
     if ! env -u CARGO_TARGET_DIR -u CARGO_BUILD_TARGET \
-        cargo build --manifest-path "$CELOX_ROOT/Cargo.toml" -p celox \
-        --example run_veryl_project_test --profile "$HELIODOR_CELOX_CARGO_PROFILE" --locked \
+        cargo build --manifest-path "$CELOX_ROOT/Cargo.toml" -p celox-bench \
+        --bin celox-heliodor --profile "$HELIODOR_CELOX_CARGO_PROFILE" --locked \
         "${target_dir_args[@]}" >"$log" 2>&1; then
         tail -n 80 "$log" >&2 || true
         return 1
@@ -956,8 +1029,8 @@ build_timed_veryl_runner() {
         target_dir_args=(--target-dir "$HELIODOR_CELOX_TARGET_DIR")
     fi
     if ! env -u CARGO_TARGET_DIR -u CARGO_BUILD_TARGET \
-        cargo build --manifest-path "$CELOX_ROOT/Cargo.toml" -p celox \
-        --example run_veryl_project_test_timed \
+        cargo build --manifest-path "$CELOX_ROOT/Cargo.toml" -p celox-bench \
+        --bin veryl-heliodor \
         --profile "$HELIODOR_CELOX_CARGO_PROFILE" --locked \
         "${target_dir_args[@]}" >"$log" 2>&1; then
         tail -n 80 "$log" >&2 || true
@@ -1100,7 +1173,7 @@ run_one() {
     local runner="$1"
     local test="$2"
     local stamp log process_status start end process_elapsed timeout_sec
-    local semantic_status reported_elapsed compile_elapsed execute_elapsed full_elapsed result_valid
+    local semantic_status reported_elapsed compile_elapsed execute_elapsed jit_execute_elapsed full_elapsed result_valid
     local veryl_aot_cache_dir=""
     local -a source_files celox_args timed_veryl_args
     collect_test_source_files "$test" source_files || return "$?"
@@ -1206,6 +1279,7 @@ run_one() {
     reported_elapsed="NA"
     compile_elapsed="NA"
     execute_elapsed="NA"
+    jit_execute_elapsed="NA"
     result_valid=1
     case "$runner" in
         celox*)
@@ -1215,11 +1289,13 @@ run_one() {
                 reported_elapsed="$CELOX_REPORTED_ELAPSED_NS"
                 compile_elapsed="$CELOX_COMPILE_ELAPSED_NS"
                 execute_elapsed="$CELOX_EXECUTE_ELAPSED_NS"
+                jit_execute_elapsed="$CELOX_JIT_EXECUTE_ELAPSED_NS"
             else
                 semantic_status="$CELOX_SEMANTIC_STATUS"
                 reported_elapsed="$CELOX_REPORTED_ELAPSED_NS"
                 compile_elapsed="$CELOX_COMPILE_ELAPSED_NS"
                 execute_elapsed="$CELOX_EXECUTE_ELAPSED_NS"
+                jit_execute_elapsed="$CELOX_JIT_EXECUTE_ELAPSED_NS"
                 result_valid=0
                 echo "error: $CELOX_RESULT_DIAGNOSTIC" >&2
             fi
@@ -1254,7 +1330,7 @@ run_one() {
     if ! append_result_row "$HELIODOR_RESULTS_DIR/results.tsv" \
         "$runner" "$test" "$process_status" "$full_elapsed" "$log" \
         "$semantic_status" "$process_elapsed" "$reported_elapsed" \
-        "$compile_elapsed" "$execute_elapsed"; then
+        "$compile_elapsed" "$execute_elapsed" "$jit_execute_elapsed"; then
         echo "error: refusing to append an invalid Heliodor result row" >&2
         return 1
     fi
@@ -1426,13 +1502,14 @@ validate_gate_results() {
     local results_file="$1"
     local invocation_dir="$2"
     local header row_count=0 canonical_invocation canonical_results canonical_log line normalized
-    local runner test legacy_status elapsed log semantic_status exit_status process_elapsed reported_elapsed compile_elapsed execute_elapsed extra
+    local runner test legacy_status elapsed log semantic_status exit_status process_elapsed reported_elapsed compile_elapsed execute_elapsed jit_execute_elapsed extra
     local expected_runner
 
     GATE_VERYL_COMPILE_NS=""
     GATE_VERYL_EXECUTE_NS=""
     GATE_CELOX_COMPILE_NS=""
     GATE_CELOX_EXECUTE_NS=""
+    GATE_CELOX_JIT_EXECUTE_NS=""
     if [[ ! -f "$results_file" ]]; then
         echo "error: gate result file does not exist: $results_file" >&2
         return 1
@@ -1450,7 +1527,7 @@ validate_gate_results() {
         return 1
     fi
     IFS= read -r header <"$results_file" || true
-    if [[ "$header" != "$RESULTS_HEADER_V3" ]]; then
+    if [[ "$header" != "$RESULTS_HEADER_V4" ]]; then
         echo "error: gate result file has the wrong schema" >&2
         return 1
     fi
@@ -1465,17 +1542,17 @@ validate_gate_results() {
                 return 1
                 ;;
         esac
-        if ! tsv_has_exact_field_count "$line" 11; then
-            echo "error: gate result row $row_count does not have exactly eleven fields" >&2
+        if ! tsv_has_exact_field_count "$line" 12; then
+            echo "error: gate result row $row_count does not have exactly twelve fields" >&2
             return 1
         fi
         normalized="${line//$'\t'/$'\x1f'}"
-        IFS=$'\x1f' read -r runner test legacy_status elapsed log semantic_status exit_status process_elapsed reported_elapsed compile_elapsed execute_elapsed extra \
+        IFS=$'\x1f' read -r runner test legacy_status elapsed log semantic_status exit_status process_elapsed reported_elapsed compile_elapsed execute_elapsed jit_execute_elapsed extra \
             <<<"$normalized"
         if [[ -n "$extra" ]] || ! validate_result_fields \
             "$runner" "$test" "$legacy_status" "$elapsed" "$log" \
             "$semantic_status" "$exit_status" "$process_elapsed" "$reported_elapsed" \
-            "$compile_elapsed" "$execute_elapsed"; then
+            "$compile_elapsed" "$execute_elapsed" "$jit_execute_elapsed"; then
             echo "error: invalid gate result row $row_count" >&2
             return 1
         fi
@@ -1507,6 +1584,10 @@ validate_gate_results() {
         fi
         case "$runner" in
             veryl-cc-sync)
+                [[ "$jit_execute_elapsed" == NA ]] || {
+                    echo "error: timed Veryl gate must not claim a Celox JIT interval" >&2
+                    return 1
+                }
                 validate_gate_timed_veryl_config "$log" "$GATE_TEST" || return "$?"
                 validate_gate_arch_completion "$log" veryl-cc-sync || return "$?"
                 classify_timed_veryl_result "$log" "$GATE_TEST" "$exit_status" || {
@@ -1542,12 +1623,14 @@ validate_gate_results() {
                     return 1
                 }
                 [[ "$compile_elapsed" == "$CELOX_COMPILE_ELAPSED_NS" \
-                    && "$execute_elapsed" == "$CELOX_EXECUTE_ELAPSED_NS" ]] || {
+                    && "$execute_elapsed" == "$CELOX_EXECUTE_ELAPSED_NS" \
+                    && "$jit_execute_elapsed" == "$CELOX_JIT_EXECUTE_ELAPSED_NS" ]] || {
                     echo "error: Celox gate row/report split timing values disagree" >&2
                     return 1
                 }
                 GATE_CELOX_COMPILE_NS="$compile_elapsed"
                 GATE_CELOX_EXECUTE_NS="$execute_elapsed"
+                GATE_CELOX_JIT_EXECUTE_NS="$jit_execute_elapsed"
                 ;;
         esac
     done < <(tail -n +2 "$results_file")
@@ -1558,8 +1641,13 @@ validate_gate_results() {
         echo "error: gate must produce exactly the paired timed Veryl and Celox rows" >&2
         return 1
     fi
-    if ((GATE_CELOX_EXECUTE_NS > GATE_VERYL_EXECUTE_NS)); then
-        echo "error: Heliodor execution gate failed: Celox ${GATE_CELOX_EXECUTE_NS}ns > Veryl ${GATE_VERYL_EXECUTE_NS}ns" >&2
+    if ! is_uint "$GATE_CELOX_JIT_EXECUTE_NS" || ((GATE_CELOX_JIT_EXECUTE_NS == 0)); then
+        echo "error: Celox gate must report a positive generated-JIT execution interval" >&2
+        return 1
+    fi
+    if ((GATE_CELOX_JIT_EXECUTE_NS > GATE_VERYL_EXECUTE_NS)); then
+        echo "error: Heliodor JIT execution gate failed: Celox ${GATE_CELOX_JIT_EXECUTE_NS}ns > Veryl ${GATE_VERYL_EXECUTE_NS}ns" >&2
+        echo "complete post-compile execution: Celox ${GATE_CELOX_EXECUTE_NS}ns" >&2
         echo "code generation (reported separately): Celox ${GATE_CELOX_COMPILE_NS}ns, Veryl ${GATE_VERYL_COMPILE_NS}ns" >&2
         return 1
     fi
@@ -1618,8 +1706,8 @@ run_gate() {
     invocation_dir="$(mktemp -d "$base_results_dir/gate_$(date -u +%Y%m%dT%H%M%SZ).XXXXXX")"
     HELIODOR_RESULTS_DIR="$invocation_dir"
     HELIODOR_CELOX_TARGET_DIR="$invocation_dir/celox-target"
-    CELOX_RUNNER_BIN="$HELIODOR_CELOX_TARGET_DIR/release/examples/run_veryl_project_test"
-    VERYL_TIMED_RUNNER_BIN="$HELIODOR_CELOX_TARGET_DIR/release/examples/run_veryl_project_test_timed"
+    CELOX_RUNNER_BIN="$HELIODOR_CELOX_TARGET_DIR/release/celox-heliodor"
+    VERYL_TIMED_RUNNER_BIN="$HELIODOR_CELOX_TARGET_DIR/release/veryl-heliodor"
     ensure_results_schema "$HELIODOR_RESULTS_DIR/results.tsv" || return "$?"
 
     build_celox_runner || return "$?"
@@ -1676,7 +1764,8 @@ run_gate() {
         echo "Heliodor gate: FAIL (artifacts: $invocation_dir)" >&2
         return 1
     fi
-    echo "Heliodor gate: PASS (execute: Celox ${GATE_CELOX_EXECUTE_NS}ns <= Veryl ${GATE_VERYL_EXECUTE_NS}ns)"
+    echo "Heliodor gate: PASS (JIT execute: Celox ${GATE_CELOX_JIT_EXECUTE_NS}ns <= Veryl ${GATE_VERYL_EXECUTE_NS}ns)"
+    echo "Complete post-compile execution: Celox ${GATE_CELOX_EXECUTE_NS}ns"
     echo "Code generation: Celox ${GATE_CELOX_COMPILE_NS}ns; Veryl ${GATE_VERYL_COMPILE_NS}ns"
     echo "Artifacts: $invocation_dir"
 }

--- a/scripts/tests/convert-heliodor-bench.sh
+++ b/scripts/tests/convert-heliodor-bench.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cat >"$TMP/results.tsv" <<'EOF'
+runner	test	status	elapsed_ns	log	semantic_status	exit_status	process_elapsed_ns	reported_elapsed_ns	compile_elapsed_ns	execute_elapsed_ns	jit_execute_elapsed_ns
+veryl-cc-sync	test_soc_linux_boot	0	900	veryl.log	pass	0	900	800	3000000	4000000	NA
+celox	test_soc_linux_boot	0	700	celox.log	pass	0	700	600	1000000	2500000	2000000
+EOF
+
+node "$ROOT/scripts/convert-heliodor-bench.mjs" \
+    "$TMP/results.tsv" "$TMP/results.json" >/dev/null
+node "$ROOT/scripts/convert-heliodor-bench.mjs" \
+    "$TMP/results.tsv" "$TMP/jit.json" --jit-only >/dev/null
+
+node -e '
+const fs = require("fs");
+const values = Object.fromEntries(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).map((x) => [x.name, x.value]));
+if (values["heliodor-celox-jit/heliodor_linux_boot_execution"] !== 2) process.exit(1);
+if (values["heliodor-celox-total/heliodor_linux_boot_execution"] !== 2.5) process.exit(1);
+if (values["heliodor-veryl/heliodor_linux_boot_execution"] !== 4) process.exit(1);
+' "$TMP/results.json"
+
+node -e '
+const fs = require("fs");
+const values = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+if (values.length !== 1 || values[0].name !== "heliodor-celox-jit/heliodor_linux_boot_execution") process.exit(1);
+' "$TMP/jit.json"
+
+echo "convert-heliodor-bench fixture test: PASS"

--- a/scripts/tests/run-heliodor-bench-gate.sh
+++ b/scripts/tests/run-heliodor-bench-gate.sh
@@ -30,6 +30,7 @@ write_valid_gate_logs() {
     local veryl_execute="${3:-40}"
     local celox_compile="${4:-10}"
     local celox_execute="${5:-20}"
+    local celox_jit_execute="${6:-$celox_execute}"
     local veryl_reported="$((veryl_compile + veryl_execute + 1))"
     local celox_reported="$((celox_compile + celox_execute + 1))"
     mkdir -p "$directory"
@@ -42,7 +43,7 @@ write_valid_gate_logs() {
     printf '%s\n%s\n%s\n%s\n' \
         "v4 SoC linux boot smoke: cy=9ae070 x3=aa pass=1" \
         "CELOX_TEST_CONFIG test=$GATE_TEST backend=native opt_level=O2 four_state=false compile_only=false" \
-        "CELOX_TEST_TIMING test=$GATE_TEST compile_ns=$celox_compile execute_ns=$celox_execute" \
+        "CELOX_TEST_TIMING test=$GATE_TEST compile_ns=$celox_compile execute_ns=$celox_execute jit_execute_ns=$celox_jit_execute" \
         "CELOX_TEST_RESULT test=$GATE_TEST status=pass elapsed_ns=$celox_reported" \
         >"$directory/celox.log"
 }
@@ -55,17 +56,18 @@ write_gate_results() {
     local veryl_execute="${5:-40}"
     local celox_compile="${6:-10}"
     local celox_execute="${7:-20}"
+    local celox_jit_execute="${8:-$celox_execute}"
     local veryl_reported="$((veryl_compile + veryl_execute + 1))"
     local celox_reported="$((celox_compile + celox_execute + 1))"
     write_valid_gate_logs "$directory" "$veryl_compile" "$veryl_execute" \
-        "$celox_compile" "$celox_execute"
-    printf '%s\n' "$RESULTS_HEADER_V3" >"$directory/results.tsv"
+        "$celox_compile" "$celox_execute" "$celox_jit_execute"
+    printf '%s\n' "$RESULTS_HEADER_V4" >"$directory/results.tsv"
     append_result_row "$directory/results.tsv" veryl-cc-sync "$GATE_TEST" 0 \
         "$veryl_elapsed" "$directory/veryl.log" pass "$veryl_elapsed" \
-        "$veryl_reported" "$veryl_compile" "$veryl_execute" >/dev/null
+        "$veryl_reported" "$veryl_compile" "$veryl_execute" NA >/dev/null
     append_result_row "$directory/results.tsv" celox "$GATE_TEST" 0 \
         "$celox_elapsed" "$directory/celox.log" pass "$celox_elapsed" \
-        "$celox_reported" "$celox_compile" "$celox_execute" >/dev/null
+        "$celox_reported" "$celox_compile" "$celox_execute" "$celox_jit_execute" >/dev/null
 }
 
 unit="$TMP/unit"
@@ -76,6 +78,7 @@ assert_eq "$GATE_VERYL_COMPILE_NS" 30 "Veryl gate compile interval"
 assert_eq "$GATE_VERYL_EXECUTE_NS" 40 "Veryl gate execute interval"
 assert_eq "$GATE_CELOX_COMPILE_NS" 10 "Celox gate compile interval"
 assert_eq "$GATE_CELOX_EXECUTE_NS" 20 "Celox gate execute interval"
+assert_eq "$GATE_CELOX_JIT_EXECUTE_NS" 20 "Celox gate JIT execute interval"
 
 trailing_empty="$TMP/trailing-empty"
 write_gate_results "$trailing_empty" 200 100
@@ -99,20 +102,25 @@ traversal="$TMP/traversal"
 outside="$TMP/outside"
 mkdir -p "$traversal" "$outside"
 write_valid_gate_logs "$outside"
-printf '%s\n' "$RESULTS_HEADER_V3" >"$traversal/results.tsv"
+printf '%s\n' "$RESULTS_HEADER_V4" >"$traversal/results.tsv"
 append_result_row "$traversal/results.tsv" veryl-cc-sync "$GATE_TEST" 0 200 \
-    "$traversal/../outside/veryl.log" pass 200 71 30 40 >/dev/null
+    "$traversal/../outside/veryl.log" pass 200 71 30 40 NA >/dev/null
 append_result_row "$traversal/results.tsv" celox "$GATE_TEST" 0 100 \
-    "$traversal/../outside/celox.log" pass 100 31 10 20 >/dev/null
+    "$traversal/../outside/celox.log" pass 100 31 10 20 20 >/dev/null
 if validate_gate_results "$traversal/results.tsv" "$traversal" 2>/dev/null; then
     fail "gate accepted path traversal to logs outside the invocation"
 fi
 
-slower_execute="$TMP/slower-execute"
-write_gate_results "$slower_execute" 200 100 30 40 10 41
-if validate_gate_results "$slower_execute/results.tsv" "$slower_execute" 2>/dev/null; then
-    fail "gate accepted slower Celox execution because its total process was faster"
+slower_jit="$TMP/slower-jit"
+write_gate_results "$slower_jit" 200 100 30 40 10 45 41
+if validate_gate_results "$slower_jit/results.tsv" "$slower_jit" 2>/dev/null; then
+    fail "gate accepted slower Celox generated-JIT execution"
 fi
+
+slower_harness="$TMP/slower-harness"
+write_gate_results "$slower_harness" 200 100 30 40 10 45 35
+validate_gate_results "$slower_harness/results.tsv" "$slower_harness" \
+    || fail "gate used testbench overhead instead of generated-JIT execution"
 
 slower_compile="$TMP/slower-compile"
 write_gate_results "$slower_compile" 200 100 30 40 50 20
@@ -127,11 +135,11 @@ fi
 
 reversed="$TMP/reversed"
 write_valid_gate_logs "$reversed"
-printf '%s\n' "$RESULTS_HEADER_V3" >"$reversed/results.tsv"
+printf '%s\n' "$RESULTS_HEADER_V4" >"$reversed/results.tsv"
 append_result_row "$reversed/results.tsv" celox "$GATE_TEST" 0 100 \
-    "$reversed/celox.log" pass 100 31 10 20 >/dev/null
+    "$reversed/celox.log" pass 100 31 10 20 20 >/dev/null
 append_result_row "$reversed/results.tsv" veryl-cc-sync "$GATE_TEST" 0 200 \
-    "$reversed/veryl.log" pass 200 71 30 40 >/dev/null
+    "$reversed/veryl.log" pass 200 71 30 40 NA >/dev/null
 if validate_gate_results "$reversed/results.tsv" "$reversed" 2>/dev/null; then
     fail "gate accepted reversed runner order"
 fi
@@ -139,7 +147,7 @@ fi
 extra="$TMP/extra"
 write_gate_results "$extra" 200 100
 append_result_row "$extra/results.tsv" celox "$GATE_TEST" 0 100 \
-    "$extra/celox.log" pass 100 31 10 20 >/dev/null
+    "$extra/celox.log" pass 100 31 10 20 20 >/dev/null
 if validate_gate_results "$extra/results.tsv" "$extra" 2>/dev/null; then
     fail "gate accepted an extra result row"
 fi
@@ -176,14 +184,14 @@ compile_only="$TMP/compile-only"
 write_valid_gate_logs "$compile_only"
 printf '%s\n%s\n%s\n' \
     "CELOX_TEST_CONFIG test=$GATE_TEST backend=native opt_level=O2 four_state=false compile_only=true" \
-    "CELOX_TEST_TIMING test=$GATE_TEST compile_ns=30 execute_ns=0" \
+    "CELOX_TEST_TIMING test=$GATE_TEST compile_ns=30 execute_ns=0 jit_execute_ns=0" \
     "CELOX_TEST_RESULT test=$GATE_TEST status=compile-only elapsed_ns=31" \
     >"$compile_only/celox.log"
-printf '%s\n' "$RESULTS_HEADER_V3" >"$compile_only/results.tsv"
+printf '%s\n' "$RESULTS_HEADER_V4" >"$compile_only/results.tsv"
 append_result_row "$compile_only/results.tsv" veryl-cc-sync "$GATE_TEST" 0 200 \
-    "$compile_only/veryl.log" pass 200 71 30 40 >/dev/null
+    "$compile_only/veryl.log" pass 200 71 30 40 NA >/dev/null
 append_result_row "$compile_only/results.tsv" celox "$GATE_TEST" 0 NA \
-    "$compile_only/celox.log" compile-only 100 31 30 0 >/dev/null
+    "$compile_only/celox.log" compile-only 100 31 30 0 0 >/dev/null
 if validate_gate_results "$compile_only/results.tsv" "$compile_only" 2>/dev/null; then
     fail "gate accepted compile-only Celox"
 fi
@@ -225,7 +233,7 @@ fi
 
 reported_mismatch="$TMP/reported-mismatch"
 write_gate_results "$reported_mismatch" 200 100
-sed -i $'s/\t31\t10\t20$/\t32\t10\t20/' "$reported_mismatch/results.tsv"
+sed -i $'s/\t31\t10\t20\t20$/\t32\t10\t20\t20/' "$reported_mismatch/results.tsv"
 if validate_gate_results "$reported_mismatch/results.tsv" "$reported_mismatch" 2>/dev/null; then
     fail "gate accepted a Celox row/log reported-time mismatch"
 fi
@@ -250,14 +258,14 @@ chmod +x "$mock_cargo_dir/cargo"
     export PATH="$mock_cargo_dir:$PATH"
     export CARGO_ARGS_LOG="$TMP/cargo-args"
     export CARGO_ENV_LOG="$TMP/cargo-env"
-    export MOCK_CARGO_RUNNER="$TMP/fixed-gate-target/release/examples/run_veryl_project_test"
+    export MOCK_CARGO_RUNNER="$TMP/fixed-gate-target/release/celox-heliodor"
     export CARGO_TARGET_DIR="$TMP/hostile-cargo-target"
     export CARGO_BUILD_TARGET=hostile-target-triple
     HELIODOR_RESULTS_DIR="$TMP/mock-build-results"
     HELIODOR_BUILD_CELOX_RUNNER=1
     HELIODOR_CELOX_TARGET_DIR="$TMP/fixed-gate-target"
     HELIODOR_CELOX_CARGO_PROFILE=release
-    CELOX_RUNNER_BIN="$TMP/fixed-gate-target/release/examples/run_veryl_project_test"
+    CELOX_RUNNER_BIN="$TMP/fixed-gate-target/release/celox-heliodor"
     build_celox_runner >/dev/null
 )
 target_arg_line="$(rg -n '^--target-dir$' "$TMP/cargo-args" | cut -d: -f1)"
@@ -265,6 +273,8 @@ target_arg_line="$(rg -n '^--target-dir$' "$TMP/cargo-args" | cut -d: -f1)"
 assert_eq "$(sed -n "$((target_arg_line + 1))p" "$TMP/cargo-args")" \
     "$TMP/fixed-gate-target" "explicit Cargo target directory argument"
 rg -qx -- '--locked' "$TMP/cargo-args" || fail "Celox build omitted --locked"
+rg -qx -- 'celox-bench' "$TMP/cargo-args" || fail "Celox build did not select celox-bench"
+rg -qx -- 'celox-heliodor' "$TMP/cargo-args" || fail "Celox build did not select celox-heliodor"
 assert_eq "$(sed -n '1p' "$TMP/cargo-env")" unset "CARGO_TARGET_DIR neutralization"
 assert_eq "$(sed -n '2p' "$TMP/cargo-env")" unset "CARGO_BUILD_TARGET neutralization"
 
@@ -369,7 +379,7 @@ CELOX_ROOT="$TMP/fake-celox"
 HELIODOR_DIR="$TMP/fake-heliodor"
 HELIODOR_RESULTS_DIR="$TMP/gate-results"
 HELIODOR_TOOLS_DIR="$TMP/fake-tools"
-mkdir -p "$CELOX_ROOT/target/release/examples" "$HELIODOR_DIR" "$HELIODOR_TOOLS_DIR"
+mkdir -p "$CELOX_ROOT/target/release" "$HELIODOR_DIR" "$HELIODOR_TOOLS_DIR"
 
 MOCK_RUNNERS=""
 MOCK_CELOX_ELAPSED=100
@@ -401,11 +411,11 @@ build_celox_runner() {
         "$HELIODOR_RESULTS_DIR/celox-target" \
         "fresh invocation-owned gate Cargo target directory"
     assert_eq "$CELOX_RUNNER_BIN" \
-        "$HELIODOR_CELOX_TARGET_DIR/release/examples/run_veryl_project_test" \
+        "$HELIODOR_CELOX_TARGET_DIR/release/celox-heliodor" \
         "gate executes the just-built target-dir artifact"
     [[ ! -e "$HELIODOR_CELOX_TARGET_DIR" ]] \
         || fail "gate Cargo target directory was not fresh"
-    [[ "$CELOX_RUNNER_BIN" != "$CELOX_ROOT/target/release/examples/run_veryl_project_test" ]] \
+    [[ "$CELOX_RUNNER_BIN" != "$CELOX_ROOT/target/release/celox-heliodor" ]] \
         || fail "gate selected a stale default-target runner"
     mkdir -p "$(dirname "$CELOX_RUNNER_BIN")"
     printf '%s\n' '#!/bin/sh' 'exit 0' >"$CELOX_RUNNER_BIN"
@@ -414,7 +424,7 @@ build_celox_runner() {
 
 build_timed_veryl_runner() {
     assert_eq "$VERYL_TIMED_RUNNER_BIN" \
-        "$HELIODOR_CELOX_TARGET_DIR/release/examples/run_veryl_project_test_timed" \
+        "$HELIODOR_CELOX_TARGET_DIR/release/veryl-heliodor" \
         "gate executes the just-built timed Veryl target-dir artifact"
     mkdir -p "$(dirname "$VERYL_TIMED_RUNNER_BIN")"
     printf '%s\n' '#!/bin/sh' 'exit 0' >"$VERYL_TIMED_RUNNER_BIN"
@@ -451,7 +461,7 @@ run_one() {
     local test="$2"
     local log="$HELIODOR_RESULTS_DIR/$runner.log"
     local process_status=0 semantic_status=pass elapsed reported=NA
-    local compile_elapsed=NA execute_elapsed=NA
+    local compile_elapsed=NA execute_elapsed=NA jit_execute_elapsed=NA
 
     assert_eq "$test" "$GATE_TEST" "fixed gate test"
     assert_eq "$HELIODOR_TESTS" "$GATE_TEST" "fixed test list"
@@ -483,6 +493,7 @@ run_one() {
             elapsed="$MOCK_CELOX_ELAPSED"
             compile_elapsed="$MOCK_CELOX_COMPILE"
             execute_elapsed="$MOCK_CELOX_EXECUTE"
+            jit_execute_elapsed="$MOCK_CELOX_EXECUTE"
             reported="$((compile_elapsed + execute_elapsed + 1))"
             if [[ "$MOCK_CELOX_STATUS" == fail ]]; then
                 process_status=1
@@ -492,7 +503,7 @@ run_one() {
             printf '%s\n%s\n%s\n%s\n' \
                 'v4 SoC linux boot smoke: cy=9ae070 x3=aa pass=1' \
                 "CELOX_TEST_CONFIG test=$GATE_TEST backend=native opt_level=O2 four_state=false compile_only=false" \
-                "CELOX_TEST_TIMING test=$GATE_TEST compile_ns=$compile_elapsed execute_ns=$execute_elapsed" \
+                "CELOX_TEST_TIMING test=$GATE_TEST compile_ns=$compile_elapsed execute_ns=$execute_elapsed jit_execute_ns=$jit_execute_elapsed" \
                 "CELOX_TEST_RESULT test=$GATE_TEST status=$MOCK_CELOX_STATUS elapsed_ns=$reported" >"$log"
             if [[ "$MOCK_MUTATE_SOURCE" == 1 ]]; then
                 : >"$HELIODOR_DIR/.fixture-mutated"
@@ -506,7 +517,8 @@ run_one() {
     MOCK_RUNNERS="${MOCK_RUNNERS:+$MOCK_RUNNERS }$runner"
     append_result_row "$HELIODOR_RESULTS_DIR/results.tsv" "$runner" "$test" \
         "$process_status" "$elapsed" "$log" "$semantic_status" \
-        "${elapsed/NA/100}" "$reported" "$compile_elapsed" "$execute_elapsed" >/dev/null
+        "${elapsed/NA/100}" "$reported" "$compile_elapsed" "$execute_elapsed" \
+        "$jit_execute_elapsed" >/dev/null
     [[ "$process_status" == 0 ]]
 }
 
@@ -515,10 +527,10 @@ run_gate_fixture() {
     local expect_success="$2"
     CELOX_ROOT="$TMP/fake-celox-$name"
     mkdir -p "$CELOX_ROOT"
-    mkdir -p "$CELOX_ROOT/target/release/examples"
+    mkdir -p "$CELOX_ROOT/target/release"
     printf '%s\n' '#!/bin/sh' 'echo stale runner; exit 9' \
-        >"$CELOX_ROOT/target/release/examples/run_veryl_project_test"
-    chmod +x "$CELOX_ROOT/target/release/examples/run_veryl_project_test"
+        >"$CELOX_ROOT/target/release/celox-heliodor"
+    chmod +x "$CELOX_ROOT/target/release/celox-heliodor"
     HELIODOR_DIR="$TMP/hostile-heliodor"
     HELIODOR_RESULTS_DIR="$TMP/hostile-results"
     HELIODOR_TOOLS_DIR="$TMP/hostile-tools"

--- a/scripts/tests/run-heliodor-bench-results.sh
+++ b/scripts/tests/run-heliodor-bench-results.sh
@@ -32,7 +32,7 @@ write_log() {
 pass_log="$TMP/pass.log"
 write_log "$pass_log" \
     'diagnostic before result' \
-    'CELOX_TEST_TIMING test=boot compile_ns=4 execute_ns=5' \
+    'CELOX_TEST_TIMING test=boot compile_ns=4 execute_ns=5 jit_execute_ns=4' \
     'CELOX_TEST_RESULT test=boot status=pass elapsed_ns=11'
 classify_celox_result "$pass_log" boot 0 0 \
     || fail "well-formed pass marker was rejected: $CELOX_RESULT_DIAGNOSTIC"
@@ -40,15 +40,17 @@ assert_eq "$CELOX_SEMANTIC_STATUS" pass "pass semantic status"
 assert_eq "$CELOX_REPORTED_ELAPSED_NS" 11 "pass reported elapsed"
 assert_eq "$CELOX_COMPILE_ELAPSED_NS" 4 "pass compile elapsed"
 assert_eq "$CELOX_EXECUTE_ELAPSED_NS" 5 "pass execute elapsed"
+assert_eq "$CELOX_JIT_EXECUTE_ELAPSED_NS" 4 "pass JIT execute elapsed"
 
 cpu_timed_log="$TMP/cpu-timed.log"
 write_log "$cpu_timed_log" \
-    'CELOX_TEST_TIMING test=boot_cpu compile_ns=6 execute_ns=7 execute_cpu_ns=8' \
+    'CELOX_TEST_TIMING test=boot_cpu compile_ns=6 execute_ns=7 jit_execute_ns=5 execute_cpu_ns=8' \
     'CELOX_TEST_RESULT test=boot_cpu status=pass elapsed_ns=15'
 classify_celox_result "$cpu_timed_log" boot_cpu 0 0 \
     || fail "timing marker with CPU time was rejected: $CELOX_RESULT_DIAGNOSTIC"
 assert_eq "$CELOX_COMPILE_ELAPSED_NS" 6 "CPU-timed compile elapsed"
 assert_eq "$CELOX_EXECUTE_ELAPSED_NS" 7 "CPU-timed execute elapsed"
+assert_eq "$CELOX_JIT_EXECUTE_ELAPSED_NS" 5 "CPU-timed JIT execute elapsed"
 
 timed_veryl_log="$TMP/timed-veryl.log"
 write_log "$timed_veryl_log" \
@@ -80,7 +82,7 @@ assert_eq "$CELOX_SEMANTIC_STATUS" invalid "missing timing semantic status"
 
 compile_log="$TMP/compile.log"
 write_log "$compile_log" \
-    'CELOX_TEST_TIMING test=boot_compile compile_ns=20 execute_ns=0' \
+    'CELOX_TEST_TIMING test=boot_compile compile_ns=20 execute_ns=0 jit_execute_ns=0' \
     'CELOX_TEST_RESULT test=boot_compile status=compile-only elapsed_ns=22'
 classify_celox_result "$compile_log" boot_compile 0 1 \
     || fail "well-formed compile-only marker was rejected: $CELOX_RESULT_DIAGNOSTIC"
@@ -90,7 +92,7 @@ assert_eq "$(full_pass_elapsed_ns "$CELOX_SEMANTIC_STATUS" 0 50)" NA \
 
 fail_log="$TMP/fail.log"
 write_log "$fail_log" \
-    'CELOX_TEST_TIMING test=boot_fail compile_ns=10 execute_ns=20' \
+    'CELOX_TEST_TIMING test=boot_fail compile_ns=10 execute_ns=20 jit_execute_ns=18' \
     'CELOX_TEST_RESULT test=boot_fail status=fail elapsed_ns=33'
 classify_celox_result "$fail_log" boot_fail 1 0 \
     || fail "well-formed fail marker was rejected: $CELOX_RESULT_DIAGNOSTIC"
@@ -167,25 +169,25 @@ ensure_results_schema "$results"
 cmp -s "$TMP/original-v1.tsv" "${results}.v1.bak" \
     || fail "v1 migration backup differs from the original"
 
-expected="$TMP/expected-v3.tsv"
+expected="$TMP/expected-v4.tsv"
 cat >"$expected" <<EOF
-$RESULTS_HEADER_V3
-celox	boot	0	100	$pass_log	pass	0	100	11	4	5
-celox	boot_compile	0	NA	$compile_log	compile-only	0	50	22	20	0
-celox	boot_timeout	124	NA	$missing_log	unreported	124	30	NA	NA	NA
-celox	boot_zero_unreported	0	NA	$missing_log	unreported	0	40	NA	NA	NA
-veryl-cc	boot	0	200	$TMP/veryl-pass.log	pass	0	200	NA	NA	NA
-veryl-cc	boot_fail	1	NA	$TMP/veryl-fail.log	fail	1	25	NA	NA	NA
+$RESULTS_HEADER_V4
+celox	boot	0	100	$pass_log	pass	0	100	11	4	5	4
+celox	boot_compile	0	NA	$compile_log	compile-only	0	50	22	20	0	0
+celox	boot_timeout	124	NA	$missing_log	unreported	124	30	NA	NA	NA	NA
+celox	boot_zero_unreported	0	NA	$missing_log	unreported	0	40	NA	NA	NA	NA
+veryl-cc	boot	0	200	$TMP/veryl-pass.log	pass	0	200	NA	NA	NA	NA
+veryl-cc	boot_fail	1	NA	$TMP/veryl-fail.log	fail	1	25	NA	NA	NA	NA
 EOF
 cmp -s "$expected" "$results" || {
     diff -u "$expected" "$results" >&2 || true
-    fail "migrated v3 results differ from expected"
+    fail "migrated v4 results differ from expected"
 }
 
 cp "$results" "$TMP/before-idempotent.tsv"
 ensure_results_schema "$results"
 cmp -s "$TMP/before-idempotent.tsv" "$results" \
-    || fail "ensuring an existing v3 schema is not idempotent"
+    || fail "ensuring an existing v4 schema is not idempotent"
 
 v2_results="$TMP/v2-results.tsv"
 printf '%s\n%s\n' "$RESULTS_HEADER_V2" \
@@ -193,42 +195,54 @@ printf '%s\n%s\n' "$RESULTS_HEADER_V2" \
     >"$v2_results"
 ensure_results_schema "$v2_results"
 [[ -f "${v2_results}.v2.bak" ]] || fail "v2 migration did not create a backup"
-assert_eq "$(sed -n '1p' "$v2_results")" "$RESULTS_HEADER_V3" "v2 migration header"
+assert_eq "$(sed -n '1p' "$v2_results")" "$RESULTS_HEADER_V4" "v2 migration header"
 assert_eq "$(awk -F '\t' 'NR == 2 { print $10 }' "$v2_results")" 4 \
     "v2 migration recovered compile elapsed"
 assert_eq "$(awk -F '\t' 'NR == 2 { print $11 }' "$v2_results")" 5 \
     "v2 migration recovered execute elapsed"
+assert_eq "$(awk -F '\t' 'NR == 2 { print $12 }' "$v2_results")" 4 \
+    "v2 migration recovered JIT execute elapsed"
+
+v3_results="$TMP/v3-results.tsv"
+printf '%s\n%s\n' "$RESULTS_HEADER_V3" \
+    $'celox\tboot\t0\t100\t'"$pass_log"$'\tpass\t0\t100\t11\t4\t5' \
+    >"$v3_results"
+ensure_results_schema "$v3_results"
+[[ -f "${v3_results}.v3.bak" ]] || fail "v3 migration did not create a backup"
+assert_eq "$(sed -n '1p' "$v3_results")" "$RESULTS_HEADER_V4" "v3 migration header"
+assert_eq "$(awk -F '\t' 'NR == 2 { print $12 }' "$v3_results")" 4 \
+    "v3 migration recovered JIT execute elapsed"
 
 new_results="$TMP/new-results.tsv"
 ensure_results_schema "$new_results"
-assert_eq "$(sed -n '1p' "$new_results")" "$RESULTS_HEADER_V3" "new results header"
+assert_eq "$(sed -n '1p' "$new_results")" "$RESULTS_HEADER_V4" "new results header"
 assert_eq "$(wc -l <"$new_results")" 1 "new results line count"
 
 append_result_row "$new_results" celox boot_compile 0 NA "$compile_log" \
-    compile-only 50 22 20 0 >/dev/null
-assert_eq "$(awk -F '\t' 'NR == 2 { print NF }' "$new_results")" 11 \
-    "appended v3 field count"
+    compile-only 50 22 20 0 0 >/dev/null
+assert_eq "$(awk -F '\t' 'NR == 2 { print NF }' "$new_results")" 12 \
+    "appended v4 field count"
 assert_eq "$(awk -F '\t' 'NR == 2 { print $4 }' "$new_results")" NA \
     "compile-only appended speed elapsed"
 before_invalid_append="$(wc -l <"$new_results")"
 if append_result_row "$new_results" celox impossible 0 1 "$compile_log" \
-    compile-only 1 1 1 0 >/dev/null 2>&1; then
+    compile-only 1 1 1 0 0 >/dev/null 2>&1; then
     fail "append accepted compile-only with a numeric speed elapsed"
 fi
 assert_eq "$(wc -l <"$new_results")" "$before_invalid_append" \
     "invalid append changed the results file"
 
 bad_results="$TMP/bad-results.tsv"
-printf '%s\n%s\n' "$RESULTS_HEADER_V3" $'celox\tboot\t0\t100\tlog' >"$bad_results"
+printf '%s\n%s\n' "$RESULTS_HEADER_V4" $'celox\tboot\t0\t100\tlog' >"$bad_results"
 if ensure_results_schema "$bad_results" 2>/dev/null; then
-    fail "v3 header with a legacy-width row was accepted"
+    fail "v4 header with a legacy-width row was accepted"
 fi
 
 bad_semantics="$TMP/bad-semantics.tsv"
-printf '%s\n%s\n' "$RESULTS_HEADER_V3" \
-    $'celox\tboot\t0\t100\tlog\tcompile-only\t0\t100\t50\t40\t0' >"$bad_semantics"
+printf '%s\n%s\n' "$RESULTS_HEADER_V4" \
+    $'celox\tboot\t0\t100\tlog\tcompile-only\t0\t100\t50\t40\t0\t0' >"$bad_semantics"
 if ensure_results_schema "$bad_semantics" 2>/dev/null; then
-    fail "v3 compile-only row with a numeric speed elapsed was accepted"
+    fail "v4 compile-only row with a numeric speed elapsed was accepted"
 fi
 
 # Exercise run_one without Heliodor or either compiler. These overrides emit
@@ -272,7 +286,7 @@ run_in_heliodor() {
 
 ensure_results_schema "$integration_results/results.tsv"
 HELIODOR_CELOX_COMPILE_ONLY=0
-FIXTURE_RESULT_LINE=$'CELOX_TEST_TIMING test=integration_pass compile_ns=20 execute_ns=30\nCELOX_TEST_RESULT test=integration_pass status=pass elapsed_ns=71'
+FIXTURE_RESULT_LINE=$'CELOX_TEST_TIMING test=integration_pass compile_ns=20 execute_ns=30 jit_execute_ns=25\nCELOX_TEST_RESULT test=integration_pass status=pass elapsed_ns=71'
 run_one celox integration_pass >/dev/null \
     || fail "run_one rejected a fixture full pass"
 assert_eq "$(awk -F '\t' 'NR == 2 { print $6 }' "$integration_results/results.tsv")" pass \
@@ -283,9 +297,11 @@ assert_eq "$(awk -F '\t' 'NR == 2 { print $10 }' "$integration_results/results.t
     "run_one pass compile elapsed"
 assert_eq "$(awk -F '\t' 'NR == 2 { print $11 }' "$integration_results/results.tsv")" 30 \
     "run_one pass execute elapsed"
+assert_eq "$(awk -F '\t' 'NR == 2 { print $12 }' "$integration_results/results.tsv")" 25 \
+    "run_one pass JIT execute elapsed"
 
 HELIODOR_CELOX_COMPILE_ONLY=1
-FIXTURE_RESULT_LINE=$'CELOX_TEST_TIMING test=integration_compile compile_ns=70 execute_ns=0\nCELOX_TEST_RESULT test=integration_compile status=compile-only elapsed_ns=72'
+FIXTURE_RESULT_LINE=$'CELOX_TEST_TIMING test=integration_compile compile_ns=70 execute_ns=0 jit_execute_ns=0\nCELOX_TEST_RESULT test=integration_compile status=compile-only elapsed_ns=72'
 run_one celox integration_compile >/dev/null \
     || fail "run_one rejected a fixture compile-only completion"
 assert_eq "$(awk -F '\t' 'NR == 3 { print $6 }' "$integration_results/results.tsv")" \
@@ -295,7 +311,7 @@ assert_eq "$(awk -F '\t' 'NR == 3 { print $4 }' "$integration_results/results.ts
 
 HELIODOR_CELOX_COMPILE_ONLY=0
 FIXTURE_EXIT_STATUS=1
-FIXTURE_RESULT_LINE=$'CELOX_TEST_TIMING test=integration_fail compile_ns=20 execute_ns=30\nCELOX_TEST_RESULT test=integration_fail status=fail elapsed_ns=73'
+FIXTURE_RESULT_LINE=$'CELOX_TEST_TIMING test=integration_fail compile_ns=20 execute_ns=30 jit_execute_ns=25\nCELOX_TEST_RESULT test=integration_fail status=fail elapsed_ns=73'
 if run_one celox integration_fail >/dev/null 2>&1; then
     fail "run_one returned success for a semantic test failure"
 fi


### PR DESCRIPTION
## Summary

- move the Heliodor runners out of public examples into a dedicated `celox-bench` workspace crate with Clap-based CLIs
- add opt-in native backend timing that accumulates only generated JIT function execution at host batch boundaries
- extend Heliodor results to TSV v4 and make the fixed performance gate use `jit_execute_elapsed_ns`
- publish Celox JIT, post-codegen total, compile, and Veryl reference metrics to the benchmark dashboard
- add a Heliodor Linux dashboard tab and a GitHub Actions workflow that rejects pull-request JIT regressions above 10%

## Motivation

The previous `execute_ns` interval excluded compilation but still included testbench scheduling and runtime event handling. That made it impossible to distinguish generated-code regressions from harness overhead. The benchmark runners also lived as public API examples despite being repository-owned performance infrastructure.

This change introduces a nested generated-JIT interval while preserving the enclosing execution and compile intervals for diagnosis. Normal simulation does not read the clock unless timing is explicitly enabled, and native tick loops are timed once per host batch rather than once per simulated tick.

## CI behavior

The pinned full Heliodor Linux workload still validates exact architectural completion and compares Celox against synchronous Veryl-CC. On `master`, all five metrics are stored under `dev/bench` and displayed on `/benchmarks/`. On pull requests, only the Celox generated-JIT metric participates in the historical 10% regression check, so compiler latency and testbench overhead do not spuriously fail the code-quality gate.

## Validation

- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked -p celox --lib -- -D warnings`
- `cargo clippy --locked -p celox-bench --bins -- -D warnings`
- `cargo test --locked -p celox --test native_exec` (17 passed)
- `bash scripts/tests/run-heliodor-bench-results.sh`
- `bash scripts/tests/run-heliodor-bench-gate.sh`
- `bash scripts/tests/convert-heliodor-bench.sh`
- VitePress production build
- Heliodor native one-tick smoke: `execute_ns=114029`, `jit_execute_ns=81522`
- repository pre-push hook

The full clean release/LTO Heliodor gate is intentionally left to the new CI job because the local gate requires a clean committed checkout and produces the long-running qualification result.