### PR TITLE
fix(ci): make release publication recoverable

### DIFF
--- a/.github/workflows/ci-napi.yml
+++ b/.github/workflows/ci-napi.yml
@@ -1,13 +1,22 @@
 name: NAPI Build & Publish
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - ".release-please-manifest.json"
+  repository_dispatch:
+    types: [napi-release]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing v-prefixed release tag to publish or retry
+        required: true
+        type: string
+
+concurrency:
+  group: napi-publish-${{ github.event.client_payload.tag || inputs.tag }}
+  cancel-in-progress: false
 
 env:
   CARGO_INCREMENTAL: "0"
+  RELEASE_TAG: ${{ github.event.client_payload.tag || inputs.tag }}
 
 permissions:
   contents: read
@@ -18,6 +27,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Check release tag
+        shell: bash
+        run: |
+          expected_tag="v$(tr -d '\r\n' < VERSION)"
+          if [ "$RELEASE_TAG" != "$expected_tag" ]; then
+            echo "Release tag $RELEASE_TAG does not match VERSION ($expected_tag)." >&2
+            exit 1
+          fi
+
+      - name: Check published GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          published_tag="$(
+            gh release view "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json tagName,isDraft,isPrerelease \
+              --jq 'select(.isDraft == false and .isPrerelease == false) | .tagName'
+          )"
+          if [ "$published_tag" != "$RELEASE_TAG" ]; then
+            echo "Published GitHub Release $RELEASE_TAG was not found." >&2
+            exit 1
+          fi
 
       - name: Check synchronized versions and stable dependencies
         run: node scripts/check-release-version.mjs
@@ -51,6 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ env.RELEASE_TAG }}
           submodules: recursive
 
       - uses: actions/setup-node@v7
@@ -121,6 +158,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ env.RELEASE_TAG }}
           submodules: recursive
 
       - uses: actions/setup-node@v7
@@ -142,7 +180,7 @@ jobs:
         run: pnpm --filter="!@celox-sim/celox-napi" --filter="!@celox-sim/playground" -r build
 
       - name: Run tests
-        run: pnpm -r test
+        run: pnpm --filter="!@celox-sim/celox-napi" --filter="!@celox-sim/playground" -r test
 
   publish:
     needs: test
@@ -154,6 +192,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ env.RELEASE_TAG }}
           submodules: recursive
 
       - uses: actions/setup-node@v7
@@ -190,10 +229,15 @@ jobs:
 
       - name: Copy index files from build artifacts
         working-directory: crates/celox-napi
+        shell: bash
         run: |
-          FIRST_DIR=$(ls -d artifacts/bindings-*/ | head -1)
-          cp "$FIRST_DIR/index.js" .
-          cp "$FIRST_DIR/index.d.ts" .
+          first_dir="$(find artifacts -mindepth 1 -maxdepth 1 -type d -name 'bindings-*' -print -quit)"
+          if [ -z "$first_dir" ]; then
+            echo "No binding artifact directory was downloaded." >&2
+            exit 1
+          fi
+          cp "$first_dir/index.js" .
+          cp "$first_dir/index.d.ts" .
 
       - name: Prepublish
         working-directory: crates/celox-napi
@@ -206,9 +250,9 @@ jobs:
         run: |
           echo "Publishing version: $(node -p "require('./package.json').version")"
           echo "=== Main package ==="
-          ls -la index.js index.d.ts *.node
+          ls -la index.js index.d.ts ./*.node
           echo "=== Platform packages ==="
-          ls -la npm/*/
+          ls -la ./npm/*/
 
       - name: Publish platform packages
         working-directory: crates/celox-napi
@@ -248,6 +292,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ env.RELEASE_TAG }}
           submodules: recursive
 
       - uses: actions/setup-node@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Resources created with GITHUB_TOKEN do not start follow-up workflows.
-      # Mint a short-lived installation token so release PR checks and the
-      # manifest-triggered publisher run normally.
+      # Use an installation token so release PR checks and release-triggered
+      # publisher workflows run normally. Workflows permission also allows a
+      # failed release to be retried after master advances across workflow edits.
       - name: Create release app token
         id: release-token
         uses: actions/create-github-app-token@v3
@@ -29,16 +30,58 @@ jobs:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
+          permission-issues: write
           permission-pull-requests: write
+          permission-workflows: write
 
-      - uses: googleapis/release-please-action@v5
+      - name: Create release or update release pull request
+        uses: googleapis/release-please-action@v5
         with:
           token: ${{ steps.release-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          # The release app intentionally has no Issues permission. The weekly
-          # queue locates the deterministic Release Please branch instead.
-          skip-labeling: true
+
+      - name: Check out the processed commit
+        if: github.event_name == 'push'
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.sha }}
+          token: ${{ steps.release-token.outputs.token }}
+
+      - name: Queue package publication for this release
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+        shell: bash
+        run: |
+          release_tag="v$(tr -d '\r\n' < VERSION)"
+          tag_sha="$(git rev-list -n 1 "$release_tag" 2>/dev/null || true)"
+
+          if [ "$tag_sha" != "$GITHUB_SHA" ]; then
+            echo "No release tag points at this workflow commit; publication is not needed."
+            exit 0
+          fi
+
+          published_tag="$(
+            gh release view "$release_tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json tagName,isDraft,isPrerelease \
+              --jq 'select(.isDraft == false and .isPrerelease == false) | .tagName'
+          )"
+          if [ "$published_tag" != "$release_tag" ]; then
+            echo "Published GitHub Release $release_tag was not found." >&2
+            exit 1
+          fi
+
+          jq -n \
+            --arg tag "$release_tag" \
+            '{event_type: "napi-release", client_payload: {tag: $tag}}' \
+            | gh api \
+                --method POST \
+                "repos/$GITHUB_REPOSITORY/dispatches" \
+                --input -
 
   queue-release:
     name: Queue weekly release

--- a/packages/playground/vitest.config.ts
+++ b/packages/playground/vitest.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import celox from "@celox-sim/vite-plugin";
 
 export default defineConfig({
   plugins: [celox()],
   test: {
-    exclude: ["test/e2e/**/*.spec.ts"],
+    exclude: [...configDefaults.exclude, "test/e2e/**/*.spec.ts"],
   },
 });


### PR DESCRIPTION
## Summary

- make Release Please lifecycle labels authoritative and request the GitHub App permissions needed for delayed retries
- start package publication only after the release workflow succeeds and the tag and published release match the processed commit
- publish from an explicit, validated release tag with manual retry support and idempotent package checks
- preserve Vitest's default excludes so dependency tests are not collected

## Root cause

Release PRs were created without the `autorelease: pending` lifecycle label, so a merged release PR could be treated as a normal version bump and another release PR opened. Package publication also started from the manifest push before GitHub Release creation had completed, and its test run collected tests from dependencies.

## Validation

- `actionlint` on the changed workflows (ignoring stale action metadata warnings for the existing v3 GitHub App token input)
- `node scripts/check-release-version.mjs`
- playground Vitest: 7 files passed, 2 skipped; 18 tests passed, 5 skipped
- release tag/dispatch payload dry-check
- YAML parse and `git diff --check`
- pre-push checks: submodules, Biome, cargo fmt, cargo check