### PR TITLE
fix(veryl): materialize array literal function arguments

### DIFF
--- a/crates/celox-frontend-veryl/src/ff.rs
+++ b/crates/celox-frontend-veryl/src/ff.rs
@@ -266,10 +266,18 @@ struct FunctionArrayView {
     owns_backing: bool,
     // Lazily evaluated literal items are keyed by their structural path in
     // the bound array literal so the cache survives cloned bindings.
-    cached_literal_items: HashMap<Vec<usize>, Vec<RegisterId>>,
+    cached_literal_items: HashMap<Vec<usize>, FunctionArrayLiteralItemCache>,
     // Branch-local lazy initialization is represented explicitly at control
     // flow joins. `None` means every path reaching the current block has a
     // valid backing view; `Some` guards the carried element snapshot.
+    initialized: Option<RegisterId>,
+}
+
+#[derive(Clone)]
+struct FunctionArrayLiteralItemCache {
+    elements: Vec<RegisterId>,
+    // `None` means the item is available on every path reaching the current
+    // block. `Some` guards a cache populated on only some predecessors.
     initialized: Option<RegisterId>,
 }
 

--- a/crates/celox-frontend-veryl/src/ff.rs
+++ b/crates/celox-frontend-veryl/src/ff.rs
@@ -277,6 +277,9 @@ pub struct FfParser<'a> {
     loop_exit_blocks: Vec<BlockId>,
     reset: Option<FfReset>,
     function_arg_stack: Vec<HashMap<VarId, Expression>>,
+    // Maps an active array formal to the formal whose working region owns
+    // its call-scoped backing storage.
+    function_array_view_stack: Vec<HashMap<VarId, VarId>>,
     runtime_errors: HashMap<i64, RuntimeErrorInfo<VarId>>,
     runtime_event_sites: Vec<RuntimeEventSite>,
     next_runtime_error_code: i64,
