### PR TITLE
refactor(diagnostics): centralize debug configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.19",
  "toml 1.1.4+spec-1.1.0",
+ "tracing",
  "veryl-analyzer",
  "veryl-metadata",
  "veryl-parser",
@@ -464,6 +465,7 @@ dependencies = [
  "cranelift-native",
  "fxhash",
  "num-bigint",
+ "tracing",
 ]
 
 [[package]]
@@ -494,6 +496,7 @@ dependencies = [
  "libc",
  "memmap2",
  "num-bigint",
+ "tracing",
 ]
 
 [[package]]
@@ -544,6 +547,7 @@ dependencies = [
  "num-traits",
  "tempfile",
  "thiserror 2.0.19",
+ "tracing",
  "veryl-analyzer",
  "veryl-metadata",
  "veryl-parser",
@@ -621,6 +625,7 @@ dependencies = [
  "itertools 0.15.0",
  "num-bigint",
  "num-traits",
+ "tracing",
 ]
 
 [[package]]
@@ -636,6 +641,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.19",
+ "tracing",
 ]
 
 [[package]]
@@ -3859,6 +3865,37 @@ name = "toml_writer"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "ts-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ serde_json      = "1.0"
 tempfile        = "3.26"
 thiserror       = "2.0"
 toml            = "1.0.3"
+tracing         = "0.1"
 
 [patch.crates-io]
 # Disable veryl-metadata's default gitoxide feature to avoid pulling aws-lc-sys
@@ -69,6 +70,8 @@ warnings = "deny"
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }
+disallowed_macros = "deny"
+disallowed_methods = "deny"
 type_complexity = "allow"
 too_many_arguments = "allow"
 collapsible_if = "allow"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,10 @@
+disallowed-macros = [
+    { path = "std::eprintln", reason = "library diagnostics must use tracing or a caller-provided writer" },
+]
+
+disallowed-methods = [
+    { path = "std::env::var", reason = "read CELOX diagnostics through DiagnosticsOptions::from_env at the application boundary" },
+    { path = "std::env::var_os", reason = "read CELOX diagnostics through DiagnosticsOptions::from_env at the application boundary" },
+    { path = "std::env::vars", reason = "read CELOX diagnostics through DiagnosticsOptions::from_env at the application boundary" },
+    { path = "std::env::vars_os", reason = "read CELOX diagnostics through DiagnosticsOptions::from_env at the application boundary" },
+]

--- a/crates/celox-backend-cranelift/Cargo.toml
+++ b/crates/celox-backend-cranelift/Cargo.toml
@@ -8,6 +8,7 @@ description = "Celox Cranelift code-generation backend"
 edition.workspace = true
 
 [dependencies]
+tracing = { workspace = true }
 celox-design = { path = "../celox-design" }
 celox-sir = { path = "../celox-sir" }
 celox-state-layout = { path = "../celox-state-layout" }

--- a/crates/celox-backend-cranelift/src/cranelift_options.rs
+++ b/crates/celox-backend-cranelift/src/cranelift_options.rs
@@ -51,6 +51,13 @@ impl RegallocAlgorithm {
 
 /// Fine-grained Cranelift backend options beyond the optimization level.
 #[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CraneliftDiagnostics {
+    pub pass_timing: bool,
+}
+
+/// Fine-grained Cranelift backend options beyond the optimization level.
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Clone, Copy)]
 pub struct CraneliftOptions {
     /// Optimization level (default: Speed).
@@ -65,6 +72,7 @@ pub struct CraneliftOptions {
     pub enable_verifier: bool,
     /// Enable backend-owned splitting for oversized functions.
     pub tail_call_split: bool,
+    pub diagnostics: CraneliftDiagnostics,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -76,6 +84,7 @@ impl Default for CraneliftOptions {
             enable_alias_analysis: true,
             enable_verifier: true,
             tail_call_split: true,
+            diagnostics: CraneliftDiagnostics::default(),
         }
     }
 }
@@ -90,6 +99,7 @@ impl CraneliftOptions {
             enable_alias_analysis: false,
             enable_verifier: false,
             tail_call_split: true,
+            diagnostics: CraneliftDiagnostics::default(),
         }
     }
 

--- a/crates/celox-backend-cranelift/src/jit_engine.rs
+++ b/crates/celox-backend-cranelift/src/jit_engine.rs
@@ -194,7 +194,7 @@ impl JitEngine {
             total_inst_cost += estimate_eu_cost(eu, four_state);
             total_value_count += estimate_eu_value_count(eu, four_state);
         }
-        if std::env::var("CELOX_PASS_TIMING").is_ok() {
+        if self.translator.options.cranelift.diagnostics.pass_timing {
             let sir_insts: usize = units
                 .iter()
                 .map(|eu| {
@@ -204,7 +204,7 @@ impl JitEngine {
                         .sum::<usize>()
                 })
                 .sum();
-            eprintln!(
+            tracing::debug!(
                 "[compile_units] {} EUs, {} SIR insts, clif_cost={total_inst_cost}/{CLIF_INST_THRESHOLD} values={total_value_count}/{VREG_VALUE_THRESHOLD}",
                 units.len(),
                 sir_insts,
@@ -234,11 +234,11 @@ impl JitEngine {
             self.translator.translate_units(units, builder);
         }
 
-        if std::env::var("CELOX_PASS_TIMING").is_ok() {
+        if self.translator.options.cranelift.diagnostics.pass_timing {
             let num_values = ctx.func.dfg.num_values();
             let num_insts = ctx.func.dfg.num_insts();
             let num_blocks = ctx.func.dfg.num_blocks();
-            eprintln!(
+            tracing::debug!(
                 "[compile_units_single] after translation: blocks={num_blocks} insts={num_insts} values={num_values}"
             );
         }
@@ -273,7 +273,7 @@ impl JitEngine {
         mut post_clif_out: Option<&mut String>,
         mut native_out: Option<&mut String>,
     ) -> Result<*const u8, String> {
-        let timing = std::env::var("CELOX_PASS_TIMING").is_ok();
+        let timing = self.translator.options.cranelift.diagnostics.pass_timing;
         let four_state = self.translator.options.four_state;
 
         // 1. Partition units into batches, each under both thresholds
@@ -324,7 +324,7 @@ impl JitEngine {
         if timing {
             let total_inst: usize = eu_metrics.iter().map(|m| m.0).sum();
             let total_val: usize = eu_metrics.iter().map(|m| m.1).sum();
-            eprintln!(
+            tracing::debug!(
                 "[jit-split] Splitting {} EUs (est. {} CLIF insts, {} values) into {} batches",
                 units.len(),
                 total_inst,
@@ -369,7 +369,7 @@ impl JitEngine {
 
             if let Some(s) = batch_start {
                 let batch_cost: usize = batch.iter().map(|&i| eu_metrics[i].0).sum();
-                eprintln!(
+                tracing::debug!(
                     "[jit-split]   batch[{batch_idx}]: {} EUs, est. {} CLIF insts, {:?}",
                     batch.len(),
                     batch_cost,

--- a/crates/celox-backend-cranelift/src/lib.rs
+++ b/crates/celox-backend-cranelift/src/lib.rs
@@ -21,7 +21,9 @@ pub mod tail_call_split;
 mod translator;
 mod wide_ops;
 
-pub use cranelift_options::{CraneliftOptLevel, CraneliftOptions, RegallocAlgorithm};
+pub use cranelift_options::{
+    CraneliftDiagnostics, CraneliftOptLevel, CraneliftOptions, RegallocAlgorithm,
+};
 pub use jit_engine::JitEngine;
 pub use translator::SIRTranslator;
 

--- a/crates/celox-backend-x86/Cargo.toml
+++ b/crates/celox-backend-x86/Cargo.toml
@@ -8,6 +8,7 @@ description = "Celox x86-64 machine-code backend"
 edition.workspace = true
 
 [dependencies]
+tracing = { workspace = true }
 celox-analysis = { path = "../celox-analysis" }
 celox-design = { path = "../celox-design" }
 celox-sir = { path = "../celox-sir" }

--- a/crates/celox-backend-x86/src/backend/native/emit.rs
+++ b/crates/celox-backend-x86/src/backend/native/emit.rs
@@ -5177,16 +5177,15 @@ pub fn emit_prepared_eu(
     layout: &crate::MemoryLayout,
     four_state: bool,
     label: &str,
-    enable_x86_slp: bool,
+    options: &crate::X86BackendOptions,
     mut trace: Option<&mut NativeFunctionTrace>,
 ) -> Result<EmitResult, ChainedEmitError> {
     use super::{isel, regalloc};
-    let timing = std::env::var_os("CELOX_PHASE_TIMING").is_some();
-    let mir_stats = std::env::var_os("CELOX_MIR_STATS").is_some();
-    let copy_stats = timing
-        || mir_stats
-        || std::env::var_os("CELOX_REGALLOC_TIMING").is_some()
-        || std::env::var_os("CELOX_REGALLOC_STATS").is_some();
+    let diagnostics = &options.diagnostics;
+    let timing = diagnostics.phase_timing;
+    let mir_stats = diagnostics.mir_stats;
+    let copy_stats =
+        timing || mir_stats || diagnostics.regalloc_timing || diagnostics.regalloc_stats;
     let total_start = timing.then(crate::timing::now);
 
     sir_eu
@@ -5204,9 +5203,10 @@ pub fn emit_prepared_eu(
 
     // Single ISel + optimize + regalloc + emit
     let isel_start = timing.then(crate::timing::now);
-    let mut mfunc = isel::lower_execution_unit(sir_eu, layout, four_state);
+    let mut mfunc =
+        isel::lower_execution_unit_with_diagnostics(sir_eu, layout, four_state, diagnostics);
     if let Some(start) = isel_start {
-        eprintln!(
+        tracing::debug!(
             "[native-timing] emit_chained isel mir_blocks={} mir_insts={} vregs={} elapsed={:?}",
             mfunc.blocks.len(),
             mir_inst_count(&mfunc),
@@ -5214,9 +5214,9 @@ pub fn emit_prepared_eu(
             start.elapsed()
         );
     }
-    dump_native_block_context(label, "after_isel", sir_eu, &mfunc);
+    dump_native_block_context(label, "after_isel", sir_eu, &mfunc, diagnostics);
     if timing {
-        eprintln!("[native-timing] emit_chained verify after_isel label={label}");
+        tracing::debug!("[native-timing] emit_chained verify after_isel label={label}");
     }
     mfunc
         .verify_result()
@@ -5227,7 +5227,7 @@ pub fn emit_prepared_eu(
     let legalize_start = timing.then(crate::timing::now);
     super::mir_legalize::legalize(&mut mfunc);
     if let Some(start) = legalize_start {
-        eprintln!(
+        tracing::debug!(
             "[native-timing] emit_chained legalize mir_blocks={} mir_insts={} vregs={} elapsed={:?}",
             mfunc.blocks.len(),
             mir_inst_count(&mfunc),
@@ -5235,9 +5235,9 @@ pub fn emit_prepared_eu(
             start.elapsed()
         );
     }
-    dump_native_block_context(label, "after_legalize", sir_eu, &mfunc);
+    dump_native_block_context(label, "after_legalize", sir_eu, &mfunc, diagnostics);
     if timing {
-        eprintln!("[native-timing] emit_chained verify after_legalize label={label}");
+        tracing::debug!("[native-timing] emit_chained verify after_legalize label={label}");
     }
     mfunc
         .verify_result()
@@ -5246,9 +5246,9 @@ pub fn emit_prepared_eu(
             error,
         })?;
     let opt_start = timing.then(crate::timing::now);
-    super::mir_opt::optimize(&mut mfunc);
+    super::mir_opt::optimize_with_diagnostics(&mut mfunc, diagnostics);
     if let Some(start) = opt_start {
-        eprintln!(
+        tracing::debug!(
             "[native-timing] emit_chained mir_opt label={label} mir_blocks={} mir_insts={} vregs={} elapsed={:?}",
             mfunc.blocks.len(),
             mir_inst_count(&mfunc),
@@ -5262,7 +5262,7 @@ pub fn emit_prepared_eu(
             phase: "after MIR optimization before x86 SLP",
             error,
         })?;
-    let slp_stats = if enable_x86_slp {
+    let slp_stats = if options.slp {
         super::x86_slp::select(&mut mfunc)
     } else {
         super::x86_slp::SlpStats::default()
@@ -5274,7 +5274,7 @@ pub fn emit_prepared_eu(
             error,
         })?;
     if timing {
-        eprintln!(
+        tracing::debug!(
             "[native-timing] emit_chained x86_slp vector_zeroes={} vector_packs={} vector_loads={} vector_binary_ops={} vector_stores={} scalar_instructions_removed={}",
             slp_stats.vector_zeroes,
             slp_stats.vector_packs,
@@ -5287,7 +5287,7 @@ pub fn emit_prepared_eu(
     let compact_start = timing.then(crate::timing::now);
     let compacted = super::mir_opt::compact_vregs(&mut mfunc);
     if let Some(start) = compact_start {
-        eprintln!(
+        tracing::debug!(
             "[native-timing] emit_chained compact_vregs before={} after={} removed={} elapsed={:?}",
             compacted.before,
             compacted.after,
@@ -5298,12 +5298,12 @@ pub fn emit_prepared_eu(
     if mir_stats {
         log_mir_stats(label, "after_mir_opt", &mfunc);
     }
-    if std::env::var_os("CELOX_MIR_BLOCK_STATS").is_some() {
+    if diagnostics.mir_block_stats {
         log_mir_block_stats(label, "after_mir_opt", &mfunc);
     }
-    dump_native_block_context(label, "after_mir_opt", sir_eu, &mfunc);
+    dump_native_block_context(label, "after_mir_opt", sir_eu, &mfunc, diagnostics);
     if timing {
-        eprintln!("[native-timing] emit_chained verify after_mir_opt label={label}");
+        tracing::debug!("[native-timing] emit_chained verify after_mir_opt label={label}");
     }
     mfunc
         .verify_result()
@@ -5316,15 +5316,20 @@ pub fn emit_prepared_eu(
     }
     let regalloc_start = timing.then(crate::timing::now);
     let mut regalloc_trace = trace.as_ref().map(|_| regalloc::RegallocTrace::default());
-    let ra =
-        regalloc::run_regalloc_with_label_and_trace(&mut mfunc, label, regalloc_trace.as_mut())?;
+    let ra = regalloc::run_regalloc_with_label_and_trace_and_diagnostics(
+        &mut mfunc,
+        label,
+        regalloc_trace.as_mut(),
+        diagnostics,
+        options.native_tick_loop,
+    )?;
     if let (Some(trace), Some(regalloc_trace)) = (trace.as_deref_mut(), regalloc_trace.as_mut()) {
         trace.mir_after_late_memory_folds =
             std::mem::take(&mut regalloc_trace.mir_after_late_memory_folds);
         trace.mir_after_scheduling = std::mem::take(&mut regalloc_trace.mir_after_scheduling);
     }
     if let Some(start) = regalloc_start {
-        eprintln!(
+        tracing::debug!(
             "[native-timing] emit_chained regalloc mir_blocks={} mir_insts={} vregs={} spill_frame={} elapsed={:?}",
             mfunc.blocks.len(),
             mir_inst_count(&mfunc),
@@ -5339,7 +5344,7 @@ pub fn emit_prepared_eu(
     super::mir_opt::post_regalloc_direct_load_cse(&mut mfunc, &ra.assignment);
     regalloc::verify_assignment(&mfunc, &ra.assignment)?;
     if let Some(start) = post_regalloc_start {
-        eprintln!(
+        tracing::debug!(
             "[native-timing] emit_chained post_regalloc_cleanup mir_blocks={} mir_insts={} vregs={} elapsed={:?}",
             mfunc.blocks.len(),
             mir_inst_count(&mfunc),
@@ -5366,10 +5371,10 @@ pub fn emit_prepared_eu(
     if mir_stats {
         log_mir_stats(label, "after_regalloc", &mfunc);
     }
-    if std::env::var_os("CELOX_MIR_BLOCK_STATS").is_some() {
+    if diagnostics.mir_block_stats {
         log_mir_block_stats(label, "after_regalloc", &mfunc);
     }
-    dump_native_block_context(label, "after_regalloc", sir_eu, &mfunc);
+    dump_native_block_context(label, "after_regalloc", sir_eu, &mfunc, diagnostics);
     // Post-allocation peepholes and CFG cleanup can change the physical value
     // present on a phi edge. Build the edge-copy plan from this final MIR, not
     // from the pre-cleanup allocation input.
@@ -5377,7 +5382,7 @@ pub fn emit_prepared_eu(
     ssa_destruction.verify(&mfunc, &ra.assignment, ra.spill_frame_size)?;
     if copy_stats {
         let stats = ssa_destruction.stats();
-        eprintln!(
+        tracing::debug!(
             "[native-edge-copy-stats] label={label} edges={} rows={} identity_rows={} effective_copies={} identity_only_edges={} direct_moves={} register_swaps={} cycle_breaks={} temporary_cycle_breaks={} ready_pops={} dependency_releases={} max_effective_per_edge={}",
             stats.edges,
             stats.rows,
@@ -5398,7 +5403,7 @@ pub fn emit_prepared_eu(
         .merged_total_size
         .checked_add(layout.triggered_bits_total_size)
         .expect("native simulation-state size overflow");
-    let result = if label == "eval_comb_apply_ff" && super::native_tick_loop_enabled() {
+    let result = if label == "eval_comb_apply_ff" && options.native_tick_loop {
         let check_runtime_events = sir_eu.blocks.values().any(|block| {
             block.instructions.iter().any(|instruction| {
                 matches!(
@@ -5433,14 +5438,14 @@ pub fn emit_prepared_eu(
         );
     }
     if let Some(start) = emit_start {
-        eprintln!(
+        tracing::debug!(
             "[native-timing] emit_chained emit bytes={} elapsed={:?}",
             result.code.len(),
             start.elapsed()
         );
     }
     if let Some(start) = total_start {
-        eprintln!(
+        tracing::debug!(
             "[native-timing] emit_chained total elapsed={:?}",
             start.elapsed()
         );
@@ -5591,7 +5596,7 @@ fn log_mir_stats(label: &str, stage: &str, func: &super::mir::MFunction) {
         }
     }
 
-    eprintln!(
+    tracing::debug!(
         "[native-mir-stats] label={label} stage={stage} phi={phi} mov={mov} imm={imm} load_sim={load_sim} load_stack={load_stack} load_ptr={load_ptr} store_sim={store_sim} store_stack={store_stack} store_ptr={store_ptr} indexed_load={indexed_load} indexed_store={indexed_store} memcopy={memcopy} alu={alu} alu_imm={alu_imm} cmp={cmp} div_rem={div_rem} bit_ops={bit_ops} select={select} branch={branch} jump={jump} ret={ret}"
     );
 }
@@ -5723,7 +5728,7 @@ fn log_mir_block_stats(label: &str, stage: &str, func: &super::mir::MFunction) {
         ),
     ) in blocks.into_iter().take(10).enumerate()
     {
-        eprintln!(
+        tracing::debug!(
             "[native-mir-block-stats] label={label} stage={stage} rank={} block={} total={} phis={} insts={} load_sim={} load_stack={} store_sim={} store_stack={} indexed_mem={} memcopy={} imm={} alu={} alu_imm={} cmp={} bit_ops={} select={} control={}",
             rank + 1,
             block_id,
@@ -5752,37 +5757,34 @@ fn dump_native_block_context(
     stage: &str,
     eu: &crate::ExecutionUnit<crate::RegionedAbsoluteAddr>,
     func: &super::mir::MFunction,
+    diagnostics: &crate::NativeDiagnostics,
 ) {
-    let Some(raw) = std::env::var_os("CELOX_NATIVE_DUMP_BLOCK") else {
+    let Some(options) = diagnostics.dump.as_ref() else {
         return;
     };
-    if let Some(raw_label) = std::env::var_os("CELOX_NATIVE_DUMP_LABEL")
-        && raw_label != label
+    if let Some(configured_label) = options.label.as_deref()
+        && configured_label != label
     {
         return;
     }
-    if let Some(raw_stage) = std::env::var_os("CELOX_NATIVE_DUMP_STAGE") {
-        if raw_stage != stage {
+    if let Some(configured_stage) = options.stage.as_deref() {
+        if configured_stage != stage {
             return;
         }
     } else if stage != "after_isel" {
         return;
     }
-    let Some(block_id) = raw.to_string_lossy().parse::<u32>().ok() else {
+    let Ok(block_id) = u32::try_from(options.block) else {
         return;
     };
-    let dump_sir = std::env::var_os("CELOX_NATIVE_DUMP_SIR").is_none_or(|raw| raw != "0");
-    let mir_limit = std::env::var_os("CELOX_NATIVE_DUMP_MIR_LIMIT")
-        .and_then(|raw| raw.to_string_lossy().parse::<usize>().ok())
-        .unwrap_or(64);
     let sir_id = crate::BlockId(block_id as usize);
-    eprintln!("[native-dump] label={label} stage={stage} block={block_id}");
-    if dump_sir {
+    tracing::debug!("[native-dump] label={label} stage={stage} block={block_id}");
+    if options.dump_sir {
         if let Some(block) = eu.blocks.get(&sir_id) {
-            eprintln!("[native-dump] SIR:\n{block}");
+            tracing::debug!("[native-dump] SIR:\n{block}");
             dump_sir_operand_defs(eu, block);
         } else {
-            eprintln!("[native-dump] SIR block b{block_id} not found");
+            tracing::debug!("[native-dump] SIR block b{block_id} not found");
         }
     }
     if let Some(block) = func
@@ -5790,7 +5792,7 @@ fn dump_native_block_context(
         .iter()
         .find(|block| block.id == super::mir::BlockId(block_id))
     {
-        eprintln!(
+        tracing::debug!(
             "[native-dump] MIR b{} phis={} insts={}",
             block.id.0,
             block.phis.len(),
@@ -5803,16 +5805,16 @@ fn dump_native_block_context(
                 .map(|(pred, src)| format!("b{}:{}", pred.0, src))
                 .collect::<Vec<_>>()
                 .join(", ");
-            eprintln!("  {} = phi({sources})", phi.dst);
+            tracing::debug!("  {} = phi({sources})", phi.dst);
         }
-        for (idx, inst) in block.insts.iter().enumerate().take(mir_limit) {
-            eprintln!("  {idx}: {inst}");
+        for (idx, inst) in block.insts.iter().enumerate().take(options.mir_limit) {
+            tracing::debug!("  {idx}: {inst}");
         }
-        if block.insts.len() > mir_limit {
-            eprintln!("  ... {} more insts", block.insts.len() - mir_limit);
+        if block.insts.len() > options.mir_limit {
+            tracing::debug!("  ... {} more insts", block.insts.len() - options.mir_limit);
         }
     } else {
-        eprintln!("[native-dump] MIR block b{block_id} not found");
+        tracing::debug!("[native-dump] MIR block b{block_id} not found");
     }
 }
 
@@ -5830,21 +5832,24 @@ fn dump_sir_operand_defs(
         let mut found = false;
         for other in eu.blocks.values() {
             if other.params.contains(&reg) {
-                eprintln!("  [sir-def] r{} is param of b{}", reg.0, other.id.0);
+                tracing::debug!("  [sir-def] r{} is param of b{}", reg.0, other.id.0);
                 found = true;
             }
             for (idx, inst) in other.instructions.iter().enumerate() {
                 if sir_inst_def(inst) == Some(reg) {
-                    eprintln!(
+                    tracing::debug!(
                         "  [sir-def] r{} defined at b{} inst {}: {}",
-                        reg.0, other.id.0, idx, inst
+                        reg.0,
+                        other.id.0,
+                        idx,
+                        inst
                     );
                     found = true;
                 }
             }
         }
         if !found {
-            eprintln!("  [sir-def] r{} has no SIR definition", reg.0);
+            tracing::debug!("  [sir-def] r{} has no SIR definition", reg.0);
         }
     }
 }
@@ -5980,7 +5985,7 @@ fn log_sir_width_stats(eu: &crate::ExecutionUnit<crate::RegionedAbsoluteAddr>) {
         }
     }
 
-    eprintln!(
+    tracing::debug!(
         "[native-timing] sir_width_stats regs={} regs_gt_1024={} max_reg_width={} max_inst_width={} wide_loads={} wide_stores={} wide_commits={} wide_slices={} est_width_chunks={}",
         eu.register_map.len(),
         regs_gt_1024,
@@ -5993,7 +5998,7 @@ fn log_sir_width_stats(eu: &crate::ExecutionUnit<crate::RegionedAbsoluteAddr>) {
         est_chunks
     );
     for example in examples {
-        eprintln!("[native-timing] sir_width_example {example}");
+        tracing::debug!("[native-timing] sir_width_example {example}");
     }
 }
 

--- a/crates/celox-backend-x86/src/backend/native/isel.rs
+++ b/crates/celox-backend-x86/src/backend/native/isel.rs
@@ -38,19 +38,6 @@ impl RegMap {
     }
 }
 
-fn parse_trace_sir_regs() -> HashSet<RegisterId> {
-    std::env::var_os("CELOX_ISEL_TRACE_REGS")
-        .or_else(|| std::env::var_os("CELOX_ISEL_TRACE_REG"))
-        .map(|raw| {
-            raw.to_string_lossy()
-                .split(',')
-                .filter_map(|part| part.trim().parse::<usize>().ok())
-                .map(RegisterId)
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
 fn find_sparse_worklist_run(
     eu: &ExecutionUnit<RegionedAbsoluteAddr>,
 ) -> Option<(crate::BlockId, usize, usize)> {
@@ -1189,7 +1176,21 @@ pub fn lower_execution_unit(
     layout: &MemoryLayout,
     four_state: bool,
 ) -> MFunction {
-    if cfg!(debug_assertions) || std::env::var_os("CELOX_SIR_VERIFY").is_some() {
+    lower_execution_unit_with_diagnostics(
+        eu,
+        layout,
+        four_state,
+        &crate::NativeDiagnostics::default(),
+    )
+}
+
+pub fn lower_execution_unit_with_diagnostics(
+    eu: &ExecutionUnit<RegionedAbsoluteAddr>,
+    layout: &MemoryLayout,
+    four_state: bool,
+    diagnostics: &crate::NativeDiagnostics,
+) -> MFunction {
+    if cfg!(debug_assertions) || diagnostics.verify_sir {
         if let Err(error) = eu.verify_result() {
             panic!("before native ISel: {error}");
         }
@@ -1198,7 +1199,12 @@ pub fn lower_execution_unit(
     let mut spill_descs: Vec<SpillDesc> = Vec::new();
     let max_sir_regs = eu.register_map.keys().map(|r| r.0).max().unwrap_or(0) + 1;
     let mut reg_map = RegMap::new(max_sir_regs);
-    let trace_regs = parse_trace_sir_regs();
+    let trace_regs = diagnostics
+        .isel_trace_regs
+        .iter()
+        .copied()
+        .map(RegisterId)
+        .collect::<HashSet<_>>();
     let mut sir_registers = eu.register_map.keys().copied().collect::<Vec<_>>();
     sir_registers.sort_unstable_by_key(|register| register.0);
 
@@ -1207,7 +1213,7 @@ pub fn lower_execution_unit(
         let vreg = vregs.alloc();
         reg_map.set(*sir_reg_id, vreg);
         if trace_regs.contains(sir_reg_id) {
-            eprintln!("[isel-trace] prealloc r{} -> {}", sir_reg_id.0, vreg);
+            tracing::debug!("[isel-trace] prealloc r{} -> {}", sir_reg_id.0, vreg);
         }
         // Spill desc will be filled during instruction lowering.
         // For now, default to transient.
@@ -1465,9 +1471,12 @@ pub fn lower_execution_unit(
             if let Some(dst) = sir_def_reg(inst)
                 && ctx.trace_regs.contains(&dst)
             {
-                eprintln!(
+                tracing::debug!(
                     "[isel-trace] b{} inst {} lowering r{}: {}",
-                    sir_block.id.0, inst_idx, dst.0, inst
+                    sir_block.id.0,
+                    inst_idx,
+                    dst.0,
+                    inst
                 );
             }
             if packed_field_compare_plans.skip_indices.contains(&inst_idx) {
@@ -1531,7 +1540,7 @@ pub fn lower_execution_unit(
             if lookup_plans.skip_indices.contains(&inst_idx) {
                 if let Some(plan) = lookup_plans.roots.get(&inst_idx) {
                     if ctx.trace_regs.contains(&plan.dst) {
-                        eprintln!(
+                        tracing::debug!(
                             "[isel-trace] b{} inst {} dense-lookup root r{} selector=r{} entries={}",
                             sir_block.id.0,
                             inst_idx,
@@ -1547,7 +1556,7 @@ pub fn lower_execution_unit(
             if priority_plans.skip_indices.contains(&inst_idx) {
                 if let Some(plan) = priority_plans.roots.get(&inst_idx) {
                     if ctx.trace_regs.contains(&plan.dst) {
-                        eprintln!(
+                        tracing::debug!(
                             "[isel-trace] b{} inst {} priority-encode root r{} -> {}",
                             sir_block.id.0,
                             inst_idx,
@@ -1559,9 +1568,11 @@ pub fn lower_execution_unit(
                 } else if let Some(dst) = sir_def_reg(inst)
                     && ctx.trace_regs.contains(&dst)
                 {
-                    eprintln!(
+                    tracing::debug!(
                         "[isel-trace] b{} inst {} skipped r{} without root",
-                        sir_block.id.0, inst_idx, dst.0
+                        sir_block.id.0,
+                        inst_idx,
+                        dst.0
                     );
                 }
                 continue;
@@ -1675,9 +1686,13 @@ pub fn lower_execution_unit(
                     let vreg = ctx.reg_map.get(dr);
                     ctx.known_bits.insert(vreg, w);
                     if ctx.trace_regs.contains(&dr) {
-                        eprintln!(
+                        tracing::debug!(
                             "[isel-trace] b{} inst {} after r{} -> {} known_bits={}",
-                            sir_block.id.0, inst_idx, dr.0, vreg, w
+                            sir_block.id.0,
+                            inst_idx,
+                            dr.0,
+                            vreg,
+                            w
                         );
                     }
                 }
@@ -12480,9 +12495,10 @@ fn lower_terminator(ctx: &mut ISelContext, block: &mut MBlock, term: &SIRTermina
         } => {
             let cond_vreg = lower_branch_condition(ctx, block, *cond);
             if ctx.trace_regs.contains(cond) {
-                eprintln!(
+                tracing::debug!(
                     "[isel-trace] terminator branch cond r{} -> {}",
-                    cond.0, cond_vreg
+                    cond.0,
+                    cond_vreg
                 );
             }
             block.push(MInst::Branch {

--- a/crates/celox-backend-x86/src/backend/native/jit_mem.rs
+++ b/crates/celox-backend-x86/src/backend/native/jit_mem.rs
@@ -28,10 +28,17 @@ impl JitCode {
 
     /// Load named machine code bytes into executable memory.
     ///
-    /// When `CELOX_PERF_MAP=1` is set, this also writes a Linux perf JIT map
-    /// entry so `perf report` can attribute samples to generated functions.
     pub fn new_named(code: &[u8], name: &str) -> Result<Self, std::io::Error> {
         Self::new_named_with_symbols(code, name, &[])
+    }
+
+    /// Load named machine code and optionally emit Linux perf-map entries.
+    pub fn new_named_profiled(
+        code: &[u8],
+        name: &str,
+        perf_map: bool,
+    ) -> Result<Self, std::io::Error> {
+        Self::new_named_with_symbols_profiled(code, name, &[], perf_map)
     }
 
     /// Load named machine code bytes with optional subrange symbols.
@@ -39,6 +46,16 @@ impl JitCode {
         code: &[u8],
         name: &str,
         symbols: &[JitSymbol],
+    ) -> Result<Self, std::io::Error> {
+        Self::new_named_with_symbols_profiled(code, name, symbols, false)
+    }
+
+    /// Load named machine code with optional subrange symbols and perf maps.
+    pub fn new_named_with_symbols_profiled(
+        code: &[u8],
+        name: &str,
+        symbols: &[JitSymbol],
+        perf_map: bool,
     ) -> Result<Self, std::io::Error> {
         // Allocate writable memory, copy code, then make executable
         let mut mmap = MmapMut::map_anon(code.len().max(1))?;
@@ -49,7 +66,9 @@ impl JitCode {
         let fn_ptr: unsafe extern "sysv64" fn(*mut u8) -> i64 =
             unsafe { std::mem::transmute(mmap.as_ptr()) };
 
-        write_perf_map_entries(mmap.as_ptr() as usize, code.len().max(1), name, symbols)?;
+        if perf_map {
+            write_perf_map_entries(mmap.as_ptr() as usize, code.len().max(1), name, symbols)?;
+        }
 
         Ok(Self {
             _mmap: mmap,
@@ -90,10 +109,6 @@ fn write_perf_map_entries(
     name: &str,
     symbols: &[JitSymbol],
 ) -> Result<(), std::io::Error> {
-    if std::env::var_os("CELOX_PERF_MAP").is_none() {
-        return Ok(());
-    }
-
     let path = format!("/tmp/perf-{}.map", std::process::id());
     // Containerized runs can reuse a PID while the previous process's map is
     // still present in /tmp.  Retaining those entries makes perf resolve an

--- a/crates/celox-backend-x86/src/backend/native/mir_opt.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt.rs
@@ -10,7 +10,7 @@ use super::mir::*;
 use super::regalloc::assignment::{AssignmentMap, PhysReg, clobbers};
 
 mod pipeline;
-pub use pipeline::optimize;
+pub use pipeline::{optimize, optimize_with_diagnostics};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct VRegCompaction {

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/pipeline.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/pipeline.rs
@@ -8,10 +8,10 @@ struct PassRunner<'a> {
 }
 
 impl<'a> PassRunner<'a> {
-    fn new(func: &'a mut MFunction) -> Self {
+    fn new(func: &'a mut MFunction, diagnostics: &crate::NativeDiagnostics) -> Self {
         Self {
             func,
-            verify_each: std::env::var_os("CELOX_MIR_VERIFY_PASSES").is_some(),
+            verify_each: diagnostics.verify_mir_passes,
         }
     }
 
@@ -35,7 +35,11 @@ impl<'a> PassRunner<'a> {
 
 /// Run all MIR optimization passes.
 pub fn optimize(func: &mut MFunction) {
-    let mut runner = PassRunner::new(func);
+    optimize_with_diagnostics(func, &crate::NativeDiagnostics::default());
+}
+
+pub fn optimize_with_diagnostics(func: &mut MFunction, diagnostics: &crate::NativeDiagnostics) {
+    let mut runner = PassRunner::new(func, diagnostics);
     if runner.has_high_pressure() {
         run_high_pressure_pipeline(&mut runner);
     } else {
@@ -43,7 +47,7 @@ pub fn optimize(func: &mut MFunction) {
     }
     run_final_pipeline(&mut runner);
 
-    if cfg!(debug_assertions) || std::env::var_os("CELOX_MIR_VERIFY").is_some() {
+    if cfg!(debug_assertions) || diagnostics.verify_mir {
         if let Err(error) = runner.func.verify_result() {
             panic!("after MIR optimizer: {error}");
         }

--- a/crates/celox-backend-x86/src/backend/native/mod.rs
+++ b/crates/celox-backend-x86/src/backend/native/mod.rs
@@ -13,16 +13,3 @@ pub mod regalloc;
 mod sparse_write_state;
 pub mod ssa_destroy;
 pub mod x86_slp;
-
-fn enabled_by_default(name: &str) -> bool {
-    let configured = std::env::var_os(name);
-    if cfg!(test) {
-        configured.is_some_and(|value| value != "0")
-    } else {
-        configured.is_none_or(|value| value != "0")
-    }
-}
-
-pub fn native_tick_loop_enabled() -> bool {
-    enabled_by_default("CELOX_NATIVE_TICK_LOOP")
-}

--- a/crates/celox-backend-x86/src/backend/native/regalloc.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc.rs
@@ -231,10 +231,27 @@ pub(crate) fn run_regalloc_with_label_and_trace(
     label: &str,
     trace: Option<&mut RegallocTrace>,
 ) -> Result<RegallocResult, RegallocError> {
+    run_regalloc_with_label_and_trace_and_diagnostics(
+        func,
+        label,
+        trace,
+        &crate::NativeDiagnostics::default(),
+        true,
+    )
+}
+
+pub(crate) fn run_regalloc_with_label_and_trace_and_diagnostics(
+    func: &mut MFunction,
+    label: &str,
+    trace: Option<&mut RegallocTrace>,
+    diagnostics: &crate::NativeDiagnostics,
+    native_tick_loop: bool,
+) -> Result<RegallocResult, RegallocError> {
     // Build the complete result privately. A structured error cannot expose
     // CFG/scheduling/SSA mutations from a failed phase to the caller.
     let mut working = func.clone();
-    let allocation = run_regalloc_in_place(&mut working, label, trace)?;
+    let allocation =
+        run_regalloc_in_place(&mut working, label, trace, diagnostics, native_tick_loop)?;
     *func = working;
     Ok(allocation)
 }
@@ -243,9 +260,10 @@ fn run_regalloc_in_place(
     func: &mut MFunction,
     label: &str,
     mut trace: Option<&mut RegallocTrace>,
+    diagnostics: &crate::NativeDiagnostics,
+    native_tick_loop: bool,
 ) -> Result<RegallocResult, RegallocError> {
-    let timing = std::env::var_os("CELOX_REGALLOC_TIMING").is_some()
-        || std::env::var_os("CELOX_PHASE_TIMING").is_some();
+    let timing = diagnostics.regalloc_timing || diagnostics.phase_timing;
     // Allocation must never depend on callers having run the optional MIR
     // optimization pipeline. Select flag-consuming register branches at the
     // allocation boundary so their unmaterialized boolean result cannot
@@ -262,7 +280,7 @@ fn run_regalloc_in_place(
     func.verify_result()
         .map_err(|error| RegallocError::mir("CFG normalization verification", error))?;
     if let Some(start) = cfg_start {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-timing] label={label} cfg_normalize blocks={} elapsed={:?}",
             func.blocks.len(),
             start.elapsed()
@@ -270,11 +288,11 @@ fn run_regalloc_in_place(
     }
     let total_start = timing.then(crate::timing::now);
     let stats_start = timing.then(crate::timing::now);
-    let before_stats = std::env::var_os("CELOX_REGALLOC_STATS")
-        .is_some()
+    let before_stats = diagnostics
+        .regalloc_stats
         .then(|| collect_regalloc_block_stats(func));
     if let Some(start) = stats_start {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-timing] label={label} collect_before_stats elapsed={:?}",
             start.elapsed()
         );
@@ -292,7 +310,7 @@ fn run_regalloc_in_place(
         trace.mir_after_late_memory_folds = func.to_string();
     }
     if let Some(start) = late_memory_fold_start {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-timing] label={label} late_memory_fold folded_direct_immediate_stores={folded_direct_immediate_stores} folded_memory_branches={folded_memory_branches} elapsed={:?}",
             start.elapsed()
         );
@@ -310,7 +328,7 @@ fn run_regalloc_in_place(
     let planning_recipes = reload::analyze_for_planning(func, &normalized_cfg)
         .map_err(|error| reload_recipe_error("reload-recipe planning analysis", error))?;
     if let Some(start) = reload_recipe_start {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-timing] label={label} reload_recipe_plan_analyze elapsed={:?}",
             start.elapsed()
         );
@@ -319,7 +337,7 @@ fn run_regalloc_in_place(
     let next_use = next_use::analyze(func, &normalized_cfg)
         .map_err(|error| next_use_error("next-use analysis", error))?;
     if let Some(start) = next_use_start {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-timing] label={label} next_use_analyze elapsed={:?}",
             start.elapsed()
         );
@@ -329,7 +347,7 @@ fn run_regalloc_in_place(
         .verify(func, &normalized_cfg)
         .map_err(|error| next_use_error("next-use verification", error))?;
     if let Some(start) = next_use_verify_start {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-timing] label={label} next_use_verify elapsed={:?}",
             start.elapsed()
         );
@@ -342,10 +360,11 @@ fn run_regalloc_in_place(
         &planning_recipes,
         &allocation_constraints,
         trace,
+        timing,
     )?;
     let mut assignment = allocation.assignment;
     let mut spill_frame_size = allocation.spill_frame_size;
-    let tick_loop = label == "eval_comb_apply_ff" && super::native_tick_loop_enabled();
+    let tick_loop = label == "eval_comb_apply_ff" && native_tick_loop;
     let vector_allocation = super::x86_slp::allocate(func, spill_frame_size, tick_loop);
     for (value, location) in vector_allocation.assignments {
         assignment.set_x86_vector(value, location);
@@ -367,13 +386,14 @@ fn run_regalloc_in_place(
             })?;
     }
     if timing && vector_allocation.spilled_values != 0 {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-timing] label={label} x86_vector_spills={} spill_bytes={}",
-            vector_allocation.spilled_values, vector_allocation.spill_bytes
+            vector_allocation.spilled_values,
+            vector_allocation.spill_bytes
         );
     }
     if let Some(start) = alloc_start {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-timing] label={label} implementation=ssa-split-color blocks={} insts={} vregs={} spill_frame={} elapsed={:?}",
             func.blocks.len(),
             func.blocks
@@ -389,7 +409,7 @@ fn run_regalloc_in_place(
     let verify_start = timing.then(crate::timing::now);
     verify_assignment(func, &assignment)?;
     if let Some(start) = verify_start {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-timing] label={label} verify elapsed={:?}",
             start.elapsed()
         );
@@ -399,14 +419,14 @@ fn run_regalloc_in_place(
         let stats_start = timing.then(crate::timing::now);
         log_regalloc_stats(label, func, &before, spill_frame_size);
         if let Some(start) = stats_start {
-            eprintln!(
+            tracing::debug!(
                 "[regalloc-timing] label={label} log_stats elapsed={:?}",
                 start.elapsed()
             );
         }
     }
     if let Some(start) = total_start {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-timing] label={label} total elapsed={:?}",
             start.elapsed()
         );
@@ -570,7 +590,7 @@ fn log_regalloc_stats(
         ));
     }
 
-    eprintln!(
+    tracing::debug!(
         "[regalloc-stats] label={label} spill_frame={spill_frame_size} total_insts={} delta_insts={} total_mov={} delta_mov={} total_load_stack={} delta_load_stack={} total_store_stack={} delta_store_stack={} total_load_imm={} delta_load_imm={}",
         total.insts,
         total_delta.insts,
@@ -588,7 +608,7 @@ fn log_regalloc_stats(
     for (rank, (_score, block_id, before_stats, after_stats, delta)) in
         rows.into_iter().take(12).enumerate()
     {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-block-stats] label={label} rank={} block={} before_insts={} after_insts={} delta_insts={} delta_mov={} delta_load_stack={} delta_store_stack={} delta_load_imm={}",
             rank + 1,
             block_id.0,

--- a/crates/celox-backend-x86/src/backend/native/regalloc/ssa.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/ssa.rs
@@ -24,9 +24,8 @@ pub(super) fn allocate(
     planning_recipes: &PlanningRecipes,
     constraints: &super::constraints::ConstraintModel,
     trace: Option<&mut super::RegallocTrace>,
+    timing: bool,
 ) -> Result<Allocation, super::RegallocError> {
-    let timing = std::env::var_os("CELOX_REGALLOC_TIMING").is_some()
-        || std::env::var_os("CELOX_PHASE_TIMING").is_some();
     let register_count = func.target_features.allocatable_register_count();
     let phase = timing.then(crate::timing::now);
     let mut plan = super::spill_plan::plan_with_integrated_schedule(
@@ -61,7 +60,7 @@ pub(super) fn allocate(
         )
     })?;
     if let Some(start) = phase {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-timing] ssa spill_plan elapsed={:?}",
             start.elapsed()
         );
@@ -89,7 +88,7 @@ pub(super) fn allocate(
         )
     })?;
     if let Some(start) = phase {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-timing] ssa packed_state_homes homes={} reloads={} elapsed={:?}",
             plan.state_homes.len(),
             plan.state_reload_recipes.len(),
@@ -169,7 +168,7 @@ pub(super) fn allocate(
         ));
     }
     if let Some(start) = phase {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-timing] ssa planner_reload_recipe_analyze_verify queries={} elapsed={:?}",
             requested_points.len(),
             start.elapsed()
@@ -191,7 +190,7 @@ pub(super) fn allocate(
             },
         )?;
     if let Some(start) = phase {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-timing] ssa reconstruct vregs={} insts={} frame={} shared_reload_blocks={} elapsed={:?}",
             func.vregs.count(),
             func.blocks
@@ -277,7 +276,7 @@ pub(super) fn allocate(
         ));
     }
     if let Some(start) = phase {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-timing] ssa reconstructed_pressure_verify elapsed={:?}",
             start.elapsed()
         );
@@ -300,7 +299,7 @@ pub(super) fn allocate(
     func.verify_result()
         .map_err(|error| super::RegallocError::mir("Perm structural verification", error))?;
     if let Some(start) = phase {
-        eprintln!(
+        tracing::debug!(
             "[regalloc-timing] ssa constraint_perms boundaries={} vregs={} elapsed={:?}",
             perms.boundaries.len(),
             func.vregs.count(),
@@ -335,7 +334,7 @@ pub(super) fn allocate(
         }
     }
     if let Some(start) = phase {
-        eprintln!("[regalloc-timing] ssa color elapsed={:?}", start.elapsed());
+        tracing::debug!("[regalloc-timing] ssa color elapsed={:?}", start.elapsed());
     }
 
     Ok(Allocation {

--- a/crates/celox-backend-x86/src/backend/native/regalloc/tests.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/tests.rs
@@ -371,7 +371,7 @@ fn test_shift_with_pressure() {
     // Dump
     for (ii, inst) in func.blocks[0].insts.iter().enumerate() {
         let r = inst.def().and_then(|d| assignment.get(d));
-        eprintln!("  [{ii:3}] {inst}  => {r:?}");
+        tracing::debug!("  [{ii:3}] {inst}  => {r:?}");
     }
 
     // Verify

--- a/crates/celox-backend-x86/src/backend/native/regalloc/unified.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/unified.rs
@@ -190,7 +190,7 @@ struct RegallocTrace {
 
 impl RegallocTrace {
     fn new_if_enabled(label: &str, func: &MFunction) -> Option<Self> {
-        std::env::var_os("CELOX_REGALLOC_TRACE").map(|_| {
+        tracing::enabled!(tracing::Level::TRACE).then(|| {
             let mut def_opcodes = vec![None; func.vregs.count() as usize];
             for block in &func.blocks {
                 for inst in &block.insts {
@@ -296,14 +296,14 @@ impl RegallocTrace {
         let mut rows = self.rows.into_iter().collect::<Vec<_>>();
         rows.sort_by_key(|(_, count)| std::cmp::Reverse(count.count));
         let total: usize = rows.iter().map(|(_, count)| count.count).sum();
-        eprintln!(
+        tracing::debug!(
             "[regalloc-trace] label={} total_events={} groups={}",
             self.label,
             total,
             rows.len()
         );
         for (rank, (key, count)) in rows.into_iter().take(40).enumerate() {
-            eprintln!(
+            tracing::debug!(
                 "[regalloc-trace] label={} rank={} event={} reason={} kind={} def={} next={} count={} stack_mem={} sim_mem={} remat={} no_store={}",
                 self.label,
                 rank + 1,
@@ -464,6 +464,20 @@ pub fn unified_alloc_with_label(
     analysis: &AnalysisResult,
     label: &str,
 ) -> (AssignmentMap, u32) {
+    unified_alloc_with_label_and_diagnostics(
+        func,
+        analysis,
+        label,
+        &crate::NativeDiagnostics::default(),
+    )
+}
+
+pub fn unified_alloc_with_label_and_diagnostics(
+    func: &mut MFunction,
+    analysis: &AnalysisResult,
+    label: &str,
+    diagnostics: &crate::NativeDiagnostics,
+) -> (AssignmentMap, u32) {
     let num_blocks = func.blocks.len();
     let k = func.target_features.allocatable_register_count();
     let mut result = AssignmentMap::default();
@@ -520,6 +534,7 @@ pub fn unified_alloc_with_label(
             &mut slots,
             &mut result,
             trace.as_mut(),
+            diagnostics.verify_regalloc,
         );
 
         func.blocks[bi].insts = new_insts;
@@ -853,6 +868,7 @@ fn process_block(
     slots: &mut SpillSlotAllocator,
     result: &mut AssignmentMap,
     mut trace: Option<&mut RegallocTrace>,
+    verify_each_instruction: bool,
 ) -> (RegFile, HashSet<VReg>, Vec<MInst>) {
     let block = func.blocks[block_idx].clone();
     let mut new_insts: Vec<MInst> = Vec::with_capacity(block.insts.len());
@@ -1279,7 +1295,7 @@ fn process_block(
             }
         }
 
-        if cfg!(debug_assertions) || std::env::var_os("CELOX_REGALLOC_VERIFY").is_some() {
+        if cfg!(debug_assertions) || verify_each_instruction {
             rf.verify_instruction(
                 &rewritten_inst,
                 result,

--- a/crates/celox-backend-x86/src/lib.rs
+++ b/crates/celox-backend-x86/src/lib.rs
@@ -7,14 +7,57 @@
 pub type HashMap<K, V> = fxhash::FxHashMap<K, V>;
 pub type HashSet<K> = fxhash::FxHashSet<K>;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeDumpOptions {
+    pub block: usize,
+    pub label: Option<String>,
+    pub stage: Option<String>,
+    pub dump_sir: bool,
+    pub mir_limit: usize,
+}
+
+impl Default for NativeDumpOptions {
+    fn default() -> Self {
+        Self {
+            block: 0,
+            label: None,
+            stage: None,
+            dump_sir: true,
+            mir_limit: 64,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NativeDiagnostics {
+    pub phase_timing: bool,
+    pub regalloc_timing: bool,
+    pub regalloc_stats: bool,
+    pub mir_stats: bool,
+    pub mir_block_stats: bool,
+    pub verify_sir: bool,
+    pub verify_mir: bool,
+    pub verify_mir_passes: bool,
+    pub verify_regalloc: bool,
+    pub isel_trace_regs: Vec<usize>,
+    pub dump: Option<NativeDumpOptions>,
+    pub perf_map: bool,
+}
+
+#[derive(Debug, Clone)]
 pub struct X86BackendOptions {
     pub slp: bool,
+    pub native_tick_loop: bool,
+    pub diagnostics: NativeDiagnostics,
 }
 
 impl Default for X86BackendOptions {
     fn default() -> Self {
-        Self { slp: true }
+        Self {
+            slp: true,
+            native_tick_loop: true,
+            diagnostics: NativeDiagnostics::default(),
+        }
     }
 }
 

--- a/crates/celox-bench/src/bin/celox-heliodor.rs
+++ b/crates/celox-bench/src/bin/celox-heliodor.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_macros)] // CLI errors and progress intentionally use stderr
+
 use std::{
     error::Error,
     fs,

--- a/crates/celox-bench/src/bin/veryl-heliodor.rs
+++ b/crates/celox-bench/src/bin/veryl-heliodor.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_macros)] // CLI errors intentionally use stderr
+
 use std::{
     error::Error,
     fs,

--- a/crates/celox-frontend-veryl/Cargo.toml
+++ b/crates/celox-frontend-veryl/Cargo.toml
@@ -8,6 +8,7 @@ description           = "Veryl frontend artifacts and source lookup for Celox"
 edition.workspace     = true
 
 [dependencies]
+tracing = { workspace = true }
 bit-set        = { workspace = true }
 celox-design   = { path = "../celox-design" }
 celox-sir      = { path = "../celox-sir" }

--- a/crates/celox-frontend-veryl/src/design_assembly.rs
+++ b/crates/celox-frontend-veryl/src/design_assembly.rs
@@ -239,13 +239,13 @@ pub fn schedule_symbolic_rtl(
         module_names,
         root_id,
     } = symbolic;
-    let flatten_timing = std::env::var("CELOX_PHASE_TIMING").is_ok();
+    let flatten_timing = trace_opts.phase_timing;
     macro_rules! timed_sub {
         ($label:expr, $body:expr) => {{
             if flatten_timing {
                 let start = std::time::Instant::now();
                 let result = $body;
-                eprintln!("[flatten] {}: {:?}", $label, start.elapsed());
+                tracing::debug!("[flatten] {}: {:?}", $label, start.elapsed());
                 result
             } else {
                 $body
@@ -542,7 +542,7 @@ pub fn schedule_symbolic_rtl(
         }
     };
     if let Some(s) = sched_start {
-        eprintln!("[flatten] scheduler::sort: {:?}", s.elapsed());
+        tracing::debug!("[flatten] scheduler::sort: {:?}", s.elapsed());
     }
     runtime_errors.extend(schedule.runtime_errors);
     let schduled: Vec<ExecutionUnit<RegionedAbsoluteAddr>> = schedule
@@ -618,7 +618,7 @@ pub fn schedule_symbolic_rtl(
             }
         };
         if let Some(start) = fused_start {
-            eprintln!("[flatten] scheduler::sort_clock: {:?}", start.elapsed());
+            tracing::debug!("[flatten] scheduler::sort_clock: {:?}", start.elapsed());
         }
         let direct_ff_writes = fused.direct_ff_writes;
         let units = fused.execution_units;
@@ -2193,7 +2193,7 @@ fn analyze_clock_dependencies(
     }
 
     // 2. Build combinational dependency graph (target -> sources)
-    let acd_timing = std::env::var("CELOX_PHASE_TIMING").is_ok();
+    let acd_timing = tracing::enabled!(tracing::Level::DEBUG);
     let acd_start = acd_timing.then(std::time::Instant::now);
     let mut comb_deps: BTreeMap<AbsoluteAddr, BTreeSet<AbsoluteAddr>> = BTreeMap::new();
     for path in comb_blocks {
@@ -2208,7 +2208,7 @@ fn analyze_clock_dependencies(
         }
     }
     if let Some(s) = acd_start {
-        eprintln!(
+        tracing::debug!(
             "[acd] comb_deps build ({} blocks): {:?}",
             comb_deps.len(),
             s.elapsed()
@@ -2234,7 +2234,7 @@ fn analyze_clock_dependencies(
         }
     }
     if let Some(s) = fp_start {
-        eprintln!(
+        tracing::debug!(
             "[acd] fixpoint: {fp_rounds} rounds, {} entries, {:?}",
             comb_deps.len(),
             s.elapsed()

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -239,16 +239,11 @@ fn dump_comb_path_stats_if_requested(
     paths: &[LogicPath<VarId>],
     arena: &SLTNodeArena<VarId>,
 ) {
-    if std::env::var_os("CELOX_COMB_PATH_STATS").is_none() {
+    if !tracing::enabled!(tracing::Level::DEBUG) {
         return;
     }
 
     let module_name = resource_table::get_str_value(module.name).unwrap_or_default();
-    if let Some(filter) = std::env::var_os("CELOX_COMB_PATH_MODULE")
-        && !module_name.contains(filter.to_string_lossy().as_ref())
-    {
-        return;
-    }
 
     let mut entries = Vec::new();
     let mut total_nodes = 0usize;
@@ -282,7 +277,7 @@ fn dump_comb_path_stats_if_requested(
     }
     entries.sort_by(|a, b| b.cmp(a));
 
-    eprintln!(
+    tracing::debug!(
         "[comb-path-summary] module={} paths={} total_nodes={} total_for_folds={} total_muxes={} total_inputs={}",
         module_name,
         paths.len(),
@@ -292,14 +287,11 @@ fn dump_comb_path_stats_if_requested(
         total_inputs,
     );
 
-    let limit = std::env::var("CELOX_COMB_PATH_STATS_LIMIT")
-        .ok()
-        .and_then(|raw| raw.parse::<usize>().ok())
-        .unwrap_or(20);
+    let limit = 20;
     for (rank, (nodes, for_folds, muxes, inputs, target)) in
         entries.into_iter().take(limit).enumerate()
     {
-        eprintln!(
+        tracing::debug!(
             "[comb-path-stats] module={} rank={} target={} nodes={} for_folds={} muxes={} inputs={}",
             module_name,
             rank + 1,

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -922,7 +922,7 @@ impl<'a> ModuleParser<'a> {
         let timing = readmem_timing_enabled();
         let total_start = timing.then(Instant::now);
         if timing {
-            eprintln!(
+            tracing::debug!(
                 "[readmem-timing] start file={} depth={} element_width={} start_addr={} radix={}",
                 path.display(),
                 depth,
@@ -943,7 +943,7 @@ impl<'a> ModuleParser<'a> {
             )
         })?;
         if let Some(start) = read_start {
-            eprintln!(
+            tracing::debug!(
                 "[readmem-timing] read file={} bytes={} elapsed={:?}",
                 path.display(),
                 content.len(),
@@ -961,7 +961,7 @@ impl<'a> ModuleParser<'a> {
             &dst.token,
         )?;
         if let Some(start) = parse_start {
-            eprintln!(
+            tracing::debug!(
                 "[readmem-timing] parse file={} words={} runs={} elapsed={:?}",
                 path.display(),
                 writes.words,
@@ -970,7 +970,7 @@ impl<'a> ModuleParser<'a> {
             );
         }
         if let Some(start) = total_start {
-            eprintln!(
+            tracing::debug!(
                 "[readmem-timing] done file={} elapsed={:?}",
                 path.display(),
                 start.elapsed()
@@ -1344,8 +1344,7 @@ fn collect_glue_sources(
 }
 
 fn readmem_timing_enabled() -> bool {
-    std::env::var_os("CELOX_READMEM_TIMING").is_some()
-        || std::env::var_os("CELOX_PHASE_TIMING").is_some()
+    tracing::enabled!(tracing::Level::DEBUG)
 }
 
 fn collect_glue_sources_with_window(

--- a/crates/celox-frontend-veryl/src/trace.rs
+++ b/crates/celox-frontend-veryl/src/trace.rs
@@ -8,6 +8,7 @@ use crate::{AbsoluteAddr, HashMap, RegionedAbsoluteAddr, SimModule};
 /// intentionally absent from this contract.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct FrontendTraceOptions {
+    pub phase_timing: bool,
     pub sim_modules: bool,
     pub pre_atomized_comb_blocks: bool,
     pub atomized_comb_blocks: bool,

--- a/crates/celox-macros/src/generator/test_generator.rs
+++ b/crates/celox-macros/src/generator/test_generator.rs
@@ -65,7 +65,6 @@ mod tests {
         let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
         // CARGO_MANIFEST_DIR is crates/celox-macros
         let target_dir = PathBuf::from(manifest_dir).join("../celox/tests/macro_project");
-        dbg!(&target_dir);
         let metadata_path = std::fs::canonicalize(target_dir.join("Veryl.toml")).unwrap();
         let mut metadata = Metadata::load(&metadata_path).unwrap();
 

--- a/crates/celox-macros/src/lib.rs
+++ b/crates/celox-macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_methods)] // proc-macro build context is an application boundary
+
 mod generator;
 
 use proc_macro::TokenStream;

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -431,6 +431,7 @@ fn parse_options(options: &Option<NapiOptions>) -> Result<ParsedOptions> {
                 enable_alias_analysis: o.enable_alias_analysis.unwrap_or(true),
                 enable_verifier: o.enable_verifier.unwrap_or(true),
                 tail_call_split: true,
+                diagnostics: celox::CraneliftDiagnostics::default(),
             };
             Ok(ParsedOptions {
                 common,

--- a/crates/celox-sir-opt/Cargo.toml
+++ b/crates/celox-sir-opt/Cargo.toml
@@ -8,6 +8,7 @@ description = "Backend-independent SIR optimization policy and passes for Celox"
 edition.workspace = true
 
 [dependencies]
+tracing = { workspace = true }
 bit-set             = { workspace = true }
 celox-analysis      = { path = "../celox-analysis" }
 celox-design        = { path = "../celox-design" }

--- a/crates/celox-sir-opt/src/lib.rs
+++ b/crates/celox-sir-opt/src/lib.rs
@@ -92,4 +92,4 @@ pub fn optimize(
 }
 
 mod policy;
-pub use policy::{OptLevel, OptimizeOptions, PassOptions, SirPass};
+pub use policy::{OptLevel, OptimizeOptions, PassOptions, SirDiagnostics, SirPass};

--- a/crates/celox-sir-opt/src/optimizer/native.rs
+++ b/crates/celox-sir-opt/src/optimizer/native.rs
@@ -13,6 +13,7 @@ pub fn optimize_merged_chain(
     packed_range_is_contiguous: impl Fn(RegionedAbsoluteAddr, usize, usize) -> bool,
     four_state: bool,
     recover_merged_effect_regions: bool,
+    diagnostics: &crate::SirDiagnostics,
 ) -> Result<(), (&'static str, crate::ir::verify::SirVerifyError)> {
     let mut changed = false;
     if crate::ir::inline_single_predecessor_jumps(eu)
@@ -102,7 +103,7 @@ pub fn optimize_merged_chain(
             .map_err(|error| ("after native fixed bit-map recovery", error))?;
     }
     if !four_state
-        && std::env::var_os("CELOX_EFFECT_CASE_DISPATCH").is_some()
+        && diagnostics.effect_case_dispatch
         && let Some(result) = pass_effect_case_dispatch::run(eu)
     {
         changed = true;
@@ -118,7 +119,7 @@ pub fn optimize_merged_chain(
             },
         );
         let cfg_cleanup_ns = cfg_cleanup_start.elapsed().as_nanos();
-        eprintln!(
+        tracing::debug!(
             "[effect-case-dispatch] origin=b{} selector=r{} cases={} sinks={} \
              path_local_exits={} estimated_saving={} planning_ms={:.3} rewrite_ms={:.3} \
              dead_control_ms={:.3} cfg_cleanup_ms={:.3}",

--- a/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_branchify_mux.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_branchify_mux.rs
@@ -307,17 +307,17 @@ fn run_branchify_mux(
     recover_controlled_joins: bool,
     enable_whole_function_rewrites: bool,
 ) {
-    let stage_timing = std::env::var_os("CELOX_PASS_TIMING").is_some()
-        || std::env::var_os("CELOX_BRANCHIFY_STATS").is_some();
+    let diagnostics = &options.optimize_options.diagnostics;
+    let stage_timing = diagnostics.pass_timing || diagnostics.branchify_stats;
     let mut previous_stage = stage_timing.then(crate::timing::now);
     let mut report_stage = |stage: &'static str| {
         if let Some(previous) = previous_stage.as_mut() {
-            eprintln!("[branchify-timing] {stage}: {:?}", previous.elapsed());
+            tracing::debug!("[branchify-timing] {stage}: {:?}", previous.elapsed());
             *previous = crate::timing::now();
         }
     };
     let verify_stage = |eu: &ExecutionUnit<RegionedAbsoluteAddr>, stage: &'static str| {
-        if std::env::var_os("CELOX_SIR_VERIFY_PASSES").is_some()
+        if diagnostics.verify_passes
             && let Err(error) = eu.verify_result()
         {
             panic!("during branchify_mux {stage}: {error}");
@@ -341,12 +341,9 @@ fn run_branchify_mux(
     verify_stage(eu, "controlled-join elimination");
     report_stage("controlled-join elimination");
 
-    let stats = std::env::var_os("CELOX_BRANCHIFY_STATS").is_some();
+    let stats = diagnostics.branchify_stats;
     let stats_start = stats.then(crate::timing::now);
-    let trace_reg = std::env::var("CELOX_BRANCHIFY_TRACE_REG")
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .map(RegisterId);
+    let trace_reg = diagnostics.branchify_trace_reg.map(RegisterId);
     let mut next_block_id = eu.blocks.keys().map(|id| id.0).max().unwrap_or(0) + 1;
     let mut reg_counter = eu.register_map.keys().map(|reg| reg.0).max().unwrap_or(0);
     let mut applied = 0usize;
@@ -374,7 +371,7 @@ fn run_branchify_mux(
             &mut reg_counter,
         );
         if let Some(start) = priority_start {
-            eprintln!(
+            tracing::debug!(
                 "[branchify-timing] coupled priority chains: {:?}",
                 start.elapsed()
             );
@@ -383,7 +380,7 @@ fn run_branchify_mux(
         applied +=
             branchify_coupled_state_updates(eu, &use_counts, &mut next_block_id, &mut reg_counter);
         if let Some(start) = state_start {
-            eprintln!(
+            tracing::debug!(
                 "[branchify-timing] coupled state updates: {:?}",
                 start.elapsed()
             );
@@ -402,7 +399,7 @@ fn run_branchify_mux(
         && let Some(plan) = find_cross_block_priority_chain_plan(eu, &use_counts)
     {
         if let Some(register) = trace_reg {
-            eprintln!(
+            tracing::debug!(
                 "[branchify-trace] selected cross-block priority plan source=b{} first_mux={} muxes={} r{} uses={}",
                 plan.block_id.0,
                 plan.first_mux_idx,
@@ -426,9 +423,11 @@ fn run_branchify_mux(
                     if def_reg(&definition.instruction) == Some(register)
                         || inst_uses(&definition.instruction).contains(&register)
                     {
-                        eprintln!(
+                        tracing::debug!(
                             "[branchify-trace] plan {kind}[{group}] b{} i{}: {}",
-                            definition.block.0, definition.index, definition.instruction
+                            definition.block.0,
+                            definition.index,
+                            definition.instruction
                         );
                     }
                 }
@@ -449,9 +448,11 @@ fn run_branchify_mux(
         if let Some((register, block, first_mux, muxes)) = trace_plan
             && let Err(error) = eu.verify_result()
         {
-            eprintln!(
+            tracing::debug!(
                 "[branchify-trace] invalid cross-block priority plan source=b{} first_mux={} muxes={}: {error}",
-                block.0, first_mux, muxes
+                block.0,
+                first_mux,
+                muxes
             );
             for candidate in eu.blocks.values() {
                 trace_reg_in_new_block(candidate, register);
@@ -519,7 +520,7 @@ fn run_branchify_mux(
                     .values()
                     .map(|block| block.instructions.len())
                     .sum::<usize>();
-                eprintln!(
+                tracing::debug!(
                     "[branchify-stats] applied={applied} blocks={} insts={} worklist={} elapsed={:?}",
                     eu.blocks.len(),
                     insts,
@@ -584,7 +585,7 @@ fn run_branchify_mux(
     report_stage("selector predicates");
 
     if stats {
-        eprintln!(
+        tracing::debug!(
             "[branchify-stats] before_pre_repair_inline applied={applied} blocks={} elapsed={:?}",
             eu.blocks.len(),
             stats_start.unwrap().elapsed()
@@ -602,14 +603,14 @@ fn run_branchify_mux(
             .values()
             .map(|block| block.instructions.len())
             .sum::<usize>();
-        eprintln!(
+        tracing::debug!(
             "[branchify-stats] done applied={applied} blocks={} insts={} elapsed={:?}",
             eu.blocks.len(),
             insts,
             stats_start.unwrap().elapsed()
         );
     }
-    if std::env::var_os("CELOX_BRANCHIFY_VERIFY").is_some() {
+    if diagnostics.branchify_verify {
         verify_all_uses_have_defs(eu);
     }
 }
@@ -4910,25 +4911,25 @@ fn resolve_boolean_alias(
 
 impl CfgAnalysis {
     fn compute(eu: &ExecutionUnit<RegionedAbsoluteAddr>) -> Option<Self> {
-        let stats = std::env::var_os("CELOX_BRANCHIFY_STATS").is_some();
+        let stats = tracing::enabled!(tracing::Level::DEBUG);
         // Controlled-join recovery needs predecessor, dominance, and
         // post-dominance queries, but not the potentially dense dominance
         // frontiers or control-dependence tables of the full analysis.
         let graph = SirCfg::analyze_structure(eu).ok()?;
         if stats {
-            eprintln!("[branchify-stats] controlled_join cfg");
+            tracing::debug!("[branchify-stats] controlled_join cfg");
         }
         let def_locations = instruction_def_locations(eu);
         if stats {
-            eprintln!("[branchify-stats] controlled_join defs");
+            tracing::debug!("[branchify-stats] controlled_join defs");
         }
         let incoming_edges = indexed_incoming_edges(eu, &graph);
         if stats {
-            eprintln!("[branchify-stats] controlled_join incoming");
+            tracing::debug!("[branchify-stats] controlled_join incoming");
         }
         let path_facts = PathFacts::compute(eu, &def_locations, &graph, &incoming_edges);
         if stats {
-            eprintln!("[branchify-stats] controlled_join path_facts");
+            tracing::debug!("[branchify-stats] controlled_join path_facts");
         }
 
         Some(Self {
@@ -6018,7 +6019,7 @@ fn trace_reg_in_original(
     if defines.is_empty() && inst_uses.is_empty() && !term_uses && !block.params.contains(&reg) {
         return;
     }
-    eprintln!(
+    tracing::debug!(
         "[branchify-trace] original block=b{} mux_idx={} dst=r{} cond=r{} true=r{} false=r{} params={} term_uses={} true_defs={:?} false_defs={:?}",
         block.id.0,
         plan.mux_idx,
@@ -6032,21 +6033,22 @@ fn trace_reg_in_original(
         plan.false_defs
     );
     for (idx, inst) in defines {
-        eprintln!(
+        tracing::debug!(
             "[branchify-trace] original defines r{} at inst {idx}: {inst}",
             reg.0
         );
     }
     for (idx, inst) in inst_uses {
-        eprintln!(
+        tracing::debug!(
             "[branchify-trace] original uses r{} at inst {idx}: {inst}",
             reg.0
         );
     }
     if term_uses {
-        eprintln!(
+        tracing::debug!(
             "[branchify-trace] original terminator uses r{}: {}",
-            reg.0, block.terminator
+            reg.0,
+            block.terminator
         );
     }
 }
@@ -6059,7 +6061,7 @@ fn trace_reg_branchify_plan(
 ) {
     for (idx, inst) in block.instructions.iter().enumerate() {
         if def_reg(inst) == Some(reg) {
-            eprintln!(
+            tracing::debug!(
                 "[branchify-trace] after restore decision block=b{} r{} def_idx={idx} removed={} inst={inst}",
                 block.id.0,
                 reg.0,
@@ -6068,7 +6070,7 @@ fn trace_reg_branchify_plan(
         }
     }
     if plan.cond == reg || plan.true_val == reg || plan.false_val == reg || plan.dst == reg {
-        eprintln!(
+        tracing::debug!(
             "[branchify-trace] plan directly references r{} block=b{} mux_idx={} dst=r{} cond=r{} true=r{} false=r{}",
             reg.0,
             block.id.0,
@@ -6098,7 +6100,7 @@ fn trace_reg_in_new_block(block: &BasicBlock<RegionedAbsoluteAddr>, reg: Registe
     if !block.params.contains(&reg) && !term_uses && inst_uses.is_empty() && defines.is_empty() {
         return;
     }
-    eprintln!(
+    tracing::debug!(
         "[branchify-trace] new block=b{} params={} term_uses={} insts={} defs={}",
         block.id.0,
         block.params.contains(&reg),
@@ -6107,21 +6109,22 @@ fn trace_reg_in_new_block(block: &BasicBlock<RegionedAbsoluteAddr>, reg: Registe
         defines.len()
     );
     for (idx, inst) in defines {
-        eprintln!(
+        tracing::debug!(
             "[branchify-trace] new defines r{} at inst {idx}: {inst}",
             reg.0
         );
     }
     for (idx, inst) in inst_uses {
-        eprintln!(
+        tracing::debug!(
             "[branchify-trace] new uses r{} at inst {idx}: {inst}",
             reg.0
         );
     }
     if term_uses {
-        eprintln!(
+        tracing::debug!(
             "[branchify-trace] new terminator uses r{}: {}",
-            reg.0, block.terminator
+            reg.0,
+            block.terminator
         );
     }
 }

--- a/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_guarded_region_sinking.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_guarded_region_sinking.rs
@@ -224,7 +224,7 @@ impl ExecutionUnitPass for GuardedRegionSinkingPass {
             return;
         }
         let verify_stage = |eu: &ExecutionUnit<RegionedAbsoluteAddr>, stage: &'static str| {
-            if std::env::var_os("CELOX_SIR_VERIFY_PASSES").is_some()
+            if options.optimize_options.diagnostics.verify_passes
                 && let Err(error) = eu.verify_result()
             {
                 panic!("after guarded-region substage {stage}: {error}");
@@ -288,13 +288,13 @@ impl ExecutionUnitPass for GuardedRegionSinkingPass {
             if last_new_block > u32::MAX as usize {
                 return;
             }
-            if std::env::var_os("CELOX_PASS_TIMING").is_some() {
+            if options.optimize_options.diagnostics.pass_timing {
                 let moved = plans.iter().map(|plan| plan.moved.len()).sum::<usize>();
                 let stores = plans
                     .iter()
                     .map(|plan| plan.distributed.len())
                     .sum::<usize>();
-                eprintln!(
+                tracing::debug!(
                     "[guarded-region-sinking] regions={} moved_instructions={moved} distributed_stores={stores}",
                     plans.len(),
                 );
@@ -2085,9 +2085,9 @@ fn form_coupled_store_regions(eu: &mut ExecutionUnit<RegionedAbsoluteAddr>) {
         return;
     }
 
-    if std::env::var_os("CELOX_PASS_TIMING").is_some() {
+    if tracing::enabled!(tracing::Level::DEBUG) {
         for plan in &plans {
-            eprintln!(
+            tracing::debug!(
                 "[coupled-store-region] block={} depth={} stores={} owned={} benefit_scaled={}",
                 plan.block_id.0,
                 plan.conditions.len(),
@@ -2743,7 +2743,7 @@ fn form_same_predicate_regions(eu: &mut ExecutionUnit<RegionedAbsoluteAddr>) {
         return;
     }
 
-    if std::env::var_os("CELOX_PASS_TIMING").is_some() {
+    if tracing::enabled!(tracing::Level::DEBUG) {
         let muxes = plans.iter().map(|plan| plan.muxes.len()).sum::<usize>();
         let true_owned = plans
             .iter()
@@ -2754,12 +2754,12 @@ fn form_same_predicate_regions(eu: &mut ExecutionUnit<RegionedAbsoluteAddr>) {
             .map(|plan| plan.false_owned.len())
             .sum::<usize>();
         let live_outs = plans.iter().map(|plan| plan.live_outs.len()).sum::<usize>();
-        eprintln!(
+        tracing::debug!(
             "[same-predicate-regions] regions={} muxes={muxes} true_owned={true_owned} false_owned={false_owned} live_outs={live_outs}",
             plans.len(),
         );
         for plan in &plans {
-            eprintln!(
+            tracing::debug!(
                 "[same-predicate-region] block={} cond=r{} segment={}..{} muxes={} true_owned={} false_owned={} true_cofactor={} false_cofactor={} live_outs={} benefit_scaled={}",
                 plan.block_id.0,
                 plan.condition.0,

--- a/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_sparse_case_dispatch.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_sparse_case_dispatch.rs
@@ -126,7 +126,8 @@ impl ExecutionUnitPass for SparseCaseDispatchPass {
         // strictly decreasing number of SIR Mux instructions; there is no
         // iteration or function-size cap.
         let mut changed = false;
-        let stats = std::env::var_os("CELOX_BRANCHIFY_STATS").is_some();
+        let diagnostics = &options.optimize_options.diagnostics;
+        let stats = diagnostics.branchify_stats;
         let mut applied = 0usize;
         loop {
             let plans = find_sparse_case_plans(eu, &self.stable_alias_class);
@@ -138,12 +139,12 @@ impl ExecutionUnitPass for SparseCaseDispatchPass {
                 changed = true;
                 applied += 1;
                 if stats && applied.is_multiple_of(100) {
-                    eprintln!("[branchify-stats] sparse_case applied={applied}");
+                    tracing::debug!("[branchify-stats] sparse_case applied={applied}");
                 }
             }
         }
-        if stats || std::env::var_os("CELOX_PASS_TIMING").is_some() {
-            eprintln!("[branchify-stats] sparse_case done applied={applied}");
+        if stats || diagnostics.pass_timing {
+            tracing::debug!("[branchify-stats] sparse_case done applied={applied}");
         }
         if changed {
             // A condition can be defined in a dominating predecessor left by

--- a/crates/celox-sir-opt/src/optimizer/passes/dataflow/pass_packed_scatter_store.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/dataflow/pass_packed_scatter_store.rs
@@ -1230,8 +1230,8 @@ fn apply_plan(eu: &mut ExecutionUnit<RegionedAbsoluteAddr>, plan: ScatterPlan) {
         block.instructions = instructions;
     }
 
-    if std::env::var_os("CELOX_PASS_TIMING").is_some() {
-        eprintln!(
+    if tracing::enabled!(tracing::Level::DEBUG) {
+        tracing::debug!(
             "[packed-scatter-store] block={} dead={} benefit={}",
             plan.block.0,
             plan.dead.len(),

--- a/crates/celox-sir-opt/src/optimizer/pipeline/cache.rs
+++ b/crates/celox-sir-opt/src/optimizer/pipeline/cache.rs
@@ -7,7 +7,7 @@ pub(super) fn optimize_unit_groups_cached(
     passes: &ExecutionUnitPassManager,
     options: &PassOptions,
 ) {
-    let timing = std::env::var_os("CELOX_PASS_TIMING").is_some();
+    let timing = options.optimize_options.diagnostics.pass_timing;
     let total_start = timing.then(crate::timing::now);
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     struct UnitShape {
@@ -97,7 +97,7 @@ pub(super) fn optimize_unit_groups_cached(
         .map(|class| class.aliases.len())
         .sum::<usize>();
     if let Some(start) = total_start {
-        eprintln!(
+        tracing::debug!(
             "[group-cache-timing] classify groups={} classes={} aliases={} elapsed={:?}",
             groups.len(),
             classes.len(),
@@ -126,7 +126,7 @@ pub(super) fn optimize_unit_groups_cached(
         }
     }
     if let Some(start) = total_start {
-        eprintln!(
+        tracing::debug!(
             "[group-cache-timing] total groups={} elapsed={:?}",
             groups.len(),
             start.elapsed()

--- a/crates/celox-sir-opt/src/optimizer/pipeline/diagnostics.rs
+++ b/crates/celox-sir-opt/src/optimizer/pipeline/diagnostics.rs
@@ -77,7 +77,7 @@ pub(super) fn dump_mux_chain_stats(units: &[ExecutionUnit<RegionedAbsoluteAddr>]
     for (rank, (len, direct_case, acc_guarded_priority, eu_idx, block_id, root)) in
         rows.into_iter().take(20).enumerate()
     {
-        eprintln!(
+        tracing::debug!(
             "[mux-chain-stats] rank={} eu={} block={} root=r{} len={} direct_case={} acc_guarded_priority={}",
             rank + 1,
             eu_idx,

--- a/crates/celox-sir-opt/src/optimizer/pipeline/late.rs
+++ b/crates/celox-sir-opt/src/optimizer/pipeline/late.rs
@@ -16,11 +16,11 @@ pub(super) fn optimize_late_comb(
     unpacked_element_widths: &crate::HashMap<AbsoluteAddr, usize>,
 ) {
     let on = |pass: SirPass| opt.is_enabled(pass);
-    let trace = std::env::var_os("CELOX_BRANCHIFY_STATS").is_some();
-    let timing = std::env::var_os("CELOX_PASS_TIMING").is_some();
+    let trace = opt.diagnostics.branchify_stats;
+    let timing = opt.diagnostics.pass_timing;
     let mut checkpoint = crate::timing::now();
     let verify_stage = |program: &OptimizationContext, stage: &'static str| {
-        if std::env::var_os("CELOX_SIR_VERIFY_PASSES").is_none() {
+        if !opt.diagnostics.verify_passes {
             return;
         }
         for (unit, eu) in program.sir.eval_comb.iter().enumerate() {
@@ -37,7 +37,7 @@ pub(super) fn optimize_late_comb(
     macro_rules! checkpoint {
         ($name:literal) => {
             if timing {
-                eprintln!("[late-comb-timing] {}: {:?}", $name, checkpoint.elapsed());
+                tracing::debug!("[late-comb-timing] {}: {:?}", $name, checkpoint.elapsed());
                 checkpoint = crate::timing::now();
             }
         };
@@ -66,7 +66,7 @@ pub(super) fn optimize_late_comb(
     verify_stage(program, "identity-store bypass");
     checkpoint!("identity-store bypass");
     if trace {
-        eprintln!("[branchify-stats] late identity");
+        tracing::debug!("[branchify-stats] late identity");
     }
 
     // Identity-store bypass can make an entire expression DAG dead.
@@ -78,7 +78,7 @@ pub(super) fn optimize_late_comb(
     verify_stage(program, "loop idiom");
     checkpoint!("loop idiom");
     if trace {
-        eprintln!("[branchify-stats] late loop");
+        tracing::debug!("[branchify-stats] late loop");
     }
     if on(SirPass::PackedScatterStore) {
         let packed_scatter_store = PackedScatterStorePass::for_program(program);
@@ -89,7 +89,7 @@ pub(super) fn optimize_late_comb(
     verify_stage(program, "packed scatter");
     checkpoint!("packed scatter");
     if trace {
-        eprintln!("[branchify-stats] late scatter");
+        tracing::debug!("[branchify-stats] late scatter");
     }
     if on(SirPass::IndexedStoreRecovery) {
         let indexed_store_recovery = IndexedStoreRecoveryPass::for_program(program);
@@ -100,7 +100,7 @@ pub(super) fn optimize_late_comb(
     verify_stage(program, "indexed-store recovery");
     checkpoint!("indexed-store recovery");
     if trace {
-        eprintln!("[branchify-stats] late indexed");
+        tracing::debug!("[branchify-stats] late indexed");
     }
     if on(SirPass::GuardedRegionSinking) {
         for eu in &mut program.sir.eval_comb {
@@ -110,13 +110,13 @@ pub(super) fn optimize_late_comb(
     verify_stage(program, "guarded-region sinking");
     checkpoint!("guarded-region sinking");
     if trace {
-        eprintln!("[branchify-stats] late guarded");
+        tracing::debug!("[branchify-stats] late guarded");
     }
     if on(SirPass::SparseCaseDispatch) {
         let sparse_case_pass =
             SparseCaseDispatchPass::new(program.layout_requirements.state_aliases());
         if trace {
-            eprintln!("[branchify-stats] late sparse constructed");
+            tracing::debug!("[branchify-stats] late sparse constructed");
         }
         for eu in &mut program.sir.eval_comb {
             pass_manager::ExecutionUnitPass::run(&sparse_case_pass, eu, options);
@@ -125,7 +125,7 @@ pub(super) fn optimize_late_comb(
     verify_stage(program, "sparse-case dispatch");
     checkpoint!("sparse-case dispatch");
     if trace {
-        eprintln!("[branchify-stats] late sparse");
+        tracing::debug!("[branchify-stats] late sparse");
     }
 
     // Recover control dependence created by the program-wide transforms, then

--- a/crates/celox-sir-opt/src/optimizer/pipeline/pass_manager.rs
+++ b/crates/celox-sir-opt/src/optimizer/pipeline/pass_manager.rs
@@ -39,10 +39,10 @@ impl ExecutionUnitPassManager {
         eu: &mut ExecutionUnit<RegionedAbsoluteAddr>,
         options: &PassOptions,
     ) {
-        let timing = std::env::var("CELOX_PASS_TIMING").is_ok();
-        let verify_boundaries =
-            cfg!(debug_assertions) || std::env::var_os("CELOX_SIR_VERIFY").is_some();
-        let verify_passes = std::env::var_os("CELOX_SIR_VERIFY_PASSES").is_some();
+        let diagnostics = &options.optimize_options.diagnostics;
+        let timing = diagnostics.pass_timing;
+        let verify_boundaries = cfg!(debug_assertions) || diagnostics.verify_boundaries;
+        let verify_passes = diagnostics.verify_passes;
         if verify_boundaries {
             if let Err(error) = eu.verify_result() {
                 panic!("before SIR pass pipeline: {error}");
@@ -70,7 +70,7 @@ impl ExecutionUnitPassManager {
             if let Some(start) = start {
                 let elapsed = start.elapsed();
                 if elapsed.as_millis() > 0 {
-                    eprintln!("[pass-timing] {:>40}: {:?}", pass.name(), elapsed);
+                    tracing::debug!("[pass-timing] {:>40}: {:?}", pass.name(), elapsed);
                 }
             }
         }

--- a/crates/celox-sir-opt/src/optimizer/pipeline/runner.rs
+++ b/crates/celox-sir-opt/src/optimizer/pipeline/runner.rs
@@ -87,7 +87,7 @@ pub(super) fn optimize_with_options(
     preserve_element_storage_layout: bool,
 ) {
     #[cfg(not(target_arch = "wasm32"))]
-    let timing = std::env::var("CELOX_PASS_TIMING").is_ok();
+    let timing = opt.diagnostics.pass_timing;
     #[cfg(target_arch = "wasm32")]
     let timing = false;
     let options = PassOptions {
@@ -149,7 +149,7 @@ pub(super) fn optimize_with_options(
                     .values()
                     .map(|block| block.instructions.len())
                     .sum();
-                eprintln!(
+                tracing::debug!(
                     "[phase] eval_apply_ffs trigger={trigger} eu[{index}]: blocks={} insts={} regs={}",
                     eu.blocks.len(),
                     instruction_count,
@@ -207,7 +207,7 @@ pub(super) fn optimize_with_options(
         &options,
     );
     if let Some(s) = phase_start {
-        eprintln!("[phase] eval_apply_ffs ({eu_count} EUs): {:?}", s.elapsed());
+        tracing::debug!("[phase] eval_apply_ffs ({eu_count} EUs): {:?}", s.elapsed());
     }
 
     // 2. Logic-Only Cache (Split Path Phase 1):
@@ -218,7 +218,7 @@ pub(super) fn optimize_with_options(
     let eu_count: usize = program.sir.eval_only_ffs.values().map(|v| v.len()).sum();
     optimize_unit_groups_cached(&mut program.sir.eval_only_ffs, &eval_only_passes, &options);
     if let Some(s) = phase_start {
-        eprintln!("[phase] eval_only_ffs ({eu_count} EUs): {:?}", s.elapsed());
+        tracing::debug!("[phase] eval_only_ffs ({eu_count} EUs): {:?}", s.elapsed());
     }
 
     // 3. Commit-Only Cache (Split Path Phase 2):
@@ -232,7 +232,7 @@ pub(super) fn optimize_with_options(
         }
     }
     if let Some(s) = phase_start {
-        eprintln!("[phase] apply_ffs ({eu_count} EUs): {:?}", s.elapsed());
+        tracing::debug!("[phase] apply_ffs ({eu_count} EUs): {:?}", s.elapsed());
     }
 
     // 4. Combinational Blocks:
@@ -244,16 +244,16 @@ pub(super) fn optimize_with_options(
         if timing {
             let inst_count: usize = eu.blocks.values().map(|b| b.instructions.len()).sum();
             let block_count = eu.blocks.len();
-            eprintln!("[phase] eval_comb eu[{i}]: blocks={block_count} insts={inst_count}");
+            tracing::debug!("[phase] eval_comb eu[{i}]: blocks={block_count} insts={inst_count}");
         }
         comb_passes.run(eu, &options);
     }
     if let Some(s) = phase_start {
-        eprintln!("[phase] eval_comb ({eu_count} EUs): {:?}", s.elapsed());
+        tracing::debug!("[phase] eval_comb ({eu_count} EUs): {:?}", s.elapsed());
     }
 
     super::late::optimize_late_comb(program, opt, &options, &unpacked_element_widths);
-    if std::env::var_os("CELOX_MUX_CHAIN_STATS").is_some() {
+    if opt.diagnostics.mux_chain_stats {
         super::diagnostics::dump_mux_chain_stats(&program.sir.eval_comb);
     }
 }

--- a/crates/celox-sir-opt/src/policy.rs
+++ b/crates/celox-sir-opt/src/policy.rs
@@ -117,6 +117,22 @@ define_sir_passes! {
     /// This is not a SIR transform and is consumed at the backend boundary.
     TailCallSplit => "tail_call_split",
 }
+/// Diagnostics and additional verification for the SIR optimizer.
+///
+/// These switches are explicit so optimizer behavior is independent of the
+/// process environment and multiple compilations can use different settings.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SirDiagnostics {
+    pub pass_timing: bool,
+    pub branchify_stats: bool,
+    pub mux_chain_stats: bool,
+    pub verify_boundaries: bool,
+    pub verify_passes: bool,
+    pub branchify_verify: bool,
+    pub branchify_trace_reg: Option<usize>,
+    pub effect_case_dispatch: bool,
+}
+
 /// Controls which SIR optimization passes are enabled.
 ///
 /// Built from an [`OptLevel`] preset, with optional per-pass overrides.
@@ -143,6 +159,7 @@ pub struct OptimizeOptions {
     enabled: HashSet<SirPass>,
     disabled: HashSet<SirPass>,
     max_native_memory_width: usize,
+    pub diagnostics: SirDiagnostics,
 }
 
 impl Default for OptimizeOptions {
@@ -163,6 +180,7 @@ impl OptimizeOptions {
             } else {
                 64
             },
+            diagnostics: SirDiagnostics::default(),
         }
     }
 

--- a/crates/celox-slt/Cargo.toml
+++ b/crates/celox-slt/Cargo.toml
@@ -8,6 +8,7 @@ description           = "Source-independent symbolic logic tree core for Celox"
 edition.workspace     = true
 
 [dependencies]
+tracing = { workspace = true }
 celox-analysis = { path = "../celox-analysis" }
 celox-design = { path = "../celox-design" }
 celox-sir    = { path = "../celox-sir" }

--- a/crates/celox-slt/src/lower.rs
+++ b/crates/celox-slt/src/lower.rs
@@ -1875,8 +1875,7 @@ impl SLTToSIRLowerer {
             unpacked_input_element_widths: crate::HashMap::default(),
             cost_cache: RefCell::new(LoweringCostCache::default()),
             cache_insert_log: RefCell::new(Vec::new()),
-            mux_stats: std::env::var_os("CELOX_MUX_LOWER_STATS")
-                .is_some()
+            mux_stats: tracing::enabled!(tracing::Level::DEBUG)
                 .then(|| RefCell::new(MuxLowerStats::default())),
         }
     }
@@ -6042,7 +6041,7 @@ impl Drop for SLTToSIRLowerer {
             return;
         };
         let stats = stats.borrow();
-        eprintln!(
+        tracing::debug!(
             "[mux-lower-stats] normal_seen={} slice_seen={} constant_folded={} cfg_cost={} cfg_div_rem={} cfg_slice_cost={} cfg_slice_div_rem={} shared_nodes_hoisted={} kept_four_state={} kept_impure={} kept_dynamic_env={} kept_unprofitable={} kept_deep_shared={} biased_conditions={} owned_cost_sum={} owned_cost_max={} unprofitable_buckets_0_7_15_31_63_127_255_inf={:?}",
             stats.normal_seen,
             stats.slice_seen,

--- a/crates/celox-wasm/Cargo.toml
+++ b/crates/celox-wasm/Cargo.toml
@@ -16,5 +16,8 @@ wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1"
 serde_json = { workspace = true }
 
+[lints]
+workspace = true
+
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-O", "--enable-bulk-memory"]

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -34,6 +34,7 @@ serde_json            = { workspace = true }
 num-traits            = { workspace = true }
 bit-set               = { workspace = true }
 itertools             = { workspace = true }
+tracing               = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 celox-macros          = { path = "../celox-macros" }

--- a/crates/celox/examples/dump_linear_sec_ir.rs
+++ b/crates/celox/examples/dump_linear_sec_ir.rs
@@ -52,12 +52,12 @@ fn main() {
 
     if let Some(sir) = trace.format_post_optimized_sir() {
         std::fs::write("linear_sec_p6_sir.txt", &sir).unwrap();
-        eprintln!("SIR: {} bytes → linear_sec_p6_sir.txt", sir.len());
+        println!("SIR: {} bytes → linear_sec_p6_sir.txt", sir.len());
     }
 
     if let Some(ref clif) = trace.pre_optimized_clif {
         std::fs::write("linear_sec_p6_clif_pre.txt", clif).unwrap();
-        eprintln!(
+        println!(
             "CLIF pre-opt: {} bytes → linear_sec_p6_clif_pre.txt",
             clif.len()
         );
@@ -65,7 +65,7 @@ fn main() {
 
     if let Some(ref clif) = trace.post_optimized_clif {
         std::fs::write("linear_sec_p6_clif_post.txt", clif).unwrap();
-        eprintln!(
+        println!(
             "CLIF post-opt: {} bytes → linear_sec_p6_clif_post.txt",
             clif.len()
         );
@@ -73,7 +73,7 @@ fn main() {
 
     if let Some(ref native) = trace.native {
         std::fs::write("linear_sec_p6_native.txt", native).unwrap();
-        eprintln!("Native: {} bytes → linear_sec_p6_native.txt", native.len());
+        println!("Native: {} bytes → linear_sec_p6_native.txt", native.len());
     }
 
     // Sanity check
@@ -82,5 +82,5 @@ fn main() {
     let o_word = sim.signal("o_word");
     sim.modify(|io| io.set(i_word, 42u64)).unwrap();
     let out: u64 = sim.get_as(o_word);
-    eprintln!("Sanity check: input=42, output={}", out);
+    println!("Sanity check: input=42, output={}", out);
 }

--- a/crates/celox/examples/profile_sorter.rs
+++ b/crates/celox/examples/profile_sorter.rs
@@ -17,7 +17,7 @@ fn main() {
         .and_then(|s| s.parse().ok())
         .unwrap_or(4);
 
-    eprintln!("=== Building SorterTreeDistEntry N={n} ===");
+    println!("=== Building SorterTreeDistEntry N={n} ===");
     let build_start = Instant::now();
     let mut sim = Simulator::builder(&code, "SorterTreeDistEntry")
         .param("N", n)
@@ -25,7 +25,7 @@ fn main() {
         .param("OUT_DEPTH", 16)
         .build()
         .unwrap();
-    eprintln!("=== Build: {:?} ===", build_start.elapsed());
+    println!("=== Build: {:?} ===", build_start.elapsed());
 
     let clk = sim.signal("clk");
     let rst = sim.signal("rst");
@@ -46,7 +46,7 @@ fn main() {
     let elapsed = run_start.elapsed();
     let ns_per_cycle = elapsed.as_nanos() as f64 / cycles as f64;
     let khz = 1e6 / ns_per_cycle;
-    eprintln!(
+    println!(
         "=== Runtime: {cycles} cycles in {elapsed:?} ({ns_per_cycle:.0} ns/cycle, {khz:.0} kHz) ==="
     );
 }

--- a/crates/celox/src/backend.rs
+++ b/crates/celox/src/backend.rs
@@ -10,9 +10,11 @@ pub mod wasm_runtime;
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) use celox_backend_cranelift::JitEngine;
 #[cfg(not(target_arch = "wasm32"))]
-pub use celox_backend_cranelift::{CraneliftOptLevel, CraneliftOptions, RegallocAlgorithm};
+pub use celox_backend_cranelift::{
+    CraneliftDiagnostics, CraneliftOptLevel, CraneliftOptions, RegallocAlgorithm,
+};
 #[cfg(target_arch = "x86_64")]
-pub use celox_backend_x86::X86BackendOptions;
+pub use celox_backend_x86::{NativeDiagnostics, NativeDumpOptions, X86BackendOptions};
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) use celox_runtime::RuntimeEventBuffer;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -139,6 +139,7 @@ fn prepare_merged_sir(
     four_state: bool,
     label: &str,
     first_ff_unit: Option<usize>,
+    diagnostics: &crate::optimizer::SirDiagnostics,
 ) -> Result<crate::ir::ExecutionUnit<crate::ir::RegionedAbsoluteAddr>, SimulatorError> {
     for (unit_index, unit) in units.iter().enumerate() {
         if let Err(error) = unit.verify_result() {
@@ -193,6 +194,7 @@ fn prepare_merged_sir(
         layout,
         four_state,
         label == "eval_comb_apply_ff",
+        diagnostics,
     )
     .map_err(|(phase, error)| codegen_err(format!("{phase}: {error}")))?;
     verify(&sir_eu, "after x86 merged-chain cleanup")?;
@@ -204,8 +206,9 @@ fn compile_units(
     layout: &MemoryLayout,
     four_state: bool,
     label: &str,
-    enable_x86_slp: bool,
+    x86_options: &crate::backend::X86BackendOptions,
     capture_trace: bool,
+    diagnostics: &crate::optimizer::SirDiagnostics,
 ) -> Result<CompiledNativeFunction, SimulatorError> {
     let units = units.iter().collect::<Vec<_>>();
     compile_unit_refs(
@@ -214,8 +217,9 @@ fn compile_units(
         four_state,
         label,
         None,
-        enable_x86_slp,
+        x86_options,
         capture_trace,
+        diagnostics,
     )
 }
 
@@ -225,10 +229,11 @@ fn compile_unit_refs(
     four_state: bool,
     label: &str,
     first_ff_unit: Option<usize>,
-    enable_x86_slp: bool,
+    x86_options: &crate::backend::X86BackendOptions,
     capture_trace: bool,
+    diagnostics: &crate::optimizer::SirDiagnostics,
 ) -> Result<CompiledNativeFunction, SimulatorError> {
-    let timing = std::env::var_os("CELOX_PHASE_TIMING").is_some();
+    let timing = x86_options.diagnostics.phase_timing;
     if units.is_empty() {
         // Empty function: just return 0
         let mut empty_func = super::mir::MFunction::new(super::mir::VRegAllocator::new(), vec![]);
@@ -249,8 +254,12 @@ fn compile_unit_refs(
             spill_frame_size: 0,
             disassembly: emit::disassemble(&empty_result.code[..empty_result.text_size], 0),
         });
-        let code = jit_mem::JitCode::new_named(&empty_result.code, label)
-            .map_err(|e| codegen_err(format!("mmap error: {e}")))?;
+        let code = jit_mem::JitCode::new_named_profiled(
+            &empty_result.code,
+            label,
+            x86_options.diagnostics.perf_map,
+        )
+        .map_err(|e| codegen_err(format!("mmap error: {e}")))?;
         return Ok(CompiledNativeFunction {
             code,
             trace,
@@ -260,25 +269,25 @@ fn compile_unit_refs(
 
     // Merge all EUs and compile the exact SIR/MIR function used at runtime.
     if timing {
-        eprintln!(
+        tracing::debug!(
             "[native-timing] compile_units start label={label} eus={}",
             units.len()
         );
     }
     let start = timing.then(crate::timing::now);
-    let sir_eu = prepare_merged_sir(units, layout, four_state, label, first_ff_unit)?;
+    let sir_eu = prepare_merged_sir(units, layout, four_state, label, first_ff_unit, diagnostics)?;
     let mut trace = capture_trace.then(emit::NativeFunctionTrace::default);
     let emit_result = emit::emit_prepared_eu(
         &sir_eu,
         layout,
         four_state,
         label,
-        enable_x86_slp,
+        x86_options,
         trace.as_mut(),
     )
     .map_err(|e| codegen_err(format!("emit error: {e}")))?;
     if let Some(start) = start {
-        eprintln!(
+        tracing::debug!(
             "[native-timing] compile_units done label={label} bytes={} elapsed={:?}",
             emit_result.code.len(),
             start.elapsed()
@@ -286,8 +295,13 @@ fn compile_unit_refs(
     }
     let symbols = perf_symbols_for_emit_result(label, &emit_result);
     let required_state_size = emit_result.required_state_size as usize;
-    let code = jit_mem::JitCode::new_named_with_symbols(&emit_result.code, label, &symbols)
-        .map_err(|e| codegen_err(format!("mmap error: {e}")))?;
+    let code = jit_mem::JitCode::new_named_with_symbols_profiled(
+        &emit_result.code,
+        label,
+        &symbols,
+        x86_options.diagnostics.perf_map,
+    )
+    .map_err(|e| codegen_err(format!("mmap error: {e}")))?;
     Ok(CompiledNativeFunction {
         code,
         trace,
@@ -603,15 +617,16 @@ fn compile_program(
     let next_task = AtomicUsize::new(0);
     let (comb_jit, mut compiled_ff_codes) = std::thread::scope(|scope| {
         let four_state = options.four_state;
-        let enable_x86_slp = options.x86_options.slp;
+        let x86_options = &options.x86_options;
         let comb_handle = scope.spawn(move || {
             compile_units(
                 &sir.sir.eval_comb,
                 layout,
                 four_state,
                 "eval_comb",
-                enable_x86_slp,
+                x86_options,
                 capture_trace,
+                &options.optimize_options.diagnostics,
             )
         });
         let task_worker_count = compile_tasks
@@ -634,8 +649,9 @@ fn compile_program(
                             four_state,
                             task.label,
                             task.first_ff_unit,
-                            enable_x86_slp,
+                            x86_options,
                             capture_trace,
+                            &options.optimize_options.diagnostics,
                         )?;
                         compiled.push((task_id, code));
                     }
@@ -1091,7 +1107,7 @@ impl super::super::SimBackend for NativeBackend {
         event: NativeEventRef,
         count: u64,
     ) -> (u64, Result<(), SimulatorErrorCode>) {
-        if super::native_tick_loop_enabled() {
+        if self.compiled.options.x86_options.native_tick_loop {
             self.call_func_many_timed(event.comb_apply_func, count)
         } else if count == 0 {
             (0, Ok(()))

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -105,7 +105,7 @@ impl CraneliftEvalCombPlan {
             return Self::Unsplit;
         }
 
-        let timing = std::env::var_os("CELOX_OPT_TIMING").is_some();
+        let timing = options.diagnostics.optimizer_timing;
         if timing {
             use celox_backend_cranelift::cost_model::{
                 CLIF_INST_THRESHOLD, VREG_VALUE_THRESHOLD, estimate_eu_cost,
@@ -114,7 +114,7 @@ impl CraneliftEvalCombPlan {
             for (i, eu) in sir.sir.eval_comb.iter().enumerate() {
                 let inst_cost = estimate_eu_cost(eu, options.four_state);
                 let value_count = estimate_eu_value_count(eu, options.four_state);
-                eprintln!(
+                tracing::debug!(
                     "[split-check] eval_comb eu[{i}]: blocks={} insts={} clif_cost={inst_cost}/{CLIF_INST_THRESHOLD} values={value_count}/{VREG_VALUE_THRESHOLD}",
                     eu.blocks.len(),
                     eu.blocks
@@ -131,7 +131,7 @@ impl CraneliftEvalCombPlan {
             tail_call_split::split_if_needed(&sir.sir.eval_comb, options.four_state)
         {
             if let Some(start) = split_start {
-                eprintln!(
+                tracing::debug!(
                     "[split] TailCallChunks: {} chunks, took {:?}",
                     chunks.len(),
                     start.elapsed()
@@ -142,7 +142,7 @@ impl CraneliftEvalCombPlan {
             tail_call_split::split_if_needed_spilled(&sir.sir.eval_comb, options.four_state)
         {
             if let Some(start) = split_start {
-                eprintln!(
+                tracing::debug!(
                     "[split] MemorySpilled: {} chunks, scratch={}B, took {:?}",
                     plan.chunks.len(),
                     plan.scratch_bytes,

--- a/crates/celox/src/debug.rs
+++ b/crates/celox/src/debug.rs
@@ -72,8 +72,12 @@ pub struct CompilationTrace {
 }
 
 impl TraceOptions {
-    pub(crate) fn frontend(&self) -> celox_frontend_veryl::FrontendTraceOptions {
+    pub(crate) fn frontend(
+        &self,
+        diagnostics: &crate::RuntimeDiagnostics,
+    ) -> celox_frontend_veryl::FrontendTraceOptions {
         celox_frontend_veryl::FrontendTraceOptions {
+            phase_timing: diagnostics.phase_timing,
             sim_modules: self.sim_modules,
             pre_atomized_comb_blocks: self.pre_atomized_comb_blocks,
             atomized_comb_blocks: self.atomized_comb_blocks,

--- a/crates/celox/src/debug/output.rs
+++ b/crates/celox/src/debug/output.rs
@@ -43,34 +43,42 @@ impl CompilationTrace {
         self.sim_modules.as_ref().map(format_slt)
     }
 
-    pub fn print(&self) {
+    /// Write every captured artifact to a caller-provided destination.
+    pub fn write_to(&self, mut output: impl std::io::Write) -> std::io::Result<()> {
         if let Some(slt) = self.format_slt() {
-            println!("{}", slt);
+            writeln!(output, "{slt}")?;
         }
         if let Some(sir) = self.format_pre_optimized_sir() {
-            println!("=== Pre-optimized SIR ===\n{}", sir);
+            writeln!(output, "=== Pre-optimized SIR ===\n{sir}")?;
         }
         if let Some(sir) = self.format_post_optimized_sir() {
-            println!("=== Post-optimized SIR ===\n{}", sir);
+            writeln!(output, "=== Post-optimized SIR ===\n{sir}")?;
         }
         if let Some(sir) = self.format_native_optimized_sir() {
-            println!("=== Native optimized merged SIR ===\n{}", sir);
+            writeln!(output, "=== Native optimized merged SIR ===\n{sir}")?;
         }
         if let Some(ir) = self.format_analyzer_ir() {
-            println!("=== Analyzer IR ===\n{}", ir);
+            writeln!(output, "=== Analyzer IR ===\n{ir}")?;
         }
         if let Some(clif) = &self.pre_optimized_clif {
-            println!("=== Pre-optimized CLIF ===\n{}", clif);
+            writeln!(output, "=== Pre-optimized CLIF ===\n{clif}")?;
         }
         if let Some(clif) = &self.post_optimized_clif {
-            println!("=== Post-optimized CLIF ===\n{}", clif);
+            writeln!(output, "=== Post-optimized CLIF ===\n{clif}")?;
         }
         if let Some(native) = &self.native {
-            println!("=== Native Machine Code ===\n{}", native);
+            writeln!(output, "=== Native Machine Code ===\n{native}")?;
         }
         if let Some(mir) = &self.mir {
-            println!("=== MIR (Native Backend) ===\n{}", mir);
+            writeln!(output, "=== MIR (Native Backend) ===\n{mir}")?;
         }
+        Ok(())
+    }
+
+    /// Print every captured artifact to standard output.
+    pub fn print(&self) {
+        self.write_to(std::io::stdout())
+            .expect("failed to write compilation trace");
     }
 }
 
@@ -399,4 +407,25 @@ pub fn format_slt(sim_modules: &HashMap<ModuleId, SimModule>) -> String {
     }
 
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CompilationTrace;
+
+    #[test]
+    fn writes_captured_artifacts_to_the_supplied_writer() {
+        let trace = CompilationTrace {
+            analyzer_ir: Some("analyzer contents".to_owned()),
+            ..CompilationTrace::default()
+        };
+        let mut output = Vec::new();
+
+        trace.write_to(&mut output).unwrap();
+
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            "=== Analyzer IR ===\nanalyzer contents\n"
+        );
+    }
 }

--- a/crates/celox/src/diagnostics.rs
+++ b/crates/celox/src/diagnostics.rs
@@ -1,0 +1,174 @@
+use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
+
+/// Diagnostics owned by the simulator facade and runtime.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RuntimeDiagnostics {
+    pub phase_timing: bool,
+    pub optimizer_timing: bool,
+    pub tick_timing_every: Option<u64>,
+    pub testbench_progress_every: Option<u64>,
+    pub address_map_filter: Option<String>,
+}
+
+/// Complete explicit diagnostics configuration for a simulator build.
+///
+/// Library code does not install a `tracing` subscriber. Applications that
+/// want diagnostic events must install and configure one at their boundary.
+#[derive(Debug, Clone, Default)]
+pub struct DiagnosticsOptions {
+    pub runtime: RuntimeDiagnostics,
+    pub sir: crate::optimizer::SirDiagnostics,
+    #[cfg(not(target_arch = "wasm32"))]
+    pub cranelift: crate::backend::CraneliftDiagnostics,
+    #[cfg(target_arch = "x86_64")]
+    pub native: crate::backend::NativeDiagnostics,
+    #[cfg(target_arch = "x86_64")]
+    pub native_tick_loop: Option<bool>,
+}
+
+impl DiagnosticsOptions {
+    /// Read legacy `CELOX_*` switches once at the application boundary.
+    ///
+    /// Prefer constructing this type explicitly in reusable library code. This
+    /// adapter exists for applications that retain the legacy environment-based
+    /// workflow.
+    #[allow(clippy::disallowed_methods)]
+    pub fn from_env() -> Self {
+        Self::from_env_iter(std::env::vars_os())
+    }
+
+    /// Parse diagnostics from an environment-like iterator without mutating
+    /// process-global state.
+    pub fn from_env_iter<K, V>(variables: impl IntoIterator<Item = (K, V)>) -> Self
+    where
+        K: Into<OsString>,
+        V: Into<OsString>,
+    {
+        let variables = variables
+            .into_iter()
+            .map(|(key, value)| (key.into(), value.into()))
+            .collect::<HashMap<_, _>>();
+        let enabled = |name: &str| {
+            variables
+                .get(OsStr::new(name))
+                .is_some_and(|value| value != "0")
+        };
+        let unsigned = |name: &str| {
+            variables
+                .get(OsStr::new(name))
+                .and_then(|value| value.to_str())
+                .and_then(|value| value.parse::<u64>().ok())
+        };
+        let usize_value = |name: &str| unsigned(name).and_then(|value| usize::try_from(value).ok());
+        let string = |name: &str| {
+            variables
+                .get(OsStr::new(name))
+                .map(|value| value.to_string_lossy().into_owned())
+        };
+
+        let phase_timing = enabled("CELOX_PHASE_TIMING");
+        let pass_timing = enabled("CELOX_PASS_TIMING");
+        let runtime = RuntimeDiagnostics {
+            phase_timing,
+            optimizer_timing: enabled("CELOX_OPT_TIMING"),
+            tick_timing_every: unsigned("CELOX_TICK_TIMING"),
+            testbench_progress_every: unsigned("CELOX_TESTBENCH_PROGRESS"),
+            address_map_filter: enabled("CELOX_ADDR_MAP_DUMP")
+                .then(|| string("CELOX_ADDR_MAP_FILTER").unwrap_or_default()),
+        };
+        let sir = crate::optimizer::SirDiagnostics {
+            pass_timing,
+            branchify_stats: enabled("CELOX_BRANCHIFY_STATS"),
+            mux_chain_stats: enabled("CELOX_MUX_CHAIN_STATS"),
+            verify_boundaries: enabled("CELOX_SIR_VERIFY"),
+            verify_passes: enabled("CELOX_SIR_VERIFY_PASSES"),
+            branchify_verify: enabled("CELOX_BRANCHIFY_VERIFY"),
+            branchify_trace_reg: usize_value("CELOX_BRANCHIFY_TRACE_REG"),
+            effect_case_dispatch: enabled("CELOX_EFFECT_CASE_DISPATCH"),
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        let cranelift = crate::backend::CraneliftDiagnostics { pass_timing };
+        #[cfg(target_arch = "x86_64")]
+        let (native, native_tick_loop) = {
+            let native_tick_loop = variables
+                .get(OsStr::new("CELOX_NATIVE_TICK_LOOP"))
+                .map(|value| value != "0");
+            let dump = usize_value("CELOX_NATIVE_DUMP_BLOCK").map(|block| {
+                crate::backend::NativeDumpOptions {
+                    block,
+                    label: string("CELOX_NATIVE_DUMP_LABEL"),
+                    stage: string("CELOX_NATIVE_DUMP_STAGE"),
+                    dump_sir: variables
+                        .get(OsStr::new("CELOX_NATIVE_DUMP_SIR"))
+                        .is_none_or(|value| value != "0"),
+                    mir_limit: usize_value("CELOX_NATIVE_DUMP_MIR_LIMIT").unwrap_or(64),
+                }
+            });
+            let native = crate::backend::NativeDiagnostics {
+                phase_timing,
+                regalloc_timing: enabled("CELOX_REGALLOC_TIMING"),
+                regalloc_stats: enabled("CELOX_REGALLOC_STATS"),
+                mir_stats: enabled("CELOX_MIR_STATS"),
+                mir_block_stats: enabled("CELOX_MIR_BLOCK_STATS"),
+                verify_sir: enabled("CELOX_SIR_VERIFY"),
+                verify_mir: enabled("CELOX_MIR_VERIFY"),
+                verify_mir_passes: enabled("CELOX_MIR_VERIFY_PASSES"),
+                verify_regalloc: enabled("CELOX_REGALLOC_VERIFY"),
+                isel_trace_regs: string("CELOX_ISEL_TRACE_REGS")
+                    .or_else(|| string("CELOX_ISEL_TRACE_REG"))
+                    .into_iter()
+                    .flat_map(|value| {
+                        value
+                            .split(',')
+                            .filter_map(|part| part.trim().parse::<usize>().ok())
+                            .collect::<Vec<_>>()
+                    })
+                    .collect(),
+                dump,
+                perf_map: enabled("CELOX_PERF_MAP"),
+            };
+            (native, native_tick_loop)
+        };
+        Self {
+            runtime,
+            sir,
+            #[cfg(not(target_arch = "wasm32"))]
+            cranelift,
+            #[cfg(target_arch = "x86_64")]
+            native,
+            #[cfg(target_arch = "x86_64")]
+            native_tick_loop,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DiagnosticsOptions;
+
+    #[test]
+    fn parses_supplied_environment_without_global_mutation() {
+        let options = DiagnosticsOptions::from_env_iter([
+            ("CELOX_PASS_TIMING", "1"),
+            ("CELOX_BRANCHIFY_TRACE_REG", "42"),
+            ("CELOX_TICK_TIMING", "100"),
+            ("CELOX_REGALLOC_VERIFY", "1"),
+        ]);
+        assert!(options.sir.pass_timing);
+        assert_eq!(options.sir.branchify_trace_reg, Some(42));
+        assert_eq!(options.runtime.tick_timing_every, Some(100));
+        #[cfg(target_arch = "x86_64")]
+        assert!(options.native.verify_regalloc);
+    }
+
+    #[test]
+    fn zero_disables_flags_and_invalid_intervals_are_ignored() {
+        let options = DiagnosticsOptions::from_env_iter([
+            ("CELOX_PASS_TIMING", "0"),
+            ("CELOX_TICK_TIMING", "not-a-number"),
+        ]);
+        assert!(!options.sir.pass_timing);
+        assert_eq!(options.runtime.tick_timing_every, None);
+    }
+}

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -1,5 +1,6 @@
 mod backend;
 mod debug;
+mod diagnostics;
 mod ir;
 mod optimizer;
 mod parser;
@@ -54,6 +55,7 @@ pub use celox_macros::veryl_test;
 #[cfg(not(target_arch = "wasm32"))]
 pub use debug::CompilationTraceResult;
 pub use debug::{CompilationTrace, NativeProfileBlock, TraceOptions};
+pub use diagnostics::{DiagnosticsOptions, RuntimeDiagnostics};
 pub(crate) use fxhash::FxHashMap as HashMap;
 pub(crate) use fxhash::FxHashSet as HashSet;
 pub use ir::{
@@ -77,16 +79,21 @@ pub type DefaultBackend = NativeBackend;
 #[cfg(all(not(target_arch = "wasm32"), not(target_arch = "x86_64")))]
 pub type DefaultBackend = backend::JitBackend;
 #[cfg(not(target_arch = "wasm32"))]
+pub use backend::CraneliftDiagnostics;
+#[cfg(not(target_arch = "wasm32"))]
 pub use backend::CraneliftOptLevel;
 #[cfg(not(target_arch = "wasm32"))]
 pub use backend::CraneliftOptions;
 #[cfg(not(target_arch = "wasm32"))]
 pub use backend::RegallocAlgorithm;
+#[cfg(target_arch = "x86_64")]
+pub use backend::{NativeDiagnostics, NativeDumpOptions};
 pub use celox_frontend_veryl::{LoweringPhase, ParserError};
 pub use celox_slt::scheduler::SchedulerError;
 pub use num_bigint::BigUint;
 pub use optimizer::OptLevel;
 pub use optimizer::OptimizeOptions;
+pub use optimizer::SirDiagnostics;
 pub use optimizer::SirPass;
 #[cfg(not(target_arch = "wasm32"))]
 pub use simulation::Simulation;

--- a/crates/celox/src/optimizer.rs
+++ b/crates/celox/src/optimizer.rs
@@ -1,4 +1,4 @@
-pub use celox_sir_opt::{OptLevel, OptimizeOptions, SirPass};
+pub use celox_sir_opt::{OptLevel, OptimizeOptions, SirDiagnostics, SirPass};
 
 pub mod sir;
 

--- a/crates/celox/src/optimizer/sir.rs
+++ b/crates/celox/src/optimizer/sir.rs
@@ -57,6 +57,7 @@ pub(crate) fn optimize_native_merged_chain(
     layout: &crate::backend::MemoryLayout,
     four_state: bool,
     recover_merged_effect_regions: bool,
+    diagnostics: &crate::optimizer::SirDiagnostics,
 ) -> Result<(), (&'static str, celox_sir::verify::SirVerifyError)> {
     let element_widths = Arc::new(
         layout
@@ -85,6 +86,7 @@ pub(crate) fn optimize_native_merged_chain(
         },
         four_state,
         recover_merged_effect_regions,
+        diagnostics,
     )
 }
 

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -49,12 +49,12 @@ fn apply_fused_optimization_hints(
     Ok(())
 }
 
-fn dump_addr_map_if_requested(program: &RuntimeProgram) {
-    if std::env::var_os("CELOX_ADDR_MAP_DUMP").is_none() {
+fn dump_addr_map_if_requested(program: &RuntimeProgram, diagnostics: &crate::RuntimeDiagnostics) {
+    let Some(raw_filter) = diagnostics.address_map_filter.as_deref() else {
         return;
-    }
+    };
 
-    let filter = parse_addr_map_filter();
+    let filter = parse_addr_map_filter(raw_filter);
     let mut entries = Vec::new();
     for (&instance_id, &module_id) in &program.frontend.instance_module {
         let Some(vars) = program.frontend.module_variables.get(&module_id) else {
@@ -86,7 +86,7 @@ fn dump_addr_map_if_requested(program: &RuntimeProgram) {
         let Some(addr) = program.state_address_for_source(instance_id, var_id) else {
             continue;
         };
-        eprintln!(
+        tracing::debug!(
             "[addr-map] inst={} var={} module={} path={} width={} array_dims={:?} 4state={} kind={:?} var_kind={}",
             instance_id,
             var_id,
@@ -101,9 +101,10 @@ fn dump_addr_map_if_requested(program: &RuntimeProgram) {
     }
 }
 
-fn parse_addr_map_filter() -> Option<HashSet<(String, String)>> {
-    let raw = std::env::var_os("CELOX_ADDR_MAP_FILTER")?;
-    let raw = raw.to_string_lossy();
+fn parse_addr_map_filter(raw: &str) -> Option<HashSet<(String, String)>> {
+    if raw.is_empty() {
+        return None;
+    }
     let mut filter = HashSet::default();
     for item in raw
         .split(',')
@@ -115,7 +116,7 @@ fn parse_addr_map_filter() -> Option<HashSet<(String, String)>> {
         };
         filter.insert((normalized_addr_id(inst), normalized_addr_id(var)));
     }
-    Some(filter)
+    (!filter.is_empty()).then_some(filter)
 }
 
 fn normalized_addr_id(raw: &str) -> String {
@@ -300,20 +301,21 @@ pub fn parse(
     trace_opts: &crate::debug::TraceOptions,
     mut trace: Option<&mut crate::debug::CompilationTrace>,
     optimize_options: &crate::optimizer::OptimizeOptions,
+    diagnostics: &crate::RuntimeDiagnostics,
     preserve_element_storage_layout: bool,
 ) -> Result<crate::ir::OptimizedSir, ParserError> {
     debug_assert!(
         loop_provenance.is_consistent_with(ir),
         "loop provenance must describe the analyzer IR passed to the parser"
     );
-    let phase_timing = std::env::var("CELOX_PHASE_TIMING").is_ok();
+    let phase_timing = diagnostics.phase_timing;
 
     macro_rules! timed_phase {
         ($label:expr, $body:expr) => {{
             if phase_timing {
                 let start = crate::timing::now();
                 let result = $body;
-                eprintln!("[phase-timing] {}: {:?}", $label, start.elapsed());
+                tracing::debug!("[phase-timing] {}: {:?}", $label, start.elapsed());
                 result
             } else {
                 $body
@@ -330,7 +332,7 @@ pub fn parse(
     {
         t.analyzer_ir = Some(ir.to_string());
     }
-    let frontend_trace_options = trace_opts.frontend();
+    let frontend_trace_options = trace_opts.frontend(diagnostics);
     let mut frontend_trace = celox_frontend_veryl::FrontendTrace::default();
     let scheduled = timed_phase!(
         "flatten",
@@ -355,7 +357,7 @@ pub fn parse(
     crate::testbench_compile::project_observability(&mut runtime, &testbench_source);
     runtime.testbench =
         crate::testbench_compile::compile_semantic_testbench(&runtime, &testbench_source);
-    dump_addr_map_if_requested(&runtime);
+    dump_addr_map_if_requested(&runtime, diagnostics);
     let mut program = UnoptimizedSir::new(sir, runtime);
     if let Some(t) = trace.as_deref_mut()
         && trace_opts.pre_optimized_sir

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -1,7 +1,7 @@
 #[cfg(not(target_arch = "wasm32"))]
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
 #[cfg(not(target_arch = "wasm32"))]
-use std::sync::{Arc, OnceLock};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::backend::RuntimeEventBuffer;
@@ -23,43 +23,6 @@ use num_bigint::BigUint;
 
 mod builder;
 mod error;
-
-#[cfg(not(target_arch = "wasm32"))]
-fn tick_timing_every() -> Option<u64> {
-    static VALUE: OnceLock<Option<u64>> = OnceLock::new();
-    *VALUE.get_or_init(|| {
-        std::env::var("CELOX_TICK_TIMING")
-            .ok()
-            .and_then(|value| value.parse().ok())
-    })
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn record_tick_timing(eval_apply_ns: u64, eval_comb_ns: u64) {
-    static TICKS: AtomicU64 = AtomicU64::new(0);
-    static EVAL_APPLY_NS: AtomicU64 = AtomicU64::new(0);
-    static EVAL_COMB_NS: AtomicU64 = AtomicU64::new(0);
-
-    let Some(every) = tick_timing_every() else {
-        return;
-    };
-    if every == 0 {
-        return;
-    }
-
-    let ticks = TICKS.fetch_add(1, Ordering::Relaxed) + 1;
-    let apply_total = EVAL_APPLY_NS.fetch_add(eval_apply_ns, Ordering::Relaxed) + eval_apply_ns;
-    let comb_total = EVAL_COMB_NS.fetch_add(eval_comb_ns, Ordering::Relaxed) + eval_comb_ns;
-    if ticks.is_multiple_of(every) {
-        eprintln!(
-            "[tick-timing] ticks={ticks} eval_apply_ms={:.3} eval_comb_ms={:.3} avg_apply_us={:.3} avg_comb_us={:.3}",
-            apply_total as f64 / 1_000_000.0,
-            comb_total as f64 / 1_000_000.0,
-            apply_total as f64 / ticks as f64 / 1_000.0,
-            comb_total as f64 / ticks as f64 / 1_000.0,
-        );
-    }
-}
 
 pub use builder::compile_to_sir;
 #[cfg(not(target_arch = "wasm32"))]
@@ -114,6 +77,10 @@ pub struct Simulator<B: SimBackend = crate::DefaultBackend> {
     runtime_event_drain_active: Arc<AtomicBool>,
     comb_observer_snapshots: Vec<Vec<(BigUint, BigUint)>>,
     comb_observer_initial_eval: bool,
+    pub(crate) diagnostics: crate::RuntimeDiagnostics,
+    tick_timing_ticks: u64,
+    tick_timing_eval_apply_ns: u64,
+    tick_timing_eval_comb_ns: u64,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -563,9 +530,36 @@ impl<B: SimBackend> Simulator<B> {
             runtime_event_drain_active: Arc::new(AtomicBool::new(false)),
             comb_observer_snapshots: Vec::new(),
             comb_observer_initial_eval: true,
+            diagnostics: crate::RuntimeDiagnostics::default(),
+            tick_timing_ticks: 0,
+            tick_timing_eval_apply_ns: 0,
+            tick_timing_eval_comb_ns: 0,
         };
         sim.comb_observer_snapshots = sim.snapshot_all_comb_observers();
         sim
+    }
+
+    fn record_tick_timing(&mut self, eval_apply_ns: u64, eval_comb_ns: u64) {
+        let Some(every) = self.diagnostics.tick_timing_every else {
+            return;
+        };
+        if every == 0 {
+            return;
+        }
+        self.tick_timing_ticks = self.tick_timing_ticks.saturating_add(1);
+        self.tick_timing_eval_apply_ns =
+            self.tick_timing_eval_apply_ns.saturating_add(eval_apply_ns);
+        self.tick_timing_eval_comb_ns = self.tick_timing_eval_comb_ns.saturating_add(eval_comb_ns);
+        if self.tick_timing_ticks.is_multiple_of(every) {
+            tracing::debug!(
+                "[tick-timing] ticks={} eval_apply_ms={:.3} eval_comb_ms={:.3} avg_apply_us={:.3} avg_comb_us={:.3}",
+                self.tick_timing_ticks,
+                self.tick_timing_eval_apply_ns as f64 / 1_000_000.0,
+                self.tick_timing_eval_comb_ns as f64 / 1_000_000.0,
+                self.tick_timing_eval_apply_ns as f64 / self.tick_timing_ticks as f64 / 1_000.0,
+                self.tick_timing_eval_comb_ns as f64 / self.tick_timing_ticks as f64 / 1_000.0,
+            );
+        }
     }
 
     pub(crate) fn apply_initial_values(&mut self) {
@@ -1010,7 +1004,7 @@ impl<B: SimBackend> Simulator<B> {
 
     /// Manually triggers a clock or event to process sequential logic.
     pub fn tick(&mut self, event: B::Event) -> Result<(), RuntimeErrorCode> {
-        let timing_enabled = tick_timing_every().is_some();
+        let timing_enabled = self.diagnostics.tick_timing_every.is_some();
         let mut eval_comb_ns = 0u64;
         let mut eval_apply_ns = 0u64;
         if self.dirty {
@@ -1039,7 +1033,7 @@ impl<B: SimBackend> Simulator<B> {
             let start = crate::timing::now();
             self.eval_comb_checked()?;
             eval_comb_ns = eval_comb_ns.saturating_add(start.elapsed().as_nanos() as u64);
-            record_tick_timing(eval_apply_ns, eval_comb_ns);
+            self.record_tick_timing(eval_apply_ns, eval_comb_ns);
         } else {
             self.eval_comb_checked()?;
         }

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -32,6 +32,7 @@ fn analyze(
     reset_type: Option<ResetType>,
     param_overrides: &[(String, u64)],
     optimize_options: &crate::optimizer::OptimizeOptions,
+    diagnostics: &crate::RuntimeDiagnostics,
     preserve_element_storage_layout: bool,
 ) -> (Result<OptimizedSir, ParserError>, Vec<AnalyzerError>) {
     symbol_table::clear();
@@ -103,6 +104,7 @@ fn analyze(
         trace_opts,
         trace_out,
         optimize_options,
+        diagnostics,
         preserve_element_storage_layout,
     );
     (sir, errors)
@@ -146,6 +148,7 @@ pub fn compile_to_sir(
         reset_type,
         param_overrides,
         optimize_options,
+        &crate::RuntimeDiagnostics::default(),
         crate::backend::memory_layout::MemoryLayoutMode::Packed,
     )
 }
@@ -170,6 +173,7 @@ fn compile_to_sir_with_layout_mode(
     reset_type: Option<ResetType>,
     param_overrides: &[(String, u64)],
     optimize_options: &crate::optimizer::OptimizeOptions,
+    diagnostics: &crate::RuntimeDiagnostics,
     layout_mode: crate::backend::memory_layout::MemoryLayoutMode,
 ) -> Result<(OptimizedSir, Vec<AnalyzerError>), SimulatorError> {
     let (sir, errors) = analyze(
@@ -185,6 +189,7 @@ fn compile_to_sir_with_layout_mode(
         reset_type,
         param_overrides,
         optimize_options,
+        diagnostics,
         layout_mode == crate::backend::memory_layout::MemoryLayoutMode::ElementStrided,
     );
     let (real_errors, warnings): (Vec<_>, Vec<_>) = errors.into_iter().partition(|e| e.is_error());
@@ -233,6 +238,7 @@ pub struct SimulatorOptions {
     #[cfg(target_arch = "x86_64")]
     pub x86_options: crate::backend::X86BackendOptions,
     pub trace: crate::debug::TraceOptions,
+    pub diagnostics: crate::RuntimeDiagnostics,
     /// When true, JIT-compiled functions emit trigger detection code for
     /// edge-based event discovery. Only needed by [`crate::Simulation`].
     pub emit_triggers: bool,
@@ -251,6 +257,7 @@ impl Default for SimulatorOptions {
             #[cfg(target_arch = "x86_64")]
             x86_options: crate::backend::X86BackendOptions::default(),
             trace: Default::default(),
+            diagnostics: Default::default(),
             emit_triggers: false,
             dead_store_policy: DeadStorePolicy::Off,
         }
@@ -438,6 +445,26 @@ impl<'a, Target> SimulatorBuilder<'a, Target> {
         self
     }
 
+    /// Configure diagnostics explicitly for this build.
+    pub fn diagnostics(mut self, diagnostics: crate::DiagnosticsOptions) -> Self {
+        self.options.diagnostics = diagnostics.runtime;
+        self.options.optimize_options.diagnostics = diagnostics.sir;
+        self.options.cranelift_options.diagnostics = diagnostics.cranelift;
+        #[cfg(target_arch = "x86_64")]
+        {
+            self.options.x86_options.diagnostics = diagnostics.native;
+            if let Some(enabled) = diagnostics.native_tick_loop {
+                self.options.x86_options.native_tick_loop = enabled;
+            }
+        }
+        self
+    }
+
+    /// Import legacy `CELOX_*` diagnostics switches once at the API boundary.
+    pub fn diagnostics_from_env(self) -> Self {
+        self.diagnostics(crate::DiagnosticsOptions::from_env())
+    }
+
     pub fn trace_sim_modules(mut self) -> Self {
         self.options.trace.sim_modules = true;
         self
@@ -596,7 +623,7 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
         ),
         SimulatorError,
     > {
-        let phase_timing = std::env::var_os("CELOX_PHASE_TIMING").is_some();
+        let phase_timing = self.options.diagnostics.phase_timing;
         let compile_start = phase_timing.then(crate::timing::now);
         let (program, warnings) = compile_to_sir_with_layout_mode(
             &self.sources,
@@ -611,24 +638,25 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
             self.reset_type,
             &self.param_overrides,
             &self.options.optimize_options,
+            &self.options.diagnostics,
             layout_mode,
         )?;
         if let Some(start) = compile_start {
-            eprintln!("[phase-timing] compile_to_sir: {:?}", start.elapsed());
+            tracing::debug!("[phase-timing] compile_to_sir: {:?}", start.elapsed());
         }
 
         // Build memory layout (consumes semantic layout requirements).
         let layout_start = phase_timing.then(crate::timing::now);
         let mut laid_out = program.into_laid_out_with_mode(self.options.four_state, layout_mode);
         if let Some(start) = layout_start {
-            eprintln!("[phase-timing] build_layout: {:?}", start.elapsed());
+            tracing::debug!("[phase-timing] build_layout: {:?}", start.elapsed());
         }
 
         if self.options.dead_store_policy != DeadStorePolicy::Off {
             let dse_start = phase_timing.then(crate::timing::now);
             run_dead_store_elimination(&mut laid_out, &self.live_signals, &self.options);
             if let Some(start) = dse_start {
-                eprintln!(
+                tracing::debug!(
                     "[phase-timing] dead_store_elimination: {:?}",
                     start.elapsed()
                 );
@@ -653,14 +681,14 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
 
     /// Compiles using the Cranelift JIT backend.
     pub fn build_cranelift(self) -> Result<Simulator<JitBackend>, SimulatorError> {
-        let phase_timing = std::env::var("CELOX_PHASE_TIMING").is_ok();
+        let phase_timing = self.options.diagnostics.phase_timing;
         let phase_start = phase_timing.then(crate::timing::now);
 
         let (laid_out, warnings, options, vcd_path) =
             self.into_laid_out_program(crate::backend::memory_layout::MemoryLayoutMode::Packed)?;
 
         if let Some(s) = phase_start {
-            eprintln!(
+            tracing::debug!(
                 "[phase-timing] compile_and_layout (total): {:?}",
                 s.elapsed()
             );
@@ -680,11 +708,12 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
             trace.print();
         }
         if let Some(s) = jit_start {
-            eprintln!("[phase-timing] jit_backend: {:?}", s.elapsed());
+            tracing::debug!("[phase-timing] jit_backend: {:?}", s.elapsed());
         }
 
         let mut sim =
             Simulator::with_backend_and_program(backend, laid_out.into_runtime(), warnings);
+        sim.diagnostics = options.diagnostics.clone();
         if let Some(path) = vcd_path {
             let descs = sim.build_vcd_descs(options.four_state);
             let vcd_writer = crate::vcd::VcdWriter::new(path, &descs)
@@ -701,13 +730,13 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
     pub fn build_native(
         self,
     ) -> Result<Simulator<crate::backend::native::NativeBackend>, SimulatorError> {
-        let phase_timing = std::env::var_os("CELOX_PHASE_TIMING").is_some();
+        let phase_timing = self.options.diagnostics.phase_timing;
         let sir_start = phase_timing.then(crate::timing::now);
         let (laid_out, warnings, options, vcd_path) = self.into_laid_out_program(
             crate::backend::memory_layout::MemoryLayoutMode::ElementStrided,
         )?;
         if let Some(start) = sir_start {
-            eprintln!(
+            tracing::debug!(
                 "[phase-timing] into_laid_out_program total: {:?}",
                 start.elapsed()
             );
@@ -715,10 +744,11 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
         let backend_start = phase_timing.then(crate::timing::now);
         let backend = crate::backend::native::NativeBackend::new(&laid_out, &options)?;
         if let Some(start) = backend_start {
-            eprintln!("[phase-timing] native_backend: {:?}", start.elapsed());
+            tracing::debug!("[phase-timing] native_backend: {:?}", start.elapsed());
         }
         let mut sim =
             Simulator::with_backend_and_program(backend, laid_out.into_runtime(), warnings);
+        sim.diagnostics = options.diagnostics.clone();
         if let Some(path) = vcd_path {
             let descs = sim.build_vcd_descs(options.four_state);
             let vcd_writer = crate::vcd::VcdWriter::new(path, &descs)
@@ -728,12 +758,12 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
         let apply_initial_start = phase_timing.then(crate::timing::now);
         sim.apply_initial_values();
         if let Some(start) = apply_initial_start {
-            eprintln!("[phase-timing] apply_initial_values: {:?}", start.elapsed());
+            tracing::debug!("[phase-timing] apply_initial_values: {:?}", start.elapsed());
         }
         let settle_start = phase_timing.then(crate::timing::now);
         sim.modify(|_| {}).map_err(SimulatorError::from)?;
         if let Some(start) = settle_start {
-            eprintln!("[phase-timing] initial_settle: {:?}", start.elapsed());
+            tracing::debug!("[phase-timing] initial_settle: {:?}", start.elapsed());
         }
         Ok(sim)
     }
@@ -747,6 +777,7 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
         let backend = crate::backend::wasm_runtime::WasmBackend::new(&laid_out, &options)?;
         let mut sim =
             Simulator::with_backend_and_program(backend, laid_out.into_runtime(), warnings);
+        sim.diagnostics = options.diagnostics.clone();
         if let Some(path) = vcd_path {
             let descs = sim.build_vcd_descs(options.four_state);
             let vcd_writer = crate::vcd::VcdWriter::new(path, &descs)
@@ -810,6 +841,7 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
             self.reset_type,
             &self.param_overrides,
             &self.options.optimize_options,
+            &self.options.diagnostics,
             layout_mode,
         );
 
@@ -842,6 +874,7 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
 
             let mut sim =
                 Simulator::with_backend_and_program(backend, laid_out.into_runtime(), warnings);
+            sim.diagnostics = self.options.diagnostics.clone();
             sim.apply_initial_values();
             sim.modify(|_| {}).map_err(SimulatorError::from)?;
             Ok(sim)
@@ -862,7 +895,7 @@ impl<'a> SimulatorBuilder<'a, Simulator> {
 fn run_test_with_sim<B: crate::backend::SimBackend>(
     mut sim: Simulator<B>,
 ) -> Result<crate::testbench::TestResult, SimulatorError> {
-    let phase_timing = std::env::var_os("CELOX_PHASE_TIMING").is_some();
+    let phase_timing = sim.diagnostics.phase_timing;
     let testbench_start = phase_timing.then(crate::timing::now);
     let testbench = crate::testbench::compile_initial_testbench(&sim).ok_or_else(|| {
         SimulatorError::new(SimulatorErrorKind::Codegen(
@@ -871,7 +904,7 @@ fn run_test_with_sim<B: crate::backend::SimBackend>(
     })?;
     let result = crate::testbench::run_testbench(&mut sim, testbench.statements());
     if let Some(start) = testbench_start {
-        eprintln!("[phase-timing] testbench: {:?}", start.elapsed());
+        tracing::debug!("[phase-timing] testbench: {:?}", start.elapsed());
     }
     Ok(result)
 }
@@ -932,6 +965,7 @@ impl<'a> SimulatorBuilder<'a, crate::Simulation> {
             self.reset_type,
             &self.param_overrides,
             &self.options.optimize_options,
+            &self.options.diagnostics,
             layout_mode,
         )?;
         let mut laid_out = program.into_laid_out_with_mode(self.options.four_state, layout_mode);
@@ -946,6 +980,7 @@ impl<'a> SimulatorBuilder<'a, crate::Simulation> {
 
         let mut sim =
             Simulator::with_backend_and_program(backend, laid_out.into_runtime(), warnings);
+        sim.diagnostics = self.options.diagnostics.clone();
         if let Some(path) = self.vcd_path {
             let descs = sim.build_vcd_descs(self.options.four_state);
             let vcd_writer = crate::vcd::VcdWriter::new(path, &descs)

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -21,10 +21,7 @@ use celox_testbench::{
 };
 use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::ToPrimitive as _;
-use std::sync::{
-    OnceLock,
-    atomic::{AtomicU64, Ordering},
-};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 // ── Public types ───────────────────────────────────────────────────────
 
@@ -969,7 +966,7 @@ fn exec_one_detailed<B: SimBackend>(
         GenericTestbenchStatement::ClockNext { clock_event, count } => {
             match eval_clock_count(sim, count) {
                 Ok(n) => {
-                    let progress_every = testbench_progress_every();
+                    let progress_every = sim.diagnostics.testbench_progress_every;
                     let mut remaining = n;
                     while remaining != 0 {
                         if tick_limit_reached(ctx) {
@@ -1001,7 +998,7 @@ fn exec_one_detailed<B: SimBackend>(
                             && every != 0
                             && ctx.current_time.is_multiple_of(every)
                         {
-                            eprintln!("[testbench-progress] tick={}", ctx.current_time);
+                            tracing::debug!("[testbench-progress] tick={}", ctx.current_time);
                         }
                         drain_runtime_assertions(sim, ctx, None);
                     }
@@ -1141,15 +1138,6 @@ fn exec_one_detailed<B: SimBackend>(
         GenericTestbenchStatement::Break => ExecResult::Break,
         GenericTestbenchStatement::Finish => ExecResult::Finished,
     }
-}
-
-fn testbench_progress_every() -> Option<u64> {
-    static VALUE: OnceLock<Option<u64>> = OnceLock::new();
-    *VALUE.get_or_init(|| {
-        std::env::var("CELOX_TESTBENCH_PROGRESS")
-            .ok()
-            .and_then(|value| value.parse().ok())
-    })
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]

--- a/crates/celox/tests/bitslice_param_repro.rs
+++ b/crates/celox/tests/bitslice_param_repro.rs
@@ -162,7 +162,7 @@ out[3:0] = data;
     })
     .unwrap();
     let val: u64 = sim.get(out).try_into().unwrap();
-    eprintln!("  sel=00, a=0, b=0 → out=0x{:08x}", val);
+    println!("  sel=00, a=0, b=0 → out=0x{:08x}", val);
     assert_eq!(
         val, 0xFFFF_FFFC,
         "sel=00: upper bits should be 1, got 0x{:08x}",
@@ -178,7 +178,7 @@ out[3:0] = data;
     })
     .unwrap();
     let val: u64 = sim.get(out).try_into().unwrap();
-    eprintln!("  sel=10, data=0b0101 → out=0x{:08x}", val);
+    println!("  sel=10, data=0b0101 → out=0x{:08x}", val);
     assert_eq!(val, 0xFFFF_FFF5, "sel=10: got 0x{:08x}", val);
 
     }
@@ -195,7 +195,7 @@ fn axi_lite_reg_file_req_last_vec() {
         // Check the register directly (bypasses the comb read path)
         let reg_val: u64 = sim.get(reg_req_last_vec).try_into().unwrap();
         let got = axl_read(&mut sim, ADDR_REQ_LAST);
-        eprintln!(
+        println!(
             "  wrote: 0b{:04b}, reg_req_last_vec: 0b{:04b}, read_mux: 0b{:04b}",
             p,
             reg_val & 0xf,
@@ -264,7 +264,7 @@ fn parametric_bitslice_multi_branch() {
     })
     .unwrap();
     let val: u64 = sim.get(out).try_into().unwrap();
-    eprintln!("  sel=00, a=1, b=0 → out=0b{:08b}", val & 0xff);
+    println!("  sel=00, a=1, b=0 → out=0b{:08b}", val & 0xff);
 
     sim.modify(|io| {
         io.set(sel, 1u8);
@@ -273,7 +273,7 @@ fn parametric_bitslice_multi_branch() {
     })
     .unwrap();
     let val: u64 = sim.get(out).try_into().unwrap();
-    eprintln!("  sel=01, a=1, b=0 → out=0b{:08b}", val & 0xff);
+    println!("  sel=01, a=1, b=0 → out=0b{:08b}", val & 0xff);
 
     // Test sel=2'b10: out[3:0] should = data
     for pattern in [0b0001u8, 0b0010, 0b0100, 0b1000, 0b1111, 0b1010] {
@@ -285,7 +285,7 @@ fn parametric_bitslice_multi_branch() {
         })
         .unwrap();
         let val: u64 = sim.get(out).try_into().unwrap();
-        eprintln!("  sel=10, data=0b{:04b}, out=0b{:04b}", pattern, val & 0xf);
+        println!("  sel=10, data=0b{:04b}, out=0b{:04b}", pattern, val & 0xf);
         assert_eq!(
             val & 0xf,
             pattern as u64,
@@ -342,7 +342,7 @@ fn hardcoded_bitslice_multi_branch() {
         })
         .unwrap();
         let val: u64 = sim.get(out).try_into().unwrap();
-        eprintln!(
+        println!(
             "  [hardcoded] sel=0, data=0b{:04b}, out=0b{:04b}",
             pattern,
             val & 0xf
@@ -387,5 +387,5 @@ fn hardcoded_bitslice_trace() {
         .trace_post_optimized_sir()
         .build_with_trace();
     let output = trace.trace.format_program().unwrap();
-    eprintln!("{}", output);
+    println!("{}", output);
 }

--- a/crates/celox/tests/native_exec.rs
+++ b/crates/celox/tests/native_exec.rs
@@ -62,19 +62,19 @@ fn compile_and_run_inner(
     let mut mfunc = isel::lower_execution_unit(eu, &layout, false);
 
     if debug {
-        eprintln!("=== MIR ===\n{mfunc}");
+        println!("=== MIR ===\n{mfunc}");
     }
 
     let ra = regalloc::run_regalloc(&mut mfunc).unwrap();
 
     if debug {
-        eprintln!("=== Assignment ===\n{:?}", ra.assignment);
+        println!("=== Assignment ===\n{:?}", ra.assignment);
     }
 
     let emit_result = emit::emit(&mfunc, &ra.assignment, ra.spill_frame_size).expect("emit failed");
 
     if debug {
-        eprintln!(
+        println!(
             "=== Disassembly ===\n{}",
             emit::disassemble(&emit_result.code[..emit_result.text_size], 0)
         );
@@ -475,7 +475,7 @@ fn test_debug_let_bitslice_write() {
         .trace_post_optimized_sir()
         .build_with_trace();
     let sir_text = trace.trace.format_program().unwrap();
-    eprintln!("{sir_text}");
+    println!("{sir_text}");
     let sir = trace.trace.post_optimized_sir.unwrap();
 
     use celox::native_backend::{emit, isel, regalloc};
@@ -483,12 +483,12 @@ fn test_debug_let_bitslice_write() {
 
     for (eu_idx, eu) in sir.sir.eval_comb.iter().enumerate() {
         let mut mfunc = isel::lower_execution_unit(eu, &layout, false);
-        eprintln!("=== EU {eu_idx} MIR ===\n{mfunc}");
+        println!("=== EU {eu_idx} MIR ===\n{mfunc}");
         let ra = regalloc::run_regalloc(&mut mfunc).unwrap();
-        eprintln!("=== EU {eu_idx} Assignment ===\n{:?}", ra.assignment);
+        println!("=== EU {eu_idx} Assignment ===\n{:?}", ra.assignment);
         let emit_result =
             emit::emit(&mfunc, &ra.assignment, ra.spill_frame_size).expect("emit failed");
-        eprintln!(
+        println!(
             "=== EU {eu_idx} Disassembly ===\n{}",
             emit::disassemble(&emit_result.code[..emit_result.text_size], 0)
         );
@@ -498,7 +498,7 @@ fn test_debug_let_bitslice_write() {
     let mut sim = SimulatorBuilder::new(code, "Top").build_native().unwrap();
     let o_hi = sim.signal("o_hi");
     let o_lo = sim.signal("o_lo");
-    eprintln!("Native: o_hi={:?}, o_lo={:?}", sim.get(o_hi), sim.get(o_lo));
+    println!("Native: o_hi={:?}, o_lo={:?}", sim.get(o_hi), sim.get(o_lo));
     assert_eq!(sim.get(o_hi), 2u64.into());
     assert_eq!(sim.get(o_lo), 102u64.into());
 }

--- a/crates/celox/tests/optimizer_scaling.rs
+++ b/crates/celox/tests/optimizer_scaling.rs
@@ -80,9 +80,9 @@ fn linear_sec_scaling_p5_to_p6() {
     let median_p6 = times_p6[SAMPLES / 2].as_secs_f64();
     let ratio = median_p6 / median_p5;
 
-    eprintln!("[scaling] linear_sec P=5 median: {median_p5:.3}s");
-    eprintln!("[scaling] linear_sec P=6 median: {median_p6:.3}s");
-    eprintln!("[scaling] ratio P6/P5: {ratio:.2}x");
+    println!("[scaling] linear_sec P=5 median: {median_p5:.3}s");
+    println!("[scaling] linear_sec P=6 median: {median_p6:.3}s");
+    println!("[scaling] ratio P6/P5: {ratio:.2}x");
 
     // Circuit size roughly doubles (P=5→P=6).
     // O(n log n) → ~2.2x, O(n²) → ~4x.
@@ -149,9 +149,9 @@ fn counter_scaling_n500_to_n1000() {
     let median_large = times_large[SAMPLES / 2].as_secs_f64();
     let ratio = median_large / median_small;
 
-    eprintln!("[scaling] counter N=500  median: {median_small:.3}s");
-    eprintln!("[scaling] counter N=1000 median: {median_large:.3}s");
-    eprintln!("[scaling] ratio N1000/N500: {ratio:.2}x");
+    println!("[scaling] counter N=500  median: {median_small:.3}s");
+    println!("[scaling] counter N=1000 median: {median_large:.3}s");
+    println!("[scaling] ratio N1000/N500: {ratio:.2}x");
 
     // N doubles → expect ~2x for linear, ~4x for quadratic.
     // Allow up to 6x as margin (these are independent EUs so should be ~linear).

--- a/crates/celox/tests/param_override.rs
+++ b/crates/celox/tests/param_override.rs
@@ -142,7 +142,7 @@ fn test_param_in_always_ff(sim) {
         sim.modify(|io| io.set(clk, 0u8)).unwrap();
         sim.modify(|io| io.set(clk, 1u8)).unwrap();
         let c: u64 = sim.get(counter).try_into().unwrap();
-        eprintln!("cycle {i}: counter={c}, done={:?}", sim.get(done));
+        println!("cycle {i}: counter={c}, done={:?}", sim.get(done));
     }
 
     // After 8 total rising edges (1 start + 7 more), counter should have hit N-1=7
@@ -458,7 +458,7 @@ fn test_param_in_always_ff_override_n4() {
         sim.modify(|io| io.set(clk, 0u8)).unwrap();
         sim.modify(|io| io.set(clk, 1u8)).unwrap();
         let c: u64 = sim.get(counter).try_into().unwrap();
-        eprintln!("override cycle {i}: counter={c}, done={:?}", sim.get(done));
+        println!("override cycle {i}: counter={c}, done={:?}", sim.get(done));
     }
 
     let done_val: u64 = sim.get(done).try_into().unwrap();

--- a/crates/celox/tests/sorter_tree_perf.rs
+++ b/crates/celox/tests/sorter_tree_perf.rs
@@ -54,7 +54,7 @@ fn sorter_tree_compilation_scales() {
     let ratio_4_8 = t8.as_secs_f64() / t4.as_secs_f64();
     let ratio_16_64 = t64.as_secs_f64() / t16.as_secs_f64();
     let ratio_32_128 = t128.as_secs_f64() / t32.as_secs_f64();
-    eprintln!(
+    println!(
         "SorterTreeDistEntry compile times: N=4 {t4:?}, N=8 {t8:?}, N=16 {t16:?}, \
          N=32 {t32:?}, N=64 {t64:?}, N=128 {t128:?}; ratios: \
          N=8/N=4 {ratio_4_8:.2}x, N=64/N=16 {ratio_16_64:.2}x, \


### PR DESCRIPTION
## What changed

- add explicit runtime, SIR, Cranelift, and native diagnostics options and thread them through simulator construction
- keep legacy `CELOX_*` support behind the opt-in `diagnostics_from_env()` application-boundary adapter
- route library diagnostics through `tracing` and add a caller-provided writer API for compilation traces
- enforce the boundary with workspace-wide Clippy bans on direct `eprintln!` and environment-variable access

## Why

Diagnostics were previously controlled by process-global environment reads scattered across library crates and wrote directly to stderr. That made behavior implicit, difficult to test, and impossible to configure independently for multiple simulator builds in one process.

The new configuration is explicit and deterministic by default. Applications that need the legacy environment workflow can opt into it once at the builder boundary, while CLI error and progress output remains on stderr intentionally.

## Impact

- reusable library code no longer reads diagnostic environment variables directly
- callers can configure separate builds independently and test parsing without mutating process-global state
- applications that want emitted diagnostic events must install a `tracing` subscriber
- existing `CELOX_*` workflows remain available through `SimulatorBuilder::diagnostics_from_env()`

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --lib --bins --tests`
- `cargo test -p celox -p celox-sir-opt -p celox-backend-x86 --lib` (902 tests)
- pre-push submodule, Biome, formatting, Cargo check, and clean-tree hooks
