### PR TITLE
fix(ci): skip product tests for release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
+    env:
+      RELEASE_PLEASE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'celox-release-please[bot]' && github.head_ref == 'release-please--branches--master--components--celox' }}
     outputs:
       docs: ${{ steps.classify.outputs.docs }}
       javascript: ${{ steps.classify.outputs.javascript }}
@@ -38,6 +40,10 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
         run: node scripts/ci-changes.mjs "$BASE_SHA" "$HEAD_SHA"
+
+      - name: Validate release version
+        if: env.RELEASE_PLEASE_PR == 'true'
+        run: node scripts/check-release-version.mjs
 
   docs:
     name: Docs Build

--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -39,6 +39,9 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install --yes ripgrep
+
       - name: Run fixed Heliodor correctness and performance gate
         id: gate
         shell: bash

--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -39,9 +39,6 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install --yes ripgrep
-
       - name: Run fixed Heliodor correctness and performance gate
         id: gate
         shell: bash

--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -10,6 +10,7 @@ on:
       - "Cargo.lock"
       - "Cargo.toml"
       - "crates/**"
+      - "!crates/celox-napi/package.json"
       - "scripts/convert-heliodor-bench.mjs"
       - "scripts/run-heliodor-bench.sh"
   workflow_dispatch:

--- a/scripts/ci-changes.mjs
+++ b/scripts/ci-changes.mjs
@@ -24,11 +24,20 @@ const NEUTRAL_FILES = new Set([
   "renovate.json",
 ]);
 
+const RELEASE_PLEASE_FILES = new Set([
+  ".release-please-manifest.json",
+  "CHANGELOG.md",
+  "VERSION",
+  "crates/celox-napi/package.json",
+  "packages/celox/package.json",
+  "packages/vite-plugin/package.json",
+]);
+
 function startsWithAny(path, prefixes) {
   return prefixes.some((prefix) => path.startsWith(prefix));
 }
 
-export function classifyFiles(files) {
+export function classifyFiles(files, { releasePlease = false } = {}) {
   const affected = {
     docs: false,
     javascript: false,
@@ -38,9 +47,16 @@ export function classifyFiles(files) {
     scripts: false,
   };
 
-  for (const rawPath of files) {
-    const path = rawPath.replace(/^\.\//, "");
+  const normalizedFiles = files.map((path) => path.replace(/^\.\//, ""));
+  if (
+    releasePlease &&
+    normalizedFiles.length > 0 &&
+    normalizedFiles.every((path) => RELEASE_PLEASE_FILES.has(path))
+  ) {
+    return affected;
+  }
 
+  for (const path of normalizedFiles) {
     if (
       path === ".github/workflows/ci.yml" ||
       startsWithAny(path, [".github/actions/", "scripts/ci-changes."])
@@ -152,5 +168,11 @@ if (
   import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
   const files = changedFiles(process.argv[2] ?? "", process.argv[3] ?? "");
-  writeOutputs(files === null ? ALL_AFFECTED : classifyFiles(files));
+  writeOutputs(
+    files === null
+      ? ALL_AFFECTED
+      : classifyFiles(files, {
+          releasePlease: process.env.RELEASE_PLEASE_PR === "true",
+        }),
+  );
 }

--- a/scripts/ci-changes.test.mjs
+++ b/scripts/ci-changes.test.mjs
@@ -51,16 +51,36 @@ test("release and repository metadata do not run product tests", () => {
   );
 });
 
-test("release package versions skip Rust tests and ARM64 builds", () => {
+const releaseFiles = [
+  ".release-please-manifest.json",
+  "CHANGELOG.md",
+  "VERSION",
+  "crates/celox-napi/package.json",
+  "packages/celox/package.json",
+  "packages/vite-plugin/package.json",
+];
+
+test("ordinary package version changes exercise JavaScript and NAPI", () => {
   assert.deepEqual(
-    classifyFiles([
-      ".release-please-manifest.json",
-      "CHANGELOG.md",
-      "VERSION",
-      "crates/celox-napi/package.json",
-      "packages/celox/package.json",
-      "packages/vite-plugin/package.json",
-    ]),
+    classifyFiles(releaseFiles),
+    {
+      ...none,
+      docs: true,
+      javascript: true,
+      napi: true,
+    },
+  );
+});
+
+test("Release Please version updates skip product validation", () => {
+  assert.deepEqual(classifyFiles(releaseFiles, { releasePlease: true }), none);
+});
+
+test("Release Please source changes still exercise affected products", () => {
+  assert.deepEqual(
+    classifyFiles([...releaseFiles, "packages/celox/src/index.ts"], {
+      releasePlease: true,
+    }),
     {
       ...none,
       docs: true,


### PR DESCRIPTION
## Summary

- recognize Release Please bot PRs that only update generated release metadata
- skip product builds and tests for those release-only changes
- run the existing release version consistency check instead
- prevent `crates/celox-napi/package.json` version bumps from triggering the Heliodor benchmark
- preserve existing CI behavior for ordinary package changes and unexpected source changes

## Why

Release PR #369 only changes generated version and changelog files, but package manifests were classified as JavaScript, docs, and NAPI changes. The broad `crates/**` Heliodor path filter also matched the NAPI package manifest, causing unrelated and expensive validation.

## Validation

- `node --test scripts/*.test.mjs`
- `node scripts/check-release-version.mjs`
- parsed the modified workflow YAML files
- verified PR #369's actual base/head diff produces all `false` product categories as a Release Please PR
- verified the same diff retains the previous Docs/JS/NAPI classification outside Release Please
- pre-push hook: submodule check, cargo fmt, Biome, cargo check, clean tree