### PR TITLE
docs(readme): add npm version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Celox
 
+[![npm version](https://img.shields.io/npm/v/%40celox-sim%2Fcelox.svg)](https://www.npmjs.com/package/@celox-sim/celox)
+
 JIT simulator for [Veryl HDL](https://veryl-lang.org/). Celox lowers Veryl
 designs to native x86-64 machine code through a custom compiler pipeline.
 


### PR DESCRIPTION
## Summary

- add an npm version badge for `@celox-sim/celox` to the README
- link the badge to the package page on npm

This makes the currently published package version visible from the repository landing page.

## Validation

- `git diff --check`
- pre-push checks: submodule consistency, `cargo fmt`, Biome, `cargo check`, and clean worktree