### PR TITLE
fix(hooks): allow uninitialized submodules

### DIFF
--- a/scripts/check-submodules.sh
+++ b/scripts/check-submodules.sh
@@ -12,10 +12,7 @@ while IFS= read -r line; do
     " ")
       ;; # OK — initialized and in sync
     -)
-      echo "ERROR: Submodule not initialized:$detail" >&2
-      echo "  Run: git submodule update --init" >&2
-      errors=1
-      ;;
+      ;; # OK — uninitialized submodules do not need validation
     +)
       echo "ERROR: Submodule out of sync with index:$detail" >&2
       echo "  Run: git submodule update  (or 'git add' if the change is intentional)" >&2
@@ -39,4 +36,4 @@ git submodule foreach --quiet '
   fi
 '
 
-echo "Submodules OK: initialized, in sync, and referenceable."
+echo "Submodules OK: initialized submodules are in sync and referenceable."


### PR DESCRIPTION
## What changed

Allow uninitialized submodules to pass the pre-push submodule check.

Initialized submodules are still checked for index mismatches, merge conflicts, and commits that are not available from a remote branch.

## Why

The hook treated an intentionally uninitialized submodule as an error and required every worktree to run `git submodule update --init` before pushing, even when the change did not use the submodule.

## Validation

- `bash -n scripts/check-submodules.sh`
- Ran the script successfully in a worktree with `examples/template` uninitialized
- Ran the script successfully against an initialized submodule checkout
- Completed the full pre-push hook without initializing the submodule: submodule check, `cargo fmt`, Biome, `cargo check`, clean-tree