### PR TITLE
fix(regalloc): preserve edge reconstruction pressure

### DIFF
--- a/crates/celox-backend-x86/src/backend/native/regalloc/home_verify.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/home_verify.rs
@@ -189,8 +189,14 @@ fn verify_with_work(
             predecessor: func.blocks[predecessor].id,
             successor: func.blocks[successor].id,
         };
-        for &operation in operations {
-            verify_edge_operation_home(func, plan, operation, location)?;
+        for (index, &operation) in operations.iter().enumerate() {
+            verify_edge_operation_home(
+                func,
+                plan,
+                operation,
+                location,
+                super::spill_plan::edge_reload_uses_transferred_home(operations, index),
+            )?;
             match operation {
                 PlannedEdgeOp::Reload { source_home, .. } => {
                     universe.insert(source_home);
@@ -905,6 +911,7 @@ fn verify_edge_operation_home(
     plan: &SpillPlan,
     operation: PlannedEdgeOp,
     location: HomeLocation,
+    transferred_home: bool,
 ) -> Result<(), HomeVerifyError> {
     let (source, destination, home, expected) = match operation {
         PlannedEdgeOp::Reload {
@@ -937,7 +944,7 @@ fn verify_edge_operation_home(
             message: "edge operation value is outside the original VReg domain".into(),
         });
     }
-    if home != expected {
+    if home != expected && !transferred_home {
         return Err(HomeVerifyError {
             rule: "HOME.CLASS_MISMATCH",
             location: Some(location),

--- a/crates/celox-backend-x86/src/backend/native/regalloc/pressure.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/pressure.rs
@@ -16,6 +16,7 @@ pub(super) struct PressureError {
     pub capacity: usize,
     pub reason: &'static str,
     pub instruction_text: String,
+    pub values: Vec<VReg>,
 }
 
 impl fmt::Display for PressureError {
@@ -50,6 +51,7 @@ pub(super) fn verify(
             registers,
             "edge",
             "block exit".into(),
+            live_after.iter().copied(),
         )?;
         for (instruction, inst) in block.insts.iter().enumerate().rev() {
             let mut live_before = live_after.clone();
@@ -64,6 +66,7 @@ pub(super) fn verify(
                 registers,
                 "general-register",
                 inst.to_string(),
+                live_before.iter().copied(),
             )?;
 
             let fixed = inst
@@ -86,6 +89,7 @@ pub(super) fn verify(
                     registers - fixed.len(),
                     "fixed-register reservation",
                     inst.to_string(),
+                    live_before.difference(&fixed).copied(),
                 )?;
             }
 
@@ -99,6 +103,7 @@ pub(super) fn verify(
                     registers - clobbered,
                     "clobber reservation",
                     inst.to_string(),
+                    live_before.intersection(&live_after).copied(),
                 )?;
             }
             live_after = live_before;
@@ -114,6 +119,7 @@ fn check(
     capacity: usize,
     reason: &'static str,
     instruction_text: String,
+    values: impl IntoIterator<Item = VReg>,
 ) -> Result<(), PressureError> {
     if pressure <= capacity {
         Ok(())
@@ -125,6 +131,7 @@ fn check(
             capacity,
             reason,
             instruction_text,
+            values: values.into_iter().collect(),
         })
     }
 }

--- a/crates/celox-backend-x86/src/backend/native/regalloc/reconstruct.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/reconstruct.rs
@@ -273,8 +273,17 @@ pub(super) fn reconstruct(
         };
         let mut reloads_only = true;
         let mut recipe_cache = PreparedRecipeCache::default();
+        let cache_scope_end = edge_home_transfer_end(operations);
         let mut operation_index = 0usize;
         while operation_index < operations.len() {
+            if cache_scope_end == Some(operation_index) {
+                // W/S deliberately completes every reload/store home transfer
+                // before it restores successor residents. A recipe prefix
+                // retained across that boundary is an unplanned live value
+                // during the resident phase, so the two phases have distinct
+                // reconstruction caches.
+                recipe_cache = PreparedRecipeCache::default();
+            }
             let operation = operations[operation_index];
             if let PlannedEdgeOp::Reload {
                 source,
@@ -487,6 +496,29 @@ pub(super) fn reconstruct(
         state_reloads,
         shared_reload_blocks,
     })
+}
+
+fn edge_home_transfer_end(operations: &[PlannedEdgeOp]) -> Option<usize> {
+    let mut index = 0usize;
+    while matches!(operations.get(index), Some(PlannedEdgeOp::Spill { .. })) {
+        index += 1;
+    }
+    let transfer_start = index;
+    while let (
+        Some(PlannedEdgeOp::Reload { destination, .. }),
+        Some(PlannedEdgeOp::Spill {
+            source,
+            destination: spill_destination,
+            ..
+        }),
+    ) = (operations.get(index), operations.get(index + 1))
+    {
+        if source != destination || spill_destination != destination {
+            break;
+        }
+        index += 2;
+    }
+    (index > transfer_start).then_some(index)
 }
 
 fn available_recipe_at_point(
@@ -2105,6 +2137,170 @@ mod tests {
         assert_eq!(second.instructions.len(), 1);
         assert_ne!(first_result, second_result);
         assert_eq!(second.instructions[0].def(), Some(second_result));
+    }
+
+    #[test]
+    fn edge_recipe_cache_does_not_cross_the_home_transfer_phase() {
+        fn fixture(reset_cache: bool) -> MFunction {
+            let mut vregs = VRegAllocator::new();
+            let residents = (0..13).map(|_| vregs.alloc()).collect::<Vec<_>>();
+            let transfer_a = vregs.alloc();
+            let transfer_b = vregs.alloc();
+            let resident_a = vregs.alloc();
+            let resident_b = vregs.alloc();
+            let transient = vregs.alloc();
+            let mut func = MFunction::new(vregs, vec![SpillDesc::transient(); 18]);
+            let mut logical_for_vreg = (0..18).map(LogicalValue).collect::<Vec<_>>();
+            let mut cache = PreparedRecipeCache::default();
+            let recipe = |base, immediate| ResolvedRecipe {
+                base: ResolvedBase::Constant(base),
+                steps: vec![PureStep::CmpImm64 {
+                    immediate,
+                    kind: crate::native::mir::CmpKind::Eq,
+                }],
+            };
+            let (transfer_a_result, transfer_a_recipe) = prepare_recipe(
+                &mut func,
+                &mut logical_for_vreg,
+                LogicalValue(transfer_a.0),
+                recipe(7, 1),
+                &mut cache,
+            )
+            .unwrap();
+            let (transfer_b_result, transfer_b_recipe) = prepare_recipe(
+                &mut func,
+                &mut logical_for_vreg,
+                LogicalValue(transfer_b.0),
+                recipe(8, 1),
+                &mut cache,
+            )
+            .unwrap();
+            if reset_cache {
+                cache = PreparedRecipeCache::default();
+            }
+            let (resident_a_result, resident_a_recipe) = prepare_recipe(
+                &mut func,
+                &mut logical_for_vreg,
+                LogicalValue(resident_a.0),
+                recipe(7, 2),
+                &mut cache,
+            )
+            .unwrap();
+            let (resident_b_result, resident_b_recipe) = prepare_recipe(
+                &mut func,
+                &mut logical_for_vreg,
+                LogicalValue(resident_b.0),
+                recipe(8, 2),
+                &mut cache,
+            )
+            .unwrap();
+
+            let mut block = MBlock::new(BlockId(0));
+            for (index, resident) in residents.iter().copied().enumerate() {
+                block.push(MInst::LoadImm {
+                    dst: resident,
+                    value: index as u64,
+                });
+            }
+            block.insts.extend(transfer_a_recipe.instructions);
+            block.push(MInst::Store {
+                base: BaseReg::StackFrame,
+                offset: 0,
+                src: transfer_a_result,
+                size: OpSize::S64,
+            });
+            block.insts.extend(transfer_b_recipe.instructions);
+            block.push(MInst::Store {
+                base: BaseReg::StackFrame,
+                offset: 8,
+                src: transfer_b_result,
+                size: OpSize::S64,
+            });
+            block.push(MInst::Load {
+                dst: transient,
+                base: BaseReg::StackFrame,
+                offset: 16,
+                size: OpSize::S64,
+            });
+            block.push(MInst::Store {
+                base: BaseReg::StackFrame,
+                offset: 24,
+                src: transient,
+                size: OpSize::S64,
+            });
+            block.insts.extend(resident_a_recipe.instructions);
+            block.insts.extend(resident_b_recipe.instructions);
+            block.push(MInst::Store {
+                base: BaseReg::SimState,
+                offset: 0,
+                src: resident_a_result,
+                size: OpSize::S64,
+            });
+            block.push(MInst::Store {
+                base: BaseReg::SimState,
+                offset: 8,
+                src: resident_b_result,
+                size: OpSize::S64,
+            });
+            for (index, resident) in residents.into_iter().enumerate() {
+                block.push(MInst::Store {
+                    base: BaseReg::SimState,
+                    offset: 16 + index as i32 * 8,
+                    src: resident,
+                    size: OpSize::S64,
+                });
+            }
+            block.push(MInst::Return);
+            func.push_block(block);
+            func.verify();
+            func
+        }
+
+        let overflowing = fixture(false);
+        let analysis = super::super::analysis::analyze(&overflowing);
+        assert!(super::super::pressure::verify(&overflowing, &analysis, 15).is_err());
+
+        let bounded = fixture(true);
+        let analysis = super::super::analysis::analyze(&bounded);
+        super::super::pressure::verify(&bounded, &analysis, 15).unwrap();
+    }
+
+    #[test]
+    fn edge_home_transfer_cache_scope_ends_before_resident_reloads() {
+        let transfer = |source, destination| {
+            [
+                PlannedEdgeOp::Reload {
+                    source,
+                    source_home: SpillHome(source.0),
+                    destination,
+                },
+                PlannedEdgeOp::Spill {
+                    source: destination,
+                    destination,
+                    destination_home: SpillHome(destination.0),
+                },
+            ]
+        };
+        let first = transfer(LogicalValue(1), LogicalValue(2));
+        let second = transfer(LogicalValue(3), LogicalValue(4));
+        let operations = [
+            PlannedEdgeOp::Spill {
+                source: LogicalValue(0),
+                destination: LogicalValue(0),
+                destination_home: SpillHome(0),
+            },
+            first[0],
+            first[1],
+            second[0],
+            second[1],
+            PlannedEdgeOp::Reload {
+                source: LogicalValue(0),
+                source_home: SpillHome(0),
+                destination: LogicalValue(0),
+            },
+        ];
+
+        assert_eq!(edge_home_transfer_end(&operations), Some(5));
     }
 
     #[test]

--- a/crates/celox-backend-x86/src/backend/native/regalloc/spill_plan.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/spill_plan.rs
@@ -65,6 +65,32 @@ pub(super) enum PlannedEdgeOp {
     },
 }
 
+pub(super) fn edge_reload_uses_transferred_home(
+    operations: &[PlannedEdgeOp],
+    reload_index: usize,
+) -> bool {
+    let Some(PlannedEdgeOp::Reload {
+        source,
+        source_home,
+        destination,
+    }) = operations.get(reload_index).copied()
+    else {
+        return false;
+    };
+    operations[..reload_index].iter().any(|operation| {
+        matches!(
+            operation,
+            PlannedEdgeOp::Spill {
+                source: spill_source,
+                destination: spill_destination,
+                destination_home,
+            } if *spill_source == source
+                && *spill_destination == destination
+                && *destination_home == source_home
+        )
+    })
+}
+
 #[derive(Debug)]
 pub(super) struct SpillPlan {
     pub logical: LogicalValues,
@@ -658,7 +684,13 @@ fn plan_internal(
                         });
                     }
                     scratch_reloads.push(PlannedEdgeOp::Reload {
-                        source: destination,
+                        // The reload is physically read from the successor
+                        // home, but it must split the predecessor logical
+                        // live range.  Using `destination` as both identities
+                        // leaves the original phi source live across every
+                        // home transfer and reconstruction reaches
+                        // NUM_REGS + 1 pressure despite the scratch spill.
+                        source,
                         source_home: destination_home,
                         destination,
                     });
@@ -2795,8 +2827,12 @@ impl SpillPlan {
                     ),
                 ));
             }
-            for &operation in operations {
-                self.verify_edge_operation(operation, Some(predecessor_block.id))?;
+            for (index, &operation) in operations.iter().enumerate() {
+                self.verify_edge_operation(
+                    operation,
+                    Some(predecessor_block.id),
+                    edge_reload_uses_transferred_home(operations, index),
+                )?;
             }
         }
         for &(point, operation) in &self.point_ops {
@@ -2917,6 +2953,7 @@ impl SpillPlan {
         &self,
         operation: PlannedEdgeOp,
         block: Option<BlockId>,
+        transferred_home: bool,
     ) -> Result<(), SpillPlanError> {
         let (source, destination, home, expected_home) = match operation {
             PlannedEdgeOp::Reload {
@@ -2954,7 +2991,7 @@ impl SpillPlan {
                 ));
             }
         }
-        if home != expected_home {
+        if home != expected_home && !transferred_home {
             return Err(SpillPlanError::new(
                 "SPILL_PLAN.HOME_CLASS",
                 block,
@@ -3669,6 +3706,35 @@ mod tests {
             translations.to_predecessor(0, 1, LogicalValue(second.0)),
             LogicalValue(source.0)
         );
+    }
+
+    #[test]
+    fn scratch_reload_splits_the_predecessor_phi_source_identity() {
+        let source = LogicalValue(3);
+        let destination = LogicalValue(9);
+        let destination_home = SpillHome(9);
+        let operations = [
+            PlannedEdgeOp::Spill {
+                source,
+                destination,
+                destination_home,
+            },
+            PlannedEdgeOp::Reload {
+                source,
+                source_home: destination_home,
+                destination,
+            },
+        ];
+
+        assert!(edge_reload_uses_transferred_home(&operations, 1));
+        assert!(matches!(
+            operations[1],
+            PlannedEdgeOp::Reload {
+                source: reload_source,
+                destination: reload_destination,
+                ..
+            } if reload_source == source && reload_destination == destination
+        ));
     }
 
     #[test]

--- a/crates/celox-backend-x86/src/backend/native/regalloc/ssa.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/ssa.rs
@@ -266,13 +266,14 @@ pub(super) fn allocate(
     let phase = timing.then(crate::timing::now);
     let reconstructed_analysis = super::analysis::analyze(func);
     if let Err(error) = super::pressure::verify(func, &reconstructed_analysis, register_count) {
+        let message = error.to_string();
         return Err(super::RegallocError::new(
             "reconstructed pressure verification",
             "PRESSURE.EXCEEDS_CAPACITY",
             Some(error.block),
             Some(error.instruction),
-            Vec::new(),
-            error.to_string(),
+            error.values,
+            message,
         ));
     }
     if let Some(start) = phase {


### PR DESCRIPTION
## Summary

- preserve the predecessor logical identity when a saturated phi edge reloads from a transferred successor home
- scope reload-recipe prefix caches to the W/S home-transfer and successor-resident phases
- include the exact live VRegs in reconstructed-pressure diagnostics
- verify transferred-home reloads without weakening the ordinary home-class invariant

## Root cause

Edge scratch handling stored a predecessor phi source into the successor destination home, then reconstructed its reload using the successor logical identity as the source. Dead-definition elimination could remove that reload without splitting the predecessor live range, leaving one extra value live.

Separately, reconstruction shared recipe prefixes across the W/S boundary between home transfers and successor-resident reloads. Those cached VRegs were not part of the planned resident set and could raise reconstructed pressure from 15 to 16.

## Impact

Large basic blocks can now exercise these saturated edge shapes without native register allocation failing. Prefix sharing remains enabled within each W/S phase.

An isolated Heliodor comparison at 1,000,000 ticks showed no runtime regression (three-run median: 5.874s with this change vs. 5.969s on master; within host noise).

## Validation

- `cargo test -p celox-backend-x86 --lib` (482 passed)
- `cargo clippy -p celox-backend-x86 --all-targets -- -D warnings`
- Heliodor `test_soc_linux_boot`, native O2, 1,000,000 ticks (Linux boot output and tick-limit completion verified)
