### PR TITLE
fix(frontend): support bitwise for-loop steps

### DIFF
--- a/crates/celox-frontend-veryl/src/ff.rs
+++ b/crates/celox-frontend-veryl/src/ff.rs
@@ -37,7 +37,7 @@ enum LoopBoundStatus {
 #[cfg(test)]
 mod loop_bound_status_tests {
     use super::{FfParser, LoopBoundStatus};
-    use veryl_analyzer::ir::ForBound;
+    use veryl_analyzer::ir::{ForBound, Op};
 
     #[test]
     fn allows_exclusive_upper_sentinel() {
@@ -53,6 +53,36 @@ mod loop_bound_status_tests {
             FfParser::loop_bound_status(&ForBound::Const(257), 8, false),
             Some(LoopBoundStatus::OutOfRange)
         );
+    }
+
+    #[test]
+    fn bitwise_stall_checks_use_the_i32_loop_counter_width() {
+        let Some(above_i32) = 1usize.checked_shl(32) else {
+            return;
+        };
+
+        for (op, step, start, expected) in [
+            (Op::BitXor, above_i32, Some(0), true),
+            (Op::BitXor, above_i32 | 1, Some(0), false),
+            (Op::BitOr, above_i32, Some(3), true),
+            (Op::BitOr, above_i32 | 3, Some(3), true),
+            (Op::BitOr, above_i32 | 4, Some(3), false),
+            (Op::BitOr, above_i32 | 3, Some(above_i32 | 3), true),
+        ] {
+            assert_eq!(
+                FfParser::step_can_stall(false, Some(op), step, start, 32),
+                expected,
+                "op={op:?}, step={step:#x}, start={start:?}",
+            );
+        }
+
+        assert!(!FfParser::step_can_stall(
+            false,
+            Some(Op::BitXor),
+            above_i32,
+            Some(0),
+            33,
+        ));
     }
 }
 
@@ -1063,6 +1093,16 @@ impl<'a> FfParser<'a> {
         }
     }
 