@@ -314,6 +317,7 @@ impl<'a> FfParser<'a> {
             loop_exit_blocks: Vec::new(),
             reset: None,
             function_arg_stack: Vec::new(),
+            function_array_view_stack: Vec::new(),
             runtime_errors: HashMap::default(),
             runtime_event_sites: Vec::new(),
             next_runtime_error_code: 2000,

--- a/crates/celox-frontend-veryl/src/ff.rs
+++ b/crates/celox-frontend-veryl/src/ff.rs
@@ -264,6 +264,10 @@ struct FunctionArrayView {
     // Aliased forwarding views do not write their backing and therefore do
     // not require the caller's snapshot to be restored.
     owns_backing: bool,
+    // Branch-local lazy initialization is represented explicitly at control
+    // flow joins. `None` means every path reaching the current block has a
+    // valid backing view; `Some` guards the carried element snapshot.
+    initialized: Option<RegisterId>,
 }
 
 impl<A> Default for FfGroupParseResult<A> {
@@ -288,6 +292,9 @@ pub struct FfParser<'a> {
     loop_exit_blocks: Vec<BlockId>,
     reset: Option<FfReset>,
     function_arg_stack: Vec<HashMap<VarId, Expression>>,
+    // Invocation-wide analysis records which formals will eventually need a
+    // complete view, without evaluating their actual arguments early.
+    function_array_view_plan_stack: Vec<HashSet<VarId>>,
     // Maps an active array formal to its call-specific register snapshot and
     // the formal working region used for O(1) dynamic element loads.
     function_array_view_stack: Vec<HashMap<VarId, FunctionArrayView>>,
@@ -328,6 +335,7 @@ impl<'a> FfParser<'a> {
             loop_exit_blocks: Vec::new(),
             reset: None,
             function_arg_stack: Vec::new(),
+            function_array_view_plan_stack: Vec::new(),
             function_array_view_stack: Vec::new(),
             runtime_errors: HashMap::default(),
             runtime_event_sites: Vec::new(),

--- a/crates/celox-frontend-veryl/src/ff.rs
+++ b/crates/celox-frontend-veryl/src/ff.rs
@@ -264,6 +264,9 @@ struct FunctionArrayView {
     // Aliased forwarding views do not write their backing and therefore do
     // not require the caller's snapshot to be restored.
     owns_backing: bool,
+    // Lazily evaluated literal items are keyed by their structural path in
+    // the bound array literal so the cache survives cloned bindings.
+    cached_literal_items: HashMap<Vec<usize>, Vec<RegisterId>>,
     // Branch-local lazy initialization is represented explicitly at control
     // flow joins. `None` means every path reaching the current block has a
     // valid backing view; `Some` guards the carried element snapshot.
@@ -292,9 +295,6 @@ pub struct FfParser<'a> {
     loop_exit_blocks: Vec<BlockId>,
     reset: Option<FfReset>,
     function_arg_stack: Vec<HashMap<VarId, Expression>>,
-    // Invocation-wide analysis records which formals will eventually need a
-    // complete view, without evaluating their actual arguments early.
-    function_array_view_plan_stack: Vec<HashSet<VarId>>,
     // Maps an active array formal to its call-specific register snapshot and
     // the formal working region used for O(1) dynamic element loads.
     function_array_view_stack: Vec<HashMap<VarId, FunctionArrayView>>,
@@ -335,7 +335,6 @@ impl<'a> FfParser<'a> {
             loop_exit_blocks: Vec::new(),
             reset: None,
             function_arg_stack: Vec::new(),
-            function_array_view_plan_stack: Vec::new(),
             function_array_view_stack: Vec::new(),
             runtime_errors: HashMap::default(),
             runtime_event_sites: Vec::new(),

--- a/crates/celox-frontend-veryl/src/ff.rs
+++ b/crates/celox-frontend-veryl/src/ff.rs
@@ -255,6 +255,17 @@ pub struct FfGroupParseResult<A = RegionedVarAddr> {
     pub dynamic_write_vars: HashSet<VarId>,
 }
 
+#[derive(Clone)]
+struct FunctionArrayView {
+    backing_var_id: VarId,
+    // Registers preserve this invocation's values if a nested invocation
+    // temporarily reuses the same formal working region.
+    elements: Vec<RegisterId>,
+    // Aliased forwarding views do not write their backing and therefore do
+    // not require the caller's snapshot to be restored.
+    owns_backing: bool,
+}
+
 impl<A> Default for FfGroupParseResult<A> {
     fn default() -> Self {
         Self {
@@ -277,9 +288,9 @@ pub struct FfParser<'a> {
     loop_exit_blocks: Vec<BlockId>,
     reset: Option<FfReset>,
     function_arg_stack: Vec<HashMap<VarId, Expression>>,
-    // Maps an active array formal to the formal whose working region owns
-    // its call-scoped backing storage.
-    function_array_view_stack: Vec<HashMap<VarId, VarId>>,
+    // Maps an active array formal to its call-specific register snapshot and
+    // the formal working region used for O(1) dynamic element loads.
+    function_array_view_stack: Vec<HashMap<VarId, FunctionArrayView>>,
     runtime_errors: HashMap<i64, RuntimeErrorInfo<VarId>>,
     runtime_event_sites: Vec<RuntimeEventSite>,
     next_runtime_error_code: i64,

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -1,9 +1,9 @@
-use super::{Domain, FfParser};
+use super::{Domain, FfParser, FunctionArrayView};
 use crate::context_width::{
     ValueContext, binary_semantics, cast_semantics, expression_signed, resolve_binary_op,
 };
 use crate::{
-    HashMap, LoweringPhase, ParserError,
+    HashMap, HashSet, LoweringPhase, ParserError,
     bitaccess::{
         celox_value_from_comptime, celox_value_from_comptime_in_context, eval_var_select,
         get_access_width, is_static_access,
@@ -434,7 +434,7 @@ impl<'a> FfParser<'a> {
         convert: &impl Fn(VarId, u32) -> A,
         sources: &mut Vec<VarAtomBase<A>>,
         ir_builder: &mut SIRBuilder<A>,
-    ) -> Result<(), ParserError> {
+    ) -> Result<FunctionArrayView, ParserError> {
         // Function bodies are lowered inline, so the formal's working region
         // is a call-scoped temporary. Populate it before lowering any output
         // or return expression so every later access is dominated by these
@@ -453,6 +453,7 @@ impl<'a> FfParser<'a> {
         let layout = self.array_view_layout(var_id)?;
 
         let mut cached_elements = std::collections::HashMap::new();
+        let mut elements = Vec::with_capacity(layout.element_count);
         for linear_index in 0..layout.element_count {
             let mut remainder = linear_index;
             let mut coordinates = vec![0usize; array_dims.len()];
@@ -491,27 +492,52 @@ impl<'a> FfParser<'a> {
                 cached_elements.insert(cache_key, reg);
                 reg
             };
+            elements.push(selected_reg);
+        }
+
+        self.store_array_view_elements(
+            var_id,
+            &elements,
+            layout.element_width,
+            convert,
+            ir_builder,
+        );
+
+        Ok(FunctionArrayView {
+            backing_var_id: var_id,
+            elements,
+            owns_backing: true,
+        })
+    }
+
+    fn store_array_view_elements<A>(
+        &self,
+        backing_var_id: VarId,
+        elements: &[RegisterId],
+        element_width: usize,
+        convert: &impl Fn(VarId, u32) -> A,
+        ir_builder: &mut SIRBuilder<A>,
+    ) {
+        for (linear_index, &element) in elements.iter().enumerate() {
             let element_index = ir_builder.alloc_bit(64, false);
             ir_builder.emit(SIRInstruction::Imm(
                 element_index,
                 SIRValue::new(linear_index as u64),
             ));
             ir_builder.emit(SIRInstruction::Store(
-                convert(var_id, WORKING_REGION),
+                convert(backing_var_id, WORKING_REGION),
                 SIROffset::Element {
                     index: element_index,
-                    element_width: layout.element_width,
+                    element_width,
                     bit_offset: 0,
                     dynamic_bit_offset: None,
                 },
-                layout.element_width,
-                selected_reg,
+                element_width,
+                element,
                 Vec::new(),
                 Vec::new(),
             ));
         }
-
-        Ok(())
     }
 
     fn materialize_converted_array_view<A>(
@@ -520,7 +546,7 @@ impl<'a> FfParser<'a> {
         backing_var_id: VarId,
         convert: &impl Fn(VarId, u32) -> A,
         ir_builder: &mut SIRBuilder<A>,
-    ) -> Result<(), ParserError> {
+    ) -> Result<FunctionArrayView, ParserError> {
         // A view can alias an existing backing only when both formals use the
         // same element storage representation. Otherwise create a converted
         // temporary for the callee while preserving element-wise coercion.
@@ -530,6 +556,7 @@ impl<'a> FfParser<'a> {
             unreachable!("function argument shape validation preserves array element count");
         }
 
+        let mut elements = Vec::with_capacity(target.element_count);
         for linear_index in 0..target.element_count {
             let element_index = ir_builder.alloc_bit(64, false);
             ir_builder.emit(SIRInstruction::Imm(
@@ -560,68 +587,330 @@ impl<'a> FfParser<'a> {
                 target.signed,
                 target.is_2state,
             );
-            ir_builder.emit(SIRInstruction::Store(
-                convert(var_id, WORKING_REGION),
-                SIROffset::Element {
-                    index: element_index,
-                    element_width: target.element_width,
-                    bit_offset: 0,
-                    dynamic_bit_offset: None,
-                },
-                target.element_width,
-                converted,
-                Vec::new(),
-                Vec::new(),
-            ));
+            elements.push(converted);
         }
-        Ok(())
+        self.store_array_view_elements(
+            var_id,
+            &elements,
+            target.element_width,
+            convert,
+            ir_builder,
+        );
+        Ok(FunctionArrayView {
+            backing_var_id: var_id,
+            elements,
+            owns_backing: true,
+        })
+    }
+
+    fn array_access_needs_view(&self, var_id: VarId, index: &VarIndex, select: &VarSelect) -> bool {
+        let Some(formal) = self.module.variables.get(&var_id) else {
+            return false;
+        };
+        if formal.r#type.array.is_empty() {
+            return false;
+        }
+        if select.1.is_some() {
+            return true;
+        }
+        let Some(array_dims) = formal
+            .r#type
+            .array
+            .iter()
+            .copied()
+            .collect::<Option<Vec<_>>>()
+        else {
+            return true;
+        };
+        let all_indices = index.0.iter().chain(&select.0).collect::<Vec<_>>();
+        all_indices.len() != array_dims.len()
+            || all_indices.iter().zip(array_dims).any(|(expr, dim)| {
+                self.get_constant_value(expr)
+                    .is_none_or(|value| value as usize >= dim)
+            })
+    }
+
+    fn collect_array_views_for_expression(
+        &self,
+        expr: &Expression,
+        views: &mut Vec<VarId>,
+        seen: &mut HashSet<VarId>,
+    ) {
+        let collect = |expr, views: &mut Vec<_>, seen: &mut HashSet<_>| {
+            self.collect_array_views_for_expression(expr, views, seen)
+        };
+        match expr {
+            Expression::Term(factor) => match factor.as_ref() {
+                Factor::Variable(var_id, index, select, _) => {
+                    let is_bound_here = self
+                        .function_arg_stack
+                        .last()
+                        .is_some_and(|bindings| bindings.contains_key(var_id));
+                    if is_bound_here
+                        && self.array_access_needs_view(*var_id, index, select)
+                        && seen.insert(*var_id)
+                    {
+                        views.push(*var_id);
+                    }
+                    for expr in &index.0 {
+                        collect(expr, views, seen);
+                    }
+                    for expr in &select.0 {
+                        collect(expr, views, seen);
+                    }
+                    if let Some((_, expr)) = &select.1 {
+                        collect(expr, views, seen);
+                    }
+                }
+                Factor::FunctionCall(call) => {
+                    for expr in call.inputs.values() {
+                        collect(expr, views, seen);
+                    }
+                }
+                Factor::SystemFunctionCall(call) => match &call.kind {
+                    SystemFunctionKind::Bits(input)
+                    | SystemFunctionKind::Size(input)
+                    | SystemFunctionKind::Clog2(input)
+                    | SystemFunctionKind::Onehot(input)
+                    | SystemFunctionKind::Signed(input)
+                    | SystemFunctionKind::Unsigned(input) => collect(&input.0, views, seen),
+                    SystemFunctionKind::Readmemh(_, _)
+                    | SystemFunctionKind::Display(_)
+                    | SystemFunctionKind::Write(_)
+                    | SystemFunctionKind::Assert { .. }
+                    | SystemFunctionKind::Finish => {}
+                },
+                Factor::Value(_) | Factor::Anonymous(_) | Factor::Unknown(_) => {}
+            },
+            Expression::Binary(lhs, _, rhs, _) => {
+                collect(lhs, views, seen);
+                collect(rhs, views, seen);
+            }
+            Expression::Unary(_, inner, _) => collect(inner, views, seen),
+            Expression::Ternary(cond, then_expr, else_expr, _) => {
+                collect(cond, views, seen);
+                collect(then_expr, views, seen);
+                collect(else_expr, views, seen);
+            }
+            Expression::Concatenation(items, _) => {
+                for (expr, repeat) in items {
+                    collect(expr, views, seen);
+                    if let Some(repeat) = repeat {
+                        collect(repeat, views, seen);
+                    }
+                }
+            }
+            Expression::ArrayLiteral(items, _) => {
+                for item in items {
+                    match item {
+                        ArrayLiteralItem::Value(expr, repeat) => {
+                            collect(expr, views, seen);
+                            if let Some(repeat) = repeat {
+                                collect(repeat, views, seen);
+                            }
+                        }
+                        ArrayLiteralItem::Defaul(expr) => collect(expr, views, seen),
+                    }
+                }
+            }
+            Expression::StructConstructor(_, fields, _) => {
+                for (_, expr) in fields {
+                    collect(expr, views, seen);
+                }
+            }
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(super) fn materialize_function_array_views<A>(
+    fn ensure_function_array_view_at<A>(
         &mut self,
-        bindings: &HashMap<VarId, Expression>,
+        frame: usize,
+        var_id: VarId,
         targets: &mut Vec<VarAtomBase<A>>,
         domain: &Domain,
         convert: &impl Fn(VarId, u32) -> A,
         sources: &mut Vec<VarAtomBase<A>>,
         ir_builder: &mut SIRBuilder<A>,
-    ) -> Result<HashMap<VarId, VarId>, ParserError> {
-        let mut views = HashMap::default();
-        for (&var_id, bound_expr) in bindings {
-            if let Expression::ArrayLiteral(items, _) = bound_expr {
-                if self.module.variables[&var_id].r#type.array.is_empty() {
-                    continue;
-                }
-                self.materialize_bound_array_literal_view(
-                    var_id, items, targets, domain, convert, sources, ir_builder,
-                )?;
-                views.insert(var_id, var_id);
-            } else if let Expression::Term(factor) = bound_expr
-                && let Factor::Variable(bound_var_id, index, select, _) = factor.as_ref()
-                && index.0.is_empty()
-                && select.0.is_empty()
-                && select.1.is_none()
-                && let Some(backing_var_id) = self.get_bound_function_array_view(*bound_var_id)
+    ) -> Result<Option<FunctionArrayView>, ParserError> {
+        if let Some(view) = self.function_array_view_stack[frame].get(&var_id) {
+            return Ok(Some(view.clone()));
+        }
+        let Some(bound_expr) = self.function_arg_stack[frame].get(&var_id).cloned() else {
+            return Ok(None);
+        };
+
+        let view = match bound_expr {
+            Expression::ArrayLiteral(items, _)
+                if !self.module.variables[&var_id].r#type.array.is_empty() =>
             {
+                Some(self.materialize_bound_array_literal_view(
+                    var_id, &items, targets, domain, convert, sources, ir_builder,
+                )?)
+            }
+            Expression::Term(factor) => {
+                let Factor::Variable(bound_var_id, index, select, _) = factor.as_ref() else {
+                    return Ok(None);
+                };
+                if !index.0.is_empty() || !select.0.is_empty() || select.1.is_some() {
+                    return Ok(None);
+                }
+                let Some(source_frame) = (0..frame)
+                    .rev()
+                    .find(|&i| self.function_arg_stack[i].contains_key(bound_var_id))
+                else {
+                    return Ok(None);
+                };
+                let Some(source_view) = self.ensure_function_array_view_at(
+                    source_frame,
+                    *bound_var_id,
+                    targets,
+                    domain,
+                    convert,
+                    sources,
+                    ir_builder,
+                )?
+                else {
+                    return Ok(None);
+                };
                 let target = self.array_view_layout(var_id)?;
-                let backing = self.array_view_layout(backing_var_id)?;
-                if target.element_width == backing.element_width
-                    && target.is_2state == backing.is_2state
+                let source = self.array_view_layout(*bound_var_id)?;
+                if target.element_width == source.element_width
+                    && target.is_2state == source.is_2state
                 {
-                    views.insert(var_id, backing_var_id);
+                    Some(FunctionArrayView {
+                        backing_var_id: source_view.backing_var_id,
+                        elements: source_view.elements,
+                        owns_backing: false,
+                    })
                 } else {
-                    self.materialize_converted_array_view(
+                    Some(self.materialize_converted_array_view(
                         var_id,
-                        backing_var_id,
+                        source_view.backing_var_id,
                         convert,
                         ir_builder,
-                    )?;
-                    views.insert(var_id, var_id);
+                    )?)
+                }
+            }
+            _ => None,
+        };
+        if let Some(view) = &view {
+            self.function_array_view_stack[frame].insert(var_id, view.clone());
+        }
+        Ok(view)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn prepare_function_array_views_for_expression<A>(
+        &mut self,
+        expr: &Expression,
+        targets: &mut Vec<VarAtomBase<A>>,
+        domain: &Domain,
+        convert: &impl Fn(VarId, u32) -> A,
+        sources: &mut Vec<VarAtomBase<A>>,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<(), ParserError> {
+        let Some(frame) = self.function_arg_stack.len().checked_sub(1) else {
+            return Ok(());
+        };
+        // Prepare outside the expression's control-flow lowering so every
+        // dynamic load is dominated by the stores that initialize its view.
+        // Fully static literal element accesses are deliberately omitted and
+        // continue through the direct-selection path below.
+        let mut views = Vec::new();
+        self.collect_array_views_for_expression(expr, &mut views, &mut HashSet::default());
+        for var_id in views {
+            self.ensure_function_array_view_at(
+                frame, var_id, targets, domain, convert, sources, ir_builder,
+            )?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn restore_active_function_array_views<A>(
+        &self,
+        finished_views: &HashMap<VarId, FunctionArrayView>,
+        convert: &impl Fn(VarId, u32) -> A,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<(), ParserError> {
+        let clobbered = finished_views
+            .values()
+            .filter(|view| view.owns_backing)
+            .map(|view| view.backing_var_id)
+            .collect::<HashSet<_>>();
+        let mut restored = HashSet::default();
+        for frame in self.function_array_view_stack.iter().rev() {
+            for view in frame.values() {
+                if clobbered.contains(&view.backing_var_id) && restored.insert(view.backing_var_id)
+                {
+                    let layout = self.array_view_layout(view.backing_var_id)?;
+                    self.store_array_view_elements(
+                        view.backing_var_id,
+                        &view.elements,
+                        layout.element_width,
+                        convert,
+                        ir_builder,
+                    );
                 }
             }
         }
-        Ok(views)
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn materialize_bound_array_literal_access<A>(
+        &mut self,
+        var_id: VarId,
+        items: &[ArrayLiteralItem],
+        index: &VarIndex,
+        select: &VarSelect,
+        targets: &mut Vec<VarAtomBase<A>>,
+        domain: &Domain,
+        convert: &impl Fn(VarId, u32) -> A,
+        sources: &mut Vec<VarAtomBase<A>>,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<bool, ParserError> {
+        if self.array_access_needs_view(var_id, index, select) {
+            return Ok(false);
+        }
+        let formal = &self.module.variables[&var_id];
+        let array_dims = formal
+            .r#type
+            .array
+            .iter()
+            .copied()
+            .flatten()
+            .collect::<Vec<_>>();
+        let all_indices = index.0.iter().chain(&select.0).collect::<Vec<_>>();
+        let resolved_indices = all_indices
+            .iter()
+            .map(|expr| self.get_constant_value(expr).unwrap() as usize)
+            .collect::<Vec<_>>();
+        let Some(selected_expr) =
+            self.select_array_literal_element(items, &resolved_indices, &array_dims)
+        else {
+            return Ok(false);
+        };
+        let access_width = get_access_width(self.module, var_id, index, select)?;
+        self.parse_expression(
+            selected_expr,
+            targets,
+            domain,
+            convert,
+            sources,
+            ir_builder,
+            Some(access_width),
+        )?;
+        let selected_reg = self.stack.pop_back().unwrap();
+        let coerced = self.coerce_register_to_formal(
+            ir_builder,
+            selected_reg,
+            access_width,
+            selected_expr.comptime().r#type.signed,
+            formal.r#type.signed,
+            formal.r#type.is_2state(),
+        );
+        self.stack.push_back(coerced);
+        Ok(true)
     }
 
     fn select_array_literal_element<'b>(
@@ -632,12 +921,8 @@ impl<'a> FfParser<'a> {
     ) -> Option<&'b Expression> {
         // Function argument shape validation has already rejected unresolved
         // repeats and duplicate defaults, including in nested literals.
-        let Some((&target_idx, rest_indices)) = indices.split_first() else {
-            return None;
-        };
-        let Some((_dim, rest_dims)) = dims.split_first() else {
-            return None;
-        };
+        let (&target_idx, rest_indices) = indices.split_first()?;
+        let (_dim, rest_dims) = dims.split_first()?;
 
         let mut pos = 0usize;
         let mut default_expr: Option<&Expression> = None;
@@ -681,9 +966,7 @@ impl<'a> FfParser<'a> {
             }
         }
 
-        let Some(default_expr) = default_expr else {
-            return None;
-        };
+        let default_expr = default_expr?;
         if rest_dims.is_empty() {
             return Some(default_expr);
         }
@@ -1119,7 +1402,7 @@ impl<'a> FfParser<'a> {
             return Ok(());
         }
 
-        let offset = self.emit_offset_calc(
+        let mut offset = self.emit_offset_calc(
             dst.id,
             &dst.index,
             &dst.select,
@@ -1128,6 +1411,29 @@ impl<'a> FfParser<'a> {
             sources,
             ir_builder,
         )?;
+        if !target_type.array.is_empty()
+            && dst.index.0.is_empty()
+            && dst.select.0.is_empty()
+            && dst.select.1.is_none()
+        {
+            let Some(element_count) = target_type
+                .array
+                .iter()
+                .copied()
+                .try_fold(1usize, |total, dim| {
+                    dim.and_then(|dim| total.checked_mul(dim))
+                })
+            else {
+                unreachable!("whole-array store dimensions are resolved without overflow");
+            };
+            if element_count == 0 || !target_width.is_multiple_of(element_count) {
+                unreachable!("whole-array store width is divisible by its nonzero element count");
+            }
+            offset = SIROffset::PackedElements {
+                bit_offset: 0,
+                element_width: target_width / element_count,
+            };
+        }
         let is_static = is_static_access(&dst.index, &dst.select);
         let store_region = if matches!(domain, Domain::Ff)
             && (!is_static || self.sparse_write_vars.contains(&dst.id))
@@ -1797,6 +2103,15 @@ impl<'a> FfParser<'a> {
                             );
                             self.stack.push_back(adjusted);
                         }
+                        return Ok(());
+                    }
+
+                    if let Expression::ArrayLiteral(items, _) = &bound_expr
+                        && self.materialize_bound_array_literal_access(
+                            *var_id, items, var_index, var_select, targets, domain, convert,
+                            sources, ir_builder,
+                        )?
+                    {
                         return Ok(());
                     }
 

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -453,6 +453,34 @@ impl<'a> FfParser<'a> {
         let layout = self.array_view_layout(var_id)?;
 
         let mut cached_elements = std::collections::HashMap::new();
+        let mut source_order = Vec::new();
+        Self::collect_array_literal_elements_in_source_order(items, &mut source_order);
+        for selected_expr in source_order {
+            let cache_key = selected_expr as *const Expression as usize;
+            if cached_elements.contains_key(&cache_key) {
+                continue;
+            }
+            self.parse_expression(
+                selected_expr,
+                targets,
+                domain,
+                convert,
+                sources,
+                ir_builder,
+                Some(layout.element_width),
+            )?;
+            let reg = self.stack.pop_back().unwrap();
+            let reg = self.coerce_register_to_formal(
+                ir_builder,
+                reg,
+                layout.element_width,
+                selected_expr.comptime().r#type.signed,
+                layout.signed,
+                layout.is_2state,
+            );
+            cached_elements.insert(cache_key, reg);
+        }
+
         let mut elements = Vec::with_capacity(layout.element_count);
         for linear_index in 0..layout.element_count {
             let mut remainder = linear_index;
@@ -468,29 +496,8 @@ impl<'a> FfParser<'a> {
                 unreachable!("validated array literal covers every formal element");
             };
             let cache_key = selected_expr as *const Expression as usize;
-            let selected_reg = if let Some(reg) = cached_elements.get(&cache_key) {
-                *reg
-            } else {
-                self.parse_expression(
-                    selected_expr,
-                    targets,
-                    domain,
-                    convert,
-                    sources,
-                    ir_builder,
-                    Some(layout.element_width),
-                )?;
-                let reg = self.stack.pop_back().unwrap();
-                let reg = self.coerce_register_to_formal(
-                    ir_builder,
-                    reg,
-                    layout.element_width,
-                    selected_expr.comptime().r#type.signed,
-                    layout.signed,
-                    layout.is_2state,
-                );
-                cached_elements.insert(cache_key, reg);
-                reg
+            let Some(&selected_reg) = cached_elements.get(&cache_key) else {
+                unreachable!("every selected element was evaluated in literal source order");
             };
             elements.push(selected_reg);
         }
@@ -508,6 +515,22 @@ impl<'a> FfParser<'a> {
             elements,
             owns_backing: true,
         })
+    }
+
+    fn collect_array_literal_elements_in_source_order<'b>(
+        items: &'b [ArrayLiteralItem],
+        elements: &mut Vec<&'b Expression>,
+    ) {
+        for item in items {
+            let expr = match item {
+                ArrayLiteralItem::Value(expr, _) | ArrayLiteralItem::Defaul(expr) => expr.as_ref(),
+            };
+            if let Expression::ArrayLiteral(nested, _) = expr {
+                Self::collect_array_literal_elements_in_source_order(nested, elements);
+            } else {
+                elements.push(expr);
+            }
+        }
     }
 
     fn store_array_view_elements<A>(
@@ -668,9 +691,10 @@ impl<'a> FfParser<'a> {
                     }
                 }
                 Factor::SystemFunctionCall(call) => match &call.kind {
-                    SystemFunctionKind::Bits(input)
-                    | SystemFunctionKind::Size(input)
-                    | SystemFunctionKind::Clog2(input)
+                    // Reflection queries are compile-time constants and do
+                    // not evaluate their operand during expression lowering.
+                    SystemFunctionKind::Bits(_) | SystemFunctionKind::Size(_) => {}
+                    SystemFunctionKind::Clog2(input)
                     | SystemFunctionKind::Onehot(input)
                     | SystemFunctionKind::Signed(input)
                     | SystemFunctionKind::Unsigned(input) => collect(&input.0, views, seen),

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -94,6 +94,19 @@ struct ArrayViewLayout {
     is_2state: bool,
 }
 
+#[derive(Clone, Copy)]
+struct ArrayLiteralSelection<'a> {
+    expr: &'a Expression,
+    element_index: usize,
+    element_count: usize,
+}
+
+#[derive(Default)]
+struct FunctionInputUsage {
+    runtime_reads: HashSet<VarId>,
+    array_views: HashSet<VarId>,
+}
+
 fn add_offset_term<A>(
     accumulator: &mut Option<RegisterId>,
     term: RegisterId,
@@ -460,6 +473,28 @@ impl<'a> FfParser<'a> {
             if cached_elements.contains_key(&cache_key) {
                 continue;
             }
+            let element_count = selected_expr
+                .comptime()
+                .r#type
+                .array
+                .iter()
+                .copied()
+                .try_fold(1usize, |total, dim| {
+                    dim.and_then(|dim| total.checked_mul(dim))
+                })
+                .unwrap_or_else(|| {
+                    unreachable!(
+                        "function argument validation resolves array literal item dimensions"
+                    )
+                });
+            self.prepare_function_array_views_for_expression(
+                selected_expr,
+                targets,
+                domain,
+                convert,
+                sources,
+                ir_builder,
+            )?;
             self.parse_expression(
                 selected_expr,
                 targets,
@@ -467,18 +502,23 @@ impl<'a> FfParser<'a> {
                 convert,
                 sources,
                 ir_builder,
-                Some(layout.element_width),
+                (element_count == 1).then_some(layout.element_width),
             )?;
             let reg = self.stack.pop_back().unwrap();
-            let reg = self.coerce_register_to_formal(
-                ir_builder,
-                reg,
-                layout.element_width,
-                selected_expr.comptime().r#type.signed,
-                layout.signed,
-                layout.is_2state,
-            );
-            cached_elements.insert(cache_key, reg);
+            let mut item_elements = Vec::with_capacity(element_count);
+            for element_index in 0..element_count {
+                let element =
+                    self.slice_array_value_element(reg, element_index, element_count, ir_builder);
+                item_elements.push(self.coerce_register_to_formal(
+                    ir_builder,
+                    element,
+                    layout.element_width,
+                    selected_expr.comptime().r#type.signed,
+                    layout.signed,
+                    layout.is_2state,
+                ));
+            }
+            cached_elements.insert(cache_key, item_elements);
         }
 
         let mut elements = Vec::with_capacity(layout.element_count);
@@ -490,14 +530,20 @@ impl<'a> FfParser<'a> {
                 remainder /= array_dims[dimension];
             }
 
-            let Some(selected_expr) =
+            let Some(selection) =
                 self.select_array_literal_element(items, &coordinates, &array_dims)
             else {
                 unreachable!("validated array literal covers every formal element");
             };
-            let cache_key = selected_expr as *const Expression as usize;
-            let Some(&selected_reg) = cached_elements.get(&cache_key) else {
+            let cache_key = selection.expr as *const Expression as usize;
+            let Some(selected_regs) = cached_elements.get(&cache_key) else {
                 unreachable!("every selected element was evaluated in literal source order");
+            };
+            if selected_regs.len() != selection.element_count {
+                unreachable!("selected array literal item has the validated element count");
+            }
+            let Some(&selected_reg) = selected_regs.get(selection.element_index) else {
+                unreachable!("selected array literal item index is in bounds");
             };
             elements.push(selected_reg);
         }
@@ -531,6 +577,41 @@ impl<'a> FfParser<'a> {
                 elements.push(expr);
             }
         }
+    }
+
+    fn slice_array_value_element<A>(
+        &self,
+        reg: RegisterId,
+        element_index: usize,
+        element_count: usize,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> RegisterId {
+        if element_count == 0 || element_index >= element_count {
+            unreachable!("validated array value element index is in bounds");
+        }
+        if element_count == 1 {
+            return reg;
+        }
+        let source_width = ir_builder.register(&reg).width();
+        if !source_width.is_multiple_of(element_count) {
+            unreachable!("validated array value has a divisible nonzero width");
+        }
+        let source_element_width = source_width / element_count;
+        let source_type = ir_builder.register(&reg).clone();
+        let element = match source_type {
+            RegisterType::Logic { .. } => ir_builder.alloc_logic(source_element_width),
+            RegisterType::Bit { signed, .. } => ir_builder.alloc_bit(source_element_width, signed),
+        };
+        // Whole unpacked-array values use PackedElements order: coordinate
+        // zero starts at the low end of the register.
+        let bit_offset = element_index * source_element_width;
+        ir_builder.emit(SIRInstruction::Slice(
+            element,
+            reg,
+            bit_offset,
+            source_element_width,
+        ));
+        element
     }
 
     fn store_array_view_elements<A>(
@@ -653,6 +734,153 @@ impl<'a> FfParser<'a> {
             })
     }
 
+    fn function_input_usage(
+        &self,
+        call: &veryl_analyzer::ir::FunctionCall,
+        active_calls: &mut HashSet<VarId>,
+    ) -> Option<FunctionInputUsage> {
+        if !active_calls.insert(call.id) {
+            return None;
+        }
+        let result = (|| {
+            let function = self.module.functions.get(&call.id)?;
+            let function_body = if let Some(index) = &call.index {
+                function.get_function(index)?
+            } else {
+                function.get_function(&[])?
+            };
+            let mut usage = FunctionInputUsage::default();
+            for arg_path in call.outputs.keys() {
+                let arg_id = *function_body.arg_map.get(arg_path)?;
+                let expr = self
+                    .extract_function_target_expr(&function_body, arg_id, &HashMap::default())
+                    .ok()?;
+                self.collect_function_input_usage(&expr, &mut usage, active_calls)?;
+            }
+            if let Some(ret_id) = function_body.ret {
+                let expr = self
+                    .extract_function_return_expr(&function_body, ret_id)
+                    .ok()?;
+                self.collect_function_input_usage(&expr, &mut usage, active_calls)?;
+            }
+            let formals = function_body
+                .arg_map
+                .values()
+                .copied()
+                .collect::<HashSet<_>>();
+            usage
+                .runtime_reads
+                .retain(|var_id| formals.contains(var_id));
+            usage.array_views.retain(|var_id| formals.contains(var_id));
+            Some(usage)
+        })();
+        active_calls.remove(&call.id);
+        result
+    }
+
+    fn collect_function_input_usage(
+        &self,
+        expr: &Expression,
+        usage: &mut FunctionInputUsage,
+        active_calls: &mut HashSet<VarId>,
+    ) -> Option<()> {
+        match expr {
+            Expression::Term(factor) => match factor.as_ref() {
+                Factor::Variable(var_id, index, select, _) => {
+                    usage.runtime_reads.insert(*var_id);
+                    if self.array_access_needs_view(*var_id, index, select) {
+                        usage.array_views.insert(*var_id);
+                    }
+                    for expr in &index.0 {
+                        self.collect_function_input_usage(expr, usage, active_calls)?;
+                    }
+                    for expr in &select.0 {
+                        self.collect_function_input_usage(expr, usage, active_calls)?;
+                    }
+                    if let Some((_, expr)) = &select.1 {
+                        self.collect_function_input_usage(expr, usage, active_calls)?;
+                    }
+                }
+                Factor::FunctionCall(call) => {
+                    let nested_usage = self.function_input_usage(call, active_calls)?;
+                    let function = self.module.functions.get(&call.id)?;
+                    let function_body = if let Some(index) = &call.index {
+                        function.get_function(index)?
+                    } else {
+                        function.get_function(&[])?
+                    };
+                    for (arg_path, arg_id) in &function_body.arg_map {
+                        let formal = &self.module.variables[arg_id];
+                        let needs_actual = if formal.r#type.array.is_empty() {
+                            nested_usage.runtime_reads.contains(arg_id)
+                        } else {
+                            nested_usage.array_views.contains(arg_id)
+                        };
+                        if needs_actual && let Some(expr) = call.inputs.get(arg_path) {
+                            self.collect_function_input_usage(expr, usage, active_calls)?;
+                        }
+                    }
+                }
+                Factor::SystemFunctionCall(call) => match &call.kind {
+                    SystemFunctionKind::Bits(_) | SystemFunctionKind::Size(_) => {}
+                    SystemFunctionKind::Clog2(input)
+                    | SystemFunctionKind::Onehot(input)
+                    | SystemFunctionKind::Signed(input)
+                    | SystemFunctionKind::Unsigned(input) => {
+                        self.collect_function_input_usage(&input.0, usage, active_calls)?;
+                    }
+                    SystemFunctionKind::Readmemh(_, _)
+                    | SystemFunctionKind::Display(_)
+                    | SystemFunctionKind::Write(_)
+                    | SystemFunctionKind::Assert { .. }
+                    | SystemFunctionKind::Finish => {}
+                },
+                Factor::Value(_) | Factor::Anonymous(_) | Factor::Unknown(_) => {}
+            },
+            Expression::Binary(lhs, _, rhs, _) => {
+                self.collect_function_input_usage(lhs, usage, active_calls)?;
+                self.collect_function_input_usage(rhs, usage, active_calls)?;
+            }
+            Expression::Unary(_, inner, _) => {
+                self.collect_function_input_usage(inner, usage, active_calls)?;
+            }
+            Expression::Ternary(cond, then_expr, else_expr, _) => {
+                self.collect_function_input_usage(cond, usage, active_calls)?;
+                self.collect_function_input_usage(then_expr, usage, active_calls)?;
+                self.collect_function_input_usage(else_expr, usage, active_calls)?;
+            }
+            Expression::Concatenation(items, _) => {
+                for (expr, repeat) in items {
+                    self.collect_function_input_usage(expr, usage, active_calls)?;
+                    if let Some(repeat) = repeat {
+                        self.collect_function_input_usage(repeat, usage, active_calls)?;
+                    }
+                }
+            }
+            Expression::ArrayLiteral(items, _) => {
+                for item in items {
+                    match item {
+                        ArrayLiteralItem::Value(expr, repeat) => {
+                            self.collect_function_input_usage(expr, usage, active_calls)?;
+                            if let Some(repeat) = repeat {
+                                self.collect_function_input_usage(repeat, usage, active_calls)?;
+                            }
+                        }
+                        ArrayLiteralItem::Defaul(expr) => {
+                            self.collect_function_input_usage(expr, usage, active_calls)?;
+                        }
+                    }
+                }
+            }
+            Expression::StructConstructor(_, fields, _) => {
+                for (_, expr) in fields {
+                    self.collect_function_input_usage(expr, usage, active_calls)?;
+                }
+            }
+        }
+        Some(())
+    }
+
     fn collect_array_views_for_expression(
         &self,
         expr: &Expression,
@@ -686,8 +914,32 @@ impl<'a> FfParser<'a> {
                     }
                 }
                 Factor::FunctionCall(call) => {
-                    for expr in call.inputs.values() {
-                        collect(expr, views, seen);
+                    let input_usage = self.function_input_usage(call, &mut HashSet::default());
+                    let function_body = self.module.functions.get(&call.id).and_then(|function| {
+                        if let Some(index) = &call.index {
+                            function.get_function(index)
+                        } else {
+                            function.get_function(&[])
+                        }
+                    });
+                    if let (Some(input_usage), Some(function_body)) = (input_usage, function_body) {
+                        for (arg_path, arg_id) in &function_body.arg_map {
+                            let formal = &self.module.variables[arg_id];
+                            let needs_actual = if formal.r#type.array.is_empty() {
+                                input_usage.runtime_reads.contains(arg_id)
+                            } else {
+                                input_usage.array_views.contains(arg_id)
+                            };
+                            if needs_actual && let Some(expr) = call.inputs.get(arg_path) {
+                                collect(expr, views, seen);
+                            }
+                        }
+                    } else {
+                        // Unsupported or recursive callees will fail during
+                        // normal lowering; keep the conservative traversal.
+                        for expr in call.inputs.values() {
+                            collect(expr, views, seen);
+                        }
                     }
                 }
                 Factor::SystemFunctionCall(call) => match &call.kind {
@@ -713,8 +965,19 @@ impl<'a> FfParser<'a> {
             Expression::Unary(_, inner, _) => collect(inner, views, seen),
             Expression::Ternary(cond, then_expr, else_expr, _) => {
                 collect(cond, views, seen);
-                collect(then_expr, views, seen);
-                collect(else_expr, views, seen);
+                let mut then_views = Vec::new();
+                let mut then_seen = HashSet::default();
+                collect(then_expr, &mut then_views, &mut then_seen);
+                let mut else_views = Vec::new();
+                let mut else_seen = HashSet::default();
+                collect(else_expr, &mut else_views, &mut else_seen);
+                // Only views required by both arms may be prepared before the
+                // condition. Arm-local views are prepared inside that arm.
+                for var_id in then_views {
+                    if else_seen.contains(&var_id) && seen.insert(var_id) {
+                        views.push(var_id);
+                    }
+                }
             }
             Expression::Concatenation(items, _) => {
                 for (expr, repeat) in items {
@@ -850,6 +1113,14 @@ impl<'a> FfParser<'a> {
         Ok(())
     }
 
+    fn expression_needs_unmaterialized_array_view(&self, expr: &Expression) -> bool {
+        let mut views = Vec::new();
+        self.collect_array_views_for_expression(expr, &mut views, &mut HashSet::default());
+        views
+            .into_iter()
+            .any(|var_id| self.get_bound_function_array_view(var_id).is_none())
+    }
+
     pub(super) fn restore_active_function_array_views<A>(
         &self,
         finished_views: &HashMap<VarId, FunctionArrayView>,
@@ -909,12 +1180,21 @@ impl<'a> FfParser<'a> {
             .iter()
             .map(|expr| self.get_constant_value(expr).unwrap() as usize)
             .collect::<Vec<_>>();
-        let Some(selected_expr) =
+        let Some(selection) =
             self.select_array_literal_element(items, &resolved_indices, &array_dims)
         else {
             return Ok(false);
         };
         let access_width = get_access_width(self.module, var_id, index, select)?;
+        let selected_expr = selection.expr;
+        self.prepare_function_array_views_for_expression(
+            selected_expr,
+            targets,
+            domain,
+            convert,
+            sources,
+            ir_builder,
+        )?;
         self.parse_expression(
             selected_expr,
             targets,
@@ -922,9 +1202,15 @@ impl<'a> FfParser<'a> {
             convert,
             sources,
             ir_builder,
-            Some(access_width),
+            (selection.element_count == 1).then_some(access_width),
         )?;
         let selected_reg = self.stack.pop_back().unwrap();
+        let selected_reg = self.slice_array_value_element(
+            selected_reg,
+            selection.element_index,
+            selection.element_count,
+            ir_builder,
+        );
         let coerced = self.coerce_register_to_formal(
             ir_builder,
             selected_reg,
@@ -942,7 +1228,7 @@ impl<'a> FfParser<'a> {
         items: &'b [ArrayLiteralItem],
         indices: &[usize],
         dims: &[usize],
-    ) -> Option<&'b Expression> {
+    ) -> Option<ArrayLiteralSelection<'b>> {
         // Function argument shape validation has already rejected unresolved
         // repeats and duplicate defaults, including in nested literals.
         let (&target_idx, rest_indices) = indices.split_first()?;
@@ -967,14 +1253,28 @@ impl<'a> FfParser<'a> {
 
                     if target_idx < pos + rep_count {
                         if rest_dims.is_empty() {
-                            return Some(expr);
+                            return Some(ArrayLiteralSelection {
+                                expr,
+                                element_index: 0,
+                                element_count: 1,
+                            });
                         }
                         return match expr.as_ref() {
                             Expression::ArrayLiteral(nested, _) => {
                                 self.select_array_literal_element(nested, rest_indices, rest_dims)
                             }
-                            _ if expr.comptime().r#type.array.is_empty() => Some(expr),
-                            _ => None,
+                            _ if expr.comptime().r#type.array.is_empty() => {
+                                Some(ArrayLiteralSelection {
+                                    expr,
+                                    element_index: 0,
+                                    element_count: 1,
+                                })
+                            }
+                            _ => Some(ArrayLiteralSelection {
+                                expr,
+                                element_index: Self::linear_array_index(rest_indices, rest_dims)?,
+                                element_count: rest_dims.iter().product(),
+                            }),
                         };
                     }
                     pos += rep_count;
@@ -992,15 +1292,41 @@ impl<'a> FfParser<'a> {
 
         let default_expr = default_expr?;
         if rest_dims.is_empty() {
-            return Some(default_expr);
+            return Some(ArrayLiteralSelection {
+                expr: default_expr,
+                element_index: 0,
+                element_count: 1,
+            });
         }
         match default_expr {
             Expression::ArrayLiteral(nested, _) => {
                 self.select_array_literal_element(nested, rest_indices, rest_dims)
             }
-            _ if default_expr.comptime().r#type.array.is_empty() => Some(default_expr),
-            _ => None,
+            _ if default_expr.comptime().r#type.array.is_empty() => Some(ArrayLiteralSelection {
+                expr: default_expr,
+                element_index: 0,
+                element_count: 1,
+            }),
+            _ => Some(ArrayLiteralSelection {
+                expr: default_expr,
+                element_index: Self::linear_array_index(rest_indices, rest_dims)?,
+                element_count: rest_dims.iter().product(),
+            }),
         }
+    }
+
+    fn linear_array_index(indices: &[usize], dims: &[usize]) -> Option<usize> {
+        if indices.len() != dims.len() {
+            return None;
+        }
+        indices
+            .iter()
+            .zip(dims)
+            .try_fold(0usize, |linear, (&index, &dim)| {
+                (index < dim)
+                    .then(|| linear.checked_mul(dim)?.checked_add(index))
+                    .flatten()
+            })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2167,8 +2493,12 @@ impl<'a> FfParser<'a> {
                         return Ok(());
                     };
 
-                    let Factor::Variable(bound_var_id, bound_var_index, bound_var_select, _) =
-                        bound_factor.as_ref()
+                    let Factor::Variable(
+                        bound_var_id,
+                        bound_var_index,
+                        bound_var_select,
+                        bound_comptime,
+                    ) = bound_factor.as_ref()
                     else {
                         let Some(access) =
                             self.eval_formal_type_select(*var_id, var_index, var_select)
@@ -2244,6 +2574,37 @@ impl<'a> FfParser<'a> {
                             sources,
                             ir_builder,
                         )?;
+                    } else if self.get_bound_function_arg_expr(*bound_var_id).is_some() {
+                        // Resolve forwarded formals recursively so a nested
+                        // static access keeps the original literal's lazy
+                        // direct-selection path.
+                        self.parse_factor(
+                            &Factor::Variable(
+                                *bound_var_id,
+                                merged_index,
+                                merged_select,
+                                bound_comptime.clone(),
+                            ),
+                            targets,
+                            domain,
+                            convert,
+                            sources,
+                            ir_builder,
+                            None,
+                        )?;
+                        let forwarded = self.stack.pop_back().unwrap();
+                        let access_width =
+                            get_access_width(self.module, *var_id, var_index, var_select)?;
+                        let formal = &self.module.variables[var_id];
+                        let forwarded = self.coerce_register_to_formal(
+                            ir_builder,
+                            forwarded,
+                            access_width,
+                            bound_comptime.r#type.signed,
+                            formal.r#type.signed,
+                            formal.r#type.is_2state(),
+                        );
+                        self.stack.push_back(forwarded);
                     } else {
                         self.op_load(
                             *bound_var_id,
@@ -2540,7 +2901,13 @@ impl<'a> FfParser<'a> {
         )?;
         let cond_reg = self.stack.pop_back().unwrap();
 
-        if !expression_has_side_effect(then) && !expression_has_side_effect(els) {
+        let branch_materializes_array_view = self.expression_needs_unmaterialized_array_view(then)
+            || self.expression_needs_unmaterialized_array_view(els);
+
+        if !expression_has_side_effect(then)
+            && !expression_has_side_effect(els)
+            && !branch_materializes_array_view
+        {
             self.parse_expression_in_context(
                 then,
                 targets,
@@ -2569,6 +2936,7 @@ impl<'a> FfParser<'a> {
 
         let pre_ternary_defined = self.defined_ranges.clone();
         let pre_ternary_dynamic = self.dynamic_defined_vars.clone();
+        let pre_ternary_array_views = self.function_array_view_stack.clone();
 
         // A known condition evaluates only the selected arm. An X/Z
         // condition evaluates both arms and merges their bits.
@@ -2614,6 +2982,9 @@ impl<'a> FfParser<'a> {
         });
 
         ir_builder.switch_to_block(then_block);
+        self.prepare_function_array_views_for_expression(
+            then, targets, domain, convert, sources, ir_builder,
+        )?;
         self.parse_expression_in_context(
             then,
             targets,
@@ -2633,7 +3004,11 @@ impl<'a> FfParser<'a> {
             false_block: (else_block, vec![then_val, merge_else]),
         });
 
+        self.function_array_view_stack = pre_ternary_array_views.clone();
         ir_builder.switch_to_block(else_block);
+        self.prepare_function_array_views_for_expression(
+            els, targets, domain, convert, sources, ir_builder,
+        )?;
         self.parse_expression_in_context(
             els,
             targets,
@@ -2662,6 +3037,10 @@ impl<'a> FfParser<'a> {
 
         ir_builder.switch_to_block(direct_else_block);
         ir_builder.seal_block(SIRTerminator::Jump(merge_block, vec![else_val]));
+
+        // An arm-local view is not initialized on paths that skip that arm,
+        // so it must not escape the ternary's merge point.
+        self.function_array_view_stack = pre_ternary_array_views;
 
         ir_builder.switch_to_block(merge_block);
         self.defined_ranges = self.intersect_defined_states(then_defined, else_defined);

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -1241,6 +1241,13 @@ impl<'a> FfParser<'a> {
             })
             && let Some(source_expr) = self.function_arg_stack[source_frame].get(bound_var_id)
         {
+            let key = ArrayViewKey {
+                frame: source_frame,
+                var_id: *bound_var_id,
+            };
+            if seen.insert(key) {
+                views.push(key);
+            }
             self.collect_array_views_in_bound_expression(source_frame, source_expr, views, seen);
         } else {
             self.collect_array_views_for_expression(expr, views, seen);
@@ -1630,11 +1637,23 @@ impl<'a> FfParser<'a> {
             .filter(|view| view.owns_backing && !view.elements.is_empty())
             .map(|view| view.backing_var_id)
             .collect::<HashSet<_>>();
+        let active_owned_backings = self
+            .function_array_view_stack
+            .iter()
+            .flat_map(|frame| frame.values())
+            .filter(|view| view.owns_backing && !view.elements.is_empty())
+            .map(|view| view.backing_var_id)
+            .collect::<HashSet<_>>();
+        // An owning snapshot is authoritative; restoring an alias afterward
+        // could overwrite it with a duplicate conditional placeholder.
         // Older callers must be restored first so that the nearest active
         // invocation is the final snapshot left in the shared formal region.
         for frame in &self.function_array_view_stack {
             for view in frame.values() {
-                if !clobbered.contains(&view.backing_var_id) || view.elements.is_empty() {
+                if !clobbered.contains(&view.backing_var_id)
+                    || view.elements.is_empty()
+                    || (!view.owns_backing && active_owned_backings.contains(&view.backing_var_id))
+                {
                     continue;
                 }
                 let layout = self.array_view_layout(view.backing_var_id)?;

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -1123,6 +1123,11 @@ impl<'a> FfParser<'a> {
                         if seen.insert(key) {
                             views.push(key);
                         }
+                        if let Some(bound_expr) = self.function_arg_stack[frame].get(var_id) {
+                            self.collect_array_views_in_bound_expression(
+                                frame, bound_expr, views, seen,
+                            );
+                        }
                     }
                     for expr in &index.0 {
                         collect(expr, views, seen);
@@ -1216,6 +1221,29 @@ impl<'a> FfParser<'a> {
                     collect(expr, views, seen);
                 }
             }
+        }
+    }
+
+    fn collect_array_views_in_bound_expression(
+        &self,
+        frame: usize,
+        expr: &Expression,
+        views: &mut Vec<ArrayViewKey>,
+        seen: &mut HashSet<ArrayViewKey>,
+    ) {
+        if let Expression::Term(factor) = expr
+            && let Factor::Variable(bound_var_id, index, select, _) = factor.as_ref()
+            && index.0.is_empty()
+            && select.0.is_empty()
+            && select.1.is_none()
+            && let Some(source_frame) = (0..frame).rev().find(|&source_frame| {
+                self.function_arg_stack[source_frame].contains_key(bound_var_id)
+            })
+            && let Some(source_expr) = self.function_arg_stack[source_frame].get(bound_var_id)
+        {
+            self.collect_array_views_in_bound_expression(source_frame, source_expr, views, seen);
+        } else {
+            self.collect_array_views_for_expression(expr, views, seen);
         }
     }
 

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -1040,6 +1040,17 @@ impl<'a> FfParser<'a> {
                             self.collect_function_input_usage(expr, usage, active_calls)?;
                         }
                     }
+                    for dst in call.outputs.values().flatten() {
+                        for expr in &dst.index.0 {
+                            self.collect_function_input_usage(expr, usage, active_calls)?;
+                        }
+                        for expr in &dst.select.0 {
+                            self.collect_function_input_usage(expr, usage, active_calls)?;
+                        }
+                        if let Some((_, expr)) = &dst.select.1 {
+                            self.collect_function_input_usage(expr, usage, active_calls)?;
+                        }
+                    }
                 }
                 Factor::SystemFunctionCall(call) => match &call.kind {
                     SystemFunctionKind::Bits(_) | SystemFunctionKind::Size(_) => {}

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -108,6 +108,12 @@ struct ArrayViewKey {
     var_id: VarId,
 }
 
+struct ArrayViewMergeCandidate {
+    key: ArrayViewKey,
+    needs_view: bool,
+    cached_literal_items: HashSet<Vec<usize>>,
+}
+
 struct ArrayViewMergeParams {
     key: ArrayViewKey,
     initialized: RegisterId,
@@ -1098,11 +1104,11 @@ impl<'a> FfParser<'a> {
     fn collect_array_views_for_expression(
         &self,
         expr: &Expression,
-        views: &mut Vec<ArrayViewKey>,
-        seen: &mut HashSet<ArrayViewKey>,
+        candidates: &mut Vec<ArrayViewMergeCandidate>,
+        candidate_indices: &mut HashMap<ArrayViewKey, usize>,
     ) {
-        let collect = |expr, views: &mut Vec<_>, seen: &mut HashSet<_>| {
-            self.collect_array_views_for_expression(expr, views, seen)
+        let collect = |expr, candidates: &mut Vec<_>, candidate_indices: &mut HashMap<_, _>| {
+            self.collect_array_views_for_expression(expr, candidates, candidate_indices)
         };
         match expr {
             Expression::Term(factor) => match factor.as_ref() {
@@ -1120,23 +1126,32 @@ impl<'a> FfParser<'a> {
                             frame,
                             var_id: *var_id,
                         };
-                        if seen.insert(key) {
-                            views.push(key);
-                        }
+                        let static_indices = self.static_array_view_indices(*var_id, index, select);
+                        self.record_array_view_merge_candidate(
+                            key,
+                            static_indices.as_deref(),
+                            candidates,
+                            candidate_indices,
+                        );
                         if let Some(bound_expr) = self.function_arg_stack[frame].get(var_id) {
                             self.collect_array_views_in_bound_expression(
-                                frame, bound_expr, views, seen,
+                                frame,
+                                *var_id,
+                                bound_expr,
+                                static_indices.as_deref(),
+                                candidates,
+                                candidate_indices,
                             );
                         }
                     }
                     for expr in &index.0 {
-                        collect(expr, views, seen);
+                        collect(expr, candidates, candidate_indices);
                     }
                     for expr in &select.0 {
-                        collect(expr, views, seen);
+                        collect(expr, candidates, candidate_indices);
                     }
                     if let Some((_, expr)) = &select.1 {
-                        collect(expr, views, seen);
+                        collect(expr, candidates, candidate_indices);
                     }
                 }
                 Factor::FunctionCall(call) => {
@@ -1158,14 +1173,25 @@ impl<'a> FfParser<'a> {
                                     || input_usage.array_views.contains(arg_id)
                             };
                             if needs_actual && let Some(expr) = call.inputs.get(arg_path) {
-                                collect(expr, views, seen);
+                                collect(expr, candidates, candidate_indices);
                             }
                         }
                     } else {
                         // Unsupported or recursive callees will fail during
                         // normal lowering; keep the conservative traversal.
                         for expr in call.inputs.values() {
-                            collect(expr, views, seen);
+                            collect(expr, candidates, candidate_indices);
+                        }
+                    }
+                    for dst in call.outputs.values().flatten() {
+                        for expr in &dst.index.0 {
+                            collect(expr, candidates, candidate_indices);
+                        }
+                        for expr in &dst.select.0 {
+                            collect(expr, candidates, candidate_indices);
+                        }
+                        if let Some((_, expr)) = &dst.select.1 {
+                            collect(expr, candidates, candidate_indices);
                         }
                     }
                 }
@@ -1176,7 +1202,9 @@ impl<'a> FfParser<'a> {
                     SystemFunctionKind::Clog2(input)
                     | SystemFunctionKind::Onehot(input)
                     | SystemFunctionKind::Signed(input)
-                    | SystemFunctionKind::Unsigned(input) => collect(&input.0, views, seen),
+                    | SystemFunctionKind::Unsigned(input) => {
+                        collect(&input.0, candidates, candidate_indices)
+                    }
                     SystemFunctionKind::Readmemh(_, _)
                     | SystemFunctionKind::Display(_)
                     | SystemFunctionKind::Write(_)
@@ -1186,20 +1214,20 @@ impl<'a> FfParser<'a> {
                 Factor::Value(_) | Factor::Anonymous(_) | Factor::Unknown(_) => {}
             },
             Expression::Binary(lhs, _, rhs, _) => {
-                collect(lhs, views, seen);
-                collect(rhs, views, seen);
+                collect(lhs, candidates, candidate_indices);
+                collect(rhs, candidates, candidate_indices);
             }
-            Expression::Unary(_, inner, _) => collect(inner, views, seen),
+            Expression::Unary(_, inner, _) => collect(inner, candidates, candidate_indices),
             Expression::Ternary(cond, then_expr, else_expr, _) => {
-                collect(cond, views, seen);
-                collect(then_expr, views, seen);
-                collect(else_expr, views, seen);
+                collect(cond, candidates, candidate_indices);
+                collect(then_expr, candidates, candidate_indices);
+                collect(else_expr, candidates, candidate_indices);
             }
             Expression::Concatenation(items, _) => {
                 for (expr, repeat) in items {
-                    collect(expr, views, seen);
+                    collect(expr, candidates, candidate_indices);
                     if let Some(repeat) = repeat {
-                        collect(repeat, views, seen);
+                        collect(repeat, candidates, candidate_indices);
                     }
                 }
             }
@@ -1207,29 +1235,88 @@ impl<'a> FfParser<'a> {
                 for item in items {
                     match item {
                         ArrayLiteralItem::Value(expr, repeat) => {
-                            collect(expr, views, seen);
+                            collect(expr, candidates, candidate_indices);
                             if let Some(repeat) = repeat {
-                                collect(repeat, views, seen);
+                                collect(repeat, candidates, candidate_indices);
                             }
                         }
-                        ArrayLiteralItem::Defaul(expr) => collect(expr, views, seen),
+                        ArrayLiteralItem::Defaul(expr) => {
+                            collect(expr, candidates, candidate_indices)
+                        }
                     }
                 }
             }
             Expression::StructConstructor(_, fields, _) => {
                 for (_, expr) in fields {
-                    collect(expr, views, seen);
+                    collect(expr, candidates, candidate_indices);
                 }
             }
+        }
+    }
+
+    fn static_array_view_indices(
+        &self,
+        var_id: VarId,
+        index: &VarIndex,
+        select: &VarSelect,
+    ) -> Option<Vec<usize>> {
+        if self.array_access_needs_view(var_id, index, select) {
+            return None;
+        }
+        index
+            .0
+            .iter()
+            .chain(&select.0)
+            .map(|expr| self.get_constant_value(expr).map(|value| value as usize))
+            .collect()
+    }
+
+    fn record_array_view_merge_candidate(
+        &self,
+        key: ArrayViewKey,
+        static_indices: Option<&[usize]>,
+        candidates: &mut Vec<ArrayViewMergeCandidate>,
+        candidate_indices: &mut HashMap<ArrayViewKey, usize>,
+    ) {
+        let candidate_index = if let Some(&candidate_index) = candidate_indices.get(&key) {
+            candidate_index
+        } else {
+            let candidate_index = candidates.len();
+            candidates.push(ArrayViewMergeCandidate {
+                key,
+                needs_view: false,
+                cached_literal_items: HashSet::default(),
+            });
+            candidate_indices.insert(key, candidate_index);
+            candidate_index
+        };
+        let candidate = &mut candidates[candidate_index];
+        if let Some(static_indices) = static_indices {
+            if let Some(items) = self.bound_array_literal_items_at(key.frame, key.var_id)
+                && let Some(array_dims) = self.module.variables[&key.var_id]
+                    .r#type
+                    .array
+                    .iter()
+                    .copied()
+                    .collect::<Option<Vec<_>>>()
+                && let Some(selection) =
+                    self.select_array_literal_element(items, static_indices, &array_dims)
+            {
+                candidate.cached_literal_items.insert(selection.cache_key);
+            }
+        } else {
+            candidate.needs_view = true;
         }
     }
 
     fn collect_array_views_in_bound_expression(
         &self,
         frame: usize,
+        var_id: VarId,
         expr: &Expression,
-        views: &mut Vec<ArrayViewKey>,
-        seen: &mut HashSet<ArrayViewKey>,
+        static_indices: Option<&[usize]>,
+        candidates: &mut Vec<ArrayViewMergeCandidate>,
+        candidate_indices: &mut HashMap<ArrayViewKey, usize>,
     ) {
         if let Expression::Term(factor) = expr
             && let Factor::Variable(bound_var_id, index, select, _) = factor.as_ref()
@@ -1245,12 +1332,34 @@ impl<'a> FfParser<'a> {
                 frame: source_frame,
                 var_id: *bound_var_id,
             };
-            if seen.insert(key) {
-                views.push(key);
-            }
-            self.collect_array_views_in_bound_expression(source_frame, source_expr, views, seen);
+            self.record_array_view_merge_candidate(
+                key,
+                static_indices,
+                candidates,
+                candidate_indices,
+            );
+            self.collect_array_views_in_bound_expression(
+                source_frame,
+                *bound_var_id,
+                source_expr,
+                static_indices,
+                candidates,
+                candidate_indices,
+            );
+        } else if let (Some(static_indices), Expression::ArrayLiteral(items, _)) =
+            (static_indices, expr)
+            && let Some(array_dims) = self.module.variables[&var_id]
+                .r#type
+                .array
+                .iter()
+                .copied()
+                .collect::<Option<Vec<_>>>()
+            && let Some(selection) =
+                self.select_array_literal_element(items, static_indices, &array_dims)
+        {
+            self.collect_array_views_for_expression(selection.expr, candidates, candidate_indices);
         } else {
-            self.collect_array_views_for_expression(expr, views, seen);
+            self.collect_array_views_for_expression(expr, candidates, candidate_indices);
         }
     }
 
@@ -1421,15 +1530,15 @@ impl<'a> FfParser<'a> {
     fn array_view_merge_candidates<'b>(
         &self,
         expressions: impl IntoIterator<Item = &'b Expression>,
-    ) -> Vec<ArrayViewKey> {
+    ) -> Vec<ArrayViewMergeCandidate> {
         let mut candidates = Vec::new();
-        let mut seen = HashSet::default();
+        let mut candidate_indices = HashMap::default();
         for expr in expressions {
-            self.collect_array_views_for_expression(expr, &mut candidates, &mut seen);
+            self.collect_array_views_for_expression(expr, &mut candidates, &mut candidate_indices);
         }
-        candidates.retain(|key| {
-            self.function_array_view_stack[key.frame]
-                .get(&key.var_id)
+        candidates.retain(|candidate| {
+            self.function_array_view_stack[candidate.key.frame]
+                .get(&candidate.key.var_id)
                 .is_none_or(|view| view.initialized.is_some())
         });
         candidates
@@ -1437,15 +1546,23 @@ impl<'a> FfParser<'a> {
 
     fn alloc_array_view_merge_params<A>(
         &self,
-        candidates: &[ArrayViewKey],
+        candidates: &[ArrayViewMergeCandidate],
         ir_builder: &mut SIRBuilder<A>,
     ) -> Result<Vec<ArrayViewMergeParams>, ParserError> {
         candidates
             .iter()
-            .map(|&key| {
-                let layout = self.array_view_layout(key.var_id)?;
+            .map(|candidate| {
+                let key = candidate.key;
+                let layout = self.array_view_layout(candidate.key.var_id)?;
                 let initialized = ir_builder.alloc_bit(1, false);
-                let elements = (0..layout.element_count)
+                let existing_view = self.function_array_view_stack[key.frame].get(&key.var_id);
+                let carries_view = candidate.needs_view
+                    || existing_view.is_some_and(|view| !view.elements.is_empty());
+                let elements = (0..if carries_view {
+                    layout.element_count
+                } else {
+                    0
+                })
                     .map(|_| {
                         if layout.is_2state {
                             ir_builder.alloc_bit(layout.element_width, layout.signed)
@@ -1454,9 +1571,18 @@ impl<'a> FfParser<'a> {
                         }
                     })
                     .collect();
+                let existing_cache_keys = existing_view
+                    .into_iter()
+                    .flat_map(|view| view.cached_literal_items.keys())
+                    .collect::<HashSet<_>>();
                 let cached_literal_items = self
                     .array_literal_item_specs(key.frame, key.var_id)
                     .into_iter()
+                    .filter(|(cache_key, _)| {
+                        carries_view
+                            || candidate.cached_literal_items.contains(cache_key)
+                            || existing_cache_keys.contains(cache_key)
+                    })
                     .map(|(cache_key, element_count)| ArrayLiteralItemMergeParams {
                         cache_key,
                         initialized: ir_builder.alloc_bit(1, false),
@@ -1501,7 +1627,7 @@ impl<'a> FfParser<'a> {
                 args.push(initialized);
                 if view.elements.is_empty() {
                     let layout = self.array_view_layout(params.key.var_id)?;
-                    for _ in 0..layout.element_count {
+                    for _ in &params.elements {
                         let element = if layout.is_2state {
                             ir_builder.alloc_bit(layout.element_width, layout.signed)
                         } else {
@@ -1511,6 +1637,9 @@ impl<'a> FfParser<'a> {
                         args.push(element);
                     }
                 } else {
+                    if view.elements.len() != params.elements.len() {
+                        unreachable!("a merged array view has the planned element count");
+                    }
                     args.extend(view.elements.iter().copied());
                 }
             } else {
@@ -1518,7 +1647,7 @@ impl<'a> FfParser<'a> {
                 ir_builder.emit(SIRInstruction::Imm(initialized, SIRValue::new(0u8)));
                 args.push(initialized);
                 let layout = self.array_view_layout(params.key.var_id)?;
-                for _ in 0..layout.element_count {
+                for _ in &params.elements {
                     let element = if layout.is_2state {
                         ir_builder.alloc_bit(layout.element_width, layout.signed)
                     } else {

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -94,15 +94,22 @@ struct ArrayViewLayout {
     is_2state: bool,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct ArrayLiteralSelection<'a> {
     expr: &'a Expression,
     element_index: usize,
     element_count: usize,
+    cache_key: Vec<usize>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct ArrayViewKey {
+    frame: usize,
+    var_id: VarId,
 }
 
 struct ArrayViewMergeParams {
-    var_id: VarId,
+    key: ArrayViewKey,
     initialized: RegisterId,
     elements: Vec<RegisterId>,
 }
@@ -446,6 +453,7 @@ impl<'a> FfParser<'a> {
     #[allow(clippy::too_many_arguments)]
     fn materialize_bound_array_literal_view<A>(
         &mut self,
+        frame: usize,
         var_id: VarId,
         items: &[ArrayLiteralItem],
         targets: &mut Vec<VarAtomBase<A>>,
@@ -471,11 +479,17 @@ impl<'a> FfParser<'a> {
         };
         let layout = self.array_view_layout(var_id)?;
 
-        let mut cached_elements = std::collections::HashMap::new();
+        let mut cached_elements = self.function_array_view_stack[frame]
+            .get(&var_id)
+            .map(|view| view.cached_literal_items.clone())
+            .unwrap_or_default();
         let mut source_order = Vec::new();
-        Self::collect_array_literal_elements_in_source_order(items, &mut source_order);
-        for selected_expr in source_order {
-            let cache_key = selected_expr as *const Expression as usize;
+        Self::collect_array_literal_elements_in_source_order(
+            items,
+            &mut Vec::new(),
+            &mut source_order,
+        );
+        for (cache_key, selected_expr) in source_order {
             if cached_elements.contains_key(&cache_key) {
                 continue;
             }
@@ -493,29 +507,16 @@ impl<'a> FfParser<'a> {
                         "function argument validation resolves array literal item dimensions"
                     )
                 });
-            self.parse_expression(
+            let item_elements = self.evaluate_array_literal_item(
                 selected_expr,
+                element_count,
+                layout,
                 targets,
                 domain,
                 convert,
                 sources,
                 ir_builder,
-                (element_count == 1).then_some(layout.element_width),
             )?;
-            let reg = self.stack.pop_back().unwrap();
-            let mut item_elements = Vec::with_capacity(element_count);
-            for element_index in 0..element_count {
-                let element =
-                    self.slice_array_value_element(reg, element_index, element_count, ir_builder);
-                item_elements.push(self.coerce_register_to_formal(
-                    ir_builder,
-                    element,
-                    layout.element_width,
-                    selected_expr.comptime().r#type.signed,
-                    layout.signed,
-                    layout.is_2state,
-                ));
-            }
             cached_elements.insert(cache_key, item_elements);
         }
 
@@ -533,8 +534,7 @@ impl<'a> FfParser<'a> {
             else {
                 unreachable!("validated array literal covers every formal element");
             };
-            let cache_key = selection.expr as *const Expression as usize;
-            let Some(selected_regs) = cached_elements.get(&cache_key) else {
+            let Some(selected_regs) = cached_elements.get(&selection.cache_key) else {
                 unreachable!("every selected element was evaluated in literal source order");
             };
             if selected_regs.len() != selection.element_count {
@@ -558,23 +558,27 @@ impl<'a> FfParser<'a> {
             backing_var_id: var_id,
             elements,
             owns_backing: true,
+            cached_literal_items: cached_elements,
             initialized: None,
         })
     }
 
     fn collect_array_literal_elements_in_source_order<'b>(
         items: &'b [ArrayLiteralItem],
-        elements: &mut Vec<&'b Expression>,
+        path: &mut Vec<usize>,
+        elements: &mut Vec<(Vec<usize>, &'b Expression)>,
     ) {
-        for item in items {
+        for (item_index, item) in items.iter().enumerate() {
+            path.push(item_index);
             let expr = match item {
                 ArrayLiteralItem::Value(expr, _) | ArrayLiteralItem::Defaul(expr) => expr.as_ref(),
             };
             if let Expression::ArrayLiteral(nested, _) = expr {
-                Self::collect_array_literal_elements_in_source_order(nested, elements);
+                Self::collect_array_literal_elements_in_source_order(nested, path, elements);
             } else {
-                elements.push(expr);
+                elements.push((path.clone(), expr));
             }
+            path.pop();
         }
     }
 
@@ -611,6 +615,44 @@ impl<'a> FfParser<'a> {
             source_element_width,
         ));
         element
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn evaluate_array_literal_item<A>(
+        &mut self,
+        expr: &Expression,
+        element_count: usize,
+        layout: ArrayViewLayout,
+        targets: &mut Vec<VarAtomBase<A>>,
+        domain: &Domain,
+        convert: &impl Fn(VarId, u32) -> A,
+        sources: &mut Vec<VarAtomBase<A>>,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<Vec<RegisterId>, ParserError> {
+        self.parse_expression(
+            expr,
+            targets,
+            domain,
+            convert,
+            sources,
+            ir_builder,
+            (element_count == 1).then_some(layout.element_width),
+        )?;
+        let item_reg = self.stack.pop_back().unwrap();
+        let mut elements = Vec::with_capacity(element_count);
+        for element_index in 0..element_count {
+            let element =
+                self.slice_array_value_element(item_reg, element_index, element_count, ir_builder);
+            elements.push(self.coerce_register_to_formal(
+                ir_builder,
+                element,
+                layout.element_width,
+                expr.comptime().r#type.signed,
+                layout.signed,
+                layout.is_2state,
+            ));
+        }
+        Ok(elements)
     }
 
     fn store_array_view_elements<A>(
@@ -703,6 +745,7 @@ impl<'a> FfParser<'a> {
             backing_var_id: var_id,
             elements,
             owns_backing: true,
+            cached_literal_items: HashMap::default(),
             initialized: None,
         })
     }
@@ -884,8 +927,8 @@ impl<'a> FfParser<'a> {
     fn collect_array_views_for_expression(
         &self,
         expr: &Expression,
-        views: &mut Vec<VarId>,
-        seen: &mut HashSet<VarId>,
+        views: &mut Vec<ArrayViewKey>,
+        seen: &mut HashSet<ArrayViewKey>,
     ) {
         let collect = |expr, views: &mut Vec<_>, seen: &mut HashSet<_>| {
             self.collect_array_views_for_expression(expr, views, seen)
@@ -893,19 +936,22 @@ impl<'a> FfParser<'a> {
         match expr {
             Expression::Term(factor) => match factor.as_ref() {
                 Factor::Variable(var_id, index, select, _) => {
-                    let is_bound_here = self
-                        .function_arg_stack
-                        .last()
-                        .is_some_and(|bindings| bindings.contains_key(var_id));
-                    let is_planned_here = self
-                        .function_array_view_plan_stack
-                        .last()
-                        .is_some_and(|plan| plan.contains(var_id));
-                    if is_bound_here
-                        && (is_planned_here || self.array_access_needs_view(*var_id, index, select))
-                        && seen.insert(*var_id)
+                    if self
+                        .module
+                        .variables
+                        .get(var_id)
+                        .is_some_and(|variable| !variable.r#type.array.is_empty())
+                        && let Some(frame) = (0..self.function_arg_stack.len())
+                            .rev()
+                            .find(|&frame| self.function_arg_stack[frame].contains_key(var_id))
                     {
-                        views.push(*var_id);
+                        let key = ArrayViewKey {
+                            frame,
+                            var_id: *var_id,
+                        };
+                        if seen.insert(key) {
+                            views.push(key);
+                        }
                     }
                     for expr in &index.0 {
                         collect(expr, views, seen);
@@ -1021,7 +1067,7 @@ impl<'a> FfParser<'a> {
                 if !self.module.variables[&var_id].r#type.array.is_empty() =>
             {
                 Some(self.materialize_bound_array_literal_view(
-                    var_id, &items, targets, domain, convert, sources, ir_builder,
+                    frame, var_id, &items, targets, domain, convert, sources, ir_builder,
                 )?)
             }
             Expression::Term(factor) => {
@@ -1059,6 +1105,7 @@ impl<'a> FfParser<'a> {
                         backing_var_id: source_view.backing_var_id,
                         elements: source_view.elements,
                         owns_backing: false,
+                        cached_literal_items: source_view.cached_literal_items,
                         initialized: None,
                     })
                 } else {
@@ -1094,15 +1141,30 @@ impl<'a> FfParser<'a> {
             let pre_defined = self.defined_ranges.clone();
             let pre_dynamic = self.dynamic_defined_vars.clone();
             let initialize_block = ir_builder.new_block();
-            let merged_elements = view
-                .elements
+            let carried_elements = if view.elements.is_empty() {
+                let layout = self.array_view_layout(var_id)?;
+                (0..layout.element_count)
+                    .map(|_| {
+                        let element = if layout.is_2state {
+                            ir_builder.alloc_bit(layout.element_width, layout.signed)
+                        } else {
+                            ir_builder.alloc_logic(layout.element_width)
+                        };
+                        ir_builder.emit(SIRInstruction::Imm(element, SIRValue::new(0u8)));
+                        element
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                view.elements.clone()
+            };
+            let merged_elements = carried_elements
                 .iter()
                 .map(|reg| ir_builder.alloc_reg(ir_builder.register(reg).clone()))
                 .collect::<Vec<_>>();
             let merge_block = ir_builder.new_block_with(merged_elements.clone());
             ir_builder.seal_block(SIRTerminator::Branch {
                 cond: initialized,
-                true_block: (merge_block, view.elements.clone()),
+                true_block: (merge_block, carried_elements),
                 false_block: (initialize_block, vec![]),
             });
 
@@ -1131,6 +1193,7 @@ impl<'a> FfParser<'a> {
                 backing_var_id: view.backing_var_id,
                 elements: merged_elements,
                 owns_backing: view.owns_backing,
+                cached_literal_items: initialized_view.cached_literal_items,
                 initialized: None,
             };
             self.function_array_view_stack[frame].insert(var_id, view.clone());
@@ -1146,33 +1209,18 @@ impl<'a> FfParser<'a> {
         Ok(view)
     }
 
-    pub(super) fn plan_function_array_views_for_expression(&mut self, expr: &Expression) {
-        let Some(frame) = self.function_arg_stack.len().checked_sub(1) else {
-            return;
-        };
-        // Record the invocation-wide strategy without evaluating any actual
-        // argument. The first relevant access performs materialization in
-        // source order at its normal evaluation point.
-        let mut views = Vec::new();
-        self.collect_array_views_for_expression(expr, &mut views, &mut HashSet::default());
-        self.function_array_view_plan_stack[frame].extend(views);
-    }
-
     fn array_view_merge_candidates<'b>(
         &self,
         expressions: impl IntoIterator<Item = &'b Expression>,
-    ) -> Vec<VarId> {
-        let Some(frame) = self.function_arg_stack.len().checked_sub(1) else {
-            return Vec::new();
-        };
+    ) -> Vec<ArrayViewKey> {
         let mut candidates = Vec::new();
         let mut seen = HashSet::default();
         for expr in expressions {
             self.collect_array_views_for_expression(expr, &mut candidates, &mut seen);
         }
-        candidates.retain(|var_id| {
-            self.function_array_view_stack[frame]
-                .get(var_id)
+        candidates.retain(|key| {
+            self.function_array_view_stack[key.frame]
+                .get(&key.var_id)
                 .is_none_or(|view| view.initialized.is_some())
         });
         candidates
@@ -1180,13 +1228,13 @@ impl<'a> FfParser<'a> {
 
     fn alloc_array_view_merge_params<A>(
         &self,
-        candidates: &[VarId],
+        candidates: &[ArrayViewKey],
         ir_builder: &mut SIRBuilder<A>,
     ) -> Result<Vec<ArrayViewMergeParams>, ParserError> {
         candidates
             .iter()
-            .map(|&var_id| {
-                let layout = self.array_view_layout(var_id)?;
+            .map(|&key| {
+                let layout = self.array_view_layout(key.var_id)?;
                 let initialized = ir_builder.alloc_bit(1, false);
                 let elements = (0..layout.element_count)
                     .map(|_| {
@@ -1198,7 +1246,7 @@ impl<'a> FfParser<'a> {
                     })
                     .collect();
                 Ok(ArrayViewMergeParams {
-                    var_id,
+                    key,
                     initialized,
                     elements,
                 })
@@ -1208,13 +1256,14 @@ impl<'a> FfParser<'a> {
 
     fn array_view_state_args<A>(
         &self,
-        frame: usize,
         params: &[ArrayViewMergeParams],
         ir_builder: &mut SIRBuilder<A>,
     ) -> Result<Vec<RegisterId>, ParserError> {
         let mut args = Vec::new();
         for params in params {
-            if let Some(view) = self.function_array_view_stack[frame].get(&params.var_id) {
+            if let Some(view) =
+                self.function_array_view_stack[params.key.frame].get(&params.key.var_id)
+            {
                 let initialized = if let Some(initialized) = view.initialized {
                     initialized
                 } else {
@@ -1223,12 +1272,25 @@ impl<'a> FfParser<'a> {
                     initialized
                 };
                 args.push(initialized);
-                args.extend(view.elements.iter().copied());
+                if view.elements.is_empty() {
+                    let layout = self.array_view_layout(params.key.var_id)?;
+                    for _ in 0..layout.element_count {
+                        let element = if layout.is_2state {
+                            ir_builder.alloc_bit(layout.element_width, layout.signed)
+                        } else {
+                            ir_builder.alloc_logic(layout.element_width)
+                        };
+                        ir_builder.emit(SIRInstruction::Imm(element, SIRValue::new(0u8)));
+                        args.push(element);
+                    }
+                } else {
+                    args.extend(view.elements.iter().copied());
+                }
             } else {
                 let initialized = ir_builder.alloc_bit(1, false);
                 ir_builder.emit(SIRInstruction::Imm(initialized, SIRValue::new(0u8)));
                 args.push(initialized);
-                let layout = self.array_view_layout(params.var_id)?;
+                let layout = self.array_view_layout(params.key.var_id)?;
                 for _ in 0..layout.element_count {
                     let element = if layout.is_2state {
                         ir_builder.alloc_bit(layout.element_width, layout.signed)
@@ -1245,14 +1307,13 @@ impl<'a> FfParser<'a> {
 
     fn install_merged_array_views(
         &mut self,
-        frame: usize,
         params: &[ArrayViewMergeParams],
-        states: &[&HashMap<VarId, FunctionArrayView>],
+        states: &[&Vec<HashMap<VarId, FunctionArrayView>>],
     ) {
         for params in params {
             let views = states
                 .iter()
-                .filter_map(|state| state.get(&params.var_id))
+                .filter_map(|state| state[params.key.frame].get(&params.key.var_id))
                 .collect::<Vec<_>>();
             let Some(first) = views.first() else {
                 continue;
@@ -1263,12 +1324,26 @@ impl<'a> FfParser<'a> {
             }) {
                 unreachable!("a function array view has stable backing metadata");
             }
-            self.function_array_view_stack[frame].insert(
-                params.var_id,
+            let cached_literal_items = first
+                .cached_literal_items
+                .iter()
+                .filter(|(key, value)| {
+                    states.iter().all(|state| {
+                        state[params.key.frame]
+                            .get(&params.key.var_id)
+                            .and_then(|view| view.cached_literal_items.get(*key))
+                            .is_some_and(|other| other == *value)
+                    })
+                })
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect();
+            self.function_array_view_stack[params.key.frame].insert(
+                params.key.var_id,
                 FunctionArrayView {
                     backing_var_id: first.backing_var_id,
                     elements: params.elements.clone(),
                     owns_backing: first.owns_backing,
+                    cached_literal_items,
                     initialized: Some(params.initialized),
                 },
             );
@@ -1283,15 +1358,34 @@ impl<'a> FfParser<'a> {
     ) -> Result<(), ParserError> {
         let clobbered = finished_views
             .values()
-            .filter(|view| view.owns_backing)
+            .filter(|view| view.owns_backing && !view.elements.is_empty())
             .map(|view| view.backing_var_id)
             .collect::<HashSet<_>>();
-        let mut restored = HashSet::default();
         for frame in self.function_array_view_stack.iter().rev() {
             for view in frame.values() {
-                if clobbered.contains(&view.backing_var_id) && restored.insert(view.backing_var_id)
-                {
-                    let layout = self.array_view_layout(view.backing_var_id)?;
+                if !clobbered.contains(&view.backing_var_id) || view.elements.is_empty() {
+                    continue;
+                }
+                let layout = self.array_view_layout(view.backing_var_id)?;
+                if let Some(initialized) = view.initialized {
+                    let restore_block = ir_builder.new_block();
+                    let merge_block = ir_builder.new_block();
+                    ir_builder.seal_block(SIRTerminator::Branch {
+                        cond: initialized,
+                        true_block: (restore_block, vec![]),
+                        false_block: (merge_block, vec![]),
+                    });
+                    ir_builder.switch_to_block(restore_block);
+                    self.store_array_view_elements(
+                        view.backing_var_id,
+                        &view.elements,
+                        layout.element_width,
+                        convert,
+                        ir_builder,
+                    );
+                    ir_builder.seal_block(SIRTerminator::Jump(merge_block, vec![]));
+                    ir_builder.switch_to_block(merge_block);
+                } else {
                     self.store_array_view_elements(
                         view.backing_var_id,
                         &view.elements,
@@ -1339,33 +1433,127 @@ impl<'a> FfParser<'a> {
         else {
             return Ok(false);
         };
-        let access_width = get_access_width(self.module, var_id, index, select)?;
-        let selected_expr = selection.expr;
-        self.parse_expression(
-            selected_expr,
-            targets,
-            domain,
-            convert,
-            sources,
-            ir_builder,
-            (selection.element_count == 1).then_some(access_width),
-        )?;
-        let selected_reg = self.stack.pop_back().unwrap();
-        let selected_reg = self.slice_array_value_element(
-            selected_reg,
-            selection.element_index,
-            selection.element_count,
-            ir_builder,
-        );
-        let coerced = self.coerce_register_to_formal(
-            ir_builder,
-            selected_reg,
-            access_width,
-            selected_expr.comptime().r#type.signed,
-            formal.r#type.signed,
-            formal.r#type.is_2state(),
-        );
-        self.stack.push_back(coerced);
+        let Some(frame) = (0..self.function_arg_stack.len())
+            .rev()
+            .find(|&frame| self.function_arg_stack[frame].contains_key(&var_id))
+        else {
+            return Ok(false);
+        };
+        let cached = self.function_array_view_stack[frame]
+            .get(&var_id)
+            .and_then(|view| view.cached_literal_items.get(&selection.cache_key))
+            .cloned();
+        let item_elements = if let Some(cached) = cached {
+            cached
+        } else if let Some((initialized, view_elements)) = self.function_array_view_stack[frame]
+            .get(&var_id)
+            .and_then(|view| {
+                (!view.elements.is_empty()).then_some((view.initialized?, view.elements.clone()))
+            })
+        {
+            let layout = self.array_view_layout(var_id)?;
+            let mut carried = vec![None; selection.element_count];
+            for linear_index in 0..layout.element_count {
+                let mut remainder = linear_index;
+                let mut coordinates = vec![0usize; array_dims.len()];
+                for dimension in (0..array_dims.len()).rev() {
+                    coordinates[dimension] = remainder % array_dims[dimension];
+                    remainder /= array_dims[dimension];
+                }
+                let Some(candidate) =
+                    self.select_array_literal_element(items, &coordinates, &array_dims)
+                else {
+                    unreachable!("validated array literal covers every formal element");
+                };
+                if candidate.cache_key == selection.cache_key {
+                    carried[candidate.element_index] = Some(view_elements[linear_index]);
+                }
+            }
+            let carried = carried
+                .into_iter()
+                .map(|element| {
+                    element.unwrap_or_else(|| {
+                        unreachable!("every array-valued literal item element maps to the formal")
+                    })
+                })
+                .collect::<Vec<_>>();
+            let merge_elements = carried
+                .iter()
+                .map(|reg| ir_builder.alloc_reg(ir_builder.register(reg).clone()))
+                .collect::<Vec<_>>();
+            let evaluate_block = ir_builder.new_block();
+            let merge_block = ir_builder.new_block_with(merge_elements.clone());
+            let pre_defined = self.defined_ranges.clone();
+            let pre_dynamic = self.dynamic_defined_vars.clone();
+            ir_builder.seal_block(SIRTerminator::Branch {
+                cond: initialized,
+                true_block: (merge_block, carried),
+                false_block: (evaluate_block, vec![]),
+            });
+            ir_builder.switch_to_block(evaluate_block);
+            let evaluated = self.evaluate_array_literal_item(
+                selection.expr,
+                selection.element_count,
+                layout,
+                targets,
+                domain,
+                convert,
+                sources,
+                ir_builder,
+            )?;
+            let evaluated_defined =
+                std::mem::replace(&mut self.defined_ranges, pre_defined.clone());
+            let evaluated_dynamic =
+                std::mem::replace(&mut self.dynamic_defined_vars, pre_dynamic.clone());
+            ir_builder.seal_block(SIRTerminator::Jump(merge_block, evaluated));
+            ir_builder.switch_to_block(merge_block);
+            self.defined_ranges = self.intersect_defined_states(pre_defined, evaluated_defined);
+            self.dynamic_defined_vars = self.intersect_dynamic_vars(pre_dynamic, evaluated_dynamic);
+            self.function_array_view_stack[frame]
+                .get_mut(&var_id)
+                .unwrap()
+                .cached_literal_items
+                .insert(selection.cache_key.clone(), merge_elements.clone());
+            merge_elements
+        } else {
+            let layout = self.array_view_layout(var_id)?;
+            let selected_expr = selection.expr;
+            let item_elements = self.evaluate_array_literal_item(
+                selected_expr,
+                selection.element_count,
+                layout,
+                targets,
+                domain,
+                convert,
+                sources,
+                ir_builder,
+            )?;
+            if let Some(view) = self.function_array_view_stack[frame].get_mut(&var_id) {
+                view.cached_literal_items
+                    .insert(selection.cache_key.clone(), item_elements.clone());
+            } else {
+                let initialized = ir_builder.alloc_bit(1, false);
+                ir_builder.emit(SIRInstruction::Imm(initialized, SIRValue::new(0u8)));
+                self.function_array_view_stack[frame].insert(
+                    var_id,
+                    FunctionArrayView {
+                        backing_var_id: var_id,
+                        elements: Vec::new(),
+                        owns_backing: true,
+                        cached_literal_items: HashMap::from_iter([(
+                            selection.cache_key.clone(),
+                            item_elements.clone(),
+                        )]),
+                        initialized: Some(initialized),
+                    },
+                );
+            }
+            item_elements
+        };
+        let Some(&selected_reg) = item_elements.get(selection.element_index) else {
+            unreachable!("selected array literal item index is in bounds");
+        };
+        self.stack.push_back(selected_reg);
         Ok(true)
     }
 
@@ -1375,15 +1563,25 @@ impl<'a> FfParser<'a> {
         indices: &[usize],
         dims: &[usize],
     ) -> Option<ArrayLiteralSelection<'b>> {
+        self.select_array_literal_element_inner(items, indices, dims, &mut Vec::new())
+    }
+
+    fn select_array_literal_element_inner<'b>(
+        &self,
+        items: &'b [ArrayLiteralItem],
+        indices: &[usize],
+        dims: &[usize],
+        path: &mut Vec<usize>,
+    ) -> Option<ArrayLiteralSelection<'b>> {
         // Function argument shape validation has already rejected unresolved
         // repeats and duplicate defaults, including in nested literals.
         let (&target_idx, rest_indices) = indices.split_first()?;
         let (_dim, rest_dims) = dims.split_first()?;
 
         let mut pos = 0usize;
-        let mut default_expr: Option<&Expression> = None;
+        let mut default_expr: Option<(&Expression, usize)> = None;
 
-        for item in items {
+        for (item_index, item) in items.iter().enumerate() {
             match item {
                 ArrayLiteralItem::Value(expr, repeat) => {
                     let rep_count = if let Some(rep_expr) = repeat {
@@ -1398,28 +1596,36 @@ impl<'a> FfParser<'a> {
                     };
 
                     if target_idx < pos + rep_count {
+                        path.push(item_index);
                         if rest_dims.is_empty() {
                             return Some(ArrayLiteralSelection {
                                 expr,
                                 element_index: 0,
                                 element_count: 1,
+                                cache_key: path.clone(),
                             });
                         }
                         return match expr.as_ref() {
-                            Expression::ArrayLiteral(nested, _) => {
-                                self.select_array_literal_element(nested, rest_indices, rest_dims)
-                            }
+                            Expression::ArrayLiteral(nested, _) => self
+                                .select_array_literal_element_inner(
+                                    nested,
+                                    rest_indices,
+                                    rest_dims,
+                                    path,
+                                ),
                             _ if expr.comptime().r#type.array.is_empty() => {
                                 Some(ArrayLiteralSelection {
                                     expr,
                                     element_index: 0,
                                     element_count: 1,
+                                    cache_key: path.clone(),
                                 })
                             }
                             _ => Some(ArrayLiteralSelection {
                                 expr,
                                 element_index: Self::linear_array_index(rest_indices, rest_dims)?,
                                 element_count: rest_dims.iter().product(),
+                                cache_key: path.clone(),
                             }),
                         };
                     }
@@ -1431,32 +1637,36 @@ impl<'a> FfParser<'a> {
                             "array literal must have at most one default after function argument shape validation"
                         );
                     }
-                    default_expr = Some(expr);
+                    default_expr = Some((expr, item_index));
                 }
             }
         }
 
-        let default_expr = default_expr?;
+        let (default_expr, default_index) = default_expr?;
+        path.push(default_index);
         if rest_dims.is_empty() {
             return Some(ArrayLiteralSelection {
                 expr: default_expr,
                 element_index: 0,
                 element_count: 1,
+                cache_key: path.clone(),
             });
         }
         match default_expr {
             Expression::ArrayLiteral(nested, _) => {
-                self.select_array_literal_element(nested, rest_indices, rest_dims)
+                self.select_array_literal_element_inner(nested, rest_indices, rest_dims, path)
             }
             _ if default_expr.comptime().r#type.array.is_empty() => Some(ArrayLiteralSelection {
                 expr: default_expr,
                 element_index: 0,
                 element_count: 1,
+                cache_key: path.clone(),
             }),
             _ => Some(ArrayLiteralSelection {
                 expr: default_expr,
                 element_index: Self::linear_array_index(rest_indices, rest_dims)?,
                 element_count: rest_dims.iter().product(),
+                cache_key: path.clone(),
             }),
         }
     }
@@ -2032,12 +2242,10 @@ impl<'a> FfParser<'a> {
             left, targets, domain, convert, sources, ir_builder, None,
         )?;
         let lhs = self.stack.pop_back().unwrap();
-        let array_view_frame = self.function_arg_stack.len().checked_sub(1);
         let array_view_candidates = self.array_view_merge_candidates([right]);
         let array_view_params =
             self.alloc_array_view_merge_params(&array_view_candidates, ir_builder)?;
-        let pre_rhs_array_views =
-            array_view_frame.map(|frame| self.function_array_view_stack[frame].clone());
+        let pre_rhs_array_views = self.function_array_view_stack.clone();
         let pre_rhs_state =
             (expression_has_side_effect(right) || !array_view_candidates.is_empty()).then(|| {
                 (
@@ -2079,13 +2287,7 @@ impl<'a> FfParser<'a> {
             SIRValue::new(if is_and { 0u8 } else { 1u8 }),
         ));
         let mut shortcut_args = vec![shortcut_value];
-        if let Some(frame) = array_view_frame {
-            shortcut_args.extend(self.array_view_state_args(
-                frame,
-                &array_view_params,
-                ir_builder,
-            )?);
-        }
+        shortcut_args.extend(self.array_view_state_args(&array_view_params, ir_builder)?);
         ir_builder.seal_block(SIRTerminator::Branch {
             cond: shortcut,
             true_block: (merge_block, shortcut_args),
@@ -2114,23 +2316,17 @@ impl<'a> FfParser<'a> {
             },
             rhs,
         ));
-        let rhs_array_views =
-            array_view_frame.map(|frame| self.function_array_view_stack[frame].clone());
+        let rhs_array_views = self.function_array_view_stack.clone();
         let mut rhs_args = vec![evaluated];
-        if let Some(frame) = array_view_frame {
-            rhs_args.extend(self.array_view_state_args(frame, &array_view_params, ir_builder)?);
-        }
+        rhs_args.extend(self.array_view_state_args(&array_view_params, ir_builder)?);
         ir_builder.seal_block(SIRTerminator::Jump(merge_block, rhs_args));
 
         ir_builder.switch_to_block(merge_block);
-        if let (Some(frame), Some(pre_views), Some(rhs_views)) = (
-            array_view_frame,
-            pre_rhs_array_views.as_ref(),
-            rhs_array_views.as_ref(),
-        ) {
-            self.function_array_view_stack[frame] = pre_views.clone();
-            self.install_merged_array_views(frame, &array_view_params, &[pre_views, rhs_views]);
-        }
+        self.function_array_view_stack = pre_rhs_array_views.clone();
+        self.install_merged_array_views(
+            &array_view_params,
+            &[&pre_rhs_array_views, &rhs_array_views],
+        );
         if let (Some((pre_defined, pre_dynamic)), Some((rhs_defined, rhs_dynamic))) =
             (pre_rhs_state, rhs_state)
         {
@@ -2588,8 +2784,7 @@ impl<'a> FfParser<'a> {
                     .rev()
                     .find(|&frame| self.function_arg_stack[frame].contains_key(var_id))
                 {
-                    let planned = self.function_array_view_plan_stack[frame].contains(var_id);
-                    if planned || self.array_access_needs_view(*var_id, var_index, var_select) {
+                    if self.array_access_needs_view(*var_id, var_index, var_select) {
                         self.ensure_function_array_view_at(
                             frame, *var_id, targets, domain, convert, sources, ir_builder,
                         )?;
@@ -3092,7 +3287,6 @@ impl<'a> FfParser<'a> {
         )?;
         let cond_reg = self.stack.pop_back().unwrap();
 
-        let array_view_frame = self.function_arg_stack.len().checked_sub(1);
         let array_view_candidates = self.array_view_merge_candidates([then, els]);
         let branch_materializes_array_view = !array_view_candidates.is_empty();
 
@@ -3182,13 +3376,7 @@ impl<'a> FfParser<'a> {
         let merge_block = ir_builder.new_block_with(merge_params);
 
         let mut initial_else_args = vec![dummy_then, direct_else];
-        if let Some(frame) = array_view_frame {
-            initial_else_args.extend(self.array_view_state_args(
-                frame,
-                &else_view_params,
-                ir_builder,
-            )?);
-        }
+        initial_else_args.extend(self.array_view_state_args(&else_view_params, ir_builder)?);
         ir_builder.seal_block(SIRTerminator::Branch {
             cond: known_false,
             true_block: (else_block, initial_else_args),
@@ -3212,18 +3400,8 @@ impl<'a> FfParser<'a> {
         let then_array_views = self.function_array_view_stack.clone();
         let mut then_merge_args = vec![then_val];
         let mut then_else_args = vec![then_val, merge_else];
-        if let Some(frame) = array_view_frame {
-            then_merge_args.extend(self.array_view_state_args(
-                frame,
-                &merge_view_params,
-                ir_builder,
-            )?);
-            then_else_args.extend(self.array_view_state_args(
-                frame,
-                &else_view_params,
-                ir_builder,
-            )?);
-        }
+        then_merge_args.extend(self.array_view_state_args(&merge_view_params, ir_builder)?);
+        then_else_args.extend(self.array_view_state_args(&else_view_params, ir_builder)?);
         ir_builder.seal_block(SIRTerminator::Branch {
             cond: known_true,
             true_block: (merge_block, then_merge_args),
@@ -3232,13 +3410,10 @@ impl<'a> FfParser<'a> {
 
         self.function_array_view_stack = pre_ternary_array_views.clone();
         ir_builder.switch_to_block(else_block);
-        if let Some(frame) = array_view_frame {
-            self.install_merged_array_views(
-                frame,
-                &else_view_params,
-                &[&pre_ternary_array_views[frame], &then_array_views[frame]],
-            );
-        }
+        self.install_merged_array_views(
+            &else_view_params,
+            &[&pre_ternary_array_views, &then_array_views],
+        );
         self.parse_expression_in_context(
             els,
             targets,
@@ -3261,13 +3436,7 @@ impl<'a> FfParser<'a> {
         ));
         let direct_else_block = ir_builder.new_block();
         let mut else_merge_state = Vec::new();
-        if let Some(frame) = array_view_frame {
-            else_merge_state.extend(self.array_view_state_args(
-                frame,
-                &merge_view_params,
-                ir_builder,
-            )?);
-        }
+        else_merge_state.extend(self.array_view_state_args(&merge_view_params, ir_builder)?);
         let mut merged_args = vec![merged];
         merged_args.extend(else_merge_state.iter().copied());
         ir_builder.seal_block(SIRTerminator::Branch {
@@ -3284,18 +3453,11 @@ impl<'a> FfParser<'a> {
         self.function_array_view_stack = pre_ternary_array_views;
 
         ir_builder.switch_to_block(merge_block);
-        if let Some(frame) = array_view_frame {
-            let pre_views = self.function_array_view_stack[frame].clone();
-            self.install_merged_array_views(
-                frame,
-                &merge_view_params,
-                &[
-                    &pre_views,
-                    &then_array_views[frame],
-                    &else_array_views[frame],
-                ],
-            );
-        }
+        let pre_views = self.function_array_view_stack.clone();
+        self.install_merged_array_views(
+            &merge_view_params,
+            &[&pre_views, &then_array_views, &else_array_views],
+        );
         self.defined_ranges = self.intersect_defined_states(then_defined, else_defined);
         self.dynamic_defined_vars = self.intersect_dynamic_vars(then_dynamic, else_dynamic);
         self.stack.push_back(result);

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -101,6 +101,12 @@ struct ArrayLiteralSelection<'a> {
     element_count: usize,
 }
 
+struct ArrayViewMergeParams {
+    var_id: VarId,
+    initialized: RegisterId,
+    elements: Vec<RegisterId>,
+}
+
 #[derive(Default)]
 struct FunctionInputUsage {
     runtime_reads: HashSet<VarId>,
@@ -449,9 +455,9 @@ impl<'a> FfParser<'a> {
         ir_builder: &mut SIRBuilder<A>,
     ) -> Result<FunctionArrayView, ParserError> {
         // Function bodies are lowered inline, so the formal's working region
-        // is a call-scoped temporary. Populate it before lowering any output
-        // or return expression so every later access is dominated by these
-        // stores, including accesses inside short-circuit control flow.
+        // is a call-scoped temporary. Populate it at the first access that
+        // needs a complete view; control-flow joins carry its initialization
+        // state and element snapshot explicitly.
         let Some(formal) = self.module.variables.get(&var_id) else {
             unreachable!("validated function argument must have a formal variable");
         };
@@ -487,14 +493,6 @@ impl<'a> FfParser<'a> {
                         "function argument validation resolves array literal item dimensions"
                     )
                 });
-            self.prepare_function_array_views_for_expression(
-                selected_expr,
-                targets,
-                domain,
-                convert,
-                sources,
-                ir_builder,
-            )?;
             self.parse_expression(
                 selected_expr,
                 targets,
@@ -560,6 +558,7 @@ impl<'a> FfParser<'a> {
             backing_var_id: var_id,
             elements,
             owns_backing: true,
+            initialized: None,
         })
     }
 
@@ -704,6 +703,7 @@ impl<'a> FfParser<'a> {
             backing_var_id: var_id,
             elements,
             owns_backing: true,
+            initialized: None,
         })
     }
 
@@ -897,8 +897,12 @@ impl<'a> FfParser<'a> {
                         .function_arg_stack
                         .last()
                         .is_some_and(|bindings| bindings.contains_key(var_id));
+                    let is_planned_here = self
+                        .function_array_view_plan_stack
+                        .last()
+                        .is_some_and(|plan| plan.contains(var_id));
                     if is_bound_here
-                        && self.array_access_needs_view(*var_id, index, select)
+                        && (is_planned_here || self.array_access_needs_view(*var_id, index, select))
                         && seen.insert(*var_id)
                     {
                         views.push(*var_id);
@@ -965,19 +969,8 @@ impl<'a> FfParser<'a> {
             Expression::Unary(_, inner, _) => collect(inner, views, seen),
             Expression::Ternary(cond, then_expr, else_expr, _) => {
                 collect(cond, views, seen);
-                let mut then_views = Vec::new();
-                let mut then_seen = HashSet::default();
-                collect(then_expr, &mut then_views, &mut then_seen);
-                let mut else_views = Vec::new();
-                let mut else_seen = HashSet::default();
-                collect(else_expr, &mut else_views, &mut else_seen);
-                // Only views required by both arms may be prepared before the
-                // condition. Arm-local views are prepared inside that arm.
-                for var_id in then_views {
-                    if else_seen.contains(&var_id) && seen.insert(var_id) {
-                        views.push(var_id);
-                    }
-                }
+                collect(then_expr, views, seen);
+                collect(else_expr, views, seen);
             }
             Expression::Concatenation(items, _) => {
                 for (expr, repeat) in items {
@@ -1009,7 +1002,7 @@ impl<'a> FfParser<'a> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn ensure_function_array_view_at<A>(
+    fn build_function_array_view_at<A>(
         &mut self,
         frame: usize,
         var_id: VarId,
@@ -1019,9 +1012,6 @@ impl<'a> FfParser<'a> {
         sources: &mut Vec<VarAtomBase<A>>,
         ir_builder: &mut SIRBuilder<A>,
     ) -> Result<Option<FunctionArrayView>, ParserError> {
-        if let Some(view) = self.function_array_view_stack[frame].get(&var_id) {
-            return Ok(Some(view.clone()));
-        }
         let Some(bound_expr) = self.function_arg_stack[frame].get(&var_id).cloned() else {
             return Ok(None);
         };
@@ -1063,11 +1053,13 @@ impl<'a> FfParser<'a> {
                 let source = self.array_view_layout(*bound_var_id)?;
                 if target.element_width == source.element_width
                     && target.is_2state == source.is_2state
+                    && target.signed == source.signed
                 {
                     Some(FunctionArrayView {
                         backing_var_id: source_view.backing_var_id,
                         elements: source_view.elements,
                         owns_backing: false,
+                        initialized: None,
                     })
                 } else {
                     Some(self.materialize_converted_array_view(
@@ -1080,45 +1072,207 @@ impl<'a> FfParser<'a> {
             }
             _ => None,
         };
+        Ok(view)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn ensure_function_array_view_at<A>(
+        &mut self,
+        frame: usize,
+        var_id: VarId,
+        targets: &mut Vec<VarAtomBase<A>>,
+        domain: &Domain,
+        convert: &impl Fn(VarId, u32) -> A,
+        sources: &mut Vec<VarAtomBase<A>>,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<Option<FunctionArrayView>, ParserError> {
+        if let Some(view) = self.function_array_view_stack[frame].get(&var_id).cloned() {
+            let Some(initialized) = view.initialized else {
+                return Ok(Some(view));
+            };
+
+            let pre_defined = self.defined_ranges.clone();
+            let pre_dynamic = self.dynamic_defined_vars.clone();
+            let initialize_block = ir_builder.new_block();
+            let merged_elements = view
+                .elements
+                .iter()
+                .map(|reg| ir_builder.alloc_reg(ir_builder.register(reg).clone()))
+                .collect::<Vec<_>>();
+            let merge_block = ir_builder.new_block_with(merged_elements.clone());
+            ir_builder.seal_block(SIRTerminator::Branch {
+                cond: initialized,
+                true_block: (merge_block, view.elements.clone()),
+                false_block: (initialize_block, vec![]),
+            });
+
+            ir_builder.switch_to_block(initialize_block);
+            let Some(initialized_view) = self.build_function_array_view_at(
+                frame, var_id, targets, domain, convert, sources, ir_builder,
+            )?
+            else {
+                unreachable!("a conditional array view has a materializable binding");
+            };
+            if initialized_view.backing_var_id != view.backing_var_id
+                || initialized_view.owns_backing != view.owns_backing
+            {
+                unreachable!("a function array view has stable backing metadata");
+            }
+            let initialized_defined =
+                std::mem::replace(&mut self.defined_ranges, pre_defined.clone());
+            let initialized_dynamic =
+                std::mem::replace(&mut self.dynamic_defined_vars, pre_dynamic.clone());
+            ir_builder.seal_block(SIRTerminator::Jump(merge_block, initialized_view.elements));
+            ir_builder.switch_to_block(merge_block);
+            self.defined_ranges = self.intersect_defined_states(pre_defined, initialized_defined);
+            self.dynamic_defined_vars =
+                self.intersect_dynamic_vars(pre_dynamic, initialized_dynamic);
+            let view = FunctionArrayView {
+                backing_var_id: view.backing_var_id,
+                elements: merged_elements,
+                owns_backing: view.owns_backing,
+                initialized: None,
+            };
+            self.function_array_view_stack[frame].insert(var_id, view.clone());
+            return Ok(Some(view));
+        }
+
+        let view = self.build_function_array_view_at(
+            frame, var_id, targets, domain, convert, sources, ir_builder,
+        )?;
         if let Some(view) = &view {
             self.function_array_view_stack[frame].insert(var_id, view.clone());
         }
         Ok(view)
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn prepare_function_array_views_for_expression<A>(
-        &mut self,
-        expr: &Expression,
-        targets: &mut Vec<VarAtomBase<A>>,
-        domain: &Domain,
-        convert: &impl Fn(VarId, u32) -> A,
-        sources: &mut Vec<VarAtomBase<A>>,
-        ir_builder: &mut SIRBuilder<A>,
-    ) -> Result<(), ParserError> {
+    pub(super) fn plan_function_array_views_for_expression(&mut self, expr: &Expression) {
         let Some(frame) = self.function_arg_stack.len().checked_sub(1) else {
-            return Ok(());
+            return;
         };
-        // Prepare outside the expression's control-flow lowering so every
-        // dynamic load is dominated by the stores that initialize its view.
-        // Fully static literal element accesses are deliberately omitted and
-        // continue through the direct-selection path below.
+        // Record the invocation-wide strategy without evaluating any actual
+        // argument. The first relevant access performs materialization in
+        // source order at its normal evaluation point.
         let mut views = Vec::new();
         self.collect_array_views_for_expression(expr, &mut views, &mut HashSet::default());
-        for var_id in views {
-            self.ensure_function_array_view_at(
-                frame, var_id, targets, domain, convert, sources, ir_builder,
-            )?;
-        }
-        Ok(())
+        self.function_array_view_plan_stack[frame].extend(views);
     }
 
-    fn expression_needs_unmaterialized_array_view(&self, expr: &Expression) -> bool {
-        let mut views = Vec::new();
-        self.collect_array_views_for_expression(expr, &mut views, &mut HashSet::default());
-        views
-            .into_iter()
-            .any(|var_id| self.get_bound_function_array_view(var_id).is_none())
+    fn array_view_merge_candidates<'b>(
+        &self,
+        expressions: impl IntoIterator<Item = &'b Expression>,
+    ) -> Vec<VarId> {
+        let Some(frame) = self.function_arg_stack.len().checked_sub(1) else {
+            return Vec::new();
+        };
+        let mut candidates = Vec::new();
+        let mut seen = HashSet::default();
+        for expr in expressions {
+            self.collect_array_views_for_expression(expr, &mut candidates, &mut seen);
+        }
+        candidates.retain(|var_id| {
+            self.function_array_view_stack[frame]
+                .get(var_id)
+                .is_none_or(|view| view.initialized.is_some())
+        });
+        candidates
+    }
+
+    fn alloc_array_view_merge_params<A>(
+        &self,
+        candidates: &[VarId],
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<Vec<ArrayViewMergeParams>, ParserError> {
+        candidates
+            .iter()
+            .map(|&var_id| {
+                let layout = self.array_view_layout(var_id)?;
+                let initialized = ir_builder.alloc_bit(1, false);
+                let elements = (0..layout.element_count)
+                    .map(|_| {
+                        if layout.is_2state {
+                            ir_builder.alloc_bit(layout.element_width, layout.signed)
+                        } else {
+                            ir_builder.alloc_logic(layout.element_width)
+                        }
+                    })
+                    .collect();
+                Ok(ArrayViewMergeParams {
+                    var_id,
+                    initialized,
+                    elements,
+                })
+            })
+            .collect()
+    }
+
+    fn array_view_state_args<A>(
+        &self,
+        frame: usize,
+        params: &[ArrayViewMergeParams],
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<Vec<RegisterId>, ParserError> {
+        let mut args = Vec::new();
+        for params in params {
+            if let Some(view) = self.function_array_view_stack[frame].get(&params.var_id) {
+                let initialized = if let Some(initialized) = view.initialized {
+                    initialized
+                } else {
+                    let initialized = ir_builder.alloc_bit(1, false);
+                    ir_builder.emit(SIRInstruction::Imm(initialized, SIRValue::new(1u8)));
+                    initialized
+                };
+                args.push(initialized);
+                args.extend(view.elements.iter().copied());
+            } else {
+                let initialized = ir_builder.alloc_bit(1, false);
+                ir_builder.emit(SIRInstruction::Imm(initialized, SIRValue::new(0u8)));
+                args.push(initialized);
+                let layout = self.array_view_layout(params.var_id)?;
+                for _ in 0..layout.element_count {
+                    let element = if layout.is_2state {
+                        ir_builder.alloc_bit(layout.element_width, layout.signed)
+                    } else {
+                        ir_builder.alloc_logic(layout.element_width)
+                    };
+                    ir_builder.emit(SIRInstruction::Imm(element, SIRValue::new(0u8)));
+                    args.push(element);
+                }
+            }
+        }
+        Ok(args)
+    }
+
+    fn install_merged_array_views(
+        &mut self,
+        frame: usize,
+        params: &[ArrayViewMergeParams],
+        states: &[&HashMap<VarId, FunctionArrayView>],
+    ) {
+        for params in params {
+            let views = states
+                .iter()
+                .filter_map(|state| state.get(&params.var_id))
+                .collect::<Vec<_>>();
+            let Some(first) = views.first() else {
+                continue;
+            };
+            if views.iter().any(|view| {
+                view.backing_var_id != first.backing_var_id
+                    || view.owns_backing != first.owns_backing
+            }) {
+                unreachable!("a function array view has stable backing metadata");
+            }
+            self.function_array_view_stack[frame].insert(
+                params.var_id,
+                FunctionArrayView {
+                    backing_var_id: first.backing_var_id,
+                    elements: params.elements.clone(),
+                    owns_backing: first.owns_backing,
+                    initialized: Some(params.initialized),
+                },
+            );
+        }
     }
 
     pub(super) fn restore_active_function_array_views<A>(
@@ -1187,14 +1341,6 @@ impl<'a> FfParser<'a> {
         };
         let access_width = get_access_width(self.module, var_id, index, select)?;
         let selected_expr = selection.expr;
-        self.prepare_function_array_views_for_expression(
-            selected_expr,
-            targets,
-            domain,
-            convert,
-            sources,
-            ir_builder,
-        )?;
         self.parse_expression(
             selected_expr,
             targets,
@@ -1886,12 +2032,19 @@ impl<'a> FfParser<'a> {
             left, targets, domain, convert, sources, ir_builder, None,
         )?;
         let lhs = self.stack.pop_back().unwrap();
-        let pre_rhs_state = expression_has_side_effect(right).then(|| {
-            (
-                self.defined_ranges.clone(),
-                self.dynamic_defined_vars.clone(),
-            )
-        });
+        let array_view_frame = self.function_arg_stack.len().checked_sub(1);
+        let array_view_candidates = self.array_view_merge_candidates([right]);
+        let array_view_params =
+            self.alloc_array_view_merge_params(&array_view_candidates, ir_builder)?;
+        let pre_rhs_array_views =
+            array_view_frame.map(|frame| self.function_array_view_stack[frame].clone());
+        let pre_rhs_state =
+            (expression_has_side_effect(right) || !array_view_candidates.is_empty()).then(|| {
+                (
+                    self.defined_ranges.clone(),
+                    self.dynamic_defined_vars.clone(),
+                )
+            });
 
         // Only a definite dominant value may short-circuit.  Logical-not
         // produces a one-bit 4-state truth value; ToTwoState maps its X result
@@ -1914,15 +2067,28 @@ impl<'a> FfParser<'a> {
 
         let rhs_block = ir_builder.new_block();
         let result_param = ir_builder.alloc_logic(1);
-        let merge_block = ir_builder.new_block_with(vec![result_param]);
+        let mut merge_params = vec![result_param];
+        for params in &array_view_params {
+            merge_params.push(params.initialized);
+            merge_params.extend(params.elements.iter().copied());
+        }
+        let merge_block = ir_builder.new_block_with(merge_params);
         let shortcut_value = ir_builder.alloc_bit(1, false);
         ir_builder.emit(SIRInstruction::Imm(
             shortcut_value,
             SIRValue::new(if is_and { 0u8 } else { 1u8 }),
         ));
+        let mut shortcut_args = vec![shortcut_value];
+        if let Some(frame) = array_view_frame {
+            shortcut_args.extend(self.array_view_state_args(
+                frame,
+                &array_view_params,
+                ir_builder,
+            )?);
+        }
         ir_builder.seal_block(SIRTerminator::Branch {
             cond: shortcut,
-            true_block: (merge_block, vec![shortcut_value]),
+            true_block: (merge_block, shortcut_args),
             false_block: (rhs_block, vec![]),
         });
 
@@ -1948,9 +2114,23 @@ impl<'a> FfParser<'a> {
             },
             rhs,
         ));
-        ir_builder.seal_block(SIRTerminator::Jump(merge_block, vec![evaluated]));
+        let rhs_array_views =
+            array_view_frame.map(|frame| self.function_array_view_stack[frame].clone());
+        let mut rhs_args = vec![evaluated];
+        if let Some(frame) = array_view_frame {
+            rhs_args.extend(self.array_view_state_args(frame, &array_view_params, ir_builder)?);
+        }
+        ir_builder.seal_block(SIRTerminator::Jump(merge_block, rhs_args));
 
         ir_builder.switch_to_block(merge_block);
+        if let (Some(frame), Some(pre_views), Some(rhs_views)) = (
+            array_view_frame,
+            pre_rhs_array_views.as_ref(),
+            rhs_array_views.as_ref(),
+        ) {
+            self.function_array_view_stack[frame] = pre_views.clone();
+            self.install_merged_array_views(frame, &array_view_params, &[pre_views, rhs_views]);
+        }
         if let (Some((pre_defined, pre_dynamic)), Some((rhs_defined, rhs_dynamic))) =
             (pre_rhs_state, rhs_state)
         {
@@ -2402,6 +2582,17 @@ impl<'a> FfParser<'a> {
                                 return Ok(());
                             }
                         }
+                    }
+                }
+                if let Some(frame) = (0..self.function_arg_stack.len())
+                    .rev()
+                    .find(|&frame| self.function_arg_stack[frame].contains_key(var_id))
+                {
+                    let planned = self.function_array_view_plan_stack[frame].contains(var_id);
+                    if planned || self.array_access_needs_view(*var_id, var_index, var_select) {
+                        self.ensure_function_array_view_at(
+                            frame, *var_id, targets, domain, convert, sources, ir_builder,
+                        )?;
                     }
                 }
                 if let Some(backing_var_id) = self.get_bound_function_array_view(*var_id) {
@@ -2901,8 +3092,9 @@ impl<'a> FfParser<'a> {
         )?;
         let cond_reg = self.stack.pop_back().unwrap();
 
-        let branch_materializes_array_view = self.expression_needs_unmaterialized_array_view(then)
-            || self.expression_needs_unmaterialized_array_view(els);
+        let array_view_frame = self.function_arg_stack.len().checked_sub(1);
+        let array_view_candidates = self.array_view_merge_candidates([then, els]);
+        let branch_materializes_array_view = !array_view_candidates.is_empty();
 
         if !expression_has_side_effect(then)
             && !expression_has_side_effect(els)
@@ -2968,23 +3160,42 @@ impl<'a> FfParser<'a> {
         let merge_else = ir_builder.alloc_bit(1, false);
         ir_builder.emit(SIRInstruction::Imm(merge_else, SIRValue::new(1u8)));
 
+        let else_view_params =
+            self.alloc_array_view_merge_params(&array_view_candidates, ir_builder)?;
+        let merge_view_params =
+            self.alloc_array_view_merge_params(&array_view_candidates, ir_builder)?;
         let then_block = ir_builder.new_block();
         let carried_then = ir_builder.alloc_logic(result_width);
         let needs_merge = ir_builder.alloc_bit(1, false);
-        let else_block = ir_builder.new_block_with(vec![carried_then, needs_merge]);
+        let mut else_params = vec![carried_then, needs_merge];
+        for params in &else_view_params {
+            else_params.push(params.initialized);
+            else_params.extend(params.elements.iter().copied());
+        }
+        let else_block = ir_builder.new_block_with(else_params);
         let result = ir_builder.alloc_logic(result_width);
-        let merge_block = ir_builder.new_block_with(vec![result]);
+        let mut merge_params = vec![result];
+        for params in &merge_view_params {
+            merge_params.push(params.initialized);
+            merge_params.extend(params.elements.iter().copied());
+        }
+        let merge_block = ir_builder.new_block_with(merge_params);
 
+        let mut initial_else_args = vec![dummy_then, direct_else];
+        if let Some(frame) = array_view_frame {
+            initial_else_args.extend(self.array_view_state_args(
+                frame,
+                &else_view_params,
+                ir_builder,
+            )?);
+        }
         ir_builder.seal_block(SIRTerminator::Branch {
             cond: known_false,
-            true_block: (else_block, vec![dummy_then, direct_else]),
+            true_block: (else_block, initial_else_args),
             false_block: (then_block, vec![]),
         });
 
         ir_builder.switch_to_block(then_block);
-        self.prepare_function_array_views_for_expression(
-            then, targets, domain, convert, sources, ir_builder,
-        )?;
         self.parse_expression_in_context(
             then,
             targets,
@@ -2998,17 +3209,36 @@ impl<'a> FfParser<'a> {
         let then_defined = std::mem::replace(&mut self.defined_ranges, pre_ternary_defined.clone());
         let then_dynamic =
             std::mem::replace(&mut self.dynamic_defined_vars, pre_ternary_dynamic.clone());
+        let then_array_views = self.function_array_view_stack.clone();
+        let mut then_merge_args = vec![then_val];
+        let mut then_else_args = vec![then_val, merge_else];
+        if let Some(frame) = array_view_frame {
+            then_merge_args.extend(self.array_view_state_args(
+                frame,
+                &merge_view_params,
+                ir_builder,
+            )?);
+            then_else_args.extend(self.array_view_state_args(
+                frame,
+                &else_view_params,
+                ir_builder,
+            )?);
+        }
         ir_builder.seal_block(SIRTerminator::Branch {
             cond: known_true,
-            true_block: (merge_block, vec![then_val]),
-            false_block: (else_block, vec![then_val, merge_else]),
+            true_block: (merge_block, then_merge_args),
+            false_block: (else_block, then_else_args),
         });
 
         self.function_array_view_stack = pre_ternary_array_views.clone();
         ir_builder.switch_to_block(else_block);
-        self.prepare_function_array_views_for_expression(
-            els, targets, domain, convert, sources, ir_builder,
-        )?;
+        if let Some(frame) = array_view_frame {
+            self.install_merged_array_views(
+                frame,
+                &else_view_params,
+                &[&pre_ternary_array_views[frame], &then_array_views[frame]],
+            );
+        }
         self.parse_expression_in_context(
             els,
             targets,
@@ -3021,6 +3251,7 @@ impl<'a> FfParser<'a> {
         let else_val = self.stack.pop_back().unwrap();
         let else_defined = std::mem::take(&mut self.defined_ranges);
         let else_dynamic = std::mem::take(&mut self.dynamic_defined_vars);
+        let else_array_views = self.function_array_view_stack.clone();
         let merged = ir_builder.alloc_logic(result_width);
         ir_builder.emit(SIRInstruction::Mux(
             merged,
@@ -3029,20 +3260,42 @@ impl<'a> FfParser<'a> {
             else_val,
         ));
         let direct_else_block = ir_builder.new_block();
+        let mut else_merge_state = Vec::new();
+        if let Some(frame) = array_view_frame {
+            else_merge_state.extend(self.array_view_state_args(
+                frame,
+                &merge_view_params,
+                ir_builder,
+            )?);
+        }
+        let mut merged_args = vec![merged];
+        merged_args.extend(else_merge_state.iter().copied());
         ir_builder.seal_block(SIRTerminator::Branch {
             cond: needs_merge,
-            true_block: (merge_block, vec![merged]),
+            true_block: (merge_block, merged_args),
             false_block: (direct_else_block, vec![]),
         });
 
         ir_builder.switch_to_block(direct_else_block);
-        ir_builder.seal_block(SIRTerminator::Jump(merge_block, vec![else_val]));
+        let mut direct_else_args = vec![else_val];
+        direct_else_args.extend(else_merge_state);
+        ir_builder.seal_block(SIRTerminator::Jump(merge_block, direct_else_args));
 
-        // An arm-local view is not initialized on paths that skip that arm,
-        // so it must not escape the ternary's merge point.
         self.function_array_view_stack = pre_ternary_array_views;
 
         ir_builder.switch_to_block(merge_block);
+        if let Some(frame) = array_view_frame {
+            let pre_views = self.function_array_view_stack[frame].clone();
+            self.install_merged_array_views(
+                frame,
+                &merge_view_params,
+                &[
+                    &pre_views,
+                    &then_array_views[frame],
+                    &else_array_views[frame],
+                ],
+            );
+        }
         self.defined_ranges = self.intersect_defined_states(then_defined, else_defined);
         self.dynamic_defined_vars = self.intersect_dynamic_vars(then_dynamic, else_dynamic);
         self.stack.push_back(result);

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -1602,7 +1602,9 @@ impl<'a> FfParser<'a> {
             .filter(|view| view.owns_backing && !view.elements.is_empty())
             .map(|view| view.backing_var_id)
             .collect::<HashSet<_>>();
-        for frame in self.function_array_view_stack.iter().rev() {
+        // Older callers must be restored first so that the nearest active
+        // invocation is the final snapshot left in the shared formal region.
+        for frame in &self.function_array_view_stack {
             for view in frame.values() {
                 if !clobbered.contains(&view.backing_var_id) || view.elements.is_empty() {
                     continue;

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -3,7 +3,7 @@ use crate::context_width::{
     ValueContext, binary_semantics, cast_semantics, expression_signed, resolve_binary_op,
 };
 use crate::{
-    LoweringPhase, ParserError,
+    HashMap, LoweringPhase, ParserError,
     bitaccess::{
         celox_value_from_comptime, celox_value_from_comptime_in_context, eval_var_select,
         get_access_width, is_static_access,
@@ -84,6 +84,14 @@ fn expression_has_side_effect(expr: &Expression) -> bool {
             .iter()
             .any(|(_, expr)| expression_has_side_effect(expr)),
     }
+}
+
+#[derive(Clone, Copy)]
+struct ArrayViewLayout {
+    element_count: usize,
+    element_width: usize,
+    signed: bool,
+    is_2state: bool,
 }
 
 fn add_offset_term<A>(
@@ -386,78 +394,234 @@ impl<'a> FfParser<'a> {
         }
     }
 
-    fn materialize_bound_array_literal_access<A>(
+    fn array_view_layout(&self, var_id: VarId) -> Result<ArrayViewLayout, ParserError> {
+        let Some(variable) = self.module.variables.get(&var_id) else {
+            unreachable!("validated function argument must have a formal variable");
+        };
+        if variable.r#type.array.is_empty() {
+            unreachable!("array view requires an array variable");
+        }
+        let Some(element_count) = variable
+            .r#type
+            .array
+            .iter()
+            .copied()
+            .try_fold(1usize, |total, dim| {
+                dim.and_then(|dim| total.checked_mul(dim))
+            })
+        else {
+            unreachable!("function argument validation resolves array dimensions without overflow");
+        };
+        let total_width = resolve_total_width(self.module, variable)?;
+        if element_count == 0 || !total_width.is_multiple_of(element_count) {
+            unreachable!("array has a nonzero element count that divides its width");
+        }
+        Ok(ArrayViewLayout {
+            element_count,
+            element_width: total_width / element_count,
+            signed: variable.r#type.signed,
+            is_2state: variable.r#type.is_2state(),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn materialize_bound_array_literal_view<A>(
         &mut self,
         var_id: VarId,
         items: &[ArrayLiteralItem],
-        index: &VarIndex,
-        select: &VarSelect,
         targets: &mut Vec<VarAtomBase<A>>,
         domain: &Domain,
         convert: &impl Fn(VarId, u32) -> A,
         sources: &mut Vec<VarAtomBase<A>>,
         ir_builder: &mut SIRBuilder<A>,
-    ) -> Result<bool, ParserError> {
+    ) -> Result<(), ParserError> {
+        // Function bodies are lowered inline, so the formal's working region
+        // is a call-scoped temporary. Populate it before lowering any output
+        // or return expression so every later access is dominated by these
+        // stores, including accesses inside short-circuit control flow.
         let Some(formal) = self.module.variables.get(&var_id) else {
-            return Ok(false);
+            unreachable!("validated function argument must have a formal variable");
         };
         if formal.r#type.array.is_empty() {
-            return Ok(false);
-        }
-        if select.1.is_some() {
-            return Ok(false);
+            unreachable!("array literal view requires an array formal");
         }
 
         let array_dims: Option<Vec<usize>> = formal.r#type.array.iter().copied().collect();
         let Some(array_dims) = array_dims else {
-            return Ok(false);
+            unreachable!("function argument shape validation resolves formal dimensions");
         };
+        let layout = self.array_view_layout(var_id)?;
 
-        let mut all_indices = index.0.clone();
-        all_indices.extend(select.0.iter().cloned());
-        if all_indices.len() != array_dims.len() {
-            return Ok(false);
-        }
-
-        let mut resolved_indices = Vec::with_capacity(all_indices.len());
-        for (i, expr) in all_indices.iter().enumerate() {
-            let Some(idx) = self.get_constant_value(expr).map(|x| x as usize) else {
-                return Ok(false);
-            };
-            let dim = array_dims[i];
-            if idx >= dim {
-                return Ok(false);
+        let mut cached_elements = std::collections::HashMap::new();
+        for linear_index in 0..layout.element_count {
+            let mut remainder = linear_index;
+            let mut coordinates = vec![0usize; array_dims.len()];
+            for dimension in (0..array_dims.len()).rev() {
+                coordinates[dimension] = remainder % array_dims[dimension];
+                remainder /= array_dims[dimension];
             }
-            resolved_indices.push(idx);
+
+            let Some(selected_expr) =
+                self.select_array_literal_element(items, &coordinates, &array_dims)
+            else {
+                unreachable!("validated array literal covers every formal element");
+            };
+            let cache_key = selected_expr as *const Expression as usize;
+            let selected_reg = if let Some(reg) = cached_elements.get(&cache_key) {
+                *reg
+            } else {
+                self.parse_expression(
+                    selected_expr,
+                    targets,
+                    domain,
+                    convert,
+                    sources,
+                    ir_builder,
+                    Some(layout.element_width),
+                )?;
+                let reg = self.stack.pop_back().unwrap();
+                let reg = self.coerce_register_to_formal(
+                    ir_builder,
+                    reg,
+                    layout.element_width,
+                    selected_expr.comptime().r#type.signed,
+                    layout.signed,
+                    layout.is_2state,
+                );
+                cached_elements.insert(cache_key, reg);
+                reg
+            };
+            let element_index = ir_builder.alloc_bit(64, false);
+            ir_builder.emit(SIRInstruction::Imm(
+                element_index,
+                SIRValue::new(linear_index as u64),
+            ));
+            ir_builder.emit(SIRInstruction::Store(
+                convert(var_id, WORKING_REGION),
+                SIROffset::Element {
+                    index: element_index,
+                    element_width: layout.element_width,
+                    bit_offset: 0,
+                    dynamic_bit_offset: None,
+                },
+                layout.element_width,
+                selected_reg,
+                Vec::new(),
+                Vec::new(),
+            ));
         }
 
-        let Some(selected_expr) =
-            self.select_array_literal_element(items, &resolved_indices, &array_dims)
-        else {
-            return Ok(false);
-        };
+        Ok(())
+    }
 
-        let access_width = get_access_width(self.module, var_id, index, select)?;
-        self.parse_expression(
-            selected_expr,
-            targets,
-            domain,
-            convert,
-            sources,
-            ir_builder,
-            Some(access_width),
-        )?;
-        let selected_reg = self.stack.pop_back().unwrap();
-        let coerced = self.coerce_register_to_formal(
-            ir_builder,
-            selected_reg,
-            access_width,
-            selected_expr.comptime().r#type.signed,
-            formal.r#type.signed,
-            formal.r#type.is_2state(),
-        );
-        self.stack.push_back(coerced);
-        Ok(true)
+    fn materialize_converted_array_view<A>(
+        &mut self,
+        var_id: VarId,
+        backing_var_id: VarId,
+        convert: &impl Fn(VarId, u32) -> A,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<(), ParserError> {
+        // A view can alias an existing backing only when both formals use the
+        // same element storage representation. Otherwise create a converted
+        // temporary for the callee while preserving element-wise coercion.
+        let target = self.array_view_layout(var_id)?;
+        let source = self.array_view_layout(backing_var_id)?;
+        if target.element_count != source.element_count {
+            unreachable!("function argument shape validation preserves array element count");
+        }
+
+        for linear_index in 0..target.element_count {
+            let element_index = ir_builder.alloc_bit(64, false);
+            ir_builder.emit(SIRInstruction::Imm(
+                element_index,
+                SIRValue::new(linear_index as u64),
+            ));
+            let source_reg = if source.is_2state {
+                ir_builder.alloc_bit(source.element_width, source.signed)
+            } else {
+                ir_builder.alloc_logic(source.element_width)
+            };
+            ir_builder.emit(SIRInstruction::Load(
+                source_reg,
+                convert(backing_var_id, WORKING_REGION),
+                SIROffset::Element {
+                    index: element_index,
+                    element_width: source.element_width,
+                    bit_offset: 0,
+                    dynamic_bit_offset: None,
+                },
+                source.element_width,
+            ));
+            let converted = self.coerce_register_to_formal(
+                ir_builder,
+                source_reg,
+                target.element_width,
+                source.signed,
+                target.signed,
+                target.is_2state,
+            );
+            ir_builder.emit(SIRInstruction::Store(
+                convert(var_id, WORKING_REGION),
+                SIROffset::Element {
+                    index: element_index,
+                    element_width: target.element_width,
+                    bit_offset: 0,
+                    dynamic_bit_offset: None,
+                },
+                target.element_width,
+                converted,
+                Vec::new(),
+                Vec::new(),
+            ));
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn materialize_function_array_views<A>(
+        &mut self,
+        bindings: &HashMap<VarId, Expression>,
+        targets: &mut Vec<VarAtomBase<A>>,
+        domain: &Domain,
+        convert: &impl Fn(VarId, u32) -> A,
+        sources: &mut Vec<VarAtomBase<A>>,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<HashMap<VarId, VarId>, ParserError> {
+        let mut views = HashMap::default();
+        for (&var_id, bound_expr) in bindings {
+            if let Expression::ArrayLiteral(items, _) = bound_expr {
+                if self.module.variables[&var_id].r#type.array.is_empty() {
+                    continue;
+                }
+                self.materialize_bound_array_literal_view(
+                    var_id, items, targets, domain, convert, sources, ir_builder,
+                )?;
+                views.insert(var_id, var_id);
+            } else if let Expression::Term(factor) = bound_expr
+                && let Factor::Variable(bound_var_id, index, select, _) = factor.as_ref()
+                && index.0.is_empty()
+                && select.0.is_empty()
+                && select.1.is_none()
+                && let Some(backing_var_id) = self.get_bound_function_array_view(*bound_var_id)
+            {
+                let target = self.array_view_layout(var_id)?;
+                let backing = self.array_view_layout(backing_var_id)?;
+                if target.element_width == backing.element_width
+                    && target.is_2state == backing.is_2state
+                {
+                    views.insert(var_id, backing_var_id);
+                } else {
+                    self.materialize_converted_array_view(
+                        var_id,
+                        backing_var_id,
+                        convert,
+                        ir_builder,
+                    )?;
+                    views.insert(var_id, var_id);
+                }
+            }
+        }
+        Ok(views)
     }
 
     fn select_array_literal_element<'b>(
@@ -530,6 +694,53 @@ impl<'a> FfParser<'a> {
             _ if default_expr.comptime().r#type.array.is_empty() => Some(default_expr),
             _ => None,
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn load_bound_array_literal_view<A>(
+        &mut self,
+        var_id: VarId,
+        backing_var_id: VarId,
+        index: &VarIndex,
+        select: &VarSelect,
+        domain: &Domain,
+        convert: &impl Fn(VarId, u32) -> A,
+        sources: &mut Vec<VarAtomBase<A>>,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> Result<(), ParserError> {
+        let width = get_access_width(self.module, var_id, index, select)?;
+        let formal = &self.module.variables[&var_id];
+        let dest = if formal.r#type.is_2state() {
+            ir_builder.alloc_bit(width, formal.r#type.signed)
+        } else {
+            ir_builder.alloc_logic(width)
+        };
+        let mut offset =
+            self.emit_offset_calc(var_id, index, select, domain, convert, sources, ir_builder)?;
+        if index.0.is_empty() && select.0.is_empty() && select.1.is_none() {
+            let element_count = formal
+                .r#type
+                .array
+                .iter()
+                .flatten()
+                .copied()
+                .product::<usize>();
+            if element_count == 0 || !width.is_multiple_of(element_count) {
+                unreachable!("array view width is divisible by its nonzero element count");
+            }
+            offset = SIROffset::PackedElements {
+                bit_offset: 0,
+                element_width: width / element_count,
+            };
+        }
+        ir_builder.emit(SIRInstruction::Load(
+            dest,
+            convert(backing_var_id, WORKING_REGION),
+            offset,
+            width,
+        ));
+        self.stack.push_back(dest);
+        Ok(())
     }
 
     fn eval_formal_type_select(
@@ -1537,6 +1748,30 @@ impl<'a> FfParser<'a> {
                         }
                     }
                 }
+                if let Some(backing_var_id) = self.get_bound_function_array_view(*var_id) {
+                    self.load_bound_array_literal_view(
+                        *var_id,
+                        backing_var_id,
+                        var_index,
+                        var_select,
+                        domain,
+                        convert,
+                        sources,
+                        ir_builder,
+                    )?;
+                    if let Some(context) = context {
+                        let selected = self.stack.pop_back().unwrap();
+                        let adjusted = self.cast_reg_width_ext(
+                            ir_builder,
+                            selected,
+                            context.width,
+                            context.signed,
+                        );
+                        self.stack.push_back(adjusted);
+                    }
+                    return Ok(());
+                }
+
                 if let Some(bound_expr) = self.get_bound_function_arg_expr(*var_id) {
                     let bound_expr = bound_expr.clone();
                     if var_index.0.is_empty() && var_select.0.is_empty() && var_select.1.is_none() {
@@ -1563,15 +1798,6 @@ impl<'a> FfParser<'a> {
                             self.stack.push_back(adjusted);
                         }
                         return Ok(());
-                    }
-
-                    if let Expression::ArrayLiteral(items, _) = &bound_expr {
-                        if self.materialize_bound_array_literal_access(
-                            *var_id, items, var_index, var_select, targets, domain, convert,
-                            sources, ir_builder,
-                        )? {
-                            return Ok(());
-                        }
                     }
 
                     let Expression::Term(bound_factor) = &bound_expr else {
@@ -1667,15 +1893,29 @@ impl<'a> FfParser<'a> {
                     merged_select.0.extend(var_select.0.iter().cloned());
                     merged_select.1 = var_select.1.clone();
 
-                    self.op_load(
-                        *bound_var_id,
-                        &merged_index,
-                        &merged_select,
-                        domain,
-                        convert,
-                        sources,
-                        ir_builder,
-                    )?;
+                    if let Some(backing_var_id) = self.get_bound_function_array_view(*bound_var_id)
+                    {
+                        self.load_bound_array_literal_view(
+                            *bound_var_id,
+                            backing_var_id,
+                            &merged_index,
+                            &merged_select,
+                            domain,
+                            convert,
+                            sources,
+                            ir_builder,
+                        )?;
+                    } else {
+                        self.op_load(
+                            *bound_var_id,
+                            &merged_index,
+                            &merged_select,
+                            domain,
+                            convert,
+                            sources,
+                            ir_builder,
+                        )?;
+                    }
                 } else {
                     self.op_load(
                         *var_id, var_index, var_select, domain, convert, sources, ir_builder,

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -1,4 +1,4 @@
-use super::{Domain, FfParser, FunctionArrayView};
+use super::{Domain, FfParser, FunctionArrayLiteralItemCache, FunctionArrayView};
 use crate::context_width::{
     ValueContext, binary_semantics, cast_semantics, expression_signed, resolve_binary_op,
 };
@@ -110,6 +110,13 @@ struct ArrayViewKey {
 
 struct ArrayViewMergeParams {
     key: ArrayViewKey,
+    initialized: RegisterId,
+    elements: Vec<RegisterId>,
+    cached_literal_items: Vec<ArrayLiteralItemMergeParams>,
+}
+
+struct ArrayLiteralItemMergeParams {
+    cache_key: Vec<usize>,
     initialized: RegisterId,
     elements: Vec<RegisterId>,
 }
@@ -490,9 +497,6 @@ impl<'a> FfParser<'a> {
             &mut source_order,
         );
         for (cache_key, selected_expr) in source_order {
-            if cached_elements.contains_key(&cache_key) {
-                continue;
-            }
             let element_count = selected_expr
                 .comptime()
                 .r#type
@@ -507,6 +511,53 @@ impl<'a> FfParser<'a> {
                         "function argument validation resolves array literal item dimensions"
                     )
                 });
+            if let Some(cached) = cached_elements.get(&cache_key).cloned() {
+                if let Some(initialized) = cached.initialized {
+                    let evaluate_block = ir_builder.new_block();
+                    let merged_elements = cached
+                        .elements
+                        .iter()
+                        .map(|reg| ir_builder.alloc_reg(ir_builder.register(reg).clone()))
+                        .collect::<Vec<_>>();
+                    let merge_block = ir_builder.new_block_with(merged_elements.clone());
+                    let pre_defined = self.defined_ranges.clone();
+                    let pre_dynamic = self.dynamic_defined_vars.clone();
+                    ir_builder.seal_block(SIRTerminator::Branch {
+                        cond: initialized,
+                        true_block: (merge_block, cached.elements),
+                        false_block: (evaluate_block, vec![]),
+                    });
+                    ir_builder.switch_to_block(evaluate_block);
+                    let evaluated = self.evaluate_array_literal_item(
+                        selected_expr,
+                        element_count,
+                        layout,
+                        targets,
+                        domain,
+                        convert,
+                        sources,
+                        ir_builder,
+                    )?;
+                    let evaluated_defined =
+                        std::mem::replace(&mut self.defined_ranges, pre_defined.clone());
+                    let evaluated_dynamic =
+                        std::mem::replace(&mut self.dynamic_defined_vars, pre_dynamic.clone());
+                    ir_builder.seal_block(SIRTerminator::Jump(merge_block, evaluated));
+                    ir_builder.switch_to_block(merge_block);
+                    self.defined_ranges =
+                        self.intersect_defined_states(pre_defined, evaluated_defined);
+                    self.dynamic_defined_vars =
+                        self.intersect_dynamic_vars(pre_dynamic, evaluated_dynamic);
+                    cached_elements.insert(
+                        cache_key,
+                        FunctionArrayLiteralItemCache {
+                            elements: merged_elements,
+                            initialized: None,
+                        },
+                    );
+                }
+                continue;
+            }
             let item_elements = self.evaluate_array_literal_item(
                 selected_expr,
                 element_count,
@@ -517,7 +568,13 @@ impl<'a> FfParser<'a> {
                 sources,
                 ir_builder,
             )?;
-            cached_elements.insert(cache_key, item_elements);
+            cached_elements.insert(
+                cache_key,
+                FunctionArrayLiteralItemCache {
+                    elements: item_elements,
+                    initialized: None,
+                },
+            );
         }
 
         let mut elements = Vec::with_capacity(layout.element_count);
@@ -537,10 +594,10 @@ impl<'a> FfParser<'a> {
             let Some(selected_regs) = cached_elements.get(&selection.cache_key) else {
                 unreachable!("every selected element was evaluated in literal source order");
             };
-            if selected_regs.len() != selection.element_count {
+            if selected_regs.elements.len() != selection.element_count {
                 unreachable!("selected array literal item has the validated element count");
             }
-            let Some(&selected_reg) = selected_regs.get(selection.element_index) else {
+            let Some(&selected_reg) = selected_regs.elements.get(selection.element_index) else {
                 unreachable!("selected array literal item index is in bounds");
             };
             elements.push(selected_reg);
@@ -580,6 +637,119 @@ impl<'a> FfParser<'a> {
             }
             path.pop();
         }
+    }
+
+    fn bound_array_literal_items_at(
+        &self,
+        frame: usize,
+        var_id: VarId,
+    ) -> Option<&[ArrayLiteralItem]> {
+        match self.function_arg_stack[frame].get(&var_id)? {
+            Expression::ArrayLiteral(items, _) => Some(items),
+            Expression::Term(factor) => {
+                let Factor::Variable(bound_var_id, index, select, _) = factor.as_ref() else {
+                    return None;
+                };
+                if !index.0.is_empty() || !select.0.is_empty() || select.1.is_some() {
+                    return None;
+                }
+                let source_frame = (0..frame).rev().find(|&source_frame| {
+                    self.function_arg_stack[source_frame].contains_key(bound_var_id)
+                })?;
+                self.bound_array_literal_items_at(source_frame, *bound_var_id)
+            }
+            _ => None,
+        }
+    }
+
+    fn array_literal_item_specs(&self, frame: usize, var_id: VarId) -> Vec<(Vec<usize>, usize)> {
+        let Some(items) = self.bound_array_literal_items_at(frame, var_id) else {
+            return Vec::new();
+        };
+        let mut source_order = Vec::new();
+        Self::collect_array_literal_elements_in_source_order(
+            items,
+            &mut Vec::new(),
+            &mut source_order,
+        );
+        source_order
+            .into_iter()
+            .map(|(cache_key, expr)| {
+                let element_count = expr
+                    .comptime()
+                    .r#type
+                    .array
+                    .iter()
+                    .copied()
+                    .try_fold(1usize, |total, dim| {
+                        dim.and_then(|dim| total.checked_mul(dim))
+                    })
+                    .unwrap_or_else(|| {
+                        unreachable!(
+                            "function argument validation resolves array literal item dimensions"
+                        )
+                    });
+                (cache_key, element_count)
+            })
+            .collect()
+    }
+
+    fn array_literal_item_elements_from_view(
+        &self,
+        frame: usize,
+        var_id: VarId,
+        cache_key: &[usize],
+        view_elements: &[RegisterId],
+        element_count: usize,
+    ) -> Option<Vec<RegisterId>> {
+        let items = self.bound_array_literal_items_at(frame, var_id)?;
+        let array_dims = self.module.variables[&var_id]
+            .r#type
+            .array
+            .iter()
+            .copied()
+            .collect::<Option<Vec<_>>>()?;
+        let mut elements = vec![None; element_count];
+        for (linear_index, &view_element) in view_elements.iter().enumerate() {
+            let mut remainder = linear_index;
+            let mut coordinates = vec![0usize; array_dims.len()];
+            for dimension in (0..array_dims.len()).rev() {
+                coordinates[dimension] = remainder % array_dims[dimension];
+                remainder /= array_dims[dimension];
+            }
+            let selection = self.select_array_literal_element(items, &coordinates, &array_dims)?;
+            if selection.cache_key == cache_key {
+                elements[selection.element_index] = Some(view_element);
+            }
+        }
+        elements.into_iter().collect()
+    }
+
+    fn definite_array_literal_caches_from_view(
+        &self,
+        frame: usize,
+        var_id: VarId,
+        view_elements: &[RegisterId],
+    ) -> HashMap<Vec<usize>, FunctionArrayLiteralItemCache> {
+        self.array_literal_item_specs(frame, var_id)
+            .into_iter()
+            .filter_map(|(cache_key, element_count)| {
+                let elements = self.array_literal_item_elements_from_view(
+                    frame,
+                    var_id,
+                    &cache_key,
+                    view_elements,
+                    element_count,
+                )?;
+                Some((
+                    cache_key,
+                    FunctionArrayLiteralItemCache {
+                        elements,
+                        initialized: None,
+                    },
+                ))
+            })
+            .collect()
     }
 
     fn slice_array_value_element<A>(
@@ -857,7 +1027,8 @@ impl<'a> FfParser<'a> {
                         let needs_actual = if formal.r#type.array.is_empty() {
                             nested_usage.runtime_reads.contains(arg_id)
                         } else {
-                            nested_usage.array_views.contains(arg_id)
+                            nested_usage.runtime_reads.contains(arg_id)
+                                || nested_usage.array_views.contains(arg_id)
                         };
                         if needs_actual && let Some(expr) = call.inputs.get(arg_path) {
                             self.collect_function_input_usage(expr, usage, active_calls)?;
@@ -978,7 +1149,8 @@ impl<'a> FfParser<'a> {
                             let needs_actual = if formal.r#type.array.is_empty() {
                                 input_usage.runtime_reads.contains(arg_id)
                             } else {
-                                input_usage.array_views.contains(arg_id)
+                                input_usage.runtime_reads.contains(arg_id)
+                                    || input_usage.array_views.contains(arg_id)
                             };
                             if needs_actual && let Some(expr) = call.inputs.get(arg_path) {
                                 collect(expr, views, seen);
@@ -1189,11 +1361,13 @@ impl<'a> FfParser<'a> {
             self.defined_ranges = self.intersect_defined_states(pre_defined, initialized_defined);
             self.dynamic_defined_vars =
                 self.intersect_dynamic_vars(pre_dynamic, initialized_dynamic);
+            let cached_literal_items =
+                self.definite_array_literal_caches_from_view(frame, var_id, &merged_elements);
             let view = FunctionArrayView {
                 backing_var_id: view.backing_var_id,
                 elements: merged_elements,
                 owns_backing: view.owns_backing,
-                cached_literal_items: initialized_view.cached_literal_items,
+                cached_literal_items,
                 initialized: None,
             };
             self.function_array_view_stack[frame].insert(var_id, view.clone());
@@ -1245,10 +1419,28 @@ impl<'a> FfParser<'a> {
                         }
                     })
                     .collect();
+                let cached_literal_items = self
+                    .array_literal_item_specs(key.frame, key.var_id)
+                    .into_iter()
+                    .map(|(cache_key, element_count)| ArrayLiteralItemMergeParams {
+                        cache_key,
+                        initialized: ir_builder.alloc_bit(1, false),
+                        elements: (0..element_count)
+                            .map(|_| {
+                                if layout.is_2state {
+                                    ir_builder.alloc_bit(layout.element_width, layout.signed)
+                                } else {
+                                    ir_builder.alloc_logic(layout.element_width)
+                                }
+                            })
+                            .collect(),
+                    })
+                    .collect();
                 Ok(ArrayViewMergeParams {
                     key,
                     initialized,
                     elements,
+                    cached_literal_items,
                 })
             })
             .collect()
@@ -1301,6 +1493,55 @@ impl<'a> FfParser<'a> {
                     args.push(element);
                 }
             }
+            let view = self.function_array_view_stack[params.key.frame].get(&params.key.var_id);
+            for cached_params in &params.cached_literal_items {
+                if let Some(cached) =
+                    view.and_then(|view| view.cached_literal_items.get(&cached_params.cache_key))
+                {
+                    let initialized = if let Some(initialized) = cached.initialized {
+                        initialized
+                    } else {
+                        let initialized = ir_builder.alloc_bit(1, false);
+                        ir_builder.emit(SIRInstruction::Imm(initialized, SIRValue::new(1u8)));
+                        initialized
+                    };
+                    args.push(initialized);
+                    args.extend(cached.elements.iter().copied());
+                } else if let Some(view) = view.filter(|view| !view.elements.is_empty()) {
+                    let initialized = if let Some(initialized) = view.initialized {
+                        initialized
+                    } else {
+                        let initialized = ir_builder.alloc_bit(1, false);
+                        ir_builder.emit(SIRInstruction::Imm(initialized, SIRValue::new(1u8)));
+                        initialized
+                    };
+                    let Some(elements) = self.array_literal_item_elements_from_view(
+                        params.key.frame,
+                        params.key.var_id,
+                        &cached_params.cache_key,
+                        &view.elements,
+                        cached_params.elements.len(),
+                    ) else {
+                        unreachable!("a materialized literal view covers every cached item");
+                    };
+                    args.push(initialized);
+                    args.extend(elements);
+                } else {
+                    let initialized = ir_builder.alloc_bit(1, false);
+                    ir_builder.emit(SIRInstruction::Imm(initialized, SIRValue::new(0u8)));
+                    args.push(initialized);
+                    let layout = self.array_view_layout(params.key.var_id)?;
+                    for _ in &cached_params.elements {
+                        let element = if layout.is_2state {
+                            ir_builder.alloc_bit(layout.element_width, layout.signed)
+                        } else {
+                            ir_builder.alloc_logic(layout.element_width)
+                        };
+                        ir_builder.emit(SIRInstruction::Imm(element, SIRValue::new(0u8)));
+                        args.push(element);
+                    }
+                }
+            }
         }
         Ok(args)
     }
@@ -1324,18 +1565,18 @@ impl<'a> FfParser<'a> {
             }) {
                 unreachable!("a function array view has stable backing metadata");
             }
-            let cached_literal_items = first
+            let cached_literal_items = params
                 .cached_literal_items
                 .iter()
-                .filter(|(key, value)| {
-                    states.iter().all(|state| {
-                        state[params.key.frame]
-                            .get(&params.key.var_id)
-                            .and_then(|view| view.cached_literal_items.get(*key))
-                            .is_some_and(|other| other == *value)
-                    })
+                .map(|cached| {
+                    (
+                        cached.cache_key.clone(),
+                        FunctionArrayLiteralItemCache {
+                            elements: cached.elements.clone(),
+                            initialized: Some(cached.initialized),
+                        },
+                    )
                 })
-                .map(|(key, value)| (key.clone(), value.clone()))
                 .collect();
             self.function_array_view_stack[params.key.frame].insert(
                 params.key.var_id,
@@ -1444,7 +1685,57 @@ impl<'a> FfParser<'a> {
             .and_then(|view| view.cached_literal_items.get(&selection.cache_key))
             .cloned();
         let item_elements = if let Some(cached) = cached {
-            cached
+            if let Some(initialized) = cached.initialized {
+                let layout = self.array_view_layout(var_id)?;
+                let merge_elements = cached
+                    .elements
+                    .iter()
+                    .map(|reg| ir_builder.alloc_reg(ir_builder.register(reg).clone()))
+                    .collect::<Vec<_>>();
+                let evaluate_block = ir_builder.new_block();
+                let merge_block = ir_builder.new_block_with(merge_elements.clone());
+                let pre_defined = self.defined_ranges.clone();
+                let pre_dynamic = self.dynamic_defined_vars.clone();
+                ir_builder.seal_block(SIRTerminator::Branch {
+                    cond: initialized,
+                    true_block: (merge_block, cached.elements),
+                    false_block: (evaluate_block, vec![]),
+                });
+                ir_builder.switch_to_block(evaluate_block);
+                let evaluated = self.evaluate_array_literal_item(
+                    selection.expr,
+                    selection.element_count,
+                    layout,
+                    targets,
+                    domain,
+                    convert,
+                    sources,
+                    ir_builder,
+                )?;
+                let evaluated_defined =
+                    std::mem::replace(&mut self.defined_ranges, pre_defined.clone());
+                let evaluated_dynamic =
+                    std::mem::replace(&mut self.dynamic_defined_vars, pre_dynamic.clone());
+                ir_builder.seal_block(SIRTerminator::Jump(merge_block, evaluated));
+                ir_builder.switch_to_block(merge_block);
+                self.defined_ranges = self.intersect_defined_states(pre_defined, evaluated_defined);
+                self.dynamic_defined_vars =
+                    self.intersect_dynamic_vars(pre_dynamic, evaluated_dynamic);
+                self.function_array_view_stack[frame]
+                    .get_mut(&var_id)
+                    .unwrap()
+                    .cached_literal_items
+                    .insert(
+                        selection.cache_key.clone(),
+                        FunctionArrayLiteralItemCache {
+                            elements: merge_elements.clone(),
+                            initialized: None,
+                        },
+                    );
+                merge_elements
+            } else {
+                cached.elements
+            }
         } else if let Some((initialized, view_elements)) = self.function_array_view_stack[frame]
             .get(&var_id)
             .and_then(|view| {
@@ -1513,7 +1804,13 @@ impl<'a> FfParser<'a> {
                 .get_mut(&var_id)
                 .unwrap()
                 .cached_literal_items
-                .insert(selection.cache_key.clone(), merge_elements.clone());
+                .insert(
+                    selection.cache_key.clone(),
+                    FunctionArrayLiteralItemCache {
+                        elements: merge_elements.clone(),
+                        initialized: None,
+                    },
+                );
             merge_elements
         } else {
             let layout = self.array_view_layout(var_id)?;
@@ -1529,8 +1826,13 @@ impl<'a> FfParser<'a> {
                 ir_builder,
             )?;
             if let Some(view) = self.function_array_view_stack[frame].get_mut(&var_id) {
-                view.cached_literal_items
-                    .insert(selection.cache_key.clone(), item_elements.clone());
+                view.cached_literal_items.insert(
+                    selection.cache_key.clone(),
+                    FunctionArrayLiteralItemCache {
+                        elements: item_elements.clone(),
+                        initialized: None,
+                    },
+                );
             } else {
                 let initialized = ir_builder.alloc_bit(1, false);
                 ir_builder.emit(SIRInstruction::Imm(initialized, SIRValue::new(0u8)));
@@ -1542,7 +1844,10 @@ impl<'a> FfParser<'a> {
                         owns_backing: true,
                         cached_literal_items: HashMap::from_iter([(
                             selection.cache_key.clone(),
-                            item_elements.clone(),
+                            FunctionArrayLiteralItemCache {
+                                elements: item_elements.clone(),
+                                initialized: None,
+                            },
                         )]),
                         initialized: Some(initialized),
                     },
@@ -2279,6 +2584,10 @@ impl<'a> FfParser<'a> {
         for params in &array_view_params {
             merge_params.push(params.initialized);
             merge_params.extend(params.elements.iter().copied());
+            for cached in &params.cached_literal_items {
+                merge_params.push(cached.initialized);
+                merge_params.extend(cached.elements.iter().copied());
+            }
         }
         let merge_block = ir_builder.new_block_with(merge_params);
         let shortcut_value = ir_builder.alloc_bit(1, false);
@@ -3365,6 +3674,10 @@ impl<'a> FfParser<'a> {
         for params in &else_view_params {
             else_params.push(params.initialized);
             else_params.extend(params.elements.iter().copied());
+            for cached in &params.cached_literal_items {
+                else_params.push(cached.initialized);
+                else_params.extend(cached.elements.iter().copied());
+            }
         }
         let else_block = ir_builder.new_block_with(else_params);
         let result = ir_builder.alloc_logic(result_width);
@@ -3372,6 +3685,10 @@ impl<'a> FfParser<'a> {
         for params in &merge_view_params {
             merge_params.push(params.initialized);
             merge_params.extend(params.elements.iter().copied());
+            for cached in &params.cached_literal_items {
+                merge_params.push(cached.initialized);
+                merge_params.extend(cached.elements.iter().copied());
+            }
         }
         let merge_block = ir_builder.new_block_with(merge_params);
 

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -519,22 +519,30 @@ impl<'a> FfParser<'a> {
                 });
             if let Some(cached) = cached_elements.get(&cache_key).cloned() {
                 if let Some(initialized) = cached.initialized {
+                    let array_view_candidates = self.array_view_merge_candidates([selected_expr]);
+                    let array_view_params =
+                        self.alloc_array_view_merge_params(&array_view_candidates, ir_builder)?;
+                    let pre_array_views = self.function_array_view_stack.clone();
                     let evaluate_block = ir_builder.new_block();
                     let merged_elements = cached
                         .elements
                         .iter()
                         .map(|reg| ir_builder.alloc_reg(ir_builder.register(reg).clone()))
                         .collect::<Vec<_>>();
-                    let merge_block = ir_builder.new_block_with(merged_elements.clone());
+                    let mut merge_params = merged_elements.clone();
+                    Self::append_array_view_merge_registers(&array_view_params, &mut merge_params);
+                    let merge_block = ir_builder.new_block_with(merge_params);
                     let pre_defined = self.defined_ranges.clone();
                     let pre_dynamic = self.dynamic_defined_vars.clone();
+                    let mut cached_args = cached.elements;
+                    cached_args.extend(self.array_view_state_args(&array_view_params, ir_builder)?);
                     ir_builder.seal_block(SIRTerminator::Branch {
                         cond: initialized,
-                        true_block: (merge_block, cached.elements),
+                        true_block: (merge_block, cached_args),
                         false_block: (evaluate_block, vec![]),
                     });
                     ir_builder.switch_to_block(evaluate_block);
-                    let evaluated = self.evaluate_array_literal_item(
+                    let mut evaluated = self.evaluate_array_literal_item(
                         selected_expr,
                         element_count,
                         layout,
@@ -548,8 +556,15 @@ impl<'a> FfParser<'a> {
                         std::mem::replace(&mut self.defined_ranges, pre_defined.clone());
                     let evaluated_dynamic =
                         std::mem::replace(&mut self.dynamic_defined_vars, pre_dynamic.clone());
+                    let evaluated_array_views = self.function_array_view_stack.clone();
+                    evaluated.extend(self.array_view_state_args(&array_view_params, ir_builder)?);
                     ir_builder.seal_block(SIRTerminator::Jump(merge_block, evaluated));
                     ir_builder.switch_to_block(merge_block);
+                    self.function_array_view_stack = pre_array_views.clone();
+                    self.install_merged_array_views(
+                        &array_view_params,
+                        &[&pre_array_views, &evaluated_array_views],
+                    );
                     self.defined_ranges =
                         self.intersect_defined_states(pre_defined, evaluated_defined);
                     self.dynamic_defined_vars =
@@ -1465,6 +1480,14 @@ impl<'a> FfParser<'a> {
                 return Ok(Some(view));
             };
 
+            let bound_expr = self.function_arg_stack[frame]
+                .get(&var_id)
+                .unwrap_or_else(|| unreachable!("an array view has a bound argument"))
+                .clone();
+            let array_view_candidates = self.array_view_merge_candidates([&bound_expr]);
+            let array_view_params =
+                self.alloc_array_view_merge_params(&array_view_candidates, ir_builder)?;
+            let pre_array_views = self.function_array_view_stack.clone();
             let pre_defined = self.defined_ranges.clone();
             let pre_dynamic = self.dynamic_defined_vars.clone();
             let initialize_block = ir_builder.new_block();
@@ -1488,10 +1511,14 @@ impl<'a> FfParser<'a> {
                 .iter()
                 .map(|reg| ir_builder.alloc_reg(ir_builder.register(reg).clone()))
                 .collect::<Vec<_>>();
-            let merge_block = ir_builder.new_block_with(merged_elements.clone());
+            let mut merge_params = merged_elements.clone();
+            Self::append_array_view_merge_registers(&array_view_params, &mut merge_params);
+            let merge_block = ir_builder.new_block_with(merge_params);
+            let mut carried_args = carried_elements;
+            carried_args.extend(self.array_view_state_args(&array_view_params, ir_builder)?);
             ir_builder.seal_block(SIRTerminator::Branch {
                 cond: initialized,
-                true_block: (merge_block, carried_elements),
+                true_block: (merge_block, carried_args),
                 false_block: (initialize_block, vec![]),
             });
 
@@ -1511,8 +1538,16 @@ impl<'a> FfParser<'a> {
                 std::mem::replace(&mut self.defined_ranges, pre_defined.clone());
             let initialized_dynamic =
                 std::mem::replace(&mut self.dynamic_defined_vars, pre_dynamic.clone());
-            ir_builder.seal_block(SIRTerminator::Jump(merge_block, initialized_view.elements));
+            let initialized_array_views = self.function_array_view_stack.clone();
+            let mut initialized_args = initialized_view.elements;
+            initialized_args.extend(self.array_view_state_args(&array_view_params, ir_builder)?);
+            ir_builder.seal_block(SIRTerminator::Jump(merge_block, initialized_args));
             ir_builder.switch_to_block(merge_block);
+            self.function_array_view_stack = pre_array_views.clone();
+            self.install_merged_array_views(
+                &array_view_params,
+                &[&pre_array_views, &initialized_array_views],
+            );
             self.defined_ranges = self.intersect_defined_states(pre_defined, initialized_defined);
             self.dynamic_defined_vars =
                 self.intersect_dynamic_vars(pre_dynamic, initialized_dynamic);
@@ -1616,6 +1651,20 @@ impl<'a> FfParser<'a> {
                 })
             })
             .collect()
+    }
+
+    fn append_array_view_merge_registers(
+        params: &[ArrayViewMergeParams],
+        registers: &mut Vec<RegisterId>,
+    ) {
+        for params in params {
+            registers.push(params.initialized);
+            registers.extend(params.elements.iter().copied());
+            for cached in &params.cached_literal_items {
+                registers.push(cached.initialized);
+                registers.extend(cached.elements.iter().copied());
+            }
+        }
     }
 
     fn array_view_state_args<A>(
@@ -1876,22 +1925,30 @@ impl<'a> FfParser<'a> {
         let item_elements = if let Some(cached) = cached {
             if let Some(initialized) = cached.initialized {
                 let layout = self.array_view_layout(var_id)?;
+                let array_view_candidates = self.array_view_merge_candidates([selection.expr]);
+                let array_view_params =
+                    self.alloc_array_view_merge_params(&array_view_candidates, ir_builder)?;
+                let pre_array_views = self.function_array_view_stack.clone();
                 let merge_elements = cached
                     .elements
                     .iter()
                     .map(|reg| ir_builder.alloc_reg(ir_builder.register(reg).clone()))
                     .collect::<Vec<_>>();
                 let evaluate_block = ir_builder.new_block();
-                let merge_block = ir_builder.new_block_with(merge_elements.clone());
+                let mut merge_params = merge_elements.clone();
+                Self::append_array_view_merge_registers(&array_view_params, &mut merge_params);
+                let merge_block = ir_builder.new_block_with(merge_params);
                 let pre_defined = self.defined_ranges.clone();
                 let pre_dynamic = self.dynamic_defined_vars.clone();
+                let mut cached_args = cached.elements;
+                cached_args.extend(self.array_view_state_args(&array_view_params, ir_builder)?);
                 ir_builder.seal_block(SIRTerminator::Branch {
                     cond: initialized,
-                    true_block: (merge_block, cached.elements),
+                    true_block: (merge_block, cached_args),
                     false_block: (evaluate_block, vec![]),
                 });
                 ir_builder.switch_to_block(evaluate_block);
-                let evaluated = self.evaluate_array_literal_item(
+                let mut evaluated = self.evaluate_array_literal_item(
                     selection.expr,
                     selection.element_count,
                     layout,
@@ -1905,8 +1962,15 @@ impl<'a> FfParser<'a> {
                     std::mem::replace(&mut self.defined_ranges, pre_defined.clone());
                 let evaluated_dynamic =
                     std::mem::replace(&mut self.dynamic_defined_vars, pre_dynamic.clone());
+                let evaluated_array_views = self.function_array_view_stack.clone();
+                evaluated.extend(self.array_view_state_args(&array_view_params, ir_builder)?);
                 ir_builder.seal_block(SIRTerminator::Jump(merge_block, evaluated));
                 ir_builder.switch_to_block(merge_block);
+                self.function_array_view_stack = pre_array_views.clone();
+                self.install_merged_array_views(
+                    &array_view_params,
+                    &[&pre_array_views, &evaluated_array_views],
+                );
                 self.defined_ranges = self.intersect_defined_states(pre_defined, evaluated_defined);
                 self.dynamic_defined_vars =
                     self.intersect_dynamic_vars(pre_dynamic, evaluated_dynamic);
@@ -1932,6 +1996,10 @@ impl<'a> FfParser<'a> {
             })
         {
             let layout = self.array_view_layout(var_id)?;
+            let array_view_candidates = self.array_view_merge_candidates([selection.expr]);
+            let array_view_params =
+                self.alloc_array_view_merge_params(&array_view_candidates, ir_builder)?;
+            let pre_array_views = self.function_array_view_stack.clone();
             let mut carried = vec![None; selection.element_count];
             for linear_index in 0..layout.element_count {
                 let mut remainder = linear_index;
@@ -1962,16 +2030,20 @@ impl<'a> FfParser<'a> {
                 .map(|reg| ir_builder.alloc_reg(ir_builder.register(reg).clone()))
                 .collect::<Vec<_>>();
             let evaluate_block = ir_builder.new_block();
-            let merge_block = ir_builder.new_block_with(merge_elements.clone());
+            let mut merge_params = merge_elements.clone();
+            Self::append_array_view_merge_registers(&array_view_params, &mut merge_params);
+            let merge_block = ir_builder.new_block_with(merge_params);
             let pre_defined = self.defined_ranges.clone();
             let pre_dynamic = self.dynamic_defined_vars.clone();
+            let mut carried_args = carried;
+            carried_args.extend(self.array_view_state_args(&array_view_params, ir_builder)?);
             ir_builder.seal_block(SIRTerminator::Branch {
                 cond: initialized,
-                true_block: (merge_block, carried),
+                true_block: (merge_block, carried_args),
                 false_block: (evaluate_block, vec![]),
             });
             ir_builder.switch_to_block(evaluate_block);
-            let evaluated = self.evaluate_array_literal_item(
+            let mut evaluated = self.evaluate_array_literal_item(
                 selection.expr,
                 selection.element_count,
                 layout,
@@ -1985,8 +2057,15 @@ impl<'a> FfParser<'a> {
                 std::mem::replace(&mut self.defined_ranges, pre_defined.clone());
             let evaluated_dynamic =
                 std::mem::replace(&mut self.dynamic_defined_vars, pre_dynamic.clone());
+            let evaluated_array_views = self.function_array_view_stack.clone();
+            evaluated.extend(self.array_view_state_args(&array_view_params, ir_builder)?);
             ir_builder.seal_block(SIRTerminator::Jump(merge_block, evaluated));
             ir_builder.switch_to_block(merge_block);
+            self.function_array_view_stack = pre_array_views.clone();
+            self.install_merged_array_views(
+                &array_view_params,
+                &[&pre_array_views, &evaluated_array_views],
+            );
             self.defined_ranges = self.intersect_defined_states(pre_defined, evaluated_defined);
             self.dynamic_defined_vars = self.intersect_dynamic_vars(pre_dynamic, evaluated_dynamic);
             self.function_array_view_stack[frame]

--- a/crates/celox-frontend-veryl/src/ff/function_call.rs
+++ b/crates/celox-frontend-veryl/src/ff/function_call.rs
@@ -273,6 +273,13 @@ impl<'a> FfParser<'a> {
             .find_map(|bindings| bindings.get(&var_id))
     }
 
+    pub(super) fn get_bound_function_array_view(&self, var_id: VarId) -> Option<VarId> {
+        self.function_array_view_stack
+            .iter()
+            .rev()
+            .find_map(|bindings| bindings.get(&var_id).copied())
+    }
+
     pub(super) fn substitute_function_expr(
         expr: &Expression,
         defs: &HashMap<VarId, Expression>,
@@ -803,6 +810,9 @@ impl<'a> FfParser<'a> {
                 bindings.insert(*arg_id, arg_expr.clone());
             }
         }
+        let array_views = self.materialize_function_array_views(
+            &bindings, targets, domain, convert, sources, ir_builder,
+        )?;
 
         for (arg_path, dsts) in &call.outputs {
             let Some(arg_id) = function_body.arg_map.get(arg_path) else {
@@ -817,8 +827,12 @@ impl<'a> FfParser<'a> {
 
             let expr = self.extract_function_target_expr(&function_body, *arg_id, &bindings)?;
             self.function_arg_stack.push(bindings.clone());
-            self.parse_expression(&expr, targets, domain, convert, sources, ir_builder, None)?;
+            self.function_array_view_stack.push(array_views.clone());
+            let parse_result =
+                self.parse_expression(&expr, targets, domain, convert, sources, ir_builder, None);
+            self.function_array_view_stack.pop();
             self.function_arg_stack.pop();
+            parse_result?;
 
             let rhs_reg = self
                 .stack
@@ -840,9 +854,11 @@ impl<'a> FfParser<'a> {
         let ret_expr = self.extract_function_return_expr(&function_body, ret_id)?;
 
         self.function_arg_stack.push(bindings);
+        self.function_array_view_stack.push(array_views);
         let result = self.parse_expression(
             &ret_expr, targets, domain, convert, sources, ir_builder, None,
         );
+        self.function_array_view_stack.pop();
         self.function_arg_stack.pop();
 
         result
@@ -897,6 +913,9 @@ impl<'a> FfParser<'a> {
                 bindings.insert(*arg_id, arg_expr.clone());
             }
         }
+        let array_views = self.materialize_function_array_views(
+            &bindings, targets, domain, convert, sources, ir_builder,
+        )?;
 
         for (arg_path, dsts) in &call.outputs {
             let Some(arg_id) = function_body.arg_map.get(arg_path) else {
@@ -911,8 +930,12 @@ impl<'a> FfParser<'a> {
 
             let expr = self.extract_function_target_expr(&function_body, *arg_id, &bindings)?;
             self.function_arg_stack.push(bindings.clone());
-            self.parse_expression(&expr, targets, domain, convert, sources, ir_builder, None)?;
+            self.function_array_view_stack.push(array_views.clone());
+            let parse_result =
+                self.parse_expression(&expr, targets, domain, convert, sources, ir_builder, None);
+            self.function_array_view_stack.pop();
             self.function_arg_stack.pop();
+            parse_result?;
 
             let rhs_reg = self
                 .stack

--- a/crates/celox-frontend-veryl/src/ff/function_call.rs
+++ b/crates/celox-frontend-veryl/src/ff/function_call.rs
@@ -274,10 +274,14 @@ impl<'a> FfParser<'a> {
     }
 
     pub(super) fn get_bound_function_array_view(&self, var_id: VarId) -> Option<VarId> {
-        self.function_array_view_stack
-            .iter()
-            .rev()
-            .find_map(|bindings| bindings.get(&var_id).copied())
+        for frame in (0..self.function_arg_stack.len()).rev() {
+            if self.function_arg_stack[frame].contains_key(&var_id) {
+                return self.function_array_view_stack[frame]
+                    .get(&var_id)
+                    .map(|view| view.backing_var_id);
+            }
+        }
+        None
     }
 
     pub(super) fn substitute_function_expr(
@@ -810,9 +814,9 @@ impl<'a> FfParser<'a> {
                 bindings.insert(*arg_id, arg_expr.clone());
             }
         }
-        let array_views = self.materialize_function_array_views(
-            &bindings, targets, domain, convert, sources, ir_builder,
-        )?;
+        let mut array_views = HashMap::default();
+        let mut symbolic_bindings = bindings.clone();
+        symbolic_bindings.retain(|var_id, _| self.module.variables[var_id].r#type.array.is_empty());
 
         for (arg_path, dsts) in &call.outputs {
             let Some(arg_id) = function_body.arg_map.get(arg_path) else {
@@ -825,12 +829,17 @@ impl<'a> FfParser<'a> {
                 ));
             };
 
-            let expr = self.extract_function_target_expr(&function_body, *arg_id, &bindings)?;
+            let expr =
+                self.extract_function_target_expr(&function_body, *arg_id, &symbolic_bindings)?;
             self.function_arg_stack.push(bindings.clone());
-            self.function_array_view_stack.push(array_views.clone());
-            let parse_result =
-                self.parse_expression(&expr, targets, domain, convert, sources, ir_builder, None);
-            self.function_array_view_stack.pop();
+            self.function_array_view_stack.push(array_views);
+            let parse_result = (|| {
+                self.prepare_function_array_views_for_expression(
+                    &expr, targets, domain, convert, sources, ir_builder,
+                )?;
+                self.parse_expression(&expr, targets, domain, convert, sources, ir_builder, None)
+            })();
+            array_views = self.function_array_view_stack.pop().unwrap();
             self.function_arg_stack.pop();
             parse_result?;
 
@@ -855,11 +864,17 @@ impl<'a> FfParser<'a> {
 
         self.function_arg_stack.push(bindings);
         self.function_array_view_stack.push(array_views);
-        let result = self.parse_expression(
-            &ret_expr, targets, domain, convert, sources, ir_builder, None,
-        );
-        self.function_array_view_stack.pop();
+        let result = (|| {
+            self.prepare_function_array_views_for_expression(
+                &ret_expr, targets, domain, convert, sources, ir_builder,
+            )?;
+            self.parse_expression(
+                &ret_expr, targets, domain, convert, sources, ir_builder, None,
+            )
+        })();
+        let finished_views = self.function_array_view_stack.pop().unwrap();
         self.function_arg_stack.pop();
+        self.restore_active_function_array_views(&finished_views, convert, ir_builder)?;
 
         result
     }
@@ -913,9 +928,9 @@ impl<'a> FfParser<'a> {
                 bindings.insert(*arg_id, arg_expr.clone());
             }
         }
-        let array_views = self.materialize_function_array_views(
-            &bindings, targets, domain, convert, sources, ir_builder,
-        )?;
+        let mut array_views = HashMap::default();
+        let mut symbolic_bindings = bindings.clone();
+        symbolic_bindings.retain(|var_id, _| self.module.variables[var_id].r#type.array.is_empty());
 
         for (arg_path, dsts) in &call.outputs {
             let Some(arg_id) = function_body.arg_map.get(arg_path) else {
@@ -928,12 +943,17 @@ impl<'a> FfParser<'a> {
                 ));
             };
 
-            let expr = self.extract_function_target_expr(&function_body, *arg_id, &bindings)?;
+            let expr =
+                self.extract_function_target_expr(&function_body, *arg_id, &symbolic_bindings)?;
             self.function_arg_stack.push(bindings.clone());
-            self.function_array_view_stack.push(array_views.clone());
-            let parse_result =
-                self.parse_expression(&expr, targets, domain, convert, sources, ir_builder, None);
-            self.function_array_view_stack.pop();
+            self.function_array_view_stack.push(array_views);
+            let parse_result = (|| {
+                self.prepare_function_array_views_for_expression(
+                    &expr, targets, domain, convert, sources, ir_builder,
+                )?;
+                self.parse_expression(&expr, targets, domain, convert, sources, ir_builder, None)
+            })();
+            array_views = self.function_array_view_stack.pop().unwrap();
             self.function_arg_stack.pop();
             parse_result?;
 
@@ -945,6 +965,8 @@ impl<'a> FfParser<'a> {
                 rhs_reg, dsts, targets, domain, convert, sources, ir_builder,
             )?;
         }
+
+        self.restore_active_function_array_views(&array_views, convert, ir_builder)?;
 
         Ok(())
     }

--- a/crates/celox-frontend-veryl/src/ff/function_call.rs
+++ b/crates/celox-frontend-veryl/src/ff/function_call.rs
@@ -815,6 +815,7 @@ impl<'a> FfParser<'a> {
             }
         }
         let mut array_views = HashMap::default();
+        let mut array_view_plan = HashSet::default();
         let mut symbolic_bindings = bindings.clone();
         symbolic_bindings.retain(|var_id, _| self.module.variables[var_id].r#type.array.is_empty());
 
@@ -848,27 +849,25 @@ impl<'a> FfParser<'a> {
         // output. A later dynamic access must turn an earlier static access
         // into a view load rather than evaluating the literal twice.
         self.function_arg_stack.push(bindings.clone());
+        self.function_array_view_plan_stack.push(array_view_plan);
         self.function_array_view_stack.push(array_views);
-        let prepare_result: Result<(), ParserError> = (|| {
-            for (_, expr) in &output_exprs {
-                self.prepare_function_array_views_for_expression(
-                    expr, targets, domain, convert, sources, ir_builder,
-                )?;
-            }
-            self.prepare_function_array_views_for_expression(
-                &ret_expr, targets, domain, convert, sources, ir_builder,
-            )
-        })();
+        for (_, expr) in &output_exprs {
+            self.plan_function_array_views_for_expression(expr);
+        }
+        self.plan_function_array_views_for_expression(&ret_expr);
         array_views = self.function_array_view_stack.pop().unwrap();
+        array_view_plan = self.function_array_view_plan_stack.pop().unwrap();
         self.function_arg_stack.pop();
-        prepare_result?;
 
         for (dsts, expr) in output_exprs {
             self.function_arg_stack.push(bindings.clone());
+            self.function_array_view_plan_stack
+                .push(array_view_plan.clone());
             self.function_array_view_stack.push(array_views);
             let parse_result =
                 self.parse_expression(&expr, targets, domain, convert, sources, ir_builder, None);
             array_views = self.function_array_view_stack.pop().unwrap();
+            self.function_array_view_plan_stack.pop();
             self.function_arg_stack.pop();
             parse_result?;
 
@@ -882,11 +881,13 @@ impl<'a> FfParser<'a> {
         }
 
         self.function_arg_stack.push(bindings);
+        self.function_array_view_plan_stack.push(array_view_plan);
         self.function_array_view_stack.push(array_views);
         let result = self.parse_expression(
             &ret_expr, targets, domain, convert, sources, ir_builder, None,
         );
         let finished_views = self.function_array_view_stack.pop().unwrap();
+        self.function_array_view_plan_stack.pop();
         self.function_arg_stack.pop();
         self.restore_active_function_array_views(&finished_views, convert, ir_builder)?;
 
@@ -943,6 +944,7 @@ impl<'a> FfParser<'a> {
             }
         }
         let mut array_views = HashMap::default();
+        let mut array_view_plan = HashSet::default();
         let mut symbolic_bindings = bindings.clone();
         symbolic_bindings.retain(|var_id, _| self.module.variables[var_id].r#type.array.is_empty());
 
@@ -964,25 +966,24 @@ impl<'a> FfParser<'a> {
         }
 
         self.function_arg_stack.push(bindings.clone());
+        self.function_array_view_plan_stack.push(array_view_plan);
         self.function_array_view_stack.push(array_views);
-        let prepare_result: Result<(), ParserError> = (|| {
-            for (_, expr) in &output_exprs {
-                self.prepare_function_array_views_for_expression(
-                    expr, targets, domain, convert, sources, ir_builder,
-                )?;
-            }
-            Ok(())
-        })();
+        for (_, expr) in &output_exprs {
+            self.plan_function_array_views_for_expression(expr);
+        }
         array_views = self.function_array_view_stack.pop().unwrap();
+        array_view_plan = self.function_array_view_plan_stack.pop().unwrap();
         self.function_arg_stack.pop();
-        prepare_result?;
 
         for (dsts, expr) in output_exprs {
             self.function_arg_stack.push(bindings.clone());
+            self.function_array_view_plan_stack
+                .push(array_view_plan.clone());
             self.function_array_view_stack.push(array_views);
             let parse_result =
                 self.parse_expression(&expr, targets, domain, convert, sources, ir_builder, None);
             array_views = self.function_array_view_stack.pop().unwrap();
+            self.function_array_view_plan_stack.pop();
             self.function_arg_stack.pop();
             parse_result?;
 

--- a/crates/celox-frontend-veryl/src/ff/function_call.rs
+++ b/crates/celox-frontend-veryl/src/ff/function_call.rs
@@ -818,6 +818,7 @@ impl<'a> FfParser<'a> {
         let mut symbolic_bindings = bindings.clone();
         symbolic_bindings.retain(|var_id, _| self.module.variables[var_id].r#type.array.is_empty());
 
+        let mut output_exprs = Vec::with_capacity(call.outputs.len());
         for (arg_path, dsts) in &call.outputs {
             let Some(arg_id) = function_body.arg_map.get(arg_path) else {
                 return Err(ParserError::unsupported(
@@ -831,14 +832,42 @@ impl<'a> FfParser<'a> {
 
             let expr =
                 self.extract_function_target_expr(&function_body, *arg_id, &symbolic_bindings)?;
+            output_exprs.push((dsts, expr));
+        }
+
+        let Some(ret_id) = function_body.ret else {
+            return Err(ParserError::illegal_context(
+                "void function call in expression",
+                format!("{call}"),
+                Some(&call.comptime.token),
+            ));
+        };
+        let ret_expr = self.extract_function_return_expr(&function_body, ret_id)?;
+
+        // Choose the invocation-wide array strategy before lowering any
+        // output. A later dynamic access must turn an earlier static access
+        // into a view load rather than evaluating the literal twice.
+        self.function_arg_stack.push(bindings.clone());
+        self.function_array_view_stack.push(array_views);
+        let prepare_result: Result<(), ParserError> = (|| {
+            for (_, expr) in &output_exprs {
+                self.prepare_function_array_views_for_expression(
+                    expr, targets, domain, convert, sources, ir_builder,
+                )?;
+            }
+            self.prepare_function_array_views_for_expression(
+                &ret_expr, targets, domain, convert, sources, ir_builder,
+            )
+        })();
+        array_views = self.function_array_view_stack.pop().unwrap();
+        self.function_arg_stack.pop();
+        prepare_result?;
+
+        for (dsts, expr) in output_exprs {
             self.function_arg_stack.push(bindings.clone());
             self.function_array_view_stack.push(array_views);
-            let parse_result = (|| {
-                self.prepare_function_array_views_for_expression(
-                    &expr, targets, domain, convert, sources, ir_builder,
-                )?;
-                self.parse_expression(&expr, targets, domain, convert, sources, ir_builder, None)
-            })();
+            let parse_result =
+                self.parse_expression(&expr, targets, domain, convert, sources, ir_builder, None);
             array_views = self.function_array_view_stack.pop().unwrap();
             self.function_arg_stack.pop();
             parse_result?;
@@ -852,26 +881,11 @@ impl<'a> FfParser<'a> {
             )?;
         }
 
-        let Some(ret_id) = function_body.ret else {
-            return Err(ParserError::illegal_context(
-                "void function call in expression",
-                format!("{call}"),
-                Some(&call.comptime.token),
-            ));
-        };
-
-        let ret_expr = self.extract_function_return_expr(&function_body, ret_id)?;
-
         self.function_arg_stack.push(bindings);
         self.function_array_view_stack.push(array_views);
-        let result = (|| {
-            self.prepare_function_array_views_for_expression(
-                &ret_expr, targets, domain, convert, sources, ir_builder,
-            )?;
-            self.parse_expression(
-                &ret_expr, targets, domain, convert, sources, ir_builder, None,
-            )
-        })();
+        let result = self.parse_expression(
+            &ret_expr, targets, domain, convert, sources, ir_builder, None,
+        );
         let finished_views = self.function_array_view_stack.pop().unwrap();
         self.function_arg_stack.pop();
         self.restore_active_function_array_views(&finished_views, convert, ir_builder)?;
@@ -932,6 +946,7 @@ impl<'a> FfParser<'a> {
         let mut symbolic_bindings = bindings.clone();
         symbolic_bindings.retain(|var_id, _| self.module.variables[var_id].r#type.array.is_empty());
 
+        let mut output_exprs = Vec::with_capacity(call.outputs.len());
         for (arg_path, dsts) in &call.outputs {
             let Some(arg_id) = function_body.arg_map.get(arg_path) else {
                 return Err(ParserError::unsupported(
@@ -945,14 +960,28 @@ impl<'a> FfParser<'a> {
 
             let expr =
                 self.extract_function_target_expr(&function_body, *arg_id, &symbolic_bindings)?;
+            output_exprs.push((dsts, expr));
+        }
+
+        self.function_arg_stack.push(bindings.clone());
+        self.function_array_view_stack.push(array_views);
+        let prepare_result: Result<(), ParserError> = (|| {
+            for (_, expr) in &output_exprs {
+                self.prepare_function_array_views_for_expression(
+                    expr, targets, domain, convert, sources, ir_builder,
+                )?;
+            }
+            Ok(())
+        })();
+        array_views = self.function_array_view_stack.pop().unwrap();
+        self.function_arg_stack.pop();
+        prepare_result?;
+
+        for (dsts, expr) in output_exprs {
             self.function_arg_stack.push(bindings.clone());
             self.function_array_view_stack.push(array_views);
-            let parse_result = (|| {
-                self.prepare_function_array_views_for_expression(
-                    &expr, targets, domain, convert, sources, ir_builder,
-                )?;
-                self.parse_expression(&expr, targets, domain, convert, sources, ir_builder, None)
-            })();
+            let parse_result =
+                self.parse_expression(&expr, targets, domain, convert, sources, ir_builder, None);
             array_views = self.function_array_view_stack.pop().unwrap();
             self.function_arg_stack.pop();
             parse_result?;

--- a/crates/celox-frontend-veryl/src/ff/function_call.rs
+++ b/crates/celox-frontend-veryl/src/ff/function_call.rs
@@ -278,6 +278,7 @@ impl<'a> FfParser<'a> {
             if self.function_arg_stack[frame].contains_key(&var_id) {
                 return self.function_array_view_stack[frame]
                     .get(&var_id)
+                    .filter(|view| view.initialized.is_none())
                     .map(|view| view.backing_var_id);
             }
         }
@@ -815,7 +816,6 @@ impl<'a> FfParser<'a> {
             }
         }
         let mut array_views = HashMap::default();
-        let mut array_view_plan = HashSet::default();
         let mut symbolic_bindings = bindings.clone();
         symbolic_bindings.retain(|var_id, _| self.module.variables[var_id].r#type.array.is_empty());
 
@@ -845,29 +845,12 @@ impl<'a> FfParser<'a> {
         };
         let ret_expr = self.extract_function_return_expr(&function_body, ret_id)?;
 
-        // Choose the invocation-wide array strategy before lowering any
-        // output. A later dynamic access must turn an earlier static access
-        // into a view load rather than evaluating the literal twice.
-        self.function_arg_stack.push(bindings.clone());
-        self.function_array_view_plan_stack.push(array_view_plan);
-        self.function_array_view_stack.push(array_views);
-        for (_, expr) in &output_exprs {
-            self.plan_function_array_views_for_expression(expr);
-        }
-        self.plan_function_array_views_for_expression(&ret_expr);
-        array_views = self.function_array_view_stack.pop().unwrap();
-        array_view_plan = self.function_array_view_plan_stack.pop().unwrap();
-        self.function_arg_stack.pop();
-
         for (dsts, expr) in output_exprs {
             self.function_arg_stack.push(bindings.clone());
-            self.function_array_view_plan_stack
-                .push(array_view_plan.clone());
             self.function_array_view_stack.push(array_views);
             let parse_result =
                 self.parse_expression(&expr, targets, domain, convert, sources, ir_builder, None);
             array_views = self.function_array_view_stack.pop().unwrap();
-            self.function_array_view_plan_stack.pop();
             self.function_arg_stack.pop();
             parse_result?;
 
@@ -881,13 +864,11 @@ impl<'a> FfParser<'a> {
         }
 
         self.function_arg_stack.push(bindings);
-        self.function_array_view_plan_stack.push(array_view_plan);
         self.function_array_view_stack.push(array_views);
         let result = self.parse_expression(
             &ret_expr, targets, domain, convert, sources, ir_builder, None,
         );
         let finished_views = self.function_array_view_stack.pop().unwrap();
-        self.function_array_view_plan_stack.pop();
         self.function_arg_stack.pop();
         self.restore_active_function_array_views(&finished_views, convert, ir_builder)?;
 
@@ -944,7 +925,6 @@ impl<'a> FfParser<'a> {
             }
         }
         let mut array_views = HashMap::default();
-        let mut array_view_plan = HashSet::default();
         let mut symbolic_bindings = bindings.clone();
         symbolic_bindings.retain(|var_id, _| self.module.variables[var_id].r#type.array.is_empty());
 
@@ -965,25 +945,12 @@ impl<'a> FfParser<'a> {
             output_exprs.push((dsts, expr));
         }
 
-        self.function_arg_stack.push(bindings.clone());
-        self.function_array_view_plan_stack.push(array_view_plan);
-        self.function_array_view_stack.push(array_views);
-        for (_, expr) in &output_exprs {
-            self.plan_function_array_views_for_expression(expr);
-        }
-        array_views = self.function_array_view_stack.pop().unwrap();
-        array_view_plan = self.function_array_view_plan_stack.pop().unwrap();
-        self.function_arg_stack.pop();
-
         for (dsts, expr) in output_exprs {
             self.function_arg_stack.push(bindings.clone());
-            self.function_array_view_plan_stack
-                .push(array_view_plan.clone());
             self.function_array_view_stack.push(array_views);
             let parse_result =
                 self.parse_expression(&expr, targets, domain, convert, sources, ir_builder, None);
             array_views = self.function_array_view_stack.pop().unwrap();
-            self.function_array_view_plan_stack.pop();
             self.function_arg_stack.pop();
             parse_result?;
 

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -2351,6 +2351,173 @@ fn test_ff_function_call_array_literal_branch_view_is_reused_after_merge(sim) {
     }
 }
 
+fn test_ff_function_call_static_array_item_stays_lazy_before_conditional_dynamic_access(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            guard: input logic,
+            out_q: output logic<8>,
+            side0: output logic<8>,
+            side1: output logic<8>
+        ) {
+            function observe (
+                x: input logic<8>,
+                side: output logic<8>
+            ) -> logic<8> {
+                side = x;
+                return x;
+            }
+            function static_then_dynamic (
+                x: input logic<8>[2],
+                index: input logic,
+                guard: input logic,
+                first: output logic<8>
+            ) -> logic<8> {
+                first = x[0];
+                return if guard ? x[index] : 8'h00;
+            }
+            var first: logic<8>;
+            always_ff (clk) {
+                side0 = 0;
+                side1 = 0;
+                out_q = static_then_dynamic(
+                    '{observe(8'h11, side0), observe(8'h22, side1)},
+                    1,
+                    guard,
+                    first
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let guard = sim.signal("guard");
+    let out_q = sim.signal("out_q");
+    let side0 = sim.signal("side0");
+    let side1 = sim.signal("side1");
+
+    sim.modify(|io| io.set(guard, 0u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0u32.into());
+    assert_eq!(sim.get(side0), 0x11u32.into());
+    assert_eq!(sim.get(side1), 0u32.into());
+
+    sim.modify(|io| io.set(guard, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x22u32.into());
+    assert_eq!(sim.get(side0), 0x11u32.into());
+    assert_eq!(sim.get(side1), 0x22u32.into());
+}
+
+fn test_ff_function_call_restores_initialized_forwarded_alias_view(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            select: input logic,
+            out_q: output logic<8>
+        ) {
+            function alias_use (
+                a: input logic<8>[2],
+                b: input logic<8>[2],
+                index: input logic,
+                select: input logic,
+                clobber: input logic<8>
+            ) -> logic<8> {
+                return (if select ? a[index] : b[index])
+                    + clobber
+                    + (if select ? a[0] : b[0]);
+            }
+            function forward (
+                x: input logic<8>[2],
+                index: input logic,
+                select: input logic,
+                clobber: input logic<8>
+            ) -> logic<8> {
+                return alias_use(x, x, index, select, clobber);
+            }
+            always_ff (clk) {
+                out_q = forward(
+                    '{8'h11, 8'h22},
+                    1,
+                    select,
+                    forward('{8'haa, 8'hbb}, 1, 0, 0)
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let select = sim.signal("select");
+    let out_q = sim.signal("out_q");
+
+    for select_value in [0u8, 1u8] {
+        sim.modify(|io| io.set(select, select_value)).unwrap();
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get(out_q), 0x98u32.into());
+    }
+}
+
+fn test_ff_function_call_merges_outer_array_view_across_nested_short_circuit(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            guard: input logic,
+            in0: input logic<8>,
+            out_q: output logic<8>,
+            side: output logic<8>
+        ) {
+            function observe (
+                x: input logic<8>,
+                side: output logic<8>
+            ) -> logic<8> {
+                side = x;
+                return x;
+            }
+            function inner (y: input logic[2], index: input logic) -> logic {
+                return y[index];
+            }
+            function outer (
+                x: input logic<8>[2],
+                index: input logic,
+                guard: input logic
+            ) -> logic<8> {
+                return inner('{guard && x[index] != 0, default: 0}, 0) + x[0];
+            }
+            always_ff (clk) {
+                side = 0;
+                out_q = outer(
+                    '{observe(in0, side), default: 8'h00},
+                    0,
+                    guard
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let guard = sim.signal("guard");
+    let in0 = sim.signal("in0");
+    let out_q = sim.signal("out_q");
+    let side = sim.signal("side");
+
+    sim.modify(|io| {
+        io.set(guard, 0u8);
+        io.set(in0, 0x5au8);
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x5au32.into());
+    assert_eq!(sim.get(side), 0x5au32.into());
+
+    sim.modify(|io| io.set(guard, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x5bu32.into());
+    assert_eq!(sim.get(side), 0x5au32.into());
+}
+
 fn test_ff_function_call_forwards_array_literal_view_to_nested_call(sim) {
     @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -2191,6 +2191,89 @@ fn test_ff_function_call_restores_array_literal_view_after_reentrant_call(sim) {
     assert_eq!(sim.get(out_q), 0x11u32.into());
 }
 
+fn test_ff_function_call_bits_and_size_do_not_evaluate_array_argument(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            in0: input logic<8>,
+            out_bits: output logic<32>,
+            out_size: output logic<32>,
+            bits_side: output logic<8>,
+            size_side: output logic<8>
+        ) {
+            function observe (
+                x: input logic<8>,
+                side: output logic<8>
+            ) -> logic<8> {
+                side = x;
+                return x;
+            }
+            function array_bits (x: input logic<8>[2]) -> logic<32> {
+                return $bits(x);
+            }
+            function array_size (x: input logic<8>[2]) -> logic<32> {
+                return $size(x);
+            }
+            always_ff (clk) {
+                out_bits = array_bits('{observe(in0, bits_side), default: 0});
+                out_size = array_size('{observe(in0, size_side), default: 0});
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let in0 = sim.signal("in0");
+    let out_bits = sim.signal("out_bits");
+    let out_size = sim.signal("out_size");
+    let bits_side = sim.signal("bits_side");
+    let size_side = sim.signal("size_side");
+
+    sim.modify(|io| io.set(in0, 0x5au8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_bits), 16u32.into());
+    assert_eq!(sim.get(out_size), 2u32.into());
+    assert_eq!(sim.get(bits_side), 0u32.into());
+    assert_eq!(sim.get(size_side), 0u32.into());
+}
+
+fn test_ff_function_call_array_literal_view_preserves_source_order(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            index: input logic,
+            out_q: output logic<8>,
+            side: output logic<8>
+        ) {
+            function observe (
+                x: input logic<8>,
+                side: output logic<8>
+            ) -> logic<8> {
+                side = x;
+                return x;
+            }
+            function pick (x: input logic<8>[2], index: input logic) -> logic<8> {
+                return x[index];
+            }
+            always_ff (clk) {
+                out_q = pick(
+                    '{default: observe(8'h11, side), observe(8'h22, side)},
+                    index
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let index = sim.signal("index");
+    let side = sim.signal("side");
+
+    sim.modify(|io| io.set(index, 0u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(side), 0x22u32.into());
+}
+
 fn test_ff_function_call_converts_array_literal_view_for_wider_nested_formal(sim) {
     @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"
@@ -2794,6 +2877,48 @@ fn test_ff_array_literal_argument_is_not_reevaluated_for_array_output() {
         var side: logic<8>;
         always_ff (clk) {
             out_q = copy('{observe(in0, side), 8'h22}, copied);
+        }
+    }
+"#;
+    let result = SimulatorBuilder::new(code, "Top")
+        .optimize(false)
+        .trace_sim_modules()
+        .trace_pre_optimized_sir()
+        .build_with_trace();
+    assert!(result.res.is_ok(), "{:?}", result.res.err());
+    let output = result.trace.format_pre_optimized_sir().unwrap();
+
+    assert_eq!(output.matches("Store(addr=side").count(), 1, "{output}");
+}
+
+#[test]
+fn test_ff_array_literal_static_then_dynamic_access_evaluates_each_item_once() {
+    let code = r#"
+    module Top (
+        clk: input clock,
+        in0: input logic<8>,
+        index: input logic,
+        out_q: output logic<8>
+    ) {
+        function observe (
+            x: input logic<8>,
+            side: output logic<8>
+        ) -> logic<8> {
+            side = x;
+            return x;
+        }
+        function mixed (
+            x: input logic<8>[2],
+            index: input logic,
+            first: output logic<8>
+        ) -> logic<8> {
+            first = x[0];
+            return x[index];
+        }
+        var first: logic<8>;
+        var side: logic<8>;
+        always_ff (clk) {
+            out_q = mixed('{observe(in0, side), 8'h00}, index, first);
         }
     }
 "#;

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -2168,6 +2168,29 @@ fn test_ff_function_call_forwards_array_literal_view_to_nested_call(sim) {
     assert_eq!(sim.get(out_q), 0x22u32.into());
 }
 
+fn test_ff_function_call_restores_array_literal_view_after_reentrant_call(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            out_q: output logic<8>
+        ) {
+            function pick (x: input logic<8>[2], index: input logic) -> logic<8> {
+                return x[index];
+            }
+            always_ff (clk) {
+                out_q = pick('{8'h11, 8'h22}, pick('{8'h00, 8'h01}, 0));
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let out_q = sim.signal("out_q");
+
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x11u32.into());
+}
+
 fn test_ff_function_call_converts_array_literal_view_for_wider_nested_formal(sim) {
     @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"
@@ -2720,6 +2743,69 @@ fn test_ff_function_array_literal_view_sir() {
     let trace = setup_and_trace(code, "Top");
     let output = trace.format_program().unwrap();
     assert_snapshot!("ff_function_array_literal_view_sir", output);
+}
+
+#[test]
+fn test_ff_function_static_array_literal_access_is_lazy() {
+    let code = r#"
+    module Top (
+        clk: input clock,
+        in0: input logic<8>,
+        out_q: output logic<8>
+    ) {
+        function first (x: input logic<8>[1024]) -> logic<8> {
+            return x[0];
+        }
+        always_ff (clk) {
+            out_q = first('{default: in0});
+        }
+    }
+"#;
+    let trace = setup_and_trace(code, "Top");
+    let output = trace.format_program().unwrap();
+
+    assert!(!output.contains("Store(addr=first.x"), "{output}");
+    assert!(output.lines().count() < 100, "{output}");
+}
+
+#[test]
+fn test_ff_array_literal_argument_is_not_reevaluated_for_array_output() {
+    let code = r#"
+    module Top (
+        clk: input clock,
+        in0: input logic<8>,
+        out_q: output logic<8>
+    ) {
+        function observe (
+            x: input logic<8>,
+            side: output logic<8>
+        ) -> logic<8> {
+            side = x;
+            return x;
+        }
+        function copy (
+            x: input logic<8>[2],
+            y: output logic<8>[2]
+        ) -> logic<8> {
+            y = x;
+            return y[0];
+        }
+        var copied: logic<8>[2];
+        var side: logic<8>;
+        always_ff (clk) {
+            out_q = copy('{observe(in0, side), 8'h22}, copied);
+        }
+    }
+"#;
+    let result = SimulatorBuilder::new(code, "Top")
+        .optimize(false)
+        .trace_sim_modules()
+        .trace_pre_optimized_sir()
+        .build_with_trace();
+    assert!(result.res.is_ok(), "{:?}", result.res.err());
+    let output = result.trace.format_pre_optimized_sir().unwrap();
+
+    assert_eq!(output.matches("Store(addr=side").count(), 1, "{output}");
 }
 
 #[test]

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -2132,6 +2132,61 @@ fn test_ff_function_call_array_literal_view_dominates_conditional_access(sim) {
     assert_eq!(sim.get(out_q), 0x33u32.into());
 }
 
+fn test_ff_function_call_array_literal_view_is_lazy_in_ternary_arm(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            guard: input logic,
+            in0: input logic<8>,
+            out_q: output logic<8>,
+            side: output logic<8>
+        ) {
+            function observe (
+                x: input logic<8>,
+                side: output logic<8>
+            ) -> logic<8> {
+                side = x;
+                return x;
+            }
+            function pick_if (
+                x: input logic<8>[2],
+                index: input logic,
+                guard: input logic
+            ) -> logic<8> {
+                return if guard ? x[index] : 8'h00;
+            }
+            always_ff (clk) {
+                out_q = pick_if(
+                    '{observe(in0, side), default: 8'h00},
+                    0,
+                    guard
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let guard = sim.signal("guard");
+    let in0 = sim.signal("in0");
+    let out_q = sim.signal("out_q");
+    let side = sim.signal("side");
+
+    sim.modify(|io| {
+        io.set(guard, 0u8);
+        io.set(in0, 0x5au8);
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0u32.into());
+    assert_eq!(sim.get(side), 0u32.into());
+
+    sim.modify(|io| io.set(guard, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x5au32.into());
+    assert_eq!(sim.get(side), 0x5au32.into());
+}
+
 fn test_ff_function_call_forwards_array_literal_view_to_nested_call(sim) {
     @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"
@@ -2237,6 +2292,45 @@ fn test_ff_function_call_bits_and_size_do_not_evaluate_array_argument(sim) {
     assert_eq!(sim.get(size_side), 0u32.into());
 }
 
+fn test_ff_function_call_nested_bits_does_not_evaluate_forwarded_array_argument(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            in0: input logic<8>,
+            out_q: output logic<32>,
+            side: output logic<8>
+        ) {
+            function observe (
+                x: input logic<8>,
+                side: output logic<8>
+            ) -> logic<8> {
+                side = x;
+                return x;
+            }
+            function inner (x: input logic<8>[2]) -> logic<32> {
+                return $bits(x);
+            }
+            function outer (x: input logic<8>[2]) -> logic<32> {
+                return inner(x);
+            }
+            always_ff (clk) {
+                out_q = outer('{observe(in0, side), default: 8'h00});
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let in0 = sim.signal("in0");
+    let out_q = sim.signal("out_q");
+    let side = sim.signal("side");
+
+    sim.modify(|io| io.set(in0, 0x5au8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 16u32.into());
+    assert_eq!(sim.get(side), 0u32.into());
+}
+
 fn test_ff_function_call_array_literal_view_preserves_source_order(sim) {
     @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"
@@ -2305,6 +2399,32 @@ fn test_ff_function_call_converts_array_literal_view_for_wider_nested_formal(sim
     sim.modify(|io| io.set(index, 1u8)).unwrap();
     sim.tick(clk).unwrap();
     assert_eq!(sim.get(out_q), 0x03u32.into());
+}
+
+fn test_ff_function_call_converts_forwarded_static_array_element(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            out_q: output logic<8>
+        ) {
+            function inner (x: input logic<8>[2]) -> logic<8> {
+                return x[0];
+            }
+            function outer (x: input logic<4>[2]) -> logic<8> {
+                return inner(x);
+            }
+            always_ff (clk) {
+                out_q = outer('{4'ha, 4'h3});
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let out_q = sim.signal("out_q");
+
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x0au32.into());
 }
 
 fn test_ff_function_call_array_literal_element_uses_element_width(sim) {
@@ -2397,6 +2517,62 @@ fn test_ff_function_call_multidim_array_literal_indexing_preserves_element_order
 
     sim.tick(clk).unwrap();
     assert_eq!(sim.get(out_q), 0x11u32.into());
+}
+
+fn test_ff_function_call_dynamic_multidim_indexing_accepts_array_valued_items(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            row: input logic,
+            col: input logic,
+            out_q: output logic<8>
+        ) {
+            function pick (
+                x: input logic<8>[2, 2],
+                row: input logic,
+                col: input logic
+            ) -> logic<8> {
+                return x[row][col];
+            }
+            function pass_rows (
+                row0: input logic<4>[2],
+                row1: input logic<4>[2],
+                row: input logic,
+                col: input logic
+            ) -> logic<8> {
+                return pick('{row0, row1}, row, col);
+            }
+            always_ff (clk) {
+                out_q = pass_rows(
+                    '{4'h1, 4'h2},
+                    '{4'h3, 4'h4},
+                    row,
+                    col
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let row = sim.signal("row");
+    let col = sim.signal("col");
+    let out_q = sim.signal("out_q");
+
+    for (i, j, expected) in [
+        (0u8, 0u8, 0x01u32),
+        (0, 1, 0x02),
+        (1, 0, 0x03),
+        (1, 1, 0x04),
+    ] {
+        sim.modify(|io| {
+            io.set(row, i);
+            io.set(col, j);
+        })
+        .unwrap();
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get(out_q), expected.into());
+    }
 }
 
 fn test_ff_function_call_bit_select_on_nonvariable_one_bit_formal(sim) {
@@ -2847,6 +3023,33 @@ fn test_ff_function_static_array_literal_access_is_lazy() {
     let trace = setup_and_trace(code, "Top");
     let output = trace.format_program().unwrap();
 
+    assert!(!output.contains("Store(addr=first.x"), "{output}");
+    assert!(output.lines().count() < 100, "{output}");
+}
+
+#[test]
+fn test_ff_nested_function_static_array_literal_access_is_lazy() {
+    let code = r#"
+    module Top (
+        clk: input clock,
+        in0: input logic<8>,
+        out_q: output logic<8>
+    ) {
+        function first (x: input logic<8>[1024]) -> logic<8> {
+            return x[0];
+        }
+        function forward (x: input logic<8>[1024]) -> logic<8> {
+            return first(x);
+        }
+        always_ff (clk) {
+            out_q = forward('{default: in0});
+        }
+    }
+"#;
+    let trace = setup_and_trace(code, "Top");
+    let output = trace.format_program().unwrap();
+
+    assert!(!output.contains("Store(addr=forward.x"), "{output}");
     assert!(!output.contains("Store(addr=first.x"), "{output}");
     assert!(output.lines().count() < 100, "{output}");
 }

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -2671,6 +2671,66 @@ fn test_ff_function_call_tracks_array_reads_in_output_indices(sim) {
     assert_eq!(sim.get(side), 0x55u32.into());
 }
 
+fn test_ff_function_call_tracks_nested_array_reads_in_output_indices(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            guard: input logic,
+            out_q: output logic<8>,
+            side: output logic<8>
+        ) {
+            var scratch: logic<8>[2];
+            function observe (
+                x: input logic<8>,
+                side: output logic<8>
+            ) -> logic<8> {
+                side = x;
+                return x;
+            }
+            function write (
+                value: input logic<8>,
+                dst: output logic<8>
+            ) -> logic<8> {
+                dst = value;
+                return 0;
+            }
+            function helper (x: input logic<8>[2]) -> logic<8> {
+                return write(0, scratch[x[0]]);
+            }
+            function outer (
+                x: input logic<8>[2],
+                guard: input logic,
+                middle: input logic<8>
+            ) -> logic<8> {
+                return (if guard ? helper(x) : 0) + middle + x[0];
+            }
+            always_ff (clk) {
+                out_q = outer(
+                    '{observe(8'h01, side), default: 8'h00},
+                    guard,
+                    observe(8'h55, side)
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let guard = sim.signal("guard");
+    let out_q = sim.signal("out_q");
+    let side = sim.signal("side");
+
+    sim.modify(|io| io.set(guard, 0u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x56u32.into());
+    assert_eq!(sim.get(side), 0x01u32.into());
+
+    sim.modify(|io| io.set(guard, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x56u32.into());
+    assert_eq!(sim.get(side), 0x55u32.into());
+}
+
 fn test_ff_function_call_restores_initialized_forwarded_alias_view(sim) {
     @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -2507,6 +2507,58 @@ fn test_ff_function_call_tracks_nested_static_array_read_through_branch(sim) {
     assert_eq!(sim.get(side), 1u32.into());
 }
 
+fn test_ff_function_call_tracks_array_view_hidden_in_bound_literal(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            guard: input logic,
+            out_q: output logic<8>,
+            side: output logic<8>
+        ) {
+            function observe (
+                x: input logic<8>,
+                side: output logic<8>
+            ) -> logic<8> {
+                side = x;
+                return x;
+            }
+            function middle (
+                x: input logic<8>[2],
+                index: input logic,
+                guard: input logic
+            ) -> logic<8> {
+                return if guard ? x[index] : 8'h00;
+            }
+            function outer (
+                y: input logic<8>[2],
+                index: input logic,
+                guard: input logic
+            ) -> logic<8> {
+                return middle('{y[index], default: 8'h00}, 0, guard) + y[0];
+            }
+            always_ff (clk) {
+                side = 0;
+                out_q = outer(
+                    '{observe(side + 1, side), default: 8'h00},
+                    0,
+                    guard
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let guard = sim.signal("guard");
+    let out_q = sim.signal("out_q");
+    let side = sim.signal("side");
+
+    sim.modify(|io| io.set(guard, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 2u32.into());
+    assert_eq!(sim.get(side), 1u32.into());
+}
+
 fn test_ff_function_call_restores_initialized_forwarded_alias_view(sim) {
     @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -2614,6 +2614,63 @@ fn test_ff_function_call_merges_directly_forwarded_array_cache(sim) {
     assert_eq!(sim.get(side), 0x55u32.into());
 }
 
+fn test_ff_function_call_tracks_array_reads_in_output_indices(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            guard: input logic,
+            out_q: output logic<8>,
+            side: output logic<8>
+        ) {
+            var scratch: logic<8>[2];
+            function observe (
+                x: input logic<8>,
+                side: output logic<8>
+            ) -> logic<8> {
+                side = x;
+                return x;
+            }
+            function write (
+                value: input logic<8>,
+                dst: output logic<8>
+            ) -> logic<8> {
+                dst = value;
+                return 0;
+            }
+            function outer (
+                x: input logic<8>[2],
+                guard: input logic,
+                middle: input logic<8>
+            ) -> logic<8> {
+                return (if guard ? write(0, scratch[x[0]]) : 0) + middle + x[0];
+            }
+            always_ff (clk) {
+                out_q = outer(
+                    '{observe(8'h01, side), default: 8'h00},
+                    guard,
+                    observe(8'h55, side)
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let guard = sim.signal("guard");
+    let out_q = sim.signal("out_q");
+    let side = sim.signal("side");
+
+    sim.modify(|io| io.set(guard, 0u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x56u32.into());
+    assert_eq!(sim.get(side), 0x01u32.into());
+
+    sim.modify(|io| io.set(guard, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x56u32.into());
+    assert_eq!(sim.get(side), 0x55u32.into());
+}
+
 fn test_ff_function_call_restores_initialized_forwarded_alias_view(sim) {
     @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"
@@ -3616,6 +3673,33 @@ fn test_ff_nested_function_static_array_literal_access_is_lazy() {
     assert!(!output.contains("Store(addr=forward.x"), "{output}");
     assert!(!output.contains("Store(addr=first.x"), "{output}");
     assert!(output.lines().count() < 100, "{output}");
+}
+
+#[test]
+fn test_ff_static_branch_array_literal_access_is_lazy() {
+    let code = r#"
+    module Top (
+        clk: input clock,
+        guard: input logic,
+        in0: input logic<8>,
+        out_q: output logic<8>
+    ) {
+        function first_if (
+            x: input logic<8>[1024],
+            guard: input logic
+        ) -> logic<8> {
+            return if guard ? x[0] : 8'h00;
+        }
+        always_ff (clk) {
+            out_q = first_if('{default: in0}, guard);
+        }
+    }
+"#;
+    let trace = setup_and_trace(code, "Top");
+    let output = trace.format_program().unwrap();
+
+    assert!(!output.contains("Store(addr=first_if.x"), "{output}");
+    assert!(output.lines().count() < 150, "{output}");
 }
 
 #[test]

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -2674,6 +2674,35 @@ fn test_ff_function_call_restores_array_literal_view_after_reentrant_call(sim) {
     assert_eq!(sim.get(out_q), 0x11u32.into());
 }
 
+fn test_ff_function_call_restores_nearest_array_view_after_deep_reentrant_call(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            out_q: output logic<8>
+        ) {
+            function pick (x: input logic<8>[2], index: input logic) -> logic<8> {
+                return x[index];
+            }
+            always_ff (clk) {
+                out_q = pick(
+                    '{8'h11, 8'h22},
+                    pick(
+                        '{8'h00, 8'h00},
+                        pick('{8'h00, 8'h00}, 0)
+                    )
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let out_q = sim.signal("out_q");
+
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x11u32.into());
+}
+
 fn test_ff_function_call_bits_and_size_do_not_evaluate_array_argument(sim) {
     @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -2559,6 +2559,116 @@ fn test_ff_function_call_tracks_array_view_hidden_in_bound_literal(sim) {
     assert_eq!(sim.get(side), 1u32.into());
 }
 
+fn test_ff_function_call_merges_nested_array_state_at_cache_completion(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            guard: input logic,
+            out_q: output logic<8>,
+            side: output logic<8>
+        ) {
+            function observe (
+                x: input logic<8>,
+                side: output logic<8>
+            ) -> logic<8> {
+                side = x;
+                return x;
+            }
+            function middle (
+                x: input logic<8>[2],
+                index: input logic,
+                guard: input logic
+            ) -> logic<8> {
+                return (if guard ? x[0] : 8'h00) + x[index];
+            }
+            function outer (
+                y: input logic<8>[2],
+                index: input logic,
+                guard: input logic
+            ) -> logic<8> {
+                return middle(
+                    '{y[index], default: 8'h00},
+                    0,
+                    guard
+                ) + y[0];
+            }
+            always_ff (clk) {
+                side = 0;
+                out_q = outer(
+                    '{observe(side + 1, side), default: 8'h00},
+                    0,
+                    guard
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let guard = sim.signal("guard");
+    let out_q = sim.signal("out_q");
+    let side = sim.signal("side");
+
+    sim.modify(|io| io.set(guard, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 3u32.into());
+    assert_eq!(sim.get(side), 1u32.into());
+}
+
+fn test_ff_function_call_merges_nested_array_state_at_static_cache_completion(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            guard: input logic,
+            out_q: output logic<8>,
+            side: output logic<8>
+        ) {
+            function observe (
+                x: input logic<8>,
+                side: output logic<8>
+            ) -> logic<8> {
+                side = x;
+                return x;
+            }
+            function middle (
+                x: input logic<8>[2],
+                guard: input logic
+            ) -> logic<8> {
+                return (if guard ? x[0] : 8'h00) + x[0];
+            }
+            function outer (
+                y: input logic<8>[2],
+                index: input logic,
+                guard: input logic
+            ) -> logic<8> {
+                return middle(
+                    '{y[index], default: 8'h00},
+                    guard
+                ) + y[0];
+            }
+            always_ff (clk) {
+                side = 0;
+                out_q = outer(
+                    '{observe(side + 1, side), default: 8'h00},
+                    0,
+                    guard
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let guard = sim.signal("guard");
+    let out_q = sim.signal("out_q");
+    let side = sim.signal("side");
+
+    sim.modify(|io| io.set(guard, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 3u32.into());
+    assert_eq!(sim.get(side), 1u32.into());
+}
+
 fn test_ff_function_call_merges_directly_forwarded_array_cache(sim) {
     @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -2410,6 +2410,103 @@ fn test_ff_function_call_static_array_item_stays_lazy_before_conditional_dynamic
     assert_eq!(sim.get(side1), 0x22u32.into());
 }
 
+fn test_ff_function_call_carries_branch_local_static_array_item_cache(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            guard: input logic,
+            out_q: output logic<8>,
+            side: output logic<8>
+        ) {
+            function observe (
+                x: input logic<8>,
+                side: output logic<8>
+            ) -> logic<8> {
+                side = x;
+                return x;
+            }
+            function branch_then_static (
+                x: input logic<8>[2],
+                guard: input logic,
+                first: output logic<8>
+            ) -> logic<8> {
+                first = if guard ? x[0] : 8'h00;
+                return x[0];
+            }
+            var first: logic<8>;
+            always_ff (clk) {
+                side = 0;
+                out_q = branch_then_static(
+                    '{observe(side + 1, side), default: 8'h00},
+                    guard,
+                    first
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let guard = sim.signal("guard");
+    let out_q = sim.signal("out_q");
+    let side = sim.signal("side");
+
+    sim.modify(|io| io.set(guard, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 1u32.into());
+    assert_eq!(sim.get(side), 1u32.into());
+}
+
+fn test_ff_function_call_tracks_nested_static_array_read_through_branch(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            guard: input logic,
+            out_q: output logic<8>,
+            side: output logic<8>
+        ) {
+            function observe (
+                x: input logic<8>,
+                side: output logic<8>
+            ) -> logic<8> {
+                side = x;
+                return x;
+            }
+            function inner (x: input logic<8>[2]) -> logic<8> {
+                return x[0];
+            }
+            function nested_then_static (
+                x: input logic<8>[2],
+                guard: input logic,
+                first: output logic<8>
+            ) -> logic<8> {
+                first = if guard ? inner(x) : 8'h00;
+                return x[0];
+            }
+            var first: logic<8>;
+            always_ff (clk) {
+                side = 0;
+                out_q = nested_then_static(
+                    '{observe(side + 1, side), default: 8'h00},
+                    guard,
+                    first
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let guard = sim.signal("guard");
+    let out_q = sim.signal("out_q");
+    let side = sim.signal("side");
+
+    sim.modify(|io| io.set(guard, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 1u32.into());
+    assert_eq!(sim.get(side), 1u32.into());
+}
+
 fn test_ff_function_call_restores_initialized_forwarded_alias_view(sim) {
     @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -2187,6 +2187,170 @@ fn test_ff_function_call_array_literal_view_is_lazy_in_ternary_arm(sim) {
     assert_eq!(sim.get(side), 0x5au32.into());
 }
 
+fn test_ff_function_call_array_literal_view_is_lazy_in_short_circuit_rhs(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            guard: input logic,
+            in0: input logic<8>,
+            out_and: output logic,
+            out_or: output logic,
+            and_side: output logic<8>,
+            or_side: output logic<8>
+        ) {
+            function observe (
+                x: input logic<8>,
+                side: output logic<8>
+            ) -> logic<8> {
+                side = x;
+                return x;
+            }
+            function pick_and (
+                x: input logic<8>[2],
+                index: input logic,
+                guard: input logic
+            ) -> logic {
+                return guard && x[index] != 0;
+            }
+            function pick_or (
+                x: input logic<8>[2],
+                index: input logic,
+                guard: input logic
+            ) -> logic {
+                return guard || x[index] != 0;
+            }
+            always_ff (clk) {
+                and_side = 0;
+                or_side = 0;
+                out_and = pick_and(
+                    '{observe(in0, and_side), default: 8'h00},
+                    0,
+                    guard
+                );
+                out_or = pick_or(
+                    '{observe(in0, or_side), default: 8'h00},
+                    0,
+                    guard
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let guard = sim.signal("guard");
+    let in0 = sim.signal("in0");
+    let out_and = sim.signal("out_and");
+    let out_or = sim.signal("out_or");
+    let and_side = sim.signal("and_side");
+    let or_side = sim.signal("or_side");
+
+    sim.modify(|io| {
+        io.set(guard, 0u8);
+        io.set(in0, 0x5au8);
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_and), 0u32.into());
+    assert_eq!(sim.get(and_side), 0u32.into());
+    assert_eq!(sim.get(out_or), 1u32.into());
+    assert_eq!(sim.get(or_side), 0x5au32.into());
+
+    sim.modify(|io| io.set(guard, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_and), 1u32.into());
+    assert_eq!(sim.get(and_side), 0x5au32.into());
+    assert_eq!(sim.get(out_or), 1u32.into());
+    assert_eq!(sim.get(or_side), 0u32.into());
+}
+
+fn test_ff_function_call_array_literal_view_preserves_expression_order(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            out_q: output logic<8>,
+            side: output logic<8>
+        ) {
+            function observe (
+                x: input logic<8>,
+                side: output logic<8>
+            ) -> logic<8> {
+                side = x;
+                return x;
+            }
+            function ordered (
+                x: input logic<8>[2],
+                index: input logic,
+                left: input logic<8>
+            ) -> logic<8> {
+                return left + x[index];
+            }
+            always_ff (clk) {
+                out_q = ordered(
+                    '{observe(8'h22, side), default: 8'h00},
+                    0,
+                    observe(8'h11, side)
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let out_q = sim.signal("out_q");
+    let side = sim.signal("side");
+
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x33u32.into());
+    assert_eq!(sim.get(side), 0x22u32.into());
+}
+
+fn test_ff_function_call_array_literal_branch_view_is_reused_after_merge(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            guard: input logic,
+            in0: input logic<8>,
+            out_q: output logic<8>
+        ) {
+            function pick_then_first (
+                x: input logic<8>[2],
+                index: input logic,
+                guard: input logic,
+                first: output logic<8>
+            ) -> logic<8> {
+                first = if guard ? x[index] : 8'h00;
+                return x[0];
+            }
+            var first: logic<8>;
+            always_ff (clk) {
+                out_q = pick_then_first(
+                    '{in0, default: 8'h00},
+                    0,
+                    guard,
+                    first
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let guard = sim.signal("guard");
+    let in0 = sim.signal("in0");
+    let out_q = sim.signal("out_q");
+
+    for guard_value in [0u8, 1u8] {
+        sim.modify(|io| {
+            io.set(guard, guard_value);
+            io.set(in0, 0x5au8);
+        })
+        .unwrap();
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get(out_q), 0x5au32.into());
+    }
+}
+
 fn test_ff_function_call_forwards_array_literal_view_to_nested_call(sim) {
     @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -2021,6 +2021,186 @@ fn test_ff_function_call_nonvariable_argument_uses_formal_shape_for_indexing(sim
     assert_eq!(sim.get(out_q), 0x3u32.into());
 }
 
+fn test_ff_function_call_array_literal_element_uses_formal_context_width(sim) {
+    @ignore_on(veryl);
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            in0: input logic<4>,
+            in1: input logic<4>,
+            out_q: output logic<8>
+        ) {
+            function f (x: input logic<8>[1]) -> logic<8> {
+                return x[0];
+            }
+            always_ff (clk) {
+                out_q = f('{in0 + in1});
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let in0 = sim.signal("in0");
+    let in1 = sim.signal("in1");
+    let out_q = sim.signal("out_q");
+
+    sim.modify(|io| {
+        io.set(in0, 0xFu8);
+        io.set(in1, 0xFu8);
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x1Eu32.into());
+}
+
+fn test_ff_function_call_array_literal_supports_dynamic_multidim_indexing(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            row: input logic,
+            col: input logic,
+            out_q: output logic<8>
+        ) {
+            function f (
+                x: input logic<8>[2, 2],
+                i: input logic,
+                j: input logic
+            ) -> logic<8> {
+                return x[i][j];
+            }
+            always_ff (clk) {
+                out_q = f(
+                    '{'{8'h11, 8'h22} repeat 1, default: '{8'h33, 8'h44}},
+                    row,
+                    col
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let row = sim.signal("row");
+    let col = sim.signal("col");
+    let out_q = sim.signal("out_q");
+
+    for (i, j, expected) in [
+        (0u8, 0u8, 0x11u32),
+        (0, 1, 0x22),
+        (1, 0, 0x33),
+        (1, 1, 0x44),
+    ] {
+        sim.modify(|io| {
+            io.set(row, i);
+            io.set(col, j);
+        })
+        .unwrap();
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get(out_q), expected.into());
+    }
+}
+
+fn test_ff_function_call_array_literal_view_dominates_conditional_access(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            guard: input logic,
+            out_q: output logic<8>
+        ) {
+            function f (x: input logic<8>[2], guard: input logic) -> logic<8> {
+                var first: logic<8>;
+                first = if guard ? x[0] : 8'h00;
+                return first + x[1];
+            }
+            always_ff (clk) {
+                out_q = f('{8'h11, 8'h22}, guard);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let guard = sim.signal("guard");
+    let out_q = sim.signal("out_q");
+
+    sim.modify(|io| io.set(guard, 0u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x22u32.into());
+
+    sim.modify(|io| io.set(guard, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x33u32.into());
+}
+
+fn test_ff_function_call_forwards_array_literal_view_to_nested_call(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            index: input logic,
+            out_q: output logic<8>
+        ) {
+            function inner (x: input logic<8>[2], index: input logic) -> logic<8> {
+                return x[index];
+            }
+            function middle (x: input logic<8>[2], index: input logic) -> logic<8> {
+                return inner(x, index);
+            }
+            function outer (x: input logic<8>[2], index: input logic) -> logic<8> {
+                return middle(x, index);
+            }
+            always_ff (clk) {
+                out_q = outer('{8'h11, 8'h22}, index);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let index = sim.signal("index");
+    let out_q = sim.signal("out_q");
+
+    sim.modify(|io| io.set(index, 0u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x11u32.into());
+
+    sim.modify(|io| io.set(index, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x22u32.into());
+}
+
+fn test_ff_function_call_converts_array_literal_view_for_wider_nested_formal(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            index: input logic,
+            out_q: output logic<8>
+        ) {
+            function inner (x: input logic<8>[2], index: input logic) -> logic<8> {
+                return x[index];
+            }
+            function outer (x: input logic<4>[2], index: input logic) -> logic<8> {
+                return inner(x, index);
+            }
+            always_ff (clk) {
+                out_q = outer('{4'ha, 4'h3}, index);
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let index = sim.signal("index");
+    let out_q = sim.signal("out_q");
+
+    sim.modify(|io| io.set(index, 0u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x0au32.into());
+
+    sim.modify(|io| io.set(index, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x03u32.into());
+}
+
 fn test_ff_function_call_array_literal_element_uses_element_width(sim) {
     @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"
@@ -2515,6 +2695,31 @@ fn test_ff_dynamic_store_sir() {
     let trace = setup_and_trace(code, "Top");
     let output = trace.format_program().unwrap();
     assert_snapshot!("ff_dynamic_store_sir", output);
+}
+
+#[test]
+fn test_ff_function_array_literal_view_sir() {
+    let code = r#"
+    module Top (
+        clk: input clock,
+        index: input logic<2>,
+        in0: input logic<8>,
+        in1: input logic<8>,
+        in2: input logic<8>,
+        in3: input logic<8>,
+        out_q: output logic<8>
+    ) {
+        function select (x: input logic<8>[4], index: input logic<2>) -> logic<8> {
+            return x[index];
+        }
+        always_ff (clk) {
+            out_q = select('{in0, in1, in2, in3}, index);
+        }
+    }
+"#;
+    let trace = setup_and_trace(code, "Top");
+    let output = trace.format_program().unwrap();
+    assert_snapshot!("ff_function_array_literal_view_sir", output);
 }
 
 #[test]

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -2559,6 +2559,61 @@ fn test_ff_function_call_tracks_array_view_hidden_in_bound_literal(sim) {
     assert_eq!(sim.get(side), 1u32.into());
 }
 
+fn test_ff_function_call_merges_directly_forwarded_array_cache(sim) {
+    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @setup { let code = r#"
+        module Top (
+            clk: input clock,
+            guard: input logic,
+            out_q: output logic<8>,
+            side: output logic<8>
+        ) {
+            function observe (
+                x: input logic<8>,
+                side: output logic<8>
+            ) -> logic<8> {
+                side = x;
+                return x;
+            }
+            function inner (
+                x: input logic<8>[2],
+                guard: input logic
+            ) -> logic<8> {
+                return if guard ? x[0] : 8'h00;
+            }
+            function outer (
+                y: input logic<8>[2],
+                guard: input logic,
+                middle: input logic<8>
+            ) -> logic<8> {
+                return inner(y, guard) + middle + y[0];
+            }
+            always_ff (clk) {
+                out_q = outer(
+                    '{observe(8'h11, side), default: 8'h00},
+                    guard,
+                    observe(8'h55, side)
+                );
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let guard = sim.signal("guard");
+    let out_q = sim.signal("out_q");
+    let side = sim.signal("side");
+
+    sim.modify(|io| io.set(guard, 0u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x66u32.into());
+    assert_eq!(sim.get(side), 0x11u32.into());
+
+    sim.modify(|io| io.set(guard, 1u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(out_q), 0x77u32.into());
+    assert_eq!(sim.get(side), 0x55u32.into());
+}
+
 fn test_ff_function_call_restores_initialized_forwarded_alias_view(sim) {
     @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"

--- a/crates/celox/tests/snapshots/flip_flop__ff_function_array_literal_view_sir.snap
+++ b/crates/celox/tests/snapshots/flip_flop__ff_function_array_literal_view_sir.snap
@@ -1,0 +1,48 @@
+---
+source: crates/celox/tests/flip_flop.rs
+expression: output
+---
+=== Evaluation Flip-Flops (eval_apply_ffs) ===
+Trigger Group: clk (AbsoluteAddr(inst0, state0))
+  Execution Unit 0:
+    Entry Block: 0
+    Registers:
+      r0: logic<8>
+      r1: bit<64>
+      r2: logic<8>
+      r3: bit<64>
+      r4: logic<8>
+      r5: bit<64>
+      r6: logic<8>
+      r7: bit<64>
+      r8: logic<8>
+      r9: logic<2>
+    b0:
+      Commit(src=out_q (region=0), dst=out_q (region=1), offset=0, bits=8)
+      r0 = Load(addr=in0 (region=0), offset=0, bits=8)
+      r2 = Load(addr=in1 (region=0), offset=0, bits=8)
+      r4 = Load(addr=in2 (region=0), offset=0, bits=8)
+      r6 = Load(addr=in3 (region=0), offset=0, bits=8)
+      r9 = Load(addr=index (region=0), offset=0, bits=2)
+      r1 = SIRValue(0x0)
+      Store(addr=select.x (region=1), offset=element(r1, width=8, bit=0), bits=8, src_reg = 0)
+      r3 = SIRValue(0x1)
+      Store(addr=select.x (region=1), offset=element(r3, width=8, bit=0), bits=8, src_reg = 2)
+      r5 = SIRValue(0x2)
+      Store(addr=select.x (region=1), offset=element(r5, width=8, bit=0), bits=8, src_reg = 4)
+      r7 = SIRValue(0x3)
+      Store(addr=select.x (region=1), offset=element(r7, width=8, bit=0), bits=8, src_reg = 6)
+      r8 = Load(addr=select.x (region=1), offset=element(r9, width=8, bit=0), bits=8)
+      Store(addr=out_q (region=0), offset=0, bits=8, src_reg = 8)
+      Return
+
+=== Evaluation Flip-Flops (eval_only_ffs) ===
+
+=== Application Flip-Flops (apply_ffs) ===
+
+=== Evaluation Combinational Logic (eval_comb) ===
+Execution Unit 0:
+  Entry Block: 0
+  Registers:
+  b0:
+    Return

--- a/crates/celox/tests/snapshots/flip_flop__ff_function_array_literal_view_sir.snap
+++ b/crates/celox/tests/snapshots/flip_flop__ff_function_array_literal_view_sir.snap
@@ -8,30 +8,30 @@ Trigger Group: clk (AbsoluteAddr(inst0, state0))
     Entry Block: 0
     Registers:
       r0: logic<8>
-      r1: bit<64>
+      r1: logic<8>
       r2: logic<8>
-      r3: bit<64>
-      r4: logic<8>
+      r3: logic<8>
+      r4: bit<64>
       r5: bit<64>
-      r6: logic<8>
+      r6: bit<64>
       r7: bit<64>
       r8: logic<8>
       r9: logic<2>
     b0:
       Commit(src=out_q (region=0), dst=out_q (region=1), offset=0, bits=8)
       r0 = Load(addr=in0 (region=0), offset=0, bits=8)
-      r2 = Load(addr=in1 (region=0), offset=0, bits=8)
-      r4 = Load(addr=in2 (region=0), offset=0, bits=8)
-      r6 = Load(addr=in3 (region=0), offset=0, bits=8)
+      r1 = Load(addr=in1 (region=0), offset=0, bits=8)
+      r2 = Load(addr=in2 (region=0), offset=0, bits=8)
+      r3 = Load(addr=in3 (region=0), offset=0, bits=8)
       r9 = Load(addr=index (region=0), offset=0, bits=2)
-      r1 = SIRValue(0x0)
-      Store(addr=select.x (region=1), offset=element(r1, width=8, bit=0), bits=8, src_reg = 0)
-      r3 = SIRValue(0x1)
-      Store(addr=select.x (region=1), offset=element(r3, width=8, bit=0), bits=8, src_reg = 2)
-      r5 = SIRValue(0x2)
-      Store(addr=select.x (region=1), offset=element(r5, width=8, bit=0), bits=8, src_reg = 4)
+      r4 = SIRValue(0x0)
+      Store(addr=select.x (region=1), offset=element(r4, width=8, bit=0), bits=8, src_reg = 0)
+      r5 = SIRValue(0x1)
+      Store(addr=select.x (region=1), offset=element(r5, width=8, bit=0), bits=8, src_reg = 1)
+      r6 = SIRValue(0x2)
+      Store(addr=select.x (region=1), offset=element(r6, width=8, bit=0), bits=8, src_reg = 2)
       r7 = SIRValue(0x3)
-      Store(addr=select.x (region=1), offset=element(r7, width=8, bit=0), bits=8, src_reg = 6)
+      Store(addr=select.x (region=1), offset=element(r7, width=8, bit=0), bits=8, src_reg = 3)
       r8 = Load(addr=select.x (region=1), offset=element(r9, width=8, bit=0), bits=8)
       Store(addr=out_q (region=0), offset=0, bits=8, src_reg = 8)
       Return


### PR DESCRIPTION
## Summary

- materialize array-literal function arguments once into call-scoped working storage
- lower dynamic indexing to element-addressed loads instead of array-sized mux trees or wide shifts
- forward compatible backing views through nested calls and materialize converted backing when formal element representations differ
- add native backend coverage and a post-optimization SIR snapshot

## Why

A non-variable array argument has no storage address for the normal dynamic-load path. Selecting every possible literal element with a mux would make compile time and runtime scale with the array length for each access.

The formal argument's working region now provides temporary backing storage. Its existing shape and stride metadata drives `SIROffset::Element` loads, keeping each dynamic access independent of array length.

This addresses the array-literal function argument portion of #68. The Veryl cross-validation cases remain ignored pending veryl-lang/veryl#3131.

## Validation

- `cargo test -p celox --test flip_flop` (256 passed, 55 ignored)
- `cargo test -p celox --test flip_flop function_call` (96 passed, 21 ignored)
- `cargo test -p celox-frontend-veryl` (65 passed)
- `cargo clippy --locked -p celox --all-targets --no-deps`
- `cargo fmt --check`
