### PR TITLE
fix(native): preserve four-state constant masks

### DIFF
--- a/crates/celox-backend-x86/src/backend/native/isel.rs
+++ b/crates/celox-backend-x86/src/backend/native/isel.rs
@@ -2090,6 +2090,18 @@ impl<'a> ISelContext<'a> {
         }
     }
 
+    fn const_mask_value(&self, reg: RegisterId) -> Option<u64> {
+        if !self.four_state {
+            return Some(0);
+        }
+
+        let vreg = self.mask_map.map.get(reg.0).copied().flatten()?;
+        match self.spill_descs.get(vreg.0 as usize).map(|desc| &desc.kind) {
+            Some(SpillKind::Remat { value }) => Some(*value),
+            _ => None,
+        }
+    }
+
     /// Resolve the mask byte offset for a variable.
     /// The mask is stored immediately after the value in memory.
     fn mask_byte_offset(&self, addr: &RegionedAbsoluteAddr, bit_offset: usize) -> i32 {
@@ -8514,7 +8526,9 @@ fn lower_instruction(
             // Constant folding: if both operands are known constants, compute result
             let lhs_const = ctx.consts.get(lhs).copied();
             let rhs_const = ctx.consts.get(rhs).copied();
-            if let (Some(lc), Some(rc)) = (lhs_const, rhs_const) {
+            let masks_are_known_zero =
+                ctx.const_mask_value(*lhs) == Some(0) && ctx.const_mask_value(*rhs) == Some(0);
+            if masks_are_known_zero && let (Some(lc), Some(rc)) = (lhs_const, rhs_const) {
                 let result = match op {
                     BinaryOp::Add => Some(lc.wrapping_add(rc)),
                     BinaryOp::Sub => Some(lc.wrapping_sub(rc)),
@@ -8537,7 +8551,6 @@ fn lower_instruction(
                     });
                     ctx.consts.insert(*dst, val);
                     set_low_zero_bits(ctx, *dst, low_zero_bits_const(val));
-                    // 4-state: constants always have mask=0
                     if ctx.four_state {
                         let z = ctx.alloc_vreg(SpillDesc::remat(0));
                         block.push(MInst::LoadImm { dst: z, value: 0 });
@@ -14594,6 +14607,85 @@ mod tests {
             runtime_event_buffer_size: 0,
             runtime_event_site_layouts: vec![],
         }
+    }
+
+    #[test]
+    fn four_state_constant_binary_preserves_unknown_mask() {
+        let output_var = VarId::default();
+        let output_abs = AbsoluteAddr {
+            instance_id: InstanceId(0),
+            var_id: output_var,
+        };
+        let output = RegionedAbsoluteAddr::from_absolute_addr(STABLE_REGION, output_abs);
+        let lhs = RegisterId(0);
+        let rhs = RegisterId(1);
+        let result = RegisterId(2);
+        let logic4 = RegisterType::Logic { width: 4 };
+        let unit = ExecutionUnit {
+            entry_block_id: SirBlockId(0),
+            blocks: [(
+                SirBlockId(0),
+                BasicBlock {
+                    id: SirBlockId(0),
+                    params: vec![],
+                    instructions: vec![
+                        SIRInstruction::Imm(lhs, SIRValue::new_four_state(0b1010u8, 0u8)),
+                        SIRInstruction::Imm(rhs, SIRValue::new_four_state(0b0010u8, 0b0011u8)),
+                        SIRInstruction::Binary(result, lhs, BinaryOp::Xor, rhs),
+                        SIRInstruction::Store(
+                            output,
+                            SIROffset::Static(0),
+                            4,
+                            result,
+                            vec![],
+                            vec![],
+                        ),
+                    ],
+                    terminator: SIRTerminator::Return,
+                },
+            )]
+            .into_iter()
+            .collect(),
+            register_map: [
+                (lhs, logic4.clone()),
+                (rhs, logic4.clone()),
+                (result, logic4),
+            ]
+            .into_iter()
+            .collect(),
+        };
+        unit.verify();
+
+        let mut layout = empty_layout();
+        layout.four_state = true;
+        layout.offsets.insert(output_abs, 0);
+        layout.widths.insert(output_abs, 4);
+        layout.is_4states.insert(output_abs, true);
+        layout.total_size = 2;
+        layout.working_base_offset = 2;
+        layout.sparse_base_offset = 2;
+        layout.merged_total_size = 2;
+        layout.triggered_bits_offset = 2;
+        layout.scratch_base_offset = 2;
+
+        let mut function = lower_execution_unit(&unit, &layout, true);
+        function.verify();
+        mir_legalize::legalize(&mut function);
+        mir_opt::optimize(&mut function);
+        let allocation = regalloc::run_regalloc(&mut function).unwrap();
+        mir_opt::post_regalloc_peephole(&mut function);
+        function.verify();
+        let emitted = emit::emit(
+            &function,
+            &allocation.assignment,
+            allocation.spill_frame_size,
+        )
+        .unwrap();
+        let jit = JitCode::new(&emitted.code).unwrap();
+        let mut state = vec![0u8; 2];
+        assert_eq!(unsafe { jit.call(&mut state) }, 0);
+        assert_eq!(state[0] & 0b1111, 0b1011, "value plane");
+        assert_eq!(state[1] & 0b1111, 0b0011, "mask plane");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- require both operand masks to be known zero before native ISel folds a binary constant expression
- keep masked or unknown-mask operands on the normal four-state lowering path
- add a direct SIR-to-native execution regression test

## Root cause

The native ISel constant map tracks only the value plane. A masked four-state immediate was therefore treated as an ordinary integer constant. Folding a binary expression from those values also installed a zero destination mask, losing X/Z information.

The regression constructs two four-state SIR immediates and an XOR directly, so it does not depend on Veryl or SystemVerilog frontend behavior. Without the fix it produces value `0b1000` instead of `0b1011`; with the fix it preserves value `0b1011` and mask `0b0011`.

## Impact

Valid four-state SIR containing binary operations over masked immediates no longer loses unknown bits in the native backend. Two-state and known-zero-mask constant folding remain enabled.

## Validation

- verified the new regression fails without the fix
- `cargo test -p celox-backend-x86` — 483 passed
- `cargo clippy -p celox-backend-x86 --all-targets -- -D warnings`
- CI
- pre-push hooks: submodule check, Biome, cargo fmt, workspace cargo check, clean-tree