### PR TITLE
test(veryl): cover loop bound evaluation timing

### DIFF
--- a/crates/celox/tests/synth_dynamic_loop.rs
+++ b/crates/celox/tests/synth_dynamic_loop.rs
@@ -165,6 +165,35 @@ fn test_runtime_bounds_in_synth_for_loops(sim) {
     assert_eq!(sim.get(sum_step), 15u32.into());
 }
 
+fn test_loop_bound_is_evaluated_once_before_body(sim) {
+    @setup { let code = r#"
+        module Top (
+            initial_limit: input logic<32>,
+            count: output logic<32>,
+        ) {
+            var limit: logic<32>;
+
+            always_comb {
+                limit = initial_limit;
+                count = 0;
+
+                for _i in 0..limit {
+                    count += 1;
+                    limit = 1;
+                }
+            }
+        }
+    "#; }
+    @build Simulator::builder(code, "Top");
+
+    let initial_limit = sim.signal("initial_limit");
+    let count = sim.signal("count");
+
+    sim.set(initial_limit, 4u32);
+    sim.eval_comb().unwrap();
+    assert_eq!(sim.get(count), 4u32.into());
+}
+
 fn test_runtime_bitwise_steps_in_synth_for_loops(sim) {
     @setup { let code = r#"
         module Top (


### PR DESCRIPTION
## Summary

- add a cross-backend regression test for a dynamic `for` loop whose body writes the variable used as its end bound
- document the current behavior: the end bound is evaluated once before the loop body, so an initial bound of `4` produces four iterations even when the body assigns the bound variable to `1`
- exercise Celox native, Cranelift, and WASM backends as well as the bundled Veryl simulator

## Context

This captures the current Celox and Veryl native-simulator behavior while the intended Veryl semantics are being clarified. Emitted SystemVerilog reevaluates the condition on every iteration and therefore produces a different result for this case.

This PR only adds coverage; it does not change runtime behavior. If Veryl instead rejects writes to variables used by loop bounds, this test can be updated to assert that diagnostic.

## Validation

- `cargo fmt --check`
- `cargo test -p celox --test synth_dynamic_loop` (`115 passed, 0 failed, 26 ignored`)
- pre-push hook: submodule check, Cargo formatting, Biome, `cargo check`, and clean-tree check
