### PR TITLE
fix(frontend): allow outputless comb statement calls

### DIFF
--- a/crates/celox-frontend-veryl/src/flattening.rs
+++ b/crates/celox-frontend-veryl/src/flattening.rs
@@ -444,11 +444,18 @@ fn collect_inputs_with_window<A: Hash + Eq + Clone + Debug>(
                     collect_inputs_with_window(update.expr, None, arena, set, visited);
                 }
                 for effect in effects {
-                    if let Some(guard) = effect.guard {
-                        collect_inputs_with_window(guard, None, arena, set, visited);
-                    }
-                    for arg in &effect.args {
-                        collect_inputs_with_window(*arg, None, arena, set, visited);
+                    match effect {
+                        celox_slt::SLTForEffect::Event { guard, args, .. } => {
+                            if let Some(guard) = guard {
+                                collect_inputs_with_window(*guard, None, arena, set, visited);
+                            }
+                            for arg in args {
+                                collect_inputs_with_window(*arg, None, arena, set, visited);
+                            }
+                        }
+                        celox_slt::SLTForEffect::Runner(runner) => {
+                            collect_inputs_with_window(*runner, None, arena, set, visited);
+                        }
                     }
                 }
                 collect_inputs_with_window(*continue_cond, None, arena, set, visited);

--- a/crates/celox-frontend-veryl/src/flattening.rs
+++ b/crates/celox-frontend-veryl/src/flattening.rs
@@ -420,6 +420,7 @@ fn collect_inputs_with_window<A: Hash + Eq + Clone + Debug>(
                 loop_var,
                 start,
                 end,
+                result,
                 initials,
                 updates,
                 effects,
@@ -431,6 +432,10 @@ fn collect_inputs_with_window<A: Hash + Eq + Clone + Debug>(
                 }
                 if let celox_slt::SLTLoopBound::Expr(node) = end {
                     collect_inputs_with_window(*node, None, arena, set, visited);
+                }
+                if let celox_slt::SLTForFoldResult::Transient { initial, update } = result {
+                    collect_inputs_with_window(*initial, None, arena, set, visited);
+                    collect_inputs_with_window(*update, None, arena, set, visited);
                 }
                 for init in initials {
                     collect_inputs_with_window(init.expr, None, arena, set, visited);

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -5,8 +5,8 @@ mod state;
 
 pub(crate) mod node {
     pub use celox_slt::{
-        NodeId, SLTForEffect, SLTForFoldGroupState, SLTForUpdate, SLTIndex, SLTIndexKind,
-        SLTLoopBound, SLTNode, SLTNodeArena, SLTNodeArenaEditError, SLTStepOp,
+        NodeId, SLTForEffect, SLTForFoldGroupState, SLTForFoldResult, SLTForUpdate, SLTIndex,
+        SLTIndexKind, SLTLoopBound, SLTNode, SLTNodeArena, SLTNodeArenaEditError, SLTStepOp,
     };
 }
 
@@ -52,8 +52,8 @@ type ActiveGuard = (NodeId, HashSet<VarAtomBase<VarId>>);
 
 pub use node::SLTNodeArenaEditError;
 pub use node::{
-    NodeId, SLTForEffect, SLTForFoldGroupState, SLTForUpdate, SLTIndex, SLTIndexKind, SLTLoopBound,
-    SLTNode, SLTNodeArena, SLTStepOp,
+    NodeId, SLTForEffect, SLTForFoldGroupState, SLTForFoldResult, SLTForUpdate, SLTIndex,
+    SLTIndexKind, SLTLoopBound, SLTNode, SLTNodeArena, SLTStepOp,
 };
 pub use node_facts::{SLTNodeFacts, SLTNodeFactsError};
 
@@ -341,6 +341,7 @@ fn collect_comb_path_stats(
         SLTNode::ForFold {
             start,
             end,
+            result,
             initials,
             updates,
             effects,
@@ -353,6 +354,10 @@ fn collect_comb_path_stats(
             }
             if let SLTLoopBound::Expr(node) = end {
                 collect_comb_path_stats(*node, arena, visited, stats);
+            }
+            if let SLTForFoldResult::Transient { initial, update } = result {
+                collect_comb_path_stats(*initial, arena, visited, stats);
+                collect_comb_path_stats(*update, arena, visited, stats);
             }
             for init in initials {
                 collect_comb_path_stats(init.expr, arena, visited, stats);
@@ -1600,7 +1605,7 @@ fn eval_for_with_effects(
             step,
             step_op,
             reverse,
-            result,
+            result: SLTForFoldResult::State(result),
             initials: initial_updates.clone(),
             updates: folded_updates.clone(),
             effects: effects.to_vec(),
@@ -1653,7 +1658,7 @@ fn eval_for_with_effects(
             step,
             step_op,
             reverse,
-            result: target,
+            result: SLTForFoldResult::State(target),
             initials: initial_updates.clone(),
             updates: folded_updates.clone(),
             effects: Vec::new(),

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -366,11 +366,18 @@ fn collect_comb_path_stats(
                 collect_comb_path_stats(update.expr, arena, visited, stats);
             }
             for effect in effects {
-                if let Some(guard) = effect.guard {
-                    collect_comb_path_stats(guard, arena, visited, stats);
-                }
-                for arg in &effect.args {
-                    collect_comb_path_stats(*arg, arena, visited, stats);
+                match effect {
+                    SLTForEffect::Event { guard, args, .. } => {
+                        if let Some(guard) = guard {
+                            collect_comb_path_stats(*guard, arena, visited, stats);
+                        }
+                        for arg in args {
+                            collect_comb_path_stats(*arg, arena, visited, stats);
+                        }
+                    }
+                    SLTForEffect::Runner(runner) => {
+                        collect_comb_path_stats(*runner, arena, visited, stats);
+                    }
                 }
             }
             collect_comb_path_stats(*continue_cond, arena, visited, stats);

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -2052,16 +2052,6 @@ fn eval_statement_form_function_call(
     arena: &mut SLTNodeArena<VarId>,
     phase: LoweringPhase,
 ) -> Result<(SymbolicStore<VarId>, BoundaryMap<VarId>), ParserError> {
-    if call.outputs.is_empty() {
-        return Err(ParserError::unsupported(
-            58,
-            phase,
-            "statement-form function call without output arguments",
-            format!("{call}"),
-            Some(&call.comptime.token),
-        ));
-    }
-
     let Some(function) = module.functions.get(&call.id) else {
         return Err(ParserError::unsupported(
             60,
@@ -2689,6 +2679,7 @@ mod tests {
     pub struct CombResult {
         pub paths: Vec<LogicPath<VarId>>,
         pub boundaries: HashMap<VarId, BTreeSet<usize>>,
+        pub runtime_events: Vec<RuntimeEventSite>,
     }
     pub fn parse_top_module(code: &str) -> Module {
         symbol_table::clear();
@@ -2739,9 +2730,16 @@ mod tests {
             })
             .expect("No always_comb found in Top");
         let mut arena = SLTNodeArena::new();
-        let (paths, _, boundaries, _, _) =
+        let (paths, _, boundaries, _, runtime_events) =
             super::parse_comb(&top_module, comb_decl, &mut arena).unwrap();
-        (top_module, CombResult { paths, boundaries })
+        (
+            top_module,
+            CombResult {
+                paths,
+                boundaries,
+                runtime_events,
+            },
+        )
     }
     pub fn var_id_of(module: &Module, var_path: &[&str]) -> VarId {
         let mut var_path_str_id = Vec::new();
@@ -2815,6 +2813,37 @@ mod tests {
 
         assert!(bounds.contains(&0));
         assert!(bounds.contains(&4));
+    }
+
+    #[test]
+    fn test_statement_form_function_call_without_outputs_in_function_body() {
+        let code = r#"
+            module Top (a: input logic<8>, q: output logic<8>) {
+                function f (x: input logic<8>) {
+                    $assert(x == x);
+                }
+
+                function g (x: input logic<8>) -> logic<8> {
+                    f(x);
+                    return x;
+                }
+
+                always_comb {
+                    q = g(a);
+                }
+            }
+        "#;
+        let (module, result) = inspect_comb(code);
+        let a_id = var_id_of(&module, &["a"]);
+        let q_id = var_id_of(&module, &["q"]);
+        let q_path = result
+            .paths
+            .iter()
+            .find(|path| path.target.var().is_some_and(|target| target.id == q_id))
+            .expect("q assignment should be lowered");
+
+        assert!(q_path.sources.iter().any(|source| source.id == a_id));
+        assert_eq!(result.runtime_events.len(), 1);
     }
 
     #[test]

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -161,14 +161,17 @@ fn collect_system_function_effect(
         }
         (RuntimeEventKind::Display, _, Some(_)) => unreachable!("display has no explicit guard"),
     };
-    let loop_effect = collector.loop_effects.as_ref().map(|_| SLTForEffect {
-        site_id,
-        guard,
-        emit_on_true: matches!(kind, RuntimeEventKind::Display),
-        args: observer_args.clone(),
-        fatal_error_code: matches!(kind, RuntimeEventKind::AssertFatal)
-            .then_some(1_000_000 + site_id as i64),
-    });
+    let loop_effect = collector
+        .loop_effects
+        .as_ref()
+        .map(|_| SLTForEffect::Event {
+            site_id,
+            guard,
+            emit_on_true: matches!(kind, RuntimeEventKind::Display),
+            args: observer_args.clone(),
+            fatal_error_code: matches!(kind, RuntimeEventKind::AssertFatal)
+                .then_some(1_000_000 + site_id as i64),
+        });
     let observed_ids: HashSet<_> = observed_inputs.iter().map(|atom| atom.id).collect();
     let position_ids: HashSet<_> = position_inputs.iter().map(|atom| atom.id).collect();
     let preceding_writes: Vec<_> = store
@@ -890,18 +893,26 @@ fn collect_function_body_effects(
         let observer_start = collector.observers.len();
         let saved_loop_effects = collector.loop_effects.take();
         collector.loop_effects = Some(Vec::new());
-        let iter_state = collect_statements(
-            module,
-            FunctionControlState {
-                store: iter_store,
-                boundaries: state.boundaries.clone(),
-                live_expr: bool_node(arena, true)?,
-                live_sources: HashSet::default(),
-            },
-            &for_stmt.body,
-            ret_id,
-            arena,
+        let iter_state = with_collector_guard(
             collector,
+            arena,
+            state.live_expr,
+            state.live_sources.clone(),
+            |collector, arena| {
+                collect_statements(
+                    module,
+                    FunctionControlState {
+                        store: iter_store,
+                        boundaries: state.boundaries.clone(),
+                        live_expr: bool_node(arena, true)?,
+                        live_sources: HashSet::default(),
+                    },
+                    &for_stmt.body,
+                    ret_id,
+                    arena,
+                    collector,
+                )
+            },
         )?;
         let loop_effects = collector.loop_effects.take().unwrap_or_default();
         collector.loop_effects = saved_loop_effects;
@@ -976,7 +987,11 @@ fn collect_function_body_effects(
                 effects: loop_effects,
                 continue_cond: effective_continue,
             })?;
-            attach_loop_runner_to_first_observer(collector, observer_start, Some(runner));
+            if let Some(parent_effects) = &mut collector.loop_effects {
+                parent_effects.push(SLTForEffect::Runner(runner));
+            } else {
+                attach_loop_runner_to_first_observer(collector, observer_start, Some(runner));
+            }
         }
 
         let initial = bool_node(arena, true)?;

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -740,6 +740,288 @@ fn collect_function_body_effects(
         })
     }
 
+    fn apply_function_guard(
+        module: &Module,
+        state: FunctionControlState,
+        next_store: SymbolicStore<VarId>,
+        next_boundaries: BoundaryMap<VarId>,
+        next_live_expr: NodeId,
+        next_live_sources: HashSet<VarAtomBase<VarId>>,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<FunctionControlState, ParserError> {
+        match constant_bool(arena, state.live_expr) {
+            Some(true) => Ok(FunctionControlState {
+                store: next_store,
+                boundaries: merge_boundaries(state.boundaries, next_boundaries),
+                live_expr: next_live_expr,
+                live_sources: next_live_sources,
+            }),
+            Some(false) => Ok(state),
+            None => {
+                let store = merge_symbolic_stores(
+                    module,
+                    &next_store,
+                    &state.store,
+                    state.live_expr,
+                    &state.live_sources,
+                    arena,
+                )?;
+                let live_expr = match constant_bool(arena, next_live_expr) {
+                    Some(true) => state.live_expr,
+                    Some(false) => bool_node(arena, false)?,
+                    None => arena.alloc(SLTNode::Binary(
+                        state.live_expr,
+                        BinaryOp::And,
+                        next_live_expr,
+                    ))?,
+                };
+                let mut live_sources = state.live_sources;
+                live_sources.extend(next_live_sources);
+                Ok(FunctionControlState {
+                    store,
+                    boundaries: merge_boundaries(state.boundaries, next_boundaries),
+                    live_expr,
+                    live_sources,
+                })
+            }
+        }
+    }
+
+    fn statement_contains_return(stmt: &Statement, ret_id: VarId) -> bool {
+        match stmt {
+            Statement::Assign(assign) => function_assigns_whole_var(assign, ret_id),
+            Statement::If(if_stmt) => if_stmt
+                .true_side
+                .iter()
+                .chain(&if_stmt.false_side)
+                .any(|stmt| statement_contains_return(stmt, ret_id)),
+            Statement::Case(case_stmt) => case_stmt
+                .arms
+                .iter()
+                .flat_map(|arm| &arm.body)
+                .chain(&case_stmt.default)
+                .any(|stmt| statement_contains_return(stmt, ret_id)),
+            Statement::For(for_stmt) => for_stmt
+                .body
+                .iter()
+                .any(|stmt| statement_contains_return(stmt, ret_id)),
+            Statement::IfReset(if_reset) => if_reset
+                .true_side
+                .iter()
+                .chain(&if_reset.false_side)
+                .any(|stmt| statement_contains_return(stmt, ret_id)),
+            Statement::SystemFunctionCall(_)
+            | Statement::FunctionCall(_)
+            | Statement::TbMethodCall(_)
+            | Statement::Break
+            | Statement::Unsupported(_)
+            | Statement::Null => false,
+        }
+    }
+
+    fn collect_function_for(
+        module: &Module,
+        state: FunctionControlState,
+        for_stmt: &ForStatement,
+        ret_id: VarId,
+        arena: &mut SLTNodeArena<VarId>,
+        collector: &mut CombEffectCollector,
+    ) -> Result<FunctionControlState, ParserError> {
+        let Some(loop_width) = for_stmt.var_type.total_width() else {
+            return Err(ParserError::unsupported(
+                65,
+                LoweringPhase::CombLowering,
+                "for loop variable width",
+                format!("{:?}", for_stmt.var_name),
+                Some(&for_stmt.token),
+            ));
+        };
+
+        let mut iter_store = state.store.clone();
+        let mut written_accesses = HashMap::default();
+        collect_written_accesses(module, &for_stmt.body, &mut written_accesses)?;
+        for (id, accesses) in written_accesses {
+            let width = resolve_total_width(module, &module.variables[&id])?;
+            let mut loop_store = RangeStore::new(None, width);
+            let mut covered = vec![false; width];
+            for access in accesses {
+                for slot in covered.iter_mut().take(access.msb + 1).skip(access.lsb) {
+                    *slot = true;
+                }
+            }
+            let original = state
+                .store
+                .get(&id)
+                .cloned()
+                .unwrap_or_else(|| RangeStore::new(None, width));
+            let mut bit = 0;
+            while bit < width {
+                if covered[bit] {
+                    bit += 1;
+                    continue;
+                }
+                let start = bit;
+                while bit < width && !covered[bit] {
+                    bit += 1;
+                }
+                let access = BitAccess::new(start, bit - 1);
+                let parts = original.get_parts(access).map_err(|error| {
+                    super::range_store_error(
+                        "function observer for-loop state",
+                        error,
+                        Some(&for_stmt.token),
+                    )
+                })?;
+                let (expr, sources) = combine_parts_with_default(id, access.lsb, parts, arena)?;
+                loop_store
+                    .update(access, Some((expr, sources)))
+                    .map_err(|error| {
+                        super::range_store_error(
+                            "function observer for-loop state",
+                            error,
+                            Some(&for_stmt.token),
+                        )
+                    })?;
+            }
+            iter_store.insert(id, loop_store);
+        }
+        iter_store.insert(for_stmt.var_id, RangeStore::new(None, loop_width));
+
+        let observer_start = collector.observers.len();
+        let saved_loop_effects = collector.loop_effects.take();
+        collector.loop_effects = Some(Vec::new());
+        let iter_state = collect_statements(
+            module,
+            FunctionControlState {
+                store: iter_store,
+                boundaries: state.boundaries.clone(),
+                live_expr: bool_node(arena, true)?,
+                live_sources: HashSet::default(),
+            },
+            &for_stmt.body,
+            ret_id,
+            arena,
+            collector,
+        )?;
+        let loop_effects = collector.loop_effects.take().unwrap_or_default();
+        collector.loop_effects = saved_loop_effects;
+
+        // Effect arguments after the loop only consume this store while the
+        // function remains live. On that path no return was taken, so the
+        // ordinary loop fold and the function-aware fold have identical data
+        // state; the separate transient result below carries the control state.
+        let (result_store, boundaries) = eval_for(
+            module,
+            state.store.clone(),
+            state.boundaries.clone(),
+            for_stmt,
+            arena,
+        )?;
+        let template = result_store
+            .values()
+            .flat_map(|range_store| range_store.ranges.values())
+            .filter_map(|(value, _, _)| value.as_ref().map(|(node, _)| *node))
+            .find(|node| {
+                matches!(
+                    arena.get(*node),
+                    SLTNode::ForFold { loop_var, .. } if *loop_var == for_stmt.var_id
+                )
+            })
+            .ok_or_else(|| {
+                ParserError::illegal_context(
+                    "function observer for-loop control",
+                    "loop result fold is absent from the symbolic store",
+                    Some(&for_stmt.token),
+                )
+            })?;
+        let SLTNode::ForFold {
+            loop_var,
+            loop_width,
+            loop_signed,
+            start,
+            end,
+            inclusive,
+            step,
+            step_op,
+            reverse,
+            result,
+            initials,
+            updates,
+            continue_cond,
+            ..
+        } = arena.get(template).clone()
+        else {
+            unreachable!();
+        };
+        let effective_continue = arena.alloc(SLTNode::Binary(
+            continue_cond,
+            BinaryOp::And,
+            iter_state.live_expr,
+        ))?;
+
+        if !loop_effects.is_empty() {
+            let runner = arena.alloc(SLTNode::ForFold {
+                loop_var,
+                loop_width,
+                loop_signed,
+                start: start.clone(),
+                end: end.clone(),
+                inclusive,
+                step,
+                step_op,
+                reverse,
+                result: result.clone(),
+                initials: initials.clone(),
+                updates: updates.clone(),
+                effects: loop_effects,
+                continue_cond: effective_continue,
+            })?;
+            attach_loop_runner_to_first_observer(collector, observer_start, Some(runner));
+        }
+
+        let initial = bool_node(arena, true)?;
+        let live_expr = arena.alloc(SLTNode::ForFold {
+            loop_var,
+            loop_width,
+            loop_signed,
+            start,
+            end,
+            inclusive,
+            step,
+            step_op,
+            reverse,
+            result: SLTForFoldResult::Transient {
+                initial,
+                update: iter_state.live_expr,
+            },
+            initials,
+            updates,
+            effects: Vec::new(),
+            continue_cond: effective_continue,
+        })?;
+
+        let (start_bound, end_bound) = match &for_stmt.range {
+            ForRange::Forward { start, end, .. }
+            | ForRange::Reverse { start, end, .. }
+            | ForRange::Stepped { start, end, .. } => (start, end),
+        };
+        let (_, start_sources, _) = eval_for_bound(module, &state.store, start_bound, arena)?;
+        let (_, end_sources, _) = eval_for_bound(module, &state.store, end_bound, arena)?;
+        let mut live_sources = iter_state.live_sources;
+        live_sources.extend(start_sources);
+        live_sources.extend(end_sources);
+
+        apply_function_guard(
+            module,
+            state,
+            result_store,
+            boundaries,
+            live_expr,
+            live_sources,
+            arena,
+        )
+    }
+
     fn collect_statement(
         module: &Module,
         state: FunctionControlState,
@@ -753,6 +1035,7 @@ fn collect_function_body_effects(
         }
         match stmt {
             Statement::Assign(assign) => {
+                let guard_state = state.clone();
                 let store = state.store.clone();
                 let live = state.live_expr;
                 let live_sources = state.live_sources.clone();
@@ -766,12 +1049,15 @@ fn collect_function_body_effects(
                 } else {
                     bool_node(arena, true)?
                 };
-                Ok(FunctionControlState {
+                apply_function_guard(
+                    module,
+                    guard_state,
                     store,
                     boundaries,
                     live_expr,
-                    live_sources: HashSet::default(),
-                })
+                    HashSet::default(),
+                    arena,
+                )
             }
             Statement::SystemFunctionCall(call) => {
                 let store = state.store.clone();
@@ -783,6 +1069,7 @@ fn collect_function_body_effects(
                 Ok(state)
             }
             Statement::FunctionCall(call) => {
+                let guard_state = state.clone();
                 let store = state.store.clone();
                 let live = state.live_expr;
                 let live_sources = state.live_sources.clone();
@@ -797,12 +1084,15 @@ fn collect_function_body_effects(
                     arena,
                     LoweringPhase::CombLowering,
                 )?;
-                Ok(FunctionControlState {
+                apply_function_guard(
+                    module,
+                    guard_state,
                     store,
                     boundaries,
-                    live_expr: bool_node(arena, true)?,
-                    live_sources: HashSet::default(),
-                })
+                    bool_node(arena, true)?,
+                    HashSet::default(),
+                    arena,
+                )
             }
             Statement::If(if_stmt) => {
                 let store = state.store.clone();
@@ -812,9 +1102,10 @@ fn collect_function_body_effects(
                     collect_expression_effects(module, &store, &if_stmt.cond, arena, collector)
                 })?;
 
-                let ((cond_node, cond_sources), _) =
+                let ((cond_node, cond_sources), cond_boundaries) =
                     eval_expression(module, &state.store, &if_stmt.cond, arena, None)?;
                 let cond_node = procedural_condition(arena, cond_node)?;
+                let boundaries = merge_boundaries(state.boundaries, cond_boundaries);
                 let true_guard = arena.alloc(SLTNode::Binary(
                     state.live_expr,
                     BinaryOp::LogicAnd,
@@ -822,21 +1113,25 @@ fn collect_function_body_effects(
                 ))?;
                 let mut true_sources = state.live_sources.clone();
                 true_sources.extend(cond_sources.iter().copied());
-                with_collector_guard(
+                let true_state = with_collector_guard(
                     collector,
                     arena,
                     true_guard,
                     true_sources,
                     |collector, arena| {
-                        let _ = collect_statements(
+                        collect_statements(
                             module,
-                            state.clone(),
+                            FunctionControlState {
+                                store: state.store.clone(),
+                                boundaries: boundaries.clone(),
+                                live_expr: state.live_expr,
+                                live_sources: state.live_sources.clone(),
+                            },
                             &if_stmt.true_side,
                             ret_id,
                             arena,
                             collector,
-                        )?;
-                        Ok(())
+                        )
                     },
                 )?;
 
@@ -848,37 +1143,59 @@ fn collect_function_body_effects(
                 ))?;
                 let mut false_sources = state.live_sources.clone();
                 false_sources.extend(cond_sources.iter().copied());
-                with_collector_guard(
+                let false_state = with_collector_guard(
                     collector,
                     arena,
                     false_guard,
                     false_sources,
                     |collector, arena| {
-                        let _ = collect_statements(
+                        collect_statements(
                             module,
-                            state.clone(),
+                            FunctionControlState {
+                                store: state.store,
+                                boundaries,
+                                live_expr: state.live_expr,
+                                live_sources: state.live_sources,
+                            },
                             &if_stmt.false_side,
                             ret_id,
                             arena,
                             collector,
-                        )?;
-                        Ok(())
+                        )
                     },
                 )?;
 
-                let (store, boundaries) =
-                    eval_if(module, state.store, state.boundaries, if_stmt, arena)?;
+                let mut live_sources = cond_sources;
+                live_sources.extend(true_state.live_sources.iter().copied());
+                live_sources.extend(false_state.live_sources.iter().copied());
+
                 Ok(FunctionControlState {
-                    store,
-                    boundaries,
-                    live_expr: bool_node(arena, true)?,
-                    live_sources: HashSet::default(),
+                    store: merge_symbolic_stores(
+                        module,
+                        &true_state.store,
+                        &false_state.store,
+                        cond_node,
+                        &live_sources,
+                        arena,
+                    )?,
+                    boundaries: merge_boundaries(true_state.boundaries, false_state.boundaries),
+                    live_expr: merge_control_expr(
+                        cond_node,
+                        true_state.live_expr,
+                        false_state.live_expr,
+                        arena,
+                    )?,
+                    live_sources,
                 })
             }
             Statement::Case(case_stmt) => {
                 collect_case_from_arm(module, state, case_stmt, 0, ret_id, arena, collector)
             }
             Statement::For(for_stmt) => {
+                if statement_contains_return(&Statement::For(for_stmt.clone()), ret_id) {
+                    return collect_function_for(module, state, for_stmt, ret_id, arena, collector);
+                }
+                let guard_state = state.clone();
                 let store = state.store.clone();
                 let live = state.live_expr;
                 let live_sources = state.live_sources.clone();
@@ -888,12 +1205,15 @@ fn collect_function_body_effects(
                 })?;
                 let (store, boundaries) =
                     eval_for(module, state.store, state.boundaries, for_stmt, arena)?;
-                Ok(FunctionControlState {
+                apply_function_guard(
+                    module,
+                    guard_state,
                     store,
                     boundaries,
-                    live_expr: bool_node(arena, true)?,
-                    live_sources: HashSet::default(),
-                })
+                    bool_node(arena, true)?,
+                    HashSet::default(),
+                    arena,
+                )
             }
             Statement::Null => Ok(state),
             Statement::IfReset(ir) => Err(ParserError::illegal_context(

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -442,14 +442,6 @@ pub(super) fn eval_function_body_return(
         Ok(combine_parts_with_default(ret_id, 0, ret_parts, arena)?)
     }
 
-    fn function_control_target(
-        module: &Module,
-        ret_id: VarId,
-    ) -> Result<VarAtomBase<VarId>, ParserError> {
-        let ret_width = resolve_total_width(module, &module.variables[&ret_id])?;
-        Ok(VarAtomBase::new(ret_id, ret_width, ret_width))
-    }
-
     fn apply_function_guard(
         module: &Module,
         state: FunctionControlState,
@@ -1165,7 +1157,7 @@ pub(super) fn eval_function_body_return(
                 step,
                 step_op,
                 reverse,
-                result: *target,
+                result: SLTForFoldResult::State(*target),
                 initials: initial_updates.clone(),
                 updates: folded_updates.clone(),
                 effects: Vec::new(),
@@ -1201,17 +1193,7 @@ pub(super) fn eval_function_body_return(
 
         let next_live_expr = if statement_contains_return(&Statement::For(for_stmt.clone()), ret_id)
         {
-            let control_target = function_control_target(module, ret_id)?;
-            let mut control_initials = initial_updates.clone();
-            control_initials.push(SLTForUpdate {
-                target: control_target,
-                expr: bool_node(arena, true)?,
-            });
-            let mut control_updates = folded_updates.clone();
-            control_updates.push(SLTForUpdate {
-                target: control_target,
-                expr: iter_state.function.live_expr,
-            });
+            let initial = bool_node(arena, true)?;
             arena.alloc(SLTNode::ForFold {
                 loop_var: for_stmt.var_id,
                 loop_width,
@@ -1222,11 +1204,14 @@ pub(super) fn eval_function_body_return(
                 step,
                 step_op,
                 reverse,
-                result: control_target,
-                initials: control_initials,
-                updates: control_updates,
+                result: SLTForFoldResult::Transient {
+                    initial,
+                    update: iter_state.function.live_expr,
+                },
+                initials: initial_updates,
+                updates: folded_updates,
                 effects: Vec::new(),
-                continue_cond: iter_state.continue_expr,
+                continue_cond: loop_effective_continue,
             })?
         } else {
             bool_node(arena, true)?
@@ -2966,7 +2951,10 @@ pub(super) fn is_signed(module: &Module, expr: NodeId, arena: &SLTNodeArena<VarI
             else_expr,
             ..
         } => is_signed(module, *then_expr, arena) && is_signed(module, *else_expr, arena),
-        SLTNode::ForFold { result, .. } => module.variables[&result.id].r#type.signed,
+        SLTNode::ForFold { result, .. } => match result {
+            SLTForFoldResult::State(result) => module.variables[&result.id].r#type.signed,
+            SLTForFoldResult::Transient { .. } => false,
+        },
         SLTNode::ForFoldGroup { .. } => false,
         SLTNode::Slice { .. } => false,
         SLTNode::Concat(_) => false,

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -1407,6 +1407,7 @@ fn collect_glue_sources_with_window(
             loop_var,
             start,
             end,
+            result,
             initials,
             updates,
             effects,
@@ -1418,6 +1419,10 @@ fn collect_glue_sources_with_window(
             }
             if let SLTLoopBound::Expr(node) = end {
                 collect_glue_sources_with_window(*node, None, arena, set);
+            }
+            if let celox_slt::SLTForFoldResult::Transient { initial, update } = result {
+                collect_glue_sources_with_window(*initial, None, arena, set);
+                collect_glue_sources_with_window(*update, None, arena, set);
             }
             for init in initials {
                 collect_glue_sources_with_window(init.expr, None, arena, set);

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -1431,11 +1431,18 @@ fn collect_glue_sources_with_window(
                 collect_glue_sources_with_window(update.expr, None, arena, set);
             }
             for effect in effects {
-                if let Some(guard) = effect.guard {
-                    collect_glue_sources_with_window(guard, None, arena, set);
-                }
-                for arg in &effect.args {
-                    collect_glue_sources_with_window(*arg, None, arena, set);
+                match effect {
+                    celox_slt::SLTForEffect::Event { guard, args, .. } => {
+                        if let Some(guard) = guard {
+                            collect_glue_sources_with_window(*guard, None, arena, set);
+                        }
+                        for arg in args {
+                            collect_glue_sources_with_window(*arg, None, arena, set);
+                        }
+                    }
+                    celox_slt::SLTForEffect::Runner(runner) => {
+                        collect_glue_sources_with_window(*runner, None, arena, set);
+                    }
                 }
             }
             collect_glue_sources_with_window(*continue_cond, None, arena, set);

--- a/crates/celox-slt/src/lib.rs
+++ b/crates/celox-slt/src/lib.rs
@@ -22,8 +22,8 @@ mod symbolic_verify;
 pub use lower::matches_slt_or_scan_group;
 pub use lower::{SLTToSIRLowerer, matches_slt_count_idiom};
 pub use node::{
-    NodeId, SLTForEffect, SLTForFoldGroupState, SLTForUpdate, SLTIndex, SLTIndexKind, SLTLoopBound,
-    SLTNode, SLTNodeArena, SLTNodeArenaEditError, SLTStepOp,
+    NodeId, SLTForEffect, SLTForFoldGroupState, SLTForFoldResult, SLTForUpdate, SLTIndex,
+    SLTIndexKind, SLTLoopBound, SLTNode, SLTNodeArena, SLTNodeArenaEditError, SLTStepOp,
 };
 pub use node_facts::{SLTNodeFacts, SLTNodeFactsError};
 pub use path::{LogicPath, LogicPathId, LogicPathTarget};

--- a/crates/celox-slt/src/lower.rs
+++ b/crates/celox-slt/src/lower.rs
@@ -3158,7 +3158,14 @@ impl SLTToSIRLowerer {
             } => {
                 self.get_bound_signed(*then_expr, arena) && self.get_bound_signed(*else_expr, arena)
             }
-            SLTNode::ForFold { loop_signed, .. } => *loop_signed,
+            SLTNode::ForFold {
+                loop_signed,
+                result,
+                ..
+            } => match result {
+                crate::SLTForFoldResult::State(_) => *loop_signed,
+                crate::SLTForFoldResult::Transient { .. } => false,
+            },
             // The grouped result has concat layout and is therefore unsigned,
             // independently of the loop counter's signedness.
             SLTNode::ForFoldGroup { .. } => false,
@@ -3925,6 +3932,7 @@ impl SLTToSIRLowerer {
             SLTNode::ForFold {
                 start,
                 end,
+                result,
                 initials,
                 updates,
                 effects,
@@ -3937,6 +3945,10 @@ impl SLTToSIRLowerer {
                 }
                 if let SLTLoopBound::Expr(node) = end {
                     children.push(*node);
+                }
+                if let crate::SLTForFoldResult::Transient { initial, update } = result {
+                    children.push(*initial);
+                    children.push(*update);
                 }
                 children.extend(initials.iter().map(|update| update.expr));
                 children.extend(updates.iter().map(|update| update.expr));
@@ -5524,7 +5536,7 @@ impl SLTToSIRLowerer {
         step: usize,
         step_op: SLTStepOp,
         reverse: bool,
-        result: &VarAtomBase<A>,
+        result: &crate::SLTForFoldResult<A>,
         initials: &[crate::SLTForUpdate<A>],
         updates: &[crate::SLTForUpdate<A>],
         effects: &[crate::SLTForEffect],
@@ -5577,7 +5589,7 @@ impl SLTToSIRLowerer {
 
         let init_counter = if reverse { end_reg } else { start_reg };
 
-        let initial_states: Vec<RegisterId> = initials
+        let mut initial_states: Vec<RegisterId> = initials
             .iter()
             .zip(updates.iter())
             .map(|(init, update)| {
@@ -5586,30 +5598,50 @@ impl SLTToSIRLowerer {
                 self.cast_reg_width(builder, reg, width)
             })
             .collect();
+        if let crate::SLTForFoldResult::Transient { initial, update } = result {
+            let reg = self.lower_inner(builder, *initial, arena, cache, None, true);
+            initial_states.push(self.cast_reg_width(builder, reg, self.get_width(*update, arena)));
+        }
+
+        let transient_width = match result {
+            crate::SLTForFoldResult::State(_) => None,
+            crate::SLTForFoldResult::Transient { update, .. } => {
+                Some(self.get_width(*update, arena))
+            }
+        };
 
         let header_counter = builder.alloc_bit(compare_width, loop_signed);
-        let header_states: Vec<_> = updates
+        let mut header_states: Vec<_> = updates
             .iter()
             .map(|update| {
                 let width = update.target.access.msb - update.target.access.lsb + 1;
                 builder.alloc_logic(width)
             })
             .collect();
+        if let Some(width) = transient_width {
+            header_states.push(builder.alloc_logic(width));
+        }
         let body_counter = builder.alloc_bit(compare_width, loop_signed);
-        let body_states: Vec<_> = updates
+        let mut body_states: Vec<_> = updates
             .iter()
             .map(|update| {
                 let width = update.target.access.msb - update.target.access.lsb + 1;
                 builder.alloc_logic(width)
             })
             .collect();
-        let exit_states: Vec<_> = updates
+        if let Some(width) = transient_width {
+            body_states.push(builder.alloc_logic(width));
+        }
+        let mut exit_states: Vec<_> = updates
             .iter()
             .map(|update| {
                 let width = update.target.access.msb - update.target.access.lsb + 1;
                 builder.alloc_logic(width)
             })
             .collect();
+        if let Some(width) = transient_width {
+            exit_states.push(builder.alloc_logic(width));
+        }
 
         let header_params = std::iter::once(header_counter)
             .chain(header_states.iter().copied())
@@ -5797,7 +5829,7 @@ impl SLTToSIRLowerer {
         };
         let mut local_cache = crate::HashMap::default();
         self.lower_for_effects(builder, arena, &mut local_cache, &env, effects);
-        let next_states: Vec<_> = updates
+        let mut next_states: Vec<_> = updates
             .iter()
             .map(|update| {
                 let reg = self.lower_inner(
@@ -5812,6 +5844,11 @@ impl SLTToSIRLowerer {
                 self.cast_reg_width(builder, reg, width)
             })
             .collect();
+        if let crate::SLTForFoldResult::Transient { update, .. } = result {
+            let reg =
+                self.lower_inner(builder, *update, arena, &mut local_cache, Some(&env), false);
+            next_states.push(self.cast_reg_width(builder, reg, self.get_width(*update, arena)));
+        }
 
         let continue_reg = self.lower_inner(
             builder,
@@ -6021,10 +6058,13 @@ impl SLTToSIRLowerer {
         }
 
         builder.switch_to_block(exit_block);
-        let result_idx = updates
-            .iter()
-            .position(|update| update.target == *result)
-            .expect("ForFold result target must be present in updates");
+        let result_idx = match result {
+            crate::SLTForFoldResult::State(result) => updates
+                .iter()
+                .position(|update| update.target == *result)
+                .expect("ForFold result target must be present in updates"),
+            crate::SLTForFoldResult::Transient { .. } => updates.len(),
+        };
         exit_states[result_idx]
     }
 
@@ -8751,7 +8791,7 @@ mod tests {
                 step: 1,
                 step_op: SLTStepOp::Add,
                 reverse: false,
-                result: target,
+                result: crate::SLTForFoldResult::State(target),
                 initials: vec![crate::SLTForUpdate {
                     target,
                     expr: initial,

--- a/crates/celox-slt/src/lower.rs
+++ b/crates/celox-slt/src/lower.rs
@@ -2655,6 +2655,7 @@ impl SLTToSIRLowerer {
                 updates,
                 effects,
                 *continue_cond,
+                env,
             ),
             SLTNode::ForFoldGroup { .. } => {
                 let spec = FoldGroupLowerSpec::from_root(node, arena)
@@ -3953,8 +3954,13 @@ impl SLTToSIRLowerer {
                 children.extend(initials.iter().map(|update| update.expr));
                 children.extend(updates.iter().map(|update| update.expr));
                 for effect in effects {
-                    children.extend(effect.guard);
-                    children.extend(effect.args.iter().copied());
+                    match effect {
+                        crate::SLTForEffect::Event { guard, args, .. } => {
+                            children.extend(*guard);
+                            children.extend(args.iter().copied());
+                        }
+                        crate::SLTForEffect::Runner(runner) => children.push(*runner),
+                    }
                 }
                 children.push(*continue_cond);
                 children
@@ -5016,6 +5022,7 @@ impl SLTToSIRLowerer {
         signed: bool,
         arena: &SLTNodeArena<A>,
         cache: &mut crate::HashMap<NodeId, RegisterId>,
+        env: Option<&LowerEnv<'_, A>>,
     ) -> RegisterId {
         match bound {
             SLTLoopBound::Const(v) => {
@@ -5024,7 +5031,7 @@ impl SLTToSIRLowerer {
                 reg
             }
             SLTLoopBound::Expr(node) => {
-                let reg = self.lower_inner(builder, *node, arena, cache, None, true);
+                let reg = self.lower_inner(builder, *node, arena, cache, env, env.is_none());
                 let source_signed = self.get_bound_signed(*node, arena);
                 let extend_signed = source_signed && signed;
                 let sized = self.cast_reg_width_ext(builder, reg, width, extend_signed);
@@ -5541,6 +5548,7 @@ impl SLTToSIRLowerer {
         updates: &[crate::SLTForUpdate<A>],
         effects: &[crate::SLTForEffect],
         continue_cond: NodeId,
+        parent_env: Option<&LowerEnv<'_, A>>,
     ) -> RegisterId {
         let mut counter_width = loop_width.max(1);
         counter_width = counter_width.max(Self::bound_width(start));
@@ -5567,6 +5575,7 @@ impl SLTToSIRLowerer {
             loop_signed,
             arena,
             cache,
+            parent_env,
         );
         let end_reg = self.lower_bound(
             builder,
@@ -5576,6 +5585,7 @@ impl SLTToSIRLowerer {
             loop_signed,
             arena,
             cache,
+            parent_env,
         );
         let one_reg = builder.alloc_bit(compare_width, loop_signed);
         builder.emit(SIRInstruction::Imm(one_reg, SIRValue::new(1u64)));
@@ -5593,13 +5603,27 @@ impl SLTToSIRLowerer {
             .iter()
             .zip(updates.iter())
             .map(|(init, update)| {
-                let reg = self.lower_inner(builder, init.expr, arena, cache, None, true);
+                let reg = self.lower_inner(
+                    builder,
+                    init.expr,
+                    arena,
+                    cache,
+                    parent_env,
+                    parent_env.is_none(),
+                );
                 let width = update.target.access.msb - update.target.access.lsb + 1;
                 self.cast_reg_width(builder, reg, width)
             })
             .collect();
         if let crate::SLTForFoldResult::Transient { initial, update } = result {
-            let reg = self.lower_inner(builder, *initial, arena, cache, None, true);
+            let reg = self.lower_inner(
+                builder,
+                *initial,
+                arena,
+                cache,
+                parent_env,
+                parent_env.is_none(),
+            );
             initial_states.push(self.cast_reg_width(builder, reg, self.get_width(*update, arena)));
         }
 
@@ -5825,7 +5849,7 @@ impl SLTToSIRLowerer {
         );
         let env = LowerEnv {
             inputs: env_inputs,
-            parent: None,
+            parent: parent_env,
         };
         let mut local_cache = crate::HashMap::default();
         self.lower_for_effects(builder, arena, &mut local_cache, &env, effects);
@@ -6077,24 +6101,37 @@ impl SLTToSIRLowerer {
         effects: &[crate::SLTForEffect],
     ) {
         for effect in effects {
+            let crate::SLTForEffect::Event {
+                site_id,
+                guard,
+                emit_on_true,
+                args,
+                fatal_error_code,
+            } = effect
+            else {
+                let crate::SLTForEffect::Runner(runner) = effect else {
+                    unreachable!()
+                };
+                self.lower_inner(builder, *runner, arena, cache, Some(env), false);
+                continue;
+            };
             let emit = |builder: &mut SIRBuilder<A>,
                         this: &Self,
                         cache: &mut crate::HashMap<NodeId, RegisterId>| {
-                let args = effect
-                    .args
+                let args = args
                     .iter()
                     .map(|arg| this.lower_inner(builder, *arg, arena, cache, Some(env), false))
                     .collect();
                 builder.emit(SIRInstruction::CombCaptureEvent {
-                    site_id: effect.site_id,
+                    site_id: *site_id,
                     args,
-                    fatal_error_code: effect.fatal_error_code,
+                    fatal_error_code: *fatal_error_code,
                     consume_enabled: false,
                 });
             };
-            if let Some(guard) = effect.guard {
-                let cond = self.lower_inner(builder, guard, arena, cache, Some(env), false);
-                let branch_cond = if effect.emit_on_true {
+            if let Some(guard) = guard {
+                let cond = self.lower_inner(builder, *guard, arena, cache, Some(env), false);
+                let branch_cond = if *emit_on_true {
                     cond
                 } else {
                     let inverted = builder.alloc_bit(1, false);
@@ -8800,7 +8837,7 @@ mod tests {
                     target,
                     expr: update,
                 }],
-                effects: vec![crate::SLTForEffect {
+                effects: vec![crate::SLTForEffect::Event {
                     site_id: 1,
                     guard: None,
                     emit_on_true: true,
@@ -10243,6 +10280,7 @@ mod tests {
             false,
             &arena,
             &mut cache,
+            None,
         );
         assert!(matches!(
             builder.register(&reg),

--- a/crates/celox-slt/src/node.rs
+++ b/crates/celox-slt/src/node.rs
@@ -209,13 +209,26 @@ impl<A: Hash + Eq + Clone> SLTNodeArena<A> {
                 continue;
             };
             for (effect_index, effect) in effects.iter().enumerate() {
-                let Some((site_id, fatal_error_code)) =
-                    remap(effect.site_id, effect.fatal_error_code)?
+                let SLTForEffect::Event {
+                    site_id,
+                    fatal_error_code,
+                    ..
+                } = effect
                 else {
                     continue;
                 };
-                if effect.site_id != site_id || effect.fatal_error_code != fatal_error_code {
-                    edits.push((node_index, effect_index, site_id, fatal_error_code));
+                let Some((mapped_site_id, mapped_fatal_error_code)) =
+                    remap(*site_id, *fatal_error_code)?
+                else {
+                    continue;
+                };
+                if *site_id != mapped_site_id || *fatal_error_code != mapped_fatal_error_code {
+                    edits.push((
+                        node_index,
+                        effect_index,
+                        mapped_site_id,
+                        mapped_fatal_error_code,
+                    ));
                 }
             }
         }
@@ -241,8 +254,16 @@ impl<A: Hash + Eq + Clone> SLTNodeArena<A> {
             if let Some(SLTNode::ForFold { effects, .. }) = nodes.get_mut(node_index)
                 && let Some(effect) = effects.get_mut(effect_index)
             {
-                effect.site_id = site_id;
-                effect.fatal_error_code = fatal_error_code;
+                let SLTForEffect::Event {
+                    site_id: current_site_id,
+                    fatal_error_code: current_fatal_error_code,
+                    ..
+                } = effect
+                else {
+                    return Err(SLTNodeArenaEditError::EditPlanMismatch);
+                };
+                *current_site_id = site_id;
+                *current_fatal_error_code = fatal_error_code;
             }
         }
         self.rebuild_cache();
@@ -612,12 +633,17 @@ pub struct SLTForFoldGroupState<A: Hash + Eq + Clone> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct SLTForEffect {
-    pub site_id: u32,
-    pub guard: Option<NodeId>,
-    pub emit_on_true: bool,
-    pub args: Vec<NodeId>,
-    pub fatal_error_code: Option<i64>,
+pub enum SLTForEffect {
+    /// Emit one runtime event for the current loop iteration.
+    Event {
+        site_id: u32,
+        guard: Option<NodeId>,
+        emit_on_true: bool,
+        args: Vec<NodeId>,
+        fatal_error_code: Option<i64>,
+    },
+    /// Evaluate a nested loop runner at this position in the effect sequence.
+    Runner(NodeId),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -976,8 +1002,13 @@ impl<A: fmt::Debug + fmt::Display + Hash + Eq + Clone> SLTNode<A> {
                         children.extend(initials.iter().map(|update| update.expr));
                         children.extend(updates.iter().map(|update| update.expr));
                         for effect in effects {
-                            children.extend(effect.guard);
-                            children.extend(effect.args.iter().copied());
+                            match effect {
+                                SLTForEffect::Event { guard, args, .. } => {
+                                    children.extend(*guard);
+                                    children.extend(args.iter().copied());
+                                }
+                                SLTForEffect::Runner(runner) => children.push(*runner),
+                            }
                         }
                         if let SLTForFoldResult::Transient { initial, update } = result {
                             children.extend([*initial, *update]);
@@ -1104,16 +1135,21 @@ impl<A: fmt::Debug + fmt::Display + Hash + Eq + Clone> SLTNode<A> {
                         .collect();
                     let mapped_effects = effects
                         .iter()
-                        .map(|effect| {
-                            let guard = effect.guard.map(mapped);
-                            let args = effect.args.iter().map(|arg| mapped(*arg)).collect();
-                            SLTForEffect {
-                                site_id: effect.site_id,
+                        .map(|effect| match effect {
+                            SLTForEffect::Event {
+                                site_id,
                                 guard,
-                                emit_on_true: effect.emit_on_true,
+                                emit_on_true,
                                 args,
-                                fatal_error_code: effect.fatal_error_code,
-                            }
+                                fatal_error_code,
+                            } => SLTForEffect::Event {
+                                site_id: *site_id,
+                                guard: guard.map(mapped),
+                                emit_on_true: *emit_on_true,
+                                args: args.iter().map(|arg| mapped(*arg)).collect(),
+                                fatal_error_code: *fatal_error_code,
+                            },
+                            SLTForEffect::Runner(runner) => SLTForEffect::Runner(mapped(*runner)),
                         })
                         .collect();
                     let mapped_result = match result {
@@ -1343,16 +1379,29 @@ impl<A: fmt::Debug + fmt::Display + Hash + Eq + Clone> SLTNode<A> {
                     writeln!(f)?;
                 }
                 for effect in effects {
-                    writeln!(f, "{}effect site={}:", child_indent, effect.site_id)?;
-                    if let Some(guard) = effect.guard {
-                        writeln!(f, "{}guard:", child_indent)?;
-                        arena.get(guard).fmt_recursive(f, depth + 2, arena)?;
-                        writeln!(f)?;
-                    }
-                    for arg in &effect.args {
-                        writeln!(f, "{}arg:", child_indent)?;
-                        arena.get(*arg).fmt_recursive(f, depth + 2, arena)?;
-                        writeln!(f)?;
+                    match effect {
+                        SLTForEffect::Event {
+                            site_id,
+                            guard,
+                            args,
+                            ..
+                        } => {
+                            writeln!(f, "{}effect site={}:", child_indent, site_id)?;
+                            if let Some(guard) = guard {
+                                writeln!(f, "{}guard:", child_indent)?;
+                                arena.get(*guard).fmt_recursive(f, depth + 2, arena)?;
+                                writeln!(f)?;
+                            }
+                            for arg in args {
+                                writeln!(f, "{}arg:", child_indent)?;
+                                arena.get(*arg).fmt_recursive(f, depth + 2, arena)?;
+                                writeln!(f)?;
+                            }
+                        }
+                        SLTForEffect::Runner(runner) => {
+                            writeln!(f, "{}effect runner:", child_indent)?;
+                            arena.get(*runner).fmt_recursive(f, depth + 2, arena)?;
+                        }
                     }
                 }
                 writeln!(f, "{}continue:", child_indent)?;
@@ -1799,7 +1848,7 @@ mod tests {
                 result: SLTForFoldResult::State(VarAtomBase::new(2, 0, 7)),
                 initials: Vec::new(),
                 updates: Vec::new(),
-                effects: vec![SLTForEffect {
+                effects: vec![SLTForEffect::Event {
                     site_id: 3,
                     guard: None,
                     emit_on_true: true,
@@ -1823,7 +1872,7 @@ mod tests {
                 result: SLTForFoldResult::State(VarAtomBase::new(2, 0, 7)),
                 initials: Vec::new(),
                 updates: Vec::new(),
-                effects: vec![SLTForEffect {
+                effects: vec![SLTForEffect::Event {
                     site_id: 4,
                     guard: None,
                     emit_on_true: true,
@@ -1843,15 +1892,31 @@ mod tests {
         let SLTNode::ForFold { effects, .. } = arena.get(first_fold) else {
             panic!("expected first ForFold");
         };
-        assert_eq!(effects[0].site_id, 13);
-        assert_eq!(effects[0].fatal_error_code, Some(99));
+        let SLTForEffect::Event {
+            site_id,
+            fatal_error_code,
+            ..
+        } = effects[0]
+        else {
+            panic!("expected event effect");
+        };
+        assert_eq!(site_id, 13);
+        assert_eq!(fatal_error_code, Some(99));
         let remapped_first = arena.get(first_fold).clone();
         assert_eq!(arena.alloc(remapped_first).unwrap(), first_fold);
         let SLTNode::ForFold { effects, .. } = arena.get(second_fold) else {
             panic!("expected second ForFold");
         };
-        assert_eq!(effects[0].site_id, 4);
-        assert_eq!(effects[0].fatal_error_code, None);
+        let SLTForEffect::Event {
+            site_id,
+            fatal_error_code,
+            ..
+        } = effects[0]
+        else {
+            panic!("expected event effect");
+        };
+        assert_eq!(site_id, 4);
+        assert_eq!(fatal_error_code, None);
 
         let error = arena
             .remap_for_fold_effect_sites(first_fold.0..second_fold.0 + 1, |site, fatal| {
@@ -1872,7 +1937,10 @@ mod tests {
         let SLTNode::ForFold { effects, .. } = arena.get(first_fold) else {
             panic!("expected first ForFold");
         };
-        assert_eq!(effects[0].site_id, 13, "failed remap must be atomic");
+        let SLTForEffect::Event { site_id, .. } = effects[0] else {
+            panic!("expected event effect");
+        };
+        assert_eq!(site_id, 13, "failed remap must be atomic");
 
         let error = arena
             .remap_for_fold_effect_sites(0..arena.len() + 1, |site, fatal| Ok(Some((site, fatal))))

--- a/crates/celox-slt/src/node.rs
+++ b/crates/celox-slt/src/node.rs
@@ -568,6 +568,32 @@ pub struct SLTForUpdate<A: Hash + Eq + Clone> {
     pub expr: NodeId,
 }
 
+/// Selects the value returned by a legacy dynamic loop fold.
+///
+/// Most folds return one of their variable-backed states. Control-flow
+/// lowering can instead carry a transient value which has no semantic HDL
+/// variable and therefore must not be represented by a fabricated bit range.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "A: Serialize + std::hash::Hash + Eq + Clone",
+    deserialize = "A: Deserialize<'de> + std::hash::Hash + Eq + Clone"
+))]
+pub enum SLTForFoldResult<A: Hash + Eq + Clone> {
+    State(VarAtomBase<A>),
+    Transient { initial: NodeId, update: NodeId },
+}
+
+impl<A: fmt::Display + Hash + Eq + Clone> fmt::Display for SLTForFoldResult<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::State(state) => state.fmt(f),
+            Self::Transient { initial, update } => {
+                write!(f, "transient(n{} -> n{})", initial.0, update.0)
+            }
+        }
+    }
+}
+
 /// One loop-carried state in a grouped fixed-trip-count fold.
 ///
 /// `initial` is evaluated before entering the loop and `update` is evaluated
@@ -628,7 +654,7 @@ pub enum SLTNode<A: Hash + Eq + Clone> {
         step: usize,
         step_op: SLTStepOp,
         reverse: bool,
-        result: VarAtomBase<A>,
+        result: SLTForFoldResult<A>,
         initials: Vec<SLTForUpdate<A>>,
         updates: Vec<SLTForUpdate<A>>,
         effects: Vec<SLTForEffect>,
@@ -688,7 +714,7 @@ enum SLTNodeSerde<A: Hash + Eq + Clone> {
         step: usize,
         step_op: SLTStepOp,
         reverse: bool,
-        result: VarAtomBase<A>,
+        result: SLTForFoldResult<A>,
         initials: Vec<SLTForUpdate<A>>,
         updates: Vec<SLTForUpdate<A>>,
         effects: Vec<SLTForEffect>,
@@ -1084,6 +1110,30 @@ impl<A: fmt::Debug + fmt::Display + Hash + Eq + Clone> SLTNode<A> {
                         })
                     })
                     .collect::<Result<Vec<_>, SLTNodeFactsError>>()?;
+                let mapped_result =
+                    match result {
+                        SLTForFoldResult::State(result) => SLTForFoldResult::State(
+                            VarAtomBase::new(f(&result.id), result.access.lsb, result.access.msb),
+                        ),
+                        SLTForFoldResult::Transient { initial, update } => {
+                            SLTForFoldResult::Transient {
+                                initial: arena.get(*initial).map_addr(
+                                    *initial,
+                                    arena,
+                                    target_arena,
+                                    cache,
+                                    f,
+                                )?,
+                                update: arena.get(*update).map_addr(
+                                    *update,
+                                    arena,
+                                    target_arena,
+                                    cache,
+                                    f,
+                                )?,
+                            }
+                        }
+                    };
                 SLTNode::ForFold {
                     loop_var: f(loop_var),
                     loop_width: *loop_width,
@@ -1094,7 +1144,7 @@ impl<A: fmt::Debug + fmt::Display + Hash + Eq + Clone> SLTNode<A> {
                     step: *step,
                     step_op: *step_op,
                     reverse: *reverse,
-                    result: VarAtomBase::new(f(&result.id), result.access.lsb, result.access.msb),
+                    result: mapped_result,
                     initials: mapped_initials,
                     updates: mapped_updates,
                     effects: mapped_effects,
@@ -1404,8 +1454,8 @@ impl<A: fmt::Debug + fmt::Display + Hash + Eq + Clone> SLTNode<A> {
 #[cfg(test)]
 mod tests {
     use super::{
-        NodeId, SLTForEffect, SLTForFoldGroupState, SLTIndex, SLTLoopBound, SLTNode, SLTNodeArena,
-        SLTNodeArenaEditError, SLTNodeArenaWire, SLTStepOp,
+        NodeId, SLTForEffect, SLTForFoldGroupState, SLTForFoldResult, SLTIndex, SLTLoopBound,
+        SLTNode, SLTNodeArena, SLTNodeArenaEditError, SLTNodeArenaWire, SLTStepOp,
     };
     use crate::{SLTNodeFacts, get_width};
     use celox_design::{BinaryOp, BitAccess, UnaryOp, VarAtomBase};
@@ -1748,7 +1798,7 @@ mod tests {
                 step: 1,
                 step_op: SLTStepOp::Add,
                 reverse: false,
-                result: VarAtomBase::new(2, 0, 7),
+                result: SLTForFoldResult::State(VarAtomBase::new(2, 0, 7)),
                 initials: Vec::new(),
                 updates: Vec::new(),
                 effects: vec![SLTForEffect {
@@ -1772,7 +1822,7 @@ mod tests {
                 step: 1,
                 step_op: SLTStepOp::Add,
                 reverse: false,
-                result: VarAtomBase::new(2, 0, 7),
+                result: SLTForFoldResult::State(VarAtomBase::new(2, 0, 7)),
                 initials: Vec::new(),
                 updates: Vec::new(),
                 effects: vec![SLTForEffect {

--- a/crates/celox-slt/src/node.rs
+++ b/crates/celox-slt/src/node.rs
@@ -918,7 +918,10 @@ impl<A: Hash + Eq + Clone> From<SLTNodeSerde<A>> for SLTNode<A> {
     }
 }
 impl<A: fmt::Debug + fmt::Display + Hash + Eq + Clone> SLTNode<A> {
-    /// Maps the address type A to B recursively throughout the tree.
+    /// Maps the address type A to B throughout the reachable graph.
+    ///
+    /// The traversal is explicitly postorder so deeply nested expressions do
+    /// not consume the host thread's call stack.
     pub fn map_addr<B, F>(
         &self,
         id: NodeId,
@@ -936,310 +939,266 @@ impl<A: fmt::Debug + fmt::Display + Hash + Eq + Clone> SLTNode<A> {
             return Ok(*mapped_id);
         }
 
-        let new_node = match self {
-            // Leaf: Transform address A to B
-            SLTNode::Input {
-                variable: addr,
-                signed,
-                index,
-                access,
-            } => {
-                let mapped_index = index
-                    .iter()
-                    .map(|idx| {
-                        Ok(SLTIndex {
-                            node: arena.get(idx.node).map_addr(
-                                idx.node,
-                                arena,
-                                target_arena,
-                                cache,
-                                f,
-                            )?,
+        let mut work = vec![(id, false)];
+        while let Some((current, expanded)) = work.pop() {
+            if cache.contains_key(&current) {
+                continue;
+            }
+
+            let node = arena.get(current);
+            if !expanded {
+                work.push((current, true));
+                let mut children = Vec::new();
+                match node {
+                    SLTNode::Input { index, .. } => {
+                        children.extend(index.iter().map(|index| index.node));
+                    }
+                    SLTNode::Constant(..) => {}
+                    SLTNode::Binary(lhs, _, rhs) => children.extend([*lhs, *rhs]),
+                    SLTNode::Unary(_, inner) => children.push(*inner),
+                    SLTNode::Mux {
+                        cond,
+                        then_expr,
+                        else_expr,
+                    } => children.extend([*cond, *then_expr, *else_expr]),
+                    SLTNode::ForFold {
+                        start,
+                        end,
+                        result,
+                        initials,
+                        updates,
+                        effects,
+                        continue_cond,
+                        ..
+                    } => {
+                        // Keep the same child order as the former recursive
+                        // implementation so mapped NodeIds remain stable.
+                        children.extend(initials.iter().map(|update| update.expr));
+                        children.extend(updates.iter().map(|update| update.expr));
+                        for effect in effects {
+                            children.extend(effect.guard);
+                            children.extend(effect.args.iter().copied());
+                        }
+                        if let SLTForFoldResult::Transient { initial, update } = result {
+                            children.extend([*initial, *update]);
+                        }
+                        if let SLTLoopBound::Expr(node) = start {
+                            children.push(*node);
+                        }
+                        if let SLTLoopBound::Expr(node) = end {
+                            children.push(*node);
+                        }
+                        children.push(*continue_cond);
+                    }
+                    SLTNode::ForFoldGroup {
+                        entry_guard,
+                        states,
+                        ..
+                    } => {
+                        for state in states {
+                            children.extend([state.initial, state.update]);
+                        }
+                        children.push(*entry_guard);
+                    }
+                    SLTNode::Concat(parts) => {
+                        children.extend(parts.iter().map(|(node, _)| *node));
+                    }
+                    SLTNode::Slice { expr, .. } => children.push(*expr),
+                }
+                work.extend(children.into_iter().rev().map(|child| (child, false)));
+                continue;
+            }
+
+            let mapped = |child: NodeId| {
+                *cache
+                    .get(&child)
+                    .expect("postorder address mapping must visit children before parents")
+            };
+            let new_node = match node {
+                // Leaf: Transform address A to B
+                SLTNode::Input {
+                    variable: addr,
+                    signed,
+                    index,
+                    access,
+                } => {
+                    let mapped_index = index
+                        .iter()
+                        .map(|idx| SLTIndex {
+                            node: mapped(idx.node),
                             stride: idx.stride,
                             kind: idx.kind,
                         })
-                    })
-                    .collect::<Result<Vec<_>, SLTNodeFactsError>>()?;
-                SLTNode::Input {
-                    variable: f(addr),
-                    signed: *signed,
-                    index: mapped_index,
-                    access: *access,
-                }
-            }
-
-            // Leaf: Constants remain unchanged
-            SLTNode::Constant(val, mask, width, signed) => {
-                SLTNode::Constant(val.clone(), mask.clone(), *width, *signed)
-            }
-
-            // Recursive cases
-            SLTNode::Binary(lhs, op, rhs) => {
-                let l = arena
-                    .get(*lhs)
-                    .map_addr(*lhs, arena, target_arena, cache, f)?;
-                let r = arena
-                    .get(*rhs)
-                    .map_addr(*rhs, arena, target_arena, cache, f)?;
-                SLTNode::Binary(l, *op, r)
-            }
-
-            SLTNode::Unary(op, inner) => {
-                let i = arena
-                    .get(*inner)
-                    .map_addr(*inner, arena, target_arena, cache, f)?;
-                SLTNode::Unary(*op, i)
-            }
-
-            SLTNode::Mux {
-                cond,
-                then_expr,
-                else_expr,
-            } => {
-                let c = arena
-                    .get(*cond)
-                    .map_addr(*cond, arena, target_arena, cache, f)?;
-                let t =
-                    arena
-                        .get(*then_expr)
-                        .map_addr(*then_expr, arena, target_arena, cache, f)?;
-                let e =
-                    arena
-                        .get(*else_expr)
-                        .map_addr(*else_expr, arena, target_arena, cache, f)?;
-                SLTNode::Mux {
-                    cond: c,
-                    then_expr: t,
-                    else_expr: e,
-                }
-            }
-
-            SLTNode::ForFold {
-                loop_var,
-                loop_width,
-                loop_signed,
-                start,
-                end,
-                inclusive,
-                step,
-                step_op,
-                reverse,
-                result,
-                initials,
-                updates,
-                effects,
-                continue_cond,
-            } => {
-                let map_bound = |bound: &SLTLoopBound,
-                                 cache: &mut HashMap<NodeId, NodeId>,
-                                 target_arena: &mut SLTNodeArena<B>|
-                 -> Result<SLTLoopBound, SLTNodeFactsError> {
-                    match bound {
-                        SLTLoopBound::Const(v) => Ok(SLTLoopBound::Const(*v)),
-                        SLTLoopBound::Expr(node) => Ok(SLTLoopBound::Expr(
-                            arena
-                                .get(*node)
-                                .map_addr(*node, arena, target_arena, cache, f)?,
-                        )),
+                        .collect();
+                    SLTNode::Input {
+                        variable: f(addr),
+                        signed: *signed,
+                        index: mapped_index,
+                        access: *access,
                     }
-                };
-                let mapped_initials = initials
-                    .iter()
-                    .map(|update| {
-                        Ok(SLTForUpdate {
+                }
+
+                // Leaf: Constants remain unchanged
+                SLTNode::Constant(val, mask, width, signed) => {
+                    SLTNode::Constant(val.clone(), mask.clone(), *width, *signed)
+                }
+
+                // Recursive cases
+                SLTNode::Binary(lhs, op, rhs) => SLTNode::Binary(mapped(*lhs), *op, mapped(*rhs)),
+
+                SLTNode::Unary(op, inner) => SLTNode::Unary(*op, mapped(*inner)),
+
+                SLTNode::Mux {
+                    cond,
+                    then_expr,
+                    else_expr,
+                } => SLTNode::Mux {
+                    cond: mapped(*cond),
+                    then_expr: mapped(*then_expr),
+                    else_expr: mapped(*else_expr),
+                },
+
+                SLTNode::ForFold {
+                    loop_var,
+                    loop_width,
+                    loop_signed,
+                    start,
+                    end,
+                    inclusive,
+                    step,
+                    step_op,
+                    reverse,
+                    result,
+                    initials,
+                    updates,
+                    effects,
+                    continue_cond,
+                } => {
+                    let map_bound = |bound: &SLTLoopBound| -> SLTLoopBound {
+                        match bound {
+                            SLTLoopBound::Const(v) => SLTLoopBound::Const(*v),
+                            SLTLoopBound::Expr(node) => SLTLoopBound::Expr(mapped(*node)),
+                        }
+                    };
+                    let mapped_initials = initials
+                        .iter()
+                        .map(|update| SLTForUpdate {
                             target: VarAtomBase::new(
                                 f(&update.target.id),
                                 update.target.access.lsb,
                                 update.target.access.msb,
                             ),
-                            expr: arena.get(update.expr).map_addr(
-                                update.expr,
-                                arena,
-                                target_arena,
-                                cache,
-                                f,
-                            )?,
+                            expr: mapped(update.expr),
                         })
-                    })
-                    .collect::<Result<Vec<_>, SLTNodeFactsError>>()?;
-                let mapped_updates = updates
-                    .iter()
-                    .map(|update| {
-                        Ok(SLTForUpdate {
+                        .collect();
+                    let mapped_updates = updates
+                        .iter()
+                        .map(|update| SLTForUpdate {
                             target: VarAtomBase::new(
                                 f(&update.target.id),
                                 update.target.access.lsb,
                                 update.target.access.msb,
                             ),
-                            expr: arena.get(update.expr).map_addr(
-                                update.expr,
-                                arena,
-                                target_arena,
-                                cache,
-                                f,
-                            )?,
+                            expr: mapped(update.expr),
                         })
-                    })
-                    .collect::<Result<Vec<_>, SLTNodeFactsError>>()?;
-                let mapped_effects = effects
-                    .iter()
-                    .map(|effect| {
-                        let guard = effect
-                            .guard
-                            .map(|guard| {
-                                arena
-                                    .get(guard)
-                                    .map_addr(guard, arena, target_arena, cache, f)
-                            })
-                            .transpose()?;
-                        let args = effect
-                            .args
-                            .iter()
-                            .map(|arg| {
-                                arena
-                                    .get(*arg)
-                                    .map_addr(*arg, arena, target_arena, cache, f)
-                            })
-                            .collect::<Result<Vec<_>, SLTNodeFactsError>>()?;
-                        Ok(SLTForEffect {
-                            site_id: effect.site_id,
-                            guard,
-                            emit_on_true: effect.emit_on_true,
-                            args,
-                            fatal_error_code: effect.fatal_error_code,
+                        .collect();
+                    let mapped_effects = effects
+                        .iter()
+                        .map(|effect| {
+                            let guard = effect.guard.map(mapped);
+                            let args = effect.args.iter().map(|arg| mapped(*arg)).collect();
+                            SLTForEffect {
+                                site_id: effect.site_id,
+                                guard,
+                                emit_on_true: effect.emit_on_true,
+                                args,
+                                fatal_error_code: effect.fatal_error_code,
+                            }
                         })
-                    })
-                    .collect::<Result<Vec<_>, SLTNodeFactsError>>()?;
-                let mapped_result =
-                    match result {
+                        .collect();
+                    let mapped_result = match result {
                         SLTForFoldResult::State(result) => SLTForFoldResult::State(
                             VarAtomBase::new(f(&result.id), result.access.lsb, result.access.msb),
                         ),
                         SLTForFoldResult::Transient { initial, update } => {
                             SLTForFoldResult::Transient {
-                                initial: arena.get(*initial).map_addr(
-                                    *initial,
-                                    arena,
-                                    target_arena,
-                                    cache,
-                                    f,
-                                )?,
-                                update: arena.get(*update).map_addr(
-                                    *update,
-                                    arena,
-                                    target_arena,
-                                    cache,
-                                    f,
-                                )?,
+                                initial: mapped(*initial),
+                                update: mapped(*update),
                             }
                         }
                     };
-                SLTNode::ForFold {
-                    loop_var: f(loop_var),
-                    loop_width: *loop_width,
-                    loop_signed: *loop_signed,
-                    start: map_bound(start, cache, target_arena)?,
-                    end: map_bound(end, cache, target_arena)?,
-                    inclusive: *inclusive,
-                    step: *step,
-                    step_op: *step_op,
-                    reverse: *reverse,
-                    result: mapped_result,
-                    initials: mapped_initials,
-                    updates: mapped_updates,
-                    effects: mapped_effects,
-                    continue_cond: arena.get(*continue_cond).map_addr(
-                        *continue_cond,
-                        arena,
-                        target_arena,
-                        cache,
-                        f,
-                    )?,
+                    SLTNode::ForFold {
+                        loop_var: f(loop_var),
+                        loop_width: *loop_width,
+                        loop_signed: *loop_signed,
+                        start: map_bound(start),
+                        end: map_bound(end),
+                        inclusive: *inclusive,
+                        step: *step,
+                        step_op: *step_op,
+                        reverse: *reverse,
+                        result: mapped_result,
+                        initials: mapped_initials,
+                        updates: mapped_updates,
+                        effects: mapped_effects,
+                        continue_cond: mapped(*continue_cond),
+                    }
                 }
-            }
 
-            SLTNode::ForFoldGroup {
-                loop_var,
-                loop_width,
-                loop_signed,
-                start,
-                step,
-                trip_count,
-                entry_guard,
-                states,
-            } => {
-                let mapped_states = states
-                    .iter()
-                    .map(|state| {
-                        Ok(SLTForFoldGroupState {
+                SLTNode::ForFoldGroup {
+                    loop_var,
+                    loop_width,
+                    loop_signed,
+                    start,
+                    step,
+                    trip_count,
+                    entry_guard,
+                    states,
+                } => {
+                    let mapped_states = states
+                        .iter()
+                        .map(|state| SLTForFoldGroupState {
                             target: VarAtomBase::new(
                                 f(&state.target.id),
                                 state.target.access.lsb,
                                 state.target.access.msb,
                             ),
-                            initial: arena.get(state.initial).map_addr(
-                                state.initial,
-                                arena,
-                                target_arena,
-                                cache,
-                                f,
-                            )?,
-                            update: arena.get(state.update).map_addr(
-                                state.update,
-                                arena,
-                                target_arena,
-                                cache,
-                                f,
-                            )?,
+                            initial: mapped(state.initial),
+                            update: mapped(state.update),
                         })
-                    })
-                    .collect::<Result<Vec<_>, SLTNodeFactsError>>()?;
-                SLTNode::ForFoldGroup {
-                    loop_var: f(loop_var),
-                    loop_width: *loop_width,
-                    loop_signed: *loop_signed,
-                    start: start.clone(),
-                    step: step.clone(),
-                    trip_count: *trip_count,
-                    entry_guard: arena.get(*entry_guard).map_addr(
-                        *entry_guard,
-                        arena,
-                        target_arena,
-                        cache,
-                        f,
-                    )?,
-                    states: mapped_states,
+                        .collect();
+                    SLTNode::ForFoldGroup {
+                        loop_var: f(loop_var),
+                        loop_width: *loop_width,
+                        loop_signed: *loop_signed,
+                        start: start.clone(),
+                        step: step.clone(),
+                        trip_count: *trip_count,
+                        entry_guard: mapped(*entry_guard),
+                        states: mapped_states,
+                    }
                 }
-            }
 
-            SLTNode::Concat(parts) => {
-                let mapped_parts = parts
-                    .iter()
-                    .map(|(node, width)| {
-                        Ok((
-                            arena
-                                .get(*node)
-                                .map_addr(*node, arena, target_arena, cache, f)?,
-                            *width,
-                        ))
-                    })
-                    .collect::<Result<Vec<_>, SLTNodeFactsError>>()?;
-                SLTNode::Concat(mapped_parts)
-            }
+                SLTNode::Concat(parts) => {
+                    let mapped_parts = parts
+                        .iter()
+                        .map(|(node, width)| (mapped(*node), *width))
+                        .collect();
+                    SLTNode::Concat(mapped_parts)
+                }
 
-            SLTNode::Slice { expr, access } => {
-                let e = arena
-                    .get(*expr)
-                    .map_addr(*expr, arena, target_arena, cache, f)?;
-                SLTNode::Slice {
-                    expr: e,
+                SLTNode::Slice { expr, access } => SLTNode::Slice {
+                    expr: mapped(*expr),
                     access: *access,
-                }
-            }
-        };
-        let new_id = target_arena.alloc(new_node)?;
-        cache.insert(id, new_id);
-        Ok(new_id)
+                },
+            };
+            let new_id = target_arena.alloc(new_node)?;
+            cache.insert(current, new_id);
+        }
+
+        Ok(*cache
+            .get(&id)
+            .expect("root must be mapped after postorder traversal"))
     }
 }
 
@@ -1610,6 +1569,45 @@ mod tests {
                 .width(mapped_group),
             Some(12)
         );
+    }
+
+    #[test]
+    fn map_addr_handles_deep_expression_without_using_the_call_stack() {
+        const DEPTH: usize = 10_000;
+
+        let mut arena = SLTNodeArena::<u32>::new();
+        let mut root = arena
+            .alloc(SLTNode::Input {
+                variable: 42,
+                signed: false,
+                index: Vec::new(),
+                access: BitAccess::new(0, 0),
+            })
+            .unwrap();
+        for _ in 0..DEPTH {
+            root = arena.alloc(SLTNode::Unary(UnaryOp::Ident, root)).unwrap();
+        }
+
+        let mut mapped_arena = SLTNodeArena::<u64>::new();
+        let mut cache = crate::HashMap::default();
+        let mut mapped = arena
+            .get(root)
+            .map_addr(root, &arena, &mut mapped_arena, &mut cache, &|address| {
+                u64::from(*address) + 1
+            })
+            .unwrap();
+
+        assert_eq!(cache.len(), DEPTH + 1);
+        for _ in 0..DEPTH {
+            let SLTNode::Unary(UnaryOp::Ident, inner) = mapped_arena.get(mapped) else {
+                panic!("mapped expression must preserve every unary node");
+            };
+            mapped = *inner;
+        }
+        let SLTNode::Input { variable, .. } = mapped_arena.get(mapped) else {
+            panic!("mapped expression must end in its input");
+        };
+        assert_eq!(*variable, 43);
     }
 
     #[test]

--- a/crates/celox-slt/src/node_facts.rs
+++ b/crates/celox-slt/src/node_facts.rs
@@ -596,11 +596,18 @@ where
             };
 
             for effect in effects {
-                if let Some(guard) = effect.guard {
-                    require_nonzero_child(guard, "ForFold effect guard")?;
-                }
-                for &arg in &effect.args {
-                    require_nonzero_child(arg, "ForFold effect argument")?;
+                match effect {
+                    crate::SLTForEffect::Event { guard, args, .. } => {
+                        if let Some(guard) = guard {
+                            require_nonzero_child(*guard, "ForFold effect guard")?;
+                        }
+                        for &arg in args {
+                            require_nonzero_child(arg, "ForFold effect argument")?;
+                        }
+                    }
+                    crate::SLTForEffect::Runner(runner) => {
+                        require_nonzero_child(*runner, "ForFold effect runner")?;
+                    }
                 }
             }
             require_nonzero_child(*continue_cond, "ForFold continue condition")?;
@@ -858,11 +865,16 @@ where
                 visit(update.expr)?;
             }
             for effect in effects {
-                if let Some(guard) = effect.guard {
-                    visit(guard)?;
-                }
-                for &arg in &effect.args {
-                    visit(arg)?;
+                match effect {
+                    crate::SLTForEffect::Event { guard, args, .. } => {
+                        if let Some(guard) = guard {
+                            visit(*guard)?;
+                        }
+                        for &arg in args {
+                            visit(arg)?;
+                        }
+                    }
+                    crate::SLTForEffect::Runner(runner) => visit(*runner)?,
                 }
             }
             visit(*continue_cond)?;
@@ -1208,7 +1220,7 @@ mod tests {
         let SLTNode::ForFold { effects, .. } = &mut node else {
             unreachable!()
         };
-        effects.push(SLTForEffect {
+        effects.push(SLTForEffect::Event {
             site_id: 0,
             guard: Some(NodeId(2)),
             emit_on_true: true,
@@ -1400,7 +1412,7 @@ mod tests {
         let SLTNode::ForFold { effects, .. } = &mut effectful else {
             unreachable!()
         };
-        effects.push(SLTForEffect {
+        effects.push(SLTForEffect::Event {
             site_id: 7,
             guard: None,
             emit_on_true: true,

--- a/crates/celox-slt/src/node_facts.rs
+++ b/crates/celox-slt/src/node_facts.rs
@@ -213,7 +213,25 @@ where
         }
         SLTNode::ForFold { result, .. } => {
             try_for_each_child(node, |child| child_width(child).map(|_| ()))?;
-            checked_access_width(node_id, result.access, "ForFold result")
+            match result {
+                crate::SLTForFoldResult::State(result) => {
+                    checked_access_width(node_id, result.access, "ForFold result")
+                }
+                crate::SLTForFoldResult::Transient { initial, update } => {
+                    let initial_width = child_width(*initial)?;
+                    let update_width = child_width(*update)?;
+                    if initial_width != update_width {
+                        return Err(SLTNodeFactsError::new(
+                            "FOR_FOLD.TRANSIENT_RESULT_WIDTH_MATCHES",
+                            node_id,
+                            format!(
+                                "ForFold transient result initial width {initial_width} does not equal update width {update_width}"
+                            ),
+                        ));
+                    }
+                    Ok(initial_width)
+                }
+            }
         }
         SLTNode::ForFoldGroup { states, .. } => {
             try_for_each_child(node, |child| child_width(child).map(|_| ()))?;
@@ -542,18 +560,40 @@ where
                 }
             }
 
-            checked_access_width(node_id, result.access, "ForFold result")?;
-            let result_count = updates
-                .iter()
-                .filter(|update| update.target == *result)
-                .count();
-            if result_count != 1 {
-                return Err(SLTNodeFactsError::new(
-                    "FOR_FOLD.RESULT_TARGET_UNIQUE",
-                    node_id,
-                    format!("ForFold result occurs {result_count} times in its update targets"),
-                ));
-            }
+            let result_width = match result {
+                crate::SLTForFoldResult::State(result) => {
+                    let width = checked_access_width(node_id, result.access, "ForFold result")?;
+                    let result_count = updates
+                        .iter()
+                        .filter(|update| update.target == *result)
+                        .count();
+                    if result_count != 1 {
+                        return Err(SLTNodeFactsError::new(
+                            "FOR_FOLD.RESULT_TARGET_UNIQUE",
+                            node_id,
+                            format!(
+                                "ForFold result occurs {result_count} times in its update targets"
+                            ),
+                        ));
+                    }
+                    width
+                }
+                crate::SLTForFoldResult::Transient { initial, update } => {
+                    let initial_width =
+                        require_nonzero_child(*initial, "ForFold transient initial")?;
+                    let update_width = require_nonzero_child(*update, "ForFold transient update")?;
+                    if initial_width != update_width {
+                        return Err(SLTNodeFactsError::new(
+                            "FOR_FOLD.TRANSIENT_RESULT_WIDTH_MATCHES",
+                            node_id,
+                            format!(
+                                "ForFold transient result initial width {initial_width} does not equal update width {update_width}"
+                            ),
+                        ));
+                    }
+                    initial_width
+                }
+            };
 
             for effect in effects {
                 if let Some(guard) = effect.guard {
@@ -564,7 +604,7 @@ where
                 }
             }
             require_nonzero_child(*continue_cond, "ForFold continue condition")?;
-            checked_access_width(node_id, result.access, "ForFold result")
+            Ok(result_width)
         }
         SLTNode::ForFoldGroup {
             loop_var,
@@ -794,6 +834,7 @@ where
         SLTNode::ForFold {
             start,
             end,
+            result,
             initials,
             updates,
             effects,
@@ -805,6 +846,10 @@ where
             }
             if let SLTLoopBound::Expr(node) = end {
                 visit(*node)?;
+            }
+            if let crate::SLTForFoldResult::Transient { initial, update } = result {
+                visit(*initial)?;
+                visit(*update)?;
             }
             for initial in initials {
                 visit(initial.expr)?;
@@ -850,7 +895,9 @@ mod tests {
     use celox_design::{BinaryOp, UnaryOp, VarAtomBase};
 
     use super::*;
-    use crate::node::{SLTForEffect, SLTForFoldGroupState, SLTForUpdate, SLTStepOp};
+    use crate::node::{
+        SLTForEffect, SLTForFoldGroupState, SLTForFoldResult, SLTForUpdate, SLTStepOp,
+    };
 
     fn arena(nodes: Vec<SLTNode<u32>>) -> SLTNodeArena<u32> {
         SLTNodeArena::try_from_nodes(nodes).expect("test node graph must verify")
@@ -876,7 +923,7 @@ mod tests {
             step: 1,
             step_op: SLTStepOp::Add,
             reverse: false,
-            result: target,
+            result: SLTForFoldResult::State(target),
             initials: vec![SLTForUpdate {
                 target,
                 expr: NodeId(0),
@@ -1106,10 +1153,33 @@ mod tests {
         let SLTNode::ForFold { result, .. } = &mut node else {
             unreachable!()
         };
-        *result = VarAtomBase::new(3, 0, 7);
+        *result = SLTForFoldResult::State(VarAtomBase::new(3, 0, 7));
         assert_eq!(
             verify_for_fold(node).unwrap_err().invariant,
             "FOR_FOLD.RESULT_TARGET_UNIQUE"
+        );
+
+        let mut transient = valid_for_fold();
+        let SLTNode::ForFold { result, .. } = &mut transient else {
+            unreachable!()
+        };
+        *result = SLTForFoldResult::Transient {
+            initial: NodeId(1),
+            update: NodeId(1),
+        };
+        verify_for_fold(transient).expect("transient ForFold result must verify");
+
+        let mut mismatched_transient = valid_for_fold();
+        let SLTNode::ForFold { result, .. } = &mut mismatched_transient else {
+            unreachable!()
+        };
+        *result = SLTForFoldResult::Transient {
+            initial: NodeId(0),
+            update: NodeId(1),
+        };
+        assert_eq!(
+            verify_for_fold(mismatched_transient).unwrap_err().invariant,
+            "FOR_FOLD.TRANSIENT_RESULT_WIDTH_MATCHES"
         );
 
         let mut node = valid_for_fold();
@@ -1414,7 +1484,7 @@ mod tests {
             step: 1,
             step_op: SLTStepOp::Add,
             reverse: false,
-            result: target,
+            result: SLTForFoldResult::State(target),
             initials: vec![SLTForUpdate {
                 target,
                 expr: NodeId(1),
@@ -1444,7 +1514,7 @@ mod tests {
                 step: 1,
                 step_op: SLTStepOp::Add,
                 reverse: false,
-                result: VarAtomBase::new(2, 7, 3),
+                result: SLTForFoldResult::State(VarAtomBase::new(2, 7, 3)),
                 initials: vec![SLTForUpdate {
                     target: VarAtomBase::new(2, 0, 0),
                     expr: NodeId(0),

--- a/crates/celox-slt/src/scheduler.rs
+++ b/crates/celox-slt/src/scheduler.rs
@@ -228,8 +228,13 @@ fn node_reads_only_covered_ranges<Addr: Clone + Eq + Hash>(
                 work.extend(initials.iter().map(|state| state.expr));
                 work.extend(updates.iter().map(|state| state.expr));
                 for effect in effects {
-                    work.extend(effect.guard);
-                    work.extend(effect.args.iter().copied());
+                    match effect {
+                        crate::SLTForEffect::Event { guard, args, .. } => {
+                            work.extend(*guard);
+                            work.extend(args.iter().copied());
+                        }
+                        crate::SLTForEffect::Runner(runner) => work.push(*runner),
+                    }
                 }
                 work.push(*continue_cond);
             }
@@ -353,11 +358,18 @@ fn collect_node_input_deps<Addr: Clone + Eq + Hash + Debug + Copy + Display>(
                 ));
             }
             for effect in effects {
-                if let Some(guard) = effect.guard {
-                    set.extend(collect_node_input_deps(guard, arena, memo, inverse_memo));
-                }
-                for arg in &effect.args {
-                    set.extend(collect_node_input_deps(*arg, arena, memo, inverse_memo));
+                match effect {
+                    crate::SLTForEffect::Event { guard, args, .. } => {
+                        if let Some(guard) = guard {
+                            set.extend(collect_node_input_deps(*guard, arena, memo, inverse_memo));
+                        }
+                        for arg in args {
+                            set.extend(collect_node_input_deps(*arg, arena, memo, inverse_memo));
+                        }
+                    }
+                    crate::SLTForEffect::Runner(runner) => {
+                        set.extend(collect_node_input_deps(*runner, arena, memo, inverse_memo));
+                    }
                 }
             }
             set.remove(loop_var);
@@ -1188,8 +1200,13 @@ fn push_scheduler_node_children<Addr: Clone + Eq + Hash>(
             work.extend(initials.iter().map(|state| state.expr));
             work.extend(updates.iter().map(|state| state.expr));
             for effect in effects {
-                work.extend(effect.guard);
-                work.extend(effect.args.iter().copied());
+                match effect {
+                    crate::SLTForEffect::Event { guard, args, .. } => {
+                        work.extend(*guard);
+                        work.extend(args.iter().copied());
+                    }
+                    crate::SLTForEffect::Runner(runner) => work.push(*runner),
+                }
             }
             work.push(*continue_cond);
         }

--- a/crates/celox-slt/src/scheduler.rs
+++ b/crates/celox-slt/src/scheduler.rs
@@ -208,6 +208,7 @@ fn node_reads_only_covered_ranges<Addr: Clone + Eq + Hash>(
             SLTNode::ForFold {
                 start,
                 end,
+                result,
                 initials,
                 updates,
                 effects,
@@ -219,6 +220,10 @@ fn node_reads_only_covered_ranges<Addr: Clone + Eq + Hash>(
                 }
                 if let crate::SLTLoopBound::Expr(node) = end {
                     work.push(*node);
+                }
+                if let crate::SLTForFoldResult::Transient { initial, update } = result {
+                    work.push(*initial);
+                    work.push(*update);
                 }
                 work.extend(initials.iter().map(|state| state.expr));
                 work.extend(updates.iter().map(|state| state.expr));
@@ -307,6 +312,7 @@ fn collect_node_input_deps<Addr: Clone + Eq + Hash + Debug + Copy + Display>(
             loop_var,
             start,
             end,
+            result,
             initials,
             updates,
             effects,
@@ -325,6 +331,10 @@ fn collect_node_input_deps<Addr: Clone + Eq + Hash + Debug + Copy + Display>(
                 crate::SLTLoopBound::Expr(node) => {
                     set.extend(collect_node_input_deps(*node, arena, memo, inverse_memo));
                 }
+            }
+            if let crate::SLTForFoldResult::Transient { initial, update } = result {
+                set.extend(collect_node_input_deps(*initial, arena, memo, inverse_memo));
+                set.extend(collect_node_input_deps(*update, arena, memo, inverse_memo));
             }
             for init in initials {
                 set.extend(collect_node_input_deps(
@@ -1158,6 +1168,7 @@ fn push_scheduler_node_children<Addr: Clone + Eq + Hash>(
         SLTNode::ForFold {
             start,
             end,
+            result,
             initials,
             updates,
             effects,
@@ -1169,6 +1180,10 @@ fn push_scheduler_node_children<Addr: Clone + Eq + Hash>(
             }
             if let crate::SLTLoopBound::Expr(node) = end {
                 work.push(*node);
+            }
+            if let crate::SLTForFoldResult::Transient { initial, update } = result {
+                work.push(*initial);
+                work.push(*update);
             }
             work.extend(initials.iter().map(|state| state.expr));
             work.extend(updates.iter().map(|state| state.expr));

--- a/crates/celox-slt/src/symbolic_verify.rs
+++ b/crates/celox-slt/src/symbolic_verify.rs
@@ -119,7 +119,9 @@ where
                         ),
                     ));
                 }
-                verify_atom(&result.id, result.access, "ForFold result", node_id)?;
+                if let crate::SLTForFoldResult::State(result) = result {
+                    verify_atom(&result.id, result.access, "ForFold result", node_id)?;
+                }
                 for update in initials.iter().chain(updates) {
                     verify_atom(
                         &update.target.id,
@@ -387,7 +389,7 @@ mod tests {
                 step: 1,
                 step_op: SLTStepOp::Add,
                 reverse: false,
-                result: target,
+                result: crate::SLTForFoldResult::State(target),
                 initials: vec![SLTForUpdate {
                     target,
                     expr: value,

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -1702,6 +1702,214 @@ module Top (
     );
 }
 
+fn test_return_before_dynamic_loop_suppresses_loop_effects(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    a: input logic<8>,
+    stop_before: input logic,
+    stop_in_loop: input logic,
+    count: input logic<2>,
+    out: output logic<8>,
+) {
+    function pass (
+        x: input logic<8>,
+        stop_before: input logic,
+        stop_in_loop: input logic,
+        count: input logic<2>,
+    ) -> logic<8> {
+        if stop_before {
+            return x;
+        }
+        for i in 0..count {
+            $display("loop=%0d", i);
+            $assert(1'd0, "loop must stay inactive");
+            if stop_in_loop && i == 1 {
+                return x + i;
+            }
+        }
+        return x;
+    }
+
+    always_comb {
+        out = pass(a, stop_before, stop_in_loop, count);
+    }
+}
+"#, "Top");
+
+    let a = sim.signal("a");
+    let stop_before = sim.signal("stop_before");
+    let stop_in_loop = sim.signal("stop_in_loop");
+    let count = sim.signal("count");
+    let out = sim.signal("out");
+
+    sim.drain_runtime_events();
+
+    sim.modify(|io| {
+        io.set(a, 7u8);
+        io.set(stop_before, 1u8);
+        io.set(stop_in_loop, 1u8);
+        io.set(count, 3u8);
+    }).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 7);
+    assert_eq!(sim.drain_runtime_events(), vec![]);
+}
+
+fn test_function_loop_with_return_and_break_preserves_effects(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    a: input logic<8>,
+    stop: input logic,
+    out: output logic<8>,
+) {
+    function pass (
+        x: input logic<8>,
+        stop: input logic,
+    ) -> logic<8> {
+        for i in 0..4 {
+            if i == 2 {
+                break;
+            }
+            $display("loop=%0d", i);
+            if stop && i == 1 {
+                return x + i;
+            }
+        }
+        return x;
+    }
+
+    always_comb {
+        out = pass(a, stop);
+    }
+}
+"#, "Top");
+
+    let a = sim.signal("a");
+    let stop = sim.signal("stop");
+    let out = sim.signal("out");
+
+    sim.drain_runtime_events();
+
+    sim.modify(|io| {
+        io.set(a, 9u8);
+        io.set(stop, 0u8);
+    }).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 9);
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![
+            celox::RuntimeEvent::Display {
+                message: "loop=0".to_string(),
+            },
+            celox::RuntimeEvent::Display {
+                message: "loop=1".to_string(),
+            },
+        ],
+    );
+
+}
+
+fn test_nested_dynamic_function_loops_preserve_effect_runners(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    a: input logic<8>,
+    stop: input logic,
+    outer_count: input logic<2>,
+    inner_count: input logic<2>,
+    out: output logic<8>,
+) {
+    function pass (
+        x: input logic<8>,
+        stop: input logic,
+        outer_count: input logic<2>,
+        inner_count: input logic<2>,
+    ) -> logic<8> {
+        for i in 0..outer_count {
+            for j in 0..inner_count {
+                $display("inner=%0d,%0d", i, j);
+                if stop && i == 1 && j == 1 {
+                    return x + i + j;
+                }
+            }
+            $display("outer=%0d", i);
+        }
+        return x;
+    }
+
+    always_comb {
+        out = pass(a, stop, outer_count, inner_count);
+    }
+}
+"#, "Top");
+
+    let a = sim.signal("a");
+    let stop = sim.signal("stop");
+    let outer_count = sim.signal("outer_count");
+    let inner_count = sim.signal("inner_count");
+    let out = sim.signal("out");
+
+    sim.drain_runtime_events();
+
+    sim.modify(|io| {
+        io.set(a, 11u8);
+        io.set(stop, 0u8);
+        io.set(outer_count, 2u8);
+        io.set(inner_count, 2u8);
+    }).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 11);
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![
+            celox::RuntimeEvent::Display {
+                message: "inner=0,0".to_string(),
+            },
+            celox::RuntimeEvent::Display {
+                message: "inner=0,1".to_string(),
+            },
+            celox::RuntimeEvent::Display {
+                message: "outer=0".to_string(),
+            },
+            celox::RuntimeEvent::Display {
+                message: "inner=1,0".to_string(),
+            },
+            celox::RuntimeEvent::Display {
+                message: "inner=1,1".to_string(),
+            },
+            celox::RuntimeEvent::Display {
+                message: "outer=1".to_string(),
+            },
+        ],
+    );
+
+    sim.modify(|io| io.set(stop, 1u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 13);
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![
+            celox::RuntimeEvent::Display {
+                message: "inner=0,0".to_string(),
+            },
+            celox::RuntimeEvent::Display {
+                message: "inner=0,1".to_string(),
+            },
+            celox::RuntimeEvent::Display {
+                message: "outer=0".to_string(),
+            },
+            celox::RuntimeEvent::Display {
+                message: "inner=1,0".to_string(),
+            },
+            celox::RuntimeEvent::Display {
+                message: "inner=1,1".to_string(),
+            },
+        ],
+    );
+}
+
 fn test_comb_display_inside_expression_function_call(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -1558,6 +1558,150 @@ module Top (
     );
 }
 
+fn test_outputless_statement_call_after_conditional_return_stays_inactive(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    a: input logic<8>,
+    stop: input logic,
+    out: output logic<8>,
+) {
+    function notify (
+        x: input logic<8>,
+    ) {
+        $display("notify=%0d", x);
+    }
+
+    function touch (
+        x: input logic<8>,
+    ) {
+        if x == 8'hff {
+            $display("touch");
+        }
+    }
+
+    function pass (
+        x: input logic<8>,
+        stop_early: input logic,
+    ) -> logic<8> {
+        var tmp: logic<8>;
+        if stop_early {
+            return x;
+        }
+        tmp = x;
+        touch(tmp);
+        notify(tmp);
+        return tmp;
+    }
+
+    always_comb {
+        out = pass(a, stop);
+    }
+}
+"#, "Top");
+
+    let a = sim.signal("a");
+    let stop = sim.signal("stop");
+    let out = sim.signal("out");
+
+    sim.drain_runtime_events();
+
+    sim.modify(|io| {
+        io.set(a, 5u8);
+        io.set(stop, 1u8);
+    }).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 5);
+    assert_eq!(sim.drain_runtime_events(), vec![]);
+
+    sim.modify(|io| io.set(stop, 0u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 5);
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "notify=5".to_string(),
+        }],
+    );
+}
+
+fn test_outputless_statement_call_after_loop_return_stays_inactive(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    a: input logic<8>,
+    stop: input logic,
+    count: input logic<2>,
+    out: output logic<8>,
+) {
+    function notify (
+        x: input logic<8>,
+    ) {
+        $display("notify=%0d", x);
+    }
+
+    function pass (
+        x: input logic<8>,
+        stop_early: input logic,
+        count: input logic<2>,
+    ) -> logic<8> {
+        for i in 0..count {
+            if stop_early && i == 1 {
+                return x + i;
+            }
+            notify(x + i);
+        }
+        notify(x);
+        return x;
+    }
+
+    always_comb {
+        out = pass(a, stop, count);
+    }
+}
+"#, "Top");
+
+    let a = sim.signal("a");
+    let stop = sim.signal("stop");
+    let count = sim.signal("count");
+    let out = sim.signal("out");
+
+    sim.drain_runtime_events();
+
+    sim.modify(|io| {
+        io.set(a, 7u8);
+        io.set(stop, 1u8);
+        io.set(count, 3u8);
+    }).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 8);
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "notify=7".to_string(),
+        }],
+    );
+
+    sim.modify(|io| io.set(stop, 0u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 7);
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![
+            celox::RuntimeEvent::Display {
+                message: "notify=7".to_string(),
+            },
+            celox::RuntimeEvent::Display {
+                message: "notify=8".to_string(),
+            },
+            celox::RuntimeEvent::Display {
+                message: "notify=9".to_string(),
+            },
+            celox::RuntimeEvent::Display {
+                message: "notify=7".to_string(),
+            },
+        ],
+    );
+}
+
 fn test_comb_display_inside_expression_function_call(sim) {
     @omit_veryl;
     @ignore_on(wasm);


### PR DESCRIPTION
## Summary

- allow combinational statement-form function calls without output arguments
- preserve function liveness when collecting runtime effects after conditional returns
- represent dynamic-loop return control as a transient `ForFold` result rather than a fabricated out-of-bounds variable bit
- stop loop effects, later iterations, and following calls after a function return
- map SLT addresses with iterative postorder traversal so deep expression graphs cannot overflow the host stack

## Root cause

The statement-call path rejected outputless calls before lowering them. Exercising the newly reachable effect path also exposed that conditional and loop returns could lose their liveness guard. In dynamic loops, return control was represented as a synthetic bit immediately past the declared variable width.

`ForFold` now distinguishes stored variable results from transient initial/update results, so the symbolic verifier remains strict for every real state target.

The larger `ForFold` representation also exposed a pre-existing stack-size dependency in recursive `SLTNode::map_addr`. Address mapping is now an explicit postorder traversal, covered by a 10,000-node deep-expression regression test.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p celox-slt` (140 passed)
- `cargo test --locked -p celox-frontend-veryl` (63 passed)
- `cargo test --locked -p celox --test loop_idiom` (5 passed)
- `cargo test --locked -p celox --test comb_observer outputless_statement_call_after_` (4 passed, 2 ignored)
- `cargo test --locked -p celox` (standard stack size)
- `cargo clippy --locked -p celox-slt -p celox-frontend-veryl -p celox --all-targets --no-deps -- -D warnings`
- pre-push hooks: submodule check, Biome, cargo fmt, cargo check, clean tree

Closes #58