### PR TITLE
fix(ci): make Heliodor benchmarks non-blocking

### DIFF
--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -39,7 +39,36 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - uses: Swatinem/rust-cache@v2
 
-      - name: Run fixed Heliodor correctness and performance gate
+      - name: Capture benchmark host metadata
+        shell: bash
+        run: |
+          {
+            echo "snapshot=before"
+            echo "captured_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "runner_name=$RUNNER_NAME"
+            echo "runner_arch=$RUNNER_ARCH"
+            echo "runner_os=$RUNNER_OS"
+            echo "image_os=${ImageOS:-unknown}"
+            echo "image_version=${ImageVersion:-unknown}"
+            echo
+            echo "[uname]"
+            uname -a
+            echo
+            echo "[lscpu]"
+            lscpu
+            echo
+            echo "[/proc/cpuinfo]"
+            cat /proc/cpuinfo
+            echo
+            echo "[process affinity]"
+            taskset -pc "$$"
+            grep -E '^(Cpus_allowed|Cpus_allowed_list|Mems_allowed|Mems_allowed_list):' /proc/self/status
+            echo
+            echo "[/proc/stat]"
+            cat /proc/stat
+          } > heliodor-host.txt
+
+      - name: Run fixed Heliodor correctness and measurement gate
         id: gate
         shell: bash
         run: |
@@ -58,6 +87,23 @@ jobs:
             exit 1
           fi
           echo "result_file=$result_file" >> "$GITHUB_OUTPUT"
+
+      - name: Capture benchmark host final state
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo
+            echo "snapshot=after"
+            echo "captured_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo
+            echo "[process affinity]"
+            taskset -pc "$$"
+            grep -E '^(Cpus_allowed|Cpus_allowed_list|Mems_allowed|Mems_allowed_list):' /proc/self/status
+            echo
+            echo "[/proc/stat]"
+            cat /proc/stat
+          } >> heliodor-host.txt
 
       - name: Convert dashboard metrics
         run: |
@@ -79,7 +125,7 @@ jobs:
           comment-on-alert: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check generated-JIT regression
+      - name: Compare generated-JIT benchmark
         if: github.event_name == 'pull_request'
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -90,7 +136,7 @@ jobs:
           benchmark-data-dir-path: dev/bench
           auto-push: false
           alert-threshold: "110%"
-          fail-on-alert: true
+          fail-on-alert: false
           comment-on-alert: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -100,6 +146,7 @@ jobs:
         with:
           name: heliodor-benchmark
           path: |
+            heliodor-host.txt
             heliodor-output.txt
             heliodor-converted.json
             heliodor-jit.json

--- a/crates/celox-bench/src/bin/veryl-heliodor.rs
+++ b/crates/celox-bench/src/bin/veryl-heliodor.rs
@@ -1,4 +1,9 @@
-use std::{error::Error, fs, path::PathBuf, time::Instant};
+use std::{
+    error::Error,
+    fs,
+    path::PathBuf,
+    time::{Duration, Instant},
+};
 
 use clap::Parser as ClapParser;
 use veryl_analyzer::ir as air;
@@ -104,16 +109,30 @@ fn run() -> Result<(), Box<dyn Error>> {
     let testbench = convert_initial_to_testbench(initial_stmts, &event_map, &clock_periods, 3);
     let compile_elapsed = compile_start.elapsed();
 
+    let execute_cpu_start = process_cpu_time();
     let execute_start = Instant::now();
     let result = run_testbench(&mut sim, &testbench);
     let execute_elapsed = execute_start.elapsed();
+    let execute_cpu_elapsed = process_cpu_time()
+        .zip(execute_cpu_start)
+        .map(|(end, start)| end.saturating_sub(start));
     let elapsed = total_start.elapsed();
-    println!(
-        "VERYL_TEST_TIMING test={} compile_ns={} execute_ns={}",
-        options.test,
-        compile_elapsed.as_nanos(),
-        execute_elapsed.as_nanos()
-    );
+    if let Some(execute_cpu_elapsed) = execute_cpu_elapsed {
+        println!(
+            "VERYL_TEST_TIMING test={} compile_ns={} execute_ns={} execute_cpu_ns={}",
+            options.test,
+            compile_elapsed.as_nanos(),
+            execute_elapsed.as_nanos(),
+            execute_cpu_elapsed.as_nanos()
+        );
+    } else {
+        println!(
+            "VERYL_TEST_TIMING test={} compile_ns={} execute_ns={}",
+            options.test,
+            compile_elapsed.as_nanos(),
+            execute_elapsed.as_nanos()
+        );
+    }
 
     match result {
         TestResult::Pass => {
@@ -133,6 +152,26 @@ fn run() -> Result<(), Box<dyn Error>> {
             Err(message.into())
         }
     }
+}
+
+#[cfg(unix)]
+fn process_cpu_time() -> Option<Duration> {
+    let mut time = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    let result = unsafe { libc::clock_gettime(libc::CLOCK_PROCESS_CPUTIME_ID, &mut time) };
+    (result == 0).then(|| {
+        Duration::new(
+            time.tv_sec.try_into().unwrap_or_default(),
+            time.tv_nsec.try_into().unwrap_or_default(),
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn process_cpu_time() -> Option<Duration> {
+    None
 }
 
 fn ensure_no_errors(stage: &str, diagnostics: Vec<AnalyzerError>) -> Result<(), Box<dyn Error>> {

--- a/scripts/run-heliodor-bench.sh
+++ b/scripts/run-heliodor-bench.sh
@@ -101,11 +101,10 @@ Examples:
   HELIODOR_RUNNERS="veryl-cranelift celox" scripts/run-heliodor-bench.sh run
   scripts/run-heliodor-bench.sh gate
 
-`gate` is the fixed acceptance comparison. Unlike diagnostic `run`, it ignores
-runner/test/configuration overrides, uses isolated generated trees, and exits
-successfully only when both full tests pass and native O2 Celox executes the
-testbench no slower than the synchronous Veryl AOT-C reference. Code generation
-time is measured and reported separately from execution time.
+`gate` is the fixed correctness and measurement run. Unlike diagnostic `run`,
+it ignores runner/test/configuration overrides, uses isolated generated trees,
+and exits successfully only when both full tests pass. Execution and code
+generation times are reported but do not affect the exit status.
 USAGE
 }
 
@@ -392,7 +391,7 @@ classify_timed_veryl_result() {
     local marker_test="" marker_status="" marker_elapsed=""
     local timing_test="" compile_elapsed="" execute_elapsed=""
     local result_pattern='^VERYL_TEST_RESULT test=([^[:space:]]+) status=(pass|fail) elapsed_ns=([0-9]+)$'
-    local timing_pattern='^VERYL_TEST_TIMING test=([^[:space:]]+) compile_ns=([0-9]+) execute_ns=([0-9]+)$'
+    local timing_pattern='^VERYL_TEST_TIMING test=([^[:space:]]+) compile_ns=([0-9]+) execute_ns=([0-9]+)( execute_cpu_ns=[0-9]+)?$'
 
     VERYL_TIMED_SEMANTIC_STATUS="unreported"
     VERYL_TIMED_REPORTED_ELAPSED_NS="NA"
@@ -1657,12 +1656,6 @@ validate_gate_results() {
         echo "error: Celox gate must report a positive generated-JIT execution interval" >&2
         return 1
     fi
-    if ((GATE_CELOX_JIT_EXECUTE_NS > GATE_VERYL_EXECUTE_NS)); then
-        echo "error: Heliodor JIT execution gate failed: Celox ${GATE_CELOX_JIT_EXECUTE_NS}ns > Veryl ${GATE_VERYL_EXECUTE_NS}ns" >&2
-        echo "complete post-compile execution: Celox ${GATE_CELOX_EXECUTE_NS}ns" >&2
-        echo "code generation (reported separately): Celox ${GATE_CELOX_COMPILE_NS}ns, Veryl ${GATE_VERYL_COMPILE_NS}ns" >&2
-        return 1
-    fi
 }
 
 run_gate() {
@@ -1671,9 +1664,9 @@ run_gate() {
     local before_manifest after_manifest start_probe end_probe timeout_help
     local overall=0
 
-    # The acceptance comparison is deliberately not configurable. Diagnostic
-    # experiments remain available through `run` and cannot silently weaken
-    # this contract.
+    # The correctness and measurement configuration is deliberately not
+    # configurable. Diagnostic experiments remain available through `run` and
+    # cannot silently weaken this contract.
     HELIODOR_REPO=https://github.com/dalance/heliodor.git
     HELIODOR_REF="$GATE_HELIODOR_REF"
     HELIODOR_DIR="$CELOX_ROOT/target/heliodor/source"
@@ -1776,7 +1769,8 @@ run_gate() {
         echo "Heliodor gate: FAIL (artifacts: $invocation_dir)" >&2
         return 1
     fi
-    echo "Heliodor gate: PASS (JIT execute: Celox ${GATE_CELOX_JIT_EXECUTE_NS}ns <= Veryl ${GATE_VERYL_EXECUTE_NS}ns)"
+    echo "Heliodor gate: PASS"
+    echo "JIT execution: Celox ${GATE_CELOX_JIT_EXECUTE_NS}ns; Veryl complete execution ${GATE_VERYL_EXECUTE_NS}ns"
     echo "Complete post-compile execution: Celox ${GATE_CELOX_EXECUTE_NS}ns"
     echo "Code generation: Celox ${GATE_CELOX_COMPILE_NS}ns; Veryl ${GATE_VERYL_COMPILE_NS}ns"
     echo "Artifacts: $invocation_dir"

--- a/scripts/tests/run-heliodor-bench-gate.sh
+++ b/scripts/tests/run-heliodor-bench-gate.sh
@@ -113,9 +113,8 @@ fi
 
 slower_jit="$TMP/slower-jit"
 write_gate_results "$slower_jit" 200 100 30 40 10 45 41
-if validate_gate_results "$slower_jit/results.tsv" "$slower_jit" 2>/dev/null; then
-    fail "gate accepted slower Celox generated-JIT execution"
-fi
+validate_gate_results "$slower_jit/results.tsv" "$slower_jit" \
+    || fail "gate treated slower Celox generated-JIT execution as a correctness failure"
 
 slower_harness="$TMP/slower-harness"
 write_gate_results "$slower_harness" 200 100 30 40 10 45 35
@@ -380,8 +379,8 @@ gate_cleanup_worktrees
     || fail "gate cleanup left detached worktrees behind"
 
 # Full run_gate fixture. Replace every external boundary while retaining the
-# fixed configuration, runner order, manifest/hash checks, result validation,
-# and performance decision in run_gate itself.
+# fixed configuration, runner order, manifest/hash checks, and result
+# validation in run_gate itself.
 REAL_CELOX_ROOT="$CELOX_ROOT"
 CELOX_ROOT="$TMP/fake-celox"
 HELIODOR_DIR="$TMP/fake-heliodor"
@@ -572,7 +571,7 @@ success_results="$(find "$LAST_GATE_RESULTS_ROOT" -name results.tsv)"
 assert_eq "$(wc -l <"$success_results")" 3 "exact paired result rows"
 
 MOCK_CELOX_EXECUTE=41
-run_gate_fixture slower-integration 0
+run_gate_fixture slower-integration 1
 MOCK_CELOX_EXECUTE=20
 
 MOCK_CELOX_STATUS=fail

--- a/scripts/tests/run-heliodor-bench-results.sh
+++ b/scripts/tests/run-heliodor-bench-results.sh
@@ -54,10 +54,10 @@ assert_eq "$CELOX_JIT_EXECUTE_ELAPSED_NS" 5 "CPU-timed JIT execute elapsed"
 
 timed_veryl_log="$TMP/timed-veryl.log"
 write_log "$timed_veryl_log" \
-    'VERYL_TEST_TIMING test=boot compile_ns=6 execute_ns=7' \
+    'VERYL_TEST_TIMING test=boot compile_ns=6 execute_ns=7 execute_cpu_ns=8' \
     'VERYL_TEST_RESULT test=boot status=pass elapsed_ns=15'
 classify_timed_veryl_result "$timed_veryl_log" boot 0 \
-    || fail "well-formed timed Veryl result was rejected: $VERYL_TIMED_RESULT_DIAGNOSTIC"
+    || fail "CPU-timed Veryl result was rejected: $VERYL_TIMED_RESULT_DIAGNOSTIC"
 assert_eq "$VERYL_TIMED_SEMANTIC_STATUS" pass "timed Veryl semantic status"
 assert_eq "$VERYL_TIMED_REPORTED_ELAPSED_NS" 15 "timed Veryl reported elapsed"
 assert_eq "$VERYL_TIMED_COMPILE_ELAPSED_NS" 6 "timed Veryl compile elapsed"


### PR DESCRIPTION
## Summary

- keep the fixed Heliodor Linux correctness and semantic checks blocking
- make relative performance differences and benchmark alerts non-blocking
- retain benchmark publication while recording runner CPU metadata, affinity, `/proc/stat`, and per-runner process CPU time

## Why

GitHub-hosted runner performance varies enough for repeated measurements to reverse the Celox/Veryl ordering. Timing noise should remain observable, but it should not fail pull request CI.

## Validation

- `bash scripts/tests/run-heliodor-bench-results.sh`
- `bash scripts/tests/run-heliodor-bench-gate.sh`
- `cargo fmt --all -- --check`
- `cargo check --locked -p celox-bench --bin veryl-heliodor`
- focused Clippy with warnings denied
- workflow YAML parse
- pre-push hook: submodule check, Cargo format/check, Biome, and clean-tree checks