### PR TITLE
fix(frontend): preserve fixed-width loop progress

### DIFF
--- a/crates/celox-frontend-veryl/src/ff.rs
+++ b/crates/celox-frontend-veryl/src/ff.rs
@@ -1426,9 +1426,10 @@ impl<'a> FfParser<'a> {
         };
 
         let init_reg = if reverse && !inclusive {
-            let reg = ir_builder.alloc_bit(compare_width, loop_signed);
-            ir_builder.emit(SIRInstruction::Binary(reg, end_reg, BinaryOp::Sub, one_reg));
-            reg
+            let raw = ir_builder.alloc_bit(compare_width, loop_signed);
+            ir_builder.emit(SIRInstruction::Binary(raw, end_reg, BinaryOp::Sub, one_reg));
+            let visible = self.cast_reg_width_ext(ir_builder, raw, loop_width, loop_signed);
+            self.cast_reg_width_ext(ir_builder, visible, compare_width, loop_signed)
         } else if reverse {
             end_reg
         } else {
@@ -1440,6 +1441,7 @@ impl<'a> FfParser<'a> {
         let body_counter = ir_builder.alloc_bit(compare_width, loop_signed);
         let needs_range_check = compare_width != loop_width;
         let precheck_bb = (!reverse && needs_range_check).then(|| ir_builder.new_block());
+        let reverse_precheck_bb = (reverse && needs_range_check).then(|| ir_builder.new_block());
         let empty_exit_counter = ir_builder.alloc_bit(compare_width, loop_signed);
         let empty_exit_check_bb =
             needs_range_check.then(|| ir_builder.new_block_with(vec![empty_exit_counter]));
@@ -1450,6 +1452,8 @@ impl<'a> FfParser<'a> {
         let exit_bb = ir_builder.new_block();
         if let Some(precheck_bb) = precheck_bb {
             ir_builder.seal_block(SIRTerminator::Jump(precheck_bb, vec![]));
+        } else if let Some(reverse_precheck_bb) = reverse_precheck_bb {
+            ir_builder.seal_block(SIRTerminator::Jump(reverse_precheck_bb, vec![]));
         } else {
             ir_builder.seal_block(SIRTerminator::Jump(header_bb, vec![init_reg]));
         }
@@ -1540,6 +1544,40 @@ impl<'a> FfParser<'a> {
                 cond: cond_reg,
                 true_block: (fitcheck_bb, vec![start_reg]),
                 false_block: (empty_exit_check_bb, vec![start_reg]),
+            });
+        }
+
+        if let (Some(reverse_precheck_bb), Some(range_error_bb)) =
+            (reverse_precheck_bb, range_error_bb)
+        {
+            ir_builder.switch_to_block(reverse_precheck_bb);
+            let start_fits = Self::emit_loop_value_fits(
+                ir_builder,
+                start_reg,
+                compare_width,
+                loop_width,
+                loop_signed,
+                false,
+            );
+            let end_fits = Self::emit_loop_value_fits(
+                ir_builder,
+                end_reg,
+                compare_width,
+                loop_width,
+                loop_signed,
+                false,
+            );
+            let bounds_fit = ir_builder.alloc_bit(1, false);
+            ir_builder.emit(SIRInstruction::Binary(
+                bounds_fit,
+                start_fits,
+                BinaryOp::LogicAnd,
+                end_fits,
+            ));
+            ir_builder.seal_block(SIRTerminator::Branch {
+                cond: bounds_fit,
+                true_block: (header_bb, vec![init_reg]),
+                false_block: (range_error_bb, vec![]),
             });
         }
 

--- a/crates/celox-frontend-veryl/src/ff.rs
+++ b/crates/celox-frontend-veryl/src/ff.rs
@@ -1565,7 +1565,7 @@ impl<'a> FfParser<'a> {
                 compare_width,
                 loop_width,
                 loop_signed,
-                false,
+                !inclusive,
             );
             let bounds_fit = ir_builder.alloc_bit(1, false);
             ir_builder.emit(SIRInstruction::Binary(

--- a/crates/celox-frontend-veryl/src/ff.rs
+++ b/crates/celox-frontend-veryl/src/ff.rs
@@ -1425,7 +1425,15 @@ impl<'a> FfParser<'a> {
             end_reg
         };
 
-        let init_reg = if reverse { end_reg } else { start_reg };
+        let init_reg = if reverse && !inclusive {
+            let reg = ir_builder.alloc_bit(compare_width, loop_signed);
+            ir_builder.emit(SIRInstruction::Binary(reg, end_reg, BinaryOp::Sub, one_reg));
+            reg
+        } else if reverse {
+            end_reg
+        } else {
+            start_reg
+        };
 
         let header_counter = ir_builder.alloc_bit(compare_width, loop_signed);
         let fitcheck_counter = ir_builder.alloc_bit(compare_width, loop_signed);
@@ -1537,109 +1545,23 @@ impl<'a> FfParser<'a> {
 
         ir_builder.switch_to_block(header_bb);
         if reverse {
-            if step == 0 {
-                let cmp_op = if loop_signed {
-                    if inclusive {
-                        BinaryOp::GeS
-                    } else {
-                        BinaryOp::GtS
-                    }
-                } else if inclusive {
+            let in_range = ir_builder.alloc_bit(1, false);
+            ir_builder.emit(SIRInstruction::Binary(
+                in_range,
+                header_counter,
+                if loop_signed {
+                    BinaryOp::GeS
+                } else {
                     BinaryOp::GeU
-                } else {
-                    BinaryOp::GtU
-                };
-                let in_range = ir_builder.alloc_bit(1, false);
-                ir_builder.emit(SIRInstruction::Binary(
-                    in_range,
-                    header_counter,
-                    cmp_op,
-                    start_reg,
-                ));
-                let singleton = if inclusive {
-                    let eq = ir_builder.alloc_bit(1, false);
-                    ir_builder.emit(SIRInstruction::Binary(
-                        eq,
-                        header_counter,
-                        BinaryOp::Eq,
-                        start_reg,
-                    ));
-                    Some(eq)
-                } else {
-                    None
-                };
-                let singleton_bb = singleton.map(|_| ir_builder.new_block());
-                let true_loop_bb = ir_builder.new_block();
-                let in_range_bb = ir_builder.new_block();
-                ir_builder.seal_block(SIRTerminator::Branch {
-                    cond: in_range,
-                    true_block: (in_range_bb, vec![]),
-                    false_block: empty_exit_check_bb
-                        .map_or((exit_bb, vec![]), |block| (block, vec![header_counter])),
-                });
-                ir_builder.switch_to_block(in_range_bb);
-                if let (Some(singleton), Some(singleton_bb)) = (singleton, singleton_bb) {
-                    ir_builder.seal_block(SIRTerminator::Branch {
-                        cond: singleton,
-                        true_block: (singleton_bb, vec![]),
-                        false_block: (true_loop_bb, vec![]),
-                    });
-                } else {
-                    ir_builder.seal_block(SIRTerminator::Jump(true_loop_bb, vec![]));
-                }
-                ir_builder.switch_to_block(true_loop_bb);
-                let error_code =
-                    self.runtime_error(non_progress_message.clone(), vec![stmt.var_id]);
-                ir_builder.seal_block(SIRTerminator::Error(error_code));
-                if let Some(singleton_bb) = singleton_bb {
-                    ir_builder.switch_to_block(singleton_bb);
-                    ir_builder.seal_block(SIRTerminator::Jump(fitcheck_bb, vec![header_counter]));
-                }
-            } else {
-                let loop_math =
-                    self.cast_reg_width_ext(ir_builder, header_counter, math_width, loop_signed);
-                let start_math =
-                    self.cast_reg_width_ext(ir_builder, start_reg, math_width, loop_signed);
-                let step_reg = ir_builder.alloc_bit(math_width, loop_signed);
-                ir_builder.emit(SIRInstruction::Imm(step_reg, SIRValue::new(step as u64)));
-                let threshold_reg = ir_builder.alloc_bit(math_width, loop_signed);
-                ir_builder.emit(SIRInstruction::Binary(
-                    threshold_reg,
-                    start_math,
-                    BinaryOp::Add,
-                    step_reg,
-                ));
-                let cond_lhs = if inclusive { start_math } else { threshold_reg };
-                let cond_reg = ir_builder.alloc_bit(1, false);
-                ir_builder.emit(SIRInstruction::Binary(
-                    cond_reg,
-                    loop_math,
-                    if loop_signed {
-                        BinaryOp::GeS
-                    } else {
-                        BinaryOp::GeU
-                    },
-                    cond_lhs,
-                ));
-                let body_counter_reg = if inclusive {
-                    header_counter
-                } else {
-                    let body_math = ir_builder.alloc_bit(math_width, loop_signed);
-                    ir_builder.emit(SIRInstruction::Binary(
-                        body_math,
-                        loop_math,
-                        BinaryOp::Sub,
-                        step_reg,
-                    ));
-                    self.cast_reg_width_ext(ir_builder, body_math, compare_width, loop_signed)
-                };
-                ir_builder.seal_block(SIRTerminator::Branch {
-                    cond: cond_reg,
-                    true_block: (fitcheck_bb, vec![body_counter_reg]),
-                    false_block: empty_exit_check_bb
-                        .map_or((exit_bb, vec![]), |block| (block, vec![header_counter])),
-                });
-            }
+                },
+                start_reg,
+            ));
+            ir_builder.seal_block(SIRTerminator::Branch {
+                cond: in_range,
+                true_block: (fitcheck_bb, vec![header_counter]),
+                false_block: empty_exit_check_bb
+                    .map_or((exit_bb, vec![]), |block| (block, vec![header_counter])),
+            });
         } else {
             let cond_reg = ir_builder.alloc_bit(1, false);
             ir_builder.emit(SIRInstruction::Binary(
@@ -1814,23 +1736,6 @@ impl<'a> FfParser<'a> {
         }
 
         if !reverse {
-            if inclusive {
-                let terminal_reg = ir_builder.alloc_bit(1, false);
-                ir_builder.emit(SIRInstruction::Binary(
-                    terminal_reg,
-                    body_counter,
-                    BinaryOp::Eq,
-                    end_reg,
-                ));
-                let advance_bb = ir_builder.new_block();
-                ir_builder.seal_block(SIRTerminator::Branch {
-                    cond: terminal_reg,
-                    true_block: (exit_bb, vec![]),
-                    false_block: (advance_bb, vec![]),
-                });
-                ir_builder.switch_to_block(advance_bb);
-            }
-
             let step_width = if matches!(stepped_op, Some(Op::BitOr | Op::BitXor)) {
                 loop_width
             } else {
@@ -1937,57 +1842,61 @@ impl<'a> FfParser<'a> {
         } else {
             let current_math =
                 self.cast_reg_width_ext(ir_builder, body_counter, math_width, loop_signed);
-            if step == 0 {
-                ir_builder.seal_block(SIRTerminator::Jump(exit_bb, vec![]));
-                self.local_working_vars.remove(&stmt.var_id);
-                ir_builder.switch_to_block(exit_bb);
-                self.defined_ranges = pre_loop_defined;
-                self.dynamic_defined_vars = pre_loop_dynamic;
-                return Ok(());
-            }
             let start_math =
                 self.cast_reg_width_ext(ir_builder, start_reg, math_width, loop_signed);
             let step_reg = ir_builder.alloc_bit(math_width, loop_signed);
             ir_builder.emit(SIRInstruction::Imm(step_reg, SIRValue::new(step as u64)));
-            let threshold_reg = ir_builder.alloc_bit(math_width, loop_signed);
+            let next_raw = ir_builder.alloc_bit(math_width, loop_signed);
             ir_builder.emit(SIRInstruction::Binary(
-                threshold_reg,
-                start_math,
-                BinaryOp::Add,
+                next_raw,
+                current_math,
+                BinaryOp::Sub,
                 step_reg,
             ));
-            let can_continue = ir_builder.alloc_bit(1, false);
+            let next_visible =
+                self.cast_reg_width_ext(ir_builder, next_raw, loop_width, loop_signed);
+            let next_reg =
+                self.cast_reg_width_ext(ir_builder, next_visible, math_width, loop_signed);
+            let decreasing_reg = ir_builder.alloc_bit(1, false);
             ir_builder.emit(SIRInstruction::Binary(
-                can_continue,
+                decreasing_reg,
+                next_reg,
+                if loop_signed {
+                    BinaryOp::LtS
+                } else {
+                    BinaryOp::LtU
+                },
                 current_math,
+            ));
+            let range_check_bb = ir_builder.new_block();
+            let stall_bb = ir_builder.new_block();
+            ir_builder.seal_block(SIRTerminator::Branch {
+                cond: decreasing_reg,
+                true_block: (range_check_bb, vec![]),
+                false_block: (stall_bb, vec![]),
+            });
+            ir_builder.switch_to_block(range_check_bb);
+            let in_range_reg = ir_builder.alloc_bit(1, false);
+            ir_builder.emit(SIRInstruction::Binary(
+                in_range_reg,
+                next_reg,
                 if loop_signed {
                     BinaryOp::GeS
                 } else {
                     BinaryOp::GeU
                 },
-                threshold_reg,
-            ));
-            let next_reg = ir_builder.alloc_bit(math_width, loop_signed);
-            ir_builder.emit(SIRInstruction::Binary(
-                next_reg,
-                current_math,
-                BinaryOp::Sub,
-                step_reg,
+                start_math,
             ));
             let next_counter =
                 self.cast_reg_width_ext(ir_builder, next_reg, compare_width, loop_signed);
             ir_builder.seal_block(SIRTerminator::Branch {
-                cond: can_continue,
-                true_block: (
-                    header_bb,
-                    vec![if inclusive {
-                        next_counter
-                    } else {
-                        body_counter
-                    }],
-                ),
+                cond: in_range_reg,
+                true_block: (header_bb, vec![next_counter]),
                 false_block: (exit_bb, vec![]),
             });
+            ir_builder.switch_to_block(stall_bb);
+            let error_code = self.runtime_error(non_progress_message, vec![stmt.var_id]);
+            ir_builder.seal_block(SIRTerminator::Error(error_code));
         }
 
         self.local_working_vars.remove(&stmt.var_id);

--- a/crates/celox-frontend-veryl/src/ff.rs
+++ b/crates/celox-frontend-veryl/src/ff.rs
@@ -1868,7 +1868,13 @@ impl<'a> FfParser<'a> {
             ));
             let current_math =
                 self.cast_reg_width_ext(ir_builder, current_step, math_width, loop_signed);
-            let next_reg = self.cast_reg_width_ext(ir_builder, next_step, math_width, loop_signed);
+            // Compound assignment updates the fixed-width loop variable
+            // before the next comparison. Truncate to that visible width so
+            // overflow cannot be hidden by the widened comparison path.
+            let next_visible =
+                self.cast_reg_width_ext(ir_builder, next_step, loop_width, loop_signed);
+            let next_reg =
+                self.cast_reg_width_ext(ir_builder, next_visible, math_width, loop_signed);
             let progress_reg = ir_builder.alloc_bit(1, false);
             ir_builder.emit(SIRInstruction::Binary(
                 progress_reg,

--- a/crates/celox-slt/src/lower.rs
+++ b/crates/celox-slt/src/lower.rs
@@ -5950,7 +5950,13 @@ impl SLTToSIRLowerer {
             ));
             let current_math =
                 self.cast_reg_width_ext(builder, current_step, math_width, loop_signed);
-            let next_math = self.cast_reg_width_ext(builder, next_step, math_width, loop_signed);
+            // The emitted SystemVerilog loop variable has `loop_width` bits
+            // (`int`/i32 for Veryl). Apply the compound assignment at that
+            // width before checking progress or the loop bound; otherwise a
+            // widened host counter can step through values the emitted loop
+            // can never represent and incorrectly terminate.
+            let next_visible = self.cast_reg_width_ext(builder, next_step, loop_width, loop_signed);
+            let next_math = self.cast_reg_width_ext(builder, next_visible, math_width, loop_signed);
 
             let progress = builder.alloc_bit(1, false);
             builder.emit(SIRInstruction::Binary(

--- a/crates/celox-slt/src/lower.rs
+++ b/crates/celox-slt/src/lower.rs
@@ -5575,7 +5575,20 @@ impl SLTToSIRLowerer {
             end_reg
         };
 
-        let init_counter = if reverse { end_reg } else { start_reg };
+        let init_source = if reverse && !inclusive {
+            let reg = builder.alloc_bit(compare_width, loop_signed);
+            builder.emit(SIRInstruction::Binary(reg, end_reg, BinaryOp::Sub, one_reg));
+            reg
+        } else if reverse {
+            end_reg
+        } else {
+            start_reg
+        };
+        // SystemVerilog declares the induction variable as a fixed-width
+        // `int`, so initialization is an assignment to that visible width.
+        let init_visible = self.cast_reg_width_ext(builder, init_source, loop_width, loop_signed);
+        let init_counter =
+            self.cast_reg_width_ext(builder, init_visible, compare_width, loop_signed);
 
         let initial_states: Vec<RegisterId> = initials
             .iter()
@@ -5630,126 +5643,27 @@ impl SLTToSIRLowerer {
 
         builder.switch_to_block(header_block);
         if reverse {
-            if step == 0 {
-                let cmp_op = if loop_signed {
-                    if inclusive {
-                        BinaryOp::GeS
-                    } else {
-                        BinaryOp::GtS
-                    }
-                } else if inclusive {
+            let in_range = builder.alloc_bit(1, false);
+            builder.emit(SIRInstruction::Binary(
+                in_range,
+                header_counter,
+                if loop_signed {
+                    BinaryOp::GeS
+                } else {
                     BinaryOp::GeU
-                } else {
-                    BinaryOp::GtU
-                };
-                let in_range = builder.alloc_bit(1, false);
-                builder.emit(SIRInstruction::Binary(
-                    in_range,
-                    header_counter,
-                    cmp_op,
-                    start_reg,
-                ));
-                let singleton = if inclusive {
-                    let eq = builder.alloc_bit(1, false);
-                    builder.emit(SIRInstruction::Binary(
-                        eq,
-                        header_counter,
-                        BinaryOp::Eq,
-                        start_reg,
-                    ));
-                    Some(eq)
-                } else {
-                    None
-                };
-                let singleton_block = builder.new_block();
-                let true_loop_block = builder.new_block();
-                let in_range_block = builder.new_block();
-                builder.seal_block(SIRTerminator::Branch {
-                    cond: in_range,
-                    true_block: (in_range_block, vec![]),
-                    false_block: (exit_block, header_states.clone()),
-                });
-                builder.switch_to_block(in_range_block);
-                if let Some(singleton) = singleton {
-                    builder.seal_block(SIRTerminator::Branch {
-                        cond: singleton,
-                        true_block: (
-                            singleton_block,
-                            std::iter::once(header_counter)
-                                .chain(header_states.iter().copied())
-                                .collect(),
-                        ),
-                        false_block: (true_loop_block, vec![]),
-                    });
-                } else {
-                    builder.seal_block(SIRTerminator::Jump(true_loop_block, vec![]));
-                }
-                builder.switch_to_block(true_loop_block);
-                builder.seal_block(SIRTerminator::Jump(
+                },
+                start_reg,
+            ));
+            builder.seal_block(SIRTerminator::Branch {
+                cond: in_range,
+                true_block: (
                     body_block,
                     std::iter::once(header_counter)
                         .chain(header_states.iter().copied())
                         .collect(),
-                ));
-                builder.switch_to_block(singleton_block);
-                builder.seal_block(SIRTerminator::Jump(
-                    body_block,
-                    std::iter::once(header_counter)
-                        .chain(header_states.iter().copied())
-                        .collect(),
-                ));
-            } else {
-                let reverse_width = Self::step_math_width(compare_width, SLTStepOp::Add, step);
-                let header_counter_ext =
-                    self.cast_reg_width_ext(builder, header_counter, reverse_width, loop_signed);
-                let start_ext =
-                    self.cast_reg_width_ext(builder, start_reg, reverse_width, loop_signed);
-                let reverse_step = builder.alloc_bit(reverse_width, loop_signed);
-                builder.emit(SIRInstruction::Imm(
-                    reverse_step,
-                    SIRValue::new(step as u64),
-                ));
-                let threshold = builder.alloc_bit(reverse_width, loop_signed);
-                builder.emit(SIRInstruction::Binary(
-                    threshold,
-                    start_ext,
-                    BinaryOp::Add,
-                    reverse_step,
-                ));
-                let cond = builder.alloc_bit(1, false);
-                builder.emit(SIRInstruction::Binary(
-                    cond,
-                    header_counter_ext,
-                    if loop_signed {
-                        BinaryOp::GeS
-                    } else {
-                        BinaryOp::GeU
-                    },
-                    if inclusive { start_ext } else { threshold },
-                ));
-                let body_counter_reg = if inclusive {
-                    header_counter
-                } else {
-                    let next_counter_ext = builder.alloc_bit(reverse_width, loop_signed);
-                    builder.emit(SIRInstruction::Binary(
-                        next_counter_ext,
-                        header_counter_ext,
-                        BinaryOp::Sub,
-                        reverse_step,
-                    ));
-                    self.cast_reg_width_ext(builder, next_counter_ext, compare_width, loop_signed)
-                };
-                builder.seal_block(SIRTerminator::Branch {
-                    cond,
-                    true_block: (
-                        body_block,
-                        std::iter::once(body_counter_reg)
-                            .chain(header_states.iter().copied())
-                            .collect(),
-                    ),
-                    false_block: (exit_block, header_states.clone()),
-                });
-            }
+                ),
+                false_block: (exit_block, header_states.clone()),
+            });
         } else {
             let cond = builder.alloc_bit(1, false);
             builder.emit(SIRInstruction::Binary(
@@ -5831,95 +5745,71 @@ impl SLTToSIRLowerer {
         builder.switch_to_block(progress_block);
 
         if reverse {
-            if step == 0 {
-                if inclusive {
-                    let error_block = builder.new_block();
-                    let terminal = builder.alloc_bit(1, false);
-                    builder.emit(SIRInstruction::Binary(
-                        terminal,
-                        body_counter,
-                        BinaryOp::Eq,
-                        start_reg,
-                    ));
-                    builder.seal_block(SIRTerminator::Branch {
-                        cond: terminal,
-                        true_block: (exit_block, next_states.clone()),
-                        false_block: (error_block, vec![]),
-                    });
-                    builder.switch_to_block(error_block);
-                }
-                builder.seal_block(SIRTerminator::Error(1));
-            } else {
-                let reverse_width = Self::step_math_width(compare_width, SLTStepOp::Add, step);
-                let current_math =
-                    self.cast_reg_width_ext(builder, body_counter, reverse_width, loop_signed);
-                let start_math =
-                    self.cast_reg_width_ext(builder, start_reg, reverse_width, loop_signed);
-                let reverse_step = builder.alloc_bit(reverse_width, loop_signed);
-                builder.emit(SIRInstruction::Imm(
-                    reverse_step,
-                    SIRValue::new(step as u64),
-                ));
-                let threshold = builder.alloc_bit(reverse_width, loop_signed);
-                builder.emit(SIRInstruction::Binary(
-                    threshold,
-                    start_math,
-                    BinaryOp::Add,
-                    reverse_step,
-                ));
-                let can_continue = builder.alloc_bit(1, false);
-                builder.emit(SIRInstruction::Binary(
-                    can_continue,
-                    current_math,
-                    if loop_signed {
-                        BinaryOp::GeS
-                    } else {
-                        BinaryOp::GeU
-                    },
-                    threshold,
-                ));
-                let next_counter_ext = builder.alloc_bit(reverse_width, loop_signed);
-                builder.emit(SIRInstruction::Binary(
-                    next_counter_ext,
-                    current_math,
-                    BinaryOp::Sub,
-                    reverse_step,
-                ));
-                let next_counter =
-                    self.cast_reg_width_ext(builder, next_counter_ext, compare_width, loop_signed);
-                builder.seal_block(SIRTerminator::Branch {
-                    cond: can_continue,
-                    true_block: (
-                        header_block,
-                        std::iter::once(if inclusive {
-                            next_counter
-                        } else {
-                            body_counter
-                        })
+            let reverse_width = Self::step_math_width(compare_width, SLTStepOp::Add, step);
+            let current_math =
+                self.cast_reg_width_ext(builder, body_counter, reverse_width, loop_signed);
+            let start_math =
+                self.cast_reg_width_ext(builder, start_reg, reverse_width, loop_signed);
+            let reverse_step = builder.alloc_bit(reverse_width, loop_signed);
+            builder.emit(SIRInstruction::Imm(
+                reverse_step,
+                SIRValue::new(step as u64),
+            ));
+            let next_raw = builder.alloc_bit(reverse_width, loop_signed);
+            builder.emit(SIRInstruction::Binary(
+                next_raw,
+                current_math,
+                BinaryOp::Sub,
+                reverse_step,
+            ));
+            let next_visible = self.cast_reg_width_ext(builder, next_raw, loop_width, loop_signed);
+            let next_math =
+                self.cast_reg_width_ext(builder, next_visible, reverse_width, loop_signed);
+            let decreasing = builder.alloc_bit(1, false);
+            builder.emit(SIRInstruction::Binary(
+                decreasing,
+                next_math,
+                if loop_signed {
+                    BinaryOp::LtS
+                } else {
+                    BinaryOp::LtU
+                },
+                current_math,
+            ));
+            let range_check_block = builder.new_block();
+            let stall_block = builder.new_block();
+            builder.seal_block(SIRTerminator::Branch {
+                cond: decreasing,
+                true_block: (range_check_block, vec![]),
+                false_block: (stall_block, vec![]),
+            });
+            builder.switch_to_block(range_check_block);
+            let in_range = builder.alloc_bit(1, false);
+            builder.emit(SIRInstruction::Binary(
+                in_range,
+                next_math,
+                if loop_signed {
+                    BinaryOp::GeS
+                } else {
+                    BinaryOp::GeU
+                },
+                start_math,
+            ));
+            let next_counter =
+                self.cast_reg_width_ext(builder, next_math, compare_width, loop_signed);
+            builder.seal_block(SIRTerminator::Branch {
+                cond: in_range,
+                true_block: (
+                    header_block,
+                    std::iter::once(next_counter)
                         .chain(next_states.iter().copied())
                         .collect(),
-                    ),
-                    false_block: (exit_block, next_states.clone()),
-                });
-            }
+                ),
+                false_block: (exit_block, next_states.clone()),
+            });
+            builder.switch_to_block(stall_block);
+            builder.seal_block(SIRTerminator::Error(1));
         } else {
-            if inclusive {
-                let terminal = builder.alloc_bit(1, false);
-                builder.emit(SIRInstruction::Binary(
-                    terminal,
-                    body_counter,
-                    BinaryOp::Eq,
-                    end_reg,
-                ));
-                let advance_block = builder.new_block();
-                builder.seal_block(SIRTerminator::Branch {
-                    cond: terminal,
-                    true_block: (exit_block, next_states.clone()),
-                    false_block: (advance_block, vec![]),
-                });
-                builder.switch_to_block(advance_block);
-            }
-
             let math_width = Self::step_math_width(compare_width, step_op, step);
             let step_width = if matches!(step_op, SLTStepOp::BitOr | SLTStepOp::BitXor) {
                 loop_width

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -201,7 +201,9 @@ fn eval_loop_bound<B: SimBackend>(
     bound: &LoopBound,
 ) -> Result<EvaluatedLoopBound, String> {
     match bound {
-        LoopBound::Static(v) => Ok(EvaluatedLoopBound::Unsigned(*v)),
+        // ForBound::Const no longer carries source signedness; use the signed
+        // i32 induction-variable semantics for static Veryl loop bounds.
+        LoopBound::Static(v) => Ok(EvaluatedLoopBound::Signed(*v as i128)),
         LoopBound::Dynamic {
             expr,
             width,
@@ -375,9 +377,9 @@ fn as_biguint_bound(bound: &EvaluatedLoopBound) -> Option<BigUint> {
 fn as_bigint_bound(bound: &EvaluatedLoopBound) -> Option<BigInt> {
     match bound {
         EvaluatedLoopBound::Unsigned(v) => Some(BigInt::from(*v)),
+        EvaluatedLoopBound::UnsignedWide(v) => Some(BigInt::from(v.clone())),
         EvaluatedLoopBound::Signed(v) => Some(BigInt::from(*v)),
         EvaluatedLoopBound::SignedWide(v) => Some(v.clone()),
-        _ => None,
     }
 }
 
@@ -401,9 +403,19 @@ fn exec_for_loop<B: SimBackend>(
         Err(e) => return ExecResult::Fail(e),
     };
 
-    if matches!(start, EvaluatedLoopBound::UnsignedWide(_))
-        || matches!(end, EvaluatedLoopBound::UnsignedWide(_))
-    {
+    let has_unsigned_wide = matches!(start, EvaluatedLoopBound::UnsignedWide(_))
+        || matches!(end, EvaluatedLoopBound::UnsignedWide(_));
+    let has_signed_wide = matches!(start, EvaluatedLoopBound::SignedWide(_))
+        || matches!(end, EvaluatedLoopBound::SignedWide(_));
+    let has_signed = matches!(
+        start,
+        EvaluatedLoopBound::Signed(_) | EvaluatedLoopBound::SignedWide(_)
+    ) || matches!(
+        end,
+        EvaluatedLoopBound::Signed(_) | EvaluatedLoopBound::SignedWide(_)
+    );
+
+    if has_unsigned_wide && !has_signed {
         let start = as_biguint_bound(&start).expect("unsigned big bound");
         let end = as_biguint_bound(&end).expect("unsigned big bound");
         let mut step_body = |sim: &mut Simulator<B>, i: BigUint| -> ExecResult {
@@ -435,9 +447,7 @@ fn exec_for_loop<B: SimBackend>(
         }
         return ExecResult::Fail("dynamic for-loop bound exceeds host usize".to_string());
     }
-    if matches!(start, EvaluatedLoopBound::SignedWide(_))
-        || matches!(end, EvaluatedLoopBound::SignedWide(_))
-    {
+    if has_signed_wide || (has_unsigned_wide && has_signed) {
         let start = as_bigint_bound(&start).expect("signed big bound");
         let end = as_bigint_bound(&end).expect("signed big bound");
         let mut step_body = |sim: &mut Simulator<B>, i: BigInt| -> ExecResult {
@@ -487,6 +497,11 @@ fn exec_for_loop<B: SimBackend>(
     };
 
     if let Some((start, end)) = start_signed {
+        let truncate_counter = |value| {
+            loop_var.as_ref().map_or(value, |(_, width, signed)| {
+                truncate_i128_to_width(value, *width, *signed)
+            })
+        };
         let mut step_body = |sim: &mut Simulator<B>, i: i128| -> ExecResult {
             if let Some((sig, width, _)) = loop_var {
                 sim_set_i128(sim, *sig, *width, i);
@@ -496,20 +511,7 @@ fn exec_for_loop<B: SimBackend>(
 
         let step_i = step as i128;
         if reverse {
-            if step == 0 {
-                if inclusive {
-                    if end < start {
-                        return ExecResult::Continue;
-                    }
-                    if end == start {
-                        return step_body(sim, end);
-                    }
-                } else if end <= start {
-                    return ExecResult::Continue;
-                }
-                return ExecResult::Fail("non-progressing stepped for loop".to_string());
-            }
-            let mut i = if inclusive { end } else { end - step_i };
+            let mut i = truncate_counter(if inclusive { end } else { end.wrapping_sub(1) });
             while i >= start {
                 let r = step_body(sim, i);
                 if matches!(r, ExecResult::Break) {
@@ -518,13 +520,14 @@ fn exec_for_loop<B: SimBackend>(
                 if r.should_stop() {
                     return r;
                 }
-                let Some(next) = i.checked_sub(step_i) else {
-                    break;
-                };
+                let next = truncate_counter(i.wrapping_sub(step_i));
+                if next >= i {
+                    return ExecResult::Fail("non-progressing stepped for loop".to_string());
+                }
                 i = next;
             }
         } else if let Some(op) = step_op {
-            let mut i = start;
+            let mut i = truncate_counter(start);
             while if inclusive { i <= end } else { i < end } {
                 let r = step_body(sim, i);
                 if matches!(r, ExecResult::Break) {
@@ -533,11 +536,8 @@ fn exec_for_loop<B: SimBackend>(
                 if r.should_stop() {
                     return r;
                 }
-                if inclusive && i == end {
-                    break;
-                }
                 let new_i = match op {
-                    Op::Mul => i.saturating_mul(step_i),
+                    Op::Mul => i.wrapping_mul(step_i),
                     Op::BitOr => i | step_i,
                     Op::BitXor => i ^ step_i,
                     Op::LogicShiftL | Op::ArithShiftL => {
@@ -547,18 +547,16 @@ fn exec_for_loop<B: SimBackend>(
                             i.checked_shl(step as u32).unwrap_or(0)
                         }
                     }
-                    _ => i.saturating_add(step_i),
+                    _ => i.wrapping_add(step_i),
                 };
-                let new_i = loop_var.as_ref().map_or(new_i, |(_, width, signed)| {
-                    truncate_i128_to_width(new_i, *width, *signed)
-                });
+                let new_i = truncate_counter(new_i);
                 if new_i <= i {
                     return ExecResult::Fail("non-progressing stepped for loop".to_string());
                 }
                 i = new_i;
             }
         } else {
-            let mut i = start;
+            let mut i = truncate_counter(start);
             while if inclusive { i <= end } else { i < end } {
                 let r = step_body(sim, i);
                 if matches!(r, ExecResult::Break) {
@@ -567,12 +565,8 @@ fn exec_for_loop<B: SimBackend>(
                 if r.should_stop() {
                     return r;
                 }
-                let Some(next) = i.checked_add(step_i) else {
-                    return ExecResult::Fail("non-progressing stepped for loop".to_string());
-                };
-                let next = loop_var.as_ref().map_or(next, |(_, width, signed)| {
-                    truncate_i128_to_width(next, *width, *signed)
-                });
+                let next = i.wrapping_add(step_i);
+                let next = truncate_counter(next);
                 if next <= i {
                     return ExecResult::Fail("non-progressing stepped for loop".to_string());
                 }
@@ -584,6 +578,11 @@ fn exec_for_loop<B: SimBackend>(
     }
 
     let (start, end) = end_signed.expect("unsigned loop bounds expected");
+    let truncate_counter = |value| {
+        loop_var.as_ref().map_or(value, |(_, width, _)| {
+            truncate_usize_to_width(value, *width)
+        })
+    };
 
     let mut step_body = |sim: &mut Simulator<B>, i: usize| -> ExecResult {
         if let Some((sig, _, _)) = loop_var {
@@ -593,26 +592,7 @@ fn exec_for_loop<B: SimBackend>(
     };
 
     if reverse {
-        if step == 0 {
-            if inclusive {
-                if end < start {
-                    return ExecResult::Continue;
-                }
-                if end == start {
-                    return step_body(sim, end);
-                }
-            } else if end <= start {
-                return ExecResult::Continue;
-            }
-            return ExecResult::Fail("non-progressing stepped for loop".to_string());
-        }
-        let mut i = if inclusive {
-            end
-        } else if let Some(v) = end.checked_sub(step) {
-            v
-        } else {
-            return ExecResult::Continue;
-        };
+        let mut i = truncate_counter(if inclusive { end } else { end.wrapping_sub(1) });
         while i >= start {
             let r = step_body(sim, i);
             if matches!(r, ExecResult::Break) {
@@ -621,13 +601,14 @@ fn exec_for_loop<B: SimBackend>(
             if r.should_stop() {
                 return r;
             }
-            let Some(next) = i.checked_sub(step) else {
-                break;
-            };
+            let next = truncate_counter(i.wrapping_sub(step));
+            if next >= i {
+                return ExecResult::Fail("non-progressing stepped for loop".to_string());
+            }
             i = next;
         }
     } else if let Some(op) = step_op {
-        let mut i = start;
+        let mut i = truncate_counter(start);
         while if inclusive { i <= end } else { i < end } {
             let r = step_body(sim, i);
             if matches!(r, ExecResult::Break) {
@@ -636,11 +617,8 @@ fn exec_for_loop<B: SimBackend>(
             if r.should_stop() {
                 return r;
             }
-            if inclusive && i == end {
-                break;
-            }
             let new_i = match op {
-                Op::Mul => i.saturating_mul(step),
+                Op::Mul => i.wrapping_mul(step),
                 Op::BitOr => i | step,
                 Op::BitXor => i ^ step,
                 Op::LogicShiftL | Op::ArithShiftL => {
@@ -650,18 +628,16 @@ fn exec_for_loop<B: SimBackend>(
                         i << step
                     }
                 }
-                _ => i.saturating_add(step),
+                _ => i.wrapping_add(step),
             };
-            let new_i = loop_var.as_ref().map_or(new_i, |(_, width, _)| {
-                truncate_usize_to_width(new_i, *width)
-            });
+            let new_i = truncate_counter(new_i);
             if new_i <= i {
                 return ExecResult::Fail("non-progressing stepped for loop".to_string());
             }
             i = new_i;
         }
     } else {
-        let mut i = start;
+        let mut i = truncate_counter(start);
         while if inclusive { i <= end } else { i < end } {
             let r = step_body(sim, i);
             if matches!(r, ExecResult::Break) {
@@ -670,12 +646,8 @@ fn exec_for_loop<B: SimBackend>(
             if r.should_stop() {
                 return r;
             }
-            let Some(next) = i.checked_add(step) else {
-                return ExecResult::Fail("non-progressing stepped for loop".to_string());
-            };
-            let next = loop_var
-                .as_ref()
-                .map_or(next, |(_, width, _)| truncate_usize_to_width(next, *width));
+            let next = i.wrapping_add(step);
+            let next = truncate_counter(next);
             if next <= i {
                 return ExecResult::Fail("non-progressing stepped for loop".to_string());
             }

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -291,6 +291,49 @@ fn truncate_i128_to_width(value: i128, width: usize, signed: bool) -> i128 {
     }
 }
 
+fn truncate_bigint_to_width(value: BigInt, width: usize, signed: bool) -> BigInt {
+    let width = width.max(1);
+    let modulus = BigInt::from(1u8) << width;
+    let mut wrapped = value % &modulus;
+    if wrapped.sign() == Sign::Minus {
+        wrapped += &modulus;
+    }
+    if signed && wrapped >= (BigInt::from(1u8) << (width - 1)) {
+        wrapped - modulus
+    } else {
+        wrapped
+    }
+}
+
+fn advance_bigint_counter(
+    current: &BigInt,
+    step: usize,
+    step_op: Option<Op>,
+    reverse: bool,
+    width: usize,
+    signed: bool,
+) -> BigInt {
+    let step_value = BigInt::from(step);
+    let raw = if reverse {
+        current - &step_value
+    } else {
+        match step_op {
+            Some(Op::Mul) => current * &step_value,
+            Some(Op::BitOr) => current | &step_value,
+            Some(Op::BitXor) => current ^ &step_value,
+            Some(Op::LogicShiftL | Op::ArithShiftL) => {
+                if step >= width.max(1) {
+                    BigInt::from(0u8)
+                } else {
+                    current << step
+                }
+            }
+            _ => current + &step_value,
+        }
+    };
+    truncate_bigint_to_width(raw, width, signed)
+}
+
 fn truncate_usize_to_width(value: usize, width: usize) -> usize {
     if width >= usize::BITS as usize {
         value
@@ -366,14 +409,6 @@ fn sim_set_bigint<B: SimBackend>(
     }
 }
 
-fn as_biguint_bound(bound: &EvaluatedLoopBound) -> Option<BigUint> {
-    match bound {
-        EvaluatedLoopBound::Unsigned(v) => Some(BigUint::from(*v)),
-        EvaluatedLoopBound::UnsignedWide(v) => Some(v.clone()),
-        _ => None,
-    }
-}
-
 fn as_bigint_bound(bound: &EvaluatedLoopBound) -> Option<BigInt> {
     match bound {
         EvaluatedLoopBound::Unsigned(v) => Some(BigInt::from(*v)),
@@ -394,62 +429,61 @@ fn exec_for_loop<B: SimBackend>(
     reverse: bool,
     mut exec_body: impl FnMut(&mut Simulator<B>) -> ExecResult,
 ) -> ExecResult {
-    let start = match eval_loop_bound(sim, start) {
+    let mut start = match eval_loop_bound(sim, start) {
         Ok(v) => v,
         Err(e) => return ExecResult::Fail(e),
     };
-    let end = match eval_loop_bound(sim, end) {
+    let mut end = match eval_loop_bound(sim, end) {
         Ok(v) => v,
         Err(e) => return ExecResult::Fail(e),
     };
+
+    let initially_wide = matches!(start, EvaluatedLoopBound::UnsignedWide(_))
+        || matches!(end, EvaluatedLoopBound::UnsignedWide(_))
+        || matches!(start, EvaluatedLoopBound::SignedWide(_))
+        || matches!(end, EvaluatedLoopBound::SignedWide(_));
+    if let Some((_, width, true)) = loop_var.as_ref()
+        && !initially_wide
+    {
+        let width = (*width).max(1);
+        let unsigned_max = if width <= usize::BITS as usize {
+            Some((1usize << (width - 1)) - 1)
+        } else {
+            None
+        };
+        let unsigned_value = |bound: &EvaluatedLoopBound| match bound {
+            EvaluatedLoopBound::Unsigned(value) => Some(*value),
+            _ => None,
+        };
+        let start_out_of_range = unsigned_max
+            .zip(unsigned_value(&start))
+            .is_some_and(|(max, value)| value > max);
+        let end_out_of_range =
+            unsigned_max
+                .zip(unsigned_value(&end))
+                .is_some_and(|(max, value)| {
+                    value > max && !(!inclusive && value == max.saturating_add(1))
+                });
+        if start_out_of_range || end_out_of_range {
+            return ExecResult::Fail("non-progressing stepped for loop".to_string());
+        }
+        start = match start {
+            EvaluatedLoopBound::Unsigned(value) => EvaluatedLoopBound::Signed(value as i128),
+            other => other,
+        };
+        end = match end {
+            EvaluatedLoopBound::Unsigned(value) => EvaluatedLoopBound::Signed(value as i128),
+            other => other,
+        };
+    }
 
     let has_unsigned_wide = matches!(start, EvaluatedLoopBound::UnsignedWide(_))
         || matches!(end, EvaluatedLoopBound::UnsignedWide(_));
     let has_signed_wide = matches!(start, EvaluatedLoopBound::SignedWide(_))
         || matches!(end, EvaluatedLoopBound::SignedWide(_));
-    let has_signed = matches!(
-        start,
-        EvaluatedLoopBound::Signed(_) | EvaluatedLoopBound::SignedWide(_)
-    ) || matches!(
-        end,
-        EvaluatedLoopBound::Signed(_) | EvaluatedLoopBound::SignedWide(_)
-    );
-
-    if has_unsigned_wide && !has_signed {
-        let start = as_biguint_bound(&start).expect("unsigned big bound");
-        let end = as_biguint_bound(&end).expect("unsigned big bound");
-        let mut step_body = |sim: &mut Simulator<B>, i: BigUint| -> ExecResult {
-            if let Some((sig, _, _)) = loop_var {
-                sim_set_biguint(sim, *sig, i);
-            }
-            exec_body(sim)
-        };
-        if reverse {
-            if inclusive {
-                if end < start {
-                    return ExecResult::Continue;
-                }
-                if end == start {
-                    return step_body(sim, end);
-                }
-            } else if end <= start {
-                return ExecResult::Continue;
-            }
-        } else if inclusive {
-            if start > end {
-                return ExecResult::Continue;
-            }
-            if start == end {
-                return step_body(sim, start);
-            }
-        } else if start >= end {
-            return ExecResult::Continue;
-        }
-        return ExecResult::Fail("dynamic for-loop bound exceeds host usize".to_string());
-    }
-    if has_signed_wide || (has_unsigned_wide && has_signed) {
-        let start = as_bigint_bound(&start).expect("signed big bound");
-        let end = as_bigint_bound(&end).expect("signed big bound");
+    if has_unsigned_wide || has_signed_wide {
+        let start = as_bigint_bound(&start).expect("big loop bound");
+        let end = as_bigint_bound(&end).expect("big loop bound");
         let mut step_body = |sim: &mut Simulator<B>, i: BigInt| -> ExecResult {
             if let Some((sig, width, _)) = loop_var {
                 sim_set_bigint(sim, *sig, *width, i);
@@ -462,7 +496,26 @@ fn exec_for_loop<B: SimBackend>(
                     return ExecResult::Continue;
                 }
                 if end == start {
-                    return step_body(sim, end);
+                    let (width, signed) = loop_var
+                        .as_ref()
+                        .map_or((usize::BITS as usize, false), |(_, width, signed)| {
+                            (*width, *signed)
+                        });
+                    let current = truncate_bigint_to_width(end, width, signed);
+                    let result = step_body(sim, current.clone());
+                    if matches!(result, ExecResult::Break) {
+                        return ExecResult::Continue;
+                    }
+                    if result.should_stop() {
+                        return result;
+                    }
+                    let next =
+                        advance_bigint_counter(&current, step, step_op, reverse, width, signed);
+                    return if next >= current {
+                        ExecResult::Fail("non-progressing stepped for loop".to_string())
+                    } else {
+                        ExecResult::Continue
+                    };
                 }
             } else if end <= start {
                 return ExecResult::Continue;
@@ -472,12 +525,34 @@ fn exec_for_loop<B: SimBackend>(
                 return ExecResult::Continue;
             }
             if start == end {
-                return step_body(sim, start);
+                let (width, signed) = loop_var
+                    .as_ref()
+                    .map_or((usize::BITS as usize, false), |(_, width, signed)| {
+                        (*width, *signed)
+                    });
+                let current = truncate_bigint_to_width(start, width, signed);
+                let result = step_body(sim, current.clone());
+                if matches!(result, ExecResult::Break) {
+                    return ExecResult::Continue;
+                }
+                if result.should_stop() {
+                    return result;
+                }
+                let next = advance_bigint_counter(&current, step, step_op, reverse, width, signed);
+                return if next <= current {
+                    ExecResult::Fail("non-progressing stepped for loop".to_string())
+                } else {
+                    ExecResult::Continue
+                };
             }
         } else if start >= end {
             return ExecResult::Continue;
         }
-        return ExecResult::Fail("dynamic signed for-loop bound exceeds host i128".to_string());
+        return ExecResult::Fail(if loop_var.as_ref().is_some_and(|(_, _, signed)| *signed) {
+            "dynamic signed for-loop bound exceeds host i128".to_string()
+        } else {
+            "dynamic for-loop bound exceeds host usize".to_string()
+        });
     }
 
     let (start_signed, end_signed) = match (start, end) {

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -542,19 +542,16 @@ fn exec_for_loop<B: SimBackend>(
                     Op::BitXor => i ^ step_i,
                     Op::LogicShiftL | Op::ArithShiftL => {
                         if step >= i128::BITS as usize {
-                            break;
+                            0
+                        } else {
+                            i.checked_shl(step as u32).unwrap_or(0)
                         }
-                        i.checked_shl(step as u32).unwrap_or(0)
                     }
                     _ => i.saturating_add(step_i),
                 };
-                let new_i = if matches!(op, Op::BitOr | Op::BitXor) {
-                    loop_var.as_ref().map_or(new_i, |(_, width, signed)| {
-                        truncate_i128_to_width(new_i, *width, *signed)
-                    })
-                } else {
-                    new_i
-                };
+                let new_i = loop_var.as_ref().map_or(new_i, |(_, width, signed)| {
+                    truncate_i128_to_width(new_i, *width, *signed)
+                });
                 if new_i <= i {
                     return ExecResult::Fail("non-progressing stepped for loop".to_string());
                 }
@@ -571,8 +568,14 @@ fn exec_for_loop<B: SimBackend>(
                     return r;
                 }
                 let Some(next) = i.checked_add(step_i) else {
-                    break;
+                    return ExecResult::Fail("non-progressing stepped for loop".to_string());
                 };
+                let next = loop_var.as_ref().map_or(next, |(_, width, signed)| {
+                    truncate_i128_to_width(next, *width, *signed)
+                });
+                if next <= i {
+                    return ExecResult::Fail("non-progressing stepped for loop".to_string());
+                }
                 i = next;
             }
         }
@@ -642,19 +645,16 @@ fn exec_for_loop<B: SimBackend>(
                 Op::BitXor => i ^ step,
                 Op::LogicShiftL | Op::ArithShiftL => {
                     if step >= usize::BITS as usize {
-                        break;
+                        0
+                    } else {
+                        i << step
                     }
-                    i << step
                 }
                 _ => i.saturating_add(step),
             };
-            let new_i = if matches!(op, Op::BitOr | Op::BitXor) {
-                loop_var.as_ref().map_or(new_i, |(_, width, _)| {
-                    truncate_usize_to_width(new_i, *width)
-                })
-            } else {
-                new_i
-            };
+            let new_i = loop_var.as_ref().map_or(new_i, |(_, width, _)| {
+                truncate_usize_to_width(new_i, *width)
+            });
             if new_i <= i {
                 return ExecResult::Fail("non-progressing stepped for loop".to_string());
             }
@@ -671,8 +671,14 @@ fn exec_for_loop<B: SimBackend>(
                 return r;
             }
             let Some(next) = i.checked_add(step) else {
-                break;
+                return ExecResult::Fail("non-progressing stepped for loop".to_string());
             };
+            let next = loop_var
+                .as_ref()
+                .map_or(next, |(_, width, _)| truncate_usize_to_width(next, *width));
+            if next <= i {
+                return ExecResult::Fail("non-progressing stepped for loop".to_string());
+            }
             i = next;
         }
     }

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -869,6 +869,37 @@ fn test_ff_runtime_reverse_step_matches_emitted_sv_order(sim) {
     assert_eq!(sim.get(q), 1u32.into());
 }
 
+fn test_ff_runtime_reverse_exclusive_i32_upper_sentinel(sim) {
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            start: input signed logic<64>,
+            end_bound: input signed logic<64>,
+            q: output logic<32>
+        ) {
+            always_ff (clk) {
+                q = 0;
+                for i in rev start..end_bound {
+                    q = i as 32;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let start = sim.signal("start");
+    let end_bound = sim.signal("end_bound");
+    let q = sim.signal("q");
+
+    sim.modify(|io| {
+        io.set(start, 2147483640u64);
+        io.set(end_bound, 2147483648u64);
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(q), 2147483640u32.into());
+}
+
 fn test_ff_runtime_reverse_min_i32_end_wraps_before_range_check(sim) {
     // veryl-simulator 0.20.2's non-JIT interpreter evaluates `end - 1` as i64
     // without truncating it to the signed 32-bit loop-counter width. It therefore

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -810,7 +810,7 @@ fn test_ff_runtime_for_zero_iteration_mul_loop_is_allowed(sim) {
     assert_eq!(sim.get(q), 0xaau32.into());
 }
 
-fn test_ff_runtime_for_terminal_inclusive_mul_loop_is_allowed(sim) {
+fn test_ff_runtime_for_terminal_inclusive_mul_loop_reports_true_loop(sim) {
     @ignore_on(veryl);
     @setup { let code = r#"
         module Top (
@@ -829,11 +829,77 @@ fn test_ff_runtime_for_terminal_inclusive_mul_loop_is_allowed(sim) {
     @build Simulator::builder(code, "Top");
     let clk = sim.event("clk");
     let count = sim.signal("count");
-    let q = sim.signal("q");
 
     sim.modify(|io| io.set(count, 0u8)).unwrap();
+    assert_eq!(
+        sim.tick(clk).unwrap_err().to_string(),
+        "Non-progressing for loop in always_ff (loop variable `i`): i"
+    );
+}
+
+fn test_ff_runtime_reverse_step_matches_emitted_sv_order(sim) {
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            start: input signed logic<64>,
+            end_bound: input signed logic<64>,
+            q: output logic<32>
+        ) {
+            always_ff (clk) {
+                q = 0;
+                for i in rev start..end_bound step += 2 {
+                    q = i as 32;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let start = sim.signal("start");
+    let end_bound = sim.signal("end_bound");
+    let q = sim.signal("q");
+
+    sim.modify(|io| {
+        io.set(start, 0u64);
+        io.set(end_bound, 10u64);
+    })
+    .unwrap();
     sim.tick(clk).unwrap();
+    // The last iteration is i = 1 for the emitted 9,7,5,3,1 order.
     assert_eq!(sim.get(q), 1u32.into());
+}
+
+fn test_ff_runtime_reverse_i32_step_truncation_reports_true_loop(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            start: input signed logic<64>,
+            end_bound: input signed logic<64>,
+            q: output logic<32>
+        ) {
+            always_ff (clk) {
+                q = 0;
+                for i in rev start..=end_bound step += 4294967296 {
+                    q += 1;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let start = sim.signal("start");
+    let end_bound = sim.signal("end_bound");
+
+    sim.modify(|io| {
+        io.set(start, 0u64);
+        io.set(end_bound, 3u64);
+    })
+    .unwrap();
+    assert_eq!(
+        sim.tick(clk).unwrap_err().to_string(),
+        "Non-progressing for loop in always_ff (loop variable `i`): i"
+    );
 }
 
 fn test_ff_runtime_for_reverse_singleton_exits_cleanly(sim) {

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -635,6 +635,64 @@ fn test_ff_i32_or_step_with_only_existing_low_bits_reports_true_loop(sim) {
     );
 }
 
+fn test_ff_i32_mul_step_overflow_reports_true_loop(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            end_bound: input signed logic<64>,
+            q: output logic<32>
+        ) {
+            always_ff (clk) {
+                q = 0;
+                for i in 1500000000..end_bound step *= 2 {
+                    q += 1;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let end_bound = sim.signal("end_bound");
+
+    // The first update overflows i32 even though its widened value would
+    // already exceed this still-representable bound.
+    sim.set(end_bound, 1_600_000_000u64);
+    assert_eq!(
+        sim.tick(clk).unwrap_err().to_string(),
+        "Non-progressing for loop in always_ff (loop variable `i`): i"
+    );
+}
+
+fn test_ff_i32_shl_step_overflow_reports_true_loop(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            end_bound: input signed logic<64>,
+            q: output logic<32>
+        ) {
+            always_ff (clk) {
+                q = 0;
+                for i in 1073741824..end_bound step <<= 1 {
+                    q += 1;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let end_bound = sim.signal("end_bound");
+
+    // The first update overflows i32 even though its widened value would
+    // already exceed this still-representable bound.
+    sim.set(end_bound, 1_500_000_000u64);
+    assert_eq!(
+        sim.tick(clk).unwrap_err().to_string(),
+        "Non-progressing for loop in always_ff (loop variable `i`): i"
+    );
+}
+
 fn test_ff_runtime_for_break(sim) {
     @setup { let code = r#"
         module Top (

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -869,6 +869,40 @@ fn test_ff_runtime_reverse_step_matches_emitted_sv_order(sim) {
     assert_eq!(sim.get(q), 1u32.into());
 }
 
+fn test_ff_runtime_reverse_min_i32_end_wraps_before_range_check(sim) {
+    // The upstream Veryl simulator currently skips this wrapped reverse range.
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            start: input signed logic<64>,
+            end_bound: input signed logic<64>,
+            q: output logic<32>
+        ) {
+            always_ff (clk) {
+                q = 0;
+                for i in rev start..end_bound {
+                    q = i as 32;
+                    break;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let start = sim.signal("start");
+    let end_bound = sim.signal("end_bound");
+    let q = sim.signal("q");
+
+    sim.modify(|io| {
+        io.set(start, (-2147483648i64) as u64);
+        io.set(end_bound, (-2147483648i64) as u64);
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(q), 0x7fff_ffffu32.into());
+}
+
 fn test_ff_runtime_reverse_i32_step_truncation_reports_true_loop(sim) {
     @ignore_on(veryl);
     @setup { let code = r#"
@@ -2214,6 +2248,40 @@ fn test_ff_runtime_for_wide_dynamic_end_errors_before_iteration() {
 
     sim.modify(|io| io.set_wide(count, BigUint::from(1u64) << 40))
         .unwrap();
+    assert_eq!(
+        sim.tick(clk).unwrap_err().to_string(),
+        "For loop value exceeds loop variable range in always_ff (loop variable `i`): i"
+    );
+}
+
+#[test]
+fn test_ff_runtime_for_wide_dynamic_reverse_end_errors_before_iteration() {
+    let code = r#"
+        module Top (
+            clk: input clock,
+            start: input signed logic<64>,
+            end_bound: input signed logic<128>,
+            q_hits: output logic<8>
+        ) {
+            always_ff (clk) {
+                q_hits = 0;
+                for i in rev start..end_bound {
+                    q_hits += 1;
+                }
+            }
+        }
+    "#;
+
+    let mut sim = Simulator::builder(code, "Top").build().unwrap();
+    let clk = sim.event("clk");
+    let start = sim.signal("start");
+    let end_bound = sim.signal("end_bound");
+
+    sim.modify(|io| {
+        io.set(start, 0u64);
+        io.set_wide(end_bound, BigUint::from(1u64) << 40);
+    })
+    .unwrap();
     assert_eq!(
         sim.tick(clk).unwrap_err().to_string(),
         "For loop value exceeds loop variable range in always_ff (loop variable `i`): i"

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -870,7 +870,9 @@ fn test_ff_runtime_reverse_step_matches_emitted_sv_order(sim) {
 }
 
 fn test_ff_runtime_reverse_min_i32_end_wraps_before_range_check(sim) {
-    // The upstream Veryl simulator currently skips this wrapped reverse range.
+    // veryl-simulator 0.20.2's non-JIT interpreter evaluates `end - 1` as i64
+    // without truncating it to the signed 32-bit loop-counter width. It therefore
+    // gets -2147483649 instead of wrapping to i32::MAX and skips the loop body.
     @ignore_on(veryl);
     @setup { let code = r#"
         module Top (

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -648,7 +648,7 @@ fn test_for_loop_expression_bound_arith_shift_step() {
 }
 
 #[test]
-fn test_for_loop_expression_bound_large_arith_shift_stops_after_first_iteration() {
+fn test_for_loop_expression_bound_large_arith_shift_reports_non_progress() {
     let code = format!(
         r#"
         {COUNTER}
@@ -670,10 +670,36 @@ fn test_for_loop_expression_bound_large_arith_shift_stops_after_first_iteration(
         }}
     "#
     );
-    assert_eq!(
-        Simulator::builder(&code, "t").run_test().unwrap(),
-        TestResult::Pass,
-    );
+    let TestResult::Fail(message) = Simulator::builder(&code, "t").run_test().unwrap() else {
+        panic!("expected non-progressing loop failure");
+    };
+    assert!(message.contains("non-progressing stepped for loop"));
+}
+
+#[test]
+fn test_for_loop_i32_mul_and_shl_overflow_fail() {
+    for (start, end, step) in [
+        ("1500000000", "3100000000", "*= 2"),
+        ("1073741824", "2147483649", "<<= 1"),
+    ] {
+        let code = format!(
+            r#"
+            #[test(t)]
+            module t {{
+                var end_bound: signed logic<64>;
+                initial {{
+                    end_bound = 64'sd{end};
+                    for _i in {start}..end_bound step {step} {{}}
+                    $finish();
+                }}
+            }}
+        "#
+        );
+        let TestResult::Fail(message) = Simulator::builder(&code, "t").run_test().unwrap() else {
+            panic!("expected non-progressing loop failure for step {step}");
+        };
+        assert!(message.contains("non-progressing stepped for loop"));
+    }
 }
 
 #[test]
@@ -975,7 +1001,7 @@ fn test_expression_vm_preserves_wide_fixed_width_semantics() {
 }
 
 #[test]
-fn test_for_loop_dynamic_inclusive_max_bound_runs_terminal_iteration() {
+fn test_for_loop_dynamic_inclusive_unrepresentable_max_bound_reports_non_progress() {
     let code = format!(
         r#"
         {COUNTER}
@@ -999,10 +1025,10 @@ fn test_for_loop_dynamic_inclusive_max_bound_runs_terminal_iteration() {
         }}
     "#
     );
-    assert_eq!(
-        Simulator::builder(&code, "t").run_test().unwrap(),
-        TestResult::Pass,
-    );
+    let TestResult::Fail(message) = Simulator::builder(&code, "t").run_test().unwrap() else {
+        panic!("expected non-progressing loop failure");
+    };
+    assert!(message.contains("non-progressing stepped for loop"));
 }
 
 #[test]

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -730,6 +730,37 @@ fn test_for_loop_static_bounds_use_signed_i32_progress() {
 }
 
 #[test]
+fn test_for_loop_unsigned_dynamic_bounds_use_signed_i32_progress() {
+    for (start, end, step) in [
+        ("2147483647", "2147483648", "+= 1"),
+        ("1500000000", "1600000000", "*= 2"),
+        ("1073741824", "1500000000", "<<= 1"),
+        ("1", "100", "|= 2147483648"),
+        ("1", "100", "^= 2147483648"),
+    ] {
+        let code = format!(
+            r#"
+            #[test(t)]
+            module t {{
+                var start: logic<64>;
+                var end_bound: logic<64>;
+                initial {{
+                    start = {start};
+                    end_bound = {end};
+                    for _i in start..end_bound step {step} {{}}
+                    $finish();
+                }}
+            }}
+        "#
+        );
+        let TestResult::Fail(message) = Simulator::builder(&code, "t").run_test().unwrap() else {
+            panic!("expected signed i32 loop failure for dynamic step {step}");
+        };
+        assert!(message.contains("non-progressing stepped for loop"));
+    }
+}
+
+#[test]
 fn test_for_loop_large_multiplier_preserves_low_i32_bits() {
     let code = r#"
         #[test(t)]
@@ -746,6 +777,25 @@ fn test_for_loop_large_multiplier_preserves_low_i32_bits() {
     "#;
     let TestResult::Fail(message) = Simulator::builder(code, "t").run_test().unwrap() else {
         panic!("expected fixed-width multiplication failure");
+    };
+    assert!(message.contains("non-progressing stepped for loop"));
+}
+
+#[test]
+fn test_for_loop_wide_singleton_still_checks_fixed_width_progress() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            var bound: logic<128>;
+            initial {
+                bound = (128'd1 << 100);
+                for _i in bound..=bound step *= 2 {}
+                $finish();
+            }
+        }
+    "#;
+    let TestResult::Fail(message) = Simulator::builder(code, "t").run_test().unwrap() else {
+        panic!("expected fixed-width progress failure for wide singleton bound");
     };
     assert!(message.contains("non-progressing stepped for loop"));
 }

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -703,6 +703,97 @@ fn test_for_loop_i32_mul_and_shl_overflow_fail() {
 }
 
 #[test]
+fn test_for_loop_static_bounds_use_signed_i32_progress() {
+    for (start, end, step) in [
+        ("2147483647", "2147483648", "+= 1"),
+        ("1500000000", "1600000000", "*= 2"),
+        ("1073741824", "1500000000", "<<= 1"),
+        ("1", "100", "|= 2147483648"),
+        ("1", "100", "^= 2147483648"),
+    ] {
+        let code = format!(
+            r#"
+            #[test(t)]
+            module t {{
+                initial {{
+                    for _i in {start}..{end} step {step} {{}}
+                    $finish();
+                }}
+            }}
+        "#
+        );
+        let TestResult::Fail(message) = Simulator::builder(&code, "t").run_test().unwrap() else {
+            panic!("expected signed i32 loop failure for step {step}");
+        };
+        assert!(message.contains("non-progressing stepped for loop"));
+    }
+}
+
+#[test]
+fn test_for_loop_large_multiplier_preserves_low_i32_bits() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            var start: logic<64>;
+            var end_bound: logic<64>;
+            initial {
+                start = 2;
+                end_bound = 3;
+                for _i in start..end_bound step *= 9223372036854775808 {}
+                $finish();
+            }
+        }
+    "#;
+    let TestResult::Fail(message) = Simulator::builder(code, "t").run_test().unwrap() else {
+        panic!("expected fixed-width multiplication failure");
+    };
+    assert!(message.contains("non-progressing stepped for loop"));
+}
+
+#[test]
+fn test_for_loop_reverse_step_matches_emitted_sv_order() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            var digits: logic<32>;
+            initial {
+                digits = 0;
+                for i in rev 0..10 step += 2 {
+                    digits = digits * 10 + i as 32;
+                }
+                $assert(digits == 32'd97531);
+                $finish();
+            }
+        }
+    "#;
+    assert_eq!(
+        Simulator::builder(code, "t").run_test().unwrap(),
+        TestResult::Pass,
+    );
+}
+
+#[test]
+fn test_for_loop_reverse_i32_step_truncation_reports_non_progress() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            var start: signed logic<64>;
+            var end_bound: signed logic<64>;
+            initial {
+                start = 0;
+                end_bound = 3;
+                for _i in rev start..=end_bound step += 4294967296 {}
+                $finish();
+            }
+        }
+    "#;
+    let TestResult::Fail(message) = Simulator::builder(code, "t").run_test().unwrap() else {
+        panic!("expected reverse fixed-width step failure");
+    };
+    assert!(message.contains("non-progressing stepped for loop"));
+}
+
+#[test]
 fn test_for_loop_expression_bound_non_progress_reports_failure() {
     let code = format!(
         r#"
@@ -731,7 +822,7 @@ fn test_for_loop_expression_bound_non_progress_reports_failure() {
 }
 
 #[test]
-fn test_for_loop_expression_bound_terminal_inclusive_mul_succeeds() {
+fn test_for_loop_expression_bound_terminal_inclusive_mul_reports_non_progress() {
     let code = format!(
         r#"
         {COUNTER}
@@ -753,10 +844,10 @@ fn test_for_loop_expression_bound_terminal_inclusive_mul_succeeds() {
         }}
     "#
     );
-    assert_eq!(
-        Simulator::builder(&code, "t").run_test().unwrap(),
-        TestResult::Pass,
-    );
+    let TestResult::Fail(message) = Simulator::builder(&code, "t").run_test().unwrap() else {
+        panic!("expected non-progressing loop failure");
+    };
+    assert!(message.contains("non-progressing stepped for loop"));
 }
 
 #[test]

--- a/crates/celox/tests/synth_dynamic_loop.rs
+++ b/crates/celox/tests/synth_dynamic_loop.rs
@@ -326,6 +326,50 @@ fn test_i32_or_step_with_only_existing_low_bits_reports_true_loop(sim) {
     assert_eq!(sim.eval_comb().unwrap_err(), RuntimeErrorCode::DetectedTrueLoop);
 }
 
+fn test_i32_mul_step_overflow_reports_true_loop(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            end_bound: input signed logic<64>,
+            hits: output logic<32>
+        ) {
+            always_comb {
+                hits = 0;
+                for i in 1500000000..end_bound step *= 2 {
+                    hits += 1;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+
+    let end_bound = sim.signal("end_bound");
+    sim.set(end_bound, 3_100_000_000u64);
+    assert_eq!(sim.eval_comb().unwrap_err(), RuntimeErrorCode::DetectedTrueLoop);
+}
+
+fn test_i32_shl_step_overflow_reports_true_loop(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            end_bound: input signed logic<64>,
+            hits: output logic<32>
+        ) {
+            always_comb {
+                hits = 0;
+                for i in 1073741824..end_bound step <<= 1 {
+                    hits += 1;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+
+    let end_bound = sim.signal("end_bound");
+    sim.set(end_bound, 2_147_483_649u64);
+    assert_eq!(sim.eval_comb().unwrap_err(), RuntimeErrorCode::DetectedTrueLoop);
+}
+
 fn test_runtime_bounds_terminal_inclusive_mul_loop_exits_cleanly(sim) {
     @ignore_on(veryl);
     @setup { let code = r#"

--- a/crates/celox/tests/synth_dynamic_loop.rs
+++ b/crates/celox/tests/synth_dynamic_loop.rs
@@ -370,7 +370,7 @@ fn test_i32_shl_step_overflow_reports_true_loop(sim) {
     assert_eq!(sim.eval_comb().unwrap_err(), RuntimeErrorCode::DetectedTrueLoop);
 }
 
-fn test_runtime_bounds_terminal_inclusive_mul_loop_exits_cleanly(sim) {
+fn test_runtime_bounds_terminal_inclusive_mul_loop_reports_true_loop(sim) {
     @ignore_on(veryl);
     @setup { let code = r#"
         module Top (
@@ -388,11 +388,59 @@ fn test_runtime_bounds_terminal_inclusive_mul_loop_exits_cleanly(sim) {
     @build Simulator::builder(code, "Top");
 
     let count = sim.signal("count");
-    let hits = sim.signal("hits");
-
     sim.set(count, 0u32);
+    assert_eq!(sim.eval_comb().unwrap_err(), RuntimeErrorCode::DetectedTrueLoop);
+}
+
+fn test_runtime_reverse_step_matches_emitted_sv_order(sim) {
+    @setup { let code = r#"
+        module Top (
+            start: input signed logic<64>,
+            end_bound: input signed logic<64>,
+            digits: output logic<32>
+        ) {
+            always_comb {
+                digits = 0;
+                for i in rev start..end_bound step += 2 {
+                    digits = digits * 10 + i as 32;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+
+    let start = sim.signal("start");
+    let end_bound = sim.signal("end_bound");
+    let digits = sim.signal("digits");
+    sim.set(start, 0u64);
+    sim.set(end_bound, 10u64);
     sim.eval_comb().unwrap();
-    assert_eq!(sim.get(hits), 1u32.into());
+    assert_eq!(sim.get(digits), 97_531u32.into());
+}
+
+fn test_runtime_reverse_i32_step_truncation_reports_true_loop(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            start: input signed logic<64>,
+            end_bound: input signed logic<64>,
+            hits: output logic<32>
+        ) {
+            always_comb {
+                hits = 0;
+                for i in rev start..=end_bound step += 4294967296 {
+                    hits += 1;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+
+    let start = sim.signal("start");
+    let end_bound = sim.signal("end_bound");
+    sim.set(start, 0u64);
+    sim.set(end_bound, 3u64);
+    assert_eq!(sim.eval_comb().unwrap_err(), RuntimeErrorCode::DetectedTrueLoop);
 }
 
 fn test_runtime_break_in_synth_comb_loop(sim) {


### PR DESCRIPTION
## Summary

- Apply stepped `for`-loop updates at the visible loop-counter width before progress and bound checks.
- Match emitted SystemVerilog reverse-loop initialization and order (`end - 1`, then fixed-width subtraction).
- Report forward and reverse stalls caused by overflow, huge steps, and inclusive terminal values.
- Add adversarial regressions for `+=`, `*=`, `<<=`, `|=`, and `^=` across combinational, flip-flop, and native-testbench paths.

## Why

Veryl emits these loop counters as SystemVerilog `int`. Celox widened some updates before checking progress, the native testbench used host-width or saturating arithmetic, and inclusive loops skipped the terminal update. Those differences could let Celox accept generated SystemVerilog that does not terminate. Reverse loops with a step greater than one also visited a different sequence of values.

## Validation

- `cargo test -p celox --test synth_dynamic_loop`
- `cargo test -p celox --test flip_flop`
- `cargo test -p celox --test native_testbench`
- `cargo test -p celox-slt`
- `cargo test -p celox-frontend-veryl`
- `cargo test -p celox --test error_detection`
- `cargo test -p celox --test simulation_step`
- `cargo check --workspace`
- `cargo clippy -p celox -p celox-slt -p celox-frontend-veryl --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
