### PR TITLE
fix(ci): extend Heliodor gate timeout

### DIFF
--- a/docs/benchmarks/heliodor.md
+++ b/docs/benchmarks/heliodor.md
@@ -98,7 +98,7 @@ The gate is deliberately not configurable. It forces all of the following:
   runners in a fresh invocation-owned Cargo target directory, and execution of
   those exact built binaries;
 - `test_soc_linux_boot`, runners `veryl-cc-sync` then `celox`, and a fixed
-  300-second timeout for each;
+  420-second timeout for each;
 - a new empty Veryl AOT cache for the invocation, removed after the run;
 - Celox native backend, `O2`, two-state mode, full execution, and no SIR pass
   overrides; and

--- a/docs/ja/benchmarks/heliodor.md
+++ b/docs/ja/benchmarks/heliodor.md
@@ -92,7 +92,7 @@ gate の構成は変更できません。以下をすべて固定します。
 - clean で途中に変化しない Celox `HEAD`。invocation ごとの空の Cargo target
   directory に時間分離版 Veryl と Celox の locked release/LTO build を行い、
   その成果物を実行
-- `test_soc_linux_boot`、runner 順序 `veryl-cc-sync`、`celox`、各 300 秒 timeout
+- `test_soc_linux_boot`、runner 順序 `veryl-cc-sync`、`celox`、各 420 秒 timeout
 - invocation ごとに新しい空の Veryl AOT cache を作り、実行後に削除
 - Celox native backend、`O2`、2-state、full execution、SIR pass override なし
 - runner ごとに別の detached Heliodor worktree。project-local な生成物を

--- a/scripts/run-heliodor-bench.sh
+++ b/scripts/run-heliodor-bench.sh
@@ -28,7 +28,7 @@ VERYL_BIN="${VERYL_BIN:-}"
 
 readonly GATE_HELIODOR_REF=7ad830fc0f8506c934b61a853ce2eadfa5926b82
 readonly GATE_TEST=test_soc_linux_boot
-readonly GATE_TIMEOUT_SEC=300
+readonly GATE_TIMEOUT_SEC=420
 readonly GATE_EXPECTED_CYCLE=9ae070
 readonly GATE_EXPECTED_X3=aa
 
@@ -1697,11 +1697,11 @@ run_gate() {
 
     gate_record_celox_checkout || return "$?"
     if ! command -v timeout >/dev/null; then
-        echo "error: the fixed 300s gate requires GNU timeout" >&2
+        echo "error: the fixed ${GATE_TIMEOUT_SEC}s gate requires GNU timeout" >&2
         return 127
     fi
     if ! timeout_help="$(timeout --help 2>&1)" || [[ "$timeout_help" != *--kill-after* ]]; then
-        echo "error: the fixed 300s gate requires timeout --kill-after support" >&2
+        echo "error: the fixed ${GATE_TIMEOUT_SEC}s gate requires timeout --kill-after support" >&2
         return 1
     fi
     if ! start_probe="$(monotonic_ns)" || ! end_probe="$(monotonic_ns)" \

--- a/scripts/tests/run-heliodor-bench-gate.sh
+++ b/scripts/tests/run-heliodor-bench-gate.sh
@@ -479,6 +479,7 @@ run_one() {
     assert_eq "$HELIODOR_REF" "$GATE_HELIODOR_REF" "pinned Heliodor commit"
     assert_eq "$HELIODOR_TOOLS_DIR" "$CELOX_ROOT/target/heliodor/tools" \
         "benchmark-owned tools directory"
+    assert_eq "$GATE_TIMEOUT_SEC" 420 "fixed gate timeout constant"
     assert_eq "$HELIODOR_TIMEOUT_SEC" "$GATE_TIMEOUT_SEC" "fixed timeout"
     assert_eq "$HELIODOR_CELOX_COMPILE_ONLY" 0 "full Celox execution"
     assert_eq "$CELOX_OPT_LEVEL" O2 "fixed Celox optimization"


### PR DESCRIPTION
## Summary

- extend the fixed Heliodor acceptance-gate timeout from 300 to 420 seconds
- derive timeout-related diagnostics from the gate constant
- update the English and Japanese benchmark documentation
- add an explicit fixture assertion for the fixed timeout

## Root cause

The failed master run timed out the synchronous Veryl baseline after 300 seconds. A subsequent run completed the same baseline in about 192 seconds, indicating hosted-runner performance variance rather than a semantic or compilation failure. The additional margin avoids treating that variance as a product regression while preserving a finite correctness/performance gate.

## Validation

- `bash -n scripts/run-heliodor-bench.sh scripts/tests/run-heliodor-bench-gate.sh scripts/tests/run-heliodor-bench-results.sh scripts/tests/convert-heliodor-bench.sh`
- `bash scripts/tests/run-heliodor-bench-gate.sh`
- `bash scripts/tests/run-heliodor-bench-results.sh`
- `bash scripts/tests/convert-heliodor-bench.sh`
- `git diff --check origin/master...HEAD`
- pre-push hook: submodule check, Cargo formatting, Biome, and `cargo check`