### PR TITLE
fix(ci): keep Heliodor host metadata outside checkout

### DIFF
--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -66,7 +66,7 @@ jobs:
             echo
             echo "[/proc/stat]"
             cat /proc/stat
-          } > heliodor-host.txt
+          } > "$RUNNER_TEMP/heliodor-host.txt"
 
       - name: Run fixed Heliodor correctness and measurement gate
         id: gate
@@ -103,7 +103,8 @@ jobs:
             echo
             echo "[/proc/stat]"
             cat /proc/stat
-          } >> heliodor-host.txt
+          } >> "$RUNNER_TEMP/heliodor-host.txt"
+          cp "$RUNNER_TEMP/heliodor-host.txt" heliodor-host.txt
 
       - name: Convert dashboard metrics
         run: |


### PR DESCRIPTION
## Summary

- capture the pre-gate Heliodor host metadata under `RUNNER_TEMP`
- append the post-gate snapshot there, then copy the completed metadata into the workspace for artifact upload
- keep the gate's clean-checkout validation unchanged

## Root cause

The host metadata step created `heliodor-host.txt` in the repository before the Heliodor gate started. The gate correctly rejected that untracked file because it requires a clean Celox checkout, so no benchmark results were produced.

## Impact

The Heliodor benchmark can run again while preserving both CPU/runner snapshots in the uploaded artifact.

## Validation

- `bash scripts/tests/run-heliodor-bench-gate.sh`
- parsed `.github/workflows/heliodor-bench.yml` with PyYAML
- executed both host-capture workflow scripts in a temporary fixture and verified that the workspace remains clean before the gate and receives the combined artifact afterward
- pre-push hook: submodule check, Cargo formatting, Biome, `cargo check`, and clean-tree check
- `git diff --check`
