### PR TITLE
fix(ci): remove Heliodor ripgrep dependency

### DIFF
--- a/scripts/run-heliodor-bench.sh
+++ b/scripts/run-heliodor-bench.sh
@@ -958,8 +958,8 @@ install_veryl() {
 
 list_tests() {
     prepare >/dev/null
-    rg -n '^\s*#\[test\(' "$HELIODOR_DIR/tb" --glob '*.veryl' \
-        | sed -E 's/.*#\[test\(([^)]*)\)\].*/\1/' \
+    find "$HELIODOR_DIR/tb" -type f -name '*.veryl' \
+        -exec sed -nE 's/^[[:space:]]*#\[test\(([^)]*)\)\].*/\1/p' {} + \
         | sort
 }
 
@@ -1044,14 +1044,26 @@ build_timed_veryl_runner() {
 
 test_source_files() {
     local test="$1"
-    local tb_output tb_file source_output relative_tb
-    local -a tb_files=()
-    if ! tb_output="$(rg -l "^\\s*#\\[test\\(${test}\\)\\]" \
-        "$HELIODOR_DIR/tb" --glob '*.veryl')"; then
-        echo "error: could not find #[test($test)] under $HELIODOR_DIR/tb" >&2
+    local tb_output tb_file source_output relative_tb grep_status
+    local -a tb_candidates=() tb_files=()
+    if ! tb_output="$(find "$HELIODOR_DIR/tb" -type f -name '*.veryl' -print)"; then
+        echo "error: could not enumerate test sources under $HELIODOR_DIR/tb" >&2
         return 1
     fi
-    mapfile -t tb_files <<<"$tb_output"
+    if [[ -n "$tb_output" ]]; then
+        mapfile -t tb_candidates <<<"$tb_output"
+    fi
+    for tb_file in "${tb_candidates[@]}"; do
+        if grep -Eq "^[[:space:]]*#\\[test\\(${test}\\)\\]" "$tb_file"; then
+            tb_files+=("$tb_file")
+        else
+            grep_status=$?
+            if ((grep_status != 1)); then
+                echo "error: could not inspect test source $tb_file" >&2
+                return 1
+            fi
+        fi
+    done
     if ((${#tb_files[@]} != 1)) || [[ -z "${tb_files[0]}" ]]; then
         echo "error: expected exactly one #[test($test)] file, found ${#tb_files[@]}" >&2
         return 1

--- a/scripts/tests/run-heliodor-bench-gate.sh
+++ b/scripts/tests/run-heliodor-bench-gate.sh
@@ -268,13 +268,13 @@ chmod +x "$mock_cargo_dir/cargo"
     CELOX_RUNNER_BIN="$TMP/fixed-gate-target/release/celox-heliodor"
     build_celox_runner >/dev/null
 )
-target_arg_line="$(rg -n '^--target-dir$' "$TMP/cargo-args" | cut -d: -f1)"
+target_arg_line="$(grep -n -x -- '--target-dir' "$TMP/cargo-args" | cut -d: -f1)"
 [[ -n "$target_arg_line" ]] || fail "Celox build omitted --target-dir"
 assert_eq "$(sed -n "$((target_arg_line + 1))p" "$TMP/cargo-args")" \
     "$TMP/fixed-gate-target" "explicit Cargo target directory argument"
-rg -qx -- '--locked' "$TMP/cargo-args" || fail "Celox build omitted --locked"
-rg -qx -- 'celox-bench' "$TMP/cargo-args" || fail "Celox build did not select celox-bench"
-rg -qx -- 'celox-heliodor' "$TMP/cargo-args" || fail "Celox build did not select celox-heliodor"
+grep -qx -- '--locked' "$TMP/cargo-args" || fail "Celox build omitted --locked"
+grep -qx -- 'celox-bench' "$TMP/cargo-args" || fail "Celox build did not select celox-bench"
+grep -qx -- 'celox-heliodor' "$TMP/cargo-args" || fail "Celox build did not select celox-heliodor"
 assert_eq "$(sed -n '1p' "$TMP/cargo-env")" unset "CARGO_TARGET_DIR neutralization"
 assert_eq "$(sed -n '2p' "$TMP/cargo-env")" unset "CARGO_BUILD_TARGET neutralization"
 
@@ -321,6 +321,14 @@ assert_eq "$(sed -n '2p' "$TMP/cargo-env")" unset "CARGO_BUILD_TARGET neutraliza
     if test_source_files "$GATE_TEST" >/dev/null 2>&1; then
         fail "test_source_files hid a find pipeline failure"
     fi
+    PATH="$saved_path"
+    mkdir -p "$TMP/failing-rg"
+    printf '%s\n' '#!/bin/sh' 'exit 127' >"$TMP/failing-rg/rg"
+    chmod +x "$TMP/failing-rg/rg"
+    PATH="$TMP/failing-rg:$PATH"
+    assert_eq "$(test_source_files "$GATE_TEST")" \
+        $'src/dummy.veryl\ntb/test.veryl' \
+        "source enumeration without ripgrep"
     PATH="$saved_path"
     mkdir -p "$HELIODOR_DIR/tb/duplicate"
     printf '%s\n' '#[test(test_soc_linux_boot)]' \


### PR DESCRIPTION
## Summary

- replace the Heliodor benchmark harness's `rg`-based test discovery with standard `find`, `grep`, and `sed`
- add a regression fixture proving source discovery works when `rg` is unavailable
- remove `rg` usage from the related fixture assertions

## Root cause

The GitHub Actions Ubuntu runner does not include ripgrep. The fixed gate called `rg` while enumerating `#[test(...)]` declarations, so both runner manifests were empty and the dashboard conversion found zero Celox rows.

Original failing job: https://github.com/celox-sim/celox/actions/runs/30703900536/job/91379551968

The completed post-merge Heliodor run exposed a separate optimization-level argument mismatch, fixed in #382.

## Impact

The Heliodor gate now discovers tests using tools available on the standard Ubuntu runner.

## Validation

- `bash -n` on the benchmark and fixture scripts
- `shellcheck` with existing repository diagnostics excluded
- `bash scripts/tests/run-heliodor-bench-gate.sh`
- `bash scripts/tests/run-heliodor-bench-results.sh`
- `bash scripts/tests/convert-heliodor-bench.sh`
- pre-push hook: submodule check, Cargo formatting, Biome, `cargo check`, and clean-tree