+    fn truncate_usize_to_width(value: usize, width: usize) -> usize {
+        if width >= usize::BITS as usize {
+            value
+        } else if width == 0 {
+            0
+        } else {
+            value & ((1usize << width) - 1)
+        }
+    }
+
     fn emit_loop_value_fits<A>(
         ir_builder: &mut SIRBuilder<A>,
         value_reg: RegisterId,
@@ -1294,13 +1334,14 @@ impl<'a> FfParser<'a> {
         let range_message = format!(
             "For loop value exceeds loop variable range in always_ff (loop variable `{loop_var_name}`)"
         );
+        let loop_width = base_loop_width.max(1);
 
         let const_empty = Self::const_range_is_empty(reverse, start_const, end_const, inclusive);
         let const_singleton =
             Self::const_range_is_singleton(reverse, start_const, end_const, inclusive);
         if start_const.is_some()
             && end_const.is_some()
-            && Self::step_can_stall(reverse, stepped_op, step, start_const)
+            && Self::step_can_stall(reverse, stepped_op, step, start_const, loop_width)
             && !const_empty
             && !const_singleton
         {
@@ -1311,7 +1352,6 @@ impl<'a> FfParser<'a> {
             ));
         }
 
-        let loop_width = base_loop_width.max(1);
         let start_bound_width = self
             .loop_bound_width(start_bound, loop_signed)
             .unwrap_or(loop_width);
@@ -1799,7 +1839,11 @@ impl<'a> FfParser<'a> {
             let current_step =
                 self.cast_reg_width_ext(ir_builder, body_counter, step_width, loop_signed);
             let step_reg = ir_builder.alloc_bit(step_width, loop_signed);
-            ir_builder.emit(SIRInstruction::Imm(step_reg, SIRValue::new(step as u64)));
+            let step_value = Self::truncate_usize_to_width(step, step_width);
+            ir_builder.emit(SIRInstruction::Imm(
+                step_reg,
+                SIRValue::new(step_value as u64),
+            ));
             let next_step = ir_builder.alloc_bit(step_width, loop_signed);
             let op = match stepped_op {
                 Some(Op::Mul) => BinaryOp::Mul,
@@ -2190,15 +2234,19 @@ impl<'a> FfParser<'a> {
         stepped_op: Option<Op>,
         step: usize,
         start_const: Option<usize>,
+        loop_width: usize,
     ) -> bool {
         if reverse {
             return step == 0;
         }
+        let bitwise_step = Self::truncate_usize_to_width(step, loop_width);
         match stepped_op {
             Some(Op::Mul) => step == 0 || step == 1 || start_const == Some(0),
             Some(Op::LogicShiftL | Op::ArithShiftL) => step == 0 || start_const == Some(0),
-            Some(Op::BitOr) => start_const.is_some_and(|start| (start | step) == start),
-            Some(Op::BitXor) => step == 0,
+            Some(Op::BitOr) => start_const
+                .map(|start| Self::truncate_usize_to_width(start, loop_width))
+                .is_some_and(|start| (start | bitwise_step) == start),
+            Some(Op::BitXor) => bitwise_step == 0,
             Some(Op::Add) | None => step == 0,
             Some(_) => false,
         }

--- a/crates/celox-frontend-veryl/src/ff.rs
+++ b/crates/celox-frontend-veryl/src/ff.rs
@@ -4,6 +4,7 @@ use crate::{
     BuildConfig, HashMap, HashSet, LoweringPhase, ParserError, RegionedVarAddr,
     bitaccess::{celox_value_from_comptime_in_context, eval_constexpr},
     case::case_arm_condition_expr,
+    resolve_total_width,
 };
 use bit_set::BitSet;
 use celox_design::{
@@ -1050,6 +1051,7 @@ impl<'a> FfParser<'a> {
                 base_width.saturating_add(step_bits)
             }
             Some(Op::LogicShiftL | Op::ArithShiftL) => base_width.saturating_add(step.max(1)),
+            Some(Op::BitOr | Op::BitXor) => base_width,
             Some(Op::Add) | None => {
                 if step <= 1 {
                     return base_width;
@@ -1232,15 +1234,8 @@ impl<'a> FfParser<'a> {
         sources: &mut Vec<VarAtomBase<A>>,
         ir_builder: &mut SIRBuilder<A>,
     ) -> Result<(), ParserError> {
-        let Some(base_loop_width) = stmt.var_type.total_width() else {
-            return Err(ParserError::unsupported(
-                65,
-                LoweringPhase::FfLowering,
-                "for loop variable width",
-                format!("{:?}", stmt.var_name),
-                Some(&stmt.token),
-            ));
-        };
+        let base_loop_width =
+            resolve_total_width(self.module, &self.module.variables[&stmt.var_id])?;
         let loop_signed = stmt.var_type.signed;
 
         let (start_bound, end_bound, inclusive, step, reverse, stepped_op, start_const, end_const) =
@@ -1309,9 +1304,7 @@ impl<'a> FfParser<'a> {
             && !const_empty
             && !const_singleton
         {
-            return Err(ParserError::unsupported(
-                65,
-                LoweringPhase::FfLowering,
+            return Err(ParserError::illegal_context(
                 "non-progressing for loop in always_ff",
                 format!("{:?}", stmt.var_name),
                 Some(&stmt.token),
@@ -1806,12 +1799,12 @@ impl<'a> FfParser<'a> {
             let op = match stepped_op {
                 Some(Op::Mul) => BinaryOp::Mul,
                 Some(Op::LogicShiftL | Op::ArithShiftL) => BinaryOp::Shl,
+                Some(Op::BitOr) => BinaryOp::Or,
+                Some(Op::BitXor) => BinaryOp::Xor,
                 Some(Op::Add) | None => BinaryOp::Add,
                 Some(other) => {
                     self.local_working_vars.remove(&stmt.var_id);
-                    return Err(ParserError::unsupported(
-                        65,
-                        LoweringPhase::FfLowering,
+                    return Err(ParserError::illegal_context(
                         "for loop step operator in always_ff",
                         format!("{other:?}"),
                         Some(&stmt.token),
@@ -1845,6 +1838,13 @@ impl<'a> FfParser<'a> {
                 },
                 current_math,
             ));
+            let range_check_bb = ir_builder.new_block();
+            ir_builder.seal_block(SIRTerminator::Branch {
+                cond: increasing_reg,
+                true_block: (range_check_bb, vec![]),
+                false_block: (stall_bb, vec![]),
+            });
+            ir_builder.switch_to_block(range_check_bb);
             let end_reg = self.cast_reg_width_ext(ir_builder, end_limit, math_width, loop_signed);
             let in_range_reg = ir_builder.alloc_bit(1, false);
             ir_builder.emit(SIRInstruction::Binary(
@@ -1861,17 +1861,10 @@ impl<'a> FfParser<'a> {
                 },
                 end_reg,
             ));
-            let can_continue_reg = ir_builder.alloc_bit(1, false);
-            ir_builder.emit(SIRInstruction::Binary(
-                can_continue_reg,
-                increasing_reg,
-                BinaryOp::LogicAnd,
-                in_range_reg,
-            ));
             let next_counter =
                 self.cast_reg_width_ext(ir_builder, next_reg, compare_width, loop_signed);
             ir_builder.seal_block(SIRTerminator::Branch {
-                cond: can_continue_reg,
+                cond: in_range_reg,
                 true_block: (header_bb, vec![next_counter]),
                 false_block: (exit_bb, vec![]),
             });
@@ -2191,6 +2184,8 @@ impl<'a> FfParser<'a> {
         match stepped_op {
             Some(Op::Mul) => step == 0 || step == 1 || start_const == Some(0),
             Some(Op::LogicShiftL | Op::ArithShiftL) => step == 0 || start_const == Some(0),
+            Some(Op::BitOr) => start_const.is_some_and(|start| (start | step) == start),
+            Some(Op::BitXor) => step == 0,
             Some(Op::Add) | None => step == 0,
             Some(_) => false,
         }

--- a/crates/celox-frontend-veryl/src/ff.rs
+++ b/crates/celox-frontend-veryl/src/ff.rs
@@ -1791,11 +1791,16 @@ impl<'a> FfParser<'a> {
                 ir_builder.switch_to_block(advance_bb);
             }
 
-            let current_math =
-                self.cast_reg_width_ext(ir_builder, body_counter, math_width, loop_signed);
-            let step_reg = ir_builder.alloc_bit(math_width, loop_signed);
+            let step_width = if matches!(stepped_op, Some(Op::BitOr | Op::BitXor)) {
+                loop_width
+            } else {
+                math_width
+            };
+            let current_step =
+                self.cast_reg_width_ext(ir_builder, body_counter, step_width, loop_signed);
+            let step_reg = ir_builder.alloc_bit(step_width, loop_signed);
             ir_builder.emit(SIRInstruction::Imm(step_reg, SIRValue::new(step as u64)));
-            let next_reg = ir_builder.alloc_bit(math_width, loop_signed);
+            let next_step = ir_builder.alloc_bit(step_width, loop_signed);
             let op = match stepped_op {
                 Some(Op::Mul) => BinaryOp::Mul,
                 Some(Op::LogicShiftL | Op::ArithShiftL) => BinaryOp::Shl,
@@ -1811,7 +1816,15 @@ impl<'a> FfParser<'a> {
                     ));
                 }
             };
-            ir_builder.emit(SIRInstruction::Binary(next_reg, current_math, op, step_reg));
+            ir_builder.emit(SIRInstruction::Binary(
+                next_step,
+                current_step,
+                op,
+                step_reg,
+            ));
+            let current_math =
+                self.cast_reg_width_ext(ir_builder, current_step, math_width, loop_signed);
+            let next_reg = self.cast_reg_width_ext(ir_builder, next_step, math_width, loop_signed);
             let progress_reg = ir_builder.alloc_bit(1, false);
             ir_builder.emit(SIRInstruction::Binary(
                 progress_reg,

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -1349,15 +1349,7 @@ fn eval_for_with_effects(
     ),
     ParserError,
 > {
-    let Some(loop_width) = for_stmt.var_type.total_width() else {
-        return Err(ParserError::unsupported(
-            65,
-            LoweringPhase::CombLowering,
-            "for loop variable width",
-            format!("{:?}", for_stmt.var_name),
-            Some(&for_stmt.token),
-        ));
-    };
+    let loop_width = resolve_total_width(module, &module.variables[&for_stmt.var_id])?;
     let (start_bound, end_bound) = match &for_stmt.range {
         ForRange::Forward { start, end, .. }
         | ForRange::Reverse { start, end, .. }
@@ -1504,10 +1496,10 @@ fn eval_for_with_effects(
             let step_op = match op {
                 Op::Mul => SLTStepOp::Mul,
                 Op::LogicShiftL | Op::ArithShiftL => SLTStepOp::Shl,
+                Op::BitOr => SLTStepOp::BitOr,
+                Op::BitXor => SLTStepOp::BitXor,
                 other => {
-                    return Err(ParserError::unsupported(
-                        65,
-                        LoweringPhase::CombLowering,
+                    return Err(ParserError::illegal_context(
                         "for loop step operator",
                         format!("{other:?}"),
                         Some(&for_stmt.token),

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -896,15 +896,7 @@ pub(super) fn eval_function_body_return(
             }
         }
 
-        let Some(loop_width) = for_stmt.var_type.total_width() else {
-            return Err(ParserError::unsupported(
-                65,
-                LoweringPhase::CombLowering,
-                "for loop variable width",
-                format!("{:?}", for_stmt.var_name),
-                Some(&for_stmt.token),
-            ));
-        };
+        let loop_width = resolve_total_width(module, &module.variables[&for_stmt.var_id])?;
         let (start_bound, end_bound) = match &for_stmt.range {
             ForRange::Forward { start, end, .. }
             | ForRange::Reverse { start, end, .. }
@@ -1066,10 +1058,10 @@ pub(super) fn eval_function_body_return(
                 let step_op = match op {
                     Op::Mul => SLTStepOp::Mul,
                     Op::LogicShiftL | Op::ArithShiftL => SLTStepOp::Shl,
+                    Op::BitOr => SLTStepOp::BitOr,
+                    Op::BitXor => SLTStepOp::BitXor,
                     other => {
-                        return Err(ParserError::unsupported(
-                            65,
-                            LoweringPhase::CombLowering,
+                        return Err(ParserError::illegal_context(
                             "for loop step operator",
                             format!("{other:?}"),
                             Some(&for_stmt.token),

--- a/crates/celox-slt/src/lower.rs
+++ b/crates/celox-slt/src/lower.rs
@@ -5911,11 +5911,16 @@ impl SLTToSIRLowerer {
             }
 
             let math_width = Self::step_math_width(compare_width, step_op, step);
-            let current_math =
-                self.cast_reg_width_ext(builder, body_counter, math_width, loop_signed);
-            let step_math = builder.alloc_bit(math_width, loop_signed);
-            builder.emit(SIRInstruction::Imm(step_math, SIRValue::new(step as u64)));
-            let next_math = builder.alloc_bit(math_width, loop_signed);
+            let step_width = if matches!(step_op, SLTStepOp::BitOr | SLTStepOp::BitXor) {
+                loop_width
+            } else {
+                math_width
+            };
+            let current_step =
+                self.cast_reg_width_ext(builder, body_counter, step_width, loop_signed);
+            let step_reg = builder.alloc_bit(step_width, loop_signed);
+            builder.emit(SIRInstruction::Imm(step_reg, SIRValue::new(step as u64)));
+            let next_step = builder.alloc_bit(step_width, loop_signed);
             let op = match step_op {
                 SLTStepOp::Add => BinaryOp::Add,
                 SLTStepOp::Mul => BinaryOp::Mul,
@@ -5924,11 +5929,14 @@ impl SLTToSIRLowerer {
                 SLTStepOp::BitXor => BinaryOp::Xor,
             };
             builder.emit(SIRInstruction::Binary(
-                next_math,
-                current_math,
+                next_step,
+                current_step,
                 op,
-                step_math,
+                step_reg,
             ));
+            let current_math =
+                self.cast_reg_width_ext(builder, current_step, math_width, loop_signed);
+            let next_math = self.cast_reg_width_ext(builder, next_step, math_width, loop_signed);
 
             let progress = builder.alloc_bit(1, false);
             builder.emit(SIRInstruction::Binary(

--- a/crates/celox-slt/src/lower.rs
+++ b/crates/celox-slt/src/lower.rs
@@ -5048,6 +5048,7 @@ impl SLTToSIRLowerer {
                 base_width.saturating_add(step_bits)
             }
             SLTStepOp::Shl => base_width.saturating_add(step.max(1)),
+            SLTStepOp::BitOr | SLTStepOp::BitXor => base_width,
         }
     }
 
@@ -5919,6 +5920,8 @@ impl SLTToSIRLowerer {
                 SLTStepOp::Add => BinaryOp::Add,
                 SLTStepOp::Mul => BinaryOp::Mul,
                 SLTStepOp::Shl => BinaryOp::Shl,
+                SLTStepOp::BitOr => BinaryOp::Or,
+                SLTStepOp::BitXor => BinaryOp::Xor,
             };
             builder.emit(SIRInstruction::Binary(
                 next_math,
@@ -5943,6 +5946,25 @@ impl SLTToSIRLowerer {
             });
 
             builder.switch_to_block(check_block);
+            let increasing = builder.alloc_bit(1, false);
+            builder.emit(SIRInstruction::Binary(
+                increasing,
+                next_math,
+                if loop_signed {
+                    BinaryOp::GtS
+                } else {
+                    BinaryOp::GtU
+                },
+                current_math,
+            ));
+            let range_check_block = builder.new_block();
+            builder.seal_block(SIRTerminator::Branch {
+                cond: increasing,
+                true_block: (range_check_block, vec![]),
+                false_block: (stall_block, vec![]),
+            });
+
+            builder.switch_to_block(range_check_block);
             let end_math = self.cast_reg_width_ext(builder, end_limit, math_width, loop_signed);
             let in_range = builder.alloc_bit(1, false);
             builder.emit(SIRInstruction::Binary(

--- a/crates/celox-slt/src/lower.rs
+++ b/crates/celox-slt/src/lower.rs
@@ -5052,6 +5052,16 @@ impl SLTToSIRLowerer {
         }
     }
 
+    fn truncate_usize_to_width(value: usize, width: usize) -> usize {
+        if width >= usize::BITS as usize {
+            value
+        } else if width == 0 {
+            0
+        } else {
+            value & ((1usize << width) - 1)
+        }
+    }
+
     fn bigint_payload(value: &BigInt, width: usize) -> BigUint {
         let modulus = BigInt::from(1u8) << width;
         let mut wrapped = value % &modulus;
@@ -5919,7 +5929,11 @@ impl SLTToSIRLowerer {
             let current_step =
                 self.cast_reg_width_ext(builder, body_counter, step_width, loop_signed);
             let step_reg = builder.alloc_bit(step_width, loop_signed);
-            builder.emit(SIRInstruction::Imm(step_reg, SIRValue::new(step as u64)));
+            let step_value = Self::truncate_usize_to_width(step, step_width);
+            builder.emit(SIRInstruction::Imm(
+                step_reg,
+                SIRValue::new(step_value as u64),
+            ));
             let next_step = builder.alloc_bit(step_width, loop_signed);
             let op = match step_op {
                 SLTStepOp::Add => BinaryOp::Add,

--- a/crates/celox-slt/src/node.rs
+++ b/crates/celox-slt/src/node.rs
@@ -448,6 +448,8 @@ impl<A: Hash + Eq + Clone> SLTNode<A> {
                     match step_op {
                         SLTStepOp::Add => write!(f, "+=")?,
                         SLTStepOp::Mul => write!(f, "*=")?,
+                        SLTStepOp::BitOr => write!(f, "|=")?,
+                        SLTStepOp::BitXor => write!(f, "^=")?,
                         SLTStepOp::Shl => write!(f, "<<=")?,
                     }
                     write!(f, " {step}")?;
@@ -552,6 +554,8 @@ pub enum SLTStepOp {
     Add,
     Mul,
     Shl,
+    BitOr,
+    BitXor,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -276,6 +276,29 @@ fn sign_extend_u128(raw: u128, width: usize) -> i128 {
     }
 }
 
+fn truncate_i128_to_width(value: i128, width: usize, signed: bool) -> i128 {
+    let width = width.max(1);
+    if width >= 128 {
+        return value;
+    }
+    let raw = (value as u128) & ((1u128 << width) - 1);
+    if signed {
+        sign_extend_u128(raw, width)
+    } else {
+        raw as i128
+    }
+}
+
+fn truncate_usize_to_width(value: usize, width: usize) -> usize {
+    if width >= usize::BITS as usize {
+        value
+    } else if width == 0 {
+        0
+    } else {
+        value & ((1usize << width) - 1)
+    }
+}
+
 fn sign_extend_biguint(raw: BigUint, width: usize) -> BigInt {
     let width = width.max(1);
     let sign_bit = BigUint::from(1u8) << (width - 1);
@@ -525,6 +548,13 @@ fn exec_for_loop<B: SimBackend>(
                     }
                     _ => i.saturating_add(step_i),
                 };
+                let new_i = if matches!(op, Op::BitOr | Op::BitXor) {
+                    loop_var.as_ref().map_or(new_i, |(_, width, signed)| {
+                        truncate_i128_to_width(new_i, *width, *signed)
+                    })
+                } else {
+                    new_i
+                };
                 if new_i <= i {
                     return ExecResult::Fail("non-progressing stepped for loop".to_string());
                 }
@@ -617,6 +647,13 @@ fn exec_for_loop<B: SimBackend>(
                     i << step
                 }
                 _ => i.saturating_add(step),
+            };
+            let new_i = if matches!(op, Op::BitOr | Op::BitXor) {
+                loop_var.as_ref().map_or(new_i, |(_, width, _)| {
+                    truncate_usize_to_width(new_i, *width)
+                })
+            } else {
+                new_i
             };
             if new_i <= i {
                 return ExecResult::Fail("non-progressing stepped for loop".to_string());

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -515,6 +515,8 @@ fn exec_for_loop<B: SimBackend>(
                 }
                 let new_i = match op {
                     Op::Mul => i.saturating_mul(step_i),
+                    Op::BitOr => i | step_i,
+                    Op::BitXor => i ^ step_i,
                     Op::LogicShiftL | Op::ArithShiftL => {
                         if step >= i128::BITS as usize {
                             break;
@@ -523,7 +525,7 @@ fn exec_for_loop<B: SimBackend>(
                     }
                     _ => i.saturating_add(step_i),
                 };
-                if new_i == i {
+                if new_i <= i {
                     return ExecResult::Fail("non-progressing stepped for loop".to_string());
                 }
                 i = new_i;
@@ -606,6 +608,8 @@ fn exec_for_loop<B: SimBackend>(
             }
             let new_i = match op {
                 Op::Mul => i.saturating_mul(step),
+                Op::BitOr => i | step,
+                Op::BitXor => i ^ step,
                 Op::LogicShiftL | Op::ArithShiftL => {
                     if step >= usize::BITS as usize {
                         break;
@@ -614,7 +618,7 @@ fn exec_for_loop<B: SimBackend>(
                 }
                 _ => i.saturating_add(step),
             };
-            if new_i == i {
+            if new_i <= i {
                 return ExecResult::Fail("non-progressing stepped for loop".to_string());
             }
             i = new_i;

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -453,6 +453,45 @@ fn test_ff_runtime_for_bounds(sim) {
     assert_eq!(sim.get(q_step), 8u32.into());
 }
 
+fn test_ff_runtime_for_bitwise_steps(sim) {
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            or_end: input logic<8>,
+            xor_end: input logic<8>,
+            q_or: output logic<8>,
+            q_xor: output logic<8>
+        ) {
+            always_ff (clk) {
+                q_or = 0;
+                for i in 3..=or_end step |= 6 {
+                    q_or = i as 8;
+                }
+
+                q_xor = 0;
+                for i in 3..=xor_end step ^= 6 {
+                    q_xor = i as 8;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let or_end = sim.signal("or_end");
+    let xor_end = sim.signal("xor_end");
+    let q_or = sim.signal("q_or");
+    let q_xor = sim.signal("q_xor");
+
+    sim.modify(|io| {
+        io.set(or_end, 7u8);
+        io.set(xor_end, 5u8);
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(q_or), 7u8.into());
+    assert_eq!(sim.get(q_xor), 5u8.into());
+}
+
 fn test_ff_runtime_for_break(sim) {
     @setup { let code = r#"
         module Top (

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -492,6 +492,39 @@ fn test_ff_runtime_for_bitwise_steps(sim) {
     assert_eq!(sim.get(q_xor), 5u8.into());
 }
 
+fn test_ff_signed_xor_step_uses_loop_counter_width(sim) {
+    // The Veryl reference simulator also evaluates this update at the widened bound width.
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            wide_start: input signed logic<32>,
+            wide_end: input signed logic<128>,
+            q: output signed logic<32>
+        ) {
+            always_ff (clk) {
+                q = 0;
+                for i in wide_start..=wide_end step ^= 2147483648 {
+                    q = i;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let wide_start = sim.signal("wide_start");
+    let wide_end = sim.signal("wide_end");
+    let q = sim.signal("q");
+
+    sim.modify(|io| {
+        io.set(wide_start, -8i32);
+        io.set_wide(wide_end, BigUint::from(2_147_483_640u32));
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(q), 0x7fff_fff8u32.into());
+}
+
 fn test_ff_runtime_for_break(sim) {
     @setup { let code = r#"
         module Top (

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -466,11 +466,17 @@ fn test_ff_runtime_for_bitwise_steps(sim) {
                 q_or = 0;
                 for i in 3..=or_end step |= 6 {
                     q_or = i as 8;
+                    if i == or_end {
+                        break;
+                    }
                 }
 
                 q_xor = 0;
                 for i in 3..=xor_end step ^= 6 {
                     q_xor = i as 8;
+                    if i == xor_end {
+                        break;
+                    }
                 }
             }
         }
@@ -493,7 +499,8 @@ fn test_ff_runtime_for_bitwise_steps(sim) {
 }
 
 fn test_ff_signed_xor_step_uses_loop_counter_width(sim) {
-    // The Veryl reference simulator also evaluates this update at the widened bound width.
+    // The Veryl simulator currently converts the signed dynamic start bound to an
+    // unsigned runtime counter and executes zero iterations.
     @ignore_on(veryl);
     @setup { let code = r#"
         module Top (
@@ -506,6 +513,9 @@ fn test_ff_signed_xor_step_uses_loop_counter_width(sim) {
                 q = 0;
                 for i in wide_start..=wide_end step ^= 2147483648 {
                     q = i;
+                    if i == 2147483640 {
+                        break;
+                    }
                 }
             }
         }
@@ -523,6 +533,106 @@ fn test_ff_signed_xor_step_uses_loop_counter_width(sim) {
     .unwrap();
     sim.tick(clk).unwrap();
     assert_eq!(sim.get(q), 0x7fff_fff8u32.into());
+}
+
+fn test_ff_i32_bitwise_steps_discard_bits_above_the_counter_width(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            or_end: input signed logic<128>,
+            xor_end: input signed logic<128>,
+            q_or: output signed logic<32>,
+            q_xor: output signed logic<32>
+        ) {
+            always_ff (clk) {
+                q_or = 0;
+                for i in 3..=or_end step |= 4294967302 {
+                    q_or = i;
+                    if i == 7 {
+                        break;
+                    }
+                }
+
+                q_xor = 0;
+                for i in 3..=xor_end step ^= 4294967302 {
+                    q_xor = i;
+                    if i == 5 {
+                        break;
+                    }
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let or_end = sim.signal("or_end");
+    let xor_end = sim.signal("xor_end");
+    let q_or = sim.signal("q_or");
+    let q_xor = sim.signal("q_xor");
+
+    sim.modify(|io| {
+        io.set_wide(or_end, BigUint::from(7u8));
+        io.set_wide(xor_end, BigUint::from(5u8));
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(q_or), 7u32.into());
+    assert_eq!(sim.get(q_xor), 5u32.into());
+}
+
+fn test_ff_i32_xor_step_with_only_high_bits_reports_true_loop(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            end_bound: input logic<32>,
+            q: output logic<32>
+        ) {
+            always_ff (clk) {
+                q = 0;
+                for i in 3..end_bound step ^= 4294967296 {
+                    q = i;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let end_bound = sim.signal("end_bound");
+
+    sim.modify(|io| io.set(end_bound, 4u32)).unwrap();
+    assert_eq!(
+        sim.tick(clk).unwrap_err().to_string(),
+        "Non-progressing for loop in always_ff (loop variable `i`): i"
+    );
+}
+
+fn test_ff_i32_or_step_with_only_existing_low_bits_reports_true_loop(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            end_bound: input logic<32>,
+            q: output logic<32>
+        ) {
+            always_ff (clk) {
+                q = 0;
+                for i in 3..end_bound step |= 4294967299 {
+                    q = i;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let end_bound = sim.signal("end_bound");
+
+    sim.modify(|io| io.set(end_bound, 4u32)).unwrap();
+    assert_eq!(
+        sim.tick(clk).unwrap_err().to_string(),
+        "Non-progressing for loop in always_ff (loop variable `i`): i"
+    );
 }
 
 fn test_ff_runtime_for_break(sim) {

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -285,6 +285,9 @@ fn test_for_loop_bitwise_steps() {
             var cnt: logic<32>;
             var or_end: logic<32>;
             var xor_end: logic<32>;
+            var xor_wide_start: signed logic<32>;
+            var xor_wide_end: signed logic<128>;
+            var xor_wide_last: signed logic<32>;
             inst dut: Counter (clk, rst, cnt);
             initial {{
                 rst.assert(clk);
@@ -298,6 +301,13 @@ fn test_for_loop_bitwise_steps() {
                     clk.next(i);
                 }}
                 $assert(cnt == 32'd18);
+                xor_wide_start = (0 - 8) as 32;
+                xor_wide_end = 2147483640;
+                xor_wide_last = 0;
+                for i in xor_wide_start..=xor_wide_end step ^= 2147483648 {{
+                    xor_wide_last = i;
+                }}
+                $assert(xor_wide_last == 32'sh7fff_fff8);
                 $finish();
             }}
         }}

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -295,10 +295,16 @@ fn test_for_loop_bitwise_steps() {
                 xor_end = 5;
                 for i in 3..=or_end step |= 6 {{
                     clk.next(i);
+                    if i == or_end {{
+                        break;
+                    }}
                 }}
                 $assert(cnt == 32'd10);
                 for i in 3..=xor_end step ^= 6 {{
                     clk.next(i);
+                    if i == xor_end {{
+                        break;
+                    }}
                 }}
                 $assert(cnt == 32'd18);
                 xor_wide_start = (0 - 8) as 32;
@@ -306,6 +312,9 @@ fn test_for_loop_bitwise_steps() {
                 xor_wide_last = 0;
                 for i in xor_wide_start..=xor_wide_end step ^= 2147483648 {{
                     xor_wide_last = i;
+                    if i == 2147483640 {{
+                        break;
+                    }}
                 }}
                 $assert(xor_wide_last == 32'sh7fff_fff8);
                 $finish();
@@ -317,6 +326,90 @@ fn test_for_loop_bitwise_steps() {
         Simulator::builder(&code, "t").run_test().unwrap(),
         TestResult::Pass,
     );
+}
+
+#[test]
+fn test_for_loop_i32_bitwise_steps_discard_high_step_bits() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            var or_end: signed logic<128>;
+            var xor_end: signed logic<128>;
+            var or_last: signed logic<32>;
+            var xor_last: signed logic<32>;
+            initial {
+                or_end = 7;
+                xor_end = 5;
+                or_last = 0;
+                for i in 3..=or_end step |= 4294967302 {
+                    or_last = i;
+                    if i == 7 {
+                        break;
+                    }
+                }
+                xor_last = 0;
+                for i in 3..=xor_end step ^= 4294967302 {
+                    xor_last = i;
+                    if i == 5 {
+                        break;
+                    }
+                }
+                $assert(or_last == 7);
+                $assert(xor_last == 5);
+                $finish();
+            }
+        }
+    "#;
+    assert_eq!(
+        Simulator::builder(code, "t").run_test().unwrap(),
+        TestResult::Pass,
+    );
+}
+
+#[test]
+fn test_for_loop_i32_xor_step_with_only_high_bits_fails() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            var end_bound: logic<32>;
+            var last: logic<32>;
+            initial {
+                end_bound = 4;
+                last = 0;
+                for i in 3..end_bound step ^= 4294967296 {
+                    last = i;
+                }
+                $finish();
+            }
+        }
+    "#;
+    let TestResult::Fail(message) = Simulator::builder(code, "t").run_test().unwrap() else {
+        panic!("expected non-progressing loop failure");
+    };
+    assert!(message.contains("non-progressing stepped for loop"));
+}
+
+#[test]
+fn test_for_loop_i32_or_step_with_only_existing_low_bits_fails() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            var end_bound: logic<32>;
+            var last: logic<32>;
+            initial {
+                end_bound = 4;
+                last = 0;
+                for i in 3..end_bound step |= 4294967299 {
+                    last = i;
+                }
+                $finish();
+            }
+        }
+    "#;
+    let TestResult::Fail(message) = Simulator::builder(code, "t").run_test().unwrap() else {
+        panic!("expected non-progressing loop failure");
+    };
+    assert!(message.contains("non-progressing stepped for loop"));
 }
 
 #[test]

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -274,6 +274,42 @@ fn test_for_loop_step() {
 }
 
 #[test]
+fn test_for_loop_bitwise_steps() {
+    let code = format!(
+        r#"
+        {COUNTER}
+        #[test(t)]
+        module t {{
+            inst clk: $tb::clock_gen;
+            inst rst: $tb::reset_gen(clk);
+            var cnt: logic<32>;
+            var or_end: logic<32>;
+            var xor_end: logic<32>;
+            inst dut: Counter (clk, rst, cnt);
+            initial {{
+                rst.assert(clk);
+                or_end = 7;
+                xor_end = 5;
+                for i in 3..=or_end step |= 6 {{
+                    clk.next(i);
+                }}
+                $assert(cnt == 32'd10);
+                for i in 3..=xor_end step ^= 6 {{
+                    clk.next(i);
+                }}
+                $assert(cnt == 32'd18);
+                $finish();
+            }}
+        }}
+    "#
+    );
+    assert_eq!(
+        Simulator::builder(&code, "t").run_test().unwrap(),
+        TestResult::Pass,
+    );
+}
+
+#[test]
 fn test_for_loop_rev() {
     let code = format!(
         r#"

--- a/crates/celox/tests/synth_dynamic_loop.rs
+++ b/crates/celox/tests/synth_dynamic_loop.rs
@@ -200,6 +200,34 @@ fn test_runtime_bitwise_steps_in_synth_for_loops(sim) {
     assert_eq!(sim.get(xor_last), 5u32.into());
 }
 
+fn test_signed_xor_step_uses_loop_counter_width(sim) {
+    // The Veryl reference simulator also evaluates this update at the widened bound width.
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            wide_end: input signed logic<128>,
+            last: output signed logic<32>
+        ) {
+            var start: signed logic<32>;
+            always_comb {
+                start = (0 - 8) as 32;
+                last = 0;
+                for i in start..=wide_end step ^= 2147483648 {
+                    last = i;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+
+    let wide_end = sim.signal("wide_end");
+    let last = sim.signal("last");
+    sim.modify(|io| io.set_wide(wide_end, BigUint::from(2_147_483_640u32)))
+        .unwrap();
+    sim.eval_comb().unwrap();
+    assert_eq!(sim.get(last), 0x7fff_fff8u32.into());
+}
+
 fn test_runtime_bounds_terminal_inclusive_mul_loop_exits_cleanly(sim) {
     @ignore_on(veryl);
     @setup { let code = r#"

--- a/crates/celox/tests/synth_dynamic_loop.rs
+++ b/crates/celox/tests/synth_dynamic_loop.rs
@@ -177,11 +177,17 @@ fn test_runtime_bitwise_steps_in_synth_for_loops(sim) {
                 or_last = 0;
                 for i in 3..=or_end step |= 6 {
                     or_last = i;
+                    if i == or_end {
+                        break;
+                    }
                 }
 
                 xor_last = 0;
                 for i in 3..=xor_end step ^= 6 {
                     xor_last = i;
+                    if i == xor_end {
+                        break;
+                    }
                 }
             }
         }
@@ -201,7 +207,8 @@ fn test_runtime_bitwise_steps_in_synth_for_loops(sim) {
 }
 
 fn test_signed_xor_step_uses_loop_counter_width(sim) {
-    // The Veryl reference simulator also evaluates this update at the widened bound width.
+    // The Veryl simulator currently converts the signed dynamic start bound to an
+    // unsigned runtime counter and executes zero iterations.
     @ignore_on(veryl);
     @setup { let code = r#"
         module Top (
@@ -214,6 +221,9 @@ fn test_signed_xor_step_uses_loop_counter_width(sim) {
                 last = 0;
                 for i in start..=wide_end step ^= 2147483648 {
                     last = i;
+                    if i == 2147483640 {
+                        break;
+                    }
                 }
             }
         }
@@ -226,6 +236,94 @@ fn test_signed_xor_step_uses_loop_counter_width(sim) {
         .unwrap();
     sim.eval_comb().unwrap();
     assert_eq!(sim.get(last), 0x7fff_fff8u32.into());
+}
+
+fn test_i32_bitwise_steps_discard_bits_above_the_counter_width(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            or_end: input signed logic<128>,
+            xor_end: input signed logic<128>,
+            or_last: output signed logic<32>,
+            xor_last: output signed logic<32>
+        ) {
+            always_comb {
+                or_last = 0;
+                for i in 3..=or_end step |= 4294967302 {
+                    or_last = i;
+                    if i == 7 {
+                        break;
+                    }
+                }
+
+                xor_last = 0;
+                for i in 3..=xor_end step ^= 4294967302 {
+                    xor_last = i;
+                    if i == 5 {
+                        break;
+                    }
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+
+    let or_end = sim.signal("or_end");
+    let xor_end = sim.signal("xor_end");
+    let or_last = sim.signal("or_last");
+    let xor_last = sim.signal("xor_last");
+    sim.modify(|io| {
+        io.set_wide(or_end, BigUint::from(7u8));
+        io.set_wide(xor_end, BigUint::from(5u8));
+    })
+    .unwrap();
+    sim.eval_comb().unwrap();
+    assert_eq!(sim.get(or_last), 7u32.into());
+    assert_eq!(sim.get(xor_last), 5u32.into());
+}
+
+fn test_i32_xor_step_with_only_high_bits_reports_true_loop(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            end_bound: input logic<32>,
+            last: output logic<32>
+        ) {
+            always_comb {
+                last = 0;
+                for i in 3..end_bound step ^= 4294967296 {
+                    last = i;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+
+    let end_bound = sim.signal("end_bound");
+    sim.set(end_bound, 4u32);
+    assert_eq!(sim.eval_comb().unwrap_err(), RuntimeErrorCode::DetectedTrueLoop);
+}
+
+fn test_i32_or_step_with_only_existing_low_bits_reports_true_loop(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            end_bound: input logic<32>,
+            last: output logic<32>
+        ) {
+            always_comb {
+                last = 0;
+                for i in 3..end_bound step |= 4294967299 {
+                    last = i;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+
+    let end_bound = sim.signal("end_bound");
+    sim.set(end_bound, 4u32);
+    assert_eq!(sim.eval_comb().unwrap_err(), RuntimeErrorCode::DetectedTrueLoop);
 }
 
 fn test_runtime_bounds_terminal_inclusive_mul_loop_exits_cleanly(sim) {

--- a/crates/celox/tests/synth_dynamic_loop.rs
+++ b/crates/celox/tests/synth_dynamic_loop.rs
@@ -165,6 +165,41 @@ fn test_runtime_bounds_in_synth_for_loops(sim) {
     assert_eq!(sim.get(sum_step), 15u32.into());
 }
 
+fn test_runtime_bitwise_steps_in_synth_for_loops(sim) {
+    @setup { let code = r#"
+        module Top (
+            or_end: input logic<32>,
+            xor_end: input logic<32>,
+            or_last: output logic<32>,
+            xor_last: output logic<32>
+        ) {
+            always_comb {
+                or_last = 0;
+                for i in 3..=or_end step |= 6 {
+                    or_last = i;
+                }
+
+                xor_last = 0;
+                for i in 3..=xor_end step ^= 6 {
+                    xor_last = i;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+
+    let or_end = sim.signal("or_end");
+    let xor_end = sim.signal("xor_end");
+    let or_last = sim.signal("or_last");
+    let xor_last = sim.signal("xor_last");
+
+    sim.set(or_end, 7u32);
+    sim.set(xor_end, 5u32);
+    sim.eval_comb().unwrap();
+    assert_eq!(sim.get(or_last), 7u32.into());
+    assert_eq!(sim.get(xor_last), 5u32.into());
+}
+
 fn test_runtime_bounds_terminal_inclusive_mul_loop_exits_cleanly(sim) {
     @ignore_on(veryl);
     @setup { let code = r#"


### PR DESCRIPTION
## Summary

- support Veryl `|=` and `^=` stepped `for` loops in combinational, FF, and native testbench lowering
- represent bitwise loop steps in SLT and reject runtime steps that stop increasing
- classify unresolved loop-variable widths and invalid step shapes with structured errors instead of issue-linked `Unsupported` fallbacks
- add comb, FF, and testbench regressions, including coverage across native, Cranelift, Wasm, and the Veryl reference backend

## Root cause

The Veryl analyzer accepts bitwise-OR and bitwise-XOR stepped loops, but Celox's simulator lowering only modeled additive, multiplicative, and left-shift steps. Those legal operators therefore fell through to `ParserError::Unsupported` for issue #65. Loop-variable width failures used the same broad fallback even though Celox already has a dedicated unresolved-width error.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p celox-frontend-veryl -p celox-slt -p celox --tests -- -D warnings`
- `cargo test -p celox-slt` (139 passed)
- `cargo test -p celox-frontend-veryl` (61 passed)
- focused comb and FF bitwise-step tests on native, Cranelift, Wasm, and Veryl backends
- `cargo test -p celox --test native_testbench` (62 passed, 1 existing ignored)
- focused non-progressing comb and FF loop regressions

Closes #65