### PR TITLE
refactor(errors): remove stringly typed results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,7 @@ dependencies = [
  "celox",
  "clap",
  "libc",
+ "thiserror 2.0.19",
  "veryl-analyzer",
  "veryl-metadata",
  "veryl-parser",

--- a/crates/celox-backend-x86/src/backend/native/regalloc.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc.rs
@@ -442,7 +442,7 @@ fn run_regalloc_in_place(
 /// allocation walk. ISel may append CFG-lowering blocks after their logical
 /// successors (for example runtime-event blocks), so numeric/block-vector
 /// order is not a valid way to distinguish forward edges from backedges.
-fn reorder_blocks_rpo(func: &mut MFunction) -> Result<(), String> {
+fn reorder_blocks_rpo(func: &mut MFunction) -> Result<(), cfg::CfgError> {
     use super::mir::BlockId;
     use std::collections::{HashMap, HashSet};
 
@@ -496,7 +496,11 @@ fn reorder_blocks_rpo(func: &mut MFunction) -> Result<(), String> {
             .iter()
             .any(|block| !positions.contains_key(&block.id))
     {
-        return Err("reverse-postorder layout is not a bijection over MIR blocks".into());
+        return Err(cfg::CfgError::new(
+            "CFG.RPO_BIJECTION",
+            None,
+            "reverse-postorder layout is not a bijection over MIR blocks",
+        ));
     }
     func.blocks
         .sort_by_key(|block| positions.get(&block.id).copied().unwrap_or(usize::MAX));

--- a/crates/celox-backend-x86/src/backend/native/regalloc/cfg.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/cfg.rs
@@ -93,7 +93,11 @@ pub(super) struct CfgError {
 }
 
 impl CfgError {
-    fn new(rule: &'static str, block: Option<BlockId>, message: impl Into<String>) -> Self {
+    pub(super) fn new(
+        rule: &'static str,
+        block: Option<BlockId>,
+        message: impl Into<String>,
+    ) -> Self {
         Self {
             rule,
             block,
@@ -393,8 +397,7 @@ pub(super) fn normalize(func: &mut MFunction) -> Result<NormalizedCfg, CfgError>
         ));
     }
     split_critical_edges(func)?;
-    super::reorder_blocks_rpo(func)
-        .map_err(|message| CfgError::new("CFG.RPO_BIJECTION", None, message))?;
+    super::reorder_blocks_rpo(func)?;
     let (block_index, _, successors) = graph(func);
     let analysis = analyze_shared_graph(successors)?;
     let dominance_frontier = analysis

--- a/crates/celox-backend-x86/src/backend/native/regalloc/schedule.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/schedule.rs
@@ -63,6 +63,35 @@ impl fmt::Display for ScheduleError {
 impl std::error::Error for ScheduleError {}
 
 #[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScheduleBlockError {
+    ConstraintShapeMismatch,
+    DependencyCycle,
+    MissingLiveInState,
+}
+
+#[cfg(test)]
+impl ScheduleBlockError {
+    fn message(self) -> &'static str {
+        match self {
+            Self::ConstraintShapeMismatch => "instruction constraint model shape mismatch",
+            Self::DependencyCycle => "candidate order violates the instruction dependency DAG",
+            Self::MissingLiveInState => "candidate schedule did not produce a live-in state",
+        }
+    }
+}
+
+#[cfg(test)]
+impl fmt::Display for ScheduleBlockError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.message())
+    }
+}
+
+#[cfg(test)]
+impl std::error::Error for ScheduleBlockError {}
+
+#[cfg(test)]
 #[derive(Debug, Default)]
 struct RegionWork {
     ready_insertions: usize,
@@ -129,10 +158,10 @@ pub(super) fn schedule_for_pressure(
             &live_out,
             &mut stats,
         )
-        .map_err(|reason| ScheduleError {
+        .map_err(|error| ScheduleError {
             rule: "SCHEDULE.DEPENDENCY_ORDER",
             block: func.blocks[block_index].id,
-            reason,
+            reason: error.message(),
         })?;
         let scheduled_cost = pressure_cost(&scheduled, &live_out, super::NUM_REGS);
         // Peak pressure alone is not a sufficient spill-cost proxy. Two
@@ -162,9 +191,9 @@ fn schedule_block(
     constraints: &[super::constraints::InstructionConstraints],
     live_out: &BTreeSet<VReg>,
     stats: &mut ScheduleStats,
-) -> Result<Vec<MInst>, &'static str> {
+) -> Result<Vec<MInst>, ScheduleBlockError> {
     if instructions.len() != constraints.len() {
-        return Err("instruction constraint model shape mismatch");
+        return Err(ScheduleBlockError::ConstraintShapeMismatch);
     }
 
     enum ReverseChunk {
@@ -200,10 +229,10 @@ fn schedule_block(
         stats.backward_liveness_steps += end - start;
         stats.add_region_work(&scheduled.work);
         if !scheduled.dependency_verified {
-            return Err("candidate order violates the instruction dependency DAG");
+            return Err(ScheduleBlockError::DependencyCycle);
         }
         let Some(live_before) = scheduled.live_before else {
-            return Err("candidate schedule did not produce a live-in state");
+            return Err(ScheduleBlockError::MissingLiveInState);
         };
         live = live_before;
         reverse_chunks.push(ReverseChunk::Region(scheduled.instructions));
@@ -2295,7 +2324,7 @@ mod tests {
         let error = schedule_block(&region, &constraints, &BTreeSet::new(), &mut stats)
             .expect_err("cyclic producer input must not silently keep the original order");
 
-        assert!(error.contains("dependency DAG"));
+        assert!(error.to_string().contains("dependency DAG"));
     }
 
     #[test]

--- a/crates/celox-bench/Cargo.toml
+++ b/crates/celox-bench/Cargo.toml
@@ -12,6 +12,7 @@ edition.workspace     = true
 celox           = { path = "../celox" }
 clap            = { workspace = true }
 libc            = { workspace = true }
+thiserror       = { workspace = true }
 veryl-analyzer  = { workspace = true }
 veryl-metadata  = { workspace = true }
 veryl-parser    = { workspace = true }

--- a/crates/celox-bench/src/bin/celox-heliodor.rs
+++ b/crates/celox-bench/src/bin/celox-heliodor.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::disallowed_macros)] // CLI errors and progress intentionally use stderr
 
 use std::{
-    error::Error,
     fs,
     path::{Path, PathBuf},
     time::{Duration, Instant},
@@ -64,6 +63,28 @@ struct Options {
     x86_slp: bool,
 }
 
+#[derive(Debug, thiserror::Error)]
+enum CeloxHeliodorError {
+    #[error(transparent)]
+    Metadata(#[from] veryl_metadata::MetadataError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error("Celox build failed: {source:?}")]
+    Build {
+        #[from]
+        #[source]
+        source: celox::SimulatorError,
+    },
+    #[error("{message}")]
+    InvalidConfiguration { message: &'static str },
+    #[error("{artifact} trace was not captured")]
+    MissingTrace { artifact: &'static str },
+    #[error("no initial block found — this module is not a native testbench")]
+    MissingInitialBlock,
+    #[error("{message}")]
+    TestFailed { message: String },
+}
+
 #[derive(Clone, Copy, ValueEnum)]
 enum Backend {
     Native,
@@ -109,7 +130,7 @@ fn main() {
     }
 }
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<(), CeloxHeliodorError> {
     let cli = Cli::parse();
     let opts = Options {
         project: cli.project,
@@ -137,10 +158,14 @@ fn run() -> Result<(), Box<dyn Error>> {
             .unwrap_or(cfg!(target_arch = "x86_64")),
     };
     if !opts.native_profile_blocks.is_empty() && opts.dump_ir_dir.is_none() {
-        return Err("--native-profile-block requires --dump-ir-dir".into());
+        return Err(CeloxHeliodorError::InvalidConfiguration {
+            message: "--native-profile-block requires --dump-ir-dir",
+        });
     }
     if opts.dump_ir_and_run && opts.dump_ir_dir.is_none() {
-        return Err("--dump-ir-and-run requires --dump-ir-dir".into());
+        return Err(CeloxHeliodorError::InvalidConfiguration {
+            message: "--dump-ir-and-run requires --dump-ir-dir",
+        });
     }
     let (sources, metadata) = load_sources(&opts.project, &opts.source_files)?;
     let source_refs: Vec<(&str, &Path)> = sources
@@ -177,7 +202,9 @@ fn run() -> Result<(), Box<dyn Error>> {
     }
     if let Some(output_dir) = opts.dump_ir_dir {
         if matches!(opts.backend, Backend::Cranelift) {
-            return Err("--dump-ir-dir is only supported with --backend native".into());
+            return Err(CeloxHeliodorError::InvalidConfiguration {
+                message: "--dump-ir-dir is only supported with --backend native",
+            });
         }
         fs::create_dir_all(&output_dir)?;
         let trace_result = builder
@@ -207,23 +234,38 @@ fn run() -> Result<(), Box<dyn Error>> {
                 sir_path.display()
             );
         }
-        let mut sim = res.map_err(|error| format!("Celox build failed: {error:?}"))?;
-        let _pre_optimized_sir =
-            pre_optimized_sir.ok_or("pre-optimized SIR trace was not captured")?;
-        let _sir = sir.ok_or("post-optimized SIR trace was not captured")?;
-        let native_sir = trace
-            .native_optimized_sir
+        let mut sim = res?;
+        let _pre_optimized_sir = pre_optimized_sir.ok_or(CeloxHeliodorError::MissingTrace {
+            artifact: "pre-optimized SIR",
+        })?;
+        let _sir = sir.ok_or(CeloxHeliodorError::MissingTrace {
+            artifact: "post-optimized SIR",
+        })?;
+        let native_sir =
+            trace
+                .native_optimized_sir
+                .take()
+                .ok_or(CeloxHeliodorError::MissingTrace {
+                    artifact: "native optimized SIR",
+                })?;
+        let mir = trace
+            .mir
             .take()
-            .ok_or("native optimized SIR trace was not captured")?;
-        let mir = trace.mir.take().ok_or("MIR trace was not captured")?;
-        let reactive_graph = trace
-            .reactive_event_graph
-            .take()
-            .ok_or("reactive event graph was not captured")?;
-        let state_layout = trace
-            .native_state_layout
-            .take()
-            .ok_or("native state-layout analysis was not captured")?;
+            .ok_or(CeloxHeliodorError::MissingTrace { artifact: "MIR" })?;
+        let reactive_graph =
+            trace
+                .reactive_event_graph
+                .take()
+                .ok_or(CeloxHeliodorError::MissingTrace {
+                    artifact: "reactive event graph",
+                })?;
+        let state_layout =
+            trace
+                .native_state_layout
+                .take()
+                .ok_or(CeloxHeliodorError::MissingTrace {
+                    artifact: "native state-layout analysis",
+                })?;
         let native_sir_path = output_dir.join("native_optimized.sir");
         let mir_path = output_dir.join("mir.txt");
         let reactive_graph_path = output_dir.join("reactive_event_graph.txt");
@@ -265,8 +307,8 @@ fn run() -> Result<(), Box<dyn Error>> {
             trace,
         ));
         if opts.dump_ir_and_run {
-            let testbench = compile_initial_testbench(&sim)
-                .ok_or("no initial block found — this module is not a native testbench")?;
+            let testbench =
+                compile_initial_testbench(&sim).ok_or(CeloxHeliodorError::MissingInitialBlock)?;
             sim.start_native_execution_timing();
             let execute_cpu_start = process_cpu_time();
             let execute_start = Instant::now();
@@ -321,7 +363,7 @@ fn run() -> Result<(), Box<dyn Error>> {
                         opts.test,
                         elapsed.as_nanos()
                     );
-                    Err(message.into())
+                    Err(CeloxHeliodorError::TestFailed { message })
                 }
             };
         }
@@ -371,8 +413,8 @@ fn run() -> Result<(), Box<dyn Error>> {
     ) = match opts.backend {
         Backend::Native => {
             let mut sim = builder.build_native()?;
-            let testbench = compile_initial_testbench(&sim)
-                .ok_or("no initial block found — this module is not a native testbench")?;
+            let testbench =
+                compile_initial_testbench(&sim).ok_or(CeloxHeliodorError::MissingInitialBlock)?;
             let compile_elapsed = compile_start.elapsed();
             sim.start_native_execution_timing();
             let execute_cpu_start = process_cpu_time();
@@ -401,8 +443,8 @@ fn run() -> Result<(), Box<dyn Error>> {
         }
         Backend::Cranelift => {
             let mut sim = builder.build_cranelift()?;
-            let testbench = compile_initial_testbench(&sim)
-                .ok_or("no initial block found — this module is not a native testbench")?;
+            let testbench =
+                compile_initial_testbench(&sim).ok_or(CeloxHeliodorError::MissingInitialBlock)?;
             let compile_elapsed = compile_start.elapsed();
             let execute_cpu_start = process_cpu_time();
             let execute_start = Instant::now();
@@ -463,7 +505,7 @@ fn run() -> Result<(), Box<dyn Error>> {
                 opts.test,
                 elapsed.as_nanos()
             );
-            Err(message.into())
+            Err(CeloxHeliodorError::TestFailed { message })
         }
     }
 }
@@ -514,41 +556,92 @@ fn process_cpu_time() -> Option<Duration> {
     None
 }
 
-fn parse_positive_u64(value: &str) -> Result<u64, String> {
+#[derive(Debug, thiserror::Error)]
+enum CliValueError {
+    #[error("invalid positive integer: {value}")]
+    InvalidPositiveInteger {
+        value: String,
+        #[source]
+        source: std::num::ParseIntError,
+    },
+    #[error("value must be greater than zero")]
+    NonPositiveInteger,
+    #[error("invalid native memory width: {value}")]
+    InvalidNativeMemoryWidth { value: String },
+    #[error("invalid native profile block: {value}")]
+    InvalidNativeProfileBlock { value: String },
+    #[error("invalid block number in native profile block: {value}")]
+    InvalidNativeProfileBlockNumber {
+        value: String,
+        #[source]
+        source: std::num::ParseIntError,
+    },
+    #[error("invalid sample count in native profile block: {value}")]
+    InvalidNativeProfileSampleCount {
+        value: String,
+        #[source]
+        source: std::num::ParseIntError,
+    },
+    #[error("invalid pass override: {value}")]
+    InvalidPassOverride { value: String },
+    #[error("unknown SIR pass: {name}")]
+    UnknownSirPass { name: String },
+}
+
+fn parse_positive_u64(value: &str) -> Result<u64, CliValueError> {
     let parsed = value
         .parse::<u64>()
-        .map_err(|_| format!("invalid positive integer: {value}"))?;
+        .map_err(|source| CliValueError::InvalidPositiveInteger {
+            value: value.to_owned(),
+            source,
+        })?;
     if parsed == 0 {
-        Err("value must be greater than zero".to_string())
+        Err(CliValueError::NonPositiveInteger)
     } else {
         Ok(parsed)
     }
 }
 
-fn parse_native_memory_width(value: &str) -> Result<usize, String> {
+fn parse_native_memory_width(value: &str) -> Result<usize, CliValueError> {
     match value {
         "64" => Ok(64),
         "128" => Ok(128),
-        _ => Err(format!("invalid native memory width: {value}")),
+        _ => Err(CliValueError::InvalidNativeMemoryWidth {
+            value: value.to_owned(),
+        }),
     }
 }
 
-fn parse_native_profile_block(value: &str) -> Result<celox::NativeProfileBlock, String> {
-    let (function_and_block, samples) = value
-        .rsplit_once(':')
-        .ok_or_else(|| format!("invalid native profile block: {value}"))?;
-    let (function, block) = function_and_block
-        .rsplit_once(':')
-        .ok_or_else(|| format!("invalid native profile block: {value}"))?;
+fn parse_native_profile_block(value: &str) -> Result<celox::NativeProfileBlock, CliValueError> {
+    let (function_and_block, samples) =
+        value
+            .rsplit_once(':')
+            .ok_or_else(|| CliValueError::InvalidNativeProfileBlock {
+                value: value.to_owned(),
+            })?;
+    let (function, block) = function_and_block.rsplit_once(':').ok_or_else(|| {
+        CliValueError::InvalidNativeProfileBlock {
+            value: value.to_owned(),
+        }
+    })?;
     let block = block.strip_prefix("bb").unwrap_or(block);
-    let block = block
-        .parse::<u32>()
-        .map_err(|_| format!("invalid block number in native profile block: {value}"))?;
-    let samples = samples
-        .parse::<u64>()
-        .map_err(|_| format!("invalid sample count in native profile block: {value}"))?;
+    let block =
+        block
+            .parse::<u32>()
+            .map_err(|source| CliValueError::InvalidNativeProfileBlockNumber {
+                value: value.to_owned(),
+                source,
+            })?;
+    let samples = samples.parse::<u64>().map_err(|source| {
+        CliValueError::InvalidNativeProfileSampleCount {
+            value: value.to_owned(),
+            source,
+        }
+    })?;
     if function.is_empty() || samples == 0 {
-        return Err(format!("invalid native profile block: {value}"));
+        return Err(CliValueError::InvalidNativeProfileBlock {
+            value: value.to_owned(),
+        });
     }
     Ok(celox::NativeProfileBlock {
         function: function.to_string(),
@@ -557,22 +650,26 @@ fn parse_native_profile_block(value: &str) -> Result<celox::NativeProfileBlock, 
     })
 }
 
-fn parse_pass_override(value: &str) -> Result<(bool, SirPass), String> {
+fn parse_pass_override(value: &str) -> Result<(bool, SirPass), CliValueError> {
     let (enable, name) = if let Some(name) = value.strip_prefix('+') {
         (true, name)
     } else if let Some(name) = value.strip_prefix('-') {
         (false, name)
     } else {
-        return Err(format!("invalid pass override: {value}"));
+        return Err(CliValueError::InvalidPassOverride {
+            value: value.to_owned(),
+        });
     };
-    let pass = SirPass::parse(name).ok_or_else(|| format!("unknown SIR pass: {name}"))?;
+    let pass = SirPass::parse(name).ok_or_else(|| CliValueError::UnknownSirPass {
+        name: name.to_owned(),
+    })?;
     Ok((enable, pass))
 }
 
 fn load_sources(
     project_path: &Path,
     source_files: &[PathBuf],
-) -> Result<(Vec<(String, PathBuf)>, Metadata), Box<dyn Error>> {
+) -> Result<(Vec<(String, PathBuf)>, Metadata), CeloxHeliodorError> {
     let toml_path = Metadata::search_from(project_path)?;
     let mut metadata = Metadata::load(&toml_path)?;
     let paths: Vec<PathBuf> = if source_files.is_empty() {
@@ -603,9 +700,22 @@ fn load_sources(
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error as _;
+
     use clap::Parser;
 
-    use super::{Cli, OptimizationLevel};
+    use super::{Cli, CliValueError, OptimizationLevel, parse_positive_u64};
+
+    #[test]
+    fn numeric_parser_preserves_parse_error_source() {
+        let error = parse_positive_u64("not-a-number").unwrap_err();
+
+        assert!(matches!(
+            &error,
+            CliValueError::InvalidPositiveInteger { .. }
+        ));
+        assert!(error.source().unwrap().is::<std::num::ParseIntError>());
+    }
 
     #[test]
     fn opt_level_is_case_insensitive() {

--- a/crates/celox-bench/src/bin/veryl-heliodor.rs
+++ b/crates/celox-bench/src/bin/veryl-heliodor.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::disallowed_macros)] // CLI errors intentionally use stderr
 
 use std::{
-    error::Error,
     fs,
     path::PathBuf,
     time::{Duration, Instant},
@@ -29,6 +28,29 @@ struct Options {
     source_files: Vec<PathBuf>,
 }
 
+#[derive(Debug, thiserror::Error)]
+enum VerylHeliodorError {
+    #[error(transparent)]
+    Metadata(#[from] veryl_metadata::MetadataError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Parser(#[from] veryl_parser::ParserError),
+    #[error(transparent)]
+    Simulator(#[from] veryl_simulator::SimulatorError),
+    #[error("{stage}: {errors:?}")]
+    Analyzer {
+        stage: &'static str,
+        errors: Vec<AnalyzerError>,
+    },
+    #[error("top module not found: {module}")]
+    TopModuleNotFound { module: String },
+    #[error("no initial block found: {module}")]
+    MissingInitialBlock { module: String },
+    #[error("{message}")]
+    TestFailed { message: String },
+}
+
 fn main() {
     if let Err(error) = run() {
         eprintln!("error: {error}");
@@ -36,7 +58,7 @@ fn main() {
     }
 }
 
-fn run() -> Result<(), Box<dyn Error>> {
+fn run() -> Result<(), VerylHeliodorError> {
     let options = Options::parse();
     let metadata_path = Metadata::search_from(&options.project)?;
     let mut metadata = Metadata::load(&metadata_path)?;
@@ -86,8 +108,11 @@ fn run() -> Result<(), Box<dyn Error>> {
         Analyzer::analyze_post_pass2(&analyzer_ir),
     )?;
 
-    let top = resource_table::get_str_id(options.test.clone())
-        .ok_or_else(|| format!("top module not found: {}", options.test))?;
+    let top = resource_table::get_str_id(options.test.clone()).ok_or_else(|| {
+        VerylHeliodorError::TopModuleNotFound {
+            module: options.test.clone(),
+        }
+    })?;
     let config = Config {
         use_jit: true,
         aot_c: true,
@@ -107,7 +132,9 @@ fn run() -> Result<(), Box<dyn Error>> {
         .ir
         .event_statements
         .get(&Event::Initial)
-        .ok_or_else(|| format!("no initial block found: {module_name}"))?;
+        .ok_or_else(|| VerylHeliodorError::MissingInitialBlock {
+            module: module_name.clone(),
+        })?;
     let testbench = convert_initial_to_testbench(initial_stmts, &event_map, &clock_periods, 3);
     let compile_elapsed = compile_start.elapsed();
 
@@ -151,7 +178,7 @@ fn run() -> Result<(), Box<dyn Error>> {
                 options.test,
                 elapsed.as_nanos()
             );
-            Err(message.into())
+            Err(VerylHeliodorError::TestFailed { message })
         }
     }
 }
@@ -176,7 +203,10 @@ fn process_cpu_time() -> Option<Duration> {
     None
 }
 
-fn ensure_no_errors(stage: &str, diagnostics: Vec<AnalyzerError>) -> Result<(), Box<dyn Error>> {
+fn ensure_no_errors(
+    stage: &'static str,
+    diagnostics: Vec<AnalyzerError>,
+) -> Result<(), VerylHeliodorError> {
     let errors = diagnostics
         .into_iter()
         .filter(AnalyzerError::is_error)
@@ -184,6 +214,6 @@ fn ensure_no_errors(stage: &str, diagnostics: Vec<AnalyzerError>) -> Result<(), 
     if errors.is_empty() {
         Ok(())
     } else {
-        Err(format!("{stage}: {errors:?}").into())
+        Err(VerylHeliodorError::Analyzer { stage, errors })
     }
 }

--- a/crates/celox-sir-opt/src/optimizer/native.rs
+++ b/crates/celox-sir-opt/src/optimizer/native.rs
@@ -14,22 +14,24 @@ pub fn optimize_merged_chain(
     four_state: bool,
     recover_merged_effect_regions: bool,
     diagnostics: &crate::SirDiagnostics,
-) -> Result<(), (&'static str, crate::ir::verify::SirVerifyError)> {
+) -> Result<(), crate::OptimizationError> {
     let mut changed = false;
-    if crate::ir::inline_single_predecessor_jumps(eu)
-        .map_err(|error| ("during native jump inlining", error))?
-    {
+    if crate::ir::inline_single_predecessor_jumps(eu).map_err(|error| {
+        crate::OptimizationError::verification("during native jump inlining", error)
+    })? {
         changed = true;
     }
-    eu.verify_result()
-        .map_err(|error| ("after native jump inlining", error))?;
+    eu.verify_result().map_err(|error| {
+        crate::OptimizationError::verification("after native jump inlining", error)
+    })?;
     OptimizeBlocksPass {
         skip_final_schedule: false,
         element_widths: Arc::clone(&element_widths),
     }
     .run(eu, &PassOptions::default());
-    eu.verify_result()
-        .map_err(|error| ("after native block optimization", error))?;
+    eu.verify_result().map_err(|error| {
+        crate::OptimizationError::verification("after native block optimization", error)
+    })?;
     // The native function is assembled after the ordinary per-EU pipeline.
     // Merging exposes constants and control-flow facts across the old EU
     // boundaries, and OptimizeBlocks can expose more of them while rewriting
@@ -43,8 +45,12 @@ pub fn optimize_merged_chain(
             ..PassOptions::default()
         },
     );
-    eu.verify_result()
-        .map_err(|error| ("after native merged-chain CFG simplification", error))?;
+    eu.verify_result().map_err(|error| {
+        crate::OptimizationError::verification(
+            "after native merged-chain CFG simplification",
+            error,
+        )
+    })?;
     if recover_merged_effect_regions && !four_state {
         pass_guarded_region_sinking::recover_merged_effect_regions(eu, four_state);
         pass_guarded_region_sinking::eliminate_dead_control_regions(eu);
@@ -56,8 +62,12 @@ pub fn optimize_merged_chain(
             },
         );
         pass_vectorize_concat::remove_dead_definitions(eu);
-        eu.verify_result()
-            .map_err(|error| ("after native merged effect-region recovery", error))?;
+        eu.verify_result().map_err(|error| {
+            crate::OptimizationError::verification(
+                "after native merged effect-region recovery",
+                error,
+            )
+        })?;
         changed = true;
     }
     if !four_state {
@@ -73,16 +83,24 @@ pub fn optimize_merged_chain(
             // Concat back into scalar shifts in ISel.
             VectorizeConcatPass::default().run(eu, &PassOptions::default());
             GvnPass.run(eu, &PassOptions::default());
-            eu.verify_result()
-                .map_err(|error| ("after native packed conditional-store recovery", error))?;
+            eu.verify_result().map_err(|error| {
+                crate::OptimizationError::verification(
+                    "after native packed conditional-store recovery",
+                    error,
+                )
+            })?;
         }
     }
     if !four_state && pass_vectorize_concat::expose_packed_bit_store_sinks(eu) {
         changed = true;
         VectorizeConcatPass::default().run(eu, &PassOptions::default());
         GvnPass.run(eu, &PassOptions::default());
-        eu.verify_result()
-            .map_err(|error| ("after native packed bit-store vectorization", error))?;
+        eu.verify_result().map_err(|error| {
+            crate::OptimizationError::verification(
+                "after native packed bit-store vectorization",
+                error,
+            )
+        })?;
     }
     let recovered_bit_maps = if four_state {
         0
@@ -99,8 +117,9 @@ pub fn optimize_merged_chain(
         .run(eu, &PassOptions::default());
         VectorizeConcatPass::default().run(eu, &PassOptions::default());
         GvnPass.run(eu, &PassOptions::default());
-        eu.verify_result()
-            .map_err(|error| ("after native fixed bit-map recovery", error))?;
+        eu.verify_result().map_err(|error| {
+            crate::OptimizationError::verification("after native fixed bit-map recovery", error)
+        })?;
     }
     if !four_state
         && diagnostics.effect_case_dispatch
@@ -134,14 +153,16 @@ pub fn optimize_merged_chain(
             dead_control_ns as f64 / 1_000_000.0,
             cfg_cleanup_ns as f64 / 1_000_000.0,
         );
-        eu.verify_result()
-            .map_err(|error| ("after native effect-case dispatch", error))?;
+        eu.verify_result().map_err(|error| {
+            crate::OptimizationError::verification("after native effect-case dispatch", error)
+        })?;
     }
     if !four_state && pass_pack_concat_phi::pack_concat_phis(eu) != 0 {
         changed = true;
         GvnPass.run(eu, &PassOptions::default());
-        eu.verify_result()
-            .map_err(|error| ("after native packed phi forwarding", error))?;
+        eu.verify_result().map_err(|error| {
+            crate::OptimizationError::verification("after native packed phi forwarding", error)
+        })?;
     }
     if !four_state {
         // Fusion and the native-only packed/control rewrites above can create
@@ -151,13 +172,15 @@ pub fn optimize_merged_chain(
         // head and kept live across the edge.
         pass_guarded_region_sinking::sink_pure_values_with_predicate_repair(eu);
         changed = true;
-        eu.verify_result()
-            .map_err(|error| ("after native final pure-value placement", error))?;
+        eu.verify_result().map_err(|error| {
+            crate::OptimizationError::verification("after native final pure-value placement", error)
+        })?;
     }
     if changed {
         pass_vectorize_concat::remove_dead_definitions(eu);
-        eu.verify_result()
-            .map_err(|error| ("after native merged-chain DCE", error))?;
+        eu.verify_result().map_err(|error| {
+            crate::OptimizationError::verification("after native merged-chain DCE", error)
+        })?;
     }
     Ok(())
 }

--- a/crates/celox-sir-opt/src/optimizer/pipeline/pass_manager.rs
+++ b/crates/celox-sir-opt/src/optimizer/pipeline/pass_manager.rs
@@ -85,7 +85,7 @@ impl ExecutionUnitPassManager {
 pub(super) fn verify_unpacked_element_boundaries(
     eu: &ExecutionUnit<RegionedAbsoluteAddr>,
     unpacked_element_widths: &HashMap<AbsoluteAddr, usize>,
-) -> Result<(), String> {
+) -> Result<(), crate::OptimizationError> {
     for block in eu.blocks.values() {
         for (instruction_index, instruction) in block.instructions.iter().enumerate() {
             let (address, offset, width, operation) = match instruction {
@@ -104,15 +104,21 @@ pub(super) fn verify_unpacked_element_boundaries(
                 continue;
             };
             let end = start.checked_add(width).ok_or_else(|| {
-                format!(
+                crate::OptimizationError::invariant(
+                    "unpacked element boundary verification",
+                    format!(
                     "{operation} at b{}/{instruction_index} overflows its unpacked range: address={address:?}, start={start}, width={width}, element_width={element_width}",
                     block.id.0
+                    ),
                 )
             })?;
             if width != 0 && *start / element_width != end.saturating_sub(1) / element_width {
-                return Err(format!(
-                    "{operation} at b{}/{instruction_index} crosses an unpacked element: address={address:?}, start={start}, width={width}, element_width={element_width}",
-                    block.id.0
+                return Err(crate::OptimizationError::invariant(
+                    "unpacked element boundary verification",
+                    format!(
+                        "{operation} at b{}/{instruction_index} crosses an unpacked element: address={address:?}, start={start}, width={width}, element_width={element_width}",
+                        block.id.0
+                    ),
                 ));
             }
         }

--- a/crates/celox/examples/transform.rs
+++ b/crates/celox/examples/transform.rs
@@ -1,12 +1,11 @@
 use std::{
-    error::Error,
     fs::File,
     io::{BufWriter, Write},
 };
 
 use celox::SimulatorBuilder;
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> std::io::Result<()> {
     // Create output file (generated in the current directory)
     let file = File::create("simulation_dump.log")?;
     let mut writer = BufWriter::new(file);

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -218,9 +218,9 @@ fn prepare_merged_sir(
         label == "eval_comb_apply_ff",
         diagnostics,
     )
-    .map_err(|(phase, source)| {
-        codegen_err(CodegenError::SirVerification {
-            phase: phase.to_string(),
+    .map_err(|source| {
+        codegen_err(CodegenError::Optimization {
+            context: "native merged-chain optimization",
             source,
         })
     })?;

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -38,6 +38,22 @@ pub enum AddrLookupError {
     AmbiguousPath { path: String },
 }
 
+/// Internal consistency failure while comparing frontend state lookup data
+/// with the source-independent elaborated design.
+#[derive(Debug, Clone, thiserror::Error)]
+pub(crate) enum DesignProjectionError {
+    #[error("state object count differs: design={design} frontend={frontend}")]
+    StateObjectCount { design: usize, frontend: usize },
+    #[error("missing state projection for {source_address}")]
+    MissingStateProjection {
+        source_address: celox_frontend_veryl::AbsoluteAddr,
+    },
+    #[error("missing flattened state object {address}")]
+    MissingStateObject { address: AbsoluteAddr },
+    #[error("metadata differs for flattened state object {address}")]
+    MetadataMismatch { address: AbsoluteAddr },
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 pub type InitialMemoryWriteRun = InitialStateWriteRun;
 #[cfg(not(target_arch = "wasm32"))]
@@ -339,7 +355,7 @@ impl RuntimeProgram {
     /// Verify the temporary migration projection from frontend lookup tables
     /// into the source-independent elaborated design. This can be removed once
     /// the frontend tables are consumed rather than retained beside `design`.
-    pub(crate) fn verify_design_projection(&self) -> Result<(), String> {
+    pub(crate) fn verify_design_projection(&self) -> Result<(), DesignProjectionError> {
         let expected_count = self
             .frontend
             .instance_module
@@ -347,10 +363,10 @@ impl RuntimeProgram {
             .map(|module_id| self.frontend.module_variables[module_id].len())
             .sum::<usize>();
         if self.design.state_objects.len() != expected_count {
-            return Err(format!(
-                "state object count differs: design={} frontend={expected_count}",
-                self.design.state_objects.len()
-            ));
+            return Err(DesignProjectionError::StateObjectCount {
+                design: self.design.state_objects.len(),
+                frontend: expected_count,
+            });
         }
 
         for (&instance_id, module_id) in &self.frontend.instance_module {
@@ -360,15 +376,13 @@ impl RuntimeProgram {
                     var_id: info.id,
                 };
                 let Some(address) = self.frontend.state_address(&source_address) else {
-                    return Err(format!("missing state projection for {source_address}"));
+                    return Err(DesignProjectionError::MissingStateProjection { source_address });
                 };
                 let Some(metadata) = self.design.state_objects.get(&address) else {
-                    return Err(format!("missing flattened state object {address}"));
+                    return Err(DesignProjectionError::MissingStateObject { address });
                 };
                 if metadata != &info.metadata {
-                    return Err(format!(
-                        "metadata differs for flattened state object {address}"
-                    ));
+                    return Err(DesignProjectionError::MetadataMismatch { address });
                 }
             }
         }

--- a/crates/celox/src/optimizer/sir.rs
+++ b/crates/celox/src/optimizer/sir.rs
@@ -58,7 +58,7 @@ pub(crate) fn optimize_native_merged_chain(
     four_state: bool,
     recover_merged_effect_regions: bool,
     diagnostics: &crate::optimizer::SirDiagnostics,
-) -> Result<(), (&'static str, celox_sir::verify::SirVerifyError)> {
+) -> Result<(), celox_sir_opt::OptimizationError> {
     let element_widths = Arc::new(
         layout
             .unpacked_arrays

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -135,8 +135,8 @@ fn verify_program_sir(
     program: &RuntimeProgram,
     phase: &'static str,
 ) -> Result<(), ParserError> {
-    program.verify_design_projection().map_err(|detail| {
-        ParserError::illegal_context("elaborated design projection", detail, None)
+    program.verify_design_projection().map_err(|error| {
+        ParserError::illegal_context("elaborated design projection", error.to_string(), None)
     })?;
     let units = sir
         .eval_comb

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -5,6 +5,7 @@
 //! memory buffer.  Signals ≤64 bits use native `u64` arithmetic with zero
 //! heap allocation; wider signals fall back to `BigUint`.
 
+use crate::RuntimeErrorCode;
 use crate::backend::memory_layout::{
     RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET,
     RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
@@ -64,6 +65,17 @@ pub(crate) type AssertMessage = ExecutableAssertMessage;
 pub type ClockCount = ExecutableClockCount;
 
 pub type LoopBound = ExecutableLoopBound;
+
+#[derive(Debug, thiserror::Error)]
+enum TestbenchEvaluationError {
+    #[error("eval_comb: {source}")]
+    EvalComb {
+        #[source]
+        source: RuntimeErrorCode,
+    },
+    #[error("dynamic signed for-loop bound exceeds host i128")]
+    SignedLoopBoundOutOfRange,
+}
 
 pub(crate) type TestbenchStatement<B> = ExecutableStatement<<B as SimBackend>::Event, SignalRef>;
 
@@ -185,11 +197,12 @@ impl From<ExecResult> for TestResult {
 fn eval_clock_count<B: SimBackend>(
     sim: &mut Simulator<B>,
     count: &ClockCount,
-) -> Result<u64, String> {
+) -> Result<u64, TestbenchEvaluationError> {
     Ok(match count {
         ClockCount::Static(n) => *n,
         ClockCount::Dynamic(expr) => {
-            sim.eval_comb().map_err(|e| format!("eval_comb: {e}"))?;
+            sim.eval_comb()
+                .map_err(|source| TestbenchEvaluationError::EvalComb { source })?;
             let (ptr, _) = sim.memory_as_mut_ptr();
             expr.eval_u64(ptr)
         }
@@ -199,7 +212,7 @@ fn eval_clock_count<B: SimBackend>(
 fn eval_loop_bound<B: SimBackend>(
     sim: &mut Simulator<B>,
     bound: &LoopBound,
-) -> Result<EvaluatedLoopBound, String> {
+) -> Result<EvaluatedLoopBound, TestbenchEvaluationError> {
     match bound {
         LoopBound::Static(v) => Ok(EvaluatedLoopBound::Unsigned(*v)),
         LoopBound::Dynamic {
@@ -207,7 +220,8 @@ fn eval_loop_bound<B: SimBackend>(
             width,
             signed,
         } => {
-            sim.eval_comb().map_err(|e| format!("eval_comb: {e}"))?;
+            sim.eval_comb()
+                .map_err(|source| TestbenchEvaluationError::EvalComb { source })?;
             let (ptr, _) = sim.memory_as_mut_ptr();
             let value = expr.eval_value(ptr);
             if *signed {
@@ -235,7 +249,10 @@ enum EvaluatedLoopBound {
     SignedWide(BigInt),
 }
 
-fn decode_signed_loop_bound(value: TbValue, width: usize) -> Result<EvaluatedLoopBound, String> {
+fn decode_signed_loop_bound(
+    value: TbValue,
+    width: usize,
+) -> Result<EvaluatedLoopBound, TestbenchEvaluationError> {
     let width = width.max(1);
     match value {
         TbValue::U64(v) => {
@@ -256,7 +273,7 @@ fn decode_signed_loop_bound(value: TbValue, width: usize) -> Result<EvaluatedLoo
             }
             let raw = v
                 .to_u128()
-                .ok_or_else(|| "dynamic signed for-loop bound exceeds host i128".to_string())?;
+                .ok_or(TestbenchEvaluationError::SignedLoopBoundOutOfRange)?;
             Ok(EvaluatedLoopBound::Signed(sign_extend_u128(raw, width)))
         }
     }
@@ -371,11 +388,11 @@ fn exec_for_loop<B: SimBackend>(
 ) -> ExecResult {
     let start = match eval_loop_bound(sim, start) {
         Ok(v) => v,
-        Err(e) => return ExecResult::Fail(e),
+        Err(error) => return ExecResult::Fail(error.to_string()),
     };
     let end = match eval_loop_bound(sim, end) {
         Ok(v) => v,
-        Err(e) => return ExecResult::Fail(e),
+        Err(error) => return ExecResult::Fail(error.to_string()),
     };
 
     if matches!(start, EvaluatedLoopBound::UnsignedWide(_))
@@ -1004,7 +1021,7 @@ fn exec_one_detailed<B: SimBackend>(
                     }
                     ExecResult::Continue
                 }
-                Err(e) => ExecResult::Fail(e),
+                Err(error) => ExecResult::Fail(error.to_string()),
             }
         }
         GenericTestbenchStatement::ResetAssert {
@@ -1142,8 +1159,19 @@ fn exec_one_detailed<B: SimBackend>(
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
+    use std::error::Error as _;
+
     use super::*;
     use crate::{Simulator, TestResult};
+
+    #[test]
+    fn evaluation_error_preserves_runtime_error_source() {
+        let error = TestbenchEvaluationError::EvalComb {
+            source: RuntimeErrorCode::InternalError,
+        };
+
+        assert!(error.source().unwrap().is::<RuntimeErrorCode>());
+    }
 
     #[test]
     fn traced_build_registers_compiled_testbench_runtime_event_sites() {


### PR DESCRIPTION
## Summary

- replace remaining `Result<_, String>` and `Result<_, &'static str>` paths with typed errors
- replace native optimizer error tuples with `OptimizationError`
- preserve runtime, parse-integer, optimizer, and simulator failures through `Error::source()`
- replace benchmark and example `Box<dyn Error>` entry points with concrete error types
- keep string conversion only at N-API and WASM JavaScript boundaries

## Why

Several internal paths still erased error categories or source chains even after the main code-generation error refactor. This made failures harder to inspect programmatically and left inconsistent error-handling conventions across the workspace.

The implementation uses the existing workspace `thiserror` dependency. It adds no nightly requirement and no direct `anyhow` dependency.

## Impact

Internal optimizer, register-allocation, testbench, design-projection, CLI parsing, and benchmark errors are now typed. Human-readable messages remain equivalent, while callers can retain structured categories and source chains until an external JavaScript boundary.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check -p celox --target wasm32-unknown-unknown`
- `cargo test -p celox-bench --bin celox-heliodor --bin veryl-heliodor` (2 passed)
- `cargo test -p celox-sir-opt --lib` (390 passed)
- `cargo test -p celox-backend-x86 --lib` (482 passed)
- `cargo test -p celox --lib` (34 passed)
- `cargo test -p celox --test error_detection` (35 passed, 1 ignored)
- `cargo test -p celox --test native_testbench` (61 passed, 1 ignored)
- `cargo test -p celox --test native_boundary_hardening` (5 passed)
