### PR TITLE
refactor(veryl): remove stale array literal diagnostics

### DIFF
--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -432,7 +432,7 @@ impl<'a> FfParser<'a> {
         }
 
         let Some(selected_expr) =
-            self.select_array_literal_element(items, &resolved_indices, &array_dims)?
+            self.select_array_literal_element(items, &resolved_indices, &array_dims)
         else {
             return Ok(false);
         };
@@ -465,12 +465,14 @@ impl<'a> FfParser<'a> {
         items: &'b [ArrayLiteralItem],
         indices: &[usize],
         dims: &[usize],
-    ) -> Result<Option<&'b Expression>, ParserError> {
+    ) -> Option<&'b Expression> {
+        // Function argument shape validation has already rejected unresolved
+        // repeats and duplicate defaults, including in nested literals.
         let Some((&target_idx, rest_indices)) = indices.split_first() else {
-            return Ok(None);
+            return None;
         };
         let Some((_dim, rest_dims)) = dims.split_first() else {
-            return Ok(None);
+            return None;
         };
 
         let mut pos = 0usize;
@@ -480,42 +482,35 @@ impl<'a> FfParser<'a> {
             match item {
                 ArrayLiteralItem::Value(expr, repeat) => {
                     let rep_count = if let Some(rep_expr) = repeat {
-                        self.get_constant_value(rep_expr).ok_or_else(|| {
-                            ParserError::unsupported(
-                                68,
-                                LoweringPhase::FfLowering,
-                                "array literal non-constant repeat",
-                                format!("{:?}", rep_expr),
-                                Some(&rep_expr.token_range()),
-                            )
-                        })? as usize
+                        let Some(rep_count) = self.get_constant_value(rep_expr) else {
+                            unreachable!(
+                                "array literal repeat must be constant after function argument shape validation"
+                            );
+                        };
+                        rep_count as usize
                     } else {
                         1
                     };
 
                     if target_idx < pos + rep_count {
                         if rest_dims.is_empty() {
-                            return Ok(Some(expr));
+                            return Some(expr);
                         }
                         return match expr.as_ref() {
                             Expression::ArrayLiteral(nested, _) => {
                                 self.select_array_literal_element(nested, rest_indices, rest_dims)
                             }
-                            _ if expr.comptime().r#type.array.is_empty() => Ok(Some(expr)),
-                            _ => Ok(None),
+                            _ if expr.comptime().r#type.array.is_empty() => Some(expr),
+                            _ => None,
                         };
                     }
                     pos += rep_count;
                 }
                 ArrayLiteralItem::Defaul(expr) => {
                     if default_expr.is_some() {
-                        return Err(ParserError::unsupported(
-                            68,
-                            LoweringPhase::FfLowering,
-                            "array literal multiple default",
-                            format!("{:?}", items),
-                            Some(&expr.token_range()),
-                        ));
+                        unreachable!(
+                            "array literal must have at most one default after function argument shape validation"
+                        );
                     }
                     default_expr = Some(expr);
                 }
@@ -523,17 +518,17 @@ impl<'a> FfParser<'a> {
         }
 
         let Some(default_expr) = default_expr else {
-            return Ok(None);
+            return None;
         };
         if rest_dims.is_empty() {
-            return Ok(Some(default_expr));
+            return Some(default_expr);
         }
         match default_expr {
             Expression::ArrayLiteral(nested, _) => {
                 self.select_array_literal_element(nested, rest_indices, rest_dims)
             }
-            _ if default_expr.comptime().r#type.array.is_empty() => Ok(Some(default_expr)),
-            _ => Ok(None),
+            _ if default_expr.comptime().r#type.array.is_empty() => Some(default_expr),
+            _ => None,
         }
     }
 

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -976,6 +976,63 @@ fn test_ff_array_literal_non_constant_repeat_is_illegal_context() {
 }
 
 #[test]
+fn test_ff_function_argument_array_literal_non_constant_repeat_is_rejected_by_shape_validation() {
+    let code = r#"
+        module Top (
+            clk: input clock,
+            n: input logic<2>,
+            out_q: output logic<8>
+        ) {
+            function f (x: input logic<8>[2]) -> logic<8> {
+                return x[1];
+            }
+            always_ff (clk) {
+                out_q = f('{8'h11 repeat n});
+            }
+        }
+    "#;
+
+    let err = Simulator::builder(code, "Top")
+        .build()
+        .expect_err("non-constant repeat must be rejected");
+    match err.kind() {
+        SimulatorErrorKind::SIRParser(ParserError::Unsupported { issue, feature, .. }) => {
+            assert_eq!(*issue, 43);
+            assert_eq!(*feature, "function call argument shape");
+        }
+        other => panic!("expected function argument shape error, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_ff_function_argument_array_literal_multiple_default_is_rejected_by_shape_validation() {
+    let code = r#"
+        module Top (
+            clk: input clock,
+            out_q: output logic<8>
+        ) {
+            function f (x: input logic<8>[2]) -> logic<8> {
+                return x[1];
+            }
+            always_ff (clk) {
+                out_q = f('{default: 8'h11, default: 8'h22});
+            }
+        }
+    "#;
+
+    let err = Simulator::builder(code, "Top")
+        .build()
+        .expect_err("multiple defaults must be rejected");
+    match err.kind() {
+        SimulatorErrorKind::SIRParser(ParserError::Unsupported { issue, feature, .. }) => {
+            assert_eq!(*issue, 43);
+            assert_eq!(*feature, "function call argument shape");
+        }
+        other => panic!("expected function argument shape error, got: {other:?}"),
+    }
+}
+
+#[test]
 fn test_ff_array_literal_width_overflow_is_illegal_context() {
     let code = r#"
         module Top (


### PR DESCRIPTION
## Summary

- Replace two issue #68 `unsupported` branches in array-literal element selection with internal invariants.
- Simplify the selector to return `Option` now that it has no recoverable error path.
- Add regressions showing non-constant repeats and duplicate defaults are rejected by function-argument shape validation before element selection.

Related to #68.

## Why

`validate_function_call_bindings` recursively checks array-literal shapes on every FF function-call path. It rejects unresolved repeat counts and duplicate defaults before a bound array literal can reach `select_array_literal_element`. Repeat validation and selection also use the same constant evaluator, so the selector's two `unsupported` results represented states already ruled out by the preceding validation.

This guarantee comes from Celox's function-argument shape validation. Veryl 0.20.2 does not consistently emit analyzer errors for these forms when they appear as function arguments.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --locked --workspace --all-targets`
- `cargo test --locked -p celox-frontend-veryl`
- `cargo test --locked -p celox --test error_detection`
- Focused valid array-literal function-argument tests across native, Cranelift, and Wasm backends
- pre-push hook (`submodule-check`, `biome`, `cargo-fmt`, `cargo-check`, `clean-tree`)