### PR TITLE
fix(frontend): classify missing function bindings as invalid

### DIFF
--- a/crates/celox-frontend-veryl/src/error.rs
+++ b/crates/celox-frontend-veryl/src/error.rs
@@ -76,6 +76,14 @@ pub enum ParserError {
         source_location: Option<SourceLocation>,
     },
 
+    #[error("Invalid argument binding for `{argument}` in call to function `{function}`: {detail}")]
+    InvalidFunctionArgumentBinding {
+        function: String,
+        argument: String,
+        detail: String,
+        source_location: Option<SourceLocation>,
+    },
+
     #[error(
         "Unresolved type width for variable `{variable}` in module `{module}`: \
              width cannot be determined at compile time (type: {typ})"
@@ -154,6 +162,20 @@ impl ParserError {
             source_location: Some(SourceLocation::from_token(&var.token)),
         }
     }
+
+    pub fn invalid_function_argument_binding(
+        function: impl Into<String>,
+        argument: impl Into<String>,
+        detail: impl Into<String>,
+        token: Option<&TokenRange>,
+    ) -> Self {
+        ParserError::InvalidFunctionArgumentBinding {
+            function: function.into(),
+            argument: argument.into(),
+            detail: detail.into(),
+            source_location: token.map(SourceLocation::from_token),
+        }
+    }
 }
 
 impl miette::Diagnostic for ParserError {
@@ -168,6 +190,9 @@ impl miette::Diagnostic for ParserError {
                 }
             ))),
             ParserError::IllegalContext { .. } => Some(Box::new("illegal_context")),
+            ParserError::InvalidFunctionArgumentBinding { .. } => {
+                Some(Box::new("invalid_function_argument_binding"))
+            }
             ParserError::UnresolvedWidth { .. } => Some(Box::new("unresolved_width")),
             ParserError::Scheduler(_) | ParserError::SchedulerWithLocation { .. } => {
                 Some(Box::new("scheduler"))
@@ -193,6 +218,9 @@ impl miette::Diagnostic for ParserError {
             | ParserError::IllegalContext {
                 source_location, ..
             }
+            | ParserError::InvalidFunctionArgumentBinding {
+                source_location, ..
+            }
             | ParserError::UnresolvedWidth {
                 source_location, ..
             } => source_location.as_ref(),
@@ -210,6 +238,9 @@ impl miette::Diagnostic for ParserError {
                 source_location, ..
             }
             | ParserError::IllegalContext {
+                source_location, ..
+            }
+            | ParserError::InvalidFunctionArgumentBinding {
                 source_location, ..
             }
             | ParserError::UnresolvedWidth {

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -32,8 +32,9 @@ use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::ToPrimitive as _;
 use veryl_analyzer::ir::{
     ArrayLiteralItem, AssignStatement, CaseStatement, CombDeclaration, Expression, Factor,
-    ForBound, ForRange, ForStatement, IfStatement, Module, Op, Statement, SystemFunctionCall,
-    SystemFunctionInput, SystemFunctionKind, VarId, VarIndex, VarSelect,
+    ForBound, ForRange, ForStatement, Function, FunctionCall, IfStatement, Module, Op, Statement,
+    SystemFunctionCall, SystemFunctionInput, SystemFunctionKind, VarId, VarIndex, VarPath,
+    VarSelect,
 };
 use veryl_analyzer::value::{Value, byte_value_to_string};
 use veryl_parser::resource_table;
@@ -63,6 +64,23 @@ pub(super) fn range_store_error(
     token: Option<&TokenRange>,
 ) -> ParserError {
     ParserError::illegal_context(context, error.to_string(), token)
+}
+
+/// Veryl validates function arity before producing usable IR. A formal argument
+/// absent from both connection maps is therefore invalid IR, not an unsupported
+/// lowering shape.
+pub(super) fn invalid_function_call_argument_error(
+    function: &Function,
+    arg_path: &VarPath,
+    detail: &'static str,
+    call: &FunctionCall,
+) -> ParserError {
+    ParserError::invalid_function_argument_binding(
+        function.path.to_string(),
+        arg_path.to_string(),
+        detail,
+        Some(&call.comptime.token),
+    )
 }
 
 #[cfg(test)]
@@ -2095,12 +2113,11 @@ fn eval_statement_form_function_call(
             if call.outputs.contains_key(arg_path) {
                 continue;
             }
-            return Err(ParserError::unsupported(
-                61,
-                phase,
-                "function call missing argument",
-                format!("{call}"),
-                Some(&call.comptime.token),
+            return Err(invalid_function_call_argument_error(
+                function,
+                arg_path,
+                "formal argument has neither an input expression nor an output destination",
+                call,
             ));
         };
 
@@ -2142,12 +2159,11 @@ fn eval_statement_form_function_call(
 
     for (arg_path, dsts) in &call.outputs {
         let Some(arg_id) = function_body.arg_map.get(arg_path) else {
-            return Err(ParserError::unsupported(
-                61,
-                phase,
-                "function call missing argument",
-                format!("{call}"),
-                Some(&call.comptime.token),
+            return Err(invalid_function_call_argument_error(
+                function,
+                arg_path,
+                "output argument does not match any formal argument",
+                call,
             ));
         };
 
@@ -2825,6 +2841,139 @@ mod tests {
 
         assert!(bounds.contains(&0));
         assert!(bounds.contains(&4));
+    }
+
+    #[test]
+    fn test_invalid_statement_function_argument_reports_binding_diagnostic() {
+        let code = r#"
+            module Top (a: input logic<8>, q: output logic<8>) {
+                function f (
+                    x: input logic<8>,
+                    y: output logic<8>,
+                ) {
+                    y = x;
+                }
+
+                always_comb {
+                    f(a, q);
+                }
+            }
+        "#;
+        let mut module = parse_top_module(code);
+        let comb_index = module
+            .declarations
+            .iter()
+            .position(|declaration| matches!(declaration, Declaration::Comb(_)))
+            .unwrap();
+        let Declaration::Comb(comb) = &mut module.declarations[comb_index] else {
+            unreachable!();
+        };
+        let Statement::FunctionCall(call) = &mut comb.statements[0] else {
+            panic!("expected statement-form function call");
+        };
+        call.inputs.clear();
+
+        let Declaration::Comb(comb) = &module.declarations[comb_index] else {
+            unreachable!();
+        };
+        let mut arena = SLTNodeArena::new();
+        let error = match super::parse_comb(&module, comb, &mut arena) {
+            Ok(_) => panic!("expected an invalid function argument error"),
+            Err(error) => error,
+        };
+        assert_eq!(
+            error.to_string(),
+            "Invalid argument binding for `x` in call to function `f`: formal argument has neither an input expression nor an output destination"
+        );
+        assert_eq!(
+            miette::Diagnostic::code(&error).unwrap().to_string(),
+            "invalid_function_argument_binding"
+        );
+        match error {
+            ParserError::InvalidFunctionArgumentBinding {
+                function,
+                argument,
+                detail,
+                source_location,
+            } => {
+                assert_eq!(function, "f");
+                assert_eq!(argument, "x");
+                assert_eq!(
+                    detail,
+                    "formal argument has neither an input expression nor an output destination"
+                );
+                assert!(source_location.is_some());
+            }
+            error => panic!("expected an argument binding diagnostic, got {error:?}"),
+        }
+    }
+
+    #[test]
+    fn test_invalid_expression_function_argument_reports_binding_diagnostic() {
+        let code = r#"
+            module Top (a: input logic<8>, q: output logic<8>) {
+                function f (x: input logic<8>) -> logic<8> {
+                    return x;
+                }
+
+                always_comb {
+                    q = f(a);
+                }
+            }
+        "#;
+        let mut module = parse_top_module(code);
+        let comb_index = module
+            .declarations
+            .iter()
+            .position(|declaration| matches!(declaration, Declaration::Comb(_)))
+            .unwrap();
+        let Declaration::Comb(comb) = &mut module.declarations[comb_index] else {
+            unreachable!();
+        };
+        let Statement::Assign(assign) = &mut comb.statements[0] else {
+            panic!("expected assignment statement");
+        };
+        let Expression::Term(factor) = &mut assign.expr else {
+            panic!("expected function-call term");
+        };
+        let Factor::FunctionCall(call) = factor.as_mut() else {
+            panic!("expected expression-form function call");
+        };
+        call.inputs.clear();
+
+        let Declaration::Comb(comb) = &module.declarations[comb_index] else {
+            unreachable!();
+        };
+        let mut arena = SLTNodeArena::new();
+        let error = match super::parse_comb(&module, comb, &mut arena) {
+            Ok(_) => panic!("expected an invalid function argument error"),
+            Err(error) => error,
+        };
+        assert_eq!(
+            error.to_string(),
+            "Invalid argument binding for `x` in call to function `f`: formal argument has neither an input expression nor an output destination"
+        );
+        assert_eq!(
+            miette::Diagnostic::code(&error).unwrap().to_string(),
+            "invalid_function_argument_binding"
+        );
+        match error {
+            ParserError::InvalidFunctionArgumentBinding {
+                function,
+                argument,
+                detail,
+                source_location,
+            } => {
+                assert_eq!(function, "f");
+                assert_eq!(argument, "x");
+                assert_eq!(
+                    detail,
+                    "formal argument has neither an input expression nor an output destination"
+                );
+                assert!(source_location.is_some());
+            }
+            error => panic!("expected an argument binding diagnostic, got {error:?}"),
+        }
     }
 
     #[test]

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -1929,12 +1929,11 @@ fn eval_function_call_expression(
     let mut arg_bounds = BoundaryMap::default();
     for (arg_path, arg_id) in &function_body.arg_map {
         let Some(arg_expr) = call.inputs.get(arg_path) else {
-            return Err(ParserError::unsupported(
-                61,
-                LoweringPhase::CombLowering,
-                "function call missing argument",
-                format!("{call}"),
-                Some(&call.comptime.token),
+            return Err(super::invalid_function_call_argument_error(
+                function,
+                arg_path,
+                "formal argument has neither an input expression nor an output destination",
+                call,
             ));
         };
 


### PR DESCRIPTION
## Summary

- classify comb function argument bindings absent from both Veryl input and output maps as invalid rather than unsupported
- add a typed, source-located `InvalidFunctionArgumentBinding` diagnostic with the code `invalid_function_argument_binding`
- cover both expression-form and statement-form comb calls with regression tests

## Root cause

Veryl validates function arity before producing usable IR and represents valid output arguments separately in `FunctionCall.outputs`. A formal argument absent from both `inputs` and `outputs` is therefore invalid analyzer IR, not a semantically valid lowering shape that Celox needs to support.

## Impact

Malformed function-call bindings now produce a precise invalid-binding diagnostic naming the function and formal argument instead of an unsupported comb-lowering error tied to a tracking issue.

## Validation

- `cargo test -p celox-frontend-veryl`
- `cargo clippy -p celox-frontend-veryl --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #61