### PR TITLE
fix(frontend): lower comb output calls in expressions

### DIFF
--- a/crates/celox-frontend-veryl/src/design_assembly.rs
+++ b/crates/celox-frontend-veryl/src/design_assembly.rs
@@ -1797,7 +1797,7 @@ fn build_comb_observer_capture_paths(
             RuntimeEventKind::AssertFatal
         )
         .then_some(observer.site_id as i64);
-        let pre_lower_nodes = observer_pre_lower_nodes(observer);
+        let pre_lower_nodes = observer_pre_lower_nodes(observer, arena);
         for idx in &order_after {
             comb_blocks[idx.0]
                 .pre_lower_nodes
@@ -1997,16 +1997,30 @@ fn observer_trigger_paths(
         .collect()
 }
 
-fn observer_pre_lower_nodes(observer: &CombObserver<AbsoluteAddr>) -> Vec<NodeId> {
-    if !observer.local_inputs.is_empty() {
-        return Vec::new();
-    }
+fn observer_pre_lower_nodes(
+    observer: &CombObserver<AbsoluteAddr>,
+    arena: &SLTNodeArena<AbsoluteAddr>,
+) -> Vec<NodeId> {
+    let local_input_ids: HashSet<_> = observer.local_inputs.iter().map(|(id, _)| *id).collect();
     let mut nodes = Vec::with_capacity(observer.args.len() + usize::from(observer.guard.is_some()));
     if let Some(guard) = observer.guard {
         nodes.push(guard);
     }
     nodes.extend(observer.args.iter().copied());
     nodes
+        .into_iter()
+        .filter(|node| {
+            let mut inputs = HashSet::default();
+            crate::flattening::collect_inputs(*node, arena, &mut inputs);
+            // A capture independent of local bindings can be materialized at
+            // its statement position. Bound captures still need the event's
+            // environment, while constants need no early snapshot.
+            !inputs.is_empty()
+                && inputs
+                    .iter()
+                    .all(|input| !local_input_ids.contains(&input.id))
+        })
+        .collect()
 }
 
 fn annotate_comb_capture_enable_sites(

--- a/crates/celox-frontend-veryl/src/design_assembly.rs
+++ b/crates/celox-frontend-veryl/src/design_assembly.rs
@@ -2007,6 +2007,9 @@ fn observer_pre_lower_nodes(
         nodes.push(guard);
     }
     nodes.extend(observer.args.iter().copied());
+    nodes.extend(observer.local_inputs.iter().filter_map(|(_, node)| {
+        matches!(arena.get(*node), celox_slt::SLTNode::Capture { .. }).then_some(*node)
+    }));
     nodes
         .into_iter()
         .filter(|node| {
@@ -2014,13 +2017,98 @@ fn observer_pre_lower_nodes(
             crate::flattening::collect_inputs(*node, arena, &mut inputs);
             // A capture independent of local bindings can be materialized at
             // its statement position. Bound captures still need the event's
-            // environment, while constants need no early snapshot.
+            // environment, unless they contain an earlier formal snapshot.
+            // Constants need no early materialization.
             !inputs.is_empty()
-                && inputs
-                    .iter()
-                    .all(|input| !local_input_ids.contains(&input.id))
+                && (capture_contains_nested_snapshot(*node, arena)
+                    || inputs
+                        .iter()
+                        .all(|input| !local_input_ids.contains(&input.id)))
         })
         .collect()
+}
+
+fn capture_contains_nested_snapshot(node: NodeId, arena: &SLTNodeArena<AbsoluteAddr>) -> bool {
+    let celox_slt::SLTNode::Capture { expr, .. } = arena.get(node) else {
+        return false;
+    };
+    let mut work = vec![*expr];
+    let mut visited = HashSet::default();
+    while let Some(node) = work.pop() {
+        if !visited.insert(node) {
+            continue;
+        }
+        match arena.get(node) {
+            celox_slt::SLTNode::Capture { .. } => return true,
+            celox_slt::SLTNode::Input { index, .. } => {
+                work.extend(index.iter().map(|entry| entry.node));
+            }
+            celox_slt::SLTNode::Constant(..) => {}
+            celox_slt::SLTNode::Binary(lhs, _, rhs) => {
+                work.push(*lhs);
+                work.push(*rhs);
+            }
+            celox_slt::SLTNode::Unary(_, inner) => work.push(*inner),
+            celox_slt::SLTNode::Mux {
+                cond,
+                then_expr,
+                else_expr,
+            } => {
+                work.push(*cond);
+                work.push(*then_expr);
+                work.push(*else_expr);
+            }
+            celox_slt::SLTNode::Concat(parts) => {
+                work.extend(parts.iter().map(|(part, _)| *part));
+            }
+            celox_slt::SLTNode::Slice { expr, .. } => work.push(*expr),
+            celox_slt::SLTNode::ForFold {
+                start,
+                end,
+                result,
+                initials,
+                updates,
+                effects,
+                continue_cond,
+                ..
+            } => {
+                if let celox_slt::SLTLoopBound::Expr(node) = start {
+                    work.push(*node);
+                }
+                if let celox_slt::SLTLoopBound::Expr(node) = end {
+                    work.push(*node);
+                }
+                if let celox_slt::SLTForFoldResult::Transient { initial, update } = result {
+                    work.push(*initial);
+                    work.push(*update);
+                }
+                work.extend(initials.iter().map(|state| state.expr));
+                work.extend(updates.iter().map(|state| state.expr));
+                for effect in effects {
+                    match effect {
+                        celox_slt::SLTForEffect::Event { guard, args, .. } => {
+                            work.extend(*guard);
+                            work.extend(args.iter().copied());
+                        }
+                        celox_slt::SLTForEffect::Runner(runner) => work.push(*runner),
+                    }
+                }
+                work.push(*continue_cond);
+            }
+            celox_slt::SLTNode::ForFoldGroup {
+                entry_guard,
+                states,
+                ..
+            } => {
+                work.push(*entry_guard);
+                for state in states {
+                    work.push(state.initial);
+                    work.push(state.update);
+                }
+            }
+        }
+    }
+    false
 }
 
 fn annotate_comb_capture_enable_sites(

--- a/crates/celox-frontend-veryl/src/design_assembly.rs
+++ b/crates/celox-frontend-veryl/src/design_assembly.rs
@@ -1715,6 +1715,7 @@ fn build_comb_observer_capture_paths(
                 local_inputs: observer.local_inputs.clone(),
                 order_before: order_before.clone(),
                 comb_capture_enable_sites: Vec::new(),
+                comb_capture_enable_always: false,
                 pre_lower_nodes: Vec::new(),
                 expr: loop_runner,
             });
@@ -1746,6 +1747,7 @@ fn build_comb_observer_capture_paths(
                     local_inputs: observer.local_inputs.clone(),
                     order_before: trigger_order_before,
                     comb_capture_enable_sites: Vec::new(),
+                    comb_capture_enable_always: false,
                     pre_lower_nodes: Vec::new(),
                     expr: loop_runner,
                 });
@@ -1826,6 +1828,7 @@ fn build_comb_observer_capture_paths(
             local_inputs: observer.local_inputs.clone(),
             order_before,
             comb_capture_enable_sites: Vec::new(),
+            comb_capture_enable_always: false,
             pre_lower_nodes: Vec::new(),
             expr,
         });
@@ -1883,6 +1886,7 @@ fn build_comb_observer_capture_paths(
                     local_inputs: member.local_inputs.clone(),
                     order_before: trigger_order_before.clone(),
                     comb_capture_enable_sites: Vec::new(),
+                    comb_capture_enable_always: false,
                     pre_lower_nodes: Vec::new(),
                     expr: member_expr,
                 });

--- a/crates/celox-frontend-veryl/src/flattening.rs
+++ b/crates/celox-frontend-veryl/src/flattening.rs
@@ -820,6 +820,35 @@ module Top (
     }
 
     #[test]
+    fn generated_comb_collectors_do_not_intern_event_captures_together() {
+        let (sim_modules, _, _) = setup(
+            r#"
+module Top (
+    x: input logic<2>,
+    out: output logic<2>,
+) {
+    function show (value: input logic) -> logic {
+        $display("value=%0d", value);
+        return value;
+    }
+    for j in 0..2 :g_show {
+        always_comb {
+            out[j] = show(x[j]);
+        }
+    }
+}
+"#,
+        );
+        let module = sim_modules.values().next().expect("missing parsed module");
+        assert_eq!(module.comb_observers.len(), 2);
+        let first = module.comb_observers[0].args[0];
+        let second = module.comb_observers[1].args[0];
+        assert_ne!(first, second);
+        assert!(matches!(module.arena.get(first), SLTNode::Capture { .. }));
+        assert!(matches!(module.arena.get(second), SLTNode::Capture { .. }));
+    }
+
+    #[test]
     fn atomization_does_not_remerge_unpacked_elements() {
         let address = AbsoluteAddr {
             instance_id: InstanceId(0),

--- a/crates/celox-frontend-veryl/src/flattening.rs
+++ b/crates/celox-frontend-veryl/src/flattening.rs
@@ -792,12 +792,20 @@ mod tests {
     fn distinct_comb_collectors_do_not_intern_event_captures_together() {
         let (sim_modules, _, _) = setup(
             r#"
-module Top (x: input logic<8>) {
-    always_comb {
-        $display("first=%0d", x);
+module Top (
+    x: input logic<8>,
+    a: output logic<8>,
+    b: output logic<8>,
+) {
+    function show (value: input logic<8>) -> logic<8> {
+        $display("value=%0d", value);
+        return value;
     }
     always_comb {
-        $display("second=%0d", x);
+        a = show(x);
+    }
+    always_comb {
+        b = show(x);
     }
 }
 "#,

--- a/crates/celox-frontend-veryl/src/flattening.rs
+++ b/crates/celox-frontend-veryl/src/flattening.rs
@@ -1010,6 +1010,66 @@ mod tests {
     }
 
     #[test]
+    fn instance_input_output_preserves_dynamic_self_address_sources() {
+        let code = r#"
+            module child(i: input logic) {}
+
+            module top(seed: input logic<2>, mem_o: output logic<2>) {
+                function set_bit (dst: output logic) -> logic {
+                    dst = 1'b1;
+                    return 1'b0;
+                }
+                var mem: logic<2>;
+                always_comb {
+                    mem = seed;
+                }
+                inst c: child(i: set_bit(mem[mem[0]]));
+                assign mem_o = mem;
+            }
+        "#;
+
+        let (sim_modules, name_to_id, ir) = setup(code);
+        let top_module_ir = ir
+            .components
+            .iter()
+            .find_map(|component| match component {
+                Component::Module(module) if module.name.to_string() == "top" => Some(module),
+                _ => None,
+            })
+            .unwrap();
+        let top_module_sim = &sim_modules[&name_to_id[&top_module_ir.name]];
+        let glue = top_module_sim
+            .glue_blocks
+            .values()
+            .flatten()
+            .next()
+            .unwrap();
+        let parent_effect = glue
+            .output_ports
+            .iter()
+            .map(|(_, path)| path)
+            .find(|path| {
+                matches!(
+                    path.target.var(),
+                    Some(VarAtomBase {
+                        id: GlueAddr::Parent(_),
+                        ..
+                    })
+                )
+            })
+            .unwrap();
+
+        assert!(
+            parent_effect.address_sources.iter().any(|address| {
+                parent_effect.previous_sources.iter().any(|previous| {
+                    previous.id == address.id && previous.access.overlaps(&address.access)
+                })
+            }),
+            "the self-referential dynamic address must remain an address source"
+        );
+    }
+
+    #[test]
     fn test_flatting_simple_hierarchy() {
         let code = r#"
             module child(

--- a/crates/celox-frontend-veryl/src/flattening.rs
+++ b/crates/celox-frontend-veryl/src/flattening.rs
@@ -789,6 +789,29 @@ mod tests {
     }
 
     #[test]
+    fn distinct_comb_collectors_do_not_intern_event_captures_together() {
+        let (sim_modules, _, _) = setup(
+            r#"
+module Top (x: input logic<8>) {
+    always_comb {
+        $display("first=%0d", x);
+    }
+    always_comb {
+        $display("second=%0d", x);
+    }
+}
+"#,
+        );
+        let module = sim_modules.values().next().expect("missing parsed module");
+        assert_eq!(module.comb_observers.len(), 2);
+        let first = module.comb_observers[0].args[0];
+        let second = module.comb_observers[1].args[0];
+        assert_ne!(first, second);
+        assert!(matches!(module.arena.get(first), SLTNode::Capture { .. }));
+        assert!(matches!(module.arena.get(second), SLTNode::Capture { .. }));
+    }
+
+    #[test]
     fn atomization_does_not_remerge_unpacked_elements() {
         let address = AbsoluteAddr {
             instance_id: InstanceId(0),

--- a/crates/celox-frontend-veryl/src/flattening.rs
+++ b/crates/celox-frontend-veryl/src/flattening.rs
@@ -405,6 +405,10 @@ fn collect_inputs_with_window<A: Hash + Eq + Clone + Debug>(
                     .flatten();
                 collect_inputs_with_window(*inner, inner_window, arena, set, visited);
             }
+            SLTNode::Capture { expr, .. } => {
+                let inner_window = dependency_window(window, *expr, arena);
+                collect_inputs_with_window(*expr, inner_window, arena, set, visited);
+            }
             SLTNode::Mux {
                 cond,
                 then_expr,

--- a/crates/celox-frontend-veryl/src/flattening.rs
+++ b/crates/celox-frontend-veryl/src/flattening.rs
@@ -233,6 +233,7 @@ fn atomize_logic_paths(
                     local_inputs: path.local_inputs.clone(),
                     order_before: path.order_before.clone(),
                     comb_capture_enable_sites: path.comb_capture_enable_sites.clone(),
+                    comb_capture_enable_always: path.comb_capture_enable_always,
                     pre_lower_nodes: path.pre_lower_nodes.clone(),
                     expr: merged_expr,
                 });
@@ -877,6 +878,7 @@ module Top (
             local_inputs: Vec::new(),
             order_before: crate::HashSet::default(),
             comb_capture_enable_sites: Vec::new(),
+            comb_capture_enable_always: false,
             pre_lower_nodes: Vec::new(),
             expr: expression,
         };
@@ -943,6 +945,7 @@ module Top (
             local_inputs: Vec::new(),
             order_before: crate::HashSet::default(),
             comb_capture_enable_sites: Vec::new(),
+            comb_capture_enable_always: false,
             pre_lower_nodes: Vec::new(),
             expr: expression,
         };
@@ -1049,6 +1052,7 @@ module Top (
             local_inputs: Vec::new(),
             order_before: crate::HashSet::default(),
             comb_capture_enable_sites: Vec::new(),
+            comb_capture_enable_always: false,
             pre_lower_nodes: Vec::new(),
             expr: expression,
         };

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -1071,18 +1071,15 @@ fn eval_loop_statement(
             Some(&ir.token),
         )),
         Statement::SystemFunctionCall(call) => {
-            let (store, boundaries) = eval_system_function_call_side_effects(
+            let guard_state = state.clone();
+            let (next_store, next_boundaries) = eval_system_function_call_side_effects(
                 module,
                 state.store,
                 state.boundaries,
                 call,
                 arena,
             )?;
-            Ok(LoopControlState {
-                store,
-                boundaries,
-                ..state
-            })
+            apply_loop_continue_guard(module, guard_state, next_store, next_boundaries, arena)
         }
         Statement::FunctionCall(fc) => {
             let guard_state = state.clone();
@@ -2455,25 +2452,25 @@ fn eval_statement_form_function_call(
 
     apply_function_call_outputs(
         module,
+        function,
         store,
         boundaries,
         call,
         &function_body,
         &final_local_store,
         arena,
-        phase,
     )
 }
 
 fn apply_function_call_outputs(
     module: &Module,
+    function: &Function,
     mut store: SymbolicStore<VarId>,
     mut boundaries: BoundaryMap<VarId>,
     call: &veryl_analyzer::ir::FunctionCall,
     function_body: &veryl_analyzer::ir::FunctionBody,
     final_local_store: &SymbolicStore<VarId>,
     arena: &mut SLTNodeArena<VarId>,
-    phase: LoweringPhase,
 ) -> Result<(SymbolicStore<VarId>, BoundaryMap<VarId>), ParserError> {
     for (arg_path, dsts) in &call.outputs {
         let Some(arg_id) = function_body.arg_map.get(arg_path) else {

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -45,7 +45,10 @@ use effect::{
     subtract_written_sensitivity,
 };
 pub use expr::coerce_node_width;
-use expr::{eval_array_literal_expression, eval_function_body_return, merge_boundaries};
+use expr::{
+    eval_array_literal_expression_effectful, eval_assignment_expression_effectful,
+    eval_function_body_return, merge_boundaries,
+};
 pub use expr::{eval_assignment_expression, eval_expression, get_width};
 use state::{FunctionControlState, LoopControlState};
 
@@ -1307,6 +1310,7 @@ fn collect_written_accesses(
     for stmt in statements {
         match stmt {
             Statement::Assign(assign) => {
+                collect_written_expression(module, &assign.expr, out)?;
                 for dst in &assign.dst {
                     collect_written_destination(module, out, dst)?;
                 }
@@ -1341,6 +1345,106 @@ fn collect_written_accesses(
         }
     }
     Ok(())
+}
+
+fn collect_written_expression(
+    module: &Module,
+    expression: &Expression,
+    out: &mut HashMap<VarId, Vec<BitAccess>>,
+) -> Result<(), ParserError> {
+    match expression {
+        Expression::Term(factor) => match factor.as_ref() {
+            Factor::FunctionCall(call) => {
+                for input in call.inputs.values() {
+                    collect_written_expression(module, input, out)?;
+                }
+                for destinations in call.outputs.values() {
+                    for destination in destinations {
+                        collect_written_destination(module, out, destination)?;
+                    }
+                }
+                Ok(())
+            }
+            Factor::Variable(_, index, select, _) => {
+                for expression in index.0.iter().chain(select.0.iter()) {
+                    collect_written_expression(module, expression, out)?;
+                }
+                if let Some((_, expression)) = &select.1 {
+                    collect_written_expression(module, expression, out)?;
+                }
+                Ok(())
+            }
+            Factor::SystemFunctionCall(call) => {
+                let mut collect_input =
+                    |input: &SystemFunctionInput| collect_written_expression(module, &input.0, out);
+                match &call.kind {
+                    SystemFunctionKind::Bits(input)
+                    | SystemFunctionKind::Size(input)
+                    | SystemFunctionKind::Clog2(input)
+                    | SystemFunctionKind::Onehot(input)
+                    | SystemFunctionKind::Signed(input)
+                    | SystemFunctionKind::Unsigned(input) => collect_input(input),
+                    SystemFunctionKind::Readmemh(input, _) => collect_input(input),
+                    SystemFunctionKind::Display(inputs) | SystemFunctionKind::Write(inputs) => {
+                        for input in inputs {
+                            collect_input(input)?;
+                        }
+                        Ok(())
+                    }
+                    SystemFunctionKind::Assert { cond, args, .. } => {
+                        collect_input(cond)?;
+                        for input in args {
+                            collect_input(input)?;
+                        }
+                        Ok(())
+                    }
+                    SystemFunctionKind::Finish => Ok(()),
+                }
+            }
+            Factor::Value(_) | Factor::Anonymous(_) | Factor::Unknown(_) => Ok(()),
+        },
+        Expression::Unary(_, inner, _) => collect_written_expression(module, inner, out),
+        Expression::Binary(lhs, _, rhs, _) => {
+            collect_written_expression(module, lhs, out)?;
+            collect_written_expression(module, rhs, out)
+        }
+        Expression::Ternary(cond, then_expr, else_expr, _) => {
+            collect_written_expression(module, cond, out)?;
+            collect_written_expression(module, then_expr, out)?;
+            collect_written_expression(module, else_expr, out)
+        }
+        Expression::Concatenation(parts, _) => {
+            for (part, repeat) in parts {
+                collect_written_expression(module, part, out)?;
+                if let Some(repeat) = repeat {
+                    collect_written_expression(module, repeat, out)?;
+                }
+            }
+            Ok(())
+        }
+        Expression::ArrayLiteral(items, _) => {
+            for item in items {
+                match item {
+                    ArrayLiteralItem::Value(expression, repeat) => {
+                        collect_written_expression(module, expression, out)?;
+                        if let Some(repeat) = repeat {
+                            collect_written_expression(module, repeat, out)?;
+                        }
+                    }
+                    ArrayLiteralItem::Defaul(expression) => {
+                        collect_written_expression(module, expression, out)?;
+                    }
+                }
+            }
+            Ok(())
+        }
+        Expression::StructConstructor(_, fields, _) => {
+            for (_, field) in fields {
+                collect_written_expression(module, field, out)?;
+            }
+            Ok(())
+        }
+    }
 }
 
 fn collect_written_destination(
@@ -1848,28 +1952,38 @@ fn eval_assign(
         "assignment destination",
         Some(&stmt.expr.token_range()),
     )?;
-    let ((rhs_expr, rhs_sources), rhs_bounds) = if let Expression::ArrayLiteral(items, _) =
-        &stmt.expr
-    {
-        let ((node, sources), bounds) =
-            eval_array_literal_expression(module, &store, items, Some(rhs_expected_width), arena)?;
-        if get_width(node, arena) == 0 {
-            return Err(ParserError::illegal_context(
-                "assignment expression",
-                "a zero-width array literal cannot be assigned",
-                Some(&stmt.expr.token_range()),
-            ));
-        }
-        (
+    let ((rhs_expr, rhs_sources), rhs_bounds) =
+        if let Expression::ArrayLiteral(items, _) = &stmt.expr {
+            let ((node, sources), bounds) = eval_array_literal_expression_effectful(
+                module,
+                &mut store,
+                items,
+                Some(rhs_expected_width),
+                arena,
+            )?;
+            if get_width(node, arena) == 0 {
+                return Err(ParserError::illegal_context(
+                    "assignment expression",
+                    "a zero-width array literal cannot be assigned",
+                    Some(&stmt.expr.token_range()),
+                ));
+            }
             (
-                coerce_node_width(arena, node, Some(rhs_expected_width), false)?,
-                sources,
-            ),
-            bounds,
-        )
-    } else {
-        eval_assignment_expression(module, &store, &stmt.expr, arena, rhs_expected_width)?
-    };
+                (
+                    coerce_node_width(arena, node, Some(rhs_expected_width), false)?,
+                    sources,
+                ),
+                bounds,
+            )
+        } else {
+            eval_assignment_expression_effectful(
+                module,
+                &mut store,
+                &stmt.expr,
+                arena,
+                rhs_expected_width,
+            )?
+        };
     let mut boundaries = merge_boundaries(boundaries, rhs_bounds);
 
     if stmt.dst.len() == 1 {
@@ -2076,7 +2190,7 @@ fn assign_node_to_dsts(
 
 fn eval_statement_form_function_call(
     module: &Module,
-    mut store: SymbolicStore<VarId>,
+    store: SymbolicStore<VarId>,
     mut boundaries: BoundaryMap<VarId>,
     call: &veryl_analyzer::ir::FunctionCall,
     arena: &mut SLTNodeArena<VarId>,
@@ -2157,6 +2271,28 @@ fn eval_statement_form_function_call(
     };
     boundaries = merge_boundaries(boundaries, local_boundaries);
 
+    apply_function_call_outputs(
+        module,
+        store,
+        boundaries,
+        call,
+        &function_body,
+        &final_local_store,
+        arena,
+        phase,
+    )
+}
+
+fn apply_function_call_outputs(
+    module: &Module,
+    mut store: SymbolicStore<VarId>,
+    mut boundaries: BoundaryMap<VarId>,
+    call: &veryl_analyzer::ir::FunctionCall,
+    function_body: &veryl_analyzer::ir::FunctionBody,
+    final_local_store: &SymbolicStore<VarId>,
+    arena: &mut SLTNodeArena<VarId>,
+    phase: LoweringPhase,
+) -> Result<(SymbolicStore<VarId>, BoundaryMap<VarId>), ParserError> {
     for (arg_path, dsts) in &call.outputs {
         let Some(arg_id) = function_body.arg_map.get(arg_path) else {
             return Err(invalid_function_call_argument_error(
@@ -3053,6 +3189,46 @@ mod tests {
 
         let q_id = var_id_of(&module, &["q"]);
         assert_eq!(written[&q_id], vec![BitAccess::new(0, 3)]);
+    }
+
+    #[test]
+    fn test_collect_written_accesses_includes_expression_function_call_outputs() {
+        let code = r#"
+            module Top (
+                d: input logic<8>,
+                q_return: output logic<8>,
+                q_output: output logic<8>,
+            ) {
+                function f (
+                    x: input logic<8>,
+                    y: output logic<8>,
+                ) -> logic<8> {
+                    y = x + 8'd1;
+                    return x + 8'd2;
+                }
+
+                always_comb {
+                    q_return = f(d, q_output);
+                }
+            }
+        "#;
+        let module = parse_top_module(code);
+        let comb_decl = module
+            .declarations
+            .iter()
+            .find_map(|declaration| {
+                if let Declaration::Comb(comb) = declaration {
+                    Some(comb)
+                } else {
+                    None
+                }
+            })
+            .expect("No always_comb found in Top");
+        let mut written = HashMap::default();
+        collect_written_accesses(&module, &comb_decl.statements, &mut written).unwrap();
+
+        let q_output = var_id_of(&module, &["q_output"]);
+        assert_eq!(written[&q_output], vec![BitAccess::new(0, 7)]);
     }
 
     #[test]

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -44,10 +44,11 @@ use effect::{
     subtract_written_sensitivity,
 };
 pub use expr::coerce_node_width;
+pub(crate) use expr::eval_assignment_expression_effectful;
 use expr::{
-    eval_array_literal_expression_effectful, eval_assignment_expression_effectful,
-    eval_case_arm_condition_effectful, eval_case_target_effectful, eval_expression_effectful,
-    eval_function_body_return, merge_boundaries,
+    eval_array_literal_expression_effectful, eval_case_arm_condition_effectful,
+    eval_case_target_effectful, eval_expression_effectful, eval_function_body_return,
+    merge_boundaries,
 };
 pub use expr::{eval_assignment_expression, eval_expression, get_width};
 use state::{FunctionControlState, LoopControlState};
@@ -1621,7 +1622,7 @@ fn collect_written_accesses(
     Ok(())
 }
 
-fn collect_written_expression(
+pub(super) fn collect_written_expression(
     module: &Module,
     expression: &Expression,
     out: &mut HashMap<VarId, Vec<BitAccess>>,

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -43,8 +43,8 @@ use veryl_parser::resource_table;
 use veryl_parser::token_range::TokenRange;
 
 pub(crate) use effect::{
-    CombEffectCollector, collect_expression_effects, expression_contains_runtime_effect,
-    subtract_written_sensitivity,
+    CombEffectCollector, collect_and_advance_expression, collect_expression_effects,
+    expression_contains_runtime_effect, subtract_written_sensitivity,
 };
 use effect::{collect_comb_effects_statements, statements_contain_runtime_effect};
 pub use expr::coerce_node_width;
@@ -3147,7 +3147,7 @@ fn eval_if(
     ))
 }
 
-fn combine_parts_with_default<A: Clone + PartialEq + Eq + Hash>(
+pub(crate) fn combine_parts_with_default<A: Clone + PartialEq + Eq + Hash>(
     var_id: A,
     start_lsb: usize,
     parts: Vec<(Option<(NodeId, HashSet<VarAtomBase<A>>)>, BitAccess)>,

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -22,7 +22,6 @@ use std::{collections::BTreeSet, hash::Hash};
 use crate::{
     HashMap, HashSet, LoweringPhase, ParserError,
     bitaccess::{PartSelectGeometry, eval_constexpr, eval_var_select, select_geometry},
-    case::case_arm_condition_expr,
     loop_provenance::LoopRecoveryCandidate,
     resolve_total_width,
 };
@@ -47,7 +46,8 @@ use effect::{
 pub use expr::coerce_node_width;
 use expr::{
     eval_array_literal_expression_effectful, eval_assignment_expression_effectful,
-    eval_expression_effectful, eval_function_body_return, merge_boundaries,
+    eval_case_arm_condition_effectful, eval_case_target_effectful, eval_expression_effectful,
+    eval_function_body_return, merge_boundaries,
 };
 pub use expr::{eval_assignment_expression, eval_expression, get_width};
 use state::{FunctionControlState, LoopControlState};
@@ -540,12 +540,14 @@ fn eval_system_function_call_side_effects(
                 eval_input(module, &mut store, &mut boundaries, input, arena)?;
             }
         }
+        SystemFunctionKind::Clog2(input)
+        | SystemFunctionKind::Onehot(input)
+        | SystemFunctionKind::Signed(input)
+        | SystemFunctionKind::Unsigned(input) => {
+            eval_input(module, &mut store, &mut boundaries, input, arena)?;
+        }
         SystemFunctionKind::Bits(_)
         | SystemFunctionKind::Size(_)
-        | SystemFunctionKind::Clog2(_)
-        | SystemFunctionKind::Onehot(_)
-        | SystemFunctionKind::Signed(_)
-        | SystemFunctionKind::Unsigned(_)
         | SystemFunctionKind::Readmemh(_, _)
         | SystemFunctionKind::Finish => {}
     }
@@ -589,7 +591,7 @@ fn eval_statements_with_recovery(
 
 fn eval_case_with_recovery(
     module: &Module,
-    store: SymbolicStore<VarId>,
+    mut store: SymbolicStore<VarId>,
     boundaries: BoundaryMap<VarId>,
     case_stmt: &CaseStatement,
     arena: &mut SLTNodeArena<VarId>,
@@ -601,6 +603,7 @@ fn eval_case_with_recovery(
         mut store: SymbolicStore<VarId>,
         boundaries: BoundaryMap<VarId>,
         case_stmt: &CaseStatement,
+        target: &expr::EvaluatedCaseTarget,
         arm_index: usize,
         arena: &mut SLTNodeArena<VarId>,
         loop_candidates: &[LoopRecoveryCandidate],
@@ -618,9 +621,14 @@ fn eval_case_with_recovery(
             );
         };
 
-        let cond = case_arm_condition_expr(&case_stmt.case_target, &arm.patterns);
-        let ((cond_expr, cond_sources), cond_bounds) =
-            eval_expression_effectful(module, &mut store, &cond, arena, None)?;
+        let ((cond_expr, cond_sources), cond_bounds) = eval_case_arm_condition_effectful(
+            module,
+            &mut store,
+            &case_stmt.case_target,
+            target,
+            &arm.patterns,
+            arena,
+        )?;
         let cond_expr = procedural_condition(arena, cond_expr)?;
         let boundaries = merge_boundaries(boundaries, cond_bounds);
 
@@ -641,6 +649,7 @@ fn eval_case_with_recovery(
                     store,
                     boundaries,
                     case_stmt,
+                    target,
                     arm_index + 1,
                     arena,
                     loop_candidates,
@@ -667,6 +676,7 @@ fn eval_case_with_recovery(
             store,
             boundaries,
             case_stmt,
+            target,
             arm_index + 1,
             arena,
             loop_candidates,
@@ -686,11 +696,15 @@ fn eval_case_with_recovery(
         ))
     }
 
+    let (target, target_boundaries) =
+        eval_case_target_effectful(module, &mut store, &case_stmt.case_target, arena)?;
+    let boundaries = merge_boundaries(boundaries, target_boundaries);
     eval_from_arm(
         module,
         store,
         boundaries,
         case_stmt,
+        &target,
         0,
         arena,
         loop_candidates,
@@ -710,6 +724,7 @@ fn eval_case(
         mut store: SymbolicStore<VarId>,
         boundaries: BoundaryMap<VarId>,
         case_stmt: &CaseStatement,
+        target: &expr::EvaluatedCaseTarget,
         arm_index: usize,
         arena: &mut SLTNodeArena<VarId>,
     ) -> Result<(SymbolicStore<VarId>, BoundaryMap<VarId>), ParserError> {
@@ -717,9 +732,14 @@ fn eval_case(
             return eval_statements(module, store, boundaries, &case_stmt.default, arena);
         };
 
-        let cond = case_arm_condition_expr(&case_stmt.case_target, &arm.patterns);
-        let ((cond_expr, cond_sources), cond_bounds) =
-            eval_expression_effectful(module, &mut store, &cond, arena, None)?;
+        let ((cond_expr, cond_sources), cond_bounds) = eval_case_arm_condition_effectful(
+            module,
+            &mut store,
+            &case_stmt.case_target,
+            target,
+            &arm.patterns,
+            arena,
+        )?;
         let cond_expr = procedural_condition(arena, cond_expr)?;
         let boundaries = merge_boundaries(boundaries, cond_bounds);
 
@@ -727,14 +747,29 @@ fn eval_case(
             return if cond_val {
                 eval_statements(module, store, boundaries, &arm.body, arena)
             } else {
-                eval_from_arm(module, store, boundaries, case_stmt, arm_index + 1, arena)
+                eval_from_arm(
+                    module,
+                    store,
+                    boundaries,
+                    case_stmt,
+                    target,
+                    arm_index + 1,
+                    arena,
+                )
             };
         }
 
         let (then_store, then_boundaries) =
             eval_statements(module, store.clone(), boundaries.clone(), &arm.body, arena)?;
-        let (else_store, else_boundaries) =
-            eval_from_arm(module, store, boundaries, case_stmt, arm_index + 1, arena)?;
+        let (else_store, else_boundaries) = eval_from_arm(
+            module,
+            store,
+            boundaries,
+            case_stmt,
+            target,
+            arm_index + 1,
+            arena,
+        )?;
 
         Ok((
             merge_symbolic_stores(
@@ -749,7 +784,18 @@ fn eval_case(
         ))
     }
 
-    eval_from_arm(module, store, boundaries, case_stmt, 0, arena)
+    let mut store = store;
+    let (target, target_boundaries) =
+        eval_case_target_effectful(module, &mut store, &case_stmt.case_target, arena)?;
+    eval_from_arm(
+        module,
+        store,
+        merge_boundaries(boundaries, target_boundaries),
+        case_stmt,
+        &target,
+        0,
+        arena,
+    )
 }
 
 fn bool_node(arena: &mut SLTNodeArena<VarId>, value: bool) -> Result<NodeId, SLTNodeFactsError> {
@@ -1070,7 +1116,7 @@ fn eval_loop_statement(
 
 fn eval_loop_case(
     module: &Module,
-    state: LoopControlState,
+    mut state: LoopControlState,
     case_stmt: &CaseStatement,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<LoopControlState, ParserError> {
@@ -1078,6 +1124,7 @@ fn eval_loop_case(
         module: &Module,
         mut state: LoopControlState,
         case_stmt: &CaseStatement,
+        target: &expr::EvaluatedCaseTarget,
         arm_index: usize,
         arena: &mut SLTNodeArena<VarId>,
     ) -> Result<LoopControlState, ParserError> {
@@ -1088,12 +1135,13 @@ fn eval_loop_case(
                 .try_fold(state, |s, step| eval_loop_statement(module, s, step, arena));
         };
 
-        let ((cond_expr, cond_sources), cond_bounds) = eval_expression_effectful(
+        let ((cond_expr, cond_sources), cond_bounds) = eval_case_arm_condition_effectful(
             module,
             &mut state.store,
-            &case_arm_condition_expr(&case_stmt.case_target, &arm.patterns),
+            &case_stmt.case_target,
+            target,
+            &arm.patterns,
             arena,
-            None,
         )?;
         let cond_expr = procedural_condition(arena, cond_expr)?;
         let boundaries = merge_boundaries(state.boundaries, cond_bounds);
@@ -1108,7 +1156,7 @@ fn eval_loop_case(
                     .iter()
                     .try_fold(state, |s, step| eval_loop_statement(module, s, step, arena))
             } else {
-                eval_from_arm(module, state, case_stmt, arm_index + 1, arena)
+                eval_from_arm(module, state, case_stmt, target, arm_index + 1, arena)
             };
         }
 
@@ -1130,6 +1178,7 @@ fn eval_loop_case(
                 continue_sources: state.continue_sources,
             },
             case_stmt,
+            target,
             arm_index + 1,
             arena,
         )?;
@@ -1158,7 +1207,10 @@ fn eval_loop_case(
         })
     }
 
-    eval_from_arm(module, state, case_stmt, 0, arena)
+    let (target, target_boundaries) =
+        eval_case_target_effectful(module, &mut state.store, &case_stmt.case_target, arena)?;
+    state.boundaries = merge_boundaries(state.boundaries, target_boundaries);
+    eval_from_arm(module, state, case_stmt, &target, 0, arena)
 }
 
 fn eval_loop_if(
@@ -1293,6 +1345,33 @@ fn eval_for_bound(
         ForBound::Expression(expr) => {
             let ((node, sources), bounds) = eval_expression(module, store, expr, arena, None)?;
             Ok((SLTLoopBound::Expr(node), sources, bounds))
+        }
+    }
+}
+
+fn eval_for_bound_effectful(
+    module: &Module,
+    store: &mut SymbolicStore<VarId>,
+    bound: &ForBound,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<
+    (
+        SLTLoopBound,
+        HashSet<VarAtomBase<VarId>>,
+        BoundaryMap<VarId>,
+    ),
+    ParserError,
+> {
+    match bound {
+        ForBound::Const(value) => Ok((
+            SLTLoopBound::Const(*value),
+            HashSet::default(),
+            BoundaryMap::default(),
+        )),
+        ForBound::Expression(expression) => {
+            let ((node, sources), boundaries) =
+                eval_expression_effectful(module, store, expression, arena, None)?;
+            Ok((SLTLoopBound::Expr(node), sources, boundaries))
         }
     }
 }
@@ -1521,9 +1600,10 @@ fn collect_written_system_function_call(
     let mut collect_input =
         |input: &SystemFunctionInput| collect_written_expression(module, &input.0, out);
     match &call.kind {
-        SystemFunctionKind::Bits(input)
-        | SystemFunctionKind::Size(input)
-        | SystemFunctionKind::Clog2(input)
+        // These operands are queried for shape only and are not evaluated at
+        // runtime, so nested output arguments are not writes of this process.
+        SystemFunctionKind::Bits(_) | SystemFunctionKind::Size(_) => Ok(()),
+        SystemFunctionKind::Clog2(input)
         | SystemFunctionKind::Onehot(input)
         | SystemFunctionKind::Signed(input)
         | SystemFunctionKind::Unsigned(input) => collect_input(input),
@@ -1574,8 +1654,8 @@ fn eval_for(
 
 fn eval_for_with_effects(
     module: &Module,
-    store: SymbolicStore<VarId>,
-    boundaries: HashMap<VarId, BTreeSet<usize>>,
+    mut store: SymbolicStore<VarId>,
+    mut boundaries: HashMap<VarId, BTreeSet<usize>>,
     for_stmt: &ForStatement,
     arena: &mut SLTNodeArena<VarId>,
     effects: &[SLTForEffect],
@@ -1611,6 +1691,96 @@ fn eval_for_with_effects(
             Some(&for_stmt.token),
         ));
     }
+
+    // Bounds are ordinary runtime expressions. Evaluate them once, from left
+    // to right, before constructing the loop state so output-argument writes
+    // are visible both inside the loop and after it.
+    let (start, end, start_sources, end_sources, inclusive, step, step_op, reverse) =
+        match &for_stmt.range {
+            ForRange::Forward {
+                start: range_start,
+                end: range_end,
+                inclusive,
+                step,
+            } => {
+                let (start, start_sources, start_bounds) =
+                    eval_for_bound_effectful(module, &mut store, range_start, arena)?;
+                boundaries = merge_boundaries(boundaries, start_bounds);
+                let (end, end_sources, end_bounds) =
+                    eval_for_bound_effectful(module, &mut store, range_end, arena)?;
+                boundaries = merge_boundaries(boundaries, end_bounds);
+                (
+                    start,
+                    end,
+                    start_sources,
+                    end_sources,
+                    *inclusive,
+                    *step,
+                    SLTStepOp::Add,
+                    false,
+                )
+            }
+            ForRange::Reverse {
+                start: range_start,
+                end: range_end,
+                inclusive,
+                step,
+            } => {
+                let (start, start_sources, start_bounds) =
+                    eval_for_bound_effectful(module, &mut store, range_start, arena)?;
+                boundaries = merge_boundaries(boundaries, start_bounds);
+                let (end, end_sources, end_bounds) =
+                    eval_for_bound_effectful(module, &mut store, range_end, arena)?;
+                boundaries = merge_boundaries(boundaries, end_bounds);
+                (
+                    start,
+                    end,
+                    start_sources,
+                    end_sources,
+                    *inclusive,
+                    *step,
+                    SLTStepOp::Add,
+                    true,
+                )
+            }
+            ForRange::Stepped {
+                start: range_start,
+                end: range_end,
+                inclusive,
+                step,
+                op,
+            } => {
+                let (start, start_sources, start_bounds) =
+                    eval_for_bound_effectful(module, &mut store, range_start, arena)?;
+                boundaries = merge_boundaries(boundaries, start_bounds);
+                let (end, end_sources, end_bounds) =
+                    eval_for_bound_effectful(module, &mut store, range_end, arena)?;
+                boundaries = merge_boundaries(boundaries, end_bounds);
+                let step_op = match op {
+                    Op::Mul => SLTStepOp::Mul,
+                    Op::LogicShiftL | Op::ArithShiftL => SLTStepOp::Shl,
+                    Op::BitOr => SLTStepOp::BitOr,
+                    Op::BitXor => SLTStepOp::BitXor,
+                    other => {
+                        return Err(ParserError::illegal_context(
+                            "for loop step operator",
+                            format!("{other:?}"),
+                            Some(&for_stmt.token),
+                        ));
+                    }
+                };
+                (
+                    start,
+                    end,
+                    start_sources,
+                    end_sources,
+                    *inclusive,
+                    *step,
+                    step_op,
+                    false,
+                )
+            }
+        };
 
     let mut symbolic_store = store.clone();
     let mut written_accesses = HashMap::default();
@@ -1663,104 +1833,7 @@ fn eval_for_with_effects(
         |state, stmt| eval_loop_statement(module, state, stmt, arena),
     )?;
     let iter_store_after = loop_state.store;
-    let mut merged_boundaries = loop_state.boundaries;
-
-    let (
-        start,
-        end,
-        start_sources,
-        end_sources,
-        start_bounds,
-        end_bounds,
-        inclusive,
-        step,
-        step_op,
-        reverse,
-    ) = match &for_stmt.range {
-        ForRange::Forward {
-            start: range_start,
-            end: range_end,
-            inclusive,
-            step,
-        } => {
-            let (start, start_sources, start_bounds) =
-                eval_for_bound(module, &store, range_start, arena)?;
-            let (end, end_sources, end_bounds) = eval_for_bound(module, &store, range_end, arena)?;
-            (
-                start,
-                end,
-                start_sources,
-                end_sources,
-                start_bounds,
-                end_bounds,
-                *inclusive,
-                *step,
-                SLTStepOp::Add,
-                false,
-            )
-        }
-        ForRange::Reverse {
-            start: range_start,
-            end: range_end,
-            inclusive,
-            step,
-        } => {
-            let (start, start_sources, start_bounds) =
-                eval_for_bound(module, &store, range_start, arena)?;
-            let (end, end_sources, end_bounds) = eval_for_bound(module, &store, range_end, arena)?;
-            (
-                start,
-                end,
-                start_sources,
-                end_sources,
-                start_bounds,
-                end_bounds,
-                *inclusive,
-                *step,
-                SLTStepOp::Add,
-                true,
-            )
-        }
-        ForRange::Stepped {
-            start: range_start,
-            end: range_end,
-            inclusive,
-            step,
-            op,
-        } => {
-            let (start, start_sources, start_bounds) =
-                eval_for_bound(module, &store, range_start, arena)?;
-            let (end, end_sources, end_bounds) = eval_for_bound(module, &store, range_end, arena)?;
-            let step_op = match op {
-                Op::Mul => SLTStepOp::Mul,
-                Op::LogicShiftL | Op::ArithShiftL => SLTStepOp::Shl,
-                Op::BitOr => SLTStepOp::BitOr,
-                Op::BitXor => SLTStepOp::BitXor,
-                other => {
-                    return Err(ParserError::illegal_context(
-                        "for loop step operator",
-                        format!("{other:?}"),
-                        Some(&for_stmt.token),
-                    ));
-                }
-            };
-            (
-                start,
-                end,
-                start_sources,
-                end_sources,
-                start_bounds,
-                end_bounds,
-                *inclusive,
-                *step,
-                step_op,
-                false,
-            )
-        }
-    };
-
-    merged_boundaries = merge_boundaries(merged_boundaries, start_bounds);
-    merged_boundaries = merge_boundaries(merged_boundaries, end_bounds);
+    let merged_boundaries = loop_state.boundaries;
 
     let updates = extract_store_updates(&iter_store_before, &iter_store_after, arena)?;
     if updates.is_empty() && effects.is_empty() {
@@ -3347,6 +3420,60 @@ mod tests {
 
         let q_output = var_id_of(&module, &["q_output"]);
         assert_eq!(written[&q_output], vec![BitAccess::new(0, 7)]);
+    }
+
+    #[test]
+    fn test_collect_written_accesses_excludes_unevaluated_shape_operands() {
+        let code = r#"
+            module Top (
+                d: input logic<8>,
+                q: output logic<32>,
+                q_output: output logic<8>,
+            ) {
+                function f (
+                    x: input logic<8>,
+                    y: output logic<8>,
+                ) -> logic<8> {
+                    y = x + 8'd1;
+                    return x;
+                }
+
+                always_comb {
+                    q_output = 8'd0;
+                    q = $bits(f(d, q_output)) + $size(f(d, q_output));
+                }
+            }
+        "#;
+        let module = parse_top_module(code);
+        let comb_decl = module
+            .declarations
+            .iter()
+            .find_map(|declaration| {
+                if let Declaration::Comb(comb) = declaration {
+                    Some(comb)
+                } else {
+                    None
+                }
+            })
+            .expect("No always_comb found in Top");
+        let q = var_id_of(&module, &["q"]);
+        let expression = comb_decl
+            .statements
+            .iter()
+            .filter_map(|statement| {
+                if let Statement::Assign(assign) = statement {
+                    Some(assign)
+                } else {
+                    None
+                }
+            })
+            .find(|assign| assign.dst.iter().any(|dst| dst.id == q))
+            .expect("No q assignment found in Top");
+        let mut written = HashMap::default();
+        collect_written_expression(&module, &expression.expr, &mut written).unwrap();
+
+        let q_output = var_id_of(&module, &["q_output"]);
+        assert!(!written.contains_key(&q_output));
     }
 
     #[test]

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -449,7 +449,9 @@ fn collect_comb_path_stats(
             collect_comb_path_stats(*lhs, arena, visited, stats);
             collect_comb_path_stats(*rhs, arena, visited, stats);
         }
-        SLTNode::Unary(_, inner) => collect_comb_path_stats(*inner, arena, visited, stats),
+        SLTNode::Unary(_, inner) | SLTNode::Capture { expr: inner, .. } => {
+            collect_comb_path_stats(*inner, arena, visited, stats)
+        }
         SLTNode::Mux {
             cond,
             then_expr,
@@ -1655,9 +1657,6 @@ pub(super) fn collect_written_expression(
                 for expression in index.0.iter().chain(select.0.iter()) {
                     collect_written_expression(module, expression, out)?;
                 }
-                if let Some((_, expression)) = &select.1 {
-                    collect_written_expression(module, expression, out)?;
-                }
                 Ok(())
             }
             Factor::SystemFunctionCall(call) => {
@@ -1668,6 +1667,9 @@ pub(super) fn collect_written_expression(
         Expression::Unary(_, inner, _) => collect_written_expression(module, inner, out),
         Expression::Binary(lhs, op, rhs, _) => {
             collect_written_expression(module, lhs, out)?;
+            if matches!(op, Op::Pow) {
+                return Ok(());
+            }
             let lhs_value = eval_fully_known_constexpr(lhs);
             let skips_rhs = match op {
                 Op::LogicAnd => lhs_value
@@ -1696,22 +1698,16 @@ pub(super) fn collect_written_expression(
             collect_written_expression(module, else_expr, out)
         }
         Expression::Concatenation(parts, _) => {
-            for (part, repeat) in parts {
+            for (part, _) in parts {
                 collect_written_expression(module, part, out)?;
-                if let Some(repeat) = repeat {
-                    collect_written_expression(module, repeat, out)?;
-                }
             }
             Ok(())
         }
         Expression::ArrayLiteral(items, _) => {
             for item in items {
                 match item {
-                    ArrayLiteralItem::Value(expression, repeat) => {
+                    ArrayLiteralItem::Value(expression, _) => {
                         collect_written_expression(module, expression, out)?;
-                        if let Some(repeat) = repeat {
-                            collect_written_expression(module, repeat, out)?;
-                        }
                     }
                     ArrayLiteralItem::Defaul(expression) => {
                         collect_written_expression(module, expression, out)?;
@@ -1768,9 +1764,6 @@ fn collect_written_destination(
     dst: &veryl_analyzer::ir::AssignDestination,
 ) -> Result<(), ParserError> {
     for expression in dst.index.0.iter().chain(dst.select.0.iter()) {
-        collect_written_expression(module, expression, out)?;
-    }
-    if let Some((_, expression)) = &dst.select.1 {
         collect_written_expression(module, expression, out)?;
     }
     let access = eval_var_select(module, dst.id, &dst.index, &dst.select)?;
@@ -3684,6 +3677,190 @@ mod tests {
 
         let q_output = var_id_of(&module, &["q_output"]);
         assert!(!written.contains_key(&q_output));
+    }
+
+    #[test]
+    fn test_collect_written_accesses_excludes_repeat_and_pow_constexpr_operands() {
+        let code = r#"
+            module Top (
+                d: input logic<8>,
+                q_repeat: output logic<16>,
+                q_pow: output logic<8>,
+                repeat_output: output logic<8>,
+                pow_output: output logic<8>,
+                sink_repeat: output logic<8>,
+                sink_pow: output logic<8>,
+            ) {
+                function constant_with_output (
+                    x: input logic<8>,
+                    y: output logic<8>,
+                ) -> logic<8> {
+                    y = x;
+                    return x;
+                }
+
+                always_comb {
+                    q_repeat = {d repeat 2};
+                    q_pow = d ** 2;
+                    sink_repeat = constant_with_output(d, repeat_output);
+                    sink_pow = constant_with_output(d, pow_output);
+                }
+            }
+        "#;
+        let mut module = parse_top_module(code);
+        let q_repeat = var_id_of(&module, &["q_repeat"]);
+        let q_pow = var_id_of(&module, &["q_pow"]);
+        let sink_repeat = var_id_of(&module, &["sink_repeat"]);
+        let sink_pow = var_id_of(&module, &["sink_pow"]);
+        let comb_decl = module
+            .declarations
+            .iter()
+            .find_map(|declaration| match declaration {
+                Declaration::Comb(comb) => Some(comb),
+                _ => None,
+            })
+            .expect("No always_comb found in Top");
+        let assignment_expression = |id| {
+            comb_decl
+                .statements
+                .iter()
+                .find_map(|statement| match statement {
+                    Statement::Assign(assign)
+                        if assign.dst.iter().any(|destination| destination.id == id) =>
+                    {
+                        Some(assign.expr.clone())
+                    }
+                    _ => None,
+                })
+                .expect("assignment expression should exist")
+        };
+        let repeat_operand = assignment_expression(sink_repeat);
+        let pow_operand = assignment_expression(sink_pow);
+
+        let comb_decl = module
+            .declarations
+            .iter_mut()
+            .find_map(|declaration| match declaration {
+                Declaration::Comb(comb) => Some(comb),
+                _ => None,
+            })
+            .expect("No always_comb found in Top");
+        for statement in &mut comb_decl.statements {
+            let Statement::Assign(assign) = statement else {
+                continue;
+            };
+            if assign
+                .dst
+                .iter()
+                .any(|destination| destination.id == q_repeat)
+            {
+                let Expression::Concatenation(parts, _) = &mut assign.expr else {
+                    panic!("q_repeat should be a concatenation");
+                };
+                parts[0].1 = Some(repeat_operand.clone());
+            } else if assign.dst.iter().any(|destination| destination.id == q_pow) {
+                let Expression::Binary(_, Op::Pow, rhs, _) = &mut assign.expr else {
+                    panic!("q_pow should be a power expression");
+                };
+                **rhs = pow_operand.clone();
+            }
+        }
+
+        let target_expressions = comb_decl
+            .statements
+            .iter()
+            .filter_map(|statement| match statement {
+                Statement::Assign(assign)
+                    if assign.dst.iter().any(
+                        |destination| matches!(destination.id, id if id == q_repeat || id == q_pow),
+                    ) =>
+                {
+                    Some(assign.expr.clone())
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        let mut written = HashMap::default();
+        for expression in &target_expressions {
+            collect_written_expression(&module, expression, &mut written).unwrap();
+        }
+
+        assert!(!written.contains_key(&var_id_of(&module, &["repeat_output"])));
+        assert!(!written.contains_key(&var_id_of(&module, &["pow_output"])));
+    }
+
+    #[test]
+    fn test_destination_analysis_excludes_static_part_select_range_operand() {
+        let code = r#"
+            module Top (
+                d: input logic<2>,
+                anchor: input logic<3>,
+                data: output logic<8>,
+                range_output: output logic<3>,
+                sink: output logic<3>,
+            ) {
+                function range_with_output (
+                    x: input logic<3>,
+                    y: output logic<3>,
+                ) -> logic<3> {
+                    y = x;
+                    return x;
+                }
+
+                always_comb {
+                    data[anchor +: 2] = d;
+                    sink = range_with_output(anchor, range_output);
+                }
+            }
+        "#;
+        let module = parse_top_module(code);
+        let data = var_id_of(&module, &["data"]);
+        let sink = var_id_of(&module, &["sink"]);
+        let range_output = var_id_of(&module, &["range_output"]);
+        let comb_decl = module
+            .declarations
+            .iter()
+            .find_map(|declaration| match declaration {
+                Declaration::Comb(comb) => Some(comb),
+                _ => None,
+            })
+            .expect("No always_comb found in Top");
+        let range_operand = comb_decl
+            .statements
+            .iter()
+            .find_map(|statement| match statement {
+                Statement::Assign(assign)
+                    if assign.dst.iter().any(|destination| destination.id == sink) =>
+                {
+                    Some(assign.expr.clone())
+                }
+                _ => None,
+            })
+            .expect("range operand source should exist");
+        let mut destination = comb_decl
+            .statements
+            .iter()
+            .find_map(|statement| match statement {
+                Statement::Assign(assign)
+                    if assign.dst.iter().any(|destination| destination.id == data) =>
+                {
+                    assign.dst.first().cloned()
+                }
+                _ => None,
+            })
+            .expect("part-select destination should exist");
+        destination.select.1.as_mut().unwrap().1 = range_operand;
+
+        assert!(!effect::destination_contains_runtime_effect(
+            &module,
+            &destination
+        ));
+        let mut written = HashMap::default();
+        // The analyzer rejects this synthetic non-constant range before normal
+        // lowering.  Even on that error path, its unevaluated output actual
+        // must not leak into the process write set.
+        assert!(collect_written_destination(&module, &mut written, &destination).is_err());
+        assert!(!written.contains_key(&range_output));
     }
 
     #[test]

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -208,7 +208,7 @@ fn parse_comb(
     ),
     ParserError,
 > {
-    parse_comb_with_loop_recovery(module, decl, arena, &[])
+    parse_comb_with_loop_recovery(module, decl, arena, &[], 0)
 }
 
 pub fn parse_comb_with_loop_recovery(
@@ -216,6 +216,7 @@ pub fn parse_comb_with_loop_recovery(
     decl: &CombDeclaration,
     arena: &mut SLTNodeArena<VarId>,
     loop_candidates: &[LoopRecoveryCandidate],
+    capture_namespace: u32,
 ) -> Result<
     (
         Vec<LogicPath<VarId>>,
@@ -257,7 +258,7 @@ pub fn parse_comb_with_loop_recovery(
         loop_candidates,
         None,
     )?;
-    let mut effects = CombEffectCollector::default();
+    let mut effects = CombEffectCollector::with_capture_namespace(capture_namespace);
     if let Some(effect_initial_store) = effect_initial_store {
         collect_comb_effects_statements(
             module,
@@ -3803,6 +3804,7 @@ mod tests {
                     x: input logic<3>,
                     y: output logic<3>,
                 ) -> logic<3> {
+                    $display("range=%0d", x);
                     y = x;
                     return x;
                 }
@@ -3810,6 +3812,7 @@ mod tests {
                 always_comb {
                     data[anchor +: 2] = d;
                     sink = range_with_output(anchor, range_output);
+                    $display("outer");
                 }
             }
         "#;
@@ -3825,7 +3828,7 @@ mod tests {
                 _ => None,
             })
             .expect("No always_comb found in Top");
-        let range_operand = comb_decl
+        let mut range_operand = comb_decl
             .statements
             .iter()
             .find_map(|statement| match statement {
@@ -3849,6 +3852,20 @@ mod tests {
                 _ => None,
             })
             .expect("part-select destination should exist");
+        let static_range_value = destination
+            .select
+            .1
+            .as_ref()
+            .expect("part-select range should exist")
+            .1
+            .comptime()
+            .value
+            .clone();
+        // Output-bearing calls are non-constant in source Veryl today. Keep
+        // the call structure but model an IR producer retaining its known
+        // static width so the collector behavior is covered directly.
+        range_operand.comptime_mut().value = static_range_value;
+        range_operand.comptime_mut().is_const = true;
         destination.select.1.as_mut().unwrap().1 = range_operand;
 
         assert!(!effect::destination_contains_runtime_effect(
@@ -3856,11 +3873,98 @@ mod tests {
             &destination
         ));
         let mut written = HashMap::default();
-        // The analyzer rejects this synthetic non-constant range before normal
-        // lowering.  Even on that error path, its unevaluated output actual
-        // must not leak into the process write set.
-        assert!(collect_written_destination(&module, &mut written, &destination).is_err());
+        collect_written_destination(&module, &mut written, &destination).unwrap();
         assert!(!written.contains_key(&range_output));
+
+        let mut synthetic_comb = comb_decl.clone();
+        let data_assignment = synthetic_comb
+            .statements
+            .iter_mut()
+            .find_map(|statement| match statement {
+                Statement::Assign(assign) if assign.dst.iter().any(|entry| entry.id == data) => {
+                    Some(assign)
+                }
+                _ => None,
+            })
+            .expect("data assignment should exist");
+        data_assignment.dst[0] = destination;
+        let mut arena = SLTNodeArena::new();
+        let (_, _, _, _, sites) = super::parse_comb(&module, &synthetic_comb, &mut arena).unwrap();
+        assert_eq!(
+            sites.len(),
+            2,
+            "the static range call must not duplicate the legitimate callee and outer events"
+        );
+    }
+
+    #[test]
+    fn test_static_event_template_effects_precede_value_argument_capture() {
+        let code = r#"
+            module Top (tmp_o: output logic<8>) {
+                function make_format (y: output logic<8>) -> string {
+                    $display("format evaluated");
+                    y = 8'd11;
+                    return "value=%0d";
+                }
+
+                var tmp: logic<8>;
+                always_comb {
+                    tmp = 8'd0;
+                    $display(make_format(tmp), tmp);
+                    $display("value=%0d", tmp);
+                }
+                assign tmp_o = tmp;
+            }
+        "#;
+        let mut module = parse_top_module(code);
+        let comb = module
+            .declarations
+            .iter_mut()
+            .find_map(|declaration| match declaration {
+                Declaration::Comb(comb) => Some(comb),
+                _ => None,
+            })
+            .expect("No always_comb found in Top");
+        let [
+            Statement::Assign(_),
+            Statement::SystemFunctionCall(first),
+            Statement::SystemFunctionCall(second),
+        ] = comb.statements.as_mut_slice()
+        else {
+            panic!("expected initialization followed by two display statements");
+        };
+        let SystemFunctionKind::Display(second_args) = &second.kind else {
+            panic!("expected second display");
+        };
+        let template_value = second_args[0].0.comptime().value.clone();
+        let SystemFunctionKind::Display(first_args) = &mut first.kind else {
+            panic!("expected first display");
+        };
+        // Output-bearing functions are currently marked non-constant by the
+        // analyzer. Model an IR producer that retains its known string value
+        // so this collector-level ordering remains covered.
+        first_args[0].0.comptime_mut().value = template_value;
+        let comb = comb.clone();
+
+        let mut arena = SLTNodeArena::new();
+        let (_, _, _, observers, sites) = super::parse_comb(&module, &comb, &mut arena).unwrap();
+        assert_eq!(
+            sites.len(),
+            3,
+            "template traversal must collect its nested event"
+        );
+        let outer = observers
+            .iter()
+            .find(|observer| observer.site_id == 0)
+            .expect("missing outer display observer");
+        let SLTNode::Capture { expr, .. } = arena.get(outer.args[0]) else {
+            panic!("outer value argument must be captured");
+        };
+        let SLTNode::Constant(value, unknown, 8, _) = arena.get(*expr) else {
+            panic!("template output must be visible to the following value argument");
+        };
+        assert_eq!(value, &num_bigint::BigUint::from(11u8));
+        assert_eq!(unknown, &num_bigint::BigUint::from(0u8));
     }
 
     #[test]

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -2656,6 +2656,27 @@ pub(super) fn apply_function_output(
     final_local_store: &SymbolicStore<VarId>,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<(SymbolicStore<VarId>, BoundaryMap<VarId>), ParserError> {
+    let (output_expr, output_sources, output_is_2state) =
+        function_output_value(module, arg_id, call, final_local_store, arena)?;
+    assign_node_to_dsts(
+        module,
+        store,
+        boundaries,
+        dsts,
+        output_expr,
+        output_sources,
+        output_is_2state,
+        arena,
+    )
+}
+
+pub(super) fn function_output_value(
+    module: &Module,
+    arg_id: VarId,
+    call: &veryl_analyzer::ir::FunctionCall,
+    final_local_store: &SymbolicStore<VarId>,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<(NodeId, HashSet<VarAtomBase<VarId>>, bool), ParserError> {
     let formal = module.variables.get(&arg_id).ok_or_else(|| {
         ParserError::illegal_context(
             "function output value",
@@ -2683,16 +2704,7 @@ pub(super) fn apply_function_output(
         range_store_error("function output value", error, Some(&call.comptime.token))
     })?;
     let (output_expr, output_sources) = combine_parts_with_default(arg_id, 0, parts, arena)?;
-    assign_node_to_dsts(
-        module,
-        store,
-        boundaries,
-        dsts,
-        output_expr,
-        output_sources,
-        formal.r#type.is_2state(),
-        arena,
-    )
+    Ok((output_expr, output_sources, formal.r#type.is_2state()))
 }
 
 struct DynamicSelectOffset {

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -21,14 +21,17 @@ use std::{collections::BTreeSet, hash::Hash};
 
 use crate::{
     HashMap, HashSet, LoweringPhase, ParserError,
-    bitaccess::{PartSelectGeometry, eval_constexpr, eval_var_select, select_geometry},
+    bitaccess::{
+        PartSelectGeometry, celox_value_from_comptime, eval_constexpr, eval_var_select,
+        select_geometry,
+    },
     loop_provenance::LoopRecoveryCandidate,
     resolve_total_width,
 };
 use celox_design::{BinaryOp, BitAccess, RuntimeEventKind, RuntimeEventSite, UnaryOp, VarAtomBase};
 use celox_slt::{CombObserver, RangeStore, RangeStoreError};
 use num_bigint::{BigInt, BigUint, Sign};
-use num_traits::ToPrimitive as _;
+use num_traits::{ToPrimitive as _, Zero as _};
 use veryl_analyzer::ir::{
     ArrayLiteralItem, AssignStatement, CasePattern, CaseStatement, CombDeclaration, Expression,
     Factor, ForBound, ForRange, ForStatement, Function, FunctionBody, FunctionCall, IfStatement,
@@ -39,10 +42,11 @@ use veryl_analyzer::value::{Value, byte_value_to_string};
 use veryl_parser::resource_table;
 use veryl_parser::token_range::TokenRange;
 
-use effect::{
-    CombEffectCollector, collect_comb_effects_statements, statements_contain_runtime_effect,
+pub(crate) use effect::{
+    CombEffectCollector, collect_expression_effects, expression_contains_runtime_effect,
     subtract_written_sensitivity,
 };
+use effect::{collect_comb_effects_statements, statements_contain_runtime_effect};
 pub use expr::coerce_node_width;
 pub(crate) use expr::eval_assignment_expression_effectful;
 use expr::{
@@ -1622,6 +1626,14 @@ fn collect_written_accesses(
     Ok(())
 }
 
+fn eval_fully_known_constexpr(expression: &Expression) -> Option<BigUint> {
+    let (_, mask, _, _) = celox_value_from_comptime(expression.comptime())?;
+    if !mask.is_zero() {
+        return None;
+    }
+    eval_constexpr(expression)
+}
+
 pub(super) fn collect_written_expression(
     module: &Module,
     expression: &Expression,
@@ -1657,7 +1669,7 @@ pub(super) fn collect_written_expression(
         Expression::Unary(_, inner, _) => collect_written_expression(module, inner, out),
         Expression::Binary(lhs, op, rhs, _) => {
             collect_written_expression(module, lhs, out)?;
-            let lhs_value = eval_constexpr(lhs);
+            let lhs_value = eval_fully_known_constexpr(lhs);
             let skips_rhs = match op {
                 Op::LogicAnd => lhs_value
                     .as_ref()
@@ -1674,7 +1686,7 @@ pub(super) fn collect_written_expression(
         }
         Expression::Ternary(cond, then_expr, else_expr, _) => {
             collect_written_expression(module, cond, out)?;
-            if let Some(value) = eval_constexpr(cond) {
+            if let Some(value) = eval_fully_known_constexpr(cond) {
                 return if value == BigUint::from(0u8) {
                     collect_written_expression(module, else_expr, out)
                 } else {
@@ -3673,6 +3685,51 @@ mod tests {
 
         let q_output = var_id_of(&module, &["q_output"]);
         assert!(!written.contains_key(&q_output));
+    }
+
+    #[test]
+    fn test_collect_written_accesses_preserves_indeterminate_expression_branches() {
+        let code = r#"
+            module Top (
+                d: input logic,
+                q: output logic,
+                ternary_then: output logic,
+                ternary_else: output logic,
+                short_circuit_rhs: output logic,
+            ) {
+                function write (
+                    x: input logic,
+                    y: output logic,
+                ) -> logic {
+                    y = x;
+                    return x;
+                }
+
+                always_comb {
+                    q = if 1'bx ? write(d, ternary_then) : write(d, ternary_else);
+                    q = 1'bx && write(d, short_circuit_rhs);
+                }
+            }
+        "#;
+        let module = parse_top_module(code);
+        let comb_decl = module
+            .declarations
+            .iter()
+            .find_map(|declaration| {
+                if let Declaration::Comb(comb) = declaration {
+                    Some(comb)
+                } else {
+                    None
+                }
+            })
+            .expect("No always_comb found in Top");
+        let mut written = HashMap::default();
+        collect_written_accesses(&module, &comb_decl.statements, &mut written).unwrap();
+
+        for name in ["ternary_then", "ternary_else", "short_circuit_rhs"] {
+            let id = var_id_of(&module, &[name]);
+            assert_eq!(written[&id], vec![BitAccess::new(0, 0)], "{name}");
+        }
     }
 
     #[test]

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -2453,20 +2453,8 @@ fn eval_statement_form_function_call(
 
     let mut evaluated_inputs = Vec::with_capacity(call.inputs.len());
 
-    for (arg_path, arg_id) in &function_body.arg_map {
-        let Some(arg_expr) = call.inputs.get(arg_path) else {
-            if call.outputs.contains_key(arg_path) {
-                continue;
-            }
-            return Err(invalid_function_call_argument_error(
-                function,
-                arg_path,
-                "formal argument has neither an input expression nor an output destination",
-                call,
-            ));
-        };
-
-        let formal = module.variables.get(arg_id).ok_or_else(|| {
+    for (arg_id, arg_expr) in ordered_function_inputs(function, &function_body, call)? {
+        let formal = module.variables.get(&arg_id).ok_or_else(|| {
             ParserError::illegal_context(
                 "function input argument",
                 "formal variable is absent from the semantic module",
@@ -2482,7 +2470,18 @@ fn eval_statement_form_function_call(
             arg_node
         };
         boundaries = merge_boundaries(boundaries, arg_bounds);
-        evaluated_inputs.push((*arg_id, arg_node, arg_sources, arg_width));
+        evaluated_inputs.push((arg_id, arg_node, arg_sources, arg_width));
+    }
+
+    for arg_path in function_body.arg_map.keys() {
+        if !call.inputs.contains_key(arg_path) && !call.outputs.contains_key(arg_path) {
+            return Err(invalid_function_call_argument_error(
+                function,
+                arg_path,
+                "formal argument has neither an input expression nor an output destination",
+                call,
+            ));
+        }
     }
 
     let mut local_store = store.clone();

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -38,7 +38,7 @@ use veryl_analyzer::ir::{
     Module, Op, Statement, SystemFunctionCall, SystemFunctionInput, SystemFunctionKind, VarId,
     VarIndex, VarPath, VarSelect,
 };
-use veryl_analyzer::value::{Value, byte_value_to_string};
+use veryl_analyzer::value::{MaskCache, Value, byte_value_to_string};
 use veryl_parser::resource_table;
 use veryl_parser::token_range::TokenRange;
 
@@ -1553,6 +1553,41 @@ fn inclusive_of(range: &ForRange) -> bool {
     }
 }
 
+fn constant_case_pattern_matches(target: &Expression, pattern: &CasePattern) -> bool {
+    fn compare(op: Op, lhs: &Value, rhs: &Value) -> bool {
+        let signed = lhs.signed() && rhs.signed();
+        op.eval_value_binary(lhs, rhs, 1, signed, &mut MaskCache::default())
+            .to_u64()
+            == Some(1)
+    }
+
+    if !target.comptime().is_const {
+        return false;
+    }
+    let Ok(target) = target.comptime().get_value() else {
+        return false;
+    };
+    match pattern {
+        CasePattern::Eq(expression) => {
+            expression.comptime().is_const
+                && expression
+                    .comptime()
+                    .get_value()
+                    .is_ok_and(|pattern| compare(Op::EqWildcard, target, pattern))
+        }
+        CasePattern::Range { lo, hi, inclusive } => {
+            if !lo.comptime().is_const || !hi.comptime().is_const {
+                return false;
+            }
+            let (Ok(lo), Ok(hi)) = (lo.comptime().get_value(), hi.comptime().get_value()) else {
+                return false;
+            };
+            compare(Op::LessEq, lo, target)
+                && compare(if *inclusive { Op::LessEq } else { Op::Less }, target, hi)
+        }
+    }
+}
+
 fn collect_written_accesses(
     module: &Module,
     statements: &[Statement],
@@ -1573,7 +1608,9 @@ fn collect_written_accesses(
             }
             Statement::Case(case_stmt) => {
                 collect_written_expression(module, &case_stmt.case_target, out)?;
+                let mut known_match = false;
                 for arm in &case_stmt.arms {
+                    let mut arm_known_match = false;
                     for pattern in &arm.patterns {
                         match pattern {
                             CasePattern::Eq(expression) => {
@@ -1584,10 +1621,20 @@ fn collect_written_accesses(
                                 collect_written_expression(module, hi, out)?;
                             }
                         }
+                        if constant_case_pattern_matches(&case_stmt.case_target, pattern) {
+                            arm_known_match = true;
+                            break;
+                        }
                     }
                     collect_written_accesses(module, &arm.body, out)?;
+                    if arm_known_match {
+                        known_match = true;
+                        break;
+                    }
                 }
-                collect_written_accesses(module, &case_stmt.default, out)?;
+                if !known_match {
+                    collect_written_accesses(module, &case_stmt.default, out)?;
+                }
             }
             Statement::For(for_stmt) => {
                 let (start, end) = match &for_stmt.range {
@@ -3624,6 +3671,57 @@ mod tests {
 
         let q_output = var_id_of(&module, &["q_output"]);
         assert_eq!(written[&q_output], vec![BitAccess::new(0, 7)]);
+    }
+
+    #[test]
+    fn test_collect_written_accesses_stops_after_known_case_match() {
+        let code = r#"
+            module Top (
+                d: input logic,
+                q: output logic,
+                unreachable_output: output logic,
+            ) {
+                function write_pattern (
+                    x: input logic,
+                    y: output logic,
+                ) -> logic {
+                    y = x;
+                    return x;
+                }
+
+                always_comb {
+                    q = write_pattern(d, unreachable_output);
+                    case 1'b0 {
+                        1'b0: q = d;
+                        1'b1: q = 1'b0;
+                        default: q = 1'b1;
+                    }
+                }
+            }
+        "#;
+        let mut module = parse_top_module(code);
+        let comb_decl = module
+            .declarations
+            .iter_mut()
+            .find_map(|declaration| match declaration {
+                Declaration::Comb(comb) => Some(comb),
+                _ => None,
+            })
+            .expect("No always_comb found in Top");
+        let Statement::Assign(seed) = &comb_decl.statements[0] else {
+            panic!("expected seed assignment");
+        };
+        let seed = seed.expr.clone();
+        let Statement::Case(case_stmt) = &mut comb_decl.statements[1] else {
+            panic!("expected case statement");
+        };
+        case_stmt.arms[1].patterns[0] = CasePattern::Eq(Box::new(seed));
+        let case_stmt = Statement::Case(case_stmt.clone());
+        let mut written = HashMap::default();
+        collect_written_accesses(&module, &[case_stmt], &mut written).unwrap();
+
+        let unreachable_output = var_id_of(&module, &["unreachable_output"]);
+        assert!(!written.contains_key(&unreachable_output));
     }
 
     #[test]

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -31,10 +31,10 @@ use celox_slt::{CombObserver, RangeStore, RangeStoreError};
 use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::ToPrimitive as _;
 use veryl_analyzer::ir::{
-    ArrayLiteralItem, AssignStatement, CaseStatement, CombDeclaration, Expression, Factor,
-    ForBound, ForRange, ForStatement, Function, FunctionCall, IfStatement, Module, Op, Statement,
-    SystemFunctionCall, SystemFunctionInput, SystemFunctionKind, VarId, VarIndex, VarPath,
-    VarSelect,
+    ArrayLiteralItem, AssignStatement, CasePattern, CaseStatement, CombDeclaration, Expression,
+    Factor, ForBound, ForRange, ForStatement, Function, FunctionCall, IfStatement, Module, Op,
+    Statement, SystemFunctionCall, SystemFunctionInput, SystemFunctionKind, VarId, VarIndex,
+    VarPath, VarSelect,
 };
 use veryl_analyzer::value::{Value, byte_value_to_string};
 use veryl_parser::resource_table;
@@ -47,7 +47,7 @@ use effect::{
 pub use expr::coerce_node_width;
 use expr::{
     eval_array_literal_expression_effectful, eval_assignment_expression_effectful,
-    eval_function_body_return, merge_boundaries,
+    eval_expression_effectful, eval_function_body_return, merge_boundaries,
 };
 pub use expr::{eval_assignment_expression, eval_expression, get_width};
 use state::{FunctionControlState, LoopControlState};
@@ -442,7 +442,9 @@ fn eval_statement(
             "if_reset".to_string(),
             Some(&ir.token),
         )),
-        Statement::SystemFunctionCall(_) => Ok((store, boundaries)),
+        Statement::SystemFunctionCall(call) => {
+            eval_system_function_call_side_effects(module, store, boundaries, call, arena)
+        }
         Statement::FunctionCall(fc) => eval_statement_form_function_call(
             module,
             store,
@@ -506,6 +508,51 @@ fn eval_statement_with_recovery(
     }
 }
 
+fn eval_system_function_call_side_effects(
+    module: &Module,
+    mut store: SymbolicStore<VarId>,
+    mut boundaries: BoundaryMap<VarId>,
+    call: &SystemFunctionCall,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<(SymbolicStore<VarId>, BoundaryMap<VarId>), ParserError> {
+    fn eval_input(
+        module: &Module,
+        store: &mut SymbolicStore<VarId>,
+        boundaries: &mut BoundaryMap<VarId>,
+        input: &SystemFunctionInput,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<(), ParserError> {
+        let (_, input_boundaries) =
+            eval_expression_effectful(module, store, &input.0, arena, None)?;
+        *boundaries = merge_boundaries(std::mem::take(boundaries), input_boundaries);
+        Ok(())
+    }
+
+    match &call.kind {
+        SystemFunctionKind::Display(inputs) | SystemFunctionKind::Write(inputs) => {
+            for input in inputs {
+                eval_input(module, &mut store, &mut boundaries, input, arena)?;
+            }
+        }
+        SystemFunctionKind::Assert { cond, args, .. } => {
+            eval_input(module, &mut store, &mut boundaries, cond, arena)?;
+            for input in args {
+                eval_input(module, &mut store, &mut boundaries, input, arena)?;
+            }
+        }
+        SystemFunctionKind::Bits(_)
+        | SystemFunctionKind::Size(_)
+        | SystemFunctionKind::Clog2(_)
+        | SystemFunctionKind::Onehot(_)
+        | SystemFunctionKind::Signed(_)
+        | SystemFunctionKind::Unsigned(_)
+        | SystemFunctionKind::Readmemh(_, _)
+        | SystemFunctionKind::Finish => {}
+    }
+
+    Ok((store, boundaries))
+}
+
 fn eval_statements(
     module: &Module,
     store: SymbolicStore<VarId>,
@@ -551,7 +598,7 @@ fn eval_case_with_recovery(
 ) -> Result<(SymbolicStore<VarId>, BoundaryMap<VarId>), ParserError> {
     fn eval_from_arm(
         module: &Module,
-        store: SymbolicStore<VarId>,
+        mut store: SymbolicStore<VarId>,
         boundaries: BoundaryMap<VarId>,
         case_stmt: &CaseStatement,
         arm_index: usize,
@@ -573,7 +620,7 @@ fn eval_case_with_recovery(
 
         let cond = case_arm_condition_expr(&case_stmt.case_target, &arm.patterns);
         let ((cond_expr, cond_sources), cond_bounds) =
-            eval_expression(module, &store, &cond, arena, None)?;
+            eval_expression_effectful(module, &mut store, &cond, arena, None)?;
         let cond_expr = procedural_condition(arena, cond_expr)?;
         let boundaries = merge_boundaries(boundaries, cond_bounds);
 
@@ -660,7 +707,7 @@ fn eval_case(
 ) -> Result<(SymbolicStore<VarId>, BoundaryMap<VarId>), ParserError> {
     fn eval_from_arm(
         module: &Module,
-        store: SymbolicStore<VarId>,
+        mut store: SymbolicStore<VarId>,
         boundaries: BoundaryMap<VarId>,
         case_stmt: &CaseStatement,
         arm_index: usize,
@@ -672,7 +719,7 @@ fn eval_case(
 
         let cond = case_arm_condition_expr(&case_stmt.case_target, &arm.patterns);
         let ((cond_expr, cond_sources), cond_bounds) =
-            eval_expression(module, &store, &cond, arena, None)?;
+            eval_expression_effectful(module, &mut store, &cond, arena, None)?;
         let cond_expr = procedural_condition(arena, cond_expr)?;
         let boundaries = merge_boundaries(boundaries, cond_bounds);
 
@@ -977,7 +1024,20 @@ fn eval_loop_statement(
             "if_reset".to_string(),
             Some(&ir.token),
         )),
-        Statement::SystemFunctionCall(_) => Ok(state),
+        Statement::SystemFunctionCall(call) => {
+            let (store, boundaries) = eval_system_function_call_side_effects(
+                module,
+                state.store,
+                state.boundaries,
+                call,
+                arena,
+            )?;
+            Ok(LoopControlState {
+                store,
+                boundaries,
+                ..state
+            })
+        }
         Statement::FunctionCall(fc) => {
             let guard_state = state.clone();
             let (next_store, next_boundaries) = eval_statement_form_function_call(
@@ -1016,7 +1076,7 @@ fn eval_loop_case(
 ) -> Result<LoopControlState, ParserError> {
     fn eval_from_arm(
         module: &Module,
-        state: LoopControlState,
+        mut state: LoopControlState,
         case_stmt: &CaseStatement,
         arm_index: usize,
         arena: &mut SLTNodeArena<VarId>,
@@ -1028,9 +1088,9 @@ fn eval_loop_case(
                 .try_fold(state, |s, step| eval_loop_statement(module, s, step, arena));
         };
 
-        let ((cond_expr, cond_sources), cond_bounds) = eval_expression(
+        let ((cond_expr, cond_sources), cond_bounds) = eval_expression_effectful(
             module,
-            &state.store,
+            &mut state.store,
             &case_arm_condition_expr(&case_stmt.case_target, &arm.patterns),
             arena,
             None,
@@ -1103,12 +1163,12 @@ fn eval_loop_case(
 
 fn eval_loop_if(
     module: &Module,
-    state: LoopControlState,
+    mut state: LoopControlState,
     stmt: &IfStatement,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<LoopControlState, ParserError> {
     let ((cond_expr, cond_sources), cond_bounds) =
-        eval_expression(module, &state.store, &stmt.cond, arena, None)?;
+        eval_expression_effectful(module, &mut state.store, &stmt.cond, arena, None)?;
     let cond_expr = procedural_condition(arena, cond_expr)?;
     let boundaries = merge_boundaries(state.boundaries, cond_bounds);
 
@@ -1316,29 +1376,59 @@ fn collect_written_accesses(
                 }
             }
             Statement::If(if_stmt) => {
+                collect_written_expression(module, &if_stmt.cond, out)?;
                 collect_written_accesses(module, &if_stmt.true_side, out)?;
                 collect_written_accesses(module, &if_stmt.false_side, out)?;
             }
             Statement::Case(case_stmt) => {
+                collect_written_expression(module, &case_stmt.case_target, out)?;
                 for arm in &case_stmt.arms {
+                    for pattern in &arm.patterns {
+                        match pattern {
+                            CasePattern::Eq(expression) => {
+                                collect_written_expression(module, expression, out)?;
+                            }
+                            CasePattern::Range { lo, hi, .. } => {
+                                collect_written_expression(module, lo, out)?;
+                                collect_written_expression(module, hi, out)?;
+                            }
+                        }
+                    }
                     collect_written_accesses(module, &arm.body, out)?;
                 }
                 collect_written_accesses(module, &case_stmt.default, out)?;
             }
-            Statement::For(for_stmt) => collect_written_accesses(module, &for_stmt.body, out)?,
+            Statement::For(for_stmt) => {
+                let (start, end) = match &for_stmt.range {
+                    ForRange::Forward { start, end, .. }
+                    | ForRange::Reverse { start, end, .. }
+                    | ForRange::Stepped { start, end, .. } => (start, end),
+                };
+                for bound in [start, end] {
+                    if let ForBound::Expression(expression) = bound {
+                        collect_written_expression(module, expression, out)?;
+                    }
+                }
+                collect_written_accesses(module, &for_stmt.body, out)?;
+            }
             Statement::IfReset(if_reset) => {
                 collect_written_accesses(module, &if_reset.true_side, out)?;
                 collect_written_accesses(module, &if_reset.false_side, out)?;
             }
             Statement::FunctionCall(call) => {
+                for input in call.inputs.values() {
+                    collect_written_expression(module, input, out)?;
+                }
                 for dsts in call.outputs.values() {
                     for dst in dsts {
                         collect_written_destination(module, out, dst)?;
                     }
                 }
             }
-            Statement::SystemFunctionCall(_)
-            | Statement::TbMethodCall(_)
+            Statement::SystemFunctionCall(call) => {
+                collect_written_system_function_call(module, call, out)?;
+            }
+            Statement::TbMethodCall(_)
             | Statement::Break
             | Statement::Unsupported(_)
             | Statement::Null => {}
@@ -1375,31 +1465,7 @@ fn collect_written_expression(
                 Ok(())
             }
             Factor::SystemFunctionCall(call) => {
-                let mut collect_input =
-                    |input: &SystemFunctionInput| collect_written_expression(module, &input.0, out);
-                match &call.kind {
-                    SystemFunctionKind::Bits(input)
-                    | SystemFunctionKind::Size(input)
-                    | SystemFunctionKind::Clog2(input)
-                    | SystemFunctionKind::Onehot(input)
-                    | SystemFunctionKind::Signed(input)
-                    | SystemFunctionKind::Unsigned(input) => collect_input(input),
-                    SystemFunctionKind::Readmemh(input, _) => collect_input(input),
-                    SystemFunctionKind::Display(inputs) | SystemFunctionKind::Write(inputs) => {
-                        for input in inputs {
-                            collect_input(input)?;
-                        }
-                        Ok(())
-                    }
-                    SystemFunctionKind::Assert { cond, args, .. } => {
-                        collect_input(cond)?;
-                        for input in args {
-                            collect_input(input)?;
-                        }
-                        Ok(())
-                    }
-                    SystemFunctionKind::Finish => Ok(()),
-                }
+                collect_written_system_function_call(module, call, out)
             }
             Factor::Value(_) | Factor::Anonymous(_) | Factor::Unknown(_) => Ok(()),
         },
@@ -1447,11 +1513,49 @@ fn collect_written_expression(
     }
 }
 
+fn collect_written_system_function_call(
+    module: &Module,
+    call: &SystemFunctionCall,
+    out: &mut HashMap<VarId, Vec<BitAccess>>,
+) -> Result<(), ParserError> {
+    let mut collect_input =
+        |input: &SystemFunctionInput| collect_written_expression(module, &input.0, out);
+    match &call.kind {
+        SystemFunctionKind::Bits(input)
+        | SystemFunctionKind::Size(input)
+        | SystemFunctionKind::Clog2(input)
+        | SystemFunctionKind::Onehot(input)
+        | SystemFunctionKind::Signed(input)
+        | SystemFunctionKind::Unsigned(input) => collect_input(input),
+        SystemFunctionKind::Readmemh(input, _) => collect_input(input),
+        SystemFunctionKind::Display(inputs) | SystemFunctionKind::Write(inputs) => {
+            for input in inputs {
+                collect_input(input)?;
+            }
+            Ok(())
+        }
+        SystemFunctionKind::Assert { cond, args, .. } => {
+            collect_input(cond)?;
+            for input in args {
+                collect_input(input)?;
+            }
+            Ok(())
+        }
+        SystemFunctionKind::Finish => Ok(()),
+    }
+}
+
 fn collect_written_destination(
     module: &Module,
     out: &mut HashMap<VarId, Vec<BitAccess>>,
     dst: &veryl_analyzer::ir::AssignDestination,
 ) -> Result<(), ParserError> {
+    for expression in dst.index.0.iter().chain(dst.select.0.iter()) {
+        collect_written_expression(module, expression, out)?;
+    }
+    if let Some((_, expression)) = &dst.select.1 {
+        collect_written_expression(module, expression, out)?;
+    }
     let access = eval_var_select(module, dst.id, &dst.index, &dst.select)?;
     out.entry(dst.id).or_default().push(access);
     Ok(())
@@ -2190,7 +2294,7 @@ fn assign_node_to_dsts(
 
 fn eval_statement_form_function_call(
     module: &Module,
-    store: SymbolicStore<VarId>,
+    mut store: SymbolicStore<VarId>,
     mut boundaries: BoundaryMap<VarId>,
     call: &veryl_analyzer::ir::FunctionCall,
     arena: &mut SLTNodeArena<VarId>,
@@ -2220,7 +2324,7 @@ fn eval_statement_form_function_call(
         ));
     };
 
-    let mut local_store = store.clone();
+    let mut evaluated_inputs = Vec::with_capacity(call.inputs.len());
 
     for (arg_path, arg_id) in &function_body.arg_map {
         let Some(arg_expr) = call.inputs.get(arg_path) else {
@@ -2244,15 +2348,20 @@ fn eval_statement_form_function_call(
         })?;
         let arg_width = resolve_total_width(module, formal)?;
         let ((arg_node, arg_sources), arg_bounds) =
-            eval_assignment_expression(module, &store, arg_expr, arena, arg_width)?;
+            eval_assignment_expression_effectful(module, &mut store, arg_expr, arena, arg_width)?;
         let arg_node = if formal.r#type.is_2state() && !arg_expr.comptime().r#type.is_2state() {
             arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, arg_node))?
         } else {
             arg_node
         };
         boundaries = merge_boundaries(boundaries, arg_bounds);
+        evaluated_inputs.push((*arg_id, arg_node, arg_sources, arg_width));
+    }
+
+    let mut local_store = store.clone();
+    for (arg_id, arg_node, arg_sources, arg_width) in evaluated_inputs {
         local_store.insert(
-            *arg_id,
+            arg_id,
             RangeStore::new(Some((arg_node, arg_sources)), arg_width),
         );
     }
@@ -2359,7 +2468,7 @@ struct DynamicSelectOffset {
 /// offset so direct dynamic loads and read-modify-write paths cannot diverge.
 fn eval_dynamic_select_offset(
     module: &Module,
-    store: &SymbolicStore<VarId>,
+    store: &mut expr::ExpressionStore<'_>,
     var_id: VarId,
     index: &VarIndex,
     select: &VarSelect,
@@ -2387,7 +2496,7 @@ fn eval_dynamic_select_offset(
     expressions.extend(select.0.clone());
     for (dimension, expression) in expressions[..geometry.dimension_count].iter().enumerate() {
         let ((node, node_sources), node_boundaries) =
-            eval_expression(module, store, expression, arena, None)?;
+            expr::eval_expression_in_context(module, store, expression, arena, None)?;
         sources.extend(node_sources);
         boundaries = merge_boundaries(boundaries, node_boundaries);
         let stride = geometry.strides.get(dimension).copied().ok_or_else(|| {
@@ -2452,7 +2561,13 @@ fn eval_dynamic_select_offset(
                     )
                 })?;
                 let ((anchor, anchor_sources), anchor_boundaries) =
-                    eval_expression(module, store, anchor_expression, arena, None)?;
+                    expr::eval_expression_in_context(
+                        module,
+                        store,
+                        anchor_expression,
+                        arena,
+                        None,
+                    )?;
                 sources.extend(anchor_sources);
                 boundaries = merge_boundaries(boundaries, anchor_boundaries);
                 match part {
@@ -2526,15 +2641,18 @@ fn eval_dynamic_assign(
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<(SymbolicStore<VarId>, BoundaryMap<VarId>), ParserError> {
     let mut all_sources = rhs_sources;
-    let select_offset = eval_dynamic_select_offset(
-        module,
-        &store,
-        dst.id,
-        &dst.index,
-        &dst.select,
-        arena,
-        Some(&dst.token),
-    )?;
+    let select_offset = {
+        let mut expression_store = expr::ExpressionStore::Effectful(&mut store);
+        eval_dynamic_select_offset(
+            module,
+            &mut expression_store,
+            dst.id,
+            &dst.index,
+            &dst.select,
+            arena,
+            Some(&dst.token),
+        )?
+    };
     boundaries = merge_boundaries(boundaries, select_offset.boundaries);
     all_sources.extend(select_offset.sources);
     let offset_node = select_offset.node;
@@ -2631,7 +2749,7 @@ fn eval_dynamic_assign(
 }
 fn eval_if_with_recovery(
     module: &Module,
-    initial_store: SymbolicStore<VarId>,
+    mut initial_store: SymbolicStore<VarId>,
     mut boundaries: HashMap<VarId, BTreeSet<usize>>,
     stmt: &IfStatement,
     arena: &mut SLTNodeArena<VarId>,
@@ -2639,7 +2757,7 @@ fn eval_if_with_recovery(
     active_guard: Option<&ActiveGuard>,
 ) -> Result<(SymbolicStore<VarId>, HashMap<VarId, BTreeSet<usize>>), ParserError> {
     let ((cond_expr, cond_sources), cond_bounds) =
-        eval_expression(module, &initial_store, &stmt.cond, arena, None)?;
+        eval_expression_effectful(module, &mut initial_store, &stmt.cond, arena, None)?;
     let cond_expr = procedural_condition(arena, cond_expr)?;
     boundaries.extend(cond_bounds);
 
@@ -2699,13 +2817,13 @@ fn eval_if_with_recovery(
 
 fn eval_if(
     module: &Module,
-    initial_store: SymbolicStore<VarId>,
+    mut initial_store: SymbolicStore<VarId>,
     mut boundaries: HashMap<VarId, BTreeSet<usize>>,
     stmt: &IfStatement,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<(SymbolicStore<VarId>, HashMap<VarId, BTreeSet<usize>>), ParserError> {
     let ((cond_expr, cond_sources), cond_bounds) =
-        eval_expression(module, &initial_store, &stmt.cond, arena, None)?;
+        eval_expression_effectful(module, &mut initial_store, &stmt.cond, arena, None)?;
     let cond_expr = procedural_condition(arena, cond_expr)?;
     boundaries.extend(cond_bounds);
 

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -2367,6 +2367,48 @@ fn eval_assign(
     Ok((store, boundaries))
 }
 
+pub(super) fn apply_assignment_destination(
+    module: &Module,
+    mut store: SymbolicStore<VarId>,
+    mut boundaries: BoundaryMap<VarId>,
+    destination: &veryl_analyzer::ir::AssignDestination,
+    rhs_expr: NodeId,
+    rhs_sources: HashSet<VarAtomBase<VarId>>,
+    rhs_is_2state: bool,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<(SymbolicStore<VarId>, BoundaryMap<VarId>), ParserError> {
+    if crate::bitaccess::is_static_access(&destination.index, &destination.select) {
+        let access = eval_var_select(
+            module,
+            destination.id,
+            &destination.index,
+            &destination.select,
+        )?;
+        record_assignment_boundary(&mut boundaries, destination, access)?;
+        update_assignment_range(
+            module,
+            &mut store,
+            destination,
+            access,
+            (rhs_expr, rhs_sources),
+            rhs_is_2state,
+            arena,
+        )?;
+        Ok((store, boundaries))
+    } else {
+        eval_dynamic_assign(
+            module,
+            store,
+            boundaries,
+            destination,
+            rhs_expr,
+            rhs_sources,
+            rhs_is_2state,
+            arena,
+        )
+    }
+}
+
 fn assign_node_to_dsts(
     module: &Module,
     mut store: SymbolicStore<VarId>,

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -1627,11 +1627,11 @@ fn collect_written_accesses(
 }
 
 fn eval_fully_known_constexpr(expression: &Expression) -> Option<BigUint> {
-    let (_, mask, _, _) = celox_value_from_comptime(expression.comptime())?;
+    let (value, mask, _, _) = celox_value_from_comptime(expression.comptime())?;
     if !mask.is_zero() {
         return None;
     }
-    eval_constexpr(expression)
+    Some(value)
 }
 
 pub(super) fn collect_written_expression(
@@ -3696,6 +3696,9 @@ mod tests {
                 ternary_then: output logic,
                 ternary_else: output logic,
                 short_circuit_rhs: output logic,
+                z_ternary_then: output logic,
+                z_ternary_else: output logic,
+                z_short_circuit_rhs: output logic,
             ) {
                 function write (
                     x: input logic,
@@ -3708,6 +3711,8 @@ mod tests {
                 always_comb {
                     q = if 1'bx ? write(d, ternary_then) : write(d, ternary_else);
                     q = 1'bx && write(d, short_circuit_rhs);
+                    q = if 1'bz ? write(d, z_ternary_then) : write(d, z_ternary_else);
+                    q = 1'bz && write(d, z_short_circuit_rhs);
                 }
             }
         "#;
@@ -3726,7 +3731,14 @@ mod tests {
         let mut written = HashMap::default();
         collect_written_accesses(&module, &comb_decl.statements, &mut written).unwrap();
 
-        for name in ["ternary_then", "ternary_else", "short_circuit_rhs"] {
+        for name in [
+            "ternary_then",
+            "ternary_else",
+            "short_circuit_rhs",
+            "z_ternary_then",
+            "z_ternary_else",
+            "z_short_circuit_rhs",
+        ] {
             let id = var_id_of(&module, &[name]);
             assert_eq!(written[&id], vec![BitAccess::new(0, 0)], "{name}");
         }

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -2169,6 +2169,45 @@ fn update_assignment_range(
     Ok(())
 }
 
+fn eval_assignment_rhs_effectful(
+    module: &Module,
+    store: &mut SymbolicStore<VarId>,
+    stmt: &AssignStatement,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+    let rhs_expected_width = checked_destination_width(
+        module,
+        &stmt.dst,
+        "assignment destination",
+        Some(&stmt.expr.token_range()),
+    )?;
+    if let Expression::ArrayLiteral(items, _) = &stmt.expr {
+        let ((node, sources), bounds) = eval_array_literal_expression_effectful(
+            module,
+            store,
+            items,
+            Some(rhs_expected_width),
+            arena,
+        )?;
+        if get_width(node, arena) == 0 {
+            return Err(ParserError::illegal_context(
+                "assignment expression",
+                "a zero-width array literal cannot be assigned",
+                Some(&stmt.expr.token_range()),
+            ));
+        }
+        Ok((
+            (
+                coerce_node_width(arena, node, Some(rhs_expected_width), false)?,
+                sources,
+            ),
+            bounds,
+        ))
+    } else {
+        eval_assignment_expression_effectful(module, store, &stmt.expr, arena, rhs_expected_width)
+    }
+}
+
 fn eval_assign(
     module: &Module,
     mut store: SymbolicStore<VarId>,
@@ -2184,37 +2223,7 @@ fn eval_assign(
         Some(&stmt.expr.token_range()),
     )?;
     let ((rhs_expr, rhs_sources), rhs_bounds) =
-        if let Expression::ArrayLiteral(items, _) = &stmt.expr {
-            let ((node, sources), bounds) = eval_array_literal_expression_effectful(
-                module,
-                &mut store,
-                items,
-                Some(rhs_expected_width),
-                arena,
-            )?;
-            if get_width(node, arena) == 0 {
-                return Err(ParserError::illegal_context(
-                    "assignment expression",
-                    "a zero-width array literal cannot be assigned",
-                    Some(&stmt.expr.token_range()),
-                ));
-            }
-            (
-                (
-                    coerce_node_width(arena, node, Some(rhs_expected_width), false)?,
-                    sources,
-                ),
-                bounds,
-            )
-        } else {
-            eval_assignment_expression_effectful(
-                module,
-                &mut store,
-                &stmt.expr,
-                arena,
-                rhs_expected_width,
-            )?
-        };
+        eval_assignment_rhs_effectful(module, &mut store, stmt, arena)?;
     let mut boundaries = merge_boundaries(boundaries, rhs_bounds);
 
     if stmt.dst.len() == 1 {

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -314,6 +314,7 @@ pub fn parse_comb_with_loop_recovery(
                     local_inputs: Vec::new(),
                     order_before: HashSet::default(),
                     comb_capture_enable_sites: Vec::new(),
+                    comb_capture_enable_always: false,
                     pre_lower_nodes: Vec::new(),
                     expr: final_expr,
                 });

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -48,13 +48,12 @@ pub(crate) use effect::{
 };
 use effect::{collect_comb_effects_statements, statements_contain_runtime_effect};
 pub use expr::coerce_node_width;
-pub(crate) use expr::eval_assignment_expression_effectful;
 use expr::{
     eval_array_literal_expression_effectful, eval_case_arm_condition_effectful,
-    eval_case_target_effectful, eval_expression_effectful, eval_function_body_return,
-    merge_boundaries,
+    eval_case_target_effectful, eval_function_body_return, merge_boundaries,
 };
 pub use expr::{eval_assignment_expression, eval_expression, get_width};
+pub(crate) use expr::{eval_assignment_expression_effectful, eval_expression_effectful};
 use state::{FunctionControlState, LoopControlState};
 
 type ActiveGuard = (NodeId, HashSet<VarAtomBase<VarId>>);

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -138,6 +138,57 @@ pub(super) fn ordered_function_inputs<'a>(
     Ok(inputs)
 }
 
+/// Returns output destinations in formal declaration order.
+///
+/// Like inputs, output connections are stored in a hash map. Destination
+/// expressions may have effects, so their order must follow the declaration.
+pub(super) fn ordered_function_outputs<'a>(
+    function: &Function,
+    function_body: &FunctionBody,
+    call: &'a FunctionCall,
+) -> Result<Vec<(VarId, &'a [veryl_analyzer::ir::AssignDestination])>, ParserError> {
+    let mut outputs = Vec::with_capacity(call.outputs.len());
+    let mut ordered_ids = HashSet::default();
+    for arg in &function.args {
+        for (arg_path, _, _) in &arg.members {
+            let Some(destinations) = call.outputs.get(arg_path) else {
+                continue;
+            };
+            let Some(arg_id) = function_body.arg_map.get(arg_path) else {
+                return Err(invalid_function_call_argument_error(
+                    function,
+                    arg_path,
+                    "output argument does not match any formal argument",
+                    call,
+                ));
+            };
+            outputs.push((*arg_id, destinations.as_slice()));
+            ordered_ids.insert(*arg_id);
+        }
+    }
+
+    for arg_path in call.outputs.keys() {
+        let Some(arg_id) = function_body.arg_map.get(arg_path) else {
+            return Err(invalid_function_call_argument_error(
+                function,
+                arg_path,
+                "output argument does not match any formal argument",
+                call,
+            ));
+        };
+        if !ordered_ids.contains(arg_id) {
+            return Err(invalid_function_call_argument_error(
+                function,
+                arg_path,
+                "output argument is absent from the function declaration",
+                call,
+            ));
+        }
+    }
+
+    Ok(outputs)
+}
+
 #[cfg(test)]
 fn parse_comb(
     module: &Module,
@@ -2537,58 +2588,69 @@ fn apply_function_call_outputs(
     final_local_store: &SymbolicStore<VarId>,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<(SymbolicStore<VarId>, BoundaryMap<VarId>), ParserError> {
-    for (arg_path, dsts) in &call.outputs {
-        let Some(arg_id) = function_body.arg_map.get(arg_path) else {
-            return Err(invalid_function_call_argument_error(
-                function,
-                arg_path,
-                "output argument does not match any formal argument",
-                call,
-            ));
-        };
-
-        let formal = module.variables.get(arg_id).ok_or_else(|| {
-            ParserError::illegal_context(
-                "function output value",
-                "formal variable is absent from the semantic module",
-                Some(&call.comptime.token),
-            )
-        })?;
-        let formal_width = resolve_total_width(module, formal)?;
-        if formal_width == 0 {
-            return Err(ParserError::illegal_context(
-                "function output value",
-                "formal output has zero width",
-                Some(&call.comptime.token),
-            ));
-        }
-        let access = BitAccess::new(0, formal_width - 1);
-        let range_store = final_local_store.get(arg_id).ok_or_else(|| {
-            ParserError::illegal_context(
-                "function output value",
-                "formal output is absent from the final symbolic store",
-                Some(&call.comptime.token),
-            )
-        })?;
-        let parts = range_store.get_parts(access).map_err(|error| {
-            range_store_error("function output value", error, Some(&call.comptime.token))
-        })?;
-        let (output_expr, output_sources) = combine_parts_with_default(*arg_id, 0, parts, arena)?;
-        let (next_store, next_boundaries) = assign_node_to_dsts(
+    for (arg_id, dsts) in ordered_function_outputs(function, function_body, call)? {
+        (store, boundaries) = apply_function_output(
             module,
             store,
             boundaries,
+            arg_id,
             dsts,
-            output_expr,
-            output_sources,
-            formal.r#type.is_2state(),
+            call,
+            final_local_store,
             arena,
         )?;
-        store = next_store;
-        boundaries = next_boundaries;
     }
 
     Ok((store, boundaries))
+}
+
+pub(super) fn apply_function_output(
+    module: &Module,
+    store: SymbolicStore<VarId>,
+    boundaries: BoundaryMap<VarId>,
+    arg_id: VarId,
+    dsts: &[veryl_analyzer::ir::AssignDestination],
+    call: &veryl_analyzer::ir::FunctionCall,
+    final_local_store: &SymbolicStore<VarId>,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<(SymbolicStore<VarId>, BoundaryMap<VarId>), ParserError> {
+    let formal = module.variables.get(&arg_id).ok_or_else(|| {
+        ParserError::illegal_context(
+            "function output value",
+            "formal variable is absent from the semantic module",
+            Some(&call.comptime.token),
+        )
+    })?;
+    let formal_width = resolve_total_width(module, formal)?;
+    if formal_width == 0 {
+        return Err(ParserError::illegal_context(
+            "function output value",
+            "formal output has zero width",
+            Some(&call.comptime.token),
+        ));
+    }
+    let access = BitAccess::new(0, formal_width - 1);
+    let range_store = final_local_store.get(&arg_id).ok_or_else(|| {
+        ParserError::illegal_context(
+            "function output value",
+            "formal output is absent from the final symbolic store",
+            Some(&call.comptime.token),
+        )
+    })?;
+    let parts = range_store.get_parts(access).map_err(|error| {
+        range_store_error("function output value", error, Some(&call.comptime.token))
+    })?;
+    let (output_expr, output_sources) = combine_parts_with_default(arg_id, 0, parts, arena)?;
+    assign_node_to_dsts(
+        module,
+        store,
+        boundaries,
+        dsts,
+        output_expr,
+        output_sources,
+        formal.r#type.is_2state(),
+        arena,
+    )
 }
 
 struct DynamicSelectOffset {

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -1655,12 +1655,32 @@ pub(super) fn collect_written_expression(
             Factor::Value(_) | Factor::Anonymous(_) | Factor::Unknown(_) => Ok(()),
         },
         Expression::Unary(_, inner, _) => collect_written_expression(module, inner, out),
-        Expression::Binary(lhs, _, rhs, _) => {
+        Expression::Binary(lhs, op, rhs, _) => {
             collect_written_expression(module, lhs, out)?;
+            let lhs_value = eval_constexpr(lhs);
+            let skips_rhs = match op {
+                Op::LogicAnd => lhs_value
+                    .as_ref()
+                    .is_some_and(|value| value == &BigUint::from(0u8)),
+                Op::LogicOr => lhs_value
+                    .as_ref()
+                    .is_some_and(|value| value != &BigUint::from(0u8)),
+                _ => false,
+            };
+            if skips_rhs {
+                return Ok(());
+            }
             collect_written_expression(module, rhs, out)
         }
         Expression::Ternary(cond, then_expr, else_expr, _) => {
             collect_written_expression(module, cond, out)?;
+            if let Some(value) = eval_constexpr(cond) {
+                return if value == BigUint::from(0u8) {
+                    collect_written_expression(module, else_expr, out)
+                } else {
+                    collect_written_expression(module, then_expr, out)
+                };
+            }
             collect_written_expression(module, then_expr, out)?;
             collect_written_expression(module, else_expr, out)
         }

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -31,9 +31,9 @@ use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::ToPrimitive as _;
 use veryl_analyzer::ir::{
     ArrayLiteralItem, AssignStatement, CasePattern, CaseStatement, CombDeclaration, Expression,
-    Factor, ForBound, ForRange, ForStatement, Function, FunctionCall, IfStatement, Module, Op,
-    Statement, SystemFunctionCall, SystemFunctionInput, SystemFunctionKind, VarId, VarIndex,
-    VarPath, VarSelect,
+    Factor, ForBound, ForRange, ForStatement, Function, FunctionBody, FunctionCall, IfStatement,
+    Module, Op, Statement, SystemFunctionCall, SystemFunctionInput, SystemFunctionKind, VarId,
+    VarIndex, VarPath, VarSelect,
 };
 use veryl_analyzer::value::{Value, byte_value_to_string};
 use veryl_parser::resource_table;
@@ -84,6 +84,58 @@ pub(super) fn invalid_function_call_argument_error(
         detail,
         Some(&call.comptime.token),
     )
+}
+
+/// Returns input expressions in formal declaration order.
+///
+/// Veryl's AIR stores call connections in a hash map, so iterating
+/// `FunctionCall::inputs` directly makes side-effect ordering depend on the hash
+/// layout. `Function::args`, in contrast, preserves the declared port order.
+pub(super) fn ordered_function_inputs<'a>(
+    function: &Function,
+    function_body: &FunctionBody,
+    call: &'a FunctionCall,
+) -> Result<Vec<(VarId, &'a Expression)>, ParserError> {
+    let mut inputs = Vec::with_capacity(call.inputs.len());
+    let mut ordered_ids = HashSet::default();
+    for arg in &function.args {
+        for (arg_path, _, _) in &arg.members {
+            let Some(arg_expr) = call.inputs.get(arg_path) else {
+                continue;
+            };
+            let Some(arg_id) = function_body.arg_map.get(arg_path) else {
+                return Err(invalid_function_call_argument_error(
+                    function,
+                    arg_path,
+                    "input argument does not match any formal argument",
+                    call,
+                ));
+            };
+            inputs.push((*arg_id, arg_expr));
+            ordered_ids.insert(*arg_id);
+        }
+    }
+
+    for arg_path in call.inputs.keys() {
+        let Some(arg_id) = function_body.arg_map.get(arg_path) else {
+            return Err(invalid_function_call_argument_error(
+                function,
+                arg_path,
+                "input argument does not match any formal argument",
+                call,
+            ));
+        };
+        if !ordered_ids.contains(arg_id) {
+            return Err(invalid_function_call_argument_error(
+                function,
+                arg_path,
+                "input argument is absent from the function declaration",
+                call,
+            ));
+        }
+    }
+
+    Ok(inputs)
 }
 
 #[cfg(test)]
@@ -1132,16 +1184,18 @@ fn eval_loop_case(
                 .try_fold(state, |s, step| eval_loop_statement(module, s, step, arena));
         };
 
+        let mut cond_store = state.store.clone();
         let ((cond_expr, cond_sources), cond_bounds) = eval_case_arm_condition_effectful(
             module,
-            &mut state.store,
+            &mut cond_store,
             &case_stmt.case_target,
             target,
             &arm.patterns,
             arena,
         )?;
+        state = apply_loop_continue_guard(module, state, cond_store, cond_bounds, arena)?;
         let cond_expr = procedural_condition(arena, cond_expr)?;
-        let boundaries = merge_boundaries(state.boundaries, cond_bounds);
+        let boundaries = state.boundaries.clone();
 
         if let Some(cond_val) = constant_bool(arena, cond_expr) {
             let state = LoopControlState {
@@ -1204,9 +1258,10 @@ fn eval_loop_case(
         })
     }
 
+    let mut target_store = state.store.clone();
     let (target, target_boundaries) =
-        eval_case_target_effectful(module, &mut state.store, &case_stmt.case_target, arena)?;
-    state.boundaries = merge_boundaries(state.boundaries, target_boundaries);
+        eval_case_target_effectful(module, &mut target_store, &case_stmt.case_target, arena)?;
+    state = apply_loop_continue_guard(module, state, target_store, target_boundaries, arena)?;
     eval_from_arm(module, state, case_stmt, &target, 0, arena)
 }
 
@@ -1216,10 +1271,12 @@ fn eval_loop_if(
     stmt: &IfStatement,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<LoopControlState, ParserError> {
+    let mut cond_store = state.store.clone();
     let ((cond_expr, cond_sources), cond_bounds) =
-        eval_expression_effectful(module, &mut state.store, &stmt.cond, arena, None)?;
+        eval_expression_effectful(module, &mut cond_store, &stmt.cond, arena, None)?;
+    state = apply_loop_continue_guard(module, state, cond_store, cond_bounds, arena)?;
     let cond_expr = procedural_condition(arena, cond_expr)?;
-    let boundaries = merge_boundaries(state.boundaries, cond_bounds);
+    let boundaries = state.boundaries.clone();
 
     if let Some(cond_val) = constant_bool(arena, cond_expr) {
         let side = if cond_val {

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -132,6 +132,15 @@ fn collect_system_function_effect(
         _ => unreachable!("non-event system functions return before event collection"),
     };
     let (site_id, value_args) = register_comb_runtime_event_site(collector, kind, args);
+    // Collector-local site IDs restart at zero. The source token keeps
+    // otherwise identical captures from different declarations distinct.
+    let capture_site_key = u32::try_from(call.comptime.token.beg.id.0).map_err(|_| {
+        ParserError::illegal_context(
+            "combinational observer capture",
+            "source token identity exceeds the capture-key range",
+            Some(&call.comptime.token),
+        )
+    })?;
     // Event operands are evaluated left to right.  Keep the environment from
     // the start of the event so writes performed by later operands cannot
     // retroactively rebind inputs in an earlier operand or in the assertion
@@ -155,6 +164,13 @@ fn collect_system_function_effect(
         None
     };
     for (arg_index, arg) in value_args.iter().enumerate() {
+        let arg_index = u32::try_from(arg_index).map_err(|_| {
+            ParserError::illegal_context(
+                "combinational observer capture",
+                "event argument count exceeds the capture-key range",
+                Some(&call.comptime.token),
+            )
+        })?;
         collect_expression_effects(module, store, &arg.0, arena, collector)?;
         let ((node, sources), arg_boundaries) =
             eval_expression_effectful(module, store, &arg.0, arena, None)?;
@@ -164,7 +180,7 @@ fn collect_system_function_effect(
         collect_expression_position_inputs(module, &arg.0, &mut position_inputs)?;
         observer_args.push(arena.alloc(SLTNode::Capture {
             expr: node,
-            key: (u64::from(site_id) << 32) | arg_index as u64,
+            key: (u64::from(capture_site_key) << 32) | u64::from(arg_index),
         })?);
     }
     observed_inputs.extend(collector.active_guard_sources.iter().copied());
@@ -189,7 +205,7 @@ fn collect_system_function_effect(
     .map(|node| {
         arena.alloc(SLTNode::Capture {
             expr: node,
-            key: (u64::from(site_id) << 32) | u64::from(u32::MAX),
+            key: (u64::from(capture_site_key) << 32) | u64::from(u32::MAX),
         })
     })
     .transpose()?;

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -460,7 +460,7 @@ fn collect_function_call_effects(
         collect_function_body_effects(
             module,
             local_store,
-            &function_body.statements,
+            &function_body,
             ret_id,
             arena,
             collector,
@@ -1133,11 +1133,12 @@ fn collect_factor_effects(
 fn collect_function_body_effects(
     module: &Module,
     local_store: SymbolicStore<VarId>,
-    statements: &[Statement],
+    body: &FunctionBody,
     ret_id: VarId,
     arena: &mut SLTNodeArena<VarId>,
     collector: &mut CombEffectCollector,
 ) -> Result<SymbolicStore<VarId>, ParserError> {
+    let initial_local_store = local_store.clone();
     fn collect_statements(
         module: &Module,
         mut state: FunctionControlState,
@@ -1970,12 +1971,22 @@ fn collect_function_body_effects(
             live_expr: bool_node(arena, true)?,
             live_sources: HashSet::default(),
         },
-        statements,
+        &body.statements,
         ret_id,
         arena,
         collector,
     )?;
-    Ok(final_state.store)
+    if body.statements.iter().any(super::statement_contains_break) {
+        // The ordinary observer collector deliberately treats `break` as a
+        // control-only statement. Re-evaluate the body with the function
+        // evaluator's break-aware loop state before exposing output-formal
+        // previews to later actual destinations.
+        let (_, _, break_aware_store) =
+            eval_function_body_return(module, &initial_local_store, body, ret_id, arena)?;
+        Ok(break_aware_store)
+    } else {
+        Ok(final_state.store)
+    }
 }
 
 fn collect_expression_position_inputs(

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -547,6 +547,23 @@ fn collect_expression_effects(
         Expression::Unary(_, inner, _) => {
             collect_expression_effects(module, store, inner, arena, collector)
         }
+        Expression::Binary(lhs, op, rhs, _) if matches!(op, Op::LogicAnd | Op::LogicOr) => {
+            collect_expression_effects(module, store, lhs, arena, collector)?;
+            let mut rhs_store = store.clone();
+            let ((lhs_node, lhs_sources), _) =
+                eval_expression_effectful(module, &mut rhs_store, lhs, arena, None)?;
+            let execute_rhs =
+                expr::short_circuit_rhs_guard(arena, lhs_node, matches!(op, Op::LogicAnd))?;
+            with_collector_guard(
+                collector,
+                arena,
+                execute_rhs,
+                lhs_sources,
+                |collector, arena| {
+                    collect_expression_effects(module, &rhs_store, rhs, arena, collector)
+                },
+            )
+        }
         Expression::Binary(lhs, _, rhs, _) => {
             collect_expression_effects(module, store, lhs, arena, collector)?;
             collect_expression_effects(module, store, rhs, arena, collector)

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -805,8 +805,18 @@ fn collect_assignment_effects(
     // Mirror that order in a collector-local store so observers in an index
     // see RHS output writes and later destination expressions see earlier ones.
     let mut destination_store = store.clone();
-    let _ = eval_assignment_rhs_effectful(module, &mut destination_store, assign, arena)?;
+    let ((rhs_expr, rhs_sources), _) =
+        eval_assignment_rhs_effectful(module, &mut destination_store, assign, arena)?;
+    let rhs_expected_width = checked_destination_width(
+        module,
+        &assign.dst,
+        "assignment destination",
+        Some(&assign.expr.token_range()),
+    )?;
+    let rhs_is_2state = assign.expr.comptime().r#type.is_2state();
+    let mut current_offset = 0;
     for destination in assign.dst.iter().rev() {
+        let mut collection_store = destination_store.clone();
         for expression in destination
             .index
             .0
@@ -820,10 +830,42 @@ fn collect_assignment_effects(
                     .map(|(_, expression)| expression),
             )
         {
-            collect_expression_effects(module, &destination_store, expression, arena, collector)?;
-            let _ =
-                eval_expression_effectful(module, &mut destination_store, expression, arena, None)?;
+            collect_and_advance_expression(
+                module,
+                &mut collection_store,
+                expression,
+                arena,
+                collector,
+            )?;
         }
+
+        let part_width = crate::bitaccess::get_access_width(
+            module,
+            destination.id,
+            &destination.index,
+            &destination.select,
+        )?;
+        let (slice_access, next_offset) =
+            checked_assignment_slice(current_offset, part_width, rhs_expected_width, destination)?;
+        let destination_expr = if assign.dst.len() == 1 {
+            rhs_expr
+        } else {
+            arena.alloc(SLTNode::Slice {
+                expr: rhs_expr,
+                access: slice_access,
+            })?
+        };
+        (destination_store, _) = super::apply_assignment_destination(
+            module,
+            destination_store,
+            BoundaryMap::default(),
+            destination,
+            destination_expr,
+            rhs_sources.clone(),
+            rhs_is_2state,
+            arena,
+        )?;
+        current_offset = next_offset;
     }
     Ok(())
 }
@@ -974,11 +1016,24 @@ fn collect_factor_effects(
 ) -> Result<(), ParserError> {
     match factor {
         Factor::Variable(_, index, select, _) => {
+            let mut position_store = store.clone();
             for expr in index.0.iter().chain(select.0.iter()) {
-                collect_expression_effects(module, store, expr, arena, collector)?;
+                collect_and_advance_expression(
+                    module,
+                    &mut position_store,
+                    expr,
+                    arena,
+                    collector,
+                )?;
             }
             if let Some((_, expr)) = &select.1 {
-                collect_expression_effects(module, store, expr, arena, collector)?;
+                collect_and_advance_expression(
+                    module,
+                    &mut position_store,
+                    expr,
+                    arena,
+                    collector,
+                )?;
             }
             Ok(())
         }
@@ -1299,7 +1354,28 @@ fn collect_function_body_effects(
             ));
         };
 
+        // Return-aware loops use this collector instead of
+        // collect_comb_effects_for. Mirror bound evaluation here so bound
+        // events are retained and the body sees output writes from both bounds.
         let mut iter_store = state.store.clone();
+        let (start_bound, end_bound) = for_range_bounds(&for_stmt.range);
+        for bound in [start_bound, end_bound] {
+            let ForBound::Expression(expression) = bound else {
+                continue;
+            };
+            let store = iter_store.clone();
+            with_collector_guard(
+                collector,
+                arena,
+                state.live_expr,
+                state.live_sources.clone(),
+                |collector, arena| {
+                    collect_expression_effects(module, &store, expression, arena, collector)
+                },
+            )?;
+            let _ = eval_expression_effectful(module, &mut iter_store, expression, arena, None)?;
+        }
+
         let mut written_accesses = HashMap::default();
         collect_written_accesses(module, &for_stmt.body, &mut written_accesses)?;
         for (id, accesses) in written_accesses {
@@ -1311,8 +1387,7 @@ fn collect_function_body_effects(
                     *slot = true;
                 }
             }
-            let original = state
-                .store
+            let original = iter_store
                 .get(&id)
                 .cloned()
                 .unwrap_or_else(|| RangeStore::new(None, width));

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -399,7 +399,20 @@ fn collect_function_call_effects(
     // writebacks without evaluating a destination effect twice.
     for (arg_id, destinations) in super::ordered_function_outputs(function, &function_body, call)? {
         let mut destination_store = actual_store.clone();
+        let destination_width = checked_destination_width(
+            module,
+            destinations,
+            "function output destination",
+            destinations.first().map(|destination| &destination.token),
+        )?;
+        let (output_expr, output_sources, output_is_2state) =
+            super::function_output_value(module, arg_id, call, &final_local_store, arena)?;
+        let output_signed = expr::is_signed(module, output_expr, arena);
+        let output_expr =
+            coerce_node_width(arena, output_expr, Some(destination_width), output_signed)?;
+        let mut current_offset = 0;
         for destination in destinations.iter().rev() {
+            let mut collection_store = destination_store.clone();
             for expression in destination
                 .index
                 .0
@@ -415,12 +428,44 @@ fn collect_function_call_effects(
             {
                 collect_and_advance_expression(
                     module,
-                    &mut destination_store,
+                    &mut collection_store,
                     expression,
                     arena,
                     collector,
                 )?;
             }
+
+            let part_width = crate::bitaccess::get_access_width(
+                module,
+                destination.id,
+                &destination.index,
+                &destination.select,
+            )?;
+            let (slice_access, next_offset) = checked_assignment_slice(
+                current_offset,
+                part_width,
+                destination_width,
+                destination,
+            )?;
+            let destination_expr = if destinations.len() == 1 {
+                output_expr
+            } else {
+                arena.alloc(SLTNode::Slice {
+                    expr: output_expr,
+                    access: slice_access,
+                })?
+            };
+            (destination_store, _) = super::apply_assignment_destination(
+                module,
+                destination_store,
+                BoundaryMap::default(),
+                destination,
+                destination_expr,
+                output_sources.clone(),
+                output_is_2state,
+                arena,
+            )?;
+            current_offset = next_offset;
         }
         (actual_store, _) = super::apply_function_output(
             module,

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(super) fn subtract_written_sensitivity<A: Copy + Eq + std::hash::Hash>(
+pub(crate) fn subtract_written_sensitivity<A: Copy + Eq + std::hash::Hash>(
     atoms: impl IntoIterator<Item = VarAtomBase<A>>,
     written_atoms: &[VarAtomBase<A>],
 ) -> HashSet<VarAtomBase<A>> {
@@ -36,10 +36,10 @@ pub(super) fn subtract_written_sensitivity<A: Copy + Eq + std::hash::Hash>(
 }
 
 #[derive(Default)]
-pub(super) struct CombEffectCollector {
-    pub(super) observers: Vec<CombObserver<VarId>>,
-    pub(super) sites: Vec<RuntimeEventSite>,
-    pub(super) sensitivity: HashSet<VarAtomBase<VarId>>,
+pub(crate) struct CombEffectCollector {
+    pub(crate) observers: Vec<CombObserver<VarId>>,
+    pub(crate) sites: Vec<RuntimeEventSite>,
+    pub(crate) sensitivity: HashSet<VarAtomBase<VarId>>,
     active_guard: Option<NodeId>,
     active_guard_sources: HashSet<VarAtomBase<VarId>>,
     loop_effects: Option<Vec<SLTForEffect>>,
@@ -364,6 +364,11 @@ fn collect_function_call_effects(
             arena,
             arg_width,
         )?;
+        let arg_node = if formal.r#type.is_2state() && !arg_expr.comptime().r#type.is_2state() {
+            arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, arg_node))?
+        } else {
+            arg_node
+        };
         // A runtime effect inside the callee executes as part of the caller's
         // always_comb process.  Its formal is only a local symbolic binding;
         // sensitivity must therefore retain the actual argument's sources.
@@ -612,7 +617,7 @@ fn for_range_contains_runtime_effect(module: &Module, range: &ForRange) -> bool 
     })
 }
 
-fn expression_contains_runtime_effect(module: &Module, expression: &Expression) -> bool {
+pub(crate) fn expression_contains_runtime_effect(module: &Module, expression: &Expression) -> bool {
     match expression {
         Expression::Term(factor) => match &**factor {
             Factor::FunctionCall(call) => function_call_contains_runtime_effect(module, call),
@@ -672,7 +677,7 @@ fn expression_contains_runtime_effect(module: &Module, expression: &Expression) 
     }
 }
 
-fn collect_expression_effects(
+pub(crate) fn collect_expression_effects(
     module: &Module,
     store: &SymbolicStore<VarId>,
     expr: &Expression,

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -661,18 +661,12 @@ pub(crate) fn expression_contains_runtime_effect(module: &Module, expression: &E
                 || expression_contains_runtime_effect(module, then_expr)
                 || expression_contains_runtime_effect(module, else_expr)
         }
-        Expression::Concatenation(items, _) => items.iter().any(|(expression, repeat)| {
-            expression_contains_runtime_effect(module, expression)
-                || repeat
-                    .as_ref()
-                    .is_some_and(|repeat| expression_contains_runtime_effect(module, repeat))
-        }),
+        Expression::Concatenation(items, _) => items
+            .iter()
+            .any(|(expression, _)| expression_contains_runtime_effect(module, expression)),
         Expression::ArrayLiteral(items, _) => items.iter().any(|item| match item {
-            ArrayLiteralItem::Value(expression, repeat) => {
+            ArrayLiteralItem::Value(expression, _) => {
                 expression_contains_runtime_effect(module, expression)
-                    || repeat
-                        .as_ref()
-                        .is_some_and(|repeat| expression_contains_runtime_effect(module, repeat))
             }
             ArrayLiteralItem::Defaul(expression) => {
                 expression_contains_runtime_effect(module, expression)
@@ -766,7 +760,7 @@ pub(crate) fn collect_expression_effects(
         }
         Expression::Concatenation(items, _) => {
             let mut item_store = store.clone();
-            for (item_expr, repeat_expr) in items {
+            for (item_expr, _) in items {
                 collect_and_advance_expression(
                     module,
                     &mut item_store,
@@ -774,15 +768,6 @@ pub(crate) fn collect_expression_effects(
                     arena,
                     collector,
                 )?;
-                if let Some(repeat_expr) = repeat_expr {
-                    collect_and_advance_expression(
-                        module,
-                        &mut item_store,
-                        repeat_expr,
-                        arena,
-                        collector,
-                    )?;
-                }
             }
             Ok(())
         }
@@ -790,7 +775,7 @@ pub(crate) fn collect_expression_effects(
             let mut item_store = store.clone();
             for item in items {
                 match item {
-                    ArrayLiteralItem::Value(item_expr, repeat_expr) => {
+                    ArrayLiteralItem::Value(item_expr, _) => {
                         collect_and_advance_expression(
                             module,
                             &mut item_store,
@@ -798,15 +783,6 @@ pub(crate) fn collect_expression_effects(
                             arena,
                             collector,
                         )?;
-                        if let Some(repeat_expr) = repeat_expr {
-                            collect_and_advance_expression(
-                                module,
-                                &mut item_store,
-                                repeat_expr,
-                                arena,
-                                collector,
-                            )?;
-                        }
                     }
                     ArrayLiteralItem::Defaul(default_expr) => {
                         collect_and_advance_expression(
@@ -1977,22 +1953,16 @@ fn collect_expression_position_inputs(
             collect_expression_position_inputs(module, else_expr, out)
         }
         Expression::Concatenation(parts, _) => {
-            for (part, repeat) in parts {
+            for (part, _) in parts {
                 collect_expression_position_inputs(module, part, out)?;
-                if let Some(repeat) = repeat {
-                    collect_expression_position_inputs(module, repeat, out)?;
-                }
             }
             Ok(())
         }
         Expression::ArrayLiteral(items, _) => {
             for item in items {
                 match item {
-                    ArrayLiteralItem::Value(expr, repeat) => {
+                    ArrayLiteralItem::Value(expr, _) => {
                         collect_expression_position_inputs(module, expr, out)?;
-                        if let Some(repeat) = repeat {
-                            collect_expression_position_inputs(module, repeat, out)?;
-                        }
                     }
                     ArrayLiteralItem::Defaul(expr) => {
                         collect_expression_position_inputs(module, expr, out)?;

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -335,26 +335,29 @@ fn collect_function_call_effects(
         ));
     };
 
+    let mut actual_store = store.clone();
     let mut local_store = store.clone();
-    for (arg_path, arg_id) in &function_body.arg_map {
-        let Some(arg_expr) = call.inputs.get(arg_path) else {
-            continue;
-        };
-        collect_expression_effects(module, store, arg_expr, arena, collector)?;
+    for (arg_id, arg_expr) in super::ordered_function_inputs(function, &function_body, call)? {
+        collect_expression_effects(module, &actual_store, arg_expr, arena, collector)?;
         let mut actual_inputs = HashSet::default();
         collect_expression_position_inputs(module, arg_expr, &mut actual_inputs)?;
         collector.sensitivity.extend(actual_inputs);
 
-        let formal = &module.variables[arg_id];
+        let formal = &module.variables[&arg_id];
         let arg_width = resolve_total_width(module, formal)?;
-        let ((arg_node, arg_sources), _) =
-            eval_expression(module, store, arg_expr, arena, Some(arg_width))?;
+        let ((arg_node, arg_sources), _) = eval_assignment_expression_effectful(
+            module,
+            &mut actual_store,
+            arg_expr,
+            arena,
+            arg_width,
+        )?;
         // A runtime effect inside the callee executes as part of the caller's
         // always_comb process.  Its formal is only a local symbolic binding;
         // sensitivity must therefore retain the actual argument's sources.
         collector.sensitivity.extend(arg_sources.iter().copied());
         local_store.insert(
-            *arg_id,
+            arg_id,
             RangeStore::new(Some((arg_node, arg_sources)), arg_width),
         );
     }
@@ -400,17 +403,27 @@ fn statement_contains_runtime_effect(module: &Module, stmt: &Statement) -> bool 
                 | SystemFunctionKind::Assert { .. }
         ),
         Statement::If(if_stmt) => {
-            statements_contain_runtime_effect(module, &if_stmt.true_side)
+            expression_contains_runtime_effect(module, &if_stmt.cond)
+                || statements_contain_runtime_effect(module, &if_stmt.true_side)
                 || statements_contain_runtime_effect(module, &if_stmt.false_side)
         }
         Statement::Case(case_stmt) => {
-            case_stmt
-                .arms
-                .iter()
-                .any(|arm| statements_contain_runtime_effect(module, &arm.body))
+            expression_contains_runtime_effect(module, &case_stmt.case_target)
+                || case_stmt.arms.iter().any(|arm| {
+                    arm.patterns
+                        .iter()
+                        .any(|pattern| case_pattern_contains_runtime_effect(module, pattern))
+                })
+                || case_stmt
+                    .arms
+                    .iter()
+                    .any(|arm| statements_contain_runtime_effect(module, &arm.body))
                 || statements_contain_runtime_effect(module, &case_stmt.default)
         }
-        Statement::For(for_stmt) => statements_contain_runtime_effect(module, &for_stmt.body),
+        Statement::For(for_stmt) => {
+            for_range_contains_runtime_effect(module, &for_stmt.range)
+                || statements_contain_runtime_effect(module, &for_stmt.body)
+        }
         Statement::FunctionCall(call) => module
             .functions
             .get(&call.id)
@@ -428,6 +441,32 @@ fn statement_contains_runtime_effect(module: &Module, stmt: &Statement) -> bool 
         | Statement::Unsupported(_)
         | Statement::Null => false,
     }
+}
+
+fn case_pattern_contains_runtime_effect(module: &Module, pattern: &CasePattern) -> bool {
+    match pattern {
+        CasePattern::Eq(expression) => expression_contains_runtime_effect(module, expression),
+        CasePattern::Range { lo, hi, .. } => {
+            expression_contains_runtime_effect(module, lo)
+                || expression_contains_runtime_effect(module, hi)
+        }
+    }
+}
+
+fn for_range_bounds(range: &ForRange) -> (&ForBound, &ForBound) {
+    match range {
+        ForRange::Forward { start, end, .. }
+        | ForRange::Reverse { start, end, .. }
+        | ForRange::Stepped { start, end, .. } => (start, end),
+    }
+}
+
+fn for_range_contains_runtime_effect(module: &Module, range: &ForRange) -> bool {
+    let (start, end) = for_range_bounds(range);
+    [start, end].into_iter().any(|bound| match bound {
+        ForBound::Const(_) => false,
+        ForBound::Expression(expression) => expression_contains_runtime_effect(module, expression),
+    })
 }
 
 fn expression_contains_runtime_effect(module: &Module, expression: &Expression) -> bool {
@@ -1651,6 +1690,16 @@ fn collect_comb_effects_for(
 ) -> Result<SymbolicStore<VarId>, ParserError> {
     let loop_width = for_stmt.var_type.total_width().unwrap_or(32);
     let original_store = store.clone();
+    let (start_bound, end_bound) = for_range_bounds(&for_stmt.range);
+    for bound in [start_bound, end_bound] {
+        let ForBound::Expression(expression) = bound else {
+            continue;
+        };
+        collect_expression_effects(module, &store, expression, arena, collector)?;
+        let ((_, sources), _) =
+            eval_expression_effectful(module, &mut store, expression, arena, None)?;
+        collector.sensitivity.extend(sources);
+    }
     let ForRange::Forward {
         start,
         end,
@@ -1662,7 +1711,7 @@ fn collect_comb_effects_for(
             collect_dynamic_for_effects(module, &store, for_stmt, arena, collector)?;
         let (store, _, runner) = eval_for_with_effects(
             module,
-            store,
+            original_store.clone(),
             BoundaryMap::default(),
             for_stmt,
             arena,
@@ -1676,7 +1725,7 @@ fn collect_comb_effects_for(
             collect_dynamic_for_effects(module, &store, for_stmt, arena, collector)?;
         let (store, _, runner) = eval_for_with_effects(
             module,
-            store,
+            original_store.clone(),
             BoundaryMap::default(),
             for_stmt,
             arena,
@@ -1690,7 +1739,7 @@ fn collect_comb_effects_for(
             collect_dynamic_for_effects(module, &store, for_stmt, arena, collector)?;
         let (store, _, runner) = eval_for_with_effects(
             module,
-            store,
+            original_store.clone(),
             BoundaryMap::default(),
             for_stmt,
             arena,

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -1480,6 +1480,7 @@ fn collect_function_body_effects(
             iter_store.insert(id, loop_store);
         }
         iter_store.insert(for_stmt.var_id, RangeStore::new(None, loop_width));
+        let iter_store_before = iter_store.clone();
 
         let observer_start = collector.observers.len();
         let saved_loop_effects = collector.loop_effects.take();
@@ -1508,11 +1509,10 @@ fn collect_function_body_effects(
         let loop_effects = collector.loop_effects.take().unwrap_or_default();
         collector.loop_effects = saved_loop_effects;
 
-        // Effect arguments after the loop only consume this store while the
-        // function remains live. On that path no return was taken, so the
-        // ordinary loop fold and the function-aware fold have identical data
-        // state; the separate transient result below carries the control state.
-        let (result_store, boundaries) = eval_for(
+        // Use the ordinary loop fold only as a geometry and initial-state
+        // template. Its data updates are replaced below with the return-aware
+        // iteration state collected for function execution.
+        let (mut result_store, boundaries) = eval_for(
             module,
             state.store.clone(),
             state.boundaries.clone(),
@@ -1560,6 +1560,65 @@ fn collect_function_body_effects(
             BinaryOp::And,
             iter_state.live_expr,
         ))?;
+        let return_aware_updates =
+            super::extract_store_updates(&iter_store_before, &iter_state.store, arena)?
+                .into_iter()
+                .map(|(target, expr, _)| SLTForUpdate { target, expr })
+                .collect::<Vec<_>>();
+        let return_aware_updates = if return_aware_updates.is_empty() {
+            updates.clone()
+        } else {
+            return_aware_updates
+        };
+
+        // The ordinary fold is useful as a geometry/template builder, but its
+        // body keeps evaluating after a function return. Replace every data
+        // result with the return-aware iteration updates collected above so
+        // output-formal previews match ordinary function evaluation.
+        for range_store in result_store.values_mut() {
+            for (value, _, _) in range_store.ranges.values_mut() {
+                let Some((node, _)) = value else {
+                    continue;
+                };
+                let SLTNode::ForFold {
+                    loop_var: node_loop_var,
+                    loop_width: node_loop_width,
+                    loop_signed: node_loop_signed,
+                    start: node_start,
+                    end: node_end,
+                    inclusive: node_inclusive,
+                    step: node_step,
+                    step_op: node_step_op,
+                    reverse: node_reverse,
+                    result: node_result,
+                    initials: node_initials,
+                    effects: node_effects,
+                    ..
+                } = arena.get(*node).clone()
+                else {
+                    continue;
+                };
+                if node_loop_var != for_stmt.var_id {
+                    continue;
+                }
+                *node = arena.alloc(SLTNode::ForFold {
+                    loop_var: node_loop_var,
+                    loop_width: node_loop_width,
+                    loop_signed: node_loop_signed,
+                    start: node_start,
+                    end: node_end,
+                    inclusive: node_inclusive,
+                    step: node_step,
+                    step_op: node_step_op,
+                    reverse: node_reverse,
+                    result: node_result,
+                    initials: node_initials,
+                    updates: return_aware_updates.clone(),
+                    effects: node_effects,
+                    continue_cond: effective_continue,
+                })?;
+            }
+        }
 
         if !loop_effects.is_empty() {
             let runner = arena.alloc(SLTNode::ForFold {
@@ -1574,7 +1633,7 @@ fn collect_function_body_effects(
                 reverse,
                 result: result.clone(),
                 initials: initials.clone(),
-                updates: updates.clone(),
+                updates: return_aware_updates.clone(),
                 effects: loop_effects,
                 continue_cond: effective_continue,
             })?;
@@ -1601,7 +1660,7 @@ fn collect_function_body_effects(
                 update: iter_state.live_expr,
             },
             initials,
-            updates,
+            updates: return_aware_updates,
             effects: Vec::new(),
             continue_cond: effective_continue,
         })?;

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -615,7 +615,7 @@ fn collect_function_body_effects(
 
     fn collect_case_from_arm(
         module: &Module,
-        state: FunctionControlState,
+        mut state: FunctionControlState,
         case_stmt: &CaseStatement,
         arm_index: usize,
         ret_id: VarId,
@@ -635,7 +635,7 @@ fn collect_function_body_effects(
         })?;
 
         let ((cond_node, cond_sources), cond_bounds) =
-            eval_expression(module, &state.store, &cond, arena, None)?;
+            eval_expression_effectful(module, &mut state.store, &cond, arena, None)?;
         let cond_node = procedural_condition(arena, cond_node)?;
         let boundaries = merge_boundaries(state.boundaries, cond_bounds);
 
@@ -1039,7 +1039,7 @@ fn collect_function_body_effects(
 
     fn collect_statement(
         module: &Module,
-        state: FunctionControlState,
+        mut state: FunctionControlState,
         stmt: &Statement,
         ret_id: VarId,
         arena: &mut SLTNodeArena<VarId>,
@@ -1075,13 +1075,29 @@ fn collect_function_body_effects(
                 )
             }
             Statement::SystemFunctionCall(call) => {
+                let guard_state = state.clone();
                 let store = state.store.clone();
                 let live = state.live_expr;
                 let live_sources = state.live_sources.clone();
                 with_collector_guard(collector, arena, live, live_sources, |collector, arena| {
                     collect_system_function_effect(module, &store, call, arena, collector)
                 })?;
-                Ok(state)
+                let (next_store, next_boundaries) = eval_system_function_call_side_effects(
+                    module,
+                    state.store,
+                    state.boundaries,
+                    call,
+                    arena,
+                )?;
+                apply_function_guard(
+                    module,
+                    guard_state,
+                    next_store,
+                    next_boundaries,
+                    bool_node(arena, true)?,
+                    HashSet::default(),
+                    arena,
+                )
             }
             Statement::FunctionCall(call) => {
                 let guard_state = state.clone();
@@ -1117,8 +1133,13 @@ fn collect_function_body_effects(
                     collect_expression_effects(module, &store, &if_stmt.cond, arena, collector)
                 })?;
 
-                let ((cond_node, cond_sources), cond_boundaries) =
-                    eval_expression(module, &state.store, &if_stmt.cond, arena, None)?;
+                let ((cond_node, cond_sources), cond_boundaries) = eval_expression_effectful(
+                    module,
+                    &mut state.store,
+                    &if_stmt.cond,
+                    arena,
+                    None,
+                )?;
                 let cond_node = procedural_condition(arena, cond_node)?;
                 let boundaries = merge_boundaries(state.boundaries, cond_boundaries);
                 let true_guard = arena.alloc(SLTNode::Binary(
@@ -1360,6 +1381,14 @@ pub(super) fn collect_comb_effects_statements(
             }
             Statement::SystemFunctionCall(call) => {
                 collect_system_function_effect(module, &store, call, arena, collector)?;
+                let (next_store, _) = eval_system_function_call_side_effects(
+                    module,
+                    store,
+                    BoundaryMap::default(),
+                    call,
+                    arena,
+                )?;
+                store = next_store;
             }
             Statement::FunctionCall(call) => {
                 collect_function_call_effects(module, &store, call, arena, collector)?;
@@ -1379,7 +1408,7 @@ pub(super) fn collect_comb_effects_statements(
             Statement::If(if_stmt) => {
                 collect_expression_effects(module, &store, &if_stmt.cond, arena, collector)?;
                 let ((cond_node, sources), _) =
-                    eval_expression(module, &store, &if_stmt.cond, arena, None)?;
+                    eval_expression_effectful(module, &mut store, &if_stmt.cond, arena, None)?;
                 let cond_node = procedural_condition(arena, cond_node)?;
                 collector.sensitivity.extend(sources.iter().copied());
                 let saved_guard = collector.active_guard;
@@ -1450,7 +1479,7 @@ fn collect_comb_effects_case(
 ) -> Result<SymbolicStore<VarId>, ParserError> {
     fn collect_from_arm(
         module: &Module,
-        store: SymbolicStore<VarId>,
+        mut store: SymbolicStore<VarId>,
         case_stmt: &CaseStatement,
         arm_index: usize,
         arena: &mut SLTNodeArena<VarId>,
@@ -1468,7 +1497,8 @@ fn collect_comb_effects_case(
 
         let cond = case_arm_condition_expr(&case_stmt.case_target, &arm.patterns);
         collect_expression_effects(module, &store, &cond, arena, collector)?;
-        let ((cond_node, sources), _) = eval_expression(module, &store, &cond, arena, None)?;
+        let ((cond_node, sources), _) =
+            eval_expression_effectful(module, &mut store, &cond, arena, None)?;
         let cond_node = procedural_condition(arena, cond_node)?;
         collector.sensitivity.extend(sources.iter().copied());
 

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -348,7 +348,7 @@ fn collect_function_call_effects(
     };
 
     let mut actual_store = store.clone();
-    let mut local_store = store.clone();
+    let mut formal_bindings = Vec::new();
     for (arg_id, arg_expr) in super::ordered_function_inputs(function, &function_body, call)? {
         collect_expression_effects(module, &actual_store, arg_expr, arena, collector)?;
         let mut actual_inputs = HashSet::default();
@@ -373,11 +373,18 @@ fn collect_function_call_effects(
         // always_comb process.  Its formal is only a local symbolic binding;
         // sensitivity must therefore retain the actual argument's sources.
         collector.sensitivity.extend(arg_sources.iter().copied());
-        local_store.insert(
+        formal_bindings.push((
             arg_id,
             RangeStore::new(Some((arg_node, arg_sources)), arg_width),
-        );
+        ));
     }
+
+    // Actuals are evaluated in caller order and may write module-scoped
+    // variables through nested output arguments.  Callee runtime effects must
+    // therefore start from that advanced caller state, just like value
+    // evaluation does, before formal bindings shadow their module entries.
+    let mut local_store = actual_store.clone();
+    local_store.extend(formal_bindings);
 
     let final_local_store = if let Some(ret_id) = function_body.ret {
         collect_function_body_effects(
@@ -830,7 +837,7 @@ pub(crate) fn collect_expression_effects(
     }
 }
 
-fn collect_and_advance_expression(
+pub(crate) fn collect_and_advance_expression(
     module: &Module,
     store: &mut SymbolicStore<VarId>,
     expression: &Expression,

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -374,11 +374,7 @@ fn collect_function_call_effects(
         );
     }
 
-    if !statements_contain_runtime_effect(module, &function_body.statements) {
-        return Ok(());
-    }
-
-    if let Some(ret_id) = function_body.ret {
+    let final_local_store = if let Some(ret_id) = function_body.ret {
         collect_function_body_effects(
             module,
             local_store,
@@ -386,14 +382,55 @@ fn collect_function_call_effects(
             ret_id,
             arena,
             collector,
-        )?;
+        )?
     } else {
-        let _ = collect_comb_effects_statements(
+        collect_comb_effects_statements(
             module,
             local_store,
             &function_body.statements,
             arena,
             collector,
+        )?
+    };
+
+    // Output destinations are resolved after the callee body. Collect their
+    // nested effects against a preview store, then apply each output once to
+    // the real collector-local caller store so later outputs observe earlier
+    // writebacks without evaluating a destination effect twice.
+    for (arg_id, destinations) in super::ordered_function_outputs(function, &function_body, call)? {
+        let mut destination_store = actual_store.clone();
+        for destination in destinations.iter().rev() {
+            for expression in destination
+                .index
+                .0
+                .iter()
+                .chain(destination.select.0.iter())
+                .chain(
+                    destination
+                        .select
+                        .1
+                        .iter()
+                        .map(|(_, expression)| expression),
+                )
+            {
+                collect_and_advance_expression(
+                    module,
+                    &mut destination_store,
+                    expression,
+                    arena,
+                    collector,
+                )?;
+            }
+        }
+        (actual_store, _) = super::apply_function_output(
+            module,
+            actual_store,
+            BoundaryMap::default(),
+            arg_id,
+            destinations,
+            call,
+            &final_local_store,
+            arena,
         )?;
     }
     Ok(())
@@ -451,17 +488,7 @@ fn statement_contains_runtime_effect(module: &Module, stmt: &Statement) -> bool 
             for_range_contains_runtime_effect(module, &for_stmt.range)
                 || statements_contain_runtime_effect(module, &for_stmt.body)
         }
-        Statement::FunctionCall(call) => module
-            .functions
-            .get(&call.id)
-            .and_then(|function| {
-                if let Some(index) = &call.index {
-                    function.get_function(index)
-                } else {
-                    function.get_function(&[])
-                }
-            })
-            .is_some_and(|body| statements_contain_runtime_effect(module, &body.statements)),
+        Statement::FunctionCall(call) => function_call_contains_runtime_effect(module, call),
         Statement::IfReset(_)
         | Statement::TbMethodCall(_)
         | Statement::Break
@@ -487,6 +514,31 @@ fn destination_contains_runtime_effect(
                 .map(|(_, expression)| expression),
         )
         .any(|expression| expression_contains_runtime_effect(module, expression))
+}
+
+fn function_call_contains_runtime_effect(
+    module: &Module,
+    call: &veryl_analyzer::ir::FunctionCall,
+) -> bool {
+    call.inputs
+        .values()
+        .any(|expression| expression_contains_runtime_effect(module, expression))
+        || call
+            .outputs
+            .values()
+            .flatten()
+            .any(|destination| destination_contains_runtime_effect(module, destination))
+        || module
+            .functions
+            .get(&call.id)
+            .and_then(|function| {
+                if let Some(index) = &call.index {
+                    function.get_function(index)
+                } else {
+                    function.get_function(&[])
+                }
+            })
+            .is_some_and(|body| statements_contain_runtime_effect(module, &body.statements))
 }
 
 fn case_pattern_contains_runtime_effect(module: &Module, pattern: &CasePattern) -> bool {
@@ -518,17 +570,7 @@ fn for_range_contains_runtime_effect(module: &Module, range: &ForRange) -> bool 
 fn expression_contains_runtime_effect(module: &Module, expression: &Expression) -> bool {
     match expression {
         Expression::Term(factor) => match &**factor {
-            Factor::FunctionCall(call) => module
-                .functions
-                .get(&call.id)
-                .and_then(|function| {
-                    if let Some(index) = &call.index {
-                        function.get_function(index)
-                    } else {
-                        function.get_function(&[])
-                    }
-                })
-                .is_some_and(|body| statements_contain_runtime_effect(module, &body.statements)),
+            Factor::FunctionCall(call) => function_call_contains_runtime_effect(module, call),
             Factor::Variable(_, index, select, _) => index
                 .0
                 .iter()
@@ -616,31 +658,93 @@ fn collect_expression_effects(
         }
         Expression::Binary(lhs, _, rhs, _) => {
             collect_expression_effects(module, store, lhs, arena, collector)?;
-            collect_expression_effects(module, store, rhs, arena, collector)
+            let mut rhs_store = store.clone();
+            let _ = eval_expression_effectful(module, &mut rhs_store, lhs, arena, None)?;
+            collect_expression_effects(module, &rhs_store, rhs, arena, collector)
         }
         Expression::Ternary(cond, then_expr, else_expr, _) => {
             collect_expression_effects(module, store, cond, arena, collector)?;
-            collect_expression_effects(module, store, then_expr, arena, collector)?;
-            collect_expression_effects(module, store, else_expr, arena, collector)
+            let mut branch_store = store.clone();
+            let ((cond_node, cond_sources), _) =
+                eval_expression_effectful(module, &mut branch_store, cond, arena, None)?;
+
+            // Match effectful ternary evaluation: a known condition executes
+            // one arm, while X/Z executes both arms from left to right.
+            let not_cond = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, cond_node))?;
+            let known_false = arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, not_cond))?;
+            let true_truth = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, not_cond))?;
+            let known_true = arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, true_truth))?;
+            let execute_then = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, known_false))?;
+
+            with_collector_guard(
+                collector,
+                arena,
+                execute_then,
+                cond_sources.clone(),
+                |collector, arena| {
+                    collect_expression_effects(module, &branch_store, then_expr, arena, collector)
+                },
+            )?;
+            let mut then_store = branch_store.clone();
+            let _ = eval_expression_effectful(module, &mut then_store, then_expr, arena, None)?;
+            let after_then = merge_symbolic_stores(
+                module,
+                &then_store,
+                &branch_store,
+                execute_then,
+                &cond_sources,
+                arena,
+            )?;
+
+            let execute_else = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, known_true))?;
+            with_collector_guard(
+                collector,
+                arena,
+                execute_else,
+                cond_sources,
+                |collector, arena| {
+                    collect_expression_effects(module, &after_then, else_expr, arena, collector)
+                },
+            )
         }
         Expression::Concatenation(items, _) => {
+            let mut item_store = store.clone();
             for (item_expr, repeat_expr) in items {
-                collect_expression_effects(module, store, item_expr, arena, collector)?;
+                collect_and_advance_expression(
+                    module,
+                    &mut item_store,
+                    item_expr,
+                    arena,
+                    collector,
+                )?;
                 if let Some(repeat_expr) = repeat_expr {
-                    collect_expression_effects(module, store, repeat_expr, arena, collector)?;
+                    collect_and_advance_expression(
+                        module,
+                        &mut item_store,
+                        repeat_expr,
+                        arena,
+                        collector,
+                    )?;
                 }
             }
             Ok(())
         }
         Expression::ArrayLiteral(items, _) => {
+            let mut item_store = store.clone();
             for item in items {
                 match item {
                     ArrayLiteralItem::Value(item_expr, repeat_expr) => {
-                        collect_expression_effects(module, store, item_expr, arena, collector)?;
+                        collect_and_advance_expression(
+                            module,
+                            &mut item_store,
+                            item_expr,
+                            arena,
+                            collector,
+                        )?;
                         if let Some(repeat_expr) = repeat_expr {
-                            collect_expression_effects(
+                            collect_and_advance_expression(
                                 module,
-                                store,
+                                &mut item_store,
                                 repeat_expr,
                                 arena,
                                 collector,
@@ -648,19 +752,44 @@ fn collect_expression_effects(
                         }
                     }
                     ArrayLiteralItem::Defaul(default_expr) => {
-                        collect_expression_effects(module, store, default_expr, arena, collector)?;
+                        collect_and_advance_expression(
+                            module,
+                            &mut item_store,
+                            default_expr,
+                            arena,
+                            collector,
+                        )?;
                     }
                 }
             }
             Ok(())
         }
         Expression::StructConstructor(_, fields, _) => {
+            let mut field_store = store.clone();
             for (_, field_expr) in fields {
-                collect_expression_effects(module, store, field_expr, arena, collector)?;
+                collect_and_advance_expression(
+                    module,
+                    &mut field_store,
+                    field_expr,
+                    arena,
+                    collector,
+                )?;
             }
             Ok(())
         }
     }
+}
+
+fn collect_and_advance_expression(
+    module: &Module,
+    store: &mut SymbolicStore<VarId>,
+    expression: &Expression,
+    arena: &mut SLTNodeArena<VarId>,
+    collector: &mut CombEffectCollector,
+) -> Result<(), ParserError> {
+    collect_expression_effects(module, store, expression, arena, collector)?;
+    let _ = eval_expression_effectful(module, store, expression, arena, None)?;
+    Ok(())
 }
 
 fn collect_assignment_effects(
@@ -877,7 +1006,7 @@ fn collect_function_body_effects(
     ret_id: VarId,
     arena: &mut SLTNodeArena<VarId>,
     collector: &mut CombEffectCollector,
-) -> Result<(), ParserError> {
+) -> Result<SymbolicStore<VarId>, ParserError> {
     fn collect_statements(
         module: &Module,
         mut state: FunctionControlState,
@@ -1623,7 +1752,7 @@ fn collect_function_body_effects(
         }
     }
 
-    let _ = collect_statements(
+    let final_state = collect_statements(
         module,
         FunctionControlState {
             store: local_store,
@@ -1636,7 +1765,7 @@ fn collect_function_body_effects(
         arena,
         collector,
     )?;
-    Ok(())
+    Ok(final_state.store)
 }
 
 fn collect_expression_position_inputs(
@@ -1800,8 +1929,8 @@ pub(super) fn collect_comb_effects_statements(
                     module,
                     &side_store,
                     &else_store,
-                    bool_node(arena, true)?,
-                    &HashSet::default(),
+                    cond_node,
+                    &sources,
                     arena,
                 )?;
             }

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -43,33 +43,22 @@ pub(crate) struct CombEffectCollector {
     active_guard: Option<NodeId>,
     active_guard_sources: HashSet<VarAtomBase<VarId>>,
     loop_effects: Option<Vec<SLTForEffect>>,
-    capture_namespace: Option<u32>,
+    capture_namespace: u32,
     next_capture_id: u32,
 }
 
 impl CombEffectCollector {
-    fn initialize_capture_namespace(
-        &mut self,
-        token: &veryl_parser::token_range::TokenRange,
-    ) -> Result<(), ParserError> {
-        if self.capture_namespace.is_some() {
-            return Ok(());
+    pub(crate) fn with_capture_namespace(capture_namespace: u32) -> Self {
+        Self {
+            capture_namespace,
+            ..Self::default()
         }
-        self.capture_namespace = Some(u32::try_from(token.beg.id.0).map_err(|_| {
-            ParserError::illegal_context(
-                "combinational observer capture",
-                "source token identity exceeds the capture-key range",
-                Some(token),
-            )
-        })?);
-        Ok(())
     }
 
     fn next_capture_key(
         &mut self,
         token: &veryl_parser::token_range::TokenRange,
     ) -> Result<u64, ParserError> {
-        self.initialize_capture_namespace(token)?;
         let capture_id = self.next_capture_id;
         self.next_capture_id = capture_id.checked_add(1).ok_or_else(|| {
             ParserError::illegal_context(
@@ -78,7 +67,7 @@ impl CombEffectCollector {
                 Some(token),
             )
         })?;
-        Ok((u64::from(self.capture_namespace.unwrap()) << 32) | u64::from(capture_id))
+        Ok((u64::from(self.capture_namespace) << 32) | u64::from(capture_id))
     }
 }
 
@@ -94,19 +83,17 @@ fn register_comb_runtime_event_site<'a>(
     collector: &mut CombEffectCollector,
     kind: RuntimeEventKind,
     args: &'a [SystemFunctionInput],
-) -> (u32, &'a [SystemFunctionInput]) {
-    let (template, value_args) = if args
-        .first()
-        .and_then(|arg| static_string_expr(&arg.0))
-        .is_some()
-    {
-        (
-            args.first().and_then(|arg| static_string_expr(&arg.0)),
-            &args[1..],
-        )
-    } else {
-        (None, args)
-    };
+) -> (
+    u32,
+    Option<&'a SystemFunctionInput>,
+    &'a [SystemFunctionInput],
+) {
+    let (template, template_arg, value_args) =
+        if let Some(template) = args.first().and_then(|arg| static_string_expr(&arg.0)) {
+            (Some(template), args.first(), &args[1..])
+        } else {
+            (None, None, args)
+        };
     let site = RuntimeEventSite {
         kind,
         template,
@@ -125,7 +112,7 @@ fn register_comb_runtime_event_site<'a>(
     };
     let id = collector.sites.len() as u32;
     collector.sites.push(site);
-    (id, value_args)
+    (id, template_arg, value_args)
 }
 
 fn collect_system_function_effect(
@@ -168,7 +155,8 @@ fn collect_system_function_effect(
         }
         _ => unreachable!("non-event system functions return before event collection"),
     };
-    let (site_id, value_args) = register_comb_runtime_event_site(collector, kind, args);
+    let (site_id, template_arg, value_args) =
+        register_comb_runtime_event_site(collector, kind, args);
     // Event operands are evaluated left to right.  Keep the environment from
     // the start of the event so writes performed by later operands cannot
     // retroactively rebind inputs in an earlier operand or in the assertion
@@ -191,6 +179,16 @@ fn collect_system_function_effect(
     } else {
         None
     };
+    // A statically known format is omitted from the emitted runtime-event
+    // operands, but its expression still executes before the value operands.
+    // Preserve nested effects and output writeback from that evaluation.
+    if let Some(template_arg) = template_arg {
+        collect_expression_effects(module, store, &template_arg.0, arena, collector)?;
+        let ((_, sources), template_boundaries) =
+            eval_expression_effectful(module, store, &template_arg.0, arena, None)?;
+        boundaries = merge_boundaries(boundaries, template_boundaries);
+        collector.sensitivity.extend(sources);
+    }
     for arg in value_args {
         collect_expression_effects(module, store, &arg.0, arena, collector)?;
         let ((node, sources), arg_boundaries) =
@@ -375,10 +373,6 @@ fn collect_function_call_effects(
     arena: &mut SLTNodeArena<VarId>,
     collector: &mut CombEffectCollector,
 ) -> Result<(), ParserError> {
-    // The outermost evaluated call site names this collector's capture
-    // namespace. Runtime tasks in a reusable callee otherwise carry the same
-    // callee-body token in every caller.
-    collector.initialize_capture_namespace(&call.comptime.token)?;
     let Some(function) = module.functions.get(&call.id) else {
         return Err(ParserError::unsupported(
             62,
@@ -920,13 +914,6 @@ fn collect_assignment_effects(
             .0
             .iter()
             .chain(destination.select.0.iter())
-            .chain(
-                destination
-                    .select
-                    .1
-                    .iter()
-                    .map(|(_, expression)| expression),
-            )
         {
             collect_and_advance_expression(
                 module,

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::case::case_arm_condition_expr;
 
 pub(super) fn subtract_written_sensitivity<A: Copy + Eq + std::hash::Hash>(
     atoms: impl IntoIterator<Item = VarAtomBase<A>>,
@@ -94,11 +93,11 @@ fn register_comb_runtime_event_site<'a>(
 
 fn collect_system_function_effect(
     module: &Module,
-    store: &SymbolicStore<VarId>,
+    store: &mut SymbolicStore<VarId>,
     call: &SystemFunctionCall,
     arena: &mut SLTNodeArena<VarId>,
     collector: &mut CombEffectCollector,
-) -> Result<(), ParserError> {
+) -> Result<BoundaryMap<VarId>, ParserError> {
     let (kind, cond, args) = match &call.kind {
         SystemFunctionKind::Display(args) | SystemFunctionKind::Write(args) => {
             (RuntimeEventKind::Display, None, args.as_slice())
@@ -121,20 +120,15 @@ fn collect_system_function_effect(
         }
     };
     let (site_id, value_args) = register_comb_runtime_event_site(collector, kind, args);
+    let mut boundaries = BoundaryMap::default();
     let mut observer_args = Vec::new();
     let mut observed_inputs = HashSet::default();
     let mut position_inputs = HashSet::default();
-    for arg in value_args {
-        collect_expression_effects(module, store, &arg.0, arena, collector)?;
-        let ((node, sources), _) = eval_expression(module, store, &arg.0, arena, None)?;
-        observed_inputs.extend(sources.iter().copied());
-        collector.sensitivity.extend(sources);
-        collect_expression_position_inputs(module, &arg.0, &mut position_inputs)?;
-        observer_args.push(node);
-    }
     let explicit_guard = if let Some(cond) = cond {
         collect_expression_effects(module, store, cond, arena, collector)?;
-        let ((cond_node, cond_sources), _) = eval_expression(module, store, cond, arena, None)?;
+        let ((cond_node, cond_sources), cond_boundaries) =
+            eval_expression_effectful(module, store, cond, arena, None)?;
+        boundaries = merge_boundaries(boundaries, cond_boundaries);
         observed_inputs.extend(cond_sources.iter().copied());
         collector.sensitivity.extend(cond_sources);
         collect_expression_position_inputs(module, cond, &mut position_inputs)?;
@@ -142,6 +136,16 @@ fn collect_system_function_effect(
     } else {
         None
     };
+    for arg in value_args {
+        collect_expression_effects(module, store, &arg.0, arena, collector)?;
+        let ((node, sources), arg_boundaries) =
+            eval_expression_effectful(module, store, &arg.0, arena, None)?;
+        boundaries = merge_boundaries(boundaries, arg_boundaries);
+        observed_inputs.extend(sources.iter().copied());
+        collector.sensitivity.extend(sources);
+        collect_expression_position_inputs(module, &arg.0, &mut position_inputs)?;
+        observer_args.push(node);
+    }
     observed_inputs.extend(collector.active_guard_sources.iter().copied());
     let guard = match (kind, collector.active_guard, explicit_guard) {
         (RuntimeEventKind::Display, active, None) => active,
@@ -188,7 +192,7 @@ fn collect_system_function_effect(
         })
         .collect();
     let mut local_inputs = Vec::new();
-    for (id, range_store) in store {
+    for (id, range_store) in store.iter() {
         if !observed_ids.contains(id) {
             continue;
         }
@@ -270,7 +274,7 @@ fn collect_system_function_effect(
     if let (Some(loop_effects), Some(loop_effect)) = (&mut collector.loop_effects, loop_effect) {
         loop_effects.push(loop_effect);
     }
-    Ok(())
+    Ok(boundaries)
 }
 
 fn with_collector_guard<T, F>(
@@ -553,6 +557,27 @@ fn collect_expression_effects(
     }
 }
 
+fn collect_case_pattern_effects(
+    module: &Module,
+    store: &SymbolicStore<VarId>,
+    patterns: &[CasePattern],
+    arena: &mut SLTNodeArena<VarId>,
+    collector: &mut CombEffectCollector,
+) -> Result<(), ParserError> {
+    for pattern in patterns {
+        match pattern {
+            CasePattern::Eq(expression) => {
+                collect_expression_effects(module, store, expression, arena, collector)?;
+            }
+            CasePattern::Range { lo, hi, .. } => {
+                collect_expression_effects(module, store, lo, arena, collector)?;
+                collect_expression_effects(module, store, hi, arena, collector)?;
+            }
+        }
+    }
+    Ok(())
+}
+
 fn collect_factor_effects(
     module: &Module,
     store: &SymbolicStore<VarId>,
@@ -574,9 +599,8 @@ fn collect_factor_effects(
             collect_function_call_effects(module, store, call, arena, collector)
         }
         Factor::SystemFunctionCall(call) => match &call.kind {
-            SystemFunctionKind::Bits(input)
-            | SystemFunctionKind::Size(input)
-            | SystemFunctionKind::Clog2(input)
+            SystemFunctionKind::Bits(_) | SystemFunctionKind::Size(_) => Ok(()),
+            SystemFunctionKind::Clog2(input)
             | SystemFunctionKind::Onehot(input)
             | SystemFunctionKind::Signed(input)
             | SystemFunctionKind::Unsigned(input) => {
@@ -617,6 +641,7 @@ fn collect_function_body_effects(
         module: &Module,
         mut state: FunctionControlState,
         case_stmt: &CaseStatement,
+        target: &expr::EvaluatedCaseTarget,
         arm_index: usize,
         ret_id: VarId,
         arena: &mut SLTNodeArena<VarId>,
@@ -626,18 +651,33 @@ fn collect_function_body_effects(
             return collect_statements(module, state, &case_stmt.default, ret_id, arena, collector);
         };
 
-        let cond = case_arm_condition_expr(&case_stmt.case_target, &arm.patterns);
         let store = state.store.clone();
         let live = state.live_expr;
         let live_sources = state.live_sources.clone();
         with_collector_guard(collector, arena, live, live_sources, |collector, arena| {
-            collect_expression_effects(module, &store, &cond, arena, collector)
+            collect_case_pattern_effects(module, &store, &arm.patterns, arena, collector)
         })?;
 
-        let ((cond_node, cond_sources), cond_bounds) =
-            eval_expression_effectful(module, &mut state.store, &cond, arena, None)?;
+        let mut next_store = state.store.clone();
+        let ((cond_node, cond_sources), cond_bounds) = eval_case_arm_condition_effectful(
+            module,
+            &mut next_store,
+            &case_stmt.case_target,
+            target,
+            &arm.patterns,
+            arena,
+        )?;
+        state = apply_function_guard(
+            module,
+            state,
+            next_store,
+            cond_bounds,
+            bool_node(arena, true)?,
+            HashSet::default(),
+            arena,
+        )?;
         let cond_node = procedural_condition(arena, cond_node)?;
-        let boundaries = merge_boundaries(state.boundaries, cond_bounds);
+        let boundaries = state.boundaries.clone();
 
         if let Some(cond_val) = constant_bool(arena, cond_node) {
             let state = FunctionControlState {
@@ -651,6 +691,7 @@ fn collect_function_body_effects(
                     module,
                     state,
                     case_stmt,
+                    target,
                     arm_index + 1,
                     ret_id,
                     arena,
@@ -711,6 +752,7 @@ fn collect_function_body_effects(
                         live_sources: state.live_sources,
                     },
                     case_stmt,
+                    target,
                     arm_index + 1,
                     ret_id,
                     arena,
@@ -788,6 +830,28 @@ fn collect_function_body_effects(
                 })
             }
         }
+    }
+
+    fn eval_guarded_function_expression(
+        module: &Module,
+        state: FunctionControlState,
+        expression: &Expression,
+        context_width: Option<usize>,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<(FunctionControlState, NodeId, HashSet<VarAtomBase<VarId>>), ParserError> {
+        let mut next_store = state.store.clone();
+        let ((node, sources), boundaries) =
+            eval_expression_effectful(module, &mut next_store, expression, arena, context_width)?;
+        let state = apply_function_guard(
+            module,
+            state,
+            next_store,
+            boundaries,
+            bool_node(arena, true)?,
+            HashSet::default(),
+            arena,
+        )?;
+        Ok((state, node, sources))
     }
 
     fn statement_contains_return(stmt: &Statement, ret_id: VarId) -> bool {
@@ -1076,24 +1140,29 @@ fn collect_function_body_effects(
             }
             Statement::SystemFunctionCall(call) => {
                 let guard_state = state.clone();
-                let store = state.store.clone();
+                let mut next_store = state.store.clone();
                 let live = state.live_expr;
                 let live_sources = state.live_sources.clone();
-                with_collector_guard(collector, arena, live, live_sources, |collector, arena| {
-                    collect_system_function_effect(module, &store, call, arena, collector)
-                })?;
-                let (next_store, next_boundaries) = eval_system_function_call_side_effects(
-                    module,
-                    state.store,
-                    state.boundaries,
-                    call,
+                let effect_boundaries = with_collector_guard(
+                    collector,
                     arena,
+                    live,
+                    live_sources,
+                    |collector, arena| {
+                        collect_system_function_effect(
+                            module,
+                            &mut next_store,
+                            call,
+                            arena,
+                            collector,
+                        )
+                    },
                 )?;
                 apply_function_guard(
                     module,
                     guard_state,
                     next_store,
-                    next_boundaries,
+                    effect_boundaries,
                     bool_node(arena, true)?,
                     HashSet::default(),
                     arena,
@@ -1133,15 +1202,11 @@ fn collect_function_body_effects(
                     collect_expression_effects(module, &store, &if_stmt.cond, arena, collector)
                 })?;
 
-                let ((cond_node, cond_sources), cond_boundaries) = eval_expression_effectful(
-                    module,
-                    &mut state.store,
-                    &if_stmt.cond,
-                    arena,
-                    None,
-                )?;
+                let (next_state, cond_node, cond_sources) =
+                    eval_guarded_function_expression(module, state, &if_stmt.cond, None, arena)?;
+                state = next_state;
                 let cond_node = procedural_condition(arena, cond_node)?;
-                let boundaries = merge_boundaries(state.boundaries, cond_boundaries);
+                let boundaries = state.boundaries.clone();
                 let true_guard = arena.alloc(SLTNode::Binary(
                     state.live_expr,
                     BinaryOp::LogicAnd,
@@ -1225,7 +1290,32 @@ fn collect_function_body_effects(
                 })
             }
             Statement::Case(case_stmt) => {
-                collect_case_from_arm(module, state, case_stmt, 0, ret_id, arena, collector)
+                let store = state.store.clone();
+                let live = state.live_expr;
+                let live_sources = state.live_sources.clone();
+                with_collector_guard(collector, arena, live, live_sources, |collector, arena| {
+                    collect_expression_effects(
+                        module,
+                        &store,
+                        &case_stmt.case_target,
+                        arena,
+                        collector,
+                    )
+                })?;
+                let (state, target_node, target_sources) = eval_guarded_function_expression(
+                    module,
+                    state,
+                    &case_stmt.case_target,
+                    None,
+                    arena,
+                )?;
+                let target = expr::EvaluatedCaseTarget {
+                    node: target_node,
+                    sources: target_sources,
+                };
+                collect_case_from_arm(
+                    module, state, case_stmt, &target, 0, ret_id, arena, collector,
+                )
             }
             Statement::For(for_stmt) => {
                 if statement_contains_return(&Statement::For(for_stmt.clone()), ret_id) {
@@ -1380,15 +1470,7 @@ pub(super) fn collect_comb_effects_statements(
                 store = next_store;
             }
             Statement::SystemFunctionCall(call) => {
-                collect_system_function_effect(module, &store, call, arena, collector)?;
-                let (next_store, _) = eval_system_function_call_side_effects(
-                    module,
-                    store,
-                    BoundaryMap::default(),
-                    call,
-                    arena,
-                )?;
-                store = next_store;
+                collect_system_function_effect(module, &mut store, call, arena, collector)?;
             }
             Statement::FunctionCall(call) => {
                 collect_function_call_effects(module, &store, call, arena, collector)?;
@@ -1472,7 +1554,7 @@ pub(super) fn collect_comb_effects_statements(
 
 fn collect_comb_effects_case(
     module: &Module,
-    store: SymbolicStore<VarId>,
+    mut store: SymbolicStore<VarId>,
     case_stmt: &CaseStatement,
     arena: &mut SLTNodeArena<VarId>,
     collector: &mut CombEffectCollector,
@@ -1481,6 +1563,7 @@ fn collect_comb_effects_case(
         module: &Module,
         mut store: SymbolicStore<VarId>,
         case_stmt: &CaseStatement,
+        target: &expr::EvaluatedCaseTarget,
         arm_index: usize,
         arena: &mut SLTNodeArena<VarId>,
         collector: &mut CombEffectCollector,
@@ -1495,10 +1578,15 @@ fn collect_comb_effects_case(
             );
         };
 
-        let cond = case_arm_condition_expr(&case_stmt.case_target, &arm.patterns);
-        collect_expression_effects(module, &store, &cond, arena, collector)?;
-        let ((cond_node, sources), _) =
-            eval_expression_effectful(module, &mut store, &cond, arena, None)?;
+        collect_case_pattern_effects(module, &store, &arm.patterns, arena, collector)?;
+        let ((cond_node, sources), _) = eval_case_arm_condition_effectful(
+            module,
+            &mut store,
+            &case_stmt.case_target,
+            target,
+            &arm.patterns,
+            arena,
+        )?;
         let cond_node = procedural_condition(arena, cond_node)?;
         collector.sensitivity.extend(sources.iter().copied());
 
@@ -1526,8 +1614,15 @@ fn collect_comb_effects_case(
         false_sources.extend(sources.iter().copied());
         collector.active_guard = Some(false_guard);
         collector.active_guard_sources = false_sources;
-        let else_store =
-            collect_from_arm(module, store, case_stmt, arm_index + 1, arena, collector)?;
+        let else_store = collect_from_arm(
+            module,
+            store,
+            case_stmt,
+            target,
+            arm_index + 1,
+            arena,
+            collector,
+        )?;
 
         collector.active_guard = saved_guard;
         collector.active_guard_sources = saved_guard_sources;
@@ -1541,7 +1636,10 @@ fn collect_comb_effects_case(
         )
     }
 
-    collect_from_arm(module, store, case_stmt, 0, arena, collector)
+    collect_expression_effects(module, &store, &case_stmt.case_target, arena, collector)?;
+    let (target, _) =
+        eval_case_target_effectful(module, &mut store, &case_stmt.case_target, arena)?;
+    collect_from_arm(module, store, case_stmt, &target, 0, arena, collector)
 }
 
 fn collect_comb_effects_for(

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -43,6 +43,43 @@ pub(crate) struct CombEffectCollector {
     active_guard: Option<NodeId>,
     active_guard_sources: HashSet<VarAtomBase<VarId>>,
     loop_effects: Option<Vec<SLTForEffect>>,
+    capture_namespace: Option<u32>,
+    next_capture_id: u32,
+}
+
+impl CombEffectCollector {
+    fn initialize_capture_namespace(
+        &mut self,
+        token: &veryl_parser::token_range::TokenRange,
+    ) -> Result<(), ParserError> {
+        if self.capture_namespace.is_some() {
+            return Ok(());
+        }
+        self.capture_namespace = Some(u32::try_from(token.beg.id.0).map_err(|_| {
+            ParserError::illegal_context(
+                "combinational observer capture",
+                "source token identity exceeds the capture-key range",
+                Some(token),
+            )
+        })?);
+        Ok(())
+    }
+
+    fn next_capture_key(
+        &mut self,
+        token: &veryl_parser::token_range::TokenRange,
+    ) -> Result<u64, ParserError> {
+        self.initialize_capture_namespace(token)?;
+        let capture_id = self.next_capture_id;
+        self.next_capture_id = capture_id.checked_add(1).ok_or_else(|| {
+            ParserError::illegal_context(
+                "combinational observer capture",
+                "capture count exceeds the capture-key range",
+                Some(token),
+            )
+        })?;
+        Ok((u64::from(self.capture_namespace.unwrap()) << 32) | u64::from(capture_id))
+    }
 }
 
 fn static_string_expr(expr: &Expression) -> Option<String> {
@@ -132,15 +169,6 @@ fn collect_system_function_effect(
         _ => unreachable!("non-event system functions return before event collection"),
     };
     let (site_id, value_args) = register_comb_runtime_event_site(collector, kind, args);
-    // Collector-local site IDs restart at zero. The source token keeps
-    // otherwise identical captures from different declarations distinct.
-    let capture_site_key = u32::try_from(call.comptime.token.beg.id.0).map_err(|_| {
-        ParserError::illegal_context(
-            "combinational observer capture",
-            "source token identity exceeds the capture-key range",
-            Some(&call.comptime.token),
-        )
-    })?;
     // Event operands are evaluated left to right.  Keep the environment from
     // the start of the event so writes performed by later operands cannot
     // retroactively rebind inputs in an earlier operand or in the assertion
@@ -163,14 +191,7 @@ fn collect_system_function_effect(
     } else {
         None
     };
-    for (arg_index, arg) in value_args.iter().enumerate() {
-        let arg_index = u32::try_from(arg_index).map_err(|_| {
-            ParserError::illegal_context(
-                "combinational observer capture",
-                "event argument count exceeds the capture-key range",
-                Some(&call.comptime.token),
-            )
-        })?;
+    for arg in value_args {
         collect_expression_effects(module, store, &arg.0, arena, collector)?;
         let ((node, sources), arg_boundaries) =
             eval_expression_effectful(module, store, &arg.0, arena, None)?;
@@ -180,7 +201,7 @@ fn collect_system_function_effect(
         collect_expression_position_inputs(module, &arg.0, &mut position_inputs)?;
         observer_args.push(arena.alloc(SLTNode::Capture {
             expr: node,
-            key: (u64::from(capture_site_key) << 32) | u64::from(arg_index),
+            key: collector.next_capture_key(&call.comptime.token)?,
         })?);
     }
     observed_inputs.extend(collector.active_guard_sources.iter().copied());
@@ -202,11 +223,11 @@ fn collect_system_function_effect(
         }
         (RuntimeEventKind::Display, _, Some(_)) => unreachable!("display has no explicit guard"),
     }
-    .map(|node| {
-        arena.alloc(SLTNode::Capture {
+    .map(|node| -> Result<NodeId, ParserError> {
+        Ok(arena.alloc(SLTNode::Capture {
             expr: node,
-            key: (u64::from(capture_site_key) << 32) | u64::from(u32::MAX),
-        })
+            key: collector.next_capture_key(&call.comptime.token)?,
+        })?)
     })
     .transpose()?;
     let loop_effect = collector
@@ -354,6 +375,10 @@ fn collect_function_call_effects(
     arena: &mut SLTNodeArena<VarId>,
     collector: &mut CombEffectCollector,
 ) -> Result<(), ParserError> {
+    // The outermost evaluated call site names this collector's capture
+    // namespace. Runtime tasks in a reusable callee otherwise carry the same
+    // callee-body token in every caller.
+    collector.initialize_capture_namespace(&call.comptime.token)?;
     let Some(function) = module.functions.get(&call.id) else {
         return Err(ParserError::unsupported(
             62,
@@ -380,7 +405,14 @@ fn collect_function_call_effects(
 
     let mut actual_store = store.clone();
     let mut formal_bindings = Vec::new();
-    for (arg_id, arg_expr) in super::ordered_function_inputs(function, &function_body, call)? {
+    let ordered_inputs = super::ordered_function_inputs(function, &function_body, call)?;
+    let mut later_input_writes = vec![HashMap::default(); ordered_inputs.len()];
+    let mut accumulated_writes = HashMap::default();
+    for (index, (_, expression)) in ordered_inputs.iter().enumerate().rev() {
+        later_input_writes[index] = accumulated_writes.clone();
+        super::collect_written_expression(module, expression, &mut accumulated_writes)?;
+    }
+    for (input_index, (arg_id, arg_expr)) in ordered_inputs.into_iter().enumerate() {
         collect_expression_effects(module, &actual_store, arg_expr, arena, collector)?;
         let mut actual_inputs = HashSet::default();
         collect_expression_position_inputs(module, arg_expr, &mut actual_inputs)?;
@@ -397,6 +429,19 @@ fn collect_function_call_effects(
         )?;
         let arg_node = if formal.r#type.is_2state() && !arg_expr.comptime().r#type.is_2state() {
             arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, arg_node))?
+        } else {
+            arg_node
+        };
+        let needs_snapshot = arg_sources.iter().any(|source| {
+            later_input_writes[input_index]
+                .get(&source.id)
+                .is_some_and(|writes| writes.iter().any(|write| write.overlaps(&source.access)))
+        });
+        let arg_node = if needs_snapshot {
+            arena.alloc(SLTNode::Capture {
+                expr: arg_node,
+                key: collector.next_capture_key(&call.comptime.token)?,
+            })?
         } else {
             arg_node
         };
@@ -461,13 +506,6 @@ fn collect_function_call_effects(
                 .0
                 .iter()
                 .chain(destination.select.0.iter())
-                .chain(
-                    destination
-                        .select
-                        .1
-                        .iter()
-                        .map(|(_, expression)| expression),
-                )
             {
                 collect_and_advance_expression(
                     module,
@@ -846,10 +884,10 @@ pub(crate) fn collect_and_advance_expression(
     expression: &Expression,
     arena: &mut SLTNodeArena<VarId>,
     collector: &mut CombEffectCollector,
-) -> Result<(), ParserError> {
+) -> Result<HashSet<VarAtomBase<VarId>>, ParserError> {
     collect_expression_effects(module, store, expression, arena, collector)?;
-    let _ = eval_expression_effectful(module, store, expression, arena, None)?;
-    Ok(())
+    let ((_, sources), _) = eval_expression_effectful(module, store, expression, arena, None)?;
+    Ok(sources)
 }
 
 fn collect_assignment_effects(

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -132,6 +132,12 @@ fn collect_system_function_effect(
         _ => unreachable!("non-event system functions return before event collection"),
     };
     let (site_id, value_args) = register_comb_runtime_event_site(collector, kind, args);
+    // Event operands are evaluated left to right.  Keep the environment from
+    // the start of the event so writes performed by later operands cannot
+    // retroactively rebind inputs in an earlier operand or in the assertion
+    // condition.  Reads after an operand write are already substituted by
+    // `eval_expression_effectful` as that operand is lowered.
+    let observer_store = store.clone();
     let mut boundaries = BoundaryMap::default();
     let mut observer_args = Vec::new();
     let mut observed_inputs = HashSet::default();
@@ -148,7 +154,7 @@ fn collect_system_function_effect(
     } else {
         None
     };
-    for arg in value_args {
+    for (arg_index, arg) in value_args.iter().enumerate() {
         collect_expression_effects(module, store, &arg.0, arena, collector)?;
         let ((node, sources), arg_boundaries) =
             eval_expression_effectful(module, store, &arg.0, arena, None)?;
@@ -156,7 +162,10 @@ fn collect_system_function_effect(
         observed_inputs.extend(sources.iter().copied());
         collector.sensitivity.extend(sources);
         collect_expression_position_inputs(module, &arg.0, &mut position_inputs)?;
-        observer_args.push(node);
+        observer_args.push(arena.alloc(SLTNode::Capture {
+            expr: node,
+            key: (u64::from(site_id) << 32) | arg_index as u64,
+        })?);
     }
     observed_inputs.extend(collector.active_guard_sources.iter().copied());
     let guard = match (kind, collector.active_guard, explicit_guard) {
@@ -176,7 +185,14 @@ fn collect_system_function_effect(
             Some(active)
         }
         (RuntimeEventKind::Display, _, Some(_)) => unreachable!("display has no explicit guard"),
-    };
+    }
+    .map(|node| {
+        arena.alloc(SLTNode::Capture {
+            expr: node,
+            key: (u64::from(site_id) << 32) | u64::from(u32::MAX),
+        })
+    })
+    .transpose()?;
     let loop_effect = collector
         .loop_effects
         .as_ref()
@@ -204,7 +220,7 @@ fn collect_system_function_effect(
         })
         .collect();
     let mut local_inputs = Vec::new();
-    for (id, range_store) in store.iter() {
+    for (id, range_store) in observer_store.iter() {
         if !observed_ids.contains(id) {
             continue;
         }
@@ -253,7 +269,6 @@ fn collect_system_function_effect(
         let (node, _) = combine_parts_with_default(*id, 0, parts, arena)?;
         local_inputs.push((*id, node));
     }
-
     collector.observers.push(CombObserver {
         site_id,
         activation_group: 0,
@@ -554,7 +569,7 @@ fn statement_contains_runtime_effect(module: &Module, stmt: &Statement) -> bool 
     }
 }
 
-fn destination_contains_runtime_effect(
+pub(super) fn destination_contains_runtime_effect(
     module: &Module,
     destination: &veryl_analyzer::ir::AssignDestination,
 ) -> bool {
@@ -563,13 +578,6 @@ fn destination_contains_runtime_effect(
         .0
         .iter()
         .chain(destination.select.0.iter())
-        .chain(
-            destination
-                .select
-                .1
-                .iter()
-                .map(|(_, expression)| expression),
-        )
         .any(|expression| expression_contains_runtime_effect(module, expression))
 }
 
@@ -632,7 +640,6 @@ pub(crate) fn expression_contains_runtime_effect(module: &Module, expression: &E
                 .0
                 .iter()
                 .chain(select.0.iter())
-                .chain(select.1.iter().map(|(_, expression)| expression))
                 .any(|expression| expression_contains_runtime_effect(module, expression)),
             Factor::SystemFunctionCall(call) => match &call.kind {
                 SystemFunctionKind::Clog2(input)
@@ -652,6 +659,7 @@ pub(crate) fn expression_contains_runtime_effect(module: &Module, expression: &E
             Factor::Value(_) | Factor::Anonymous(_) | Factor::Unknown(_) => false,
         },
         Expression::Unary(_, inner, _) => expression_contains_runtime_effect(module, inner),
+        Expression::Binary(lhs, Op::Pow, _, _) => expression_contains_runtime_effect(module, lhs),
         Expression::Binary(lhs, _, rhs, _) => {
             expression_contains_runtime_effect(module, lhs)
                 || expression_contains_runtime_effect(module, rhs)
@@ -706,6 +714,9 @@ pub(crate) fn collect_expression_effects(
                     collect_expression_effects(module, &rhs_store, rhs, arena, collector)
                 },
             )
+        }
+        Expression::Binary(lhs, Op::Pow, _, _) => {
+            collect_expression_effects(module, store, lhs, arena, collector)
         }
         Expression::Binary(lhs, _, rhs, _) => {
             collect_expression_effects(module, store, lhs, arena, collector)?;
@@ -1051,15 +1062,6 @@ fn collect_factor_effects(
         Factor::Variable(_, index, select, _) => {
             let mut position_store = store.clone();
             for expr in index.0.iter().chain(select.0.iter()) {
-                collect_and_advance_expression(
-                    module,
-                    &mut position_store,
-                    expr,
-                    arena,
-                    collector,
-                )?;
-            }
-            if let Some((_, expr)) = &select.1 {
                 collect_and_advance_expression(
                     module,
                     &mut position_store,
@@ -1942,6 +1944,9 @@ fn collect_expression_position_inputs(
 ) -> Result<(), ParserError> {
     match expr {
         Expression::Term(factor) => collect_factor_position_inputs(module, factor, out),
+        Expression::Binary(lhs, Op::Pow, _, _) => {
+            collect_expression_position_inputs(module, lhs, out)
+        }
         Expression::Binary(lhs, _, rhs, _) => {
             collect_expression_position_inputs(module, lhs, out)?;
             collect_expression_position_inputs(module, rhs, out)
@@ -1992,9 +1997,6 @@ fn collect_factor_position_inputs(
                 out.insert(VarAtomBase::new(*var_id, access.lsb, access.msb));
             }
             for expr in index.0.iter().chain(select.0.iter()) {
-                collect_expression_position_inputs(module, expr, out)?;
-            }
-            if let Some((_, expr)) = &select.1 {
                 collect_expression_position_inputs(module, expr, out)?;
             }
             Ok(())

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -98,6 +98,26 @@ fn collect_system_function_effect(
     arena: &mut SLTNodeArena<VarId>,
     collector: &mut CombEffectCollector,
 ) -> Result<BoundaryMap<VarId>, ParserError> {
+    match &call.kind {
+        SystemFunctionKind::Clog2(input)
+        | SystemFunctionKind::Onehot(input)
+        | SystemFunctionKind::Signed(input)
+        | SystemFunctionKind::Unsigned(input) => {
+            collect_expression_effects(module, store, &input.0, arena, collector)?;
+            let ((_, sources), boundaries) =
+                eval_expression_effectful(module, store, &input.0, arena, None)?;
+            collector.sensitivity.extend(sources);
+            return Ok(boundaries);
+        }
+        SystemFunctionKind::Bits(_)
+        | SystemFunctionKind::Size(_)
+        | SystemFunctionKind::Readmemh(_, _)
+        | SystemFunctionKind::Finish => return Ok(BoundaryMap::default()),
+        SystemFunctionKind::Display(_)
+        | SystemFunctionKind::Write(_)
+        | SystemFunctionKind::Assert { .. } => {}
+    }
+
     let (kind, cond, args) = match &call.kind {
         SystemFunctionKind::Display(args) | SystemFunctionKind::Write(args) => {
             (RuntimeEventKind::Display, None, args.as_slice())
@@ -109,15 +129,7 @@ fn collect_system_function_effect(
             };
             (event_kind, Some(&cond.0), args.as_slice())
         }
-        _ => {
-            return Err(ParserError::unsupported(
-                66,
-                LoweringPhase::CombLowering,
-                "system function call",
-                format!("{call}"),
-                Some(&call.comptime.token),
-            ));
-        }
+        _ => unreachable!("non-event system functions return before event collection"),
     };
     let (site_id, value_args) = register_comb_runtime_event_site(collector, kind, args);
     let mut boundaries = BoundaryMap::default();
@@ -395,13 +407,28 @@ pub(super) fn statements_contain_runtime_effect(module: &Module, statements: &[S
 
 fn statement_contains_runtime_effect(module: &Module, stmt: &Statement) -> bool {
     match stmt {
-        Statement::Assign(assign) => expression_contains_runtime_effect(module, &assign.expr),
-        Statement::SystemFunctionCall(call) => matches!(
-            call.kind,
+        Statement::Assign(assign) => {
+            expression_contains_runtime_effect(module, &assign.expr)
+                || assign
+                    .dst
+                    .iter()
+                    .any(|destination| destination_contains_runtime_effect(module, destination))
+        }
+        Statement::SystemFunctionCall(call) => match &call.kind {
             SystemFunctionKind::Display(_)
-                | SystemFunctionKind::Write(_)
-                | SystemFunctionKind::Assert { .. }
-        ),
+            | SystemFunctionKind::Write(_)
+            | SystemFunctionKind::Assert { .. } => true,
+            SystemFunctionKind::Clog2(input)
+            | SystemFunctionKind::Onehot(input)
+            | SystemFunctionKind::Signed(input)
+            | SystemFunctionKind::Unsigned(input) => {
+                expression_contains_runtime_effect(module, &input.0)
+            }
+            SystemFunctionKind::Bits(_)
+            | SystemFunctionKind::Size(_)
+            | SystemFunctionKind::Readmemh(_, _)
+            | SystemFunctionKind::Finish => false,
+        },
         Statement::If(if_stmt) => {
             expression_contains_runtime_effect(module, &if_stmt.cond)
                 || statements_contain_runtime_effect(module, &if_stmt.true_side)
@@ -441,6 +468,25 @@ fn statement_contains_runtime_effect(module: &Module, stmt: &Statement) -> bool 
         | Statement::Unsupported(_)
         | Statement::Null => false,
     }
+}
+
+fn destination_contains_runtime_effect(
+    module: &Module,
+    destination: &veryl_analyzer::ir::AssignDestination,
+) -> bool {
+    destination
+        .index
+        .0
+        .iter()
+        .chain(destination.select.0.iter())
+        .chain(
+            destination
+                .select
+                .1
+                .iter()
+                .map(|(_, expression)| expression),
+        )
+        .any(|expression| expression_contains_runtime_effect(module, expression))
 }
 
 fn case_pattern_contains_runtime_effect(module: &Module, pattern: &CasePattern) -> bool {
@@ -490,15 +536,19 @@ fn expression_contains_runtime_effect(module: &Module, expression: &Expression) 
                 .chain(select.1.iter().map(|(_, expression)| expression))
                 .any(|expression| expression_contains_runtime_effect(module, expression)),
             Factor::SystemFunctionCall(call) => match &call.kind {
-                SystemFunctionKind::Bits(input)
-                | SystemFunctionKind::Size(input)
-                | SystemFunctionKind::Clog2(input)
+                SystemFunctionKind::Clog2(input)
                 | SystemFunctionKind::Onehot(input)
                 | SystemFunctionKind::Signed(input)
                 | SystemFunctionKind::Unsigned(input) => {
                     expression_contains_runtime_effect(module, &input.0)
                 }
-                _ => false,
+                SystemFunctionKind::Bits(_)
+                | SystemFunctionKind::Size(_)
+                | SystemFunctionKind::Display(_)
+                | SystemFunctionKind::Write(_)
+                | SystemFunctionKind::Assert { .. }
+                | SystemFunctionKind::Readmemh(_, _)
+                | SystemFunctionKind::Finish => false,
             },
             Factor::Value(_) | Factor::Anonymous(_) | Factor::Unknown(_) => false,
         },
@@ -613,23 +663,175 @@ fn collect_expression_effects(
     }
 }
 
+fn collect_assignment_effects(
+    module: &Module,
+    store: &SymbolicStore<VarId>,
+    assign: &AssignStatement,
+    arena: &mut SLTNodeArena<VarId>,
+    collector: &mut CombEffectCollector,
+) -> Result<(), ParserError> {
+    collect_expression_effects(module, store, &assign.expr, arena, collector)?;
+
+    // eval_assign evaluates the RHS before resolving dynamic destinations.
+    // Mirror that order in a collector-local store so observers in an index
+    // see RHS output writes and later destination expressions see earlier ones.
+    let mut destination_store = store.clone();
+    let _ = eval_assignment_rhs_effectful(module, &mut destination_store, assign, arena)?;
+    for destination in assign.dst.iter().rev() {
+        for expression in destination
+            .index
+            .0
+            .iter()
+            .chain(destination.select.0.iter())
+            .chain(
+                destination
+                    .select
+                    .1
+                    .iter()
+                    .map(|(_, expression)| expression),
+            )
+        {
+            collect_expression_effects(module, &destination_store, expression, arena, collector)?;
+            let _ =
+                eval_expression_effectful(module, &mut destination_store, expression, arena, None)?;
+        }
+    }
+    Ok(())
+}
+
 fn collect_case_pattern_effects(
     module: &Module,
     store: &SymbolicStore<VarId>,
+    target_expr: &Expression,
+    target: &expr::EvaluatedCaseTarget,
     patterns: &[CasePattern],
     arena: &mut SLTNodeArena<VarId>,
     collector: &mut CombEffectCollector,
 ) -> Result<(), ParserError> {
-    for pattern in patterns {
+    fn collect_pattern(
+        module: &Module,
+        store: &SymbolicStore<VarId>,
+        target_expr: &Expression,
+        target: &expr::EvaluatedCaseTarget,
+        pattern: &CasePattern,
+        arena: &mut SLTNodeArena<VarId>,
+        collector: &mut CombEffectCollector,
+    ) -> Result<(), ParserError> {
         match pattern {
             CasePattern::Eq(expression) => {
-                collect_expression_effects(module, store, expression, arena, collector)?;
+                collect_expression_effects(module, store, expression, arena, collector)
             }
             CasePattern::Range { lo, hi, .. } => {
                 collect_expression_effects(module, store, lo, arena, collector)?;
-                collect_expression_effects(module, store, hi, arena, collector)?;
+                let mut hi_store = store.clone();
+                let ((lo_matches, lo_sources), _) = {
+                    let mut expression_store = expr::ExpressionStore::Effectful(&mut hi_store);
+                    expr::eval_case_comparison(
+                        module,
+                        &mut expression_store,
+                        target_expr,
+                        target,
+                        lo,
+                        false,
+                        Op::LessEq,
+                        arena,
+                    )?
+                };
+                let execute_hi = expr::short_circuit_rhs_guard(arena, lo_matches, true)?;
+                with_collector_guard(
+                    collector,
+                    arena,
+                    execute_hi,
+                    lo_sources,
+                    |collector, arena| {
+                        collect_expression_effects(module, &hi_store, hi, arena, collector)
+                    },
+                )
             }
         }
+    }
+
+    let mut pattern_store = store.clone();
+    let mut matched: Option<(NodeId, HashSet<VarAtomBase<VarId>>)> = None;
+    for pattern in patterns {
+        let execute_pattern = matched
+            .as_ref()
+            .map(|(condition, _)| expr::short_circuit_rhs_guard(arena, *condition, false))
+            .transpose()?;
+        if let Some(execute_pattern) = execute_pattern {
+            let guard_sources = matched
+                .as_ref()
+                .map(|(_, sources)| sources.clone())
+                .unwrap_or_default();
+            with_collector_guard(
+                collector,
+                arena,
+                execute_pattern,
+                guard_sources,
+                |collector, arena| {
+                    collect_pattern(
+                        module,
+                        &pattern_store,
+                        target_expr,
+                        target,
+                        pattern,
+                        arena,
+                        collector,
+                    )
+                },
+            )?;
+        } else {
+            collect_pattern(
+                module,
+                &pattern_store,
+                target_expr,
+                target,
+                pattern,
+                arena,
+                collector,
+            )?;
+        }
+
+        let base_store = pattern_store.clone();
+        let mut evaluated_store = base_store.clone();
+        let ((pattern_condition, pattern_sources), _) = eval_case_arm_condition_effectful(
+            module,
+            &mut evaluated_store,
+            target_expr,
+            target,
+            std::slice::from_ref(pattern),
+            arena,
+        )?;
+        pattern_store = if let Some(execute_pattern) = execute_pattern {
+            let condition_sources = matched
+                .as_ref()
+                .map(|(_, sources)| sources)
+                .cloned()
+                .unwrap_or_default();
+            merge_symbolic_stores(
+                module,
+                &evaluated_store,
+                &base_store,
+                execute_pattern,
+                &condition_sources,
+                arena,
+            )?
+        } else {
+            evaluated_store
+        };
+        matched = Some(if let Some((condition, mut sources)) = matched {
+            sources.extend(pattern_sources);
+            (
+                arena.alloc(SLTNode::Binary(
+                    condition,
+                    BinaryOp::LogicOr,
+                    pattern_condition,
+                ))?,
+                sources,
+            )
+        } else {
+            (pattern_condition, pattern_sources)
+        });
     }
     Ok(())
 }
@@ -711,7 +913,15 @@ fn collect_function_body_effects(
         let live = state.live_expr;
         let live_sources = state.live_sources.clone();
         with_collector_guard(collector, arena, live, live_sources, |collector, arena| {
-            collect_case_pattern_effects(module, &store, &arm.patterns, arena, collector)
+            collect_case_pattern_effects(
+                module,
+                &store,
+                &case_stmt.case_target,
+                target,
+                &arm.patterns,
+                arena,
+                collector,
+            )
         })?;
 
         let mut next_store = state.store.clone();
@@ -1175,7 +1385,7 @@ fn collect_function_body_effects(
                 let live = state.live_expr;
                 let live_sources = state.live_sources.clone();
                 with_collector_guard(collector, arena, live, live_sources, |collector, arena| {
-                    collect_expression_effects(module, &store, &assign.expr, arena, collector)
+                    collect_assignment_effects(module, &store, assign, arena, collector)
                 })?;
                 let (store, boundaries) =
                     eval_assign(module, state.store, state.boundaries, assign, arena)?;
@@ -1520,7 +1730,7 @@ pub(super) fn collect_comb_effects_statements(
     for stmt in statements {
         match stmt {
             Statement::Assign(assign) => {
-                collect_expression_effects(module, &store, &assign.expr, arena, collector)?;
+                collect_assignment_effects(module, &store, assign, arena, collector)?;
                 let (next_store, _) =
                     eval_assign(module, store, BoundaryMap::default(), assign, arena)?;
                 store = next_store;
@@ -1634,7 +1844,15 @@ fn collect_comb_effects_case(
             );
         };
 
-        collect_case_pattern_effects(module, &store, &arm.patterns, arena, collector)?;
+        collect_case_pattern_effects(
+            module,
+            &store,
+            &case_stmt.case_target,
+            target,
+            &arm.patterns,
+            arena,
+            collector,
+        )?;
         let ((cond_node, sources), _) = eval_case_arm_condition_effectful(
             module,
             &mut store,
@@ -1682,14 +1900,7 @@ fn collect_comb_effects_case(
 
         collector.active_guard = saved_guard;
         collector.active_guard_sources = saved_guard_sources;
-        merge_symbolic_stores(
-            module,
-            &side_store,
-            &else_store,
-            bool_node(arena, true)?,
-            &HashSet::default(),
-            arena,
-        )
+        merge_symbolic_stores(module, &side_store, &else_store, cond_node, &sources, arena)
     }
 
     collect_expression_effects(module, &store, &case_stmt.case_target, arena, collector)?;

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -13,36 +13,23 @@ use veryl_analyzer::ir::{CasePattern, Type, ValueVariant};
 use super::state::{FunctionControlState, FunctionLoopControlState};
 
 pub(super) enum ExpressionStore<'a> {
-    ReadOnly {
-        store: &'a SymbolicStore<VarId>,
-        reject_output_calls: bool,
-    },
+    ReadOnly(&'a SymbolicStore<VarId>),
     Effectful(&'a mut SymbolicStore<VarId>),
 }
 
 impl ExpressionStore<'_> {
     pub(super) fn current(&self) -> &SymbolicStore<VarId> {
         match self {
-            Self::ReadOnly { store, .. } => store,
+            Self::ReadOnly(store) => store,
             Self::Effectful(store) => store,
         }
     }
 
     fn effectful_mut(&mut self) -> Option<&mut SymbolicStore<VarId>> {
         match self {
-            Self::ReadOnly { .. } => None,
+            Self::ReadOnly(_) => None,
             Self::Effectful(store) => Some(store),
         }
-    }
-
-    fn rejects_output_calls(&self) -> bool {
-        matches!(
-            self,
-            Self::ReadOnly {
-                reject_output_calls: true,
-                ..
-            }
-        )
     }
 }
 
@@ -2059,16 +2046,6 @@ fn eval_function_call_expression(
     call: &veryl_analyzer::ir::FunctionCall,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
-    if !call.outputs.is_empty() && store.rejects_output_calls() {
-        return Err(ParserError::unsupported(
-            60,
-            LoweringPhase::CombLowering,
-            "function call with output arguments",
-            format!("{call}"),
-            Some(&call.comptime.token),
-        ));
-    }
-
     let Some(function) = module.functions.get(&call.id) else {
         return Err(ParserError::unsupported(
             62,
@@ -2182,10 +2159,7 @@ pub fn eval_expression(
         width,
         signed: expression_signed(expr),
     });
-    let mut store = ExpressionStore::ReadOnly {
-        store,
-        reject_output_calls: false,
-    };
+    let mut store = ExpressionStore::ReadOnly(store);
     eval_expression_in_context(module, &mut store, expr, arena, context)
 }
 
@@ -2959,27 +2933,11 @@ pub fn eval_assignment_expression(
         ));
     }
 
-    // Instance input glue has no effectful caller store in which a function
-    // output can be written back. Reject such calls instead of silently
-    // accepting their return value and discarding the output assignment.
-    let mut store = ExpressionStore::ReadOnly {
-        store,
-        reject_output_calls: true,
-    };
-    let value = eval_expression_in_context(
-        module,
-        &mut store,
-        expr,
-        arena,
-        Some(ValueContext {
-            width: target_width,
-            signed: expression_signed(expr),
-        }),
-    )?;
+    let value = eval_expression(module, store, expr, arena, Some(target_width))?;
     finish_assignment_expression(expr, arena, target_width, value)
 }
 
-pub(super) fn eval_assignment_expression_effectful(
+pub(crate) fn eval_assignment_expression_effectful(
     module: &Module,
     store: &mut SymbolicStore<VarId>,
     expr: &Expression,

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -13,9 +13,41 @@ use veryl_analyzer::ir::{CasePattern, Type, ValueVariant};
 
 use super::state::{FunctionControlState, FunctionLoopControlState};
 
-pub(super) fn eval_array_literal_expression(
+enum ExpressionStore<'a> {
+    ReadOnly(&'a SymbolicStore<VarId>),
+    Effectful(&'a mut SymbolicStore<VarId>),
+}
+
+impl ExpressionStore<'_> {
+    fn current(&self) -> &SymbolicStore<VarId> {
+        match self {
+            Self::ReadOnly(store) => store,
+            Self::Effectful(store) => store,
+        }
+    }
+
+    fn effectful_mut(&mut self) -> Option<&mut SymbolicStore<VarId>> {
+        match self {
+            Self::ReadOnly(_) => None,
+            Self::Effectful(store) => Some(store),
+        }
+    }
+}
+
+pub(super) fn eval_array_literal_expression_effectful(
     module: &Module,
-    store: &SymbolicStore<VarId>,
+    store: &mut SymbolicStore<VarId>,
+    items: &[ArrayLiteralItem],
+    expected_width: Option<usize>,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+    let mut store = ExpressionStore::Effectful(store);
+    eval_array_literal_expression_in_store(module, &mut store, items, expected_width, arena)
+}
+
+fn eval_array_literal_expression_in_store(
+    module: &Module,
+    store: &mut ExpressionStore<'_>,
     items: &[ArrayLiteralItem],
     expected_width: Option<usize>,
     arena: &mut SLTNodeArena<VarId>,
@@ -31,7 +63,7 @@ pub(super) fn eval_array_literal_expression(
         match item {
             ArrayLiteralItem::Value(sub_expr, repeat) => {
                 let ((part_expr, part_sources), p_bounds) =
-                    eval_expression(module, store, sub_expr, arena, None)?;
+                    eval_expression_in_context(module, store, sub_expr, arena, None)?;
                 all_bounds = merge_boundaries(all_bounds, p_bounds);
                 total_sources.extend(part_sources);
 
@@ -69,7 +101,7 @@ pub(super) fn eval_array_literal_expression(
                 }
 
                 let ((part_expr, part_sources), p_bounds) =
-                    eval_expression(module, store, default_expr, arena, None)?;
+                    eval_expression_in_context(module, store, default_expr, arena, None)?;
                 all_bounds = merge_boundaries(all_bounds, p_bounds);
                 total_sources.extend(part_sources);
                 let width = get_width(part_expr, arena);
@@ -1879,11 +1911,11 @@ pub(super) fn eval_function_body_return(
 
 fn eval_function_call_expression(
     module: &Module,
-    store: &SymbolicStore<VarId>,
+    store: &mut ExpressionStore<'_>,
     call: &veryl_analyzer::ir::FunctionCall,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
-    if !call.outputs.is_empty() {
+    if !call.outputs.is_empty() && store.effectful_mut().is_none() {
         return Err(ParserError::unsupported(
             60,
             LoweringPhase::CombLowering,
@@ -1925,18 +1957,17 @@ fn eval_function_call_expression(
         ));
     };
 
-    let mut local_store = store.clone();
     let mut arg_bounds = BoundaryMap::default();
-    for (arg_path, arg_id) in &function_body.arg_map {
-        let Some(arg_expr) = call.inputs.get(arg_path) else {
+    let mut evaluated_inputs = Vec::with_capacity(call.inputs.len());
+    for (arg_path, arg_expr) in &call.inputs {
+        let Some(arg_id) = function_body.arg_map.get(arg_path) else {
             return Err(super::invalid_function_call_argument_error(
                 function,
                 arg_path,
-                "formal argument has neither an input expression nor an output destination",
+                "input argument does not match any formal argument",
                 call,
             ));
         };
-
         let Some(arg_var) = module.variables.get(arg_id) else {
             return Err(ParserError::unsupported(
                 67,
@@ -1948,24 +1979,62 @@ fn eval_function_call_expression(
         };
         let arg_width = resolve_total_width(module, arg_var)?;
         let ((arg_node, sources), bounds) =
-            eval_assignment_expression(module, store, arg_expr, arena, arg_width)?;
+            eval_assignment_expression_in_store(module, store, arg_expr, arena, arg_width)?;
         let arg_node = if arg_var.r#type.is_2state() && !arg_expr.comptime().r#type.is_2state() {
             arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, arg_node))?
         } else {
             arg_node
         };
         arg_bounds = merge_boundaries(arg_bounds, bounds);
+        evaluated_inputs.push((*arg_id, arg_node, sources, arg_width));
+    }
+
+    for arg_path in function_body.arg_map.keys() {
+        if !call.inputs.contains_key(arg_path) && !call.outputs.contains_key(arg_path) {
+            return Err(super::invalid_function_call_argument_error(
+                function,
+                arg_path,
+                "formal argument has neither an input expression nor an output destination",
+                call,
+            ));
+        }
+    }
+
+    let mut local_store = store.current().clone();
+    for (arg_id, arg_node, sources, arg_width) in evaluated_inputs {
         local_store.insert(
-            *arg_id,
+            arg_id,
             RangeStore::new(Some((arg_node, sources)), arg_width),
         );
     }
 
-    let ((ret_node, ret_sources), ret_bounds, _) =
+    let ((ret_node, ret_sources), ret_bounds, final_local_store) =
         eval_function_body_return(module, &local_store, &function_body, ret_id, arena)?;
+
+    let output_bounds = if call.outputs.is_empty() {
+        BoundaryMap::default()
+    } else {
+        let caller_store = store
+            .effectful_mut()
+            .expect("output calls require effectful store");
+        let current_store = std::mem::take(caller_store);
+        let (next_store, bounds) = super::apply_function_call_outputs(
+            module,
+            current_store,
+            BoundaryMap::default(),
+            call,
+            &function_body,
+            &final_local_store,
+            arena,
+            LoweringPhase::CombLowering,
+        )?;
+        *caller_store = next_store;
+        bounds
+    };
+
     Ok((
         (ret_node, ret_sources),
-        merge_boundaries(arg_bounds, ret_bounds),
+        merge_boundaries(arg_bounds, merge_boundaries(ret_bounds, output_bounds)),
     ))
 }
 
@@ -1980,12 +2049,13 @@ pub fn eval_expression(
         width,
         signed: expression_signed(expr),
     });
-    eval_expression_in_context(module, store, expr, arena, context)
+    let mut store = ExpressionStore::ReadOnly(store);
+    eval_expression_in_context(module, &mut store, expr, arena, context)
 }
 
 fn eval_expression_in_context(
     module: &Module,
-    store: &SymbolicStore<VarId>,
+    store: &mut ExpressionStore<'_>,
     expr: &Expression,
     arena: &mut SLTNodeArena<VarId>,
     context: Option<ValueContext>,
@@ -2128,7 +2198,38 @@ fn eval_expression_in_context(
             let ((l_expr, l_sources), l_bounds) =
                 eval_expression_in_context(module, store, lhs, arena, semantics.lhs_context)?;
             let ((r_expr, r_sources), r_bounds) =
-                eval_expression_in_context(module, store, rhs, arena, semantics.rhs_context)?;
+                if store.effectful_mut().is_some() && matches!(op, Op::LogicAnd | Op::LogicOr) {
+                    let base_store = store.current().clone();
+                    let mut rhs_store = base_store.clone();
+                    let mut rhs_state = ExpressionStore::Effectful(&mut rhs_store);
+                    let rhs_value = eval_expression_in_context(
+                        module,
+                        &mut rhs_state,
+                        rhs,
+                        arena,
+                        semantics.rhs_context,
+                    )?;
+                    let execute_rhs = if matches!(op, Op::LogicAnd) {
+                        l_expr
+                    } else {
+                        arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, l_expr))?
+                    };
+                    let merged_store = super::merge_symbolic_stores(
+                        module,
+                        &rhs_store,
+                        &base_store,
+                        execute_rhs,
+                        &l_sources,
+                        arena,
+                    )?;
+                    *store
+                        .effectful_mut()
+                        .expect("effectful binary expression must retain a mutable store") =
+                        merged_store;
+                    rhs_value
+                } else {
+                    eval_expression_in_context(module, store, rhs, arena, semantics.rhs_context)?
+                };
 
             let mut sources = l_sources;
             sources.extend(r_sources);
@@ -2288,10 +2389,49 @@ fn eval_expression_in_context(
             });
             let ((cond_expr, cond_sources), cond_bounds) =
                 eval_expression_in_context(module, store, cond, arena, None)?;
-            let ((then_expr, then_sources), then_bounds) =
-                eval_expression_in_context(module, store, then_expr, arena, branch_context)?;
-            let ((else_expr, else_sources), else_bounds) =
-                eval_expression_in_context(module, store, else_expr, arena, branch_context)?;
+            let (
+                ((then_expr, then_sources), then_bounds),
+                ((else_expr, else_sources), else_bounds),
+            ) = if store.effectful_mut().is_some() {
+                let base_store = store.current().clone();
+                let mut then_store = base_store.clone();
+                let mut then_state = ExpressionStore::Effectful(&mut then_store);
+                let then_value = eval_expression_in_context(
+                    module,
+                    &mut then_state,
+                    then_expr,
+                    arena,
+                    branch_context,
+                )?;
+
+                let mut else_store = base_store;
+                let mut else_state = ExpressionStore::Effectful(&mut else_store);
+                let else_value = eval_expression_in_context(
+                    module,
+                    &mut else_state,
+                    else_expr,
+                    arena,
+                    branch_context,
+                )?;
+
+                let merged_store = super::merge_symbolic_stores(
+                    module,
+                    &then_store,
+                    &else_store,
+                    cond_expr,
+                    &cond_sources,
+                    arena,
+                )?;
+                *store
+                    .effectful_mut()
+                    .expect("effectful ternary must retain a mutable store") = merged_store;
+                (then_value, else_value)
+            } else {
+                (
+                    eval_expression_in_context(module, store, then_expr, arena, branch_context)?,
+                    eval_expression_in_context(module, store, else_expr, arena, branch_context)?,
+                )
+            };
 
             let mut sources = cond_sources;
             sources.extend(then_sources);
@@ -2373,7 +2513,7 @@ fn eval_expression_in_context(
         }
         Expression::ArrayLiteral(items, _) => {
             let ((result, sources), bounds) =
-                eval_array_literal_expression(module, store, items, context_width, arena)?;
+                eval_array_literal_expression_in_store(module, store, items, context_width, arena)?;
             let result = coerce_node_width(
                 arena,
                 result,
@@ -2408,8 +2548,50 @@ pub fn eval_assignment_expression(
         ));
     }
 
-    let ((node, sources), boundaries) =
-        eval_expression(module, store, expr, arena, Some(target_width))?;
+    let value = eval_expression(module, store, expr, arena, Some(target_width))?;
+    finish_assignment_expression(expr, arena, target_width, value)
+}
+
+pub(super) fn eval_assignment_expression_effectful(
+    module: &Module,
+    store: &mut SymbolicStore<VarId>,
+    expr: &Expression,
+    arena: &mut SLTNodeArena<VarId>,
+    target_width: usize,
+) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+    if target_width == 0 {
+        return Err(ParserError::illegal_context(
+            "assignment expression",
+            "target width must be nonzero",
+            Some(&expr.token_range()),
+        ));
+    }
+
+    let mut store = ExpressionStore::Effectful(store);
+    eval_assignment_expression_in_store(module, &mut store, expr, arena, target_width)
+}
+
+fn eval_assignment_expression_in_store(
+    module: &Module,
+    store: &mut ExpressionStore<'_>,
+    expr: &Expression,
+    arena: &mut SLTNodeArena<VarId>,
+    target_width: usize,
+) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+    let context = Some(ValueContext {
+        width: target_width,
+        signed: expression_signed(expr),
+    });
+    let value = eval_expression_in_context(module, store, expr, arena, context)?;
+    finish_assignment_expression(expr, arena, target_width, value)
+}
+
+fn finish_assignment_expression(
+    expr: &Expression,
+    arena: &mut SLTNodeArena<VarId>,
+    target_width: usize,
+    ((node, sources), boundaries): ((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>),
+) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
     let source_width = get_width(node, arena);
     if source_width == 0 {
         return Err(ParserError::illegal_context(
@@ -2429,7 +2611,7 @@ pub fn eval_assignment_expression(
 
 fn eval_factor(
     module: &Module,
-    store: &SymbolicStore<VarId>,
+    store: &mut ExpressionStore<'_>,
     factor: &Factor,
     arena: &mut SLTNodeArena<VarId>,
     context: Option<ValueContext>,
@@ -2492,7 +2674,7 @@ fn eval_factor(
                 var_bounds.insert(access.lsb);
                 var_bounds.insert(access_end);
 
-                let range_store = store.get(var_id).ok_or_else(|| {
+                let range_store = store.current().get(var_id).ok_or_else(|| {
                     ParserError::illegal_context(
                         "static variable read",
                         "source variable is absent from the symbolic store",
@@ -2536,7 +2718,7 @@ fn eval_factor(
                     boundaries: all_bounds,
                 } = super::eval_dynamic_select_offset(
                     module,
-                    store,
+                    store.current(),
                     *var_id,
                     index,
                     select,
@@ -2546,7 +2728,7 @@ fn eval_factor(
                 all_sources.extend(offset_sources);
 
                 // 2. Check SymbolicStore to determine if "already written"
-                let range_store = store.get(var_id).ok_or_else(|| {
+                let range_store = store.current().get(var_id).ok_or_else(|| {
                     ParserError::illegal_context(
                         "dynamic variable read",
                         "source variable is absent from the symbolic store",
@@ -2625,7 +2807,7 @@ fn eval_factor(
             Ok(((node, HashSet::default()), BoundaryMap::default()))
         }
         Factor::SystemFunctionCall(call) => {
-            eval_system_function_call(module, store, call, arena, context)
+            eval_system_function_call(module, store.current(), call, arena, context)
         }
         Factor::FunctionCall(call) => {
             let ((node, sources), bounds) =

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -2,7 +2,6 @@ use super::*;
 
 use crate::{
     bitaccess::{celox_value_from_comptime, celox_value_from_comptime_in_context},
-    case::case_arm_condition_expr,
     context_width::{
         ValueContext, binary_semantics, cast_semantics, expression_signed, get_expr_width,
         resolve_binary_op,
@@ -521,17 +520,48 @@ pub(super) fn eval_function_body_return(
         }
     }
 
+    fn eval_function_expression(
+        module: &Module,
+        state: FunctionControlState,
+        expression: &Expression,
+        context_width: Option<usize>,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<(FunctionControlState, NodeId, HashSet<VarAtomBase<VarId>>), ParserError> {
+        let mut next_store = state.store.clone();
+        let ((node, sources), boundaries) =
+            eval_expression_effectful(module, &mut next_store, expression, arena, context_width)?;
+        let state = apply_function_guard(
+            module,
+            state,
+            next_store,
+            boundaries,
+            bool_node(arena, true)?,
+            HashSet::default(),
+            arena,
+        )?;
+        Ok((state, node, sources))
+    }
+
+    fn eval_function_condition(
+        module: &Module,
+        state: FunctionControlState,
+        condition: &Expression,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<(FunctionControlState, NodeId, HashSet<VarAtomBase<VarId>>), ParserError> {
+        let (state, condition, sources) =
+            eval_function_expression(module, state, condition, Some(1), arena)?;
+        Ok((state, procedural_condition(arena, condition)?, sources))
+    }
+
     fn eval_function_if(
         module: &Module,
-        mut state: FunctionControlState,
+        state: FunctionControlState,
         if_stmt: &IfStatement,
         ret_id: VarId,
         arena: &mut SLTNodeArena<VarId>,
     ) -> Result<FunctionControlState, ParserError> {
-        let ((cond_expr, cond_sources), cond_bounds) =
-            eval_expression_effectful(module, &mut state.store, &if_stmt.cond, arena, Some(1))?;
-        let cond_expr = procedural_condition(arena, cond_expr)?;
-        let boundaries = merge_boundaries(state.boundaries, cond_bounds);
+        let (state, cond_expr, cond_sources) =
+            eval_function_condition(module, state, &if_stmt.cond, arena)?;
 
         if let Some(cond_val) = constant_bool(arena, cond_expr) {
             let side = if cond_val {
@@ -539,23 +569,14 @@ pub(super) fn eval_function_body_return(
             } else {
                 &if_stmt.false_side
             };
-            return eval_function_statements(
-                module,
-                FunctionControlState {
-                    boundaries,
-                    ..state
-                },
-                side,
-                ret_id,
-                arena,
-            );
+            return eval_function_statements(module, state, side, ret_id, arena);
         }
 
         let then_state = eval_function_statements(
             module,
             FunctionControlState {
                 store: state.store.clone(),
-                boundaries: boundaries.clone(),
+                boundaries: state.boundaries.clone(),
                 live_expr: state.live_expr,
                 live_sources: state.live_sources.clone(),
             },
@@ -567,7 +588,7 @@ pub(super) fn eval_function_body_return(
             module,
             FunctionControlState {
                 store: state.store,
-                boundaries,
+                boundaries: state.boundaries,
                 live_expr: state.live_expr,
                 live_sources: state.live_sources,
             },
@@ -660,15 +681,9 @@ pub(super) fn eval_function_body_return(
             ret_id: VarId,
             arena: &mut SLTNodeArena<VarId>,
         ) -> Result<FunctionLoopControlState, ParserError> {
-            let ((cond_expr, cond_sources), cond_bounds) = eval_expression_effectful(
-                module,
-                &mut state.function.store,
-                &if_stmt.cond,
-                arena,
-                Some(1),
-            )?;
-            let cond_expr = procedural_condition(arena, cond_expr)?;
-            let boundaries = merge_boundaries(state.function.boundaries, cond_bounds);
+            let (function, cond_expr, cond_sources) =
+                eval_function_condition(module, state.function.clone(), &if_stmt.cond, arena)?;
+            state.function = function;
 
             if let Some(cond_val) = constant_bool(arena, cond_expr) {
                 let side = if cond_val {
@@ -676,23 +691,16 @@ pub(super) fn eval_function_body_return(
                 } else {
                     &if_stmt.false_side
                 };
-                return side.iter().try_fold(
-                    FunctionLoopControlState {
-                        function: FunctionControlState {
-                            boundaries,
-                            ..state.function
-                        },
-                        ..state
-                    },
-                    |s, step| eval_function_loop_statement(module, s, step, ret_id, arena),
-                );
+                return side.iter().try_fold(state, |s, step| {
+                    eval_function_loop_statement(module, s, step, ret_id, arena)
+                });
             }
 
             let then_state = if_stmt.true_side.iter().try_fold(
                 FunctionLoopControlState {
                     function: FunctionControlState {
                         store: state.function.store.clone(),
-                        boundaries: boundaries.clone(),
+                        boundaries: state.function.boundaries.clone(),
                         live_expr: state.function.live_expr,
                         live_sources: state.function.live_sources.clone(),
                     },
@@ -705,7 +713,7 @@ pub(super) fn eval_function_body_return(
                 FunctionLoopControlState {
                     function: FunctionControlState {
                         store: state.function.store,
-                        boundaries,
+                        boundaries: state.function.boundaries,
                         live_expr: state.function.live_expr,
                         live_sources: state.function.live_sources,
                     },
@@ -756,7 +764,7 @@ pub(super) fn eval_function_body_return(
 
         fn eval_function_loop_case(
             module: &Module,
-            state: FunctionLoopControlState,
+            mut state: FunctionLoopControlState,
             case_stmt: &CaseStatement,
             ret_id: VarId,
             arena: &mut SLTNodeArena<VarId>,
@@ -765,6 +773,7 @@ pub(super) fn eval_function_body_return(
                 module: &Module,
                 mut state: FunctionLoopControlState,
                 case_stmt: &CaseStatement,
+                target: &EvaluatedCaseTarget,
                 arm_index: usize,
                 ret_id: VarId,
                 arena: &mut SLTNodeArena<VarId>,
@@ -775,15 +784,26 @@ pub(super) fn eval_function_body_return(
                     });
                 };
 
-                let ((cond_expr, cond_sources), cond_bounds) = eval_expression_effectful(
+                let mut next_store = state.function.store.clone();
+                let ((cond_expr, cond_sources), cond_bounds) = eval_case_arm_condition_effectful(
                     module,
-                    &mut state.function.store,
-                    &case_arm_condition_expr(&case_stmt.case_target, &arm.patterns),
+                    &mut next_store,
+                    &case_stmt.case_target,
+                    target,
+                    &arm.patterns,
                     arena,
-                    Some(1),
+                )?;
+                state.function = apply_function_guard(
+                    module,
+                    state.function,
+                    next_store,
+                    cond_bounds,
+                    bool_node(arena, true)?,
+                    HashSet::default(),
+                    arena,
                 )?;
                 let cond_expr = procedural_condition(arena, cond_expr)?;
-                let boundaries = merge_boundaries(state.function.boundaries, cond_bounds);
+                let boundaries = state.function.boundaries.clone();
 
                 if let Some(cond_val) = constant_bool(arena, cond_expr) {
                     let state = FunctionLoopControlState {
@@ -798,7 +818,15 @@ pub(super) fn eval_function_body_return(
                             eval_function_loop_statement(module, s, step, ret_id, arena)
                         })
                     } else {
-                        eval_from_arm(module, state, case_stmt, arm_index + 1, ret_id, arena)
+                        eval_from_arm(
+                            module,
+                            state,
+                            case_stmt,
+                            target,
+                            arm_index + 1,
+                            ret_id,
+                            arena,
+                        )
                     };
                 }
 
@@ -828,6 +856,7 @@ pub(super) fn eval_function_body_return(
                         continue_sources: state.continue_sources,
                     },
                     case_stmt,
+                    target,
                     arm_index + 1,
                     ret_id,
                     arena,
@@ -872,7 +901,19 @@ pub(super) fn eval_function_body_return(
                 })
             }
 
-            eval_from_arm(module, state, case_stmt, 0, ret_id, arena)
+            let (function, target_node, target_sources) = eval_function_expression(
+                module,
+                state.function.clone(),
+                &case_stmt.case_target,
+                None,
+                arena,
+            )?;
+            state.function = function;
+            let target = EvaluatedCaseTarget {
+                node: target_node,
+                sources: target_sources,
+            };
+            eval_from_arm(module, state, case_stmt, &target, 0, ret_id, arena)
         }
 
         fn eval_function_loop_statement(
@@ -1318,22 +1359,10 @@ pub(super) fn eval_function_body_return(
         ret_id: VarId,
         arena: &mut SLTNodeArena<VarId>,
     ) -> Result<FunctionLoopControlState, ParserError> {
-        let ((cond_expr, cond_sources), cond_bounds) = eval_expression_effectful(
-            module,
-            &mut state.function.store,
-            &if_stmt.cond,
-            arena,
-            Some(1),
-        )?;
-        let cond_expr = procedural_condition(arena, cond_expr)?;
-        let boundaries = merge_boundaries(state.function.boundaries.clone(), cond_bounds);
-        let outer_state = FunctionLoopControlState {
-            function: FunctionControlState {
-                boundaries: boundaries.clone(),
-                ..state.function.clone()
-            },
-            ..state.clone()
-        };
+        let (function, cond_expr, cond_sources) =
+            eval_function_condition(module, state.function.clone(), &if_stmt.cond, arena)?;
+        state.function = function;
+        let outer_state = state.clone();
 
         let executed_state = if let Some(cond_val) = constant_bool(arena, cond_expr) {
             let side = if cond_val {
@@ -1341,22 +1370,15 @@ pub(super) fn eval_function_body_return(
             } else {
                 &if_stmt.false_side
             };
-            side.iter().try_fold(
-                FunctionLoopControlState {
-                    function: FunctionControlState {
-                        boundaries,
-                        ..state.function
-                    },
-                    ..state
-                },
-                |s, step| eval_function_break_statement(module, s, step, ret_id, arena),
-            )?
+            side.iter().try_fold(state, |s, step| {
+                eval_function_break_statement(module, s, step, ret_id, arena)
+            })?
         } else {
             let then_state = if_stmt.true_side.iter().try_fold(
                 FunctionLoopControlState {
                     function: FunctionControlState {
                         store: state.function.store.clone(),
-                        boundaries: boundaries.clone(),
+                        boundaries: state.function.boundaries.clone(),
                         live_expr: state.function.live_expr,
                         live_sources: state.function.live_sources.clone(),
                     },
@@ -1369,7 +1391,7 @@ pub(super) fn eval_function_body_return(
                 FunctionLoopControlState {
                     function: FunctionControlState {
                         store: state.function.store,
-                        boundaries,
+                        boundaries: state.function.boundaries,
                         live_expr: state.function.live_expr,
                         live_sources: state.function.live_sources,
                     },
@@ -1448,7 +1470,7 @@ pub(super) fn eval_function_body_return(
 
     fn eval_function_break_case(
         module: &Module,
-        state: FunctionLoopControlState,
+        mut state: FunctionLoopControlState,
         case_stmt: &CaseStatement,
         ret_id: VarId,
         arena: &mut SLTNodeArena<VarId>,
@@ -1457,6 +1479,7 @@ pub(super) fn eval_function_body_return(
             module: &Module,
             mut state: FunctionLoopControlState,
             case_stmt: &CaseStatement,
+            target: &EvaluatedCaseTarget,
             arm_index: usize,
             ret_id: VarId,
             arena: &mut SLTNodeArena<VarId>,
@@ -1467,15 +1490,26 @@ pub(super) fn eval_function_body_return(
                 });
             };
 
-            let ((cond_expr, cond_sources), cond_bounds) = eval_expression_effectful(
+            let mut next_store = state.function.store.clone();
+            let ((cond_expr, cond_sources), cond_bounds) = eval_case_arm_condition_effectful(
                 module,
-                &mut state.function.store,
-                &case_arm_condition_expr(&case_stmt.case_target, &arm.patterns),
+                &mut next_store,
+                &case_stmt.case_target,
+                target,
+                &arm.patterns,
                 arena,
-                Some(1),
+            )?;
+            state.function = apply_function_guard(
+                module,
+                state.function,
+                next_store,
+                cond_bounds,
+                bool_node(arena, true)?,
+                HashSet::default(),
+                arena,
             )?;
             let cond_expr = procedural_condition(arena, cond_expr)?;
-            let boundaries = merge_boundaries(state.function.boundaries, cond_bounds);
+            let boundaries = state.function.boundaries.clone();
 
             if let Some(cond_val) = constant_bool(arena, cond_expr) {
                 let state = FunctionLoopControlState {
@@ -1490,7 +1524,15 @@ pub(super) fn eval_function_body_return(
                         eval_function_break_statement(module, s, step, ret_id, arena)
                     })
                 } else {
-                    eval_from_arm(module, state, case_stmt, arm_index + 1, ret_id, arena)
+                    eval_from_arm(
+                        module,
+                        state,
+                        case_stmt,
+                        target,
+                        arm_index + 1,
+                        ret_id,
+                        arena,
+                    )
                 };
             }
 
@@ -1520,6 +1562,7 @@ pub(super) fn eval_function_body_return(
                     continue_sources: state.continue_sources,
                 },
                 case_stmt,
+                target,
                 arm_index + 1,
                 ret_id,
                 arena,
@@ -1564,8 +1607,20 @@ pub(super) fn eval_function_body_return(
             })
         }
 
+        let (function, target_node, target_sources) = eval_function_expression(
+            module,
+            state.function.clone(),
+            &case_stmt.case_target,
+            None,
+            arena,
+        )?;
+        state.function = function;
+        let target = EvaluatedCaseTarget {
+            node: target_node,
+            sources: target_sources,
+        };
         let outer_state = state.clone();
-        let executed_state = eval_from_arm(module, state, case_stmt, 0, ret_id, arena)?;
+        let executed_state = eval_from_arm(module, state, case_stmt, &target, 0, ret_id, arena)?;
 
         if matches!(constant_bool(arena, outer_state.continue_expr), Some(true)) {
             return Ok(executed_state);
@@ -1700,7 +1755,7 @@ pub(super) fn eval_function_body_return(
 
     fn eval_function_case(
         module: &Module,
-        state: FunctionControlState,
+        mut state: FunctionControlState,
         case_stmt: &CaseStatement,
         ret_id: VarId,
         arena: &mut SLTNodeArena<VarId>,
@@ -1709,6 +1764,7 @@ pub(super) fn eval_function_body_return(
             module: &Module,
             mut state: FunctionControlState,
             case_stmt: &CaseStatement,
+            target: &EvaluatedCaseTarget,
             arm_index: usize,
             ret_id: VarId,
             arena: &mut SLTNodeArena<VarId>,
@@ -1717,15 +1773,26 @@ pub(super) fn eval_function_body_return(
                 return eval_function_statements(module, state, &case_stmt.default, ret_id, arena);
             };
 
-            let ((cond_expr, cond_sources), cond_bounds) = eval_expression_effectful(
+            let mut next_store = state.store.clone();
+            let ((cond_expr, cond_sources), cond_bounds) = eval_case_arm_condition_effectful(
                 module,
-                &mut state.store,
-                &case_arm_condition_expr(&case_stmt.case_target, &arm.patterns),
+                &mut next_store,
+                &case_stmt.case_target,
+                target,
+                &arm.patterns,
                 arena,
-                Some(1),
+            )?;
+            state = apply_function_guard(
+                module,
+                state,
+                next_store,
+                cond_bounds,
+                bool_node(arena, true)?,
+                HashSet::default(),
+                arena,
             )?;
             let cond_expr = procedural_condition(arena, cond_expr)?;
-            let boundaries = merge_boundaries(state.boundaries, cond_bounds);
+            let boundaries = state.boundaries.clone();
 
             if let Some(cond_val) = constant_bool(arena, cond_expr) {
                 let state = FunctionControlState {
@@ -1735,7 +1802,15 @@ pub(super) fn eval_function_body_return(
                 return if cond_val {
                     eval_function_statements(module, state, &arm.body, ret_id, arena)
                 } else {
-                    eval_from_arm(module, state, case_stmt, arm_index + 1, ret_id, arena)
+                    eval_from_arm(
+                        module,
+                        state,
+                        case_stmt,
+                        target,
+                        arm_index + 1,
+                        ret_id,
+                        arena,
+                    )
                 };
             }
 
@@ -1760,6 +1835,7 @@ pub(super) fn eval_function_body_return(
                     live_sources: state.live_sources,
                 },
                 case_stmt,
+                target,
                 arm_index + 1,
                 ret_id,
                 arena,
@@ -1789,7 +1865,14 @@ pub(super) fn eval_function_body_return(
             })
         }
 
-        eval_from_arm(module, state, case_stmt, 0, ret_id, arena)
+        let (next_state, target_node, target_sources) =
+            eval_function_expression(module, state, &case_stmt.case_target, None, arena)?;
+        state = next_state;
+        let target = EvaluatedCaseTarget {
+            node: target_node,
+            sources: target_sources,
+        };
+        eval_from_arm(module, state, case_stmt, &target, 0, ret_id, arena)
     }
 
     fn eval_function_statement(
@@ -2089,6 +2172,241 @@ pub(super) fn eval_expression_effectful(
     eval_expression_in_context(module, &mut store, expr, arena, context)
 }
 
+pub(super) struct EvaluatedCaseTarget {
+    pub(super) node: NodeId,
+    pub(super) sources: HashSet<VarAtomBase<VarId>>,
+}
+
+pub(super) fn eval_case_target_effectful(
+    module: &Module,
+    store: &mut SymbolicStore<VarId>,
+    target: &Expression,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<(EvaluatedCaseTarget, BoundaryMap<VarId>), ParserError> {
+    let ((node, sources), boundaries) =
+        eval_expression_effectful(module, store, target, arena, None)?;
+    Ok((EvaluatedCaseTarget { node, sources }, boundaries))
+}
+
+fn short_circuit_rhs_guard(
+    arena: &mut SLTNodeArena<VarId>,
+    lhs: NodeId,
+    is_and: bool,
+) -> Result<NodeId, ParserError> {
+    let not_lhs = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, lhs))?;
+    let shortcut_truth = if is_and {
+        not_lhs
+    } else {
+        arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, not_lhs))?
+    };
+    let shortcut = arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, shortcut_truth))?;
+    Ok(arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, shortcut))?)
+}
+
+fn eval_case_comparison(
+    module: &Module,
+    store: &mut ExpressionStore<'_>,
+    target_expr: &Expression,
+    target: &EvaluatedCaseTarget,
+    other: &Expression,
+    target_is_lhs: bool,
+    op: Op,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+    let target_width = get_expr_width(target_expr)
+        .or_else(|| target_expr.comptime().r#type.total_width())
+        .unwrap_or(1);
+    let other_width = get_expr_width(other)
+        .or_else(|| other.comptime().r#type.total_width())
+        .unwrap_or(1);
+    let target_signed = expression_signed(target_expr);
+    let other_signed = expression_signed(other);
+    let (lhs_width, rhs_width, lhs_signed, rhs_signed) = if target_is_lhs {
+        (target_width, other_width, target_signed, other_signed)
+    } else {
+        (other_width, target_width, other_signed, target_signed)
+    };
+    let semantics = binary_semantics(
+        op,
+        lhs_width,
+        rhs_width,
+        lhs_signed,
+        rhs_signed,
+        Some(ValueContext {
+            width: 1,
+            signed: false,
+        }),
+    );
+
+    let target_context = if target_is_lhs {
+        semantics.lhs_context
+    } else {
+        semantics.rhs_context
+    };
+    let target_node = coerce_node_width(
+        arena,
+        target.node,
+        target_context.map(|context| context.width),
+        target_context
+            .map(|context| context.signed)
+            .unwrap_or(target_signed),
+    )?;
+    let other_context = if target_is_lhs {
+        semantics.rhs_context
+    } else {
+        semantics.lhs_context
+    };
+    let ((other_node, other_sources), boundaries) =
+        eval_expression_in_context(module, store, other, arena, other_context)?;
+    let (lhs, rhs) = if target_is_lhs {
+        (target_node, other_node)
+    } else {
+        (other_node, target_node)
+    };
+    let node = arena.alloc(SLTNode::Binary(
+        lhs,
+        resolve_binary_op(op, semantics.lhs_signed, semantics.rhs_signed),
+        rhs,
+    ))?;
+    let node = coerce_node_width(
+        arena,
+        node,
+        Some(semantics.result_width),
+        semantics.result_signed,
+    )?;
+    let mut sources = target.sources.clone();
+    sources.extend(other_sources);
+    Ok(((node, sources), boundaries))
+}
+
+fn merge_short_circuit_case_condition(
+    module: &Module,
+    store: &mut SymbolicStore<VarId>,
+    lhs: ((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>),
+    eval_rhs: impl FnOnce(
+        &mut SymbolicStore<VarId>,
+        &mut SLTNodeArena<VarId>,
+    ) -> Result<
+        ((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>),
+        ParserError,
+    >,
+    is_and: bool,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+    let ((lhs_node, mut sources), lhs_boundaries) = lhs;
+    let base_store = store.clone();
+    let mut rhs_store = base_store.clone();
+    let ((rhs_node, rhs_sources), rhs_boundaries) = eval_rhs(&mut rhs_store, arena)?;
+    let execute_rhs = short_circuit_rhs_guard(arena, lhs_node, is_and)?;
+    *store = super::merge_symbolic_stores(
+        module,
+        &rhs_store,
+        &base_store,
+        execute_rhs,
+        &sources,
+        arena,
+    )?;
+    sources.extend(rhs_sources);
+    let op = if is_and {
+        BinaryOp::LogicAnd
+    } else {
+        BinaryOp::LogicOr
+    };
+    Ok((
+        (
+            arena.alloc(SLTNode::Binary(lhs_node, op, rhs_node))?,
+            sources,
+        ),
+        merge_boundaries(lhs_boundaries, rhs_boundaries),
+    ))
+}
+
+pub(super) fn eval_case_arm_condition_effectful(
+    module: &Module,
+    store: &mut SymbolicStore<VarId>,
+    target_expr: &Expression,
+    target: &EvaluatedCaseTarget,
+    patterns: &[CasePattern],
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+    fn eval_pattern(
+        module: &Module,
+        store: &mut SymbolicStore<VarId>,
+        target_expr: &Expression,
+        target: &EvaluatedCaseTarget,
+        pattern: &CasePattern,
+        arena: &mut SLTNodeArena<VarId>,
+    ) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+        match pattern {
+            CasePattern::Eq(value) => {
+                let mut store = ExpressionStore::Effectful(store);
+                eval_case_comparison(
+                    module,
+                    &mut store,
+                    target_expr,
+                    target,
+                    value,
+                    true,
+                    Op::EqWildcard,
+                    arena,
+                )
+            }
+            CasePattern::Range { lo, hi, inclusive } => {
+                let lhs = {
+                    let mut expression_store = ExpressionStore::Effectful(store);
+                    eval_case_comparison(
+                        module,
+                        &mut expression_store,
+                        target_expr,
+                        target,
+                        lo,
+                        false,
+                        Op::LessEq,
+                        arena,
+                    )?
+                };
+                merge_short_circuit_case_condition(
+                    module,
+                    store,
+                    lhs,
+                    |rhs_store, arena| {
+                        let mut expression_store = ExpressionStore::Effectful(rhs_store);
+                        eval_case_comparison(
+                            module,
+                            &mut expression_store,
+                            target_expr,
+                            target,
+                            hi,
+                            true,
+                            if *inclusive { Op::LessEq } else { Op::Less },
+                            arena,
+                        )
+                    },
+                    true,
+                    arena,
+                )
+            }
+        }
+    }
+
+    let mut patterns = patterns.iter();
+    let first = patterns
+        .next()
+        .expect("CaseArm must have at least one pattern");
+    let mut condition = eval_pattern(module, store, target_expr, target, first, arena)?;
+    for pattern in patterns {
+        condition = merge_short_circuit_case_condition(
+            module,
+            store,
+            condition,
+            |rhs_store, arena| eval_pattern(module, rhs_store, target_expr, target, pattern, arena),
+            false,
+            arena,
+        )?;
+    }
+    Ok(condition)
+}
+
 pub(super) fn eval_expression_in_context(
     module: &Module,
     store: &mut ExpressionStore<'_>,
@@ -2233,39 +2551,46 @@ pub(super) fn eval_expression_in_context(
             }
             let ((l_expr, l_sources), l_bounds) =
                 eval_expression_in_context(module, store, lhs, arena, semantics.lhs_context)?;
-            let ((r_expr, r_sources), r_bounds) =
-                if store.effectful_mut().is_some() && matches!(op, Op::LogicAnd | Op::LogicOr) {
-                    let base_store = store.current().clone();
-                    let mut rhs_store = base_store.clone();
-                    let mut rhs_state = ExpressionStore::Effectful(&mut rhs_store);
-                    let rhs_value = eval_expression_in_context(
-                        module,
-                        &mut rhs_state,
-                        rhs,
-                        arena,
-                        semantics.rhs_context,
-                    )?;
-                    let execute_rhs = if matches!(op, Op::LogicAnd) {
-                        l_expr
-                    } else {
-                        arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, l_expr))?
-                    };
-                    let merged_store = super::merge_symbolic_stores(
-                        module,
-                        &rhs_store,
-                        &base_store,
-                        execute_rhs,
-                        &l_sources,
-                        arena,
-                    )?;
-                    *store
-                        .effectful_mut()
-                        .expect("effectful binary expression must retain a mutable store") =
-                        merged_store;
-                    rhs_value
+            let ((r_expr, r_sources), r_bounds) = if store.effectful_mut().is_some()
+                && matches!(op, Op::LogicAnd | Op::LogicOr)
+            {
+                let base_store = store.current().clone();
+                let mut rhs_store = base_store.clone();
+                let mut rhs_state = ExpressionStore::Effectful(&mut rhs_store);
+                let rhs_value = eval_expression_in_context(
+                    module,
+                    &mut rhs_state,
+                    rhs,
+                    arena,
+                    semantics.rhs_context,
+                )?;
+                // Only a definite dominant value skips the RHS.  Map the
+                // four-state shortcut predicate through ToTwoState so X/Z
+                // continues into the RHS, matching the FF lowering.
+                let not_lhs = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, l_expr))?;
+                let shortcut_truth = if matches!(op, Op::LogicAnd) {
+                    not_lhs
                 } else {
-                    eval_expression_in_context(module, store, rhs, arena, semantics.rhs_context)?
+                    arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, not_lhs))?
                 };
+                let shortcut = arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, shortcut_truth))?;
+                let execute_rhs = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, shortcut))?;
+                let merged_store = super::merge_symbolic_stores(
+                    module,
+                    &rhs_store,
+                    &base_store,
+                    execute_rhs,
+                    &l_sources,
+                    arena,
+                )?;
+                *store
+                    .effectful_mut()
+                    .expect("effectful binary expression must retain a mutable store") =
+                    merged_store;
+                rhs_value
+            } else {
+                eval_expression_in_context(module, store, rhs, arena, semantics.rhs_context)?
+            };
 
             let mut sources = l_sources;
             sources.extend(r_sources);

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -2180,7 +2180,7 @@ pub(super) fn eval_case_target_effectful(
     Ok((EvaluatedCaseTarget { node, sources }, boundaries))
 }
 
-fn short_circuit_rhs_guard(
+pub(super) fn short_circuit_rhs_guard(
     arena: &mut SLTNodeArena<VarId>,
     lhs: NodeId,
     is_and: bool,

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -13,13 +13,13 @@ use veryl_analyzer::ir::{CasePattern, Type, ValueVariant};
 
 use super::state::{FunctionControlState, FunctionLoopControlState};
 
-enum ExpressionStore<'a> {
+pub(super) enum ExpressionStore<'a> {
     ReadOnly(&'a SymbolicStore<VarId>),
     Effectful(&'a mut SymbolicStore<VarId>),
 }
 
 impl ExpressionStore<'_> {
-    fn current(&self) -> &SymbolicStore<VarId> {
+    pub(super) fn current(&self) -> &SymbolicStore<VarId> {
         match self {
             Self::ReadOnly(store) => store,
             Self::Effectful(store) => store,
@@ -523,13 +523,13 @@ pub(super) fn eval_function_body_return(
 
     fn eval_function_if(
         module: &Module,
-        state: FunctionControlState,
+        mut state: FunctionControlState,
         if_stmt: &IfStatement,
         ret_id: VarId,
         arena: &mut SLTNodeArena<VarId>,
     ) -> Result<FunctionControlState, ParserError> {
         let ((cond_expr, cond_sources), cond_bounds) =
-            eval_expression(module, &state.store, &if_stmt.cond, arena, Some(1))?;
+            eval_expression_effectful(module, &mut state.store, &if_stmt.cond, arena, Some(1))?;
         let cond_expr = procedural_condition(arena, cond_expr)?;
         let boundaries = merge_boundaries(state.boundaries, cond_bounds);
 
@@ -655,13 +655,18 @@ pub(super) fn eval_function_body_return(
 
         fn eval_function_loop_if(
             module: &Module,
-            state: FunctionLoopControlState,
+            mut state: FunctionLoopControlState,
             if_stmt: &IfStatement,
             ret_id: VarId,
             arena: &mut SLTNodeArena<VarId>,
         ) -> Result<FunctionLoopControlState, ParserError> {
-            let ((cond_expr, cond_sources), cond_bounds) =
-                eval_expression(module, &state.function.store, &if_stmt.cond, arena, Some(1))?;
+            let ((cond_expr, cond_sources), cond_bounds) = eval_expression_effectful(
+                module,
+                &mut state.function.store,
+                &if_stmt.cond,
+                arena,
+                Some(1),
+            )?;
             let cond_expr = procedural_condition(arena, cond_expr)?;
             let boundaries = merge_boundaries(state.function.boundaries, cond_bounds);
 
@@ -758,7 +763,7 @@ pub(super) fn eval_function_body_return(
         ) -> Result<FunctionLoopControlState, ParserError> {
             fn eval_from_arm(
                 module: &Module,
-                state: FunctionLoopControlState,
+                mut state: FunctionLoopControlState,
                 case_stmt: &CaseStatement,
                 arm_index: usize,
                 ret_id: VarId,
@@ -770,9 +775,9 @@ pub(super) fn eval_function_body_return(
                     });
                 };
 
-                let ((cond_expr, cond_sources), cond_bounds) = eval_expression(
+                let ((cond_expr, cond_sources), cond_bounds) = eval_expression_effectful(
                     module,
-                    &state.function.store,
+                    &mut state.function.store,
                     &case_arm_condition_expr(&case_stmt.case_target, &arm.patterns),
                     arena,
                     Some(1),
@@ -893,6 +898,7 @@ pub(super) fn eval_function_body_return(
                 Statement::Assign(_)
                 | Statement::For(_)
                 | Statement::FunctionCall(_)
+                | Statement::SystemFunctionCall(_)
                 | Statement::Null => {
                     let guard_state = state.clone();
                     let next_function =
@@ -909,7 +915,6 @@ pub(super) fn eval_function_body_return(
                     format!("{stmt}"),
                     Some(&ir.token),
                 )),
-                Statement::SystemFunctionCall(_) => Ok(state),
                 Statement::TbMethodCall(_) | Statement::Unsupported(_) => {
                     Err(ParserError::illegal_context(
                         "statement in comb function body",
@@ -1308,16 +1313,27 @@ pub(super) fn eval_function_body_return(
 
     fn eval_function_break_if(
         module: &Module,
-        state: FunctionLoopControlState,
+        mut state: FunctionLoopControlState,
         if_stmt: &IfStatement,
         ret_id: VarId,
         arena: &mut SLTNodeArena<VarId>,
     ) -> Result<FunctionLoopControlState, ParserError> {
-        let outer_state = state.clone();
-        let ((cond_expr, cond_sources), cond_bounds) =
-            eval_expression(module, &state.function.store, &if_stmt.cond, arena, Some(1))?;
+        let ((cond_expr, cond_sources), cond_bounds) = eval_expression_effectful(
+            module,
+            &mut state.function.store,
+            &if_stmt.cond,
+            arena,
+            Some(1),
+        )?;
         let cond_expr = procedural_condition(arena, cond_expr)?;
-        let boundaries = merge_boundaries(state.function.boundaries, cond_bounds);
+        let boundaries = merge_boundaries(state.function.boundaries.clone(), cond_bounds);
+        let outer_state = FunctionLoopControlState {
+            function: FunctionControlState {
+                boundaries: boundaries.clone(),
+                ..state.function.clone()
+            },
+            ..state.clone()
+        };
 
         let executed_state = if let Some(cond_val) = constant_bool(arena, cond_expr) {
             let side = if cond_val {
@@ -1439,7 +1455,7 @@ pub(super) fn eval_function_body_return(
     ) -> Result<FunctionLoopControlState, ParserError> {
         fn eval_from_arm(
             module: &Module,
-            state: FunctionLoopControlState,
+            mut state: FunctionLoopControlState,
             case_stmt: &CaseStatement,
             arm_index: usize,
             ret_id: VarId,
@@ -1451,9 +1467,9 @@ pub(super) fn eval_function_body_return(
                 });
             };
 
-            let ((cond_expr, cond_sources), cond_bounds) = eval_expression(
+            let ((cond_expr, cond_sources), cond_bounds) = eval_expression_effectful(
                 module,
-                &state.function.store,
+                &mut state.function.store,
                 &case_arm_condition_expr(&case_stmt.case_target, &arm.patterns),
                 arena,
                 Some(1),
@@ -1600,6 +1616,7 @@ pub(super) fn eval_function_body_return(
             Statement::Assign(_)
             | Statement::For(_)
             | Statement::FunctionCall(_)
+            | Statement::SystemFunctionCall(_)
             | Statement::Null => {
                 let guard_state = state.clone();
                 let next_function =
@@ -1616,7 +1633,6 @@ pub(super) fn eval_function_body_return(
                 format!("{stmt}"),
                 Some(&ir.token),
             )),
-            Statement::SystemFunctionCall(_) => Ok(state),
             Statement::TbMethodCall(_) | Statement::Unsupported(_) => {
                 Err(ParserError::illegal_context(
                     "statement in comb function body",
@@ -1691,7 +1707,7 @@ pub(super) fn eval_function_body_return(
     ) -> Result<FunctionControlState, ParserError> {
         fn eval_from_arm(
             module: &Module,
-            state: FunctionControlState,
+            mut state: FunctionControlState,
             case_stmt: &CaseStatement,
             arm_index: usize,
             ret_id: VarId,
@@ -1701,9 +1717,9 @@ pub(super) fn eval_function_body_return(
                 return eval_function_statements(module, state, &case_stmt.default, ret_id, arena);
             };
 
-            let ((cond_expr, cond_sources), cond_bounds) = eval_expression(
+            let ((cond_expr, cond_sources), cond_bounds) = eval_expression_effectful(
                 module,
-                &state.store,
+                &mut state.store,
                 &case_arm_condition_expr(&case_stmt.case_target, &arm.patterns),
                 arena,
                 Some(1),
@@ -1838,7 +1854,25 @@ pub(super) fn eval_function_body_return(
                 format!("{stmt}"),
                 Some(&ir.token),
             )),
-            Statement::SystemFunctionCall(_) => Ok(state),
+            Statement::SystemFunctionCall(call) => {
+                let guard_state = state.clone();
+                let (next_store, next_bounds) = super::eval_system_function_call_side_effects(
+                    module,
+                    state.store,
+                    state.boundaries,
+                    call,
+                    arena,
+                )?;
+                apply_function_guard(
+                    module,
+                    guard_state,
+                    next_store,
+                    next_bounds,
+                    bool_node(arena, true)?,
+                    HashSet::default(),
+                    arena,
+                )
+            }
             Statement::TbMethodCall(_) | Statement::Break | Statement::Unsupported(_) => {
                 Err(ParserError::illegal_context(
                     "statement in comb function body",
@@ -1915,16 +1949,6 @@ fn eval_function_call_expression(
     call: &veryl_analyzer::ir::FunctionCall,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
-    if !call.outputs.is_empty() && store.effectful_mut().is_none() {
-        return Err(ParserError::unsupported(
-            60,
-            LoweringPhase::CombLowering,
-            "function call with output arguments",
-            format!("{call}"),
-            Some(&call.comptime.token),
-        ));
-    }
-
     let Some(function) = module.functions.get(&call.id) else {
         return Err(ParserError::unsupported(
             62,
@@ -2011,12 +2035,7 @@ fn eval_function_call_expression(
     let ((ret_node, ret_sources), ret_bounds, final_local_store) =
         eval_function_body_return(module, &local_store, &function_body, ret_id, arena)?;
 
-    let output_bounds = if call.outputs.is_empty() {
-        BoundaryMap::default()
-    } else {
-        let caller_store = store
-            .effectful_mut()
-            .expect("output calls require effectful store");
+    let output_bounds = if let Some(caller_store) = store.effectful_mut() {
         let current_store = std::mem::take(caller_store);
         let (next_store, bounds) = super::apply_function_call_outputs(
             module,
@@ -2030,6 +2049,8 @@ fn eval_function_call_expression(
         )?;
         *caller_store = next_store;
         bounds
+    } else {
+        BoundaryMap::default()
     };
 
     Ok((
@@ -2053,7 +2074,22 @@ pub fn eval_expression(
     eval_expression_in_context(module, &mut store, expr, arena, context)
 }
 
-fn eval_expression_in_context(
+pub(super) fn eval_expression_effectful(
+    module: &Module,
+    store: &mut SymbolicStore<VarId>,
+    expr: &Expression,
+    arena: &mut SLTNodeArena<VarId>,
+    context_width: Option<usize>,
+) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+    let context = context_width.map(|width| ValueContext {
+        width,
+        signed: expression_signed(expr),
+    });
+    let mut store = ExpressionStore::Effectful(store);
+    eval_expression_in_context(module, &mut store, expr, arena, context)
+}
+
+pub(super) fn eval_expression_in_context(
     module: &Module,
     store: &mut ExpressionStore<'_>,
     expr: &Expression,
@@ -2718,7 +2754,7 @@ fn eval_factor(
                     boundaries: all_bounds,
                 } = super::eval_dynamic_select_offset(
                     module,
-                    store.current(),
+                    store,
                     *var_id,
                     index,
                     select,
@@ -2807,7 +2843,7 @@ fn eval_factor(
             Ok(((node, HashSet::default()), BoundaryMap::default()))
         }
         Factor::SystemFunctionCall(call) => {
-            eval_system_function_call(module, store.current(), call, arena, context)
+            eval_system_function_call(module, store, call, arena, context)
         }
         Factor::FunctionCall(call) => {
             let ((node, sources), bounds) =
@@ -2902,7 +2938,7 @@ pub fn coerce_node_width<A: Hash + Eq + Clone>(
 
 fn eval_system_function_call(
     module: &Module,
-    store: &SymbolicStore<VarId>,
+    store: &mut ExpressionStore<'_>,
     call: &SystemFunctionCall,
     arena: &mut SLTNodeArena<VarId>,
     context: Option<ValueContext>,
@@ -2910,7 +2946,7 @@ fn eval_system_function_call(
     let context_width = context.map(|context| context.width);
     match &call.kind {
         SystemFunctionKind::Bits(input) => {
-            let width = system_function_input_bits_width(module, store, &input.0, arena)?;
+            let width = system_function_input_bits_width(module, store.current(), &input.0, arena)?;
             let result = arena.alloc(SLTNode::Constant(
                 BigUint::from(width),
                 BigUint::from(0u8),
@@ -2926,7 +2962,7 @@ fn eval_system_function_call(
             Ok(((result, HashSet::default()), HashMap::default()))
         }
         SystemFunctionKind::Size(input) => {
-            let size = system_function_input_size(module, store, &input.0, arena)?;
+            let size = system_function_input_size(module, store.current(), &input.0, arena)?;
             let result = arena.alloc(SLTNode::Constant(
                 BigUint::from(size),
                 BigUint::from(0u8),
@@ -2942,7 +2978,8 @@ fn eval_system_function_call(
             Ok(((result, HashSet::default()), HashMap::default()))
         }
         SystemFunctionKind::Clog2(input) => {
-            let ((arg, sources), bounds) = eval_expression(module, store, &input.0, arena, None)?;
+            let ((arg, sources), bounds) =
+                eval_expression_in_context(module, store, &input.0, arena, None)?;
             let width = get_width(arg, arena);
             let mut result = arena.alloc(SLTNode::Constant(
                 BigUint::from(0u8),
@@ -2979,7 +3016,8 @@ fn eval_system_function_call(
             Ok(((result, sources), bounds))
         }
         SystemFunctionKind::Onehot(input) => {
-            let ((arg, sources), bounds) = eval_expression(module, store, &input.0, arena, None)?;
+            let ((arg, sources), bounds) =
+                eval_expression_in_context(module, store, &input.0, arena, None)?;
             let width = get_width(arg, arena);
             let zero = arena.alloc(SLTNode::Constant(
                 BigUint::from(0u8),
@@ -3007,7 +3045,8 @@ fn eval_system_function_call(
             Ok(((result, sources), bounds))
         }
         SystemFunctionKind::Signed(input) | SystemFunctionKind::Unsigned(input) => {
-            let ((arg, sources), bounds) = eval_expression(module, store, &input.0, arena, None)?;
+            let ((arg, sources), bounds) =
+                eval_expression_in_context(module, store, &input.0, arena, None)?;
             let signed = matches!(call.kind, SystemFunctionKind::Signed(_));
             Ok((
                 (

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -3515,6 +3515,7 @@ pub(super) fn is_signed(module: &Module, expr: NodeId, arena: &SLTNodeArena<VarI
             UnaryOp::Ident | UnaryOp::ToTwoState | UnaryOp::Minus | UnaryOp::BitNot,
             inner,
         ) => is_signed(module, *inner, arena),
+        SLTNode::Capture { expr, .. } => is_signed(module, *expr, arena),
         SLTNode::Mux {
             then_expr,
             else_expr,

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -993,6 +993,8 @@ pub(super) fn eval_function_body_return(
             ));
         }
 
+        let guard_state = state.clone();
+        let mut bound_store = state.store.clone();
         let (
             start,
             end,
@@ -1012,9 +1014,9 @@ pub(super) fn eval_function_body_return(
                 step,
             } => {
                 let (start, start_sources, start_bounds) =
-                    eval_for_bound_effectful(module, &mut state.store, range_start, arena)?;
+                    eval_for_bound_effectful(module, &mut bound_store, range_start, arena)?;
                 let (end, end_sources, end_bounds) =
-                    eval_for_bound_effectful(module, &mut state.store, range_end, arena)?;
+                    eval_for_bound_effectful(module, &mut bound_store, range_end, arena)?;
                 (
                     start,
                     end,
@@ -1035,9 +1037,9 @@ pub(super) fn eval_function_body_return(
                 step,
             } => {
                 let (start, start_sources, start_bounds) =
-                    eval_for_bound_effectful(module, &mut state.store, range_start, arena)?;
+                    eval_for_bound_effectful(module, &mut bound_store, range_start, arena)?;
                 let (end, end_sources, end_bounds) =
-                    eval_for_bound_effectful(module, &mut state.store, range_end, arena)?;
+                    eval_for_bound_effectful(module, &mut bound_store, range_end, arena)?;
                 (
                     start,
                     end,
@@ -1059,9 +1061,9 @@ pub(super) fn eval_function_body_return(
                 op,
             } => {
                 let (start, start_sources, start_bounds) =
-                    eval_for_bound_effectful(module, &mut state.store, range_start, arena)?;
+                    eval_for_bound_effectful(module, &mut bound_store, range_start, arena)?;
                 let (end, end_sources, end_bounds) =
-                    eval_for_bound_effectful(module, &mut state.store, range_end, arena)?;
+                    eval_for_bound_effectful(module, &mut bound_store, range_end, arena)?;
                 let step_op = match op {
                     Op::Mul => SLTStepOp::Mul,
                     Op::LogicShiftL | Op::ArithShiftL => SLTStepOp::Shl,
@@ -1089,8 +1091,16 @@ pub(super) fn eval_function_body_return(
                 )
             }
         };
-        state.boundaries = merge_boundaries(state.boundaries, start_bounds);
-        state.boundaries = merge_boundaries(state.boundaries, end_bounds);
+        let bound_boundaries = merge_boundaries(start_bounds, end_bounds);
+        state = apply_function_guard(
+            module,
+            guard_state,
+            bound_store,
+            bound_boundaries,
+            bool_node(arena, true)?,
+            HashSet::default(),
+            arena,
+        )?;
 
         let mut symbolic_store = state.store.clone();
         let mut written_accesses = HashMap::default();

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -623,7 +623,7 @@ pub(super) fn eval_function_body_return(
 
     fn eval_function_for(
         module: &Module,
-        state: FunctionControlState,
+        mut state: FunctionControlState,
         for_stmt: &ForStatement,
         ret_id: VarId,
         arena: &mut SLTNodeArena<VarId>,
@@ -681,9 +681,10 @@ pub(super) fn eval_function_body_return(
             ret_id: VarId,
             arena: &mut SLTNodeArena<VarId>,
         ) -> Result<FunctionLoopControlState, ParserError> {
+            let guard_state = state.clone();
             let (function, cond_expr, cond_sources) =
                 eval_function_condition(module, state.function.clone(), &if_stmt.cond, arena)?;
-            state.function = function;
+            state = apply_function_loop_continue_guard(module, guard_state, function, arena)?;
 
             if let Some(cond_val) = constant_bool(arena, cond_expr) {
                 let side = if cond_val {
@@ -793,15 +794,18 @@ pub(super) fn eval_function_body_return(
                     &arm.patterns,
                     arena,
                 )?;
-                state.function = apply_function_guard(
+                let next_function = apply_function_guard(
                     module,
-                    state.function,
+                    state.function.clone(),
                     next_store,
                     cond_bounds,
                     bool_node(arena, true)?,
                     HashSet::default(),
                     arena,
                 )?;
+                let guard_state = state.clone();
+                state =
+                    apply_function_loop_continue_guard(module, guard_state, next_function, arena)?;
                 let cond_expr = procedural_condition(arena, cond_expr)?;
                 let boundaries = state.function.boundaries.clone();
 
@@ -901,6 +905,7 @@ pub(super) fn eval_function_body_return(
                 })
             }
 
+            let guard_state = state.clone();
             let (function, target_node, target_sources) = eval_function_expression(
                 module,
                 state.function.clone(),
@@ -908,7 +913,7 @@ pub(super) fn eval_function_body_return(
                 None,
                 arena,
             )?;
-            state.function = function;
+            state = apply_function_loop_continue_guard(module, guard_state, function, arena)?;
             let target = EvaluatedCaseTarget {
                 node: target_node,
                 sources: target_sources,
@@ -988,6 +993,105 @@ pub(super) fn eval_function_body_return(
             ));
         }
 
+        let (
+            start,
+            end,
+            start_sources,
+            end_sources,
+            start_bounds,
+            end_bounds,
+            inclusive,
+            step,
+            step_op,
+            reverse,
+        ) = match &for_stmt.range {
+            ForRange::Forward {
+                start: range_start,
+                end: range_end,
+                inclusive,
+                step,
+            } => {
+                let (start, start_sources, start_bounds) =
+                    eval_for_bound_effectful(module, &mut state.store, range_start, arena)?;
+                let (end, end_sources, end_bounds) =
+                    eval_for_bound_effectful(module, &mut state.store, range_end, arena)?;
+                (
+                    start,
+                    end,
+                    start_sources,
+                    end_sources,
+                    start_bounds,
+                    end_bounds,
+                    *inclusive,
+                    *step,
+                    SLTStepOp::Add,
+                    false,
+                )
+            }
+            ForRange::Reverse {
+                start: range_start,
+                end: range_end,
+                inclusive,
+                step,
+            } => {
+                let (start, start_sources, start_bounds) =
+                    eval_for_bound_effectful(module, &mut state.store, range_start, arena)?;
+                let (end, end_sources, end_bounds) =
+                    eval_for_bound_effectful(module, &mut state.store, range_end, arena)?;
+                (
+                    start,
+                    end,
+                    start_sources,
+                    end_sources,
+                    start_bounds,
+                    end_bounds,
+                    *inclusive,
+                    *step,
+                    SLTStepOp::Add,
+                    true,
+                )
+            }
+            ForRange::Stepped {
+                start: range_start,
+                end: range_end,
+                inclusive,
+                step,
+                op,
+            } => {
+                let (start, start_sources, start_bounds) =
+                    eval_for_bound_effectful(module, &mut state.store, range_start, arena)?;
+                let (end, end_sources, end_bounds) =
+                    eval_for_bound_effectful(module, &mut state.store, range_end, arena)?;
+                let step_op = match op {
+                    Op::Mul => SLTStepOp::Mul,
+                    Op::LogicShiftL | Op::ArithShiftL => SLTStepOp::Shl,
+                    Op::BitOr => SLTStepOp::BitOr,
+                    Op::BitXor => SLTStepOp::BitXor,
+                    other => {
+                        return Err(ParserError::illegal_context(
+                            "for loop step operator",
+                            format!("{other:?}"),
+                            Some(&for_stmt.token),
+                        ));
+                    }
+                };
+                (
+                    start,
+                    end,
+                    start_sources,
+                    end_sources,
+                    start_bounds,
+                    end_bounds,
+                    *inclusive,
+                    *step,
+                    step_op,
+                    false,
+                )
+            }
+        };
+        state.boundaries = merge_boundaries(state.boundaries, start_bounds);
+        state.boundaries = merge_boundaries(state.boundaries, end_bounds);
+
         let mut symbolic_store = state.store.clone();
         let mut written_accesses = HashMap::default();
         collect_written_accesses(module, &for_stmt.body, &mut written_accesses)?;
@@ -1054,107 +1158,7 @@ pub(super) fn eval_function_body_return(
             |s, stmt| eval_function_loop_statement(module, s, stmt, ret_id, arena),
         )?;
         let iter_store_after = iter_state.function.store;
-        let mut merged_boundaries = iter_state.function.boundaries;
-
-        let (
-            start,
-            end,
-            start_sources,
-            end_sources,
-            start_bounds,
-            end_bounds,
-            inclusive,
-            step,
-            step_op,
-            reverse,
-        ) = match &for_stmt.range {
-            ForRange::Forward {
-                start: range_start,
-                end: range_end,
-                inclusive,
-                step,
-            } => {
-                let (start, start_sources, start_bounds) =
-                    eval_for_bound(module, &state.store, range_start, arena)?;
-                let (end, end_sources, end_bounds) =
-                    eval_for_bound(module, &state.store, range_end, arena)?;
-                (
-                    start,
-                    end,
-                    start_sources,
-                    end_sources,
-                    start_bounds,
-                    end_bounds,
-                    *inclusive,
-                    *step,
-                    SLTStepOp::Add,
-                    false,
-                )
-            }
-            ForRange::Reverse {
-                start: range_start,
-                end: range_end,
-                inclusive,
-                step,
-            } => {
-                let (start, start_sources, start_bounds) =
-                    eval_for_bound(module, &state.store, range_start, arena)?;
-                let (end, end_sources, end_bounds) =
-                    eval_for_bound(module, &state.store, range_end, arena)?;
-                (
-                    start,
-                    end,
-                    start_sources,
-                    end_sources,
-                    start_bounds,
-                    end_bounds,
-                    *inclusive,
-                    *step,
-                    SLTStepOp::Add,
-                    true,
-                )
-            }
-            ForRange::Stepped {
-                start: range_start,
-                end: range_end,
-                inclusive,
-                step,
-                op,
-            } => {
-                let (start, start_sources, start_bounds) =
-                    eval_for_bound(module, &state.store, range_start, arena)?;
-                let (end, end_sources, end_bounds) =
-                    eval_for_bound(module, &state.store, range_end, arena)?;
-                let step_op = match op {
-                    Op::Mul => SLTStepOp::Mul,
-                    Op::LogicShiftL | Op::ArithShiftL => SLTStepOp::Shl,
-                    Op::BitOr => SLTStepOp::BitOr,
-                    Op::BitXor => SLTStepOp::BitXor,
-                    other => {
-                        return Err(ParserError::illegal_context(
-                            "for loop step operator",
-                            format!("{other:?}"),
-                            Some(&for_stmt.token),
-                        ));
-                    }
-                };
-                (
-                    start,
-                    end,
-                    start_sources,
-                    end_sources,
-                    start_bounds,
-                    end_bounds,
-                    *inclusive,
-                    *step,
-                    step_op,
-                    false,
-                )
-            }
-        };
-
-        merged_boundaries = merge_boundaries(merged_boundaries, start_bounds);
-        merged_boundaries = merge_boundaries(merged_boundaries, end_bounds);
+        let merged_boundaries = iter_state.function.boundaries;
 
         let updates = extract_store_updates(&iter_store_before, &iter_store_after, arena)?;
         let folded_updates: Vec<_> = updates
@@ -1359,10 +1363,10 @@ pub(super) fn eval_function_body_return(
         ret_id: VarId,
         arena: &mut SLTNodeArena<VarId>,
     ) -> Result<FunctionLoopControlState, ParserError> {
+        let outer_state = state.clone();
         let (function, cond_expr, cond_sources) =
             eval_function_condition(module, state.function.clone(), &if_stmt.cond, arena)?;
         state.function = function;
-        let outer_state = state.clone();
 
         let executed_state = if let Some(cond_val) = constant_bool(arena, cond_expr) {
             let side = if cond_val {
@@ -1607,6 +1611,7 @@ pub(super) fn eval_function_body_return(
             })
         }
 
+        let outer_state = state.clone();
         let (function, target_node, target_sources) = eval_function_expression(
             module,
             state.function.clone(),
@@ -1619,7 +1624,6 @@ pub(super) fn eval_function_body_return(
             node: target_node,
             sources: target_sources,
         };
-        let outer_state = state.clone();
         let executed_state = eval_from_arm(module, state, case_stmt, &target, 0, ret_id, arena)?;
 
         if matches!(constant_bool(arena, outer_state.continue_expr), Some(true)) {

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -2066,16 +2066,8 @@ fn eval_function_call_expression(
 
     let mut arg_bounds = BoundaryMap::default();
     let mut evaluated_inputs = Vec::with_capacity(call.inputs.len());
-    for (arg_path, arg_expr) in &call.inputs {
-        let Some(arg_id) = function_body.arg_map.get(arg_path) else {
-            return Err(super::invalid_function_call_argument_error(
-                function,
-                arg_path,
-                "input argument does not match any formal argument",
-                call,
-            ));
-        };
-        let Some(arg_var) = module.variables.get(arg_id) else {
+    for (arg_id, arg_expr) in super::ordered_function_inputs(function, &function_body, call)? {
+        let Some(arg_var) = module.variables.get(&arg_id) else {
             return Err(ParserError::unsupported(
                 67,
                 LoweringPhase::CombLowering,
@@ -2093,7 +2085,7 @@ fn eval_function_call_expression(
             arg_node
         };
         arg_bounds = merge_boundaries(arg_bounds, bounds);
-        evaluated_inputs.push((*arg_id, arg_node, sources, arg_width));
+        evaluated_inputs.push((arg_id, arg_node, sources, arg_width));
     }
 
     for arg_path in function_body.arg_map.keys() {

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -2195,7 +2195,7 @@ pub(super) fn short_circuit_rhs_guard(
     Ok(arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, shortcut))?)
 }
 
-fn eval_case_comparison(
+pub(super) fn eval_case_comparison(
     module: &Module,
     store: &mut ExpressionStore<'_>,
     target_expr: &Expression,

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -13,23 +13,36 @@ use veryl_analyzer::ir::{CasePattern, Type, ValueVariant};
 use super::state::{FunctionControlState, FunctionLoopControlState};
 
 pub(super) enum ExpressionStore<'a> {
-    ReadOnly(&'a SymbolicStore<VarId>),
+    ReadOnly {
+        store: &'a SymbolicStore<VarId>,
+        reject_output_calls: bool,
+    },
     Effectful(&'a mut SymbolicStore<VarId>),
 }
 
 impl ExpressionStore<'_> {
     pub(super) fn current(&self) -> &SymbolicStore<VarId> {
         match self {
-            Self::ReadOnly(store) => store,
+            Self::ReadOnly { store, .. } => store,
             Self::Effectful(store) => store,
         }
     }
 
     fn effectful_mut(&mut self) -> Option<&mut SymbolicStore<VarId>> {
         match self {
-            Self::ReadOnly(_) => None,
+            Self::ReadOnly { .. } => None,
             Self::Effectful(store) => Some(store),
         }
+    }
+
+    fn rejects_output_calls(&self) -> bool {
+        matches!(
+            self,
+            Self::ReadOnly {
+                reject_output_calls: true,
+                ..
+            }
+        )
     }
 }
 
@@ -2046,6 +2059,16 @@ fn eval_function_call_expression(
     call: &veryl_analyzer::ir::FunctionCall,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+    if !call.outputs.is_empty() && store.rejects_output_calls() {
+        return Err(ParserError::unsupported(
+            60,
+            LoweringPhase::CombLowering,
+            "function call with output arguments",
+            format!("{call}"),
+            Some(&call.comptime.token),
+        ));
+    }
+
     let Some(function) = module.functions.get(&call.id) else {
         return Err(ParserError::unsupported(
             62,
@@ -2159,7 +2182,10 @@ pub fn eval_expression(
         width,
         signed: expression_signed(expr),
     });
-    let mut store = ExpressionStore::ReadOnly(store);
+    let mut store = ExpressionStore::ReadOnly {
+        store,
+        reject_output_calls: false,
+    };
     eval_expression_in_context(module, &mut store, expr, arena, context)
 }
 
@@ -2933,7 +2959,23 @@ pub fn eval_assignment_expression(
         ));
     }
 
-    let value = eval_expression(module, store, expr, arena, Some(target_width))?;
+    // Instance input glue has no effectful caller store in which a function
+    // output can be written back. Reject such calls instead of silently
+    // accepting their return value and discarding the output assignment.
+    let mut store = ExpressionStore::ReadOnly {
+        store,
+        reject_output_calls: true,
+    };
+    let value = eval_expression_in_context(
+        module,
+        &mut store,
+        expr,
+        arena,
+        Some(ValueContext {
+            width: target_width,
+            signed: expression_signed(expr),
+        }),
+    )?;
     finish_assignment_expression(expr, arena, target_width, value)
 }
 

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -2163,7 +2163,7 @@ pub fn eval_expression(
     eval_expression_in_context(module, &mut store, expr, arena, context)
 }
 
-pub(super) fn eval_expression_effectful(
+pub(crate) fn eval_expression_effectful(
     module: &Module,
     store: &mut SymbolicStore<VarId>,
     expr: &Expression,

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -2122,13 +2122,13 @@ fn eval_function_call_expression(
         let current_store = std::mem::take(caller_store);
         let (next_store, bounds) = super::apply_function_call_outputs(
             module,
+            function,
             current_store,
             BoundaryMap::default(),
             call,
             &function_body,
             &final_local_store,
             arena,
-            LoweringPhase::CombLowering,
         )?;
         *caller_store = next_store;
         bounds
@@ -2765,7 +2765,24 @@ pub(super) fn eval_expression_in_context(
                     branch_context,
                 )?;
 
-                let mut else_store = base_store;
+                // A known condition evaluates only its selected arm. An X/Z
+                // condition evaluates both arms in order, so the else arm must
+                // observe writes made by the then arm.
+                let not_cond = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, cond_expr))?;
+                let known_false = arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, not_cond))?;
+                let true_truth = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, not_cond))?;
+                let known_true = arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, true_truth))?;
+                let execute_then = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, known_false))?;
+                let after_then = super::merge_symbolic_stores(
+                    module,
+                    &then_store,
+                    &base_store,
+                    execute_then,
+                    &cond_sources,
+                    arena,
+                )?;
+
+                let mut else_store = after_then.clone();
                 let mut else_state = ExpressionStore::Effectful(&mut else_store);
                 let else_value = eval_expression_in_context(
                     module,
@@ -2775,17 +2792,18 @@ pub(super) fn eval_expression_in_context(
                     branch_context,
                 )?;
 
-                let merged_store = super::merge_symbolic_stores(
+                let execute_else = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, known_true))?;
+                let final_store = super::merge_symbolic_stores(
                     module,
-                    &then_store,
                     &else_store,
-                    cond_expr,
+                    &after_then,
+                    execute_else,
                     &cond_sources,
                     arena,
                 )?;
                 *store
                     .effectful_mut()
-                    .expect("effectful ternary must retain a mutable store") = merged_store;
+                    .expect("effectful ternary must retain a mutable store") = final_store;
                 (then_value, else_value)
             } else {
                 (

--- a/crates/celox-frontend-veryl/src/logic_tree/recover_unrolled.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/recover_unrolled.rs
@@ -11,7 +11,7 @@ use veryl_parser::token_range::TokenRange;
 
 use super::{
     ActiveGuard, BoundaryMap, NodeId, SLTForFoldGroupState, SLTNode, SLTNodeArena, SymbolicStore,
-    combine_active_guard, combine_parts_with_default, eval_expression, eval_statement,
+    combine_active_guard, combine_parts_with_default, eval_expression_effectful, eval_statement,
     eval_statement_with_recovery, get_width, merge_boundaries, procedural_condition,
     range_store_error,
 };
@@ -38,7 +38,7 @@ pub(super) fn eval_statements(
             if guarded_matches.len() == 1 {
                 let candidate = guarded_matches[0];
                 let ((guard, guard_sources), guard_boundaries) =
-                    eval_expression(module, &store, &if_stmt.cond, arena, None)?;
+                    eval_expression_effectful(module, &mut store, &if_stmt.cond, arena, None)?;
                 let guard = procedural_condition(arena, guard)?;
                 let guard = combine_active_guard(arena, active_guard, guard, &guard_sources)?;
                 if let Some((next_store, recovered_boundaries)) = recover_group(

--- a/crates/celox-frontend-veryl/src/logic_tree/recover_unrolled.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/recover_unrolled.rs
@@ -3907,7 +3907,7 @@ mod tests {
             .expect("always_comb must exist");
         let mut arena = SLTNodeArena::new();
         let (paths, _, _, _, _) =
-            parse_comb_with_loop_recovery(module, declaration, &mut arena, candidates)
+            parse_comb_with_loop_recovery(module, declaration, &mut arena, candidates, 0)
                 .expect("comb lowering must succeed");
         (paths, arena)
     }

--- a/crates/celox-frontend-veryl/src/logic_tree/recover_unrolled.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/recover_unrolled.rs
@@ -37,6 +37,7 @@ pub(super) fn eval_statements(
             let guarded_matches = matching_candidates(module, &if_stmt.true_side, candidates);
             if guarded_matches.len() == 1 {
                 let candidate = guarded_matches[0];
+                let store_before_probe = store.clone();
                 let ((guard, guard_sources), guard_boundaries) =
                     eval_expression_effectful(module, &mut store, &if_stmt.cond, arena, None)?;
                 let guard = procedural_condition(arena, guard)?;
@@ -57,6 +58,7 @@ pub(super) fn eval_statements(
                     index += 1;
                     continue;
                 }
+                store = store_before_probe;
             }
         }
 
@@ -4456,6 +4458,71 @@ mod tests {
         candidates[0].unrolled.iterations[2].value = 9;
         let (_, arena) = parse_with_candidates(&module, &candidates);
         assert_eq!(group_count(&arena), 0);
+    }
+
+    #[test]
+    fn failed_guarded_probe_restores_effectful_guard_store() {
+        let (module, provenance) = analyze(
+            r#"
+                module Top (
+                    en         : input  logic,
+                    bits       : input  logic<4>,
+                    guard_calls: output logic<8>,
+                ) {
+                    function guard (
+                        enabled : input  logic,
+                        previous: input  logic<8>,
+                        next    : output logic<8>,
+                    ) -> logic {
+                        next = previous + 8'd1;
+                        return enabled;
+                    }
+
+                    var state: logic<4>;
+                    var calls: logic<8>;
+                    always_comb {
+                        state = 4'd0;
+                        calls = 8'd0;
+                        if guard(en, calls, calls) {
+                            for i in 0..4 {
+                                state[i] = bits[i];
+                            }
+                        }
+                        guard_calls = calls;
+                    }
+                }
+            "#,
+        );
+        let mut candidates = provenance.candidates_for_module(&module);
+        assert_eq!(candidates.len(), 1);
+        // Keep the source-range match intact while making recovery decline
+        // the candidate after the speculative guard evaluation.
+        candidates[0].unrolled.iterations[2].value = 9;
+
+        let (paths, arena) = parse_with_candidates(&module, &candidates);
+        assert_eq!(group_count(&arena), 0);
+        let guard_calls = variable(&module, "guard_calls");
+        let path = paths
+            .iter()
+            .find(|path| {
+                path.target
+                    .var()
+                    .is_some_and(|target| target.id == guard_calls)
+            })
+            .expect("guard_calls path must exist");
+        let SLTNode::Binary(lhs, BinaryOp::Add, rhs) = arena.get(path.expr) else {
+            panic!("guard_calls expression: {:?}", arena.get(path.expr));
+        };
+        assert!(matches!(
+            arena.get(*lhs),
+            SLTNode::Constant(value, mask, 8, false)
+                if value.is_zero() && mask.is_zero()
+        ));
+        assert!(matches!(
+            arena.get(*rhs),
+            SLTNode::Constant(value, mask, 8, false)
+                if value == &BigUint::from(1u8) && mask.is_zero()
+        ));
     }
 
     #[test]

--- a/crates/celox-frontend-veryl/src/logic_tree/recover_unrolled.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/recover_unrolled.rs
@@ -2011,7 +2011,7 @@ fn slt_reaches_input_id(
                 pending.push(*lhs);
                 pending.push(*rhs);
             }
-            SLTNode::Unary(_, inner) => pending.push(*inner),
+            SLTNode::Unary(_, inner) | SLTNode::Capture { expr: inner, .. } => pending.push(*inner),
             SLTNode::Mux {
                 cond,
                 then_expr,
@@ -2055,7 +2055,7 @@ fn collect_slt_input_sources(
                 pending.push(*lhs);
                 pending.push(*rhs);
             }
-            SLTNode::Unary(_, inner) => pending.push(*inner),
+            SLTNode::Unary(_, inner) | SLTNode::Capture { expr: inner, .. } => pending.push(*inner),
             SLTNode::Mux {
                 cond,
                 then_expr,
@@ -2285,7 +2285,7 @@ fn specialize_slt_node(
                 pending.push(lhs);
                 pending.push(rhs);
             }
-            SLTNode::Unary(_, inner) => pending.push(inner),
+            SLTNode::Unary(_, inner) | SLTNode::Capture { expr: inner, .. } => pending.push(inner),
             SLTNode::Mux {
                 cond,
                 then_expr,
@@ -2450,6 +2450,12 @@ fn specialize_slt_node(
                     arena.alloc(SLTNode::Unary(op, inner)).ok()?
                 }
             }
+            SLTNode::Capture { expr, key } => arena
+                .alloc(SLTNode::Capture {
+                    expr: *cache.get(&expr)?,
+                    key,
+                })
+                .ok()?,
             SLTNode::Mux {
                 cond,
                 then_expr,
@@ -2910,6 +2916,7 @@ fn proof_node_signed(node: NodeId, arena: &SLTNodeArena<VarId>) -> bool {
             UnaryOp::Ident | UnaryOp::ToTwoState | UnaryOp::Minus | UnaryOp::BitNot,
             inner,
         ) => proof_node_signed(*inner, arena),
+        SLTNode::Capture { expr, .. } => proof_node_signed(*expr, arena),
         SLTNode::Mux {
             then_expr,
             else_expr,
@@ -3585,7 +3592,9 @@ fn collect_template_inputs(
             collect_template_inputs(*lhs, arena, visited, inputs)
                 && collect_template_inputs(*rhs, arena, visited, inputs)
         }
-        SLTNode::Unary(_, inner) => collect_template_inputs(*inner, arena, visited, inputs),
+        SLTNode::Unary(_, inner) | SLTNode::Capture { expr: inner, .. } => {
+            collect_template_inputs(*inner, arena, visited, inputs)
+        }
         SLTNode::Mux {
             cond,
             then_expr,
@@ -5267,7 +5276,7 @@ mod tests {
                 update_has_dynamic_loop_index(*lhs, loop_var, arena, visited)
                     || update_has_dynamic_loop_index(*rhs, loop_var, arena, visited)
             }
-            SLTNode::Unary(_, inner) => {
+            SLTNode::Unary(_, inner) | SLTNode::Capture { expr: inner, .. } => {
                 update_has_dynamic_loop_index(*inner, loop_var, arena, visited)
             }
             SLTNode::Mux {
@@ -5332,7 +5341,7 @@ mod tests {
                 collect_narrow_dynamic_input_widths(*lhs, loop_var, arena, visited, widths);
                 collect_narrow_dynamic_input_widths(*rhs, loop_var, arena, visited, widths);
             }
-            SLTNode::Unary(_, inner) => {
+            SLTNode::Unary(_, inner) | SLTNode::Capture { expr: inner, .. } => {
                 collect_narrow_dynamic_input_widths(*inner, loop_var, arena, visited, widths)
             }
             SLTNode::Mux {

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -1325,13 +1325,14 @@ impl<'a> ModuleParser<'a> {
             // "Current offset starts at 0" and "dst in dsts.iter().rev()".
             for dst in output.dst.iter().rev() {
                 for address in dst.index.0.iter().chain(dst.select.0.iter()) {
-                    collect_and_advance_expression(
+                    let address_sources = collect_and_advance_expression(
                         self.module,
                         &mut output_effect_store,
                         address,
                         &mut self.arena,
                         &mut output_effects,
                     )?;
+                    output_effects.sensitivity.extend(address_sources);
                     collect_written_expression(
                         self.module,
                         address,

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -59,7 +59,7 @@ pub struct ModuleParser<'a> {
 
 fn build_dynamic_output_glue(
     module: &Module,
-    parent_store: &SymbolicStore<VarId>,
+    parent_store: &mut SymbolicStore<VarId>,
     parent_arena: &mut SLTNodeArena<VarId>,
     glue_arena: &mut SLTNodeArena<GlueAddr>,
     dst: &AssignDestination,
@@ -91,8 +91,13 @@ fn build_dynamic_output_glue(
     let dim_limit = geometry.dimension_count;
 
     for (dimension, index_expr) in index_exprs[..dim_limit].iter().enumerate() {
-        let ((index, _), _) =
-            eval_expression(module, parent_store, index_expr, parent_arena, None)?;
+        let ((index, _), _) = crate::logic_tree::eval_expression_effectful(
+            module,
+            parent_store,
+            index_expr,
+            parent_arena,
+            None,
+        )?;
         let mut cache = HashMap::default();
         let mapped = parent_arena.get(index).map_addr(
             index,
@@ -161,8 +166,13 @@ fn build_dynamic_output_glue(
             PartSelectGeometry::PlusColon { .. }
             | PartSelectGeometry::MinusColon { .. }
             | PartSelectGeometry::Step { .. } => {
-                let ((anchor, _), _) =
-                    eval_expression(module, parent_store, anchor_expr, parent_arena, None)?;
+                let ((anchor, _), _) = crate::logic_tree::eval_expression_effectful(
+                    module,
+                    parent_store,
+                    anchor_expr,
+                    parent_arena,
+                    None,
+                )?;
                 let mut cache = HashMap::default();
                 let anchor = parent_arena.get(anchor).map_addr(
                     anchor,
@@ -1025,11 +1035,34 @@ impl<'a> ModuleParser<'a> {
 
             // LHS: output.dst (AssignDestination).
             let mut current_offset = 0usize;
+            let mut destination_store = parent_store.clone();
+            let mut destination_written_accesses = HashMap::default();
+            let mut destination_address_sources = HashMap::default();
             // Iterate destinations from LSB (last in list for multi-dst assign usually? No wait)
             // `emit_multi_dst_assign` iterates `dsts.iter().rev()`.
             // So we strictly follow `emit_multi_dst_assign` logic.
             // "Current offset starts at 0" and "dst in dsts.iter().rev()".
             for dst in output.dst.iter().rev() {
+                for address in dst
+                    .index
+                    .0
+                    .iter()
+                    .chain(dst.select.0.iter())
+                    .chain(dst.select.1.iter().map(|(_, expression)| expression))
+                {
+                    collect_written_expression(
+                        self.module,
+                        address,
+                        &mut destination_written_accesses,
+                    )?;
+                    collect_parent_output_address_sources(
+                        self.module,
+                        &destination_store,
+                        address,
+                        &mut self.arena,
+                        &mut destination_address_sources,
+                    )?;
+                }
                 let prefix_access = eval_var_select(self.module, dst.id, &dst.index, &dst.select)?;
                 let part_width = get_access_width(self.module, dst.id, &dst.index, &dst.select)?;
 
@@ -1081,7 +1114,7 @@ impl<'a> ModuleParser<'a> {
                     } else {
                         build_dynamic_output_glue(
                             self.module,
-                            &parent_store,
+                            &mut destination_store,
                             &mut self.arena,
                             &mut glue_arena,
                             dst,
@@ -1110,6 +1143,14 @@ impl<'a> ModuleParser<'a> {
 
                 current_offset = slice_end;
             }
+            output_ports.extend(build_parent_effect_glue(
+                &parent_store,
+                &destination_store,
+                &destination_written_accesses,
+                &destination_address_sources,
+                &self.arena,
+                &mut glue_arena,
+            )?);
             if current_offset != width {
                 return Err(ParserError::illegal_context(
                     "output port destination",

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -608,26 +608,18 @@ fn collect_parent_output_address_sources(
             collect_parent_output_address_sources(module, store, else_expression, arena, out)
         }
         Expression::Concatenation(parts, _) => {
-            for (part, repeat) in parts {
+            for (part, _) in parts {
                 collect_parent_output_address_sources(module, store, part, arena, out)?;
-                if let Some(repeat) = repeat {
-                    collect_parent_output_address_sources(module, store, repeat, arena, out)?;
-                }
             }
             Ok(())
         }
         Expression::ArrayLiteral(items, _) => {
             for item in items {
                 match item {
-                    ArrayLiteralItem::Value(expression, repeat) => {
+                    ArrayLiteralItem::Value(expression, _) => {
                         collect_parent_output_address_sources(
                             module, store, expression, arena, out,
                         )?;
-                        if let Some(repeat) = repeat {
-                            collect_parent_output_address_sources(
-                                module, store, repeat, arena, out,
-                            )?;
-                        }
                     }
                     ArrayLiteralItem::Defaul(expression) => {
                         collect_parent_output_address_sources(
@@ -1477,6 +1469,32 @@ impl<'a> ModuleParser<'a> {
                     )?;
                     destination_store = next_store;
                 }
+
+                // Runtime effects in a later destination execute after this
+                // child slice has been written. Model that statement position
+                // with a parent read: scheduling orders the observer after the
+                // corresponding glue path, and capture then sees the actual
+                // child-driven value without introducing a child VarId into
+                // the parent module arena.
+                let effect_preview = self.arena.alloc(SLTNode::Input {
+                    variable: dst.id,
+                    signed: self.module.variables[&dst.id].r#type.signed,
+                    index: vec![],
+                    access,
+                })?;
+                let effect_sources =
+                    std::iter::once(VarAtomBase::new(dst.id, access.lsb, access.msb)).collect();
+                output_effect_store
+                    .get_mut(&dst.id)
+                    .expect("output effect store contains every parent variable")
+                    .update(access, Some((effect_preview, effect_sources)))
+                    .map_err(|error| {
+                        ParserError::illegal_context(
+                            "output connection effect preview",
+                            error.to_string(),
+                            Some(&dst.token),
+                        )
+                    })?;
 
                 current_offset = slice_end;
             }

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -865,9 +865,16 @@ impl<'a> ModuleParser<'a> {
             if expression_contains_runtime_effect(self.module, &input.expr) {
                 let arena_start = self.arena.len();
                 let mut effects = CombEffectCollector::default();
+                let mut effect_store = SymbolicStore::default();
+                for (&id, variable) in &self.module.variables {
+                    effect_store.insert(
+                        id,
+                        RangeStore::new(None, resolve_total_width(self.module, variable)?),
+                    );
+                }
                 collect_expression_effects(
                     self.module,
-                    &parent_store,
+                    &effect_store,
                     &input.expr,
                     &mut self.arena,
                     &mut effects,

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -1324,13 +1324,7 @@ impl<'a> ModuleParser<'a> {
             // So we strictly follow `emit_multi_dst_assign` logic.
             // "Current offset starts at 0" and "dst in dsts.iter().rev()".
             for dst in output.dst.iter().rev() {
-                for address in dst
-                    .index
-                    .0
-                    .iter()
-                    .chain(dst.select.0.iter())
-                    .chain(dst.select.1.iter().map(|(_, expression)| expression))
-                {
+                for address in dst.index.0.iter().chain(dst.select.0.iter()) {
                     collect_and_advance_expression(
                         self.module,
                         &mut output_effect_store,

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -997,19 +997,20 @@ impl<'a> ModuleParser<'a> {
         decl: &veryl_analyzer::ir::CombDeclaration,
     ) -> Result<(), ParserError> {
         let arena_start = self.arena.len();
+        let site_offset = self.comb_runtime_event_sites.len() as u32;
         let (paths, store, boundaries, mut observers, sites) = parse_comb_with_loop_recovery(
             self.module,
             decl,
             &mut self.arena,
             &self.loop_candidates,
+            site_offset,
         )?;
-        let site_offset = self.comb_runtime_event_sites.len();
         for observer in &mut observers {
-            observer.site_id += site_offset as u32;
-            observer.activation_group = site_offset as u32;
+            observer.site_id += site_offset;
+            observer.activation_group = site_offset;
         }
         let arena_end = self.arena.len();
-        remap_for_effect_site_ids(&mut self.arena, arena_start..arena_end, site_offset as u32)?;
+        remap_for_effect_site_ids(&mut self.arena, arena_start..arena_end, site_offset)?;
         self.store.extend(store);
         self.comb_blocks.extend(paths);
         self.comb_observers.extend(observers);
@@ -1159,7 +1160,9 @@ impl<'a> ModuleParser<'a> {
 
             if expression_contains_runtime_effect(self.module, &input.expr) {
                 let arena_start = self.arena.len();
-                let mut effects = CombEffectCollector::default();
+                let mut effects = CombEffectCollector::with_capture_namespace(
+                    self.comb_runtime_event_sites.len() as u32,
+                );
                 let mut effect_store = SymbolicStore::default();
                 for (&id, variable) in &self.module.variables {
                     effect_store.insert(
@@ -1311,7 +1314,9 @@ impl<'a> ModuleParser<'a> {
             let mut destination_address_sources = HashMap::default();
             let mut composed_output_accesses = Vec::new();
             let output_effect_arena_start = self.arena.len();
-            let mut output_effects = CombEffectCollector::default();
+            let mut output_effects = CombEffectCollector::with_capture_namespace(
+                self.comb_runtime_event_sites.len() as u32,
+            );
             let mut output_effect_store = SymbolicStore::default();
             for (&id, variable) in &self.module.variables {
                 output_effect_store.insert(

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -773,6 +773,7 @@ fn build_parent_effect_glue(
                         local_inputs: Vec::new(),
                         order_before: HashSet::default(),
                         comb_capture_enable_sites: Vec::new(),
+                        comb_capture_enable_always: false,
                         pre_lower_nodes: Vec::new(),
                     },
                 ));
@@ -1230,6 +1231,7 @@ impl<'a> ModuleParser<'a> {
                 local_inputs: Vec::new(),
                 order_before: HashSet::default(),
                 comb_capture_enable_sites: Vec::new(),
+                comb_capture_enable_always: false,
                 pre_lower_nodes: Vec::new(),
             };
 
@@ -1447,6 +1449,7 @@ impl<'a> ModuleParser<'a> {
                     local_inputs: Vec::new(),
                     order_before: HashSet::default(),
                     comb_capture_enable_sites: Vec::new(),
+                    comb_capture_enable_always: false,
                     pre_lower_nodes: Vec::new(),
                     expr,
                 };
@@ -1509,6 +1512,7 @@ impl<'a> ModuleParser<'a> {
             for (_, path) in &mut output_ports[output_port_start..] {
                 path.comb_capture_enable_sites
                     .extend(output_effect_site_ids.iter().copied());
+                path.comb_capture_enable_always = !output_effect_site_ids.is_empty();
             }
             let mut remaining_written_accesses = destination_written_accesses.clone();
             subtract_composed_accesses(&mut remaining_written_accesses, &composed_output_accesses);

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -10,7 +10,8 @@ use crate::{
     bitslicer::BitSlicer,
     ff::FfParser,
     logic_tree::{
-        SymbolicStore, coerce_node_width, eval_assignment_expression, eval_expression, get_width,
+        SymbolicStore, coerce_node_width, collect_written_expression,
+        eval_assignment_expression_effectful, eval_expression, get_width,
         parse_comb_with_loop_recovery,
     },
     loop_provenance::{LoopProvenance, LoopRecoveryCandidate},
@@ -295,6 +296,99 @@ fn build_dynamic_output_glue(
     Ok((result, prefix, sources, previous_sources, address_sources))
 }
 
+fn build_parent_effect_glue(
+    store: &SymbolicStore<VarId>,
+    written_accesses: &HashMap<VarId, Vec<BitAccess>>,
+    parent_arena: &SLTNodeArena<VarId>,
+    glue_arena: &mut SLTNodeArena<GlueAddr>,
+) -> Result<Vec<(Vec<VarId>, LogicPath<GlueAddr>)>, ParserError> {
+    let mut paths = Vec::new();
+
+    for (id, accesses) in written_accesses {
+        let Some(range_store) = store.get(id) else {
+            continue;
+        };
+        let mut emitted = BTreeSet::new();
+
+        for (&lsb, (value, width, origin)) in &range_store.ranges {
+            let Some((expr, _)) = value else {
+                continue;
+            };
+            let msb = lsb
+                .checked_add(*width)
+                .and_then(|end| end.checked_sub(1))
+                .ok_or_else(|| {
+                    ParserError::illegal_context(
+                        "instance input function output",
+                        "symbolic output range overflows usize",
+                        None,
+                    )
+                })?;
+            let stored_access = BitAccess::new(lsb, msb);
+
+            for written_access in accesses {
+                let target_lsb = stored_access.lsb.max(written_access.lsb);
+                let target_msb = stored_access.msb.min(written_access.msb);
+                if target_lsb > target_msb || !emitted.insert((target_lsb, target_msb)) {
+                    continue;
+                }
+
+                let target_width = target_msb - target_lsb + 1;
+                let relative_lsb = target_lsb.checked_sub(*origin).ok_or_else(|| {
+                    ParserError::illegal_context(
+                        "instance input function output",
+                        "symbolic output range precedes its source origin",
+                        None,
+                    )
+                })?;
+                let relative_msb = relative_lsb + target_width - 1;
+                let mut cache = HashMap::default();
+                let mapped = parent_arena.get(*expr).map_addr(
+                    *expr,
+                    parent_arena,
+                    glue_arena,
+                    &mut cache,
+                    &|var_id| GlueAddr::Parent(*var_id),
+                )?;
+                let mapped = if relative_lsb == 0 && target_width == get_width(mapped, glue_arena) {
+                    mapped
+                } else {
+                    glue_arena.alloc(SLTNode::Slice {
+                        expr: mapped,
+                        access: BitAccess::new(relative_lsb, relative_msb),
+                    })?
+                };
+                let sources = collect_glue_sources(mapped, glue_arena);
+                let target = VarAtomBase::new(GlueAddr::Parent(*id), target_lsb, target_msb);
+                let previous_sources = sources
+                    .iter()
+                    .copied()
+                    .filter(|source| {
+                        source.id == target.id && source.access.overlaps(&target.access)
+                    })
+                    .collect();
+
+                paths.push((
+                    vec![*id],
+                    LogicPath {
+                        target: LogicPathTarget::Var(target),
+                        expr: mapped,
+                        sources,
+                        previous_sources,
+                        address_sources: HashSet::default(),
+                        local_inputs: Vec::new(),
+                        order_before: HashSet::default(),
+                        comb_capture_enable_sites: Vec::new(),
+                        pre_lower_nodes: Vec::new(),
+                    },
+                ));
+            }
+        }
+    }
+
+    Ok(paths)
+}
+
 fn verify_glue_block(
     block: &GlueBlock,
     variable_widths: &HashMap<GlueAddr, usize>,
@@ -524,6 +618,7 @@ impl<'a> ModuleParser<'a> {
 
         // 1. Inputs (Parent -> Child)
         let mut input_ports = Vec::new();
+        let mut output_ports = Vec::new();
         let mut glue_arena = SLTNodeArena::<GlueAddr>::new();
 
         // Parent context store
@@ -556,9 +651,12 @@ impl<'a> ModuleParser<'a> {
                     Some(&input.expr.token_range()),
                 ));
             }
-            let ((expr_node, expr_sources), _bounds) = eval_assignment_expression(
+            let mut written_accesses = HashMap::default();
+            collect_written_expression(self.module, &input.expr, &mut written_accesses)?;
+            let mut connection_store = parent_store.clone();
+            let ((expr_node, expr_sources), _bounds) = eval_assignment_expression_effectful(
                 self.module,
-                &parent_store,
+                &mut connection_store,
                 &input.expr,
                 &mut self.arena,
                 width,
@@ -592,11 +690,15 @@ impl<'a> ModuleParser<'a> {
 
             let parent_vars: Vec<_> = expr_sources.iter().map(|s| s.id).collect();
             input_ports.push((parent_vars, path));
+            output_ports.extend(build_parent_effect_glue(
+                &connection_store,
+                &written_accesses,
+                &self.arena,
+                &mut glue_arena,
+            )?);
         }
 
         // 2. Outputs (Child -> Parent)
-        let mut output_ports = Vec::new();
-
         for output in &decl.outputs {
             // The analyzer includes deliberately unconnected child outputs
             // with an empty destination list. They produce no parent glue;

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -2204,6 +2204,9 @@ fn collect_glue_sources_with_window(
         SLTNode::Unary(_, inner) => {
             collect_glue_sources_with_window(*inner, None, arena, set);
         }
+        SLTNode::Capture { expr, .. } => {
+            collect_glue_sources_with_window(*expr, window, arena, set);
+        }
         SLTNode::Mux {
             cond,
             then_expr,

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -10,10 +10,10 @@ use crate::{
     bitslicer::BitSlicer,
     ff::FfParser,
     logic_tree::{
-        CombEffectCollector, SymbolicStore, coerce_node_width, collect_expression_effects,
-        collect_written_expression, eval_assignment_expression_effectful, eval_expression,
-        expression_contains_runtime_effect, get_width, parse_comb_with_loop_recovery,
-        subtract_written_sensitivity,
+        CombEffectCollector, SymbolicStore, coerce_node_width, collect_and_advance_expression,
+        collect_expression_effects, collect_written_expression, combine_parts_with_default,
+        eval_assignment_expression_effectful, eval_expression, expression_contains_runtime_effect,
+        get_width, parse_comb_with_loop_recovery, subtract_written_sensitivity,
     },
     loop_provenance::{LoopProvenance, LoopRecoveryCandidate},
     registry::get_port_type,
@@ -247,12 +247,36 @@ fn build_dynamic_output_glue(
         ));
     }
     let full_access = BitAccess::new(0, variable_width - 1);
-    let old_value = glue_arena.alloc(SLTNode::Input {
-        variable: GlueAddr::Parent(dst.id),
-        signed: variable.r#type.signed,
-        index: Vec::new(),
-        access: full_access,
+    let range_store = parent_store.get(&dst.id).ok_or_else(|| {
+        ParserError::illegal_context(
+            "dynamic output port destination",
+            "destination variable is absent from the parent symbolic store",
+            Some(&dst.token),
+        )
     })?;
+    let parts = range_store.get_parts(full_access).map_err(|error| {
+        ParserError::illegal_context(
+            "dynamic output port destination",
+            error.to_string(),
+            Some(&dst.token),
+        )
+    })?;
+    let (old_value, _) =
+        combine_parts_with_default(dst.id, 0, parts, parent_arena).map_err(|error| {
+            ParserError::SltVerify {
+                phase: "dynamic output port destination",
+                error,
+            }
+        })?;
+    let mut cache = HashMap::default();
+    let old_value = parent_arena.get(old_value).map_addr(
+        old_value,
+        parent_arena,
+        glue_arena,
+        &mut cache,
+        &|id| GlueAddr::Parent(*id),
+    )?;
+    sources.extend(collect_glue_sources(old_value, glue_arena));
 
     let low_mask = (BigUint::from(1u8) << access_width) - BigUint::from(1u8);
     let low_mask = glue_arena.alloc(SLTNode::Constant(
@@ -591,6 +615,32 @@ fn build_parent_effect_glue(
     Ok(paths)
 }
 
+fn subtract_composed_accesses(
+    written_accesses: &mut HashMap<VarId, Vec<BitAccess>>,
+    composed_accesses: &[(VarId, BitAccess)],
+) {
+    for &(id, composed) in composed_accesses {
+        let Some(accesses) = written_accesses.get_mut(&id) else {
+            continue;
+        };
+        let mut remaining = Vec::new();
+        for access in accesses.drain(..) {
+            if !access.overlaps(&composed) {
+                remaining.push(access);
+                continue;
+            }
+            if access.lsb < composed.lsb {
+                remaining.push(BitAccess::new(access.lsb, composed.lsb - 1));
+            }
+            if access.msb > composed.msb {
+                remaining.push(BitAccess::new(composed.msb + 1, access.msb));
+            }
+        }
+        *accesses = remaining;
+    }
+    written_accesses.retain(|_, accesses| !accesses.is_empty());
+}
+
 fn verify_glue_block(
     block: &GlueBlock,
     variable_widths: &HashMap<GlueAddr, usize>,
@@ -798,6 +848,64 @@ impl<'a> ModuleParser<'a> {
         Ok(())
     }
 
+    fn attach_connection_effects(
+        &mut self,
+        arena_start: usize,
+        mut effects: CombEffectCollector,
+        written_accesses: &HashMap<VarId, Vec<BitAccess>>,
+        process_sensitivity: HashSet<VarAtomBase<VarId>>,
+        preserved_address_sources: HashSet<VarAtomBase<VarId>>,
+    ) -> Result<(), ParserError> {
+        if effects.observers.is_empty() && effects.sites.is_empty() {
+            return Ok(());
+        }
+
+        let written_atoms: Vec<_> = written_accesses
+            .iter()
+            .flat_map(|(&id, accesses)| {
+                accesses
+                    .iter()
+                    .map(move |access| VarAtomBase::new(id, access.lsb, access.msb))
+            })
+            .collect();
+        let mut process_sensitivity =
+            subtract_written_sensitivity(process_sensitivity, &written_atoms);
+        process_sensitivity.extend(preserved_address_sources);
+        let process_sensitivity: Vec<_> = process_sensitivity.into_iter().collect();
+        for observer in &mut effects.observers {
+            observer.sensitivity = process_sensitivity.clone();
+            observer.written_input_atoms = observer
+                .observed_inputs
+                .iter()
+                .chain(observer.position_inputs.iter())
+                .copied()
+                .filter(|atom| {
+                    written_atoms.iter().any(|written| {
+                        written.id == atom.id && written.access.overlaps(&atom.access)
+                    })
+                })
+                .collect();
+            observer.written_inputs = observer
+                .written_input_atoms
+                .iter()
+                .map(|atom| atom.id)
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect();
+        }
+
+        let site_offset = self.comb_runtime_event_sites.len();
+        for observer in &mut effects.observers {
+            observer.site_id += site_offset as u32;
+            observer.activation_group = site_offset as u32;
+        }
+        let arena_end = self.arena.len();
+        remap_for_effect_site_ids(&mut self.arena, arena_start..arena_end, site_offset as u32)?;
+        self.comb_observers.extend(effects.observers);
+        self.comb_runtime_event_sites.extend(effects.sites);
+        Ok(())
+    }
+
     fn parse_inst_declaration(
         &mut self,
         decl: &InstDeclaration,
@@ -890,14 +998,6 @@ impl<'a> ModuleParser<'a> {
                     &mut effects,
                 )?;
 
-                let written_atoms: Vec<_> = written_accesses
-                    .iter()
-                    .flat_map(|(&id, accesses)| {
-                        accesses
-                            .iter()
-                            .map(move |access| VarAtomBase::new(id, access.lsb, access.msb))
-                    })
-                    .collect();
                 let mut process_sensitivity = std::mem::take(&mut effects.sensitivity);
                 process_sensitivity.extend(expr_sources.iter().copied());
                 for (&id, accesses) in &written_accesses {
@@ -918,49 +1018,17 @@ impl<'a> ModuleParser<'a> {
                         }
                     }
                 }
-                let mut process_sensitivity =
-                    subtract_written_sensitivity(process_sensitivity, &written_atoms);
-                process_sensitivity.extend(
-                    output_address_sources
-                        .values()
-                        .flat_map(|sources| sources.iter().copied()),
-                );
-                let process_sensitivity: Vec<_> = process_sensitivity.into_iter().collect();
-                for observer in &mut effects.observers {
-                    observer.sensitivity = process_sensitivity.clone();
-                    observer.written_input_atoms = observer
-                        .observed_inputs
-                        .iter()
-                        .chain(observer.position_inputs.iter())
-                        .copied()
-                        .filter(|atom| {
-                            written_atoms.iter().any(|written| {
-                                written.id == atom.id && written.access.overlaps(&atom.access)
-                            })
-                        })
-                        .collect();
-                    observer.written_inputs = observer
-                        .written_input_atoms
-                        .iter()
-                        .map(|atom| atom.id)
-                        .collect::<HashSet<_>>()
-                        .into_iter()
-                        .collect();
-                }
-
-                let site_offset = self.comb_runtime_event_sites.len();
-                for observer in &mut effects.observers {
-                    observer.site_id += site_offset as u32;
-                    observer.activation_group = site_offset as u32;
-                }
-                let arena_end = self.arena.len();
-                remap_for_effect_site_ids(
-                    &mut self.arena,
-                    arena_start..arena_end,
-                    site_offset as u32,
+                let preserved_address_sources = output_address_sources
+                    .values()
+                    .flat_map(|sources| sources.iter().copied())
+                    .collect();
+                self.attach_connection_effects(
+                    arena_start,
+                    effects,
+                    &written_accesses,
+                    process_sensitivity,
+                    preserved_address_sources,
                 )?;
-                self.comb_observers.extend(effects.observers);
-                self.comb_runtime_event_sites.extend(effects.sites);
             }
 
             // Map Parent VarId to GlueAddr::Parent
@@ -1038,6 +1106,16 @@ impl<'a> ModuleParser<'a> {
             let mut destination_store = parent_store.clone();
             let mut destination_written_accesses = HashMap::default();
             let mut destination_address_sources = HashMap::default();
+            let mut composed_output_accesses = Vec::new();
+            let output_effect_arena_start = self.arena.len();
+            let mut output_effects = CombEffectCollector::default();
+            let mut output_effect_store = SymbolicStore::default();
+            for (&id, variable) in &self.module.variables {
+                output_effect_store.insert(
+                    id,
+                    RangeStore::new(None, resolve_total_width(self.module, variable)?),
+                );
+            }
             // Iterate destinations from LSB (last in list for multi-dst assign usually? No wait)
             // `emit_multi_dst_assign` iterates `dsts.iter().rev()`.
             // So we strictly follow `emit_multi_dst_assign` logic.
@@ -1050,6 +1128,13 @@ impl<'a> ModuleParser<'a> {
                     .chain(dst.select.0.iter())
                     .chain(dst.select.1.iter().map(|(_, expression)| expression))
                 {
+                    collect_and_advance_expression(
+                        self.module,
+                        &mut output_effect_store,
+                        address,
+                        &mut self.arena,
+                        &mut output_effects,
+                    )?;
                     collect_written_expression(
                         self.module,
                         address,
@@ -1096,33 +1181,40 @@ impl<'a> ModuleParser<'a> {
                     })?
                 };
 
-                let (expr, access, sources, previous_sources, address_sources) =
-                    if is_static_access(&dst.index, &dst.select) {
-                        let mut sources = HashSet::default();
-                        sources.insert(VarAtomBase::new(
-                            GlueAddr::Child(child_port_id),
-                            0,
-                            width - 1,
-                        ));
-                        (
-                            rhs_part,
-                            prefix_access,
-                            sources,
-                            HashSet::default(),
-                            HashSet::default(),
-                        )
-                    } else {
-                        build_dynamic_output_glue(
-                            self.module,
-                            &mut destination_store,
-                            &mut self.arena,
-                            &mut glue_arena,
-                            dst,
-                            rhs_part,
-                            output.dst.len() == 1
-                                && child_module.variables[&child_port_id].r#type.signed,
-                        )?
-                    };
+                let dynamic_access = !is_static_access(&dst.index, &dst.select);
+                let (expr, access, sources, previous_sources, address_sources) = if !dynamic_access
+                {
+                    let mut sources = HashSet::default();
+                    sources.insert(VarAtomBase::new(
+                        GlueAddr::Child(child_port_id),
+                        0,
+                        width - 1,
+                    ));
+                    (
+                        rhs_part,
+                        prefix_access,
+                        sources,
+                        HashSet::default(),
+                        HashSet::default(),
+                    )
+                } else {
+                    build_dynamic_output_glue(
+                        self.module,
+                        &mut destination_store,
+                        &mut self.arena,
+                        &mut glue_arena,
+                        dst,
+                        rhs_part,
+                        output.dst.len() == 1
+                            && child_module.variables[&child_port_id].r#type.signed,
+                    )?
+                };
+                if dynamic_access {
+                    // The dynamic child assignment expression was built from
+                    // the advanced destination store, so it already contains
+                    // preceding index-call writes within this access.
+                    composed_output_accesses.push((dst.id, access));
+                }
 
                 let path = LogicPath {
                     target: LogicPathTarget::Var(VarAtomBase::new(
@@ -1143,10 +1235,24 @@ impl<'a> ModuleParser<'a> {
 
                 current_offset = slice_end;
             }
+            let process_sensitivity = std::mem::take(&mut output_effects.sensitivity);
+            let preserved_address_sources = destination_address_sources
+                .values()
+                .flat_map(|sources| sources.iter().copied())
+                .collect();
+            self.attach_connection_effects(
+                output_effect_arena_start,
+                output_effects,
+                &destination_written_accesses,
+                process_sensitivity,
+                preserved_address_sources,
+            )?;
+            let mut remaining_written_accesses = destination_written_accesses.clone();
+            subtract_composed_accesses(&mut remaining_written_accesses, &composed_output_accesses);
             output_ports.extend(build_parent_effect_glue(
                 &parent_store,
                 &destination_store,
-                &destination_written_accesses,
+                &remaining_written_accesses,
                 &destination_address_sources,
                 &self.arena,
                 &mut glue_arena,

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -297,6 +297,7 @@ fn build_dynamic_output_glue(
 }
 
 fn build_parent_effect_glue(
+    initial_store: &SymbolicStore<VarId>,
     store: &SymbolicStore<VarId>,
     written_accesses: &HashMap<VarId, Vec<BitAccess>>,
     parent_arena: &SLTNodeArena<VarId>,
@@ -333,6 +334,30 @@ fn build_parent_effect_glue(
                     continue;
                 }
 
+                let target_access = BitAccess::new(target_lsb, target_msb);
+                if let Some(initial_range_store) = initial_store.get(id) {
+                    let final_parts = range_store.get_parts(target_access).map_err(|error| {
+                        ParserError::illegal_context(
+                            "instance input function output",
+                            error.to_string(),
+                            None,
+                        )
+                    })?;
+                    let initial_parts =
+                        initial_range_store
+                            .get_parts(target_access)
+                            .map_err(|error| {
+                                ParserError::illegal_context(
+                                    "instance input function output",
+                                    error.to_string(),
+                                    None,
+                                )
+                            })?;
+                    if final_parts == initial_parts {
+                        continue;
+                    }
+                }
+
                 let target_width = target_msb - target_lsb + 1;
                 let relative_lsb = target_lsb.checked_sub(*origin).ok_or_else(|| {
                     ParserError::illegal_context(
@@ -359,7 +384,8 @@ fn build_parent_effect_glue(
                     })?
                 };
                 let sources = collect_glue_sources(mapped, glue_arena);
-                let target = VarAtomBase::new(GlueAddr::Parent(*id), target_lsb, target_msb);
+                let target =
+                    VarAtomBase::new(GlueAddr::Parent(*id), target_access.lsb, target_access.msb);
                 let previous_sources = sources
                     .iter()
                     .copied()
@@ -691,6 +717,7 @@ impl<'a> ModuleParser<'a> {
             let parent_vars: Vec<_> = expr_sources.iter().map(|s| s.id).collect();
             input_ports.push((parent_vars, path));
             output_ports.extend(build_parent_effect_glue(
+                &parent_store,
                 &connection_store,
                 &written_accesses,
                 &self.arena,

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -10,10 +10,11 @@ use crate::{
     bitslicer::BitSlicer,
     ff::FfParser,
     logic_tree::{
-        CombEffectCollector, SymbolicStore, coerce_node_width, collect_and_advance_expression,
-        collect_expression_effects, collect_written_expression, combine_parts_with_default,
-        eval_assignment_expression_effectful, eval_expression, expression_contains_runtime_effect,
-        get_width, parse_comb_with_loop_recovery, subtract_written_sensitivity,
+        CombEffectCollector, SymbolicStore, apply_assignment_destination, coerce_node_width,
+        collect_and_advance_expression, collect_expression_effects, collect_written_expression,
+        combine_parts_with_default, eval_assignment_expression_effectful, eval_expression,
+        expression_contains_runtime_effect, get_width, parse_comb_with_loop_recovery,
+        subtract_written_sensitivity,
     },
     loop_provenance::{LoopProvenance, LoopRecoveryCandidate},
     registry::get_port_type,
@@ -62,9 +63,13 @@ fn build_dynamic_output_glue(
     parent_store: &mut SymbolicStore<VarId>,
     parent_arena: &mut SLTNodeArena<VarId>,
     glue_arena: &mut SLTNodeArena<GlueAddr>,
+    child_port_id: VarId,
     dst: &AssignDestination,
     rhs: NodeId,
     rhs_signed: bool,
+    preview_rhs: NodeId,
+    preview_rhs_sources: HashSet<VarAtomBase<VarId>>,
+    preview_rhs_is_2state: bool,
 ) -> Result<
     (
         NodeId,
@@ -82,29 +87,43 @@ fn build_dynamic_output_glue(
         64,
         false,
     ))?;
+    let mut parent_offset = parent_arena.alloc(SLTNode::Constant(
+        BigUint::from(0u8),
+        BigUint::from(0u8),
+        64,
+        false,
+    ))?;
 
     let mut sources = collect_glue_sources(rhs, glue_arena);
     let mut address_sources = HashSet::default();
+    let mut preview_sources = preview_rhs_sources;
 
     let mut index_exprs = dst.index.0.clone();
     index_exprs.extend(dst.select.0.clone());
     let dim_limit = geometry.dimension_count;
 
     for (dimension, index_expr) in index_exprs[..dim_limit].iter().enumerate() {
-        let ((index, _), _) = crate::logic_tree::eval_expression_effectful(
+        let ((index, index_sources), _) = crate::logic_tree::eval_expression_effectful(
             module,
             parent_store,
             index_expr,
             parent_arena,
             None,
         )?;
+        preview_sources.extend(index_sources);
         let mut cache = HashMap::default();
         let mapped = parent_arena.get(index).map_addr(
             index,
             parent_arena,
             glue_arena,
             &mut cache,
-            &|id| GlueAddr::Parent(*id),
+            &|id| {
+                if *id == child_port_id {
+                    GlueAddr::Child(*id)
+                } else {
+                    GlueAddr::Parent(*id)
+                }
+            },
         )?;
         let mapped_sources = collect_glue_sources(mapped, glue_arena);
         sources.extend(mapped_sources.iter().copied());
@@ -127,6 +146,16 @@ fn build_dynamic_output_glue(
         ))?;
         let term = glue_arena.alloc(SLTNode::Binary(mapped, BinaryOp::Mul, stride))?;
         offset = glue_arena.alloc(SLTNode::Binary(offset, BinaryOp::Add, term))?;
+        let parent_stride = parent_arena.alloc(SLTNode::Constant(
+            BigUint::from(geometry.strides[dimension]),
+            BigUint::from(0u8),
+            64,
+            false,
+        ))?;
+        let parent_term =
+            parent_arena.alloc(SLTNode::Binary(index, BinaryOp::Mul, parent_stride))?;
+        parent_offset =
+            parent_arena.alloc(SLTNode::Binary(parent_offset, BinaryOp::Add, parent_term))?;
     }
 
     if let Some(part) = geometry.part {
@@ -147,7 +176,7 @@ fn build_dynamic_output_glue(
                 Some(&dst.token),
             ));
         };
-        let part_offset = match part {
+        let (part_offset, parent_part_offset) = match part {
             PartSelectGeometry::Colon { lsb, .. } => {
                 let bit_offset = lsb.checked_mul(weight).ok_or_else(|| {
                     ParserError::illegal_context(
@@ -156,37 +185,53 @@ fn build_dynamic_output_glue(
                         Some(&dst.token),
                     )
                 })?;
-                glue_arena.alloc(SLTNode::Constant(
-                    BigUint::from(bit_offset),
-                    BigUint::from(0u8),
-                    64,
-                    false,
-                ))?
+                (
+                    glue_arena.alloc(SLTNode::Constant(
+                        BigUint::from(bit_offset),
+                        BigUint::from(0u8),
+                        64,
+                        false,
+                    ))?,
+                    parent_arena.alloc(SLTNode::Constant(
+                        BigUint::from(bit_offset),
+                        BigUint::from(0u8),
+                        64,
+                        false,
+                    ))?,
+                )
             }
             PartSelectGeometry::PlusColon { .. }
             | PartSelectGeometry::MinusColon { .. }
             | PartSelectGeometry::Step { .. } => {
-                let ((anchor, _), _) = crate::logic_tree::eval_expression_effectful(
+                let ((anchor, anchor_sources), _) = crate::logic_tree::eval_expression_effectful(
                     module,
                     parent_store,
                     anchor_expr,
                     parent_arena,
                     None,
                 )?;
+                preview_sources.extend(anchor_sources);
+                let parent_anchor = anchor;
                 let mut cache = HashMap::default();
                 let anchor = parent_arena.get(anchor).map_addr(
                     anchor,
                     parent_arena,
                     glue_arena,
                     &mut cache,
-                    &|id| GlueAddr::Parent(*id),
+                    &|id| {
+                        if *id == child_port_id {
+                            GlueAddr::Child(*id)
+                        } else {
+                            GlueAddr::Parent(*id)
+                        }
+                    },
                 )?;
                 let mapped_sources = collect_glue_sources(anchor, glue_arena);
                 sources.extend(mapped_sources.iter().copied());
                 address_sources.extend(mapped_sources);
 
-                let element_offset = match part {
-                    PartSelectGeometry::PlusColon { .. } => anchor,
+                let (element_offset, parent_element_offset) = match part {
+                    PartSelectGeometry::PlusColon { .. } => (anchor, parent_anchor),
                     PartSelectGeometry::MinusColon { elements } => {
                         let decrement = elements.checked_sub(1).ok_or_else(|| {
                             ParserError::illegal_context(
@@ -201,16 +246,43 @@ fn build_dynamic_output_glue(
                             64,
                             false,
                         ))?;
-                        glue_arena.alloc(SLTNode::Binary(anchor, BinaryOp::Sub, decrement))?
-                    }
-                    PartSelectGeometry::Step { elements } => {
-                        let elements = glue_arena.alloc(SLTNode::Constant(
-                            BigUint::from(elements),
+                        let parent_decrement = parent_arena.alloc(SLTNode::Constant(
+                            BigUint::from(elements - 1),
                             BigUint::from(0u8),
                             64,
                             false,
                         ))?;
-                        glue_arena.alloc(SLTNode::Binary(anchor, BinaryOp::Mul, elements))?
+                        (
+                            glue_arena.alloc(SLTNode::Binary(anchor, BinaryOp::Sub, decrement))?,
+                            parent_arena.alloc(SLTNode::Binary(
+                                parent_anchor,
+                                BinaryOp::Sub,
+                                parent_decrement,
+                            ))?,
+                        )
+                    }
+                    PartSelectGeometry::Step { elements } => {
+                        let element_count = elements;
+                        let elements = glue_arena.alloc(SLTNode::Constant(
+                            BigUint::from(element_count),
+                            BigUint::from(0u8),
+                            64,
+                            false,
+                        ))?;
+                        let parent_elements = parent_arena.alloc(SLTNode::Constant(
+                            BigUint::from(element_count),
+                            BigUint::from(0u8),
+                            64,
+                            false,
+                        ))?;
+                        (
+                            glue_arena.alloc(SLTNode::Binary(anchor, BinaryOp::Mul, elements))?,
+                            parent_arena.alloc(SLTNode::Binary(
+                                parent_anchor,
+                                BinaryOp::Mul,
+                                parent_elements,
+                            ))?,
+                        )
                     }
                     PartSelectGeometry::Colon { .. } => {
                         return Err(ParserError::illegal_context(
@@ -221,19 +293,38 @@ fn build_dynamic_output_glue(
                     }
                 };
                 if weight == 1 {
-                    element_offset
+                    (element_offset, parent_element_offset)
                 } else {
+                    let weight_value = weight;
                     let weight = glue_arena.alloc(SLTNode::Constant(
-                        BigUint::from(weight),
+                        BigUint::from(weight_value),
                         BigUint::from(0u8),
                         64,
                         false,
                     ))?;
-                    glue_arena.alloc(SLTNode::Binary(element_offset, BinaryOp::Mul, weight))?
+                    let parent_weight = parent_arena.alloc(SLTNode::Constant(
+                        BigUint::from(weight_value),
+                        BigUint::from(0u8),
+                        64,
+                        false,
+                    ))?;
+                    (
+                        glue_arena.alloc(SLTNode::Binary(element_offset, BinaryOp::Mul, weight))?,
+                        parent_arena.alloc(SLTNode::Binary(
+                            parent_element_offset,
+                            BinaryOp::Mul,
+                            parent_weight,
+                        ))?,
+                    )
                 }
             }
         };
         offset = glue_arena.alloc(SLTNode::Binary(offset, BinaryOp::Add, part_offset))?;
+        parent_offset = parent_arena.alloc(SLTNode::Binary(
+            parent_offset,
+            BinaryOp::Add,
+            parent_part_offset,
+        ))?;
     }
 
     let access_width = get_access_width(module, dst.id, &dst.index, &dst.select)?;
@@ -261,20 +352,26 @@ fn build_dynamic_output_glue(
             Some(&dst.token),
         )
     })?;
-    let (old_value, _) =
-        combine_parts_with_default(dst.id, 0, parts, parent_arena).map_err(|error| {
-            ParserError::SltVerify {
-                phase: "dynamic output port destination",
-                error,
-            }
+    let (old_value, old_sources) = combine_parts_with_default(dst.id, 0, parts, parent_arena)
+        .map_err(|error| ParserError::SltVerify {
+            phase: "dynamic output port destination",
+            error,
         })?;
+    preview_sources.extend(old_sources.into_iter().filter(|source| source.id != dst.id));
+    let preview_old_value = old_value;
     let mut cache = HashMap::default();
     let old_value = parent_arena.get(old_value).map_addr(
         old_value,
         parent_arena,
         glue_arena,
         &mut cache,
-        &|id| GlueAddr::Parent(*id),
+        &|id| {
+            if *id == child_port_id {
+                GlueAddr::Child(*id)
+            } else {
+                GlueAddr::Parent(*id)
+            }
+        },
     )?;
     sources.extend(collect_glue_sources(old_value, glue_arena));
 
@@ -313,6 +410,59 @@ fn build_dynamic_output_glue(
     let kept_value = glue_arena.alloc(SLTNode::Binary(old_value, BinaryOp::And, keep_mask))?;
     let updated_value = glue_arena.alloc(SLTNode::Binary(kept_value, BinaryOp::Or, shifted_rhs))?;
 
+    let parent_low_mask = (BigUint::from(1u8) << access_width) - BigUint::from(1u8);
+    let parent_low_mask = parent_arena.alloc(SLTNode::Constant(
+        parent_low_mask,
+        BigUint::from(0u8),
+        variable_width,
+        false,
+    ))?;
+    let parent_shifted_mask = parent_arena.alloc(SLTNode::Binary(
+        parent_low_mask,
+        BinaryOp::Shl,
+        parent_offset,
+    ))?;
+    let parent_keep_mask =
+        parent_arena.alloc(SLTNode::Unary(UnaryOp::BitNot, parent_shifted_mask))?;
+    let preview_rhs = coerce_node_width(parent_arena, preview_rhs, Some(access_width), rhs_signed)?;
+    let preview_rhs = if variable.r#type.is_2state() && !preview_rhs_is_2state {
+        parent_arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, preview_rhs))?
+    } else {
+        preview_rhs
+    };
+    let preview_rhs = if access_width < variable_width {
+        let padding_width = variable_width - access_width;
+        let padding = parent_arena.alloc(SLTNode::Constant(
+            BigUint::from(0u8),
+            BigUint::from(0u8),
+            padding_width,
+            false,
+        ))?;
+        parent_arena.alloc(SLTNode::Concat(vec![
+            (padding, padding_width),
+            (preview_rhs, access_width),
+        ]))?
+    } else {
+        preview_rhs
+    };
+    let parent_shifted_rhs =
+        parent_arena.alloc(SLTNode::Binary(preview_rhs, BinaryOp::Shl, parent_offset))?;
+    let parent_shifted_rhs = parent_arena.alloc(SLTNode::Binary(
+        parent_shifted_rhs,
+        BinaryOp::And,
+        parent_shifted_mask,
+    ))?;
+    let parent_kept_value = parent_arena.alloc(SLTNode::Binary(
+        preview_old_value,
+        BinaryOp::And,
+        parent_keep_mask,
+    ))?;
+    let parent_updated_value = parent_arena.alloc(SLTNode::Binary(
+        parent_kept_value,
+        BinaryOp::Or,
+        parent_shifted_rhs,
+    ))?;
+
     let prefix = eval_var_select(module, dst.id, &dst.index, &dst.select)?;
     let result = if prefix == full_access {
         updated_value
@@ -322,6 +472,25 @@ fn build_dynamic_output_glue(
             access: prefix,
         })?
     };
+    let preview_result = if prefix == full_access {
+        parent_updated_value
+    } else {
+        parent_arena.alloc(SLTNode::Slice {
+            expr: parent_updated_value,
+            access: prefix,
+        })?
+    };
+    parent_store
+        .get_mut(&dst.id)
+        .expect("destination store entry checked above")
+        .update(prefix, Some((preview_result, preview_sources)))
+        .map_err(|error| {
+            ParserError::illegal_context(
+                "dynamic output port destination preview",
+                error.to_string(),
+                Some(&dst.token),
+            )
+        })?;
     let previous_sources = std::iter::once(VarAtomBase::new(
         GlueAddr::Parent(dst.id),
         prefix.lsb,
@@ -485,6 +654,7 @@ fn build_parent_effect_glue(
     output_address_sources: &HashMap<VarId, HashSet<VarAtomBase<VarId>>>,
     parent_arena: &SLTNodeArena<VarId>,
     glue_arena: &mut SLTNodeArena<GlueAddr>,
+    child_port_id: Option<VarId>,
 ) -> Result<Vec<(Vec<VarId>, LogicPath<GlueAddr>)>, ParserError> {
     let mut paths = Vec::new();
 
@@ -556,7 +726,13 @@ fn build_parent_effect_glue(
                     parent_arena,
                     glue_arena,
                     &mut cache,
-                    &|var_id| GlueAddr::Parent(*var_id),
+                    &|var_id| {
+                        if child_port_id == Some(*var_id) {
+                            GlueAddr::Child(*var_id)
+                        } else {
+                            GlueAddr::Parent(*var_id)
+                        }
+                    },
                 )?;
                 let mapped = if relative_lsb == 0 && target_width == get_width(mapped, glue_arena) {
                     mapped
@@ -582,7 +758,11 @@ fn build_parent_effect_glue(
                     .flatten()
                     .map(|source| {
                         VarAtomBase::new(
-                            GlueAddr::Parent(source.id),
+                            if child_port_id == Some(source.id) {
+                                GlueAddr::Child(source.id)
+                            } else {
+                                GlueAddr::Parent(source.id)
+                            },
                             source.access.lsb,
                             source.access.msb,
                         )
@@ -855,9 +1035,9 @@ impl<'a> ModuleParser<'a> {
         written_accesses: &HashMap<VarId, Vec<BitAccess>>,
         process_sensitivity: HashSet<VarAtomBase<VarId>>,
         preserved_address_sources: HashSet<VarAtomBase<VarId>>,
-    ) -> Result<(), ParserError> {
+    ) -> Result<Vec<u32>, ParserError> {
         if effects.observers.is_empty() && effects.sites.is_empty() {
-            return Ok(());
+            return Ok(Vec::new());
         }
 
         let written_atoms: Vec<_> = written_accesses
@@ -899,11 +1079,16 @@ impl<'a> ModuleParser<'a> {
             observer.site_id += site_offset as u32;
             observer.activation_group = site_offset as u32;
         }
+        let site_ids = effects
+            .observers
+            .iter()
+            .map(|observer| observer.site_id)
+            .collect();
         let arena_end = self.arena.len();
         remap_for_effect_site_ids(&mut self.arena, arena_start..arena_end, site_offset as u32)?;
         self.comb_observers.extend(effects.observers);
         self.comb_runtime_event_sites.extend(effects.sites);
-        Ok(())
+        Ok(site_ids)
     }
 
     fn parse_inst_declaration(
@@ -1022,7 +1207,7 @@ impl<'a> ModuleParser<'a> {
                     .values()
                     .flat_map(|sources| sources.iter().copied())
                     .collect();
-                self.attach_connection_effects(
+                let _ = self.attach_connection_effects(
                     arena_start,
                     effects,
                     &written_accesses,
@@ -1066,6 +1251,7 @@ impl<'a> ModuleParser<'a> {
                 &output_address_sources,
                 &self.arena,
                 &mut glue_arena,
+                None,
             )?);
         }
 
@@ -1078,6 +1264,7 @@ impl<'a> ModuleParser<'a> {
                 continue;
             }
             let child_port_id = output.id;
+            let output_port_start = output_ports.len();
             let ty = get_port_type(child_module, &child_port_id)?;
             let width = ty.width();
             if width == 0 {
@@ -1100,10 +1287,34 @@ impl<'a> ModuleParser<'a> {
                 index: vec![],
                 access: BitAccess::new(0, width - 1),
             })?;
-
             // LHS: output.dst (AssignDestination).
             let mut current_offset = 0usize;
-            let mut destination_store = parent_store.clone();
+            let mut destination_arena = SLTNodeArena::<VarId>::new();
+            let mut destination_store = SymbolicStore::default();
+            for (id, var) in &self.module.variables {
+                let parent_width = resolve_total_width(self.module, var)?;
+                if parent_width == 0 {
+                    destination_store.insert(*id, RangeStore::new(None, 0));
+                    continue;
+                }
+                let initial_node = destination_arena.alloc(SLTNode::Input {
+                    variable: *id,
+                    signed: var.r#type.signed,
+                    index: vec![],
+                    access: BitAccess::new(0, parent_width - 1),
+                })?;
+                let sources = std::iter::once(VarAtomBase::new(*id, 0, parent_width - 1)).collect();
+                destination_store.insert(
+                    *id,
+                    RangeStore::new(Some((initial_node, sources)), parent_width),
+                );
+            }
+            let preview_rhs_node = destination_arena.alloc(SLTNode::Input {
+                variable: child_port_id,
+                signed: child_port.r#type.signed,
+                index: vec![],
+                access: BitAccess::new(0, width - 1),
+            })?;
             let mut destination_written_accesses = HashMap::default();
             let mut destination_address_sources = HashMap::default();
             let mut composed_output_accesses = Vec::new();
@@ -1144,7 +1355,7 @@ impl<'a> ModuleParser<'a> {
                         self.module,
                         &destination_store,
                         address,
-                        &mut self.arena,
+                        &mut destination_arena,
                         &mut destination_address_sources,
                     )?;
                 }
@@ -1180,6 +1391,22 @@ impl<'a> ModuleParser<'a> {
                         access: slice_access,
                     })?
                 };
+                let preview_rhs_part = if slice_access.lsb == 0
+                    && slice_access.msb == get_width(preview_rhs_node, &destination_arena) - 1
+                {
+                    preview_rhs_node
+                } else {
+                    destination_arena.alloc(SLTNode::Slice {
+                        expr: preview_rhs_node,
+                        access: slice_access,
+                    })?
+                };
+                let preview_rhs_sources: HashSet<_> = std::iter::once(VarAtomBase::new(
+                    child_port_id,
+                    slice_access.lsb,
+                    slice_access.msb,
+                ))
+                .collect();
 
                 let dynamic_access = !is_static_access(&dst.index, &dst.select);
                 let (expr, access, sources, previous_sources, address_sources) = if !dynamic_access
@@ -1201,12 +1428,16 @@ impl<'a> ModuleParser<'a> {
                     build_dynamic_output_glue(
                         self.module,
                         &mut destination_store,
-                        &mut self.arena,
+                        &mut destination_arena,
                         &mut glue_arena,
+                        child_port_id,
                         dst,
                         rhs_part,
                         output.dst.len() == 1
                             && child_module.variables[&child_port_id].r#type.signed,
+                        preview_rhs_part,
+                        preview_rhs_sources.clone(),
+                        child_port.r#type.is_2state(),
                     )?
                 };
                 if dynamic_access {
@@ -1233,6 +1464,20 @@ impl<'a> ModuleParser<'a> {
                 };
                 output_ports.push((vec![dst.id], path));
 
+                if !dynamic_access {
+                    let (next_store, _) = apply_assignment_destination(
+                        self.module,
+                        destination_store,
+                        HashMap::default(),
+                        dst,
+                        preview_rhs_part,
+                        preview_rhs_sources,
+                        child_port.r#type.is_2state(),
+                        &mut destination_arena,
+                    )?;
+                    destination_store = next_store;
+                }
+
                 current_offset = slice_end;
             }
             let process_sensitivity = std::mem::take(&mut output_effects.sensitivity);
@@ -1240,13 +1485,17 @@ impl<'a> ModuleParser<'a> {
                 .values()
                 .flat_map(|sources| sources.iter().copied())
                 .collect();
-            self.attach_connection_effects(
+            let output_effect_site_ids = self.attach_connection_effects(
                 output_effect_arena_start,
                 output_effects,
                 &destination_written_accesses,
                 process_sensitivity,
                 preserved_address_sources,
             )?;
+            for (_, path) in &mut output_ports[output_port_start..] {
+                path.comb_capture_enable_sites
+                    .extend(output_effect_site_ids.iter().copied());
+            }
             let mut remaining_written_accesses = destination_written_accesses.clone();
             subtract_composed_accesses(&mut remaining_written_accesses, &composed_output_accesses);
             output_ports.extend(build_parent_effect_glue(
@@ -1254,8 +1503,9 @@ impl<'a> ModuleParser<'a> {
                 &destination_store,
                 &remaining_written_accesses,
                 &destination_address_sources,
-                &self.arena,
+                &destination_arena,
                 &mut glue_arena,
+                Some(child_port_id),
             )?);
             if current_offset != width {
                 return Err(ParserError::illegal_context(

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -10,9 +10,10 @@ use crate::{
     bitslicer::BitSlicer,
     ff::FfParser,
     logic_tree::{
-        SymbolicStore, coerce_node_width, collect_written_expression,
-        eval_assignment_expression_effectful, eval_expression, get_width,
-        parse_comb_with_loop_recovery,
+        CombEffectCollector, SymbolicStore, coerce_node_width, collect_expression_effects,
+        collect_written_expression, eval_assignment_expression_effectful, eval_expression,
+        expression_contains_runtime_effect, get_width, parse_comb_with_loop_recovery,
+        subtract_written_sensitivity,
     },
     loop_provenance::{LoopProvenance, LoopRecoveryCandidate},
     registry::get_port_type,
@@ -31,8 +32,8 @@ use celox_slt::{
 };
 use num_bigint::BigUint;
 use veryl_analyzer::ir::{
-    AssignDestination, Component, Declaration, Expression, InstDeclaration, Module, Statement,
-    SystemFunctionInput, SystemFunctionKind, VarId,
+    ArrayLiteralItem, AssignDestination, Component, Declaration, Expression, Factor,
+    InstDeclaration, Module, Statement, SystemFunctionInput, SystemFunctionKind, VarId,
 };
 use veryl_analyzer::value::Value;
 use veryl_analyzer::value::byte_value_to_string;
@@ -296,10 +297,158 @@ fn build_dynamic_output_glue(
     Ok((result, prefix, sources, previous_sources, address_sources))
 }
 
+fn collect_parent_address_expression_sources(
+    module: &Module,
+    store: &SymbolicStore<VarId>,
+    target: VarId,
+    expression: &Expression,
+    arena: &mut SLTNodeArena<VarId>,
+    out: &mut HashMap<VarId, HashSet<VarAtomBase<VarId>>>,
+) -> Result<(), ParserError> {
+    let ((_, sources), _) = eval_expression(module, store, expression, arena, None)?;
+    out.entry(target).or_default().extend(sources);
+    collect_parent_output_address_sources(module, store, expression, arena, out)
+}
+
+fn collect_parent_output_address_sources(
+    module: &Module,
+    store: &SymbolicStore<VarId>,
+    expression: &Expression,
+    arena: &mut SLTNodeArena<VarId>,
+    out: &mut HashMap<VarId, HashSet<VarAtomBase<VarId>>>,
+) -> Result<(), ParserError> {
+    match expression {
+        Expression::Term(factor) => match factor.as_ref() {
+            Factor::FunctionCall(call) => {
+                for input in call.inputs.values() {
+                    collect_parent_output_address_sources(module, store, input, arena, out)?;
+                }
+                for destinations in call.outputs.values() {
+                    for destination in destinations {
+                        for address in destination
+                            .index
+                            .0
+                            .iter()
+                            .chain(destination.select.0.iter())
+                            .chain(
+                                destination
+                                    .select
+                                    .1
+                                    .iter()
+                                    .map(|(_, expression)| expression),
+                            )
+                        {
+                            collect_parent_address_expression_sources(
+                                module,
+                                store,
+                                destination.id,
+                                address,
+                                arena,
+                                out,
+                            )?;
+                        }
+                    }
+                }
+                Ok(())
+            }
+            Factor::Variable(_, index, select, _) => {
+                for address in index
+                    .0
+                    .iter()
+                    .chain(select.0.iter())
+                    .chain(select.1.iter().map(|(_, expression)| expression))
+                {
+                    collect_parent_output_address_sources(module, store, address, arena, out)?;
+                }
+                Ok(())
+            }
+            Factor::SystemFunctionCall(call) => {
+                let mut collect = |input: &SystemFunctionInput| {
+                    collect_parent_output_address_sources(module, store, &input.0, arena, out)
+                };
+                match &call.kind {
+                    SystemFunctionKind::Clog2(input)
+                    | SystemFunctionKind::Onehot(input)
+                    | SystemFunctionKind::Signed(input)
+                    | SystemFunctionKind::Unsigned(input) => collect(input),
+                    SystemFunctionKind::Display(inputs) | SystemFunctionKind::Write(inputs) => {
+                        for input in inputs {
+                            collect(input)?;
+                        }
+                        Ok(())
+                    }
+                    SystemFunctionKind::Assert { cond, args, .. } => {
+                        collect(cond)?;
+                        for input in args {
+                            collect(input)?;
+                        }
+                        Ok(())
+                    }
+                    SystemFunctionKind::Bits(_)
+                    | SystemFunctionKind::Size(_)
+                    | SystemFunctionKind::Readmemh(_, _)
+                    | SystemFunctionKind::Finish => Ok(()),
+                }
+            }
+            Factor::Value(_) | Factor::Anonymous(_) | Factor::Unknown(_) => Ok(()),
+        },
+        Expression::Unary(_, inner, _) => {
+            collect_parent_output_address_sources(module, store, inner, arena, out)
+        }
+        Expression::Binary(lhs, _, rhs, _) => {
+            collect_parent_output_address_sources(module, store, lhs, arena, out)?;
+            collect_parent_output_address_sources(module, store, rhs, arena, out)
+        }
+        Expression::Ternary(cond, then_expression, else_expression, _) => {
+            collect_parent_output_address_sources(module, store, cond, arena, out)?;
+            collect_parent_output_address_sources(module, store, then_expression, arena, out)?;
+            collect_parent_output_address_sources(module, store, else_expression, arena, out)
+        }
+        Expression::Concatenation(parts, _) => {
+            for (part, repeat) in parts {
+                collect_parent_output_address_sources(module, store, part, arena, out)?;
+                if let Some(repeat) = repeat {
+                    collect_parent_output_address_sources(module, store, repeat, arena, out)?;
+                }
+            }
+            Ok(())
+        }
+        Expression::ArrayLiteral(items, _) => {
+            for item in items {
+                match item {
+                    ArrayLiteralItem::Value(expression, repeat) => {
+                        collect_parent_output_address_sources(
+                            module, store, expression, arena, out,
+                        )?;
+                        if let Some(repeat) = repeat {
+                            collect_parent_output_address_sources(
+                                module, store, repeat, arena, out,
+                            )?;
+                        }
+                    }
+                    ArrayLiteralItem::Defaul(expression) => {
+                        collect_parent_output_address_sources(
+                            module, store, expression, arena, out,
+                        )?;
+                    }
+                }
+            }
+            Ok(())
+        }
+        Expression::StructConstructor(_, fields, _) => {
+            for (_, expression) in fields {
+                collect_parent_output_address_sources(module, store, expression, arena, out)?;
+            }
+            Ok(())
+        }
+    }
+}
+
 fn build_parent_effect_glue(
     initial_store: &SymbolicStore<VarId>,
     store: &SymbolicStore<VarId>,
     written_accesses: &HashMap<VarId, Vec<BitAccess>>,
+    output_address_sources: &HashMap<VarId, HashSet<VarAtomBase<VarId>>>,
     parent_arena: &SLTNodeArena<VarId>,
     glue_arena: &mut SLTNodeArena<GlueAddr>,
 ) -> Result<Vec<(Vec<VarId>, LogicPath<GlueAddr>)>, ParserError> {
@@ -393,6 +542,23 @@ fn build_parent_effect_glue(
                         source.id == target.id && source.access.overlaps(&target.access)
                     })
                     .collect();
+                let address_sources = output_address_sources
+                    .get(id)
+                    .into_iter()
+                    .flatten()
+                    .map(|source| {
+                        VarAtomBase::new(
+                            GlueAddr::Parent(source.id),
+                            source.access.lsb,
+                            source.access.msb,
+                        )
+                    })
+                    .filter(|address| {
+                        sources.iter().any(|source| {
+                            source.id == address.id && source.access.overlaps(&address.access)
+                        })
+                    })
+                    .collect();
 
                 paths.push((
                     vec![*id],
@@ -401,7 +567,7 @@ fn build_parent_effect_glue(
                         expr: mapped,
                         sources,
                         previous_sources,
-                        address_sources: HashSet::default(),
+                        address_sources,
                         local_inputs: Vec::new(),
                         order_before: HashSet::default(),
                         comb_capture_enable_sites: Vec::new(),
@@ -687,6 +853,98 @@ impl<'a> ModuleParser<'a> {
                 &mut self.arena,
                 width,
             )?;
+            let mut output_address_sources = HashMap::default();
+            collect_parent_output_address_sources(
+                self.module,
+                &parent_store,
+                &input.expr,
+                &mut self.arena,
+                &mut output_address_sources,
+            )?;
+
+            if expression_contains_runtime_effect(self.module, &input.expr) {
+                let arena_start = self.arena.len();
+                let mut effects = CombEffectCollector::default();
+                collect_expression_effects(
+                    self.module,
+                    &parent_store,
+                    &input.expr,
+                    &mut self.arena,
+                    &mut effects,
+                )?;
+
+                let written_atoms: Vec<_> = written_accesses
+                    .iter()
+                    .flat_map(|(&id, accesses)| {
+                        accesses
+                            .iter()
+                            .map(move |access| VarAtomBase::new(id, access.lsb, access.msb))
+                    })
+                    .collect();
+                let mut process_sensitivity = std::mem::take(&mut effects.sensitivity);
+                process_sensitivity.extend(expr_sources.iter().copied());
+                for (&id, accesses) in &written_accesses {
+                    let Some(range_store) = connection_store.get(&id) else {
+                        continue;
+                    };
+                    for &access in accesses {
+                        for (value, _) in range_store.get_parts(access).map_err(|error| {
+                            ParserError::illegal_context(
+                                "instance input function output",
+                                error.to_string(),
+                                Some(&input.expr.token_range()),
+                            )
+                        })? {
+                            if let Some((_, sources)) = value {
+                                process_sensitivity.extend(sources);
+                            }
+                        }
+                    }
+                }
+                let mut process_sensitivity =
+                    subtract_written_sensitivity(process_sensitivity, &written_atoms);
+                process_sensitivity.extend(
+                    output_address_sources
+                        .values()
+                        .flat_map(|sources| sources.iter().copied()),
+                );
+                let process_sensitivity: Vec<_> = process_sensitivity.into_iter().collect();
+                for observer in &mut effects.observers {
+                    observer.sensitivity = process_sensitivity.clone();
+                    observer.written_input_atoms = observer
+                        .observed_inputs
+                        .iter()
+                        .chain(observer.position_inputs.iter())
+                        .copied()
+                        .filter(|atom| {
+                            written_atoms.iter().any(|written| {
+                                written.id == atom.id && written.access.overlaps(&atom.access)
+                            })
+                        })
+                        .collect();
+                    observer.written_inputs = observer
+                        .written_input_atoms
+                        .iter()
+                        .map(|atom| atom.id)
+                        .collect::<HashSet<_>>()
+                        .into_iter()
+                        .collect();
+                }
+
+                let site_offset = self.comb_runtime_event_sites.len();
+                for observer in &mut effects.observers {
+                    observer.site_id += site_offset as u32;
+                    observer.activation_group = site_offset as u32;
+                }
+                let arena_end = self.arena.len();
+                remap_for_effect_site_ids(
+                    &mut self.arena,
+                    arena_start..arena_end,
+                    site_offset as u32,
+                )?;
+                self.comb_observers.extend(effects.observers);
+                self.comb_runtime_event_sites.extend(effects.sites);
+            }
 
             // Map Parent VarId to GlueAddr::Parent
             let mut cache = HashMap::default();
@@ -720,6 +978,7 @@ impl<'a> ModuleParser<'a> {
                 &parent_store,
                 &connection_store,
                 &written_accesses,
+                &output_address_sources,
                 &self.arena,
                 &mut glue_arena,
             )?);

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -389,6 +389,11 @@ fn build_dynamic_output_glue(
     // after truncation/sign-extension is complete may the value be embedded in
     // the full variable; otherwise high RHS bits can corrupt adjacent fields.
     let rhs = coerce_node_width(glue_arena, rhs, Some(access_width), rhs_signed)?;
+    let rhs = if variable.r#type.is_2state() && !preview_rhs_is_2state {
+        glue_arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, rhs))?
+    } else {
+        rhs
+    };
     let rhs = if access_width < variable_width {
         let padding_width = variable_width - access_width;
         let padding = glue_arena.alloc(SLTNode::Constant(
@@ -533,13 +538,6 @@ fn collect_parent_output_address_sources(
                             .0
                             .iter()
                             .chain(destination.select.0.iter())
-                            .chain(
-                                destination
-                                    .select
-                                    .1
-                                    .iter()
-                                    .map(|(_, expression)| expression),
-                            )
                         {
                             collect_parent_address_expression_sources(
                                 module,
@@ -555,12 +553,7 @@ fn collect_parent_output_address_sources(
                 Ok(())
             }
             Factor::Variable(_, index, select, _) => {
-                for address in index
-                    .0
-                    .iter()
-                    .chain(select.0.iter())
-                    .chain(select.1.iter().map(|(_, expression)| expression))
-                {
+                for address in index.0.iter().chain(select.0.iter()) {
                     collect_parent_output_address_sources(module, store, address, arena, out)?;
                 }
                 Ok(())
@@ -597,6 +590,9 @@ fn collect_parent_output_address_sources(
         },
         Expression::Unary(_, inner, _) => {
             collect_parent_output_address_sources(module, store, inner, arena, out)
+        }
+        Expression::Binary(lhs, veryl_analyzer::ir::Op::Pow, _, _) => {
+            collect_parent_output_address_sources(module, store, lhs, arena, out)
         }
         Expression::Binary(lhs, _, rhs, _) => {
             collect_parent_output_address_sources(module, store, lhs, arena, out)?;
@@ -2532,12 +2528,117 @@ fn resolve_readmem_path_with_fallback(
 #[cfg(test)]
 mod tests {
     use num_bigint::{BigInt, BigUint};
-    use veryl_analyzer::ir::VarId;
+    use veryl_analyzer::{
+        Analyzer, Context, attribute_table,
+        ir::{Component, Declaration, Expression, Factor, Ir, Op, Statement, VarId},
+        symbol_table,
+    };
+    use veryl_metadata::Metadata;
+    use veryl_parser::Parser;
 
-    use super::{collect_glue_sources, resolve_readmem_path_with_fallback};
-    use crate::GlueAddr;
+    use super::{
+        collect_glue_sources, collect_parent_output_address_sources,
+        resolve_readmem_path_with_fallback,
+    };
+    use crate::{GlueAddr, HashMap};
     use celox_design::{BinaryOp, BitAccess, VarAtomBase};
     use celox_slt::{SLTForFoldGroupState, SLTNode, SLTNodeArena};
+
+    fn parse_top_module(code: &str) -> veryl_analyzer::ir::Module {
+        symbol_table::clear();
+        attribute_table::clear();
+
+        let metadata = Metadata::create_default("prj").unwrap();
+        let parser = Parser::parse(code, &"").unwrap();
+        let analyzer = Analyzer::new(&metadata);
+        let mut context = Context::default();
+        let mut ir = Ir::default();
+        assert!(analyzer.analyze_pass1("prj", &parser.veryl).is_empty());
+        assert!(Analyzer::analyze_post_pass1().is_empty());
+        assert!(
+            analyzer
+                .analyze_pass2("prj", &parser.veryl, &mut context, Some(&mut ir))
+                .is_empty()
+        );
+        assert!(Analyzer::analyze_post_pass2(&ir).is_empty());
+
+        let top = veryl_parser::resource_table::insert_str("Top");
+        ir.components
+            .into_iter()
+            .find_map(|component| match component {
+                Component::Module(module) if module.name == top => Some(module),
+                _ => None,
+            })
+            .expect("Top module not found")
+    }
+
+    #[test]
+    fn output_address_sources_skip_power_exponent() {
+        let mut module = parse_top_module(
+            r#"
+module Top (
+    base: input logic<2>,
+    idx: input logic,
+    q: output logic<4>,
+    data: output logic<2>,
+) {
+    function exponent (x: input logic, y: output logic) -> logic {
+        y = x;
+        return 1'b1;
+    }
+    always_comb {
+        q = exponent(idx, data[idx]);
+        q = base ** 2;
+    }
+}
+"#,
+        );
+        let comb = module
+            .declarations
+            .iter_mut()
+            .find_map(|declaration| match declaration {
+                Declaration::Comb(comb) => Some(comb),
+                _ => None,
+            })
+            .expect("No always_comb found in Top");
+        let Statement::Assign(seed) = &comb.statements[0] else {
+            panic!("expected seed assignment");
+        };
+        let seed = seed.expr.clone();
+        let Expression::Term(seed_factor) = &seed else {
+            panic!("expected function call expression");
+        };
+        let Factor::FunctionCall(call) = seed_factor.as_ref() else {
+            panic!("expected function call expression");
+        };
+        let data_id = call
+            .outputs
+            .values()
+            .flatten()
+            .next()
+            .expect("missing output actual")
+            .id;
+        let Statement::Assign(pow_assign) = &mut comb.statements[1] else {
+            panic!("expected power assignment");
+        };
+        let Expression::Binary(_, Op::Pow, exponent, _) = &mut pow_assign.expr else {
+            panic!("expected power expression");
+        };
+        **exponent = seed;
+        let expression = pow_assign.expr.clone();
+
+        let mut arena = SLTNodeArena::new();
+        let mut sources = HashMap::default();
+        collect_parent_output_address_sources(
+            &module,
+            &Default::default(),
+            &expression,
+            &mut arena,
+            &mut sources,
+        )
+        .unwrap();
+        assert!(!sources.contains_key(&data_id));
+    }
 
     #[test]
     fn readmem_path_falls_back_to_project_root() {

--- a/crates/celox-slt/src/lower.rs
+++ b/crates/celox-slt/src/lower.rs
@@ -1320,7 +1320,9 @@ fn slt_tree_reads_any_variable<A: Hash + Eq + Clone>(
             }
             SLTNode::Constant(..) => {}
             SLTNode::Binary(lhs, _, rhs) => work.extend([*lhs, *rhs]),
-            SLTNode::Unary(_, inner) | SLTNode::Slice { expr: inner, .. } => {
+            SLTNode::Unary(_, inner)
+            | SLTNode::Capture { expr: inner, .. }
+            | SLTNode::Slice { expr: inner, .. } => {
                 work.push(*inner);
             }
             SLTNode::Mux {
@@ -2171,7 +2173,9 @@ impl SLTToSIRLowerer {
                     work.push(*lhs);
                     work.push(*rhs);
                 }
-                SLTNode::Unary(_, inner) => work.push(*inner),
+                SLTNode::Unary(_, inner) | SLTNode::Capture { expr: inner, .. } => {
+                    work.push(*inner)
+                }
                 SLTNode::Mux {
                     cond,
                     then_expr,
@@ -2601,6 +2605,9 @@ impl SLTToSIRLowerer {
                 };
                 builder.emit(SIRInstruction::Unary(dest, *op, i));
                 dest
+            }
+            SLTNode::Capture { expr, .. } => {
+                self.lower_inner(builder, *expr, arena, cache, env, allow_cache)
             }
             SLTNode::Slice { expr, access } => {
                 self.lower_slice_inner(builder, *expr, access, arena, cache, env, allow_cache)
@@ -3152,6 +3159,7 @@ impl SLTToSIRLowerer {
                 UnaryOp::Ident | UnaryOp::ToTwoState | UnaryOp::Minus | UnaryOp::BitNot,
                 inner,
             ) => self.get_bound_signed(*inner, arena),
+            SLTNode::Capture { expr, .. } => self.get_bound_signed(*expr, arena),
             SLTNode::Mux {
                 then_expr,
                 else_expr,
@@ -3493,6 +3501,7 @@ impl SLTToSIRLowerer {
                     | UnaryOp::CountLeadingZeros
                     | UnaryOp::CountTrailingZeros => ZeroControllerFacts::default(),
                 },
+                SLTNode::Capture { expr, .. } => child(*expr),
                 SLTNode::Slice { expr, .. } => child(*expr),
                 SLTNode::Concat(parts) => {
                     let mut combined = ZeroControllerFacts {
@@ -3923,6 +3932,7 @@ impl SLTToSIRLowerer {
             SLTNode::Constant(..) => Vec::new(),
             SLTNode::Binary(lhs, _, rhs) => vec![*lhs, *rhs],
             SLTNode::Unary(_, inner) => vec![*inner],
+            SLTNode::Capture { expr, .. } => vec![*expr],
             SLTNode::Mux {
                 cond,
                 then_expr,
@@ -4037,6 +4047,7 @@ impl SLTToSIRLowerer {
                     _ => 2 * chunks,
                 }
             }
+            SLTNode::Capture { .. } => 0,
             SLTNode::Mux {
                 then_expr,
                 else_expr,
@@ -4144,6 +4155,7 @@ impl SLTToSIRLowerer {
                 SLTNode::Slice { .. } => 0,
                 SLTNode::Binary(_, op, _) => Self::binary_operation_cost(*op, 1),
                 SLTNode::Unary(..) => 1,
+                SLTNode::Capture { .. } => 0,
                 SLTNode::ForFold { updates, .. } => 8 + 2 * updates.len() as u128,
                 SLTNode::ForFoldGroup { states, .. } => 6 + 2 * states.len() as u128,
                 SLTNode::Input { .. }
@@ -4302,7 +4314,9 @@ impl SLTToSIRLowerer {
                 Self::fold_node_is_invariant(*lhs, rebound_variables, arena, memo)
                     && Self::fold_node_is_invariant(*rhs, rebound_variables, arena, memo)
             }
-            SLTNode::Unary(_, inner) | SLTNode::Slice { expr: inner, .. } => {
+            SLTNode::Unary(_, inner)
+            | SLTNode::Capture { expr: inner, .. }
+            | SLTNode::Slice { expr: inner, .. } => {
                 Self::fold_node_is_invariant(*inner, rebound_variables, arena, memo)
             }
             SLTNode::Mux {

--- a/crates/celox-slt/src/node.rs
+++ b/crates/celox-slt/src/node.rs
@@ -414,6 +414,11 @@ impl<A: Hash + Eq + Clone> SLTNode<A> {
                 arena.get(*inner).fmt_expression(f, arena)?;
                 write!(f, ")")
             }
+            SLTNode::Capture { expr, key } => {
+                write!(f, "capture[{key}](n{}:", expr.0)?;
+                arena.get(*expr).fmt_expression(f, arena)?;
+                write!(f, ")")
+            }
             SLTNode::Mux {
                 cond,
                 then_expr,
@@ -705,6 +710,14 @@ pub enum SLTNode<A: Hash + Eq + Clone> {
         expr: NodeId,
         access: BitAccess,
     },
+    /// A value materialized at a specific semantic evaluation position.
+    ///
+    /// `key` keeps captures from distinct runtime-event operands separate even
+    /// when their expressions are structurally identical.
+    Capture {
+        expr: NodeId,
+        key: u64,
+    },
 }
 
 /// Serde-friendly mirror of [`SLTNode`] that replaces [`BigUint`] with `Vec<u8>` (little-endian).
@@ -763,6 +776,10 @@ enum SLTNodeSerde<A: Hash + Eq + Clone> {
         expr: NodeId,
         access: BitAccess,
     },
+    Capture {
+        expr: NodeId,
+        key: u64,
+    },
 }
 
 impl<A: Hash + Eq + Clone> From<SLTNode<A>> for SLTNodeSerde<A> {
@@ -787,6 +804,7 @@ impl<A: Hash + Eq + Clone> From<SLTNode<A>> for SLTNodeSerde<A> {
             },
             SLTNode::Binary(a, op, b) => SLTNodeSerde::Binary(a, op, b),
             SLTNode::Unary(op, a) => SLTNodeSerde::Unary(op, a),
+            SLTNode::Capture { expr, key } => SLTNodeSerde::Capture { expr, key },
             SLTNode::Mux {
                 cond,
                 then_expr,
@@ -879,6 +897,7 @@ impl<A: Hash + Eq + Clone> From<SLTNodeSerde<A>> for SLTNode<A> {
             ),
             SLTNodeSerde::Binary(a, op, b) => SLTNode::Binary(a, op, b),
             SLTNodeSerde::Unary(op, a) => SLTNode::Unary(op, a),
+            SLTNodeSerde::Capture { expr, key } => SLTNode::Capture { expr, key },
             SLTNodeSerde::Mux {
                 cond,
                 then_expr,
@@ -982,6 +1001,7 @@ impl<A: fmt::Debug + fmt::Display + Hash + Eq + Clone> SLTNode<A> {
                     SLTNode::Constant(..) => {}
                     SLTNode::Binary(lhs, _, rhs) => children.extend([*lhs, *rhs]),
                     SLTNode::Unary(_, inner) => children.push(*inner),
+                    SLTNode::Capture { expr, .. } => children.push(*expr),
                     SLTNode::Mux {
                         cond,
                         then_expr,
@@ -1078,6 +1098,10 @@ impl<A: fmt::Debug + fmt::Display + Hash + Eq + Clone> SLTNode<A> {
                 SLTNode::Binary(lhs, op, rhs) => SLTNode::Binary(mapped(*lhs), *op, mapped(*rhs)),
 
                 SLTNode::Unary(op, inner) => SLTNode::Unary(*op, mapped(*inner)),
+                SLTNode::Capture { expr, key } => SLTNode::Capture {
+                    expr: mapped(*expr),
+                    key: *key,
+                },
 
                 SLTNode::Mux {
                     cond,
@@ -1323,6 +1347,10 @@ impl<A: fmt::Debug + fmt::Display + Hash + Eq + Clone> SLTNode<A> {
             SLTNode::Unary(op, inner) => {
                 writeln!(f, "{}Unary({:?})", indent, op)?;
                 arena.get(*inner).fmt_recursive(f, depth + 1, arena)
+            }
+            SLTNode::Capture { expr, key } => {
+                writeln!(f, "{}Capture({key})", indent)?;
+                arena.get(*expr).fmt_recursive(f, depth + 1, arena)
             }
             SLTNode::Mux {
                 cond,

--- a/crates/celox-slt/src/node_facts.rs
+++ b/crates/celox-slt/src/node_facts.rs
@@ -200,6 +200,7 @@ where
             child_width(*rhs)?,
         )),
         SLTNode::Unary(op, inner) => Ok(node_rules::unary_width(*op, child_width(*inner)?)),
+        SLTNode::Capture { expr, .. } => child_width(*expr),
         SLTNode::Mux {
             cond,
             then_expr,
@@ -443,6 +444,7 @@ where
                 .map_err(|error| rule_error(node_id, error))
         }
         SLTNode::Unary(op, inner) => Ok(node_rules::unary_width(*op, child_width(*inner)?)),
+        SLTNode::Capture { expr, .. } => child_width(*expr),
         SLTNode::Mux {
             then_expr,
             else_expr,
@@ -829,6 +831,7 @@ where
             visit(*rhs)?;
         }
         SLTNode::Unary(_, inner) => visit(*inner)?,
+        SLTNode::Capture { expr, .. } => visit(*expr)?,
         SLTNode::Mux {
             cond,
             then_expr,

--- a/crates/celox-slt/src/path.rs
+++ b/crates/celox-slt/src/path.rs
@@ -65,6 +65,10 @@ pub struct LogicPath<A: Hash + Eq + Clone> {
     pub local_inputs: Vec<(A, NodeId)>,
     pub order_before: HashSet<LogicPathId>,
     pub comb_capture_enable_sites: Vec<u32>,
+    /// Enable the listed capture sites whenever this path executes, even when
+    /// assignment conversion leaves the stored target unchanged.
+    #[serde(default)]
+    pub comb_capture_enable_always: bool,
     pub pre_lower_nodes: Vec<NodeId>,
     pub expr: NodeId,
 }
@@ -172,6 +176,7 @@ impl<A: fmt::Debug + fmt::Display + Hash + Eq + Clone> LogicPath<A> {
             local_inputs,
             order_before: self.order_before.clone(),
             comb_capture_enable_sites: self.comb_capture_enable_sites.clone(),
+            comb_capture_enable_always: self.comb_capture_enable_always,
             pre_lower_nodes,
             expr,
         })

--- a/crates/celox-slt/src/scheduler.rs
+++ b/crates/celox-slt/src/scheduler.rs
@@ -193,7 +193,7 @@ fn node_reads_only_covered_ranges<Addr: Clone + Eq + Hash>(
                 work.push(*lhs);
                 work.push(*rhs);
             }
-            SLTNode::Unary(_, inner) => work.push(*inner),
+            SLTNode::Unary(_, inner) | SLTNode::Capture { expr: inner, .. } => work.push(*inner),
             SLTNode::Mux {
                 cond,
                 then_expr,
@@ -292,6 +292,9 @@ fn collect_node_input_deps<Addr: Clone + Eq + Hash + Debug + Copy + Display>(
         }
         crate::SLTNode::Unary(_, inner) => {
             collect_node_input_deps(*inner, arena, memo, inverse_memo)
+        }
+        crate::SLTNode::Capture { expr, .. } => {
+            collect_node_input_deps(*expr, arena, memo, inverse_memo)
         }
         crate::SLTNode::Mux {
             cond,
@@ -816,6 +819,9 @@ fn lower_logic_path_node<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display>
     arena: &SLTNodeArena<Addr>,
     lower_cache: &mut HashMap<NodeId, RegisterId>,
 ) -> RegisterId {
+    if path.local_inputs.is_empty() {
+        return lowerer.lower(builder, node, arena, lower_cache);
+    }
     let mut env_inputs = HashMap::default();
     for (addr, local_node) in &path.local_inputs {
         let reg = lowerer.lower(builder, *local_node, arena, lower_cache);
@@ -996,7 +1002,9 @@ fn invalidate_logic_path_target<Addr: Clone + Eq + Ord + Hash + Debug + Copy + D
     };
     if let Some(to_remove) = inverse_dep_memo.get(&target.id) {
         for node in to_remove {
-            lower_cache.remove(node);
+            if !path.pre_lower_nodes.contains(node) {
+                lower_cache.remove(node);
+            }
         }
     }
 }
@@ -1165,7 +1173,7 @@ fn push_scheduler_node_children<Addr: Clone + Eq + Hash>(
             work.push(*lhs);
             work.push(*rhs);
         }
-        SLTNode::Unary(_, inner) => work.push(*inner),
+        SLTNode::Unary(_, inner) | SLTNode::Capture { expr: inner, .. } => work.push(*inner),
         SLTNode::Mux {
             cond,
             then_expr,
@@ -1361,6 +1369,7 @@ fn normalize_index_expr<Addr: Clone + Eq + Hash + Copy>(
             *op,
             Box::new(normalize_index_expr(*inner, loop_var, arena, memo)?),
         )),
+        SLTNode::Capture { expr, .. } => normalize_index_expr(*expr, loop_var, arena, memo),
         SLTNode::Mux {
             cond,
             then_expr,
@@ -2387,9 +2396,9 @@ fn collect_pure_scheduled_nodes<A: Clone + Eq + Hash>(
             collect_pure_scheduled_nodes(*lhs, arena, nodes)
                 && collect_pure_scheduled_nodes(*rhs, arena, nodes)
         }
-        SLTNode::Unary(_, inner) | SLTNode::Slice { expr: inner, .. } => {
-            collect_pure_scheduled_nodes(*inner, arena, nodes)
-        }
+        SLTNode::Unary(_, inner)
+        | SLTNode::Capture { expr: inner, .. }
+        | SLTNode::Slice { expr: inner, .. } => collect_pure_scheduled_nodes(*inner, arena, nodes),
         SLTNode::Mux {
             cond,
             then_expr,
@@ -2520,7 +2529,9 @@ fn condition_reads_target<A: Clone + Eq + Hash>(
             }
             SLTNode::Constant(..) => {}
             SLTNode::Binary(lhs, _, rhs) => work.extend([*lhs, *rhs]),
-            SLTNode::Unary(_, inner) | SLTNode::Slice { expr: inner, .. } => work.push(*inner),
+            SLTNode::Unary(_, inner)
+            | SLTNode::Capture { expr: inner, .. }
+            | SLTNode::Slice { expr: inner, .. } => work.push(*inner),
             SLTNode::Mux {
                 cond,
                 then_expr,

--- a/crates/celox-slt/src/scheduler.rs
+++ b/crates/celox-slt/src/scheduler.rs
@@ -822,6 +822,13 @@ fn lower_logic_path_node<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display>
     if path.local_inputs.is_empty() {
         return lowerer.lower(builder, node, arena, lower_cache);
     }
+    // Unbound captures may already have been materialized before a later
+    // write. Do not rebuild them under the observer's unrelated local inputs.
+    if matches!(arena.get(node), crate::SLTNode::Capture { .. })
+        && let Some(reg) = lower_cache.get(&node)
+    {
+        return *reg;
+    }
     let mut env_inputs = HashMap::default();
     for (addr, local_node) in &path.local_inputs {
         let reg = lowerer.lower(builder, *local_node, arena, lower_cache);

--- a/crates/celox-slt/src/scheduler.rs
+++ b/crates/celox-slt/src/scheduler.rs
@@ -895,18 +895,19 @@ fn emit_logic_path_store_with_result<Addr: Clone + Eq + Ord + Hash + Debug + Cop
             };
             let width = 1 + target.access.msb - target.access.lsb;
             let offset = static_access_offset(&target.id, target.access, unpacked_element_widths);
-            let old_reg = if path.comb_capture_enable_sites.is_empty() {
-                None
-            } else {
-                let old_reg = builder.alloc_bit(width, false);
-                builder.emit(SIRInstruction::Load(
-                    old_reg,
-                    target.id,
-                    offset.clone(),
-                    width,
-                ));
-                Some(old_reg)
-            };
+            let old_reg =
+                if path.comb_capture_enable_sites.is_empty() || path.comb_capture_enable_always {
+                    None
+                } else {
+                    let old_reg = builder.alloc_bit(width, false);
+                    builder.emit(SIRInstruction::Load(
+                        old_reg,
+                        target.id,
+                        offset.clone(),
+                        width,
+                    ));
+                    Some(old_reg)
+                };
             builder.emit(SIRInstruction::Store(
                 target.id,
                 offset,
@@ -915,10 +916,22 @@ fn emit_logic_path_store_with_result<Addr: Clone + Eq + Ord + Hash + Debug + Cop
                 Vec::new(),
                 Vec::new(),
             ));
-            if let Some(old) = old_reg {
+            if !path.comb_capture_enable_sites.is_empty() {
+                let (old, new) = if path.comb_capture_enable_always {
+                    let old = builder.alloc_bit(1, false);
+                    let new = builder.alloc_bit(1, false);
+                    builder.emit(SIRInstruction::Imm(old, SIRValue::new(0u8)));
+                    builder.emit(SIRInstruction::Imm(new, SIRValue::new(1u8)));
+                    (old, new)
+                } else {
+                    (
+                        old_reg.expect("changed capture enable loads the old value"),
+                        result_reg,
+                    )
+                };
                 builder.emit(SIRInstruction::CombCaptureEnableIfChanged {
                     old,
-                    new: result_reg,
+                    new,
                     sites: path.comb_capture_enable_sites.clone(),
                 });
             }
@@ -3550,9 +3563,18 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
                         Vec::new(),
                     ));
                     if !path.comb_capture_enable_sites.is_empty() {
+                        let (old, new) = if path.comb_capture_enable_always {
+                            let old = builder.alloc_bit(1, false);
+                            let new = builder.alloc_bit(1, false);
+                            builder.emit(SIRInstruction::Imm(old, SIRValue::new(0u8)));
+                            builder.emit(SIRInstruction::Imm(new, SIRValue::new(1u8)));
+                            (old, new)
+                        } else {
+                            (old_val_reg, new_val_reg)
+                        };
                         builder.emit(SIRInstruction::CombCaptureEnableIfChanged {
-                            old: old_val_reg,
-                            new: new_val_reg,
+                            old,
+                            new,
                             sites: path.comb_capture_enable_sites.clone(),
                         });
                     }
@@ -3860,6 +3882,7 @@ mod tests {
             local_inputs: Vec::new(),
             order_before: crate::HashSet::default(),
             comb_capture_enable_sites: Vec::new(),
+            comb_capture_enable_always: false,
             pre_lower_nodes: Vec::new(),
             expr,
         }
@@ -3909,6 +3932,7 @@ mod tests {
                 local_inputs: Vec::new(),
                 order_before: crate::HashSet::default(),
                 comb_capture_enable_sites: Vec::new(),
+                comb_capture_enable_always: false,
                 pre_lower_nodes: Vec::new(),
                 expr,
             });
@@ -4057,6 +4081,7 @@ mod tests {
                 local_inputs: Vec::new(),
                 order_before: crate::HashSet::default(),
                 comb_capture_enable_sites: Vec::new(),
+                comb_capture_enable_always: false,
                 pre_lower_nodes: Vec::new(),
                 expr,
             });
@@ -4320,6 +4345,7 @@ mod tests {
             local_inputs: Vec::new(),
             order_before: crate::HashSet::default(),
             comb_capture_enable_sites: Vec::new(),
+            comb_capture_enable_always: false,
             pre_lower_nodes: Vec::new(),
             expr: group,
         }
@@ -4801,6 +4827,7 @@ mod tests {
             local_inputs: Vec::new(),
             order_before: crate::HashSet::default(),
             comb_capture_enable_sites: Vec::new(),
+            comb_capture_enable_always: false,
             pre_lower_nodes: Vec::new(),
             expr,
         };

--- a/crates/celox-slt/src/symbolic_verify.rs
+++ b/crates/celox-slt/src/symbolic_verify.rs
@@ -346,6 +346,7 @@ mod tests {
             local_inputs: Vec::new(),
             order_before: HashSet::default(),
             comb_capture_enable_sites: Vec::new(),
+            comb_capture_enable_always: false,
             pre_lower_nodes: Vec::new(),
             expr,
         }

--- a/crates/celox/tests/basic.rs
+++ b/crates/celox/tests/basic.rs
@@ -474,6 +474,177 @@ module Top (
 
     }
 
+    fn test_comb_function_call_expression_with_output_argument(sim) {
+        @setup { let code = r#"
+module Top (
+    d: input logic<8>,
+    q_return: output logic<8>,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x + 8'd2;
+    }
+
+    always_comb {
+        q_return = f(d, q_output);
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q_return = sim.signal("q_return");
+    let q_output = sim.signal("q_output");
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(sim.get(q_return), 12u32.into());
+    assert_eq!(sim.get(q_output), 11u32.into());
+
+    }
+
+    fn test_comb_function_call_expression_output_is_visible_to_later_operand(sim) {
+        @setup { let code = r#"
+module Top (
+    d: input logic<8>,
+    q: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x + 8'd2;
+    }
+
+    var tmp: logic<8>;
+    always_comb {
+        q = f(d, tmp) + tmp;
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(sim.get(q), 23u32.into());
+
+    }
+
+    fn test_comb_function_call_expression_with_constant_input_keeps_output_write(sim) {
+        @setup { let code = r#"
+module Top (
+    q_return: output logic<8>,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x + 8'd2;
+    }
+
+    always_comb {
+        q_return = f(8'd10, q_output) + 8'd1;
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let q_return = sim.signal("q_return");
+    let q_output = sim.signal("q_output");
+
+    assert_eq!(sim.get(q_return), 13u32.into());
+    assert_eq!(sim.get(q_output), 11u32.into());
+
+    }
+
+    fn test_comb_function_call_expression_output_is_guarded_by_ternary(sim) {
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    sel: input logic,
+    d: input logic<8>,
+    q_return: output logic<8>,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x + 8'd2;
+    }
+
+    always_comb {
+        q_output = d;
+        q_return = if sel ? f(d, q_output) : 8'd7;
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let sel = sim.signal("sel");
+    let d = sim.signal("d");
+    let q_return = sim.signal("q_return");
+    let q_output = sim.signal("q_output");
+
+    sim.modify(|io| {
+        io.set(sel, 0u8);
+        io.set(d, 10u8);
+    }).unwrap();
+    assert_eq!(sim.get(q_return), 7u32.into());
+    assert_eq!(sim.get(q_output), 10u32.into());
+
+    sim.modify(|io| io.set(sel, 1u8)).unwrap();
+    assert_eq!(sim.get(q_return), 12u32.into());
+    assert_eq!(sim.get(q_output), 11u32.into());
+
+    }
+
+    fn test_comb_function_call_expression_output_respects_short_circuit(sim) {
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    d: input logic<8>,
+    and_result: output logic,
+    or_result: output logic,
+    and_output: output logic<8>,
+    or_output: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic {
+        y = x + 8'd1;
+        return 1'b1;
+    }
+
+    always_comb {
+        and_output = 8'd0;
+        or_output = 8'd0;
+        and_result = 1'b0 && f(d, and_output);
+        or_result = 1'b1 || f(d, or_output);
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let and_result = sim.signal("and_result");
+    let or_result = sim.signal("or_result");
+    let and_output = sim.signal("and_output");
+    let or_output = sim.signal("or_output");
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(sim.get(and_result), 0u32.into());
+    assert_eq!(sim.get(or_result), 1u32.into());
+    assert_eq!(sim.get(and_output), 0u32.into());
+    assert_eq!(sim.get(or_output), 0u32.into());
+
+    }
+
     fn test_comb_function_call_statement_ignores_return_value(sim) {
         @ignore_on(veryl);
         @setup { let code = r#"

--- a/crates/celox/tests/basic.rs
+++ b/crates/celox/tests/basic.rs
@@ -562,6 +562,136 @@ module Top (
 
     }
 
+    fn test_comb_function_call_expression_output_survives_system_function_wrapper(sim) {
+        @setup { let code = r#"
+module Top (
+    d: input logic<8>,
+    q_return: output logic<8>,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x + 8'd2;
+    }
+
+    always_comb {
+        q_return = $unsigned(f(d, q_output));
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q_return = sim.signal("q_return");
+    let q_output = sim.signal("q_output");
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(sim.get(q_return), 12u32.into());
+    assert_eq!(sim.get(q_output), 11u32.into());
+
+    }
+
+    fn test_comb_function_call_with_output_argument_in_display_argument(sim) {
+        @setup { let code = r#"
+module Top (
+    d: input logic<8>,
+    q: output logic<8>,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x + 8'd2;
+    }
+
+    always_comb {
+        $display("ret=%0d", f(d, q_output));
+        q = q_output;
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    let q_output = sim.signal("q_output");
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(sim.get(q), 11u32.into());
+    assert_eq!(sim.get(q_output), 11u32.into());
+    }
+
+    fn test_comb_function_call_with_output_argument_in_index_expression(sim) {
+        @setup { let code = r#"
+module Top (
+    data: input logic<4>,
+    sel: input logic<2>,
+    q: output logic,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<2>,
+        y: output logic<8>,
+    ) -> logic<2> {
+        y = 8'd10 + x;
+        return x;
+    }
+
+    always_comb {
+        q = data[f(sel, q_output)];
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let data = sim.signal("data");
+    let sel = sim.signal("sel");
+    let q = sim.signal("q");
+    let q_output = sim.signal("q_output");
+
+    sim.modify(|io| {
+        io.set(data, 0b1010u8);
+        io.set(sel, 1u8);
+    }).unwrap();
+    assert_eq!(sim.get(q), 1u32.into());
+    assert_eq!(sim.get(q_output), 11u32.into());
+    }
+
+    fn test_comb_function_call_with_output_argument_in_destination_index(sim) {
+        @setup { let code = r#"
+module Top (
+    sel: input logic<2>,
+    q: output logic<4>,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<2>,
+        y: output logic<8>,
+    ) -> logic<2> {
+        y = 8'd10 + x;
+        return x;
+    }
+
+    var data: logic<4>;
+    always_comb {
+        data = 4'b0000;
+        data[f(sel, q_output)] = 1'b1;
+        q = data;
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let sel = sim.signal("sel");
+    let q = sim.signal("q");
+    let q_output = sim.signal("q_output");
+
+    sim.modify(|io| io.set(sel, 2u8)).unwrap();
+    assert_eq!(sim.get(q), 4u32.into());
+    assert_eq!(sim.get(q_output), 12u32.into());
+    }
+
     fn test_comb_function_call_expression_output_is_guarded_by_ternary(sim) {
         @ignore_on(veryl);
         @setup { let code = r#"
@@ -643,6 +773,158 @@ module Top (
     assert_eq!(sim.get(and_output), 0u32.into());
     assert_eq!(sim.get(or_output), 0u32.into());
 
+    }
+
+    fn test_comb_function_call_with_output_argument_in_if_condition(sim) {
+        @setup { let code = r#"
+module Top (
+    d: input logic<8>,
+    q: output logic,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic {
+        y = x + 8'd1;
+        return x != 8'd0;
+    }
+
+    always_comb {
+        if f(d, q_output) {
+            q = 1'b1;
+        } else {
+            q = 1'b0;
+        }
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    let q_output = sim.signal("q_output");
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(sim.get(q), 1u32.into());
+    assert_eq!(sim.get(q_output), 11u32.into());
+
+    sim.modify(|io| io.set(d, 0u8)).unwrap();
+    assert_eq!(sim.get(q), 0u32.into());
+    assert_eq!(sim.get(q_output), 1u32.into());
+    }
+
+    fn test_comb_function_call_with_output_argument_in_case_target(sim) {
+        @setup { let code = r#"
+module Top (
+    d: input logic<8>,
+    q: output logic<8>,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<2> {
+        y = x + 8'd1;
+        return x[1:0];
+    }
+
+    always_comb {
+        case f(d, q_output) {
+            2'd0: q = 8'd10;
+            2'd1: q = 8'd11;
+            default: q = 8'd12;
+        }
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    let q_output = sim.signal("q_output");
+
+    sim.modify(|io| io.set(d, 5u8)).unwrap();
+    assert_eq!(sim.get(q), 11u32.into());
+    assert_eq!(sim.get(q_output), 6u32.into());
+
+    sim.modify(|io| io.set(d, 6u8)).unwrap();
+    assert_eq!(sim.get(q), 12u32.into());
+    assert_eq!(sim.get(q_output), 7u32.into());
+    }
+
+    fn test_comb_function_call_with_output_argument_in_loop_condition(sim) {
+        @setup { let code = r#"
+module Top (
+    d: input logic<8>,
+    q: output logic<8>,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic {
+        y = x + 8'd1;
+        return x != 8'd0;
+    }
+
+    always_comb {
+        q = 8'd0;
+        for i in 0..2 {
+            if f(d + i, q_output) {
+                q = q + 8'd1;
+            }
+        }
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    let q_output = sim.signal("q_output");
+
+    sim.modify(|io| io.set(d, 3u8)).unwrap();
+    assert_eq!(sim.get(q), 2u32.into());
+    assert_eq!(sim.get(q_output), 5u32.into());
+    }
+
+    fn test_comb_nested_function_output_call_in_function_condition(sim) {
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    d: input logic<8>,
+    q: output logic<8>,
+    q_output: output logic<8>,
+) {
+    function inner (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic {
+        y = x + 8'd1;
+        return x != 8'd0;
+    }
+
+    function outer (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        if inner(x, y) {
+            return x + 8'd2;
+        }
+        return 8'd0;
+    }
+
+    always_comb {
+        q = outer(d, q_output);
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    let q_output = sim.signal("q_output");
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(sim.get(q), 12u32.into());
+    assert_eq!(sim.get(q_output), 11u32.into());
     }
 
     fn test_comb_function_call_statement_ignores_return_value(sim) {

--- a/crates/celox/tests/basic.rs
+++ b/crates/celox/tests/basic.rs
@@ -1129,6 +1129,45 @@ module Top (
     assert_eq!(sim.get(q_output), 11u32.into());
     }
 
+    fn test_statement_call_inputs_follow_output_writeback_order(sim) {
+        @setup { let code = r#"
+module Top (
+    d: input logic<8>,
+    q: output logic<8>,
+    tmp: output logic<8>,
+) {
+    function inner (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x + 8'd2;
+    }
+
+    function outer (
+        first: input logic<8>,
+        second: input logic<8>,
+        result: output logic<8>,
+    ) {
+        result = first + second;
+    }
+
+    always_comb {
+        tmp = 8'd0;
+        outer(inner(d, tmp), tmp, q);
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    let tmp = sim.signal("tmp");
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(sim.get(q), 23u32.into());
+    assert_eq!(sim.get(tmp), 11u32.into());
+    }
+
     fn test_comb_effectful_case_after_dynamic_break_stays_inactive(sim) {
         // Veryl simulator 0.20.2 drops the case-target output writeback when
         // the case contains only a default arm with break.

--- a/crates/celox/tests/basic.rs
+++ b/crates/celox/tests/basic.rs
@@ -1083,6 +1083,101 @@ module Top (
     assert_eq!(sim.get(q_output), 11u32.into());
     }
 
+    fn test_comb_effectful_if_condition_after_dynamic_break_stays_inactive(sim) {
+        @setup { let code = r#"
+module Top (
+    stop: input logic,
+    d: input logic<8>,
+    count: input logic<8>,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic {
+        y = x + 8'd1;
+        return 1'b1;
+    }
+
+    always_comb {
+        q_output = 8'd0;
+        for i in 0..count {
+            if stop && i == 0 {
+                break;
+            }
+            if f(d + i, q_output) {
+                break;
+            }
+        }
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let stop = sim.signal("stop");
+    let d = sim.signal("d");
+    let count = sim.signal("count");
+    let q_output = sim.signal("q_output");
+
+    sim.modify(|io| {
+        io.set(stop, 1u8);
+        io.set(d, 10u8);
+        io.set(count, 2u8);
+    }).unwrap();
+    assert_eq!(sim.get(q_output), 0u32.into());
+
+    sim.modify(|io| io.set(stop, 0u8)).unwrap();
+    assert_eq!(sim.get(q_output), 11u32.into());
+    }
+
+    fn test_comb_effectful_case_after_dynamic_break_stays_inactive(sim) {
+        // Veryl simulator 0.20.2 drops the case-target output writeback when
+        // the case contains only a default arm with break.
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    stop: input logic,
+    d: input logic<8>,
+    count: input logic<8>,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic {
+        y = x + 8'd1;
+        return 1'b1;
+    }
+
+    always_comb {
+        q_output = 8'd0;
+        for i in 0..count {
+            if stop && i == 0 {
+                break;
+            }
+            case f(d + i, q_output) {
+                default: break;
+            }
+        }
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let stop = sim.signal("stop");
+    let d = sim.signal("d");
+    let count = sim.signal("count");
+    let q_output = sim.signal("q_output");
+
+    sim.modify(|io| {
+        io.set(stop, 1u8);
+        io.set(d, 10u8);
+        io.set(count, 2u8);
+    }).unwrap();
+    assert_eq!(sim.get(q_output), 0u32.into());
+
+    sim.modify(|io| io.set(stop, 0u8)).unwrap();
+    assert_eq!(sim.get(q_output), 11u32.into());
+    }
+
     fn test_comb_function_condition_output_is_guarded_after_early_return(sim) {
         // Veryl simulator 0.20.2 does not preserve this nested early-return
         // behavior when the later condition contains an output call.

--- a/crates/celox/tests/basic.rs
+++ b/crates/celox/tests/basic.rs
@@ -927,6 +927,174 @@ module Top (
     assert_eq!(sim.get(q_output), 11u32.into());
     }
 
+    fn test_comb_case_target_output_call_is_evaluated_once(sim) {
+        // Veryl simulator 0.20.2 re-evaluates the effectful case target for
+        // each arm, so the second comparison observes the first writeback.
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    q: output logic<8>,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x;
+    }
+
+    var tmp: logic<8>;
+    always_comb {
+        tmp = 8'd0;
+        case f(tmp, tmp) {
+            8'd9: q = 8'd9;
+            8'd0: q = 8'd10;
+            default: q = 8'd12;
+        }
+        q_output = tmp;
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let q = sim.signal("q");
+    let q_output = sim.signal("q_output");
+
+    assert_eq!(sim.get(q), 10u32.into());
+    assert_eq!(sim.get(q_output), 1u32.into());
+    }
+
+    fn test_comb_loop_bound_output_call_writes_back_once(sim) {
+        // Veryl simulator 0.20.2 accepts this program but drops the output
+        // argument writeback from the runtime loop-bound expression.
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    d: input logic<8>,
+    q: output logic<8>,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x;
+    }
+
+    always_comb {
+        q = 8'd0;
+        q_output = 8'd0;
+        for i in f(d, q_output)..4 {
+            q = q + 8'd1;
+        }
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    let q_output = sim.signal("q_output");
+
+    sim.modify(|io| io.set(d, 1u8)).unwrap();
+    assert_eq!(sim.get(q), 3u32.into());
+    assert_eq!(sim.get(q_output), 2u32.into());
+    }
+
+    fn test_comb_value_system_function_statement_applies_argument_outputs(sim) {
+        // Veryl simulator 0.20.2 rejects value-returning system functions in
+        // statement position even though the analyzer accepts the source.
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    d: input logic<8>,
+    q: output logic<8>,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x + 8'd2;
+    }
+
+    always_comb {
+        q_output = 8'd0;
+        $unsigned(f(d, q_output));
+        q = q_output;
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    let q_output = sim.signal("q_output");
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(sim.get(q), 11u32.into());
+    assert_eq!(sim.get(q_output), 11u32.into());
+    }
+
+    fn test_comb_function_condition_output_is_guarded_after_early_return(sim) {
+        // Veryl simulator 0.20.2 does not preserve this nested early-return
+        // behavior when the later condition contains an output call.
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    sel: input logic,
+    d: input logic<8>,
+    q: output logic<8>,
+    q_output: output logic<8>,
+) {
+    function inner (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic {
+        y = x + 8'd1;
+        return 1'b1;
+    }
+
+    function outer (
+        sel: input logic,
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        if sel {
+            return 8'd0;
+        }
+        if inner(x, y) {
+            return x + 8'd2;
+        }
+        return 8'd1;
+    }
+
+    always_comb {
+        q_output = 8'd7;
+        q = outer(sel, d, q_output);
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let sel = sim.signal("sel");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    let q_output = sim.signal("q_output");
+
+    sim.modify(|io| {
+        io.set(sel, 1u8);
+        io.set(d, 10u8);
+    }).unwrap();
+    assert_eq!(sim.get(q), 0u32.into());
+    // The outer output formal is still copied back with its default value,
+    // but the skipped inner call must not overwrite it with d + 1.
+    assert_eq!(sim.get(q_output), 0u32.into());
+
+    sim.modify(|io| io.set(sel, 0u8)).unwrap();
+    assert_eq!(sim.get(q), 12u32.into());
+    assert_eq!(sim.get(q_output), 11u32.into());
+    }
+
     fn test_comb_function_call_statement_ignores_return_value(sim) {
         @ignore_on(veryl);
         @setup { let code = r#"

--- a/crates/celox/tests/basic.rs
+++ b/crates/celox/tests/basic.rs
@@ -1036,6 +1036,53 @@ module Top (
     assert_eq!(sim.get(q_output), 11u32.into());
     }
 
+    fn test_comb_value_system_function_after_dynamic_break_stays_inactive(sim) {
+        // Veryl simulator 0.20.2 rejects value-returning system functions in
+        // statement position even though the analyzer accepts the source.
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Top (
+    stop: input logic,
+    d: input logic<8>,
+    count: input logic<8>,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x;
+    }
+
+    always_comb {
+        q_output = 8'd0;
+        for i in 0..count {
+            if stop && i == 0 {
+                break;
+            }
+            $unsigned(f(d, q_output));
+        }
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let stop = sim.signal("stop");
+    let d = sim.signal("d");
+    let count = sim.signal("count");
+    let q_output = sim.signal("q_output");
+
+    sim.modify(|io| {
+        io.set(stop, 1u8);
+        io.set(d, 10u8);
+        io.set(count, 2u8);
+    }).unwrap();
+    assert_eq!(sim.get(q_output), 0u32.into());
+
+    sim.modify(|io| io.set(stop, 0u8)).unwrap();
+    assert_eq!(sim.get(q_output), 11u32.into());
+    }
+
     fn test_comb_function_condition_output_is_guarded_after_early_return(sim) {
         // Veryl simulator 0.20.2 does not preserve this nested early-return
         // behavior when the later condition contains an output call.

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -6,6 +6,42 @@ use celox::{DeadStorePolicy, Simulator};
 mod test_utils;
 
 all_backends! {
+fn test_comb_display_preserves_argument_value_before_later_output_writeback(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    d: input logic<8>,
+    tmp: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x + 8'd2;
+    }
+
+    always_comb {
+        $display("before=%0d ret=%0d", tmp, f(d, tmp));
+    }
+}
+"#, "Top");
+
+    let d = sim.signal("d");
+    let tmp = sim.signal("tmp");
+    sim.drain_runtime_events();
+    assert_eq!(sim.get_as::<u8>(tmp), 1);
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "before=1 ret=12".to_string(),
+        }],
+    );
+}
+
 fn test_comb_display_arguments_observe_output_call_writeback_order(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -85,6 +85,40 @@ module Top (
     );
 }
 
+fn test_comb_callee_observer_converts_two_state_formal(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    a: input logic,
+    q: output logic,
+) {
+    function observe (x: input bit) -> logic {
+        $display("x=%0d", x);
+        return x;
+    }
+
+    always_comb {
+        q = observe(a);
+    }
+}
+"#, "Top").four_state(true);
+
+    let a = sim.signal("a");
+    sim.drain_runtime_events();
+    sim.modify(|io| io.set(a, 1u8)).unwrap();
+    sim.drain_runtime_events();
+    sim.modify(|io| {
+        io.set_four_state(a, celox::BigUint::from(1u8), celox::BigUint::from(1u8));
+    }).unwrap();
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "x=0".to_string(),
+        }],
+    );
+}
+
 fn test_comb_runtime_effect_inside_if_condition_is_collected(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -129,6 +129,58 @@ module Top (
     );
 }
 
+fn test_comb_condition_runtime_effect_respects_short_circuit(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    and_enable: input logic,
+    or_enable: input logic,
+    d: input logic<8>,
+    and_result: output logic,
+    or_result: output logic,
+) {
+    function predicate (x: input logic<8>) -> logic {
+        $display("rhs=%0d", x);
+        return 1'b1;
+    }
+
+    always_comb {
+        and_result = and_enable && predicate(d);
+        or_result = or_enable || predicate(d + 8'd1);
+    }
+}
+"#, "Top");
+
+    let and_enable = sim.signal("and_enable");
+    let or_enable = sim.signal("or_enable");
+    let d = sim.signal("d");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| {
+        io.set(and_enable, 0u8);
+        io.set(or_enable, 1u8);
+        io.set(d, 10u8);
+    }).unwrap();
+    assert!(sim.drain_runtime_events().is_empty());
+
+    sim.modify(|io| {
+        io.set(and_enable, 1u8);
+        io.set(or_enable, 0u8);
+    }).unwrap();
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![
+            celox::RuntimeEvent::Display {
+                message: "rhs=10".to_string(),
+            },
+            celox::RuntimeEvent::Display {
+                message: "rhs=11".to_string(),
+            },
+        ],
+    );
+}
+
 fn test_comb_runtime_effect_inside_case_target_is_collected(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -3872,6 +3872,282 @@ module Top (
     assert_eq!(sim.drain_runtime_events(), vec![]);
 }
 
+fn test_comb_expression_operands_observe_prior_output_write(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (a: input logic<8>, out: output logic<8>) {
+    function write_tmp (x: input logic<8>, y: output logic<8>) -> logic<8> {
+        y = x;
+        return 8'd1;
+    }
+    function observe (x: input logic<8>) -> logic<8> {
+        $display("observed=%0d", x);
+        return x;
+    }
+    var tmp: logic<8>;
+    always_comb {
+        tmp = 8'd0;
+        out = write_tmp(a, tmp) + observe(tmp);
+    }
+}
+"#, "Top");
+
+    let a = sim.signal("a");
+    let out = sim.signal("out");
+    sim.drain_runtime_events();
+    sim.modify(|io| io.set(a, 12u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 13);
+    assert_eq!(sim.drain_runtime_events(), vec![celox::RuntimeEvent::Display {
+        message: "observed=12".to_string(),
+    }]);
+}
+
+fn test_comb_ternary_collects_only_executed_runtime_arm(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (sel: input logic, a: input logic<8>, b: input logic<8>, out: output logic<8>) {
+    function left (x: input logic<8>) -> logic<8> {
+        $display("left=%0d", x);
+        return x;
+    }
+    function right (x: input logic<8>) -> logic<8> {
+        $display("right=%0d", x);
+        return x;
+    }
+    always_comb {
+        out = if sel ? left(a) : right(b);
+    }
+}
+"#, "Top");
+
+    let sel = sim.signal("sel");
+    let a = sim.signal("a");
+    let b = sim.signal("b");
+    let out = sim.signal("out");
+    sim.drain_runtime_events();
+    sim.modify(|io| {
+        io.set(sel, 1u8);
+        io.set(a, 7u8);
+        io.set(b, 9u8);
+    }).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 7);
+    assert_eq!(sim.drain_runtime_events(), vec![celox::RuntimeEvent::Display {
+        message: "left=7".to_string(),
+    }]);
+    sim.modify(|io| io.set(sel, 0u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 9);
+    assert_eq!(sim.drain_runtime_events(), vec![celox::RuntimeEvent::Display {
+        message: "right=9".to_string(),
+    }]);
+}
+
+fn test_comb_runtime_effect_in_nested_function_actual_is_detected(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (a: input logic<8>, out: output logic<8>) {
+    function inner (x: input logic<8>) -> logic<8> {
+        $display("inner=%0d", x);
+        return x;
+    }
+    function passthrough (x: input logic<8>) -> logic<8> {
+        return x;
+    }
+    always_comb {
+        out = passthrough(inner(a));
+    }
+}
+"#, "Top");
+
+    let a = sim.signal("a");
+    let out = sim.signal("out");
+    sim.drain_runtime_events();
+    sim.modify(|io| io.set(a, 23u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 23);
+    assert_eq!(sim.drain_runtime_events(), vec![celox::RuntimeEvent::Display {
+        message: "inner=23".to_string(),
+    }]);
+}
+
+fn test_comb_runtime_effect_in_function_output_destination_is_detected(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (index: input logic<2>, value: input logic<8>, out: output logic<8>) {
+    function choose_index (
+        x: input logic<2>,
+        seen: output logic<8>,
+    ) -> logic<2> {
+        seen = 8'd40 + x;
+        $display("index=%0d", x);
+        return x;
+    }
+    function poke (x: input logic<8>, y: output logic<8>) {
+        y = x;
+    }
+    var mem: logic<8>[4];
+    var seen: logic<8>;
+    always_comb {
+        mem[0] = 8'd0;
+        mem[1] = 8'd0;
+        mem[2] = 8'd0;
+        mem[3] = 8'd0;
+        seen = 8'd0;
+        poke(value, mem[choose_index(index, seen)]);
+        out = seen;
+    }
+}
+"#, "Top");
+
+    let index = sim.signal("index");
+    let value = sim.signal("value");
+    let out = sim.signal("out");
+    sim.drain_runtime_events();
+    sim.modify(|io| {
+        io.set(index, 2u8);
+        io.set(value, 55u8);
+    }).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 42);
+    assert_eq!(sim.drain_runtime_events(), vec![celox::RuntimeEvent::Display {
+        message: "index=2".to_string(),
+    }]);
+}
+
+fn test_comb_if_merge_preserves_selected_output_write_for_later_observer(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (sel: input logic, a: input logic<8>, out: output logic<8>) {
+    function set_tmp (x: input logic<8>, y: output logic<8>) {
+        y = x;
+    }
+    function observe (x: input logic<8>) -> logic<8> {
+        $display("after=%0d", x);
+        return x;
+    }
+    var tmp: logic<8>;
+    always_comb {
+        tmp = 8'd1;
+        if sel {
+            set_tmp(a, tmp);
+        }
+        out = observe(tmp);
+    }
+}
+"#, "Top");
+
+    let sel = sim.signal("sel");
+    let a = sim.signal("a");
+    let out = sim.signal("out");
+    sim.drain_runtime_events();
+    sim.modify(|io| {
+        io.set(sel, 0u8);
+        io.set(a, 17u8);
+    }).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 1);
+    assert_eq!(sim.drain_runtime_events(), vec![celox::RuntimeEvent::Display {
+        message: "after=1".to_string(),
+    }]);
+    sim.modify(|io| io.set(sel, 1u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 17);
+    assert_eq!(sim.drain_runtime_events(), vec![celox::RuntimeEvent::Display {
+        message: "after=17".to_string(),
+    }]);
+}
+
+fn test_comb_function_loop_bounds_apply_output_effects_left_to_right(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (value: input logic<4>, out: output logic<8>) {
+    function start_bound (x: input logic<4>, seen: output logic<8>) -> logic<4> {
+        seen = 8'd16 + x;
+        return 4'd0;
+    }
+    function end_bound (seen: input logic<8>) -> logic<4> {
+        return seen[3:0];
+    }
+    function run (x: input logic<4>, seen: output logic<8>) -> logic<8> {
+        seen = 8'd0;
+        for i in start_bound(x, seen)..end_bound(seen) {}
+        return seen;
+    }
+    var seen: logic<8>;
+    always_comb {
+        out = run(value, seen);
+    }
+}
+"#, "Top");
+
+    let value = sim.signal("value");
+    let out = sim.signal("out");
+    sim.modify(|io| io.set(value, 5u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 21);
+}
+
+fn test_comb_function_loop_skips_conditions_after_break(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    stop: input logic,
+    value: input logic<8>,
+    if_out: output logic<8>,
+    case_out: output logic<8>,
+) {
+    function mark (x: input logic<8>, seen: output logic<8>) -> logic {
+        seen = x;
+        return 1'b0;
+    }
+    function run_if (
+        stop: input logic, x: input logic<8>, seen: output logic<8>,
+    ) -> logic<8> {
+        seen = 8'd0;
+        for i in 0..3 {
+            if stop { break; }
+            if mark(x, seen) { break; }
+        }
+        return seen;
+    }
+    function run_case (
+        stop: input logic, x: input logic<8>, seen: output logic<8>,
+    ) -> logic<8> {
+        seen = 8'd0;
+        for i in 0..3 {
+            if stop { break; }
+            case mark(x, seen) {
+                1'b1: { break; }
+                default: {}
+            }
+        }
+        return seen;
+    }
+    var if_seen: logic<8>;
+    var case_seen: logic<8>;
+    always_comb {
+        if_out = run_if(stop, value, if_seen);
+        case_out = run_case(stop, value, case_seen);
+    }
+}
+"#, "Top");
+
+    let stop = sim.signal("stop");
+    let value = sim.signal("value");
+    let if_out = sim.signal("if_out");
+    let case_out = sim.signal("case_out");
+    sim.modify(|io| {
+        io.set(stop, 1u8);
+        io.set(value, 29u8);
+    }).unwrap();
+    assert_eq!(sim.get_as::<u8>(if_out), 0);
+    assert_eq!(sim.get_as::<u8>(case_out), 0);
+    sim.modify(|io| io.set(stop, 0u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(if_out), 29);
+    assert_eq!(sim.get_as::<u8>(case_out), 29);
+}
+
 }
 
 #[test]

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -4296,6 +4296,36 @@ module Top (trigger: input logic, out: output logic<2>) {
     }]);
 }
 
+fn test_comb_function_output_concat_observes_prior_destination_write(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (trigger: input logic, out: output logic<2>) {
+    function observe (x: input logic) -> logic {
+        $display("function_concat_seen=%0d", x);
+        return x;
+    }
+    function poke (dst: output logic<2>) {
+        dst = 2'b11;
+    }
+    var data: logic<2>;
+    var tmp: logic;
+    always_comb {
+        data = 2'b00;
+        tmp = trigger;
+        poke({data[observe(tmp)], tmp});
+        out = data;
+    }
+}
+"#, "Top");
+
+    let out = sim.signal("out");
+    assert_eq!(sim.get_as::<u8>(out), 2);
+    assert_eq!(sim.drain_runtime_events(), vec![celox::RuntimeEvent::Display {
+        message: "function_concat_seen=1".to_string(),
+    }]);
+}
+
 }
 
 #[test]

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -4398,6 +4398,59 @@ module Top (
     assert_eq!(sim.get_as::<u8>(case_out), 29);
 }
 
+fn test_comb_function_output_preview_honors_loop_break(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    value: input logic<8>,
+    first_out: output logic<8>,
+    slots_out: output logic<2>,
+    ret_out: output logic,
+) {
+    function observe (x: input logic<8>) -> logic {
+        $display("preview=%0d", x);
+        return 1'b0;
+    }
+    function run (
+        x: input logic<8>,
+        first: output logic<8>,
+        second: output logic,
+    ) -> logic {
+        first = x;
+        for i in 0..4 {
+            if i == 2 { break; }
+            first = first + 8'd1;
+        }
+        second = 1'b1;
+        return 1'b0;
+    }
+    var first: logic<8>;
+    var slots: logic<2>;
+    always_comb {
+        ret_out = run(value, first, slots[observe(first)]);
+    }
+    assign first_out = first;
+    assign slots_out = slots;
+}
+"#, "Top");
+
+    let value = sim.signal("value");
+    let first_out = sim.signal("first_out");
+    let slots_out = sim.signal("slots_out");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(value, 10u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(first_out), 12);
+    assert_eq!(sim.get_as::<u8>(slots_out), 1);
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "preview=12".to_string(),
+        }],
+    );
+}
+
 fn test_comb_return_aware_function_loop_collects_bound_effects(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -42,6 +42,49 @@ module Top (
     );
 }
 
+fn test_comb_display_preserves_unbound_argument_with_local_bindings(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    d: input logic<8>,
+    prior: input logic<8>,
+    tmp: output logic<8>,
+    local_value: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x + 8'd2;
+    }
+
+    always_comb {
+        local_value = prior;
+        $display("before=%0d local=%0d ret=%0d", tmp, local_value, f(d, tmp));
+    }
+}
+"#, "Top");
+
+    let d = sim.signal("d");
+    let prior = sim.signal("prior");
+    let tmp = sim.signal("tmp");
+    sim.drain_runtime_events();
+    assert_eq!(sim.get_as::<u8>(tmp), 1);
+
+    sim.modify(|io| io.set(prior, 7u8)).unwrap();
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "before=1 local=7 ret=12".to_string(),
+        }],
+    );
+}
+
 fn test_comb_display_arguments_observe_output_call_writeback_order(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -85,6 +85,47 @@ module Top (
     );
 }
 
+fn test_comb_callee_observer_sees_actual_output_writeback_in_module_state(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    d: input logic<8>,
+    q_output: output logic<8>,
+) {
+    function inner (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x + 8'd2;
+    }
+
+    function outer (first: input logic<8>) -> logic {
+        $display("first=%0d module=%0d", first, q_output);
+        return 1'b0;
+    }
+
+    var unused: logic;
+    always_comb {
+        q_output = 8'd0;
+        unused = outer(inner(d, q_output));
+    }
+}
+"#, "Top");
+
+    let d = sim.signal("d");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "first=12 module=11".to_string(),
+        }],
+    );
+}
+
 fn test_comb_callee_observer_converts_two_state_formal(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -4451,6 +4451,57 @@ module Top (
     );
 }
 
+fn test_comb_outputless_function_output_preview_honors_loop_break(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    value: input logic<8>,
+    first_out: output logic<8>,
+    slots_out: output logic<2>,
+) {
+    function observe (x: input logic<8>) -> logic {
+        $display("preview=%0d", x);
+        return 1'b0;
+    }
+    function run (
+        x: input logic<8>,
+        first: output logic<8>,
+        second: output logic,
+    ) {
+        first = x;
+        for i in 0..4 {
+            if i == 2 { break; }
+            first = first + 8'd1;
+        }
+        second = 1'b1;
+    }
+    var first: logic<8>;
+    var slots: logic<2>;
+    always_comb {
+        run(value, first, slots[observe(first)]);
+    }
+    assign first_out = first;
+    assign slots_out = slots;
+}
+"#, "Top");
+
+    let value = sim.signal("value");
+    let first_out = sim.signal("first_out");
+    let slots_out = sim.signal("slots_out");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(value, 10u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(first_out), 12);
+    assert_eq!(sim.get_as::<u8>(slots_out), 1);
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "preview=12".to_string(),
+        }],
+    );
+}
+
 fn test_comb_return_aware_function_loop_collects_bound_effects(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -164,6 +164,49 @@ module Top (
     );
 }
 
+fn test_comb_callee_observer_snapshots_formal_before_later_actual_writeback(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    d: input logic<8>,
+    q_output: output logic<8>,
+) {
+    function inner (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x + 8'd2;
+    }
+
+    function outer (
+        first: input logic<8>,
+        second: input logic<8>,
+    ) -> logic {
+        $display("first=%0d second=%0d", first, second);
+        return 1'b0;
+    }
+
+    var unused: logic;
+    always_comb {
+        unused = outer(q_output, inner(d, q_output));
+    }
+}
+"#, "Top");
+
+    let d = sim.signal("d");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "first=1 second=12".to_string(),
+        }],
+    );
+}
+
 fn test_comb_callee_observer_sees_actual_output_writeback_in_module_state(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -4148,6 +4148,154 @@ module Top (
     assert_eq!(sim.get_as::<u8>(case_out), 29);
 }
 
+fn test_comb_return_aware_function_loop_collects_bound_effects(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (value: input logic<8>, out: output logic<8>) {
+    function bound (x: input logic<8>, seen: output logic<8>) -> logic<2> {
+        seen = x;
+        $display("bound=%0d", seen);
+        return x[1:0];
+    }
+    function run (x: input logic<8>, seen: output logic<8>) -> logic<8> {
+        seen = 8'd0;
+        for i in bound(x, seen)..4 {
+            $display("body=%0d", seen);
+            if i == 3 {
+                return seen;
+            }
+        }
+        return 8'd0;
+    }
+    var seen: logic<8>;
+    always_comb {
+        out = run(value, seen);
+    }
+}
+"#, "Top");
+
+    let value = sim.signal("value");
+    let out = sim.signal("out");
+    sim.drain_runtime_events();
+    sim.modify(|io| io.set(value, 31u8)).unwrap();
+    assert_eq!(sim.drain_runtime_events(), vec![
+        celox::RuntimeEvent::Display { message: "bound=31".to_string() },
+        celox::RuntimeEvent::Display { message: "body=31".to_string() },
+    ]);
+    assert_eq!(sim.get_as::<u8>(out), 31);
+}
+
+fn test_comb_variable_indices_observe_prior_index_output_write(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (value: input logic, out: output logic) {
+    function set_index (x: input logic, seen: output logic) -> logic {
+        seen = x;
+        return 1'b0;
+    }
+    function observe_index (seen: input logic) -> logic {
+        $display("index_seen=%0d", seen);
+        return seen;
+    }
+    var data: logic<2>[2];
+    var seen: logic;
+    always_comb {
+        data[0] = 2'b10;
+        data[1] = 2'b00;
+        seen = 1'b0;
+        out = data[set_index(value, seen)][observe_index(seen)];
+    }
+}
+"#, "Top");
+
+    let value = sim.signal("value");
+    let out = sim.signal("out");
+    sim.drain_runtime_events();
+    sim.modify(|io| io.set(value, 1u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 1);
+    assert_eq!(sim.drain_runtime_events(), vec![celox::RuntimeEvent::Display {
+        message: "index_seen=1".to_string(),
+    }]);
+}
+
+fn test_comb_function_loop_bound_write_is_guarded_after_return(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    skip: input logic,
+    value: input logic<8>,
+    out: output logic<8>,
+) {
+    function bound (x: input logic<8>, seen: output logic<8>) -> logic<2> {
+        seen = x;
+        $display("active_bound=%0d", seen);
+        return x[1:0];
+    }
+    function run (
+        skip: input logic, x: input logic<8>, seen: output logic<8>,
+    ) -> logic<8> {
+        seen = 8'd0;
+        if skip {
+            return 8'd0;
+        }
+        for i in bound(x, seen)..4 {}
+        return seen;
+    }
+    var seen: logic<8>;
+    always_comb {
+        out = run(skip, value, seen);
+    }
+}
+"#, "Top");
+
+    let skip = sim.signal("skip");
+    let value = sim.signal("value");
+    let out = sim.signal("out");
+    sim.drain_runtime_events();
+    sim.modify(|io| {
+        io.set(skip, 1u8);
+        io.set(value, 45u8);
+    }).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 0);
+    assert_eq!(sim.drain_runtime_events(), vec![]);
+
+    sim.modify(|io| io.set(skip, 0u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 45);
+    assert_eq!(sim.drain_runtime_events(), vec![celox::RuntimeEvent::Display {
+        message: "active_bound=45".to_string(),
+    }]);
+}
+
+fn test_comb_concat_destination_observes_prior_destination_write(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (trigger: input logic, out: output logic<2>) {
+    function observe (x: input logic) -> logic {
+        $display("concat_seen=%0d", x);
+        return x;
+    }
+    var data: logic<2>;
+    var tmp: logic;
+    always_comb {
+        data = 2'b00;
+        tmp = trigger;
+        {data[observe(tmp)], tmp} = 2'b11;
+        out = data;
+    }
+}
+"#, "Top");
+
+    let out = sim.signal("out");
+    assert_eq!(sim.get_as::<u8>(out), 2);
+    assert_eq!(sim.drain_runtime_events(), vec![celox::RuntimeEvent::Display {
+        message: "concat_seen=1".to_string(),
+    }]);
+}
+
 }
 
 #[test]

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -41,6 +41,183 @@ module Top (
     );
 }
 
+fn test_comb_callee_observer_inputs_follow_output_writeback_order(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    d: input logic<8>,
+    q_output: output logic<8>,
+) {
+    function inner (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x + 8'd2;
+    }
+
+    function outer (
+        first: input logic<8>,
+        second: input logic<8>,
+    ) -> logic {
+        $display("first=%0d second=%0d", first, second);
+        return 1'b0;
+    }
+
+    var unused: logic;
+    always_comb {
+        q_output = 8'd0;
+        unused = outer(inner(d, q_output), q_output);
+    }
+}
+"#, "Top");
+
+    let d = sim.signal("d");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "first=12 second=11".to_string(),
+        }],
+    );
+}
+
+fn test_comb_runtime_effect_inside_if_condition_is_collected(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    d: input logic<8>,
+    q: output logic,
+    q_output: output logic<8>,
+) {
+    function predicate (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic {
+        $display("if=%0d", x);
+        y = x + 8'd1;
+        return x != 8'd0;
+    }
+
+    always_comb {
+        if predicate(d, q_output) {
+            q = 1'b1;
+        } else {
+            q = 1'b0;
+        }
+    }
+}
+"#, "Top");
+
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    let q_output = sim.signal("q_output");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(q), 1);
+    assert_eq!(sim.get_as::<u8>(q_output), 11);
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "if=10".to_string(),
+        }],
+    );
+}
+
+fn test_comb_runtime_effect_inside_case_target_is_collected(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    d: input logic<2>,
+    q: output logic,
+    q_output: output logic<8>,
+) {
+    function effectful_target (
+        x: input logic<2>,
+        y: output logic<8>,
+    ) -> logic<2> {
+        $display("target=%0d", x);
+        y = 8'd10 + x;
+        return x;
+    }
+
+    always_comb {
+        case effectful_target(d, q_output) {
+            2'd2: q = 1'b1;
+            default: q = 1'b0;
+        }
+    }
+}
+"#, "Top");
+
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    let q_output = sim.signal("q_output");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| {
+        io.set(d, 2u8);
+    }).unwrap();
+    assert_eq!(sim.get_as::<u8>(q), 1);
+    assert_eq!(sim.get_as::<u8>(q_output), 12);
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "target=2".to_string(),
+        }],
+    );
+}
+
+fn test_comb_runtime_effect_inside_loop_bound_is_collected(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    d: input logic<8>,
+    q: output logic<8>,
+    q_output: output logic<8>,
+) {
+    function start_bound (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        $display("bound=%0d", x);
+        y = x + 8'd1;
+        return x;
+    }
+
+    always_comb {
+        q = 8'd0;
+        q_output = 8'd0;
+        for i in start_bound(d, q_output)..4 {
+            q = q + 8'd1;
+        }
+    }
+}
+"#, "Top");
+
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    let q_output = sim.signal("q_output");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(d, 1u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(q), 3);
+    assert_eq!(sim.get_as::<u8>(q_output), 2);
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "bound=1".to_string(),
+        }],
+    );
+}
+
 fn test_comb_display_follows_always_comb_sensitivity_after_settle(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -226,6 +226,118 @@ module Top (
     );
 }
 
+fn test_comb_runtime_effect_inside_assignment_destination_is_collected(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    sel: input logic<2>,
+    data: output logic<4>,
+    tmp: output logic<8>,
+) {
+    function index (
+        x: input logic<2>,
+        y: output logic<8>,
+    ) -> logic<2> {
+        $display("index=%0d", x);
+        y = 8'd10 + x;
+        return x;
+    }
+
+    always_comb {
+        data = 4'd0;
+        tmp = 8'd0;
+        data[index(sel, tmp)] = 1'b1;
+    }
+}
+"#, "Top");
+
+    let sel = sim.signal("sel");
+    let data = sim.signal("data");
+    let tmp = sim.signal("tmp");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(sel, 2u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(data), 4);
+    assert_eq!(sim.get_as::<u8>(tmp), 12);
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "index=2".to_string(),
+        }],
+    );
+}
+
+fn test_comb_runtime_effect_inside_value_system_statement_is_collected(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    d: input logic<8>,
+    tmp: output logic<8>,
+) {
+    function effectful (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        $display("wrapped=%0d", x);
+        y = x + 8'd1;
+        return x;
+    }
+
+    always_comb {
+        tmp = 8'd0;
+        $unsigned(effectful(d, tmp));
+    }
+}
+"#, "Top");
+
+    let d = sim.signal("d");
+    let tmp = sim.signal("tmp");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(tmp), 11);
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "wrapped=10".to_string(),
+        }],
+    );
+}
+
+fn test_comb_observer_after_case_uses_selected_arm_store(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    sel: input logic<2>,
+    value: output logic<8>,
+) {
+    always_comb {
+        case sel {
+            2'd0: value = 8'd10;
+            2'd1: value = 8'd11;
+            default: value = 8'd12;
+        }
+        $display("case=%0d", value);
+    }
+}
+"#, "Top");
+
+    let sel = sim.signal("sel");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(sel, 1u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(sim.signal("value")), 11);
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "case=11".to_string(),
+        }],
+    );
+}
+
 fn test_comb_runtime_effect_inside_loop_bound_is_collected(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -160,6 +160,59 @@ module Top (
     );
 }
 
+fn test_comb_output_destination_observer_uses_return_aware_loop_value(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    d: input logic,
+    tmp_o: output logic,
+) {
+    function observe_index (x: input logic) -> logic {
+        $display("index=%0d", x);
+        return x;
+    }
+
+    function produce (
+        x: input logic,
+        y: output logic<2>,
+    ) -> logic {
+        y = 2'b01;
+        for i in 0..2 {
+            if i == 0 {
+                return x;
+            }
+            y = 2'b10;
+        }
+        return x;
+    }
+
+    var mem: logic<2>;
+    var tmp: logic;
+    var unused: logic;
+    always_comb {
+        mem = 2'b00;
+        tmp = 1'b0;
+        unused = produce(d, {mem[observe_index(tmp)], tmp});
+        tmp_o = tmp;
+    }
+}
+"#, "Top");
+
+    let d = sim.signal("d");
+    let tmp_o = sim.signal("tmp_o");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(d, 1u8)).unwrap();
+    assert_eq!(sim.get(tmp_o), 1u8.into());
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "index=1".to_string(),
+        }],
+    );
+}
+
 fn test_comb_runtime_effect_inside_if_condition_is_collected(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -6,6 +6,41 @@ use celox::{DeadStorePolicy, Simulator};
 mod test_utils;
 
 all_backends! {
+fn test_comb_display_arguments_observe_output_call_writeback_order(sim) {
+    @omit_veryl;
+    @ignore_on(wasm);
+    @build Simulator::builder(r#"
+module Top (
+    d: input logic<8>,
+    q_output: output logic<8>,
+) {
+    function f (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic<8> {
+        y = x + 8'd1;
+        return x + 8'd2;
+    }
+
+    always_comb {
+        q_output = 8'd0;
+        $display("ret=%0d out=%0d", f(d, q_output), q_output);
+    }
+}
+"#, "Top");
+
+    let d = sim.signal("d");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(d, 10u8)).unwrap();
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "ret=12 out=11".to_string(),
+        }],
+    );
+}
+
 fn test_comb_display_follows_always_comb_sensitivity_after_settle(sim) {
     @omit_veryl;
     @ignore_on(wasm);

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -903,6 +903,48 @@ fn test_comb_void_function_call_in_expression_is_illegal_context() {
 }
 
 #[test]
+fn test_instance_input_rejects_function_output_call() {
+    let code = r#"
+        module Child (
+            i: input logic,
+            o: output logic,
+        ) {
+            assign o = i;
+        }
+
+        module Top (
+            a: input logic,
+            o: output logic,
+        ) {
+            function write_seen (
+                x: input logic,
+                seen: output logic,
+            ) -> logic {
+                seen = x;
+                return x;
+            }
+
+            var seen: logic;
+            inst child: Child (
+                i: write_seen(a, seen),
+                o,
+            );
+        }
+    "#;
+
+    let err = Simulator::builder(code, "Top")
+        .build()
+        .expect_err("output calls in read-only instance connections must be rejected");
+    match err.kind() {
+        SimulatorErrorKind::SIRParser(ParserError::Unsupported { issue, feature, .. }) => {
+            assert_eq!(*issue, 60);
+            assert_eq!(*feature, "function call with output arguments");
+        }
+        kind => panic!("expected unsupported output call diagnostic, got {kind:?}"),
+    }
+}
+
+#[test]
 fn test_ff_void_function_call_in_expression_is_illegal_context() {
     let code = r#"
         module Top (clk: input clock, q: output logic) {

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -903,48 +903,6 @@ fn test_comb_void_function_call_in_expression_is_illegal_context() {
 }
 
 #[test]
-fn test_instance_input_rejects_function_output_call() {
-    let code = r#"
-        module Child (
-            i: input logic,
-            o: output logic,
-        ) {
-            assign o = i;
-        }
-
-        module Top (
-            a: input logic,
-            o: output logic,
-        ) {
-            function write_seen (
-                x: input logic,
-                seen: output logic,
-            ) -> logic {
-                seen = x;
-                return x;
-            }
-
-            var seen: logic;
-            inst child: Child (
-                i: write_seen(a, seen),
-                o,
-            );
-        }
-    "#;
-
-    let err = Simulator::builder(code, "Top")
-        .build()
-        .expect_err("output calls in read-only instance connections must be rejected");
-    match err.kind() {
-        SimulatorErrorKind::SIRParser(ParserError::Unsupported { issue, feature, .. }) => {
-            assert_eq!(*issue, 60);
-            assert_eq!(*feature, "function call with output arguments");
-        }
-        kind => panic!("expected unsupported output call diagnostic, got {kind:?}"),
-    }
-}
-
-#[test]
 fn test_ff_void_function_call_in_expression_is_illegal_context() {
     let code = r#"
         module Top (clk: input clock, q: output logic) {

--- a/crates/celox/tests/four_state_expression_semantics.rs
+++ b/crates/celox/tests/four_state_expression_semantics.rs
@@ -39,6 +39,61 @@ module Top (
         assert_eq!(sim.get(sim.signal("or_output")), 1u8.into());
     }
 
+    fn indeterminate_ternary_executes_effectful_arms_in_order(sim) {
+        @omit_veryl;
+        @build Simulator::builder(r#"
+module Top (
+    sel: input logic,
+    seed: input logic<8>,
+    q_output: output logic<8>,
+    result: output logic,
+) {
+    function set_two (y: output logic<8>) -> logic {
+        y = 8'd2;
+        return 1'b0;
+    }
+
+    function increment (
+        x: input logic<8>,
+        y: output logic<8>,
+    ) -> logic {
+        y = x + 8'd1;
+        return 1'b0;
+    }
+
+    always_comb {
+        q_output = seed;
+        result = if sel ? set_two(q_output) : increment(q_output, q_output);
+    }
+}
+"#, "Top").four_state(true);
+
+        let sel = sim.signal("sel");
+        let seed = sim.signal("seed");
+        let q_output = sim.signal("q_output");
+
+        sim.modify(|io| {
+            io.set(seed, 1u8);
+            io.set_four_state(sel, BigUint::from(1u8), BigUint::from(1u8));
+        })
+        .unwrap();
+        assert_eq!(sim.get_four_state(q_output), (3u8.into(), 0u8.into()));
+
+        sim.modify(|io| {
+            io.set_four_state(sel, BigUint::from(0u8), BigUint::from(1u8));
+        })
+        .unwrap();
+        assert_eq!(sim.get_four_state(q_output), (3u8.into(), 0u8.into()));
+
+        sim.modify(|io| io.set_four_state(sel, 1u8.into(), 0u8.into()))
+            .unwrap();
+        assert_eq!(sim.get_four_state(q_output), (2u8.into(), 0u8.into()));
+
+        sim.modify(|io| io.set_four_state(sel, 0u8.into(), 0u8.into()))
+            .unwrap();
+        assert_eq!(sim.get_four_state(q_output), (2u8.into(), 0u8.into()));
+    }
+
     fn logical_unknown_truth_table_matches_comb_and_ff(sim) {
         @omit_veryl;
         @build Simulator::builder(r#"

--- a/crates/celox/tests/four_state_expression_semantics.rs
+++ b/crates/celox/tests/four_state_expression_semantics.rs
@@ -5,6 +5,40 @@ use celox::{BigUint, Simulator};
 mod test_utils;
 
 all_backends! {
+    fn indeterminate_short_circuit_lhs_executes_effectful_rhs(sim) {
+        @omit_veryl;
+        @build Simulator::builder(r#"
+module Top (
+    u: input logic,
+    and_output: output logic,
+    or_output: output logic,
+    and_result: output logic,
+    or_result: output logic,
+) {
+    function set_output (y: output logic) -> logic {
+        y = 1'b1;
+        return 1'b1;
+    }
+
+    always_comb {
+        and_output = 1'b0;
+        or_output = 1'b0;
+        and_result = u && set_output(and_output);
+        or_result = u || set_output(or_output);
+    }
+}
+"#, "Top").four_state(true);
+
+        let u = sim.signal("u");
+        sim.modify(|io| {
+            io.set_four_state(u, BigUint::from(0u8), BigUint::from(1u8));
+        })
+        .unwrap();
+
+        assert_eq!(sim.get(sim.signal("and_output")), 1u8.into());
+        assert_eq!(sim.get(sim.signal("or_output")), 1u8.into());
+    }
+
     fn logical_unknown_truth_table_matches_comb_and_ff(sim) {
         @omit_veryl;
         @build Simulator::builder(r#"

--- a/crates/celox/tests/hierarchy.rs
+++ b/crates/celox/tests/hierarchy.rs
@@ -719,6 +719,28 @@ assign out = mem;
 
     }
 
+    fn test_dynamic_output_port_converts_four_state_child_to_two_state_parent(sim) {
+        @omit_veryl;
+        @setup { let code = r#"
+module Child (y: output logic) {
+assign y = 1'bx;
+}
+module Top (idx: input logic, out: output bit<2>) {
+var mem: bit<2>;
+inst child: Child (y: mem[idx]);
+assign out = mem;
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let idx = sim.signal("idx");
+    let out = sim.signal("out");
+
+    assert_eq!(sim.get_as::<u8>(out), 0);
+    sim.modify(|io| io.set(idx, 1u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(out), 0);
+
+    }
+
     fn test_dynamic_minus_colon_output_port_rmw(sim) {
         @omit_veryl;
         @setup { let code = r#"

--- a/crates/celox/tests/hierarchy.rs
+++ b/crates/celox/tests/hierarchy.rs
@@ -311,6 +311,92 @@ assign tmp_o = tmp;
 
     }
 
+    fn test_instance_output_dynamic_index_preserves_runtime_display(sim) {
+        // veryl-simulator does not write the dynamic connection index call's
+        // output actual back; wasm does not currently expose runtime events.
+        @omit_veryl;
+        @ignore_on(wasm);
+        @setup { let code = r#"
+module Child (i: input logic, o: output logic) {
+assign o = i;
+}
+module Top (
+sel: input logic,
+mem_o: output logic<2>,
+tmp_o: output logic
+) {
+function choose_index (
+x: input logic,
+tmp: output logic
+) -> logic {
+tmp = x;
+$display("index=%0d", x);
+return x;
+}
+var mem: logic<2>;
+var tmp: logic;
+inst child: Child (
+i: 1'b1,
+o: mem[choose_index(sel, tmp)]
+);
+assign mem_o = mem;
+assign tmp_o = tmp;
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let sel = sim.signal("sel");
+    let mem_o = sim.signal("mem_o");
+    let tmp_o = sim.signal("tmp_o");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(sel, 1u8)).unwrap();
+    assert_eq!(sim.get(mem_o), 3u8.into());
+    assert_eq!(sim.get(tmp_o), 1u8.into());
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "index=1".to_string(),
+        }],
+    );
+
+    }
+
+    fn test_instance_output_dynamic_index_composes_aliasing_writeback(sim) {
+        // veryl-simulator does not write the dynamic connection index call's
+        // output actual back to the parent array.
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Child (i: input logic, o: output logic) {
+assign o = i;
+}
+module Top (
+sel: input logic,
+mem_o: output logic<2>
+) {
+function choose_index (
+x: input logic,
+tmp: output logic
+) -> logic {
+tmp = x;
+return x;
+}
+var mem: logic<2>;
+inst child: Child (
+i: 1'b1,
+o: mem[choose_index(sel, mem[0])]
+);
+assign mem_o = mem;
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let sel = sim.signal("sel");
+    let mem_o = sim.signal("mem_o");
+
+    sim.modify(|io| io.set(sel, 1u8)).unwrap();
+    assert_eq!(sim.get(mem_o), 3u8.into());
+
+    }
+
     fn test_unconnected_child_output_needs_no_parent_glue(sim) {
         @setup { let code = r#"
 module Child (

--- a/crates/celox/tests/hierarchy.rs
+++ b/crates/celox/tests/hierarchy.rs
@@ -216,6 +216,50 @@ assign seen_o = seen;
 
     }
 
+    fn test_instance_input_function_output_preserves_runtime_display(sim) {
+        // veryl-simulator does not write the connection's function output
+        // actual back; wasm does not currently expose runtime event draining.
+        @omit_veryl;
+        @ignore_on(wasm);
+        @setup { let code = r#"
+module Child (
+i: input logic
+) {}
+module Top (
+a: input logic,
+seen_o: output logic
+) {
+function write_seen (
+x: input logic,
+seen: output logic
+) -> logic {
+seen = x;
+$display("seen=%0d", seen);
+return x;
+}
+var seen: logic;
+inst child: Child (
+i: write_seen(a, seen)
+);
+assign seen_o = seen;
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let a = sim.signal("a");
+    let seen_o = sim.signal("seen_o");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(a, 1u8)).unwrap();
+    assert_eq!(sim.get(seen_o), 1u8.into());
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "seen=1".to_string(),
+        }],
+    );
+
+    }
+
     fn test_unconnected_child_output_needs_no_parent_glue(sim) {
         @setup { let code = r#"
 module Child (

--- a/crates/celox/tests/hierarchy.rs
+++ b/crates/celox/tests/hierarchy.rs
@@ -397,6 +397,82 @@ assign mem_o = mem;
 
     }
 
+    fn test_instance_output_concat_advances_each_destination(sim) {
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Child (i: input logic<2>, o: output logic<2>) {
+assign o = i;
+}
+module Top (
+value: input logic<2>,
+mem_o: output logic<2>,
+tmp_o: output logic
+) {
+var mem: logic<2>;
+var tmp: logic;
+inst child: Child (
+i: value,
+o: {mem[tmp], tmp}
+);
+assign mem_o = mem;
+assign tmp_o = tmp;
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let value = sim.signal("value");
+    let mem_o = sim.signal("mem_o");
+    let tmp_o = sim.signal("tmp_o");
+
+    sim.modify(|io| io.set(value, 3u8)).unwrap();
+    assert_eq!(sim.get(tmp_o), 1u8.into());
+    assert_eq!(sim.get(mem_o), 2u8.into());
+
+    }
+
+    fn test_instance_output_index_runtime_effect_triggers_on_child_change(sim) {
+        @omit_veryl;
+        @ignore_on(wasm);
+        @setup { let code = r#"
+module Child (i: input logic, o: output logic) {
+assign o = i;
+}
+module Top (
+data: input logic,
+sel: input logic,
+mem_o: output logic<2>
+) {
+function observe_index (x: input logic) -> logic {
+$display("index=%0d", x);
+return x;
+}
+var mem: logic<2>;
+inst child: Child (
+i: data,
+o: mem[observe_index(sel)]
+);
+assign mem_o = mem;
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let data = sim.signal("data");
+    let sel = sim.signal("sel");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| {
+        io.set(data, 0u8);
+        io.set(sel, 1u8);
+    }).unwrap();
+    sim.drain_runtime_events();
+    sim.modify(|io| io.set(data, 1u8)).unwrap();
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "index=1".to_string(),
+        }],
+    );
+
+    }
+
     fn test_unconnected_child_output_needs_no_parent_glue(sim) {
         @setup { let code = r#"
 module Child (

--- a/crates/celox/tests/hierarchy.rs
+++ b/crates/celox/tests/hierarchy.rs
@@ -82,6 +82,100 @@ o_data: top_out
 
     }
 
+    fn test_instance_input_function_output_writeback(sim) {
+        // veryl-simulator currently evaluates the connection value but does
+        // not write the function output actual back to the parent variable.
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Child (
+i: input logic,
+o: output logic
+) {
+assign o = i;
+}
+module Top (
+a: input logic,
+child_o: output logic,
+seen_o: output logic
+) {
+function write_seen (
+x: input logic,
+seen: output logic
+) -> logic {
+seen = x;
+return x;
+}
+var seen: logic;
+inst child: Child (
+i: write_seen(a, seen),
+o: child_o
+);
+assign seen_o = seen;
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let a = sim.signal("a");
+    let child_o = sim.signal("child_o");
+    let seen_o = sim.signal("seen_o");
+
+    sim.modify(|io| io.set(a, 1u8)).unwrap();
+    assert_eq!(sim.get(child_o), 1u8.into());
+    assert_eq!(sim.get(seen_o), 1u8.into());
+
+    }
+
+    fn test_instance_input_function_output_concat_dynamic_writeback(sim) {
+        // veryl-simulator currently evaluates the connection value but does
+        // not write the function output actual back to the parent variables.
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Child (
+i: input logic,
+o: output logic
+) {
+assign o = i;
+}
+module Top (
+value: input logic<2>,
+index: input logic,
+child_o: output logic,
+mem_o: output logic<2>,
+tmp_o: output logic
+) {
+function write_pair (
+x: input logic<2>,
+dst: output logic<2>
+) -> logic {
+dst = x;
+return x[0];
+}
+var mem: logic<2>;
+var tmp: logic;
+inst child: Child (
+i: write_pair(value, {mem[index], tmp}),
+o: child_o
+);
+assign mem_o = mem;
+assign tmp_o = tmp;
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let value = sim.signal("value");
+    let index = sim.signal("index");
+    let child_o = sim.signal("child_o");
+    let mem_o = sim.signal("mem_o");
+    let tmp_o = sim.signal("tmp_o");
+
+    sim.modify(|io| {
+        io.set(value, 3u8);
+        io.set(index, 1u8);
+    }).unwrap();
+    assert_eq!(sim.get(child_o), 1u8.into());
+    assert_eq!(sim.get(mem_o), 2u8.into());
+    assert_eq!(sim.get(tmp_o), 1u8.into());
+
+    }
+
     fn test_unconnected_child_output_needs_no_parent_glue(sim) {
         @setup { let code = r#"
 module Child (

--- a/crates/celox/tests/hierarchy.rs
+++ b/crates/celox/tests/hierarchy.rs
@@ -267,6 +267,50 @@ assign seen_o = seen;
 
     }
 
+    fn test_instance_output_dynamic_index_function_output_writeback(sim) {
+        // veryl-simulator does not write the dynamic connection index call's
+        // output actual back to the parent variable.
+        @ignore_on(veryl);
+        @setup { let code = r#"
+module Child (
+i: input logic,
+o: output logic
+) {
+assign o = i;
+}
+module Top (
+sel: input logic,
+mem_o: output logic<2>,
+tmp_o: output logic
+) {
+function choose_index (
+x: input logic,
+tmp: output logic
+) -> logic {
+tmp = x;
+return x;
+}
+var mem: logic<2>;
+var tmp: logic;
+inst child: Child (
+i: 1'b1,
+o: mem[choose_index(sel, tmp)]
+);
+assign mem_o = mem;
+assign tmp_o = tmp;
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let sel = sim.signal("sel");
+    let mem_o = sim.signal("mem_o");
+    let tmp_o = sim.signal("tmp_o");
+
+    sim.modify(|io| io.set(sel, 1u8)).unwrap();
+    assert_eq!(sim.get(mem_o), 2u8.into());
+    assert_eq!(sim.get(tmp_o), 1u8.into());
+
+    }
+
     fn test_unconnected_child_output_needs_no_parent_glue(sim) {
         @setup { let code = r#"
 module Child (

--- a/crates/celox/tests/hierarchy.rs
+++ b/crates/celox/tests/hierarchy.rs
@@ -429,6 +429,48 @@ assign tmp_o = tmp;
 
     }
 
+    fn test_instance_output_concat_runtime_effect_observes_prior_slice(sim) {
+        @omit_veryl;
+        @ignore_on(wasm);
+        @setup { let code = r#"
+module Child (i: input logic<2>, o: output logic<2>) {
+assign o = i;
+}
+module Top (
+value: input logic<2>,
+mem_o: output logic<2>,
+tmp_o: output logic
+) {
+function observe_index (x: input logic) -> logic {
+$display("index=%0d", x);
+return x;
+}
+var mem: logic<2>;
+var tmp: logic;
+inst child: Child (
+i: value,
+o: {mem[observe_index(tmp)], tmp}
+);
+assign mem_o = mem;
+assign tmp_o = tmp;
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let value = sim.signal("value");
+    let tmp_o = sim.signal("tmp_o");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(value, 3u8)).unwrap();
+    assert_eq!(sim.get(tmp_o), 1u8.into());
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "index=1".to_string(),
+        }],
+    );
+
+    }
+
     fn test_instance_output_index_runtime_effect_triggers_on_child_change(sim) {
         @omit_veryl;
         @ignore_on(wasm);

--- a/crates/celox/tests/hierarchy.rs
+++ b/crates/celox/tests/hierarchy.rs
@@ -176,6 +176,46 @@ assign tmp_o = tmp;
 
     }
 
+    fn test_inactive_instance_input_output_call_adds_no_parent_driver(sim) {
+        @setup { let code = r#"
+module Child (
+i: input logic,
+o: output logic
+) {
+assign o = i;
+}
+module Top (
+a: input logic,
+child_o: output logic,
+seen_o: output logic
+) {
+function write_seen (
+x: input logic,
+seen: output logic
+) -> logic {
+seen = !x;
+return x;
+}
+var seen: logic;
+inst child: Child (
+i: if 1'b0 ? write_seen(a, seen) : a,
+o: child_o
+);
+assign seen = a;
+assign seen_o = seen;
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let a = sim.signal("a");
+    let child_o = sim.signal("child_o");
+    let seen_o = sim.signal("seen_o");
+
+    sim.modify(|io| io.set(a, 1u8)).unwrap();
+    assert_eq!(sim.get(child_o), 1u8.into());
+    assert_eq!(sim.get(seen_o), 1u8.into());
+
+    }
+
     fn test_unconnected_child_output_needs_no_parent_glue(sim) {
         @setup { let code = r#"
 module Child (

--- a/crates/celox/tests/hierarchy.rs
+++ b/crates/celox/tests/hierarchy.rs
@@ -361,6 +361,50 @@ assign tmp_o = tmp;
 
     }
 
+    fn test_instance_output_index_runtime_effect_tracks_plain_sibling_source(sim) {
+        @omit_veryl;
+        @ignore_on(wasm);
+        @setup { let code = r#"
+module Child (i: input logic, o: output logic) {
+assign o = i;
+}
+module Top (
+d: input logic,
+offset: input logic,
+mem_o: output logic<2>
+) {
+function emit (x: input logic) -> logic {
+$display("d=%0d", x);
+return 1'b0;
+}
+var mem: logic<2>;
+inst child: Child (
+i: 1'b1,
+o: mem[emit(d) + offset]
+);
+assign mem_o = mem;
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let offset = sim.signal("offset");
+    sim.drain_runtime_events();
+
+    sim.modify(|io| io.set(offset, 1u8)).unwrap();
+    sim.drain_runtime_events();
+
+    // Both destinations already contain the driven value, so no generated
+    // parent write changes. The ordinary address source must still activate
+    // the runtime effect when the selected location changes.
+    sim.modify(|io| io.set(offset, 0u8)).unwrap();
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "d=0".to_string(),
+        }],
+    );
+
+    }
+
     fn test_instance_output_dynamic_index_composes_aliasing_writeback(sim) {
         // veryl-simulator does not write the dynamic connection index call's
         // output actual back to the parent array.

--- a/crates/celox/tests/hierarchy.rs
+++ b/crates/celox/tests/hierarchy.rs
@@ -559,6 +559,61 @@ assign mem_o = mem;
 
     }
 
+    fn test_instance_output_index_effect_triggers_when_two_state_parent_is_unchanged(sim) {
+        @omit_veryl;
+        @ignore_on(wasm);
+        @setup { let code = r#"
+module Child (mode: input logic<2>, o: output logic) {
+always_comb {
+case mode {
+2'd0: o = 1'b0;
+2'd1: o = 1'bx;
+default: o = 1'bz;
+}
+}
+}
+module Top (
+mode: input logic<2>,
+index: input logic,
+mem_o: output bit<2>
+) {
+function observe_index (x: input logic) -> logic {
+$display("index=%0d", x);
+return x;
+}
+var mem: bit<2>;
+inst child: Child (
+mode,
+o: mem[observe_index(index)]
+);
+assign mem_o = mem;
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let mode = sim.signal("mode");
+    let index = sim.signal("index");
+    let mem_o = sim.signal("mem_o");
+    sim.modify(|io| {
+        io.set(mode, 0u8);
+        io.set(index, 0u8);
+    }).unwrap();
+    sim.drain_runtime_events();
+
+    assert_eq!(sim.get_as::<u8>(mem_o), 0);
+    sim.modify(|io| io.set(mode, 1u8)).unwrap();
+    let x_parent_value = sim.get_as::<u8>(mem_o);
+    sim.drain_runtime_events();
+    sim.modify(|io| io.set(mode, 2u8)).unwrap();
+    assert_eq!(sim.get_as::<u8>(mem_o), x_parent_value);
+    assert_eq!(
+        sim.drain_runtime_events(),
+        vec![celox::RuntimeEvent::Display {
+            message: "index=0".to_string(),
+        }],
+    );
+
+    }
+
     fn test_unconnected_child_output_needs_no_parent_glue(sim) {
         @setup { let code = r#"
 module Child (

--- a/crates/celox/tests/hierarchy.rs
+++ b/crates/celox/tests/hierarchy.rs
@@ -223,10 +223,14 @@ assign seen_o = seen;
         @ignore_on(wasm);
         @setup { let code = r#"
 module Child (
-i: input logic
-) {}
+i: input logic,
+o: output logic
+) {
+assign o = i;
+}
 module Top (
 a: input logic,
+child_o: output logic,
 seen_o: output logic
 ) {
 function write_seen (
@@ -239,17 +243,20 @@ return x;
 }
 var seen: logic;
 inst child: Child (
-i: write_seen(a, seen)
+i: write_seen(a, seen),
+o: child_o
 );
 assign seen_o = seen;
 }
 "#; }
         @build Simulator::builder(code, "Top");
     let a = sim.signal("a");
+    let child_o = sim.signal("child_o");
     let seen_o = sim.signal("seen_o");
     sim.drain_runtime_events();
 
     sim.modify(|io| io.set(a, 1u8)).unwrap();
+    assert_eq!(sim.get(child_o), 1u8.into());
     assert_eq!(sim.get(seen_o), 1u8.into());
     assert_eq!(
         sim.drain_runtime_events(),


### PR DESCRIPTION
## Summary

- lower function-call output arguments in combinational expressions and write the resulting values back to the caller
- preserve expression evaluation order, conditional/short-circuit guards, and caller writes across assignments, conditions, case expressions, nested function bodies, dynamic selects, and system-function arguments
- include hidden output writes in combinational write-set and observer/effect analysis
- add cross-backend regression coverage for the supported expression contexts

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p celox-frontend-veryl`
- `cargo test --locked -p celox --test basic`
- `cargo test --locked -p celox --test comb_observer`
- `cargo test --locked -p celox`
- `cargo clippy --locked -p celox-frontend-veryl -p celox --all-targets --no-deps -- -D warnings`
- pre-push hooks: submodule check, formatting, Biome, workspace cargo check, clean tree

Closes #60