### PR TITLE
feat(arm64): add experimental native backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,26 @@ jobs:
       - name: Build NAPI WASM compatibility target
         run: pnpm --filter @celox-sim/celox-napi exec napi build --platform --target wasm32-wasip1-threads --manifest-path ../../Cargo.toml -p celox-napi
 
+  arm64-backend:
+    name: ARM64 Backend Test
+    needs: changes
+    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.rust == 'true')
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/setup-rust
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Lint ARM64 backend
+        run: cargo clippy --locked -p celox-backend-common -p celox-backend-arm64 --all-targets -- -D warnings
+
+      - name: Run ARM64 backend tests natively
+        run: cargo test --locked -p celox-backend-common -p celox-backend-arm64
+
   napi-windows:
     name: NAPI Build (Windows)
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,10 +184,25 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Lint ARM64 backend
-        run: cargo clippy --locked -p celox-backend-common -p celox-backend-arm64 --all-targets -- -D warnings
+        run: >-
+          cargo clippy --locked
+          -p celox-backend-common -p celox-backend-arm64
+          --all-targets --no-deps --
+          -D warnings
+          -A clippy::useless_conversion
+          -A clippy::missing_transmute_annotations
 
       - name: Run ARM64 backend tests natively
         run: cargo test --locked -p celox-backend-common -p celox-backend-arm64
+
+      - name: Check default AArch64 facade and benchmark runner (ARM64 backend off)
+        run: cargo check --locked -p celox -p celox-bench
+
+      - name: Check experimental AArch64 facade and benchmark runner
+        run: cargo check --locked -p celox -p celox-bench --features experimental-arm64-backend
+
+      - name: Test experimental AArch64 facade integration
+        run: cargo test --locked -p celox --lib --features experimental-arm64-backend
 
   napi-windows:
     name: NAPI Build (Windows)

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ crates/celox-napi/wasi-worker-browser.mjs
 # Claude Code
 .claude/settings.local.json
 .claude/worktrees/
+.worktrees/
 .codex
 .codex/
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,18 @@ name = "celox-analysis"
 version = "0.0.0"
 
 [[package]]
+name = "celox-backend-arm64"
+version = "0.0.0"
+dependencies = [
+ "celox-backend-common",
+ "libc",
+]
+
+[[package]]
+name = "celox-backend-common"
+version = "0.0.0"
+
+[[package]]
 name = "celox-backend-cranelift"
 version = "0.0.0"
 dependencies = [
@@ -486,6 +498,7 @@ name = "celox-backend-x86"
 version = "0.0.0"
 dependencies = [
  "celox-analysis",
+ "celox-backend-common",
  "celox-design",
  "celox-sir",
  "celox-sir-opt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,7 @@ version = "0.0.0"
 dependencies = [
  "bit-set 0.11.1",
  "celox-analysis",
+ "celox-backend-arm64",
  "celox-backend-cranelift",
  "celox-backend-wasm",
  "celox-backend-x86",
@@ -454,6 +455,9 @@ name = "celox-backend-arm64"
 version = "0.0.0"
 dependencies = [
  "celox-backend-common",
+ "celox-backend-x86",
+ "celox-state-layout",
+ "dynasmrt",
  "libc",
 ]
 
@@ -1550,6 +1554,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "dynasm"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd358e74d2f8d71a11b7a2c51c67ad5df3de06003b0596875e47bc09126c894e"
+dependencies = [
+ "bitflags 2.13.0",
+ "byteorder",
+ "lazy_static",
+ "proc-macro-error3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6efe03f6bd356ae85eeea7ee14c2bf54e664a949d089d238364b5a99afbc4116"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "fnv",
+ "memmap2",
 ]
 
 [[package]]
@@ -2952,9 +2983,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr3"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e4dd828515431dd6c4a030d26f7eaed7dd4778226e9d2bb968d65ca4ec3d4d"
+checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2962,14 +2993,14 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error3"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee475e440453418ff1335189eddf7101ba502cd818ab7ae04209bc83aa925aa"
+checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
 dependencies = [
  "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,9 @@ dependencies = [
 [[package]]
 name = "celox-backend-common"
 version = "0.0.0"
+dependencies = [
+ "fxhash",
+]
 
 [[package]]
 name = "celox-backend-cranelift"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ members = [
     "crates/celox",
     "crates/celox-analysis",
     "crates/celox-backend-cranelift",
+    "crates/celox-backend-common",
+    "crates/celox-backend-arm64",
     "crates/celox-backend-wasm",
     "crates/celox-backend-x86",
     "crates/celox-bench",

--- a/crates/celox-backend-arm64/Cargo.toml
+++ b/crates/celox-backend-arm64/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "celox-backend-arm64"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+description = "Celox AArch64 machine-code backend"
+edition.workspace = true
+
+[dependencies]
+celox-backend-common = { path = "../celox-backend-common" }
+
+[target.'cfg(all(target_arch = "aarch64", target_os = "linux"))'.dev-dependencies]
+libc = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/celox-backend-arm64/Cargo.toml
+++ b/crates/celox-backend-arm64/Cargo.toml
@@ -9,6 +9,9 @@ edition.workspace = true
 
 [dependencies]
 celox-backend-common = { path = "../celox-backend-common" }
+celox-backend-x86 = { path = "../celox-backend-x86" }
+celox-state-layout = { path = "../celox-state-layout" }
+dynasmrt = "5.1.0"
 
 [target.'cfg(all(target_arch = "aarch64", target_os = "linux"))'.dev-dependencies]
 libc = { workspace = true }

--- a/crates/celox-backend-arm64/src/allocation.rs
+++ b/crates/celox-backend-arm64/src/allocation.rs
@@ -30,6 +30,10 @@ where
     pub(crate) fn set(&mut self, value: V, register: Arm64Reg) {
         self.registers.insert(value, register);
     }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&V, &Arm64Reg)> {
+        self.registers.iter()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/celox-backend-arm64/src/allocation.rs
+++ b/crates/celox-backend-arm64/src/allocation.rs
@@ -1,0 +1,89 @@
+//! AArch64-owned register assignments and out-of-SSA copy plans.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use crate::Arm64Reg;
+
+/// Physical register assignment produced for one target MIR function.
+#[derive(Debug, Clone)]
+pub(crate) struct Assignment<V> {
+    registers: HashMap<V, Arm64Reg>,
+}
+
+impl<V> Default for Assignment<V> {
+    fn default() -> Self {
+        Self {
+            registers: HashMap::new(),
+        }
+    }
+}
+
+impl<V> Assignment<V>
+where
+    V: Eq + Hash,
+{
+    pub(crate) fn get(&self, value: &V) -> Option<Arm64Reg> {
+        self.registers.get(value).copied()
+    }
+
+    pub(crate) fn set(&mut self, value: V, register: Arm64Reg) {
+        self.registers.insert(value, register);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CopyDestination {
+    Register(Arm64Reg),
+    Stack(i32),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CopySource {
+    Register(Arm64Reg),
+    Stack(i32),
+    Immediate(u64),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CopyOperation {
+    Move {
+        destination: CopyDestination,
+        source: CopySource,
+    },
+    SwapRegisters {
+        left: Arm64Reg,
+        right: Arm64Reg,
+    },
+    SaveTemporary(CopyDestination),
+    RestoreTemporary(CopyDestination),
+}
+
+/// Dependency-ordered physical copies indexed by normalized CFG edge.
+#[derive(Debug, Clone)]
+pub(crate) struct EdgeCopyPlan<B> {
+    edges: HashMap<(B, B), Vec<CopyOperation>>,
+}
+
+impl<B> Default for EdgeCopyPlan<B> {
+    fn default() -> Self {
+        Self {
+            edges: HashMap::new(),
+        }
+    }
+}
+
+impl<B> EdgeCopyPlan<B>
+where
+    B: Copy + Eq + Hash,
+{
+    pub(crate) fn insert(&mut self, predecessor: B, successor: B, copies: Vec<CopyOperation>) {
+        if !copies.is_empty() {
+            self.edges.insert((predecessor, successor), copies);
+        }
+    }
+
+    pub(crate) fn edge(&self, predecessor: B, successor: B) -> Option<&[CopyOperation]> {
+        self.edges.get(&(predecessor, successor)).map(Vec::as_slice)
+    }
+}

--- a/crates/celox-backend-arm64/src/jit_mem.rs
+++ b/crates/celox-backend-arm64/src/jit_mem.rs
@@ -1,0 +1,66 @@
+//! Executable-memory ownership for emitted AArch64 functions.
+
+use dynasmrt::mmap::MutableBuffer;
+use dynasmrt::{AssemblyOffset, ExecutableBuffer};
+
+/// Optional subrange symbol retained for parity with the native runtime API.
+pub struct JitSymbol {
+    pub offset: usize,
+    pub size: usize,
+    pub name: String,
+}
+
+/// Executable AArch64 code region.
+pub struct JitCode {
+    buffer: ExecutableBuffer,
+    pub fn_ptr: unsafe extern "C" fn(*mut u8) -> i64,
+}
+
+impl JitCode {
+    pub fn new(code: &[u8]) -> Result<Self, std::io::Error> {
+        Self::new_named(code, "celox_arm64_jit")
+    }
+
+    pub fn new_named(code: &[u8], name: &str) -> Result<Self, std::io::Error> {
+        Self::new_named_with_symbols(code, name, &[])
+    }
+
+    pub fn new_named_with_symbols(
+        code: &[u8],
+        _name: &str,
+        _symbols: &[JitSymbol],
+    ) -> Result<Self, std::io::Error> {
+        let mut mutable = MutableBuffer::new(code.len().max(1))?;
+        mutable.set_len(code.len().max(1));
+        mutable[..code.len()].copy_from_slice(code);
+        let buffer = mutable.make_exec()?;
+        dynasmrt::cache_control::prepare_for_execution(&buffer);
+        let fn_ptr = unsafe { std::mem::transmute(buffer.ptr(AssemblyOffset(0))) };
+        Ok(Self { buffer, fn_ptr })
+    }
+
+    /// Execute standalone code with a private spill arena following state.
+    ///
+    /// # Safety
+    /// The emitted function must follow the backend ABI and may only access
+    /// the provided state and arena allocation.
+    pub unsafe fn call(&self, state: &mut [u8]) -> i64 {
+        const STANDALONE_ARENA_BYTES: usize = 1024 * 1024;
+        let total = state
+            .len()
+            .checked_add(STANDALONE_ARENA_BYTES)
+            .expect("standalone ARM64 state size overflow");
+        let mut owned = vec![0u64; total.div_ceil(8)];
+        let bytes = unsafe {
+            std::slice::from_raw_parts_mut(owned.as_mut_ptr().cast::<u8>(), owned.len() * 8)
+        };
+        bytes[..state.len()].copy_from_slice(state);
+        let result = unsafe { (self.fn_ptr)(bytes.as_mut_ptr()) };
+        state.copy_from_slice(&bytes[..state.len()]);
+        result
+    }
+
+    pub fn code(&self) -> &[u8] {
+        &self.buffer
+    }
+}

--- a/crates/celox-backend-arm64/src/jit_mem.rs
+++ b/crates/celox-backend-arm64/src/jit_mem.rs
@@ -25,6 +25,14 @@ impl JitCode {
         Self::new_named_with_symbols(code, name, &[])
     }
 
+    pub fn new_named_profiled(
+        code: &[u8],
+        name: &str,
+        _perf_map: bool,
+    ) -> Result<Self, std::io::Error> {
+        Self::new_named(code, name)
+    }
+
     pub fn new_named_with_symbols(
         code: &[u8],
         _name: &str,
@@ -37,6 +45,15 @@ impl JitCode {
         dynasmrt::cache_control::prepare_for_execution(&buffer);
         let fn_ptr = unsafe { std::mem::transmute(buffer.ptr(AssemblyOffset(0))) };
         Ok(Self { buffer, fn_ptr })
+    }
+
+    pub fn new_named_with_symbols_profiled(
+        code: &[u8],
+        name: &str,
+        symbols: &[JitSymbol],
+        _perf_map: bool,
+    ) -> Result<Self, std::io::Error> {
+        Self::new_named_with_symbols(code, name, symbols)
     }
 
     /// Execute standalone code with a private spill arena following state.

--- a/crates/celox-backend-arm64/src/legacy_allocation.rs
+++ b/crates/celox-backend-arm64/src/legacy_allocation.rs
@@ -8,14 +8,11 @@ use std::fmt;
 
 use celox_backend_x86::native::mir as legacy_mir;
 use celox_backend_x86::native::regalloc::AssignmentMap as LegacyAssignment;
-use celox_backend_x86::native::regalloc::assignment::PhysReg;
-use celox_backend_x86::native::ssa_destroy::{
-    ParallelCopyDestination, ParallelCopyOperation, ParallelCopySource, SsaDestructionError,
-    SsaDestructionPlan,
-};
+use celox_backend_x86::native::regalloc::assignment::EdgeLocation;
+use celox_backend_x86::native::ssa_destroy::{SsaDestructionError, SsaDestructionPlan};
 
 use crate::Arm64Reg;
-use crate::allocation::{Assignment, CopyDestination, CopyOperation, CopySource, EdgeCopyPlan};
+use crate::allocation::{CopyDestination, CopyOperation, CopySource, EdgeCopyPlan};
 use crate::mir::{self, AllocatedFunction};
 
 #[derive(Debug)]
@@ -59,24 +56,8 @@ pub(crate) fn adapt(
     let legacy_plan = SsaDestructionPlan::build(function, assignment)?;
     legacy_plan.verify(function, assignment, spill_frame_size)?;
 
-    let mut target_assignment = Assignment::default();
-    for (value, register) in assignment.sorted_entries() {
-        target_assignment.set(adapt_vreg(value), adapt_register(register));
-    }
-
-    let mut target_plan = EdgeCopyPlan::default();
-    for block in &function.blocks {
-        for successor in block.successors() {
-            let Some(edge) = legacy_plan.edge(block.id, successor) else {
-                continue;
-            };
-            target_plan.insert(
-                adapt_block(block.id),
-                adapt_block(successor),
-                edge.operations.iter().copied().map(adapt_copy).collect(),
-            );
-        }
-    }
+    // The legacy plan proves that every pre-existing spill home and phi source
+    // is complete. Physical register colors are deliberately discarded below.
     let blocks = function
         .blocks
         .iter()
@@ -105,13 +86,146 @@ pub(crate) fn adapt(
             })
         })
         .collect::<Result<_, LegacyLoweringError>>()?;
-    let allocated = AllocatedFunction {
-        function: mir::MFunction::new(blocks, function.constant_tables().to_vec()),
-        assignment: target_assignment,
-        edge_copies: target_plan,
-    };
-    crate::regalloc::verify_allocated(&allocated)?;
-    Ok(allocated)
+    let mut target = crate::regalloc::allocate_without_spills(mir::MFunction::new(
+        blocks,
+        function.constant_tables().to_vec(),
+    ))?;
+    target.edge_copies = rebuild_legacy_home_copies(function, assignment, &target)?;
+    Ok(target)
+}
+
+fn rebuild_legacy_home_copies(
+    function: &legacy_mir::MFunction,
+    legacy_assignment: &LegacyAssignment,
+    target: &AllocatedFunction,
+) -> Result<EdgeCopyPlan<mir::BlockId>, LegacyLoweringError> {
+    use celox_backend_common::regalloc as common;
+
+    let mut plan = EdgeCopyPlan::default();
+    for successor in &function.blocks {
+        let mut rows_by_predecessor = std::collections::BTreeMap::<
+            legacy_mir::BlockId,
+            Vec<common::ParallelCopy<Arm64Reg>>,
+        >::new();
+        for phi in &successor.phis {
+            if legacy_assignment.is_semantic_phi_definition(phi.dst) {
+                continue;
+            }
+            let destination = if let Some(offset) = legacy_assignment.edge_spill_slot(phi.dst) {
+                common::CopyDestination::Stack(offset)
+            } else {
+                common::CopyDestination::Register(
+                    target.assignment.get(&adapt_vreg(phi.dst)).ok_or(
+                        crate::regalloc::TargetRegallocError::MissingAssignment {
+                            block: adapt_block(successor.id),
+                            instruction: 0,
+                            value: adapt_vreg(phi.dst),
+                        },
+                    )?,
+                )
+            };
+            for &(predecessor, source_value) in &phi.sources {
+                let source = match legacy_assignment.resolved_phi_source_location(
+                    predecessor,
+                    successor.id,
+                    phi.dst,
+                    source_value,
+                ) {
+                    Some(EdgeLocation::Stack(offset)) => common::CopySource::Stack(offset),
+                    Some(EdgeLocation::Immediate(value)) => common::CopySource::Immediate(value),
+                    Some(EdgeLocation::Register(_)) => common::CopySource::Register(
+                        target.assignment.get(&adapt_vreg(source_value)).ok_or(
+                            crate::regalloc::TargetRegallocError::MissingAssignment {
+                                block: adapt_block(predecessor),
+                                instruction: 0,
+                                value: adapt_vreg(source_value),
+                            },
+                        )?,
+                    ),
+                    None => {
+                        return Err(SsaDestructionError {
+                            rule: "SSA_DEST.MISSING_PHI_SOURCE_LOCATION",
+                            predecessor: Some(predecessor),
+                            successor: Some(successor.id),
+                            phi_destination: Some(phi.dst),
+                            source_value: Some(source_value),
+                            message: "phi source has no completed legacy edge location".into(),
+                        }
+                        .into());
+                    }
+                };
+                rows_by_predecessor
+                    .entry(predecessor)
+                    .or_default()
+                    .push(common::ParallelCopy {
+                        destination,
+                        source,
+                    });
+            }
+        }
+        for (predecessor, rows) in rows_by_predecessor {
+            let resolution = common::resolve_parallel_copies(&rows).map_err(|error| {
+                crate::regalloc::TargetRegallocError::ParallelCopy {
+                    predecessor: adapt_block(predecessor),
+                    successor: adapt_block(successor.id),
+                    message: error.to_string(),
+                }
+            })?;
+            let operations = resolution
+                .operations
+                .into_iter()
+                .map(|operation| match operation {
+                    common::CopyOperation::Move {
+                        destination,
+                        source,
+                    } => CopyOperation::Move {
+                        destination: adapt_common_destination(destination),
+                        source: adapt_common_source(source),
+                    },
+                    common::CopyOperation::SwapRegisters { left, right } => {
+                        CopyOperation::SwapRegisters { left, right }
+                    }
+                    common::CopyOperation::SaveTemporary(destination) => {
+                        CopyOperation::SaveTemporary(adapt_common_destination(destination))
+                    }
+                    common::CopyOperation::RestoreTemporary(destination) => {
+                        CopyOperation::RestoreTemporary(adapt_common_destination(destination))
+                    }
+                })
+                .collect();
+            plan.insert(
+                adapt_block(predecessor),
+                adapt_block(successor.id),
+                operations,
+            );
+        }
+    }
+    Ok(plan)
+}
+
+fn adapt_common_destination(
+    destination: celox_backend_common::regalloc::CopyDestination<Arm64Reg>,
+) -> CopyDestination {
+    match destination {
+        celox_backend_common::regalloc::CopyDestination::Register(register) => {
+            CopyDestination::Register(register)
+        }
+        celox_backend_common::regalloc::CopyDestination::Stack(offset) => {
+            CopyDestination::Stack(offset)
+        }
+    }
+}
+
+fn adapt_common_source(source: celox_backend_common::regalloc::CopySource<Arm64Reg>) -> CopySource {
+    match source {
+        celox_backend_common::regalloc::CopySource::Register(register) => {
+            CopySource::Register(register)
+        }
+        celox_backend_common::regalloc::CopySource::Stack(offset) => CopySource::Stack(offset),
+        celox_backend_common::regalloc::CopySource::Immediate(value) => {
+            CopySource::Immediate(value)
+        }
+    }
 }
 
 fn adapt_vreg(value: legacy_mir::VReg) -> mir::VReg {
@@ -713,65 +827,6 @@ fn adapt_unary(
     make(adapt_vreg(dst), adapt_vreg(src))
 }
 
-fn adapt_register(register: PhysReg) -> Arm64Reg {
-    match register {
-        PhysReg::RAX => Arm64Reg::new(1),
-        PhysReg::RCX => Arm64Reg::new(2),
-        PhysReg::RDX => Arm64Reg::new(3),
-        PhysReg::RBX => Arm64Reg::new(4),
-        PhysReg::RBP => Arm64Reg::new(5),
-        PhysReg::RSI => Arm64Reg::new(6),
-        PhysReg::RDI => Arm64Reg::new(7),
-        PhysReg::R8 => Arm64Reg::new(8),
-        PhysReg::R9 => Arm64Reg::new(9),
-        PhysReg::R10 => Arm64Reg::new(10),
-        PhysReg::R11 => Arm64Reg::new(11),
-        PhysReg::R12 => Arm64Reg::new(12),
-        PhysReg::R13 => Arm64Reg::new(13),
-        PhysReg::R14 => Arm64Reg::new(14),
-        PhysReg::R15 => Arm64Reg::new(15),
-    }
-}
-
-fn adapt_copy(operation: ParallelCopyOperation) -> CopyOperation {
-    match operation {
-        ParallelCopyOperation::Move {
-            destination,
-            source,
-        } => CopyOperation::Move {
-            destination: adapt_destination(destination),
-            source: adapt_source(source),
-        },
-        ParallelCopyOperation::SwapRegisters { left, right } => CopyOperation::SwapRegisters {
-            left: adapt_register(left),
-            right: adapt_register(right),
-        },
-        ParallelCopyOperation::SaveTemporary(destination) => {
-            CopyOperation::SaveTemporary(adapt_destination(destination))
-        }
-        ParallelCopyOperation::RestoreTemporary(destination) => {
-            CopyOperation::RestoreTemporary(adapt_destination(destination))
-        }
-    }
-}
-
-fn adapt_destination(destination: ParallelCopyDestination) -> CopyDestination {
-    match destination {
-        ParallelCopyDestination::Register(register) => {
-            CopyDestination::Register(adapt_register(register))
-        }
-        ParallelCopyDestination::Stack(offset) => CopyDestination::Stack(offset),
-    }
-}
-
-fn adapt_source(source: ParallelCopySource) -> CopySource {
-    match source {
-        ParallelCopySource::Register(register) => CopySource::Register(adapt_register(register)),
-        ParallelCopySource::Stack(offset) => CopySource::Stack(offset),
-        ParallelCopySource::Immediate(value) => CopySource::Immediate(value),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -818,42 +873,34 @@ mod tests {
     }
 
     #[test]
-    fn legacy_colors_map_to_distinct_non_reserved_aarch64_registers() {
-        let colors = [
-            PhysReg::RAX,
-            PhysReg::RCX,
-            PhysReg::RDX,
-            PhysReg::RBX,
-            PhysReg::RBP,
-            PhysReg::RSI,
-            PhysReg::RDI,
-            PhysReg::R8,
-            PhysReg::R9,
-            PhysReg::R10,
-            PhysReg::R11,
-            PhysReg::R12,
-            PhysReg::R13,
-            PhysReg::R14,
-            PhysReg::R15,
-        ];
-        let mut registers = colors.map(adapt_register).map(Arm64Reg::number);
-        registers.sort_unstable();
+    fn recolors_legacy_mir_with_the_aarch64_register_file() {
+        use celox_backend_x86::native::regalloc::assignment::PhysReg;
 
-        assert_eq!(
-            registers,
-            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-        );
-        assert!(
-            !registers.contains(&0),
-            "x0 is the simulator-state register"
-        );
-        assert!(
-            !registers.contains(&16),
-            "x16 is an emitter scratch register"
-        );
-        assert!(
-            !registers.contains(&17),
-            "x17 is an emitter scratch register"
-        );
+        let mut values = legacy_mir::VRegAllocator::new();
+        let lhs = values.alloc();
+        let rhs = values.alloc();
+        let result = values.alloc();
+        let mut function =
+            legacy_mir::MFunction::new(values, vec![legacy_mir::SpillDesc::transient(); 3]);
+        let mut block = legacy_mir::MBlock::new(legacy_mir::BlockId(0));
+        block.push(legacy_mir::MInst::LoadImm { dst: lhs, value: 2 });
+        block.push(legacy_mir::MInst::LoadImm { dst: rhs, value: 3 });
+        block.push(legacy_mir::MInst::Add {
+            dst: result,
+            lhs,
+            rhs,
+        });
+        block.push(legacy_mir::MInst::Return);
+        function.push_block(block);
+        let mut legacy_assignment = LegacyAssignment::default();
+        legacy_assignment.set(lhs, PhysReg::R13);
+        legacy_assignment.set(rhs, PhysReg::R14);
+        legacy_assignment.set(result, PhysReg::R15);
+
+        let target = adapt(&function, &legacy_assignment, 0).unwrap();
+        let target_registers = [lhs, rhs, result]
+            .map(|value| target.assignment.get(&adapt_vreg(value)).unwrap().number());
+
+        assert!(target_registers.into_iter().all(|register| register <= 2));
     }
 }

--- a/crates/celox-backend-arm64/src/legacy_allocation.rs
+++ b/crates/celox-backend-arm64/src/legacy_allocation.rs
@@ -1,10 +1,12 @@
-//! Transitional adapter from the established x86 allocator result.
+//! Transitional lowering from the established x86 MIR and allocator result.
 //!
-//! No AArch64 emitter code should interpret x86 register colors directly.
-//! This module is deleted once the production AArch64 MIR uses its own target
-//! driver with the shared opcode-free allocation facts.
+//! No AArch64 emitter code should interpret x86 opcodes or register colors
+//! directly. This module is deleted once AArch64 instruction selection and
+//! allocation produce the target-owned MIR without a legacy input.
 
-use celox_backend_x86::native::mir::{BlockId, MFunction, VReg};
+use std::fmt;
+
+use celox_backend_x86::native::mir as legacy_mir;
 use celox_backend_x86::native::regalloc::AssignmentMap as LegacyAssignment;
 use celox_backend_x86::native::regalloc::assignment::PhysReg;
 use celox_backend_x86::native::ssa_destroy::{
@@ -14,18 +16,44 @@ use celox_backend_x86::native::ssa_destroy::{
 
 use crate::Arm64Reg;
 use crate::allocation::{Assignment, CopyDestination, CopyOperation, CopySource, EdgeCopyPlan};
+use crate::mir::{self, AllocatedFunction};
+
+#[derive(Debug)]
+pub(crate) enum LegacyLoweringError {
+    Ssa(SsaDestructionError),
+    Unsupported(&'static str),
+}
+
+impl fmt::Display for LegacyLoweringError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Ssa(error) => error.fmt(formatter),
+            Self::Unsupported(instruction) => {
+                write!(formatter, "AArch64 lowering does not support {instruction}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for LegacyLoweringError {}
+
+impl From<SsaDestructionError> for LegacyLoweringError {
+    fn from(error: SsaDestructionError) -> Self {
+        Self::Ssa(error)
+    }
+}
 
 pub(crate) fn adapt(
-    function: &MFunction,
+    function: &legacy_mir::MFunction,
     assignment: &LegacyAssignment,
     spill_frame_size: u32,
-) -> Result<(Assignment<VReg>, EdgeCopyPlan<BlockId>), SsaDestructionError> {
+) -> Result<AllocatedFunction, LegacyLoweringError> {
     let legacy_plan = SsaDestructionPlan::build(function, assignment)?;
     legacy_plan.verify(function, assignment, spill_frame_size)?;
 
     let mut target_assignment = Assignment::default();
     for (value, register) in assignment.sorted_entries() {
-        target_assignment.set(value, adapt_register(register));
+        target_assignment.set(adapt_vreg(value), adapt_register(register));
     }
 
     let mut target_plan = EdgeCopyPlan::default();
@@ -35,13 +63,630 @@ pub(crate) fn adapt(
                 continue;
             };
             target_plan.insert(
-                block.id,
-                successor,
+                adapt_block(block.id),
+                adapt_block(successor),
                 edge.operations.iter().copied().map(adapt_copy).collect(),
             );
         }
     }
-    Ok((target_assignment, target_plan))
+    let blocks = function
+        .blocks
+        .iter()
+        .map(|block| {
+            Ok(mir::MBlock {
+                id: adapt_block(block.id),
+                insts: block
+                    .insts
+                    .iter()
+                    .map(adapt_instruction)
+                    .collect::<Result<_, _>>()?,
+            })
+        })
+        .collect::<Result<_, LegacyLoweringError>>()?;
+    Ok(AllocatedFunction {
+        function: mir::MFunction::new(blocks, function.constant_tables().to_vec()),
+        assignment: target_assignment,
+        edge_copies: target_plan,
+    })
+}
+
+fn adapt_vreg(value: legacy_mir::VReg) -> mir::VReg {
+    mir::VReg(value.0)
+}
+
+fn adapt_block(block: legacy_mir::BlockId) -> mir::BlockId {
+    mir::BlockId(block.0)
+}
+
+fn adapt_size(size: legacy_mir::OpSize) -> mir::OpSize {
+    match size {
+        legacy_mir::OpSize::S8 => mir::OpSize::S8,
+        legacy_mir::OpSize::S16 => mir::OpSize::S16,
+        legacy_mir::OpSize::S32 => mir::OpSize::S32,
+        legacy_mir::OpSize::S64 => mir::OpSize::S64,
+    }
+}
+
+fn adapt_base(base: legacy_mir::BaseReg) -> mir::BaseReg {
+    match base {
+        legacy_mir::BaseReg::SimState => mir::BaseReg::SimState,
+        legacy_mir::BaseReg::StackFrame => mir::BaseReg::StackFrame,
+    }
+}
+
+fn adapt_cmp(kind: legacy_mir::CmpKind) -> mir::CmpKind {
+    match kind {
+        legacy_mir::CmpKind::Eq => mir::CmpKind::Eq,
+        legacy_mir::CmpKind::Ne => mir::CmpKind::Ne,
+        legacy_mir::CmpKind::LtU => mir::CmpKind::LtU,
+        legacy_mir::CmpKind::LtS => mir::CmpKind::LtS,
+        legacy_mir::CmpKind::LeU => mir::CmpKind::LeU,
+        legacy_mir::CmpKind::LeS => mir::CmpKind::LeS,
+        legacy_mir::CmpKind::GtU => mir::CmpKind::GtU,
+        legacy_mir::CmpKind::GtS => mir::CmpKind::GtS,
+        legacy_mir::CmpKind::GeU => mir::CmpKind::GeU,
+        legacy_mir::CmpKind::GeS => mir::CmpKind::GeS,
+    }
+}
+
+fn adapt_predicate(predicate: legacy_mir::BranchPredicate) -> mir::BranchPredicate {
+    match predicate {
+        legacy_mir::BranchPredicate::Compare { lhs, rhs, kind } => mir::BranchPredicate::Compare {
+            lhs: adapt_vreg(lhs),
+            rhs: adapt_vreg(rhs),
+            kind: adapt_cmp(kind),
+        },
+        legacy_mir::BranchPredicate::CompareImm { lhs, imm, kind } => {
+            mir::BranchPredicate::CompareImm {
+                lhs: adapt_vreg(lhs),
+                imm,
+                kind: adapt_cmp(kind),
+            }
+        }
+        legacy_mir::BranchPredicate::MemoryNonZero { base, offset, size } => {
+            mir::BranchPredicate::MemoryNonZero {
+                base: adapt_base(base),
+                offset,
+                size: adapt_size(size),
+            }
+        }
+    }
+}
+
+fn adapt_lane_rhs(rhs: legacy_mir::PackedLaneCompareRhs) -> mir::PackedLaneCompareRhs {
+    match rhs {
+        legacy_mir::PackedLaneCompareRhs::Scalar(value) => {
+            mir::PackedLaneCompareRhs::Scalar(adapt_vreg(value))
+        }
+        legacy_mir::PackedLaneCompareRhs::Memory { offset, .. } => {
+            mir::PackedLaneCompareRhs::Memory { offset }
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn adapt_instruction(instruction: &legacy_mir::MInst) -> Result<mir::MInst, LegacyLoweringError> {
+    use legacy_mir::MInst as L;
+    use mir::MInst as A;
+
+    let instruction =
+        match instruction {
+            L::X86Simd(_) => return Err(LegacyLoweringError::Unsupported("x86 SIMD MIR")),
+            L::Mov { dst, src } => A::Mov {
+                dst: adapt_vreg(*dst),
+                src: adapt_vreg(*src),
+            },
+            L::Mov32 { dst, src } => A::Mov32 {
+                dst: adapt_vreg(*dst),
+                src: adapt_vreg(*src),
+            },
+            L::LoadImm { dst, value } => A::LoadImm {
+                dst: adapt_vreg(*dst),
+                value: *value,
+            },
+            L::Scratch { dst } => A::Scratch {
+                dst: adapt_vreg(*dst),
+            },
+            L::LoadConstantTableAddr { dst, table } => A::LoadConstantTableAddr {
+                dst: adapt_vreg(*dst),
+                table: mir::ConstantTableId(table.0),
+            },
+            L::Load {
+                dst,
+                base,
+                offset,
+                size,
+            } => A::Load {
+                dst: adapt_vreg(*dst),
+                base: adapt_base(*base),
+                offset: *offset,
+                size: adapt_size(*size),
+            },
+            L::Store {
+                base,
+                offset,
+                src,
+                size,
+            } => A::Store {
+                base: adapt_base(*base),
+                offset: *offset,
+                src: adapt_vreg(*src),
+                size: adapt_size(*size),
+            },
+            L::AndStoreImm {
+                base,
+                offset,
+                size,
+                imm,
+            } => A::AndStoreImm {
+                base: adapt_base(*base),
+                offset: *offset,
+                size: adapt_size(*size),
+                imm: *imm,
+            },
+            L::OrStoreImm {
+                base,
+                offset,
+                size,
+                imm,
+            } => A::OrStoreImm {
+                base: adapt_base(*base),
+                offset: *offset,
+                size: adapt_size(*size),
+                imm: *imm,
+            },
+            L::LoadPtr {
+                dst,
+                ptr,
+                offset,
+                size,
+            } => A::LoadPtr {
+                dst: adapt_vreg(*dst),
+                ptr: adapt_vreg(*ptr),
+                offset: *offset,
+                size: adapt_size(*size),
+            },
+            L::StorePtr {
+                ptr,
+                offset,
+                src,
+                size,
+            } => A::StorePtr {
+                ptr: adapt_vreg(*ptr),
+                offset: *offset,
+                src: adapt_vreg(*src),
+                size: adapt_size(*size),
+            },
+            L::ReleaseStorePtr {
+                ptr,
+                offset,
+                src,
+                size,
+            } => A::ReleaseStorePtr {
+                ptr: adapt_vreg(*ptr),
+                offset: *offset,
+                src: adapt_vreg(*src),
+                size: adapt_size(*size),
+            },
+            L::LoadIndexed {
+                dst,
+                base,
+                offset,
+                index,
+                scale,
+                size,
+                ..
+            } => A::LoadIndexed {
+                dst: adapt_vreg(*dst),
+                base: adapt_base(*base),
+                offset: *offset,
+                index: adapt_vreg(*index),
+                scale: *scale,
+                size: adapt_size(*size),
+            },
+            L::PackedLaneCompare {
+                dst,
+                rhs,
+                kind,
+                offset,
+                lane_count,
+                element_stride,
+                bit_offset,
+                field_width,
+                ..
+            } => A::PackedLaneCompare {
+                dst: adapt_vreg(*dst),
+                rhs: adapt_lane_rhs(*rhs),
+                kind: adapt_cmp(*kind),
+                offset: *offset,
+                lane_count: *lane_count,
+                element_stride: *element_stride,
+                bit_offset: *bit_offset,
+                field_width: *field_width,
+            },
+            L::PackedByteAffineCompare {
+                dst,
+                base,
+                rhs,
+                kind,
+            } => A::PackedByteAffineCompare {
+                dst: adapt_vreg(*dst),
+                base: adapt_vreg(*base),
+                rhs: adapt_vreg(*rhs),
+                kind: adapt_cmp(*kind),
+            },
+            L::StoreIndexed {
+                base,
+                offset,
+                index,
+                src,
+                size,
+                ..
+            } => A::StoreIndexed {
+                base: adapt_base(*base),
+                offset: *offset,
+                index: adapt_vreg(*index),
+                src: adapt_vreg(*src),
+                size: adapt_size(*size),
+            },
+            L::OrStoreIndexed {
+                base,
+                offset,
+                index,
+                src,
+                size,
+                ..
+            } => A::OrStoreIndexed {
+                base: adapt_base(*base),
+                offset: *offset,
+                index: adapt_vreg(*index),
+                src: adapt_vreg(*src),
+                size: adapt_size(*size),
+            },
+            L::LoadPtrIndexed {
+                dst,
+                ptr,
+                offset,
+                index,
+                size,
+            } => A::LoadPtrIndexed {
+                dst: adapt_vreg(*dst),
+                ptr: adapt_vreg(*ptr),
+                offset: *offset,
+                index: adapt_vreg(*index),
+                size: adapt_size(*size),
+            },
+            L::StorePtrIndexed {
+                ptr,
+                offset,
+                index,
+                src,
+                size,
+            } => A::StorePtrIndexed {
+                ptr: adapt_vreg(*ptr),
+                offset: *offset,
+                index: adapt_vreg(*index),
+                src: adapt_vreg(*src),
+                size: adapt_size(*size),
+            },
+            L::ReleaseStorePtrIndexed {
+                ptr,
+                offset,
+                index,
+                src,
+                size,
+            } => A::ReleaseStorePtrIndexed {
+                ptr: adapt_vreg(*ptr),
+                offset: *offset,
+                index: adapt_vreg(*index),
+                src: adapt_vreg(*src),
+                size: adapt_size(*size),
+            },
+            L::MemCopy {
+                src_offset,
+                dst_offset,
+                byte_len,
+            } => A::MemCopy {
+                src_offset: *src_offset,
+                dst_offset: *dst_offset,
+                byte_len: *byte_len,
+            },
+            L::MemFill {
+                dst_offset,
+                byte_len,
+                value,
+            } => A::MemFill {
+                dst_offset: *dst_offset,
+                byte_len: *byte_len,
+                value: *value,
+            },
+            L::SparseCommit {
+                src_offset,
+                dst_offset,
+                byte_size,
+                dirty_words_offset,
+                dirty_word_count,
+                summary_words_offset,
+                summary_word_count,
+                four_state,
+            } => A::SparseCommit {
+                src_offset: *src_offset,
+                dst_offset: *dst_offset,
+                byte_size: *byte_size,
+                dirty_words_offset: *dirty_words_offset,
+                dirty_word_count: *dirty_word_count,
+                summary_words_offset: *summary_words_offset,
+                summary_word_count: *summary_word_count,
+                four_state: *four_state,
+            },
+            L::SparseMarkActive {
+                active_index,
+                active_bits_offset,
+                active_capacity,
+            } => A::SparseMarkActive {
+                active_index: *active_index,
+                active_bits_offset: *active_bits_offset,
+                active_capacity: *active_capacity,
+            },
+            L::SparseCommitWorklist {
+                descriptor_table,
+                active_bits_offset,
+                active_capacity,
+            } => A::SparseCommitWorklist {
+                descriptor_table: mir::ConstantTableId(descriptor_table.0),
+                active_bits_offset: *active_bits_offset,
+                active_capacity: *active_capacity,
+            },
+            L::Add { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::Add { dst, lhs, rhs })
+            }
+            L::Add32 { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::Add32 { dst, lhs, rhs })
+            }
+            L::Sub { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::Sub { dst, lhs, rhs })
+            }
+            L::Sub32 { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::Sub32 { dst, lhs, rhs })
+            }
+            L::Mul { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::Mul { dst, lhs, rhs })
+            }
+            L::Mul32 { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::Mul32 { dst, lhs, rhs })
+            }
+            L::UMulHi { dst, lhs, rhs } => adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| {
+                A::UMulHi { dst, lhs, rhs }
+            }),
+            L::And { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::And { dst, lhs, rhs })
+            }
+            L::And32 { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::And32 { dst, lhs, rhs })
+            }
+            L::Or { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::Or { dst, lhs, rhs })
+            }
+            L::Or32 { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::Or32 { dst, lhs, rhs })
+            }
+            L::Xor { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::Xor { dst, lhs, rhs })
+            }
+            L::Xor32 { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::Xor32 { dst, lhs, rhs })
+            }
+            L::Shr { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::Shr { dst, lhs, rhs })
+            }
+            L::Shl { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::Shl { dst, lhs, rhs })
+            }
+            L::Sar { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::Sar { dst, lhs, rhs })
+            }
+            L::AndImm { dst, src, imm } => A::AndImm {
+                dst: adapt_vreg(*dst),
+                src: adapt_vreg(*src),
+                imm: *imm,
+            },
+            L::AndImm32 { dst, src, imm } => A::AndImm32 {
+                dst: adapt_vreg(*dst),
+                src: adapt_vreg(*src),
+                imm: *imm,
+            },
+            L::OrImm { dst, src, imm } => A::OrImm {
+                dst: adapt_vreg(*dst),
+                src: adapt_vreg(*src),
+                imm: *imm,
+            },
+            L::ShrImm { dst, src, imm } => A::ShrImm {
+                dst: adapt_vreg(*dst),
+                src: adapt_vreg(*src),
+                imm: *imm,
+            },
+            L::ShlImm { dst, src, imm } => A::ShlImm {
+                dst: adapt_vreg(*dst),
+                src: adapt_vreg(*src),
+                imm: *imm,
+            },
+            L::SarImm { dst, src, imm } => A::SarImm {
+                dst: adapt_vreg(*dst),
+                src: adapt_vreg(*src),
+                imm: *imm,
+            },
+            L::AddImm { dst, src, imm } => A::AddImm {
+                dst: adapt_vreg(*dst),
+                src: adapt_vreg(*src),
+                imm: *imm,
+            },
+            L::SubImm { dst, src, imm } => A::SubImm {
+                dst: adapt_vreg(*dst),
+                src: adapt_vreg(*src),
+                imm: *imm,
+            },
+            L::Cmp {
+                dst,
+                lhs,
+                rhs,
+                kind,
+            } => A::Cmp {
+                dst: adapt_vreg(*dst),
+                lhs: adapt_vreg(*lhs),
+                rhs: adapt_vreg(*rhs),
+                kind: adapt_cmp(*kind),
+            },
+            L::CmpImm {
+                dst,
+                lhs,
+                imm,
+                kind,
+            } => A::CmpImm {
+                dst: adapt_vreg(*dst),
+                lhs: adapt_vreg(*lhs),
+                imm: *imm,
+                kind: adapt_cmp(*kind),
+            },
+            L::UDiv { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::UDiv { dst, lhs, rhs })
+            }
+            L::URem { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::URem { dst, lhs, rhs })
+            }
+            L::SDiv { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::SDiv { dst, lhs, rhs })
+            }
+            L::SRem { dst, lhs, rhs } => {
+                adapt_binary(*dst, *lhs, *rhs, |dst, lhs, rhs| A::SRem { dst, lhs, rhs })
+            }
+            L::BitNot { dst, src } => adapt_unary(*dst, *src, |dst, src| A::BitNot { dst, src }),
+            L::Neg { dst, src } => adapt_unary(*dst, *src, |dst, src| A::Neg { dst, src }),
+            L::Popcnt { dst, src } => adapt_unary(*dst, *src, |dst, src| A::Popcnt { dst, src }),
+            L::Bsf { dst, src } => adapt_unary(*dst, *src, |dst, src| A::Bsf { dst, src }),
+            L::Bsr { dst, src } => adapt_unary(*dst, *src, |dst, src| A::Bsr { dst, src }),
+            L::BsrOr {
+                dst,
+                src,
+                zero_value,
+            } => A::BsrOr {
+                dst: adapt_vreg(*dst),
+                src: adapt_vreg(*src),
+                zero_value: *zero_value,
+            },
+            L::Pext { dst, src, mask } => A::Pext {
+                dst: adapt_vreg(*dst),
+                src: adapt_vreg(*src),
+                mask: adapt_vreg(*mask),
+            },
+            L::Pdep { dst, src, mask } => A::Pdep {
+                dst: adapt_vreg(*dst),
+                src: adapt_vreg(*src),
+                mask: adapt_vreg(*mask),
+            },
+            L::Select {
+                dst,
+                cond,
+                true_val,
+                false_val,
+            } => A::Select {
+                dst: adapt_vreg(*dst),
+                cond: adapt_vreg(*cond),
+                true_val: adapt_vreg(*true_val),
+                false_val: adapt_vreg(*false_val),
+            },
+            L::CmpSelect {
+                dst,
+                lhs,
+                rhs,
+                kind,
+                true_val,
+                false_val,
+            } => A::CmpSelect {
+                dst: adapt_vreg(*dst),
+                lhs: adapt_vreg(*lhs),
+                rhs: adapt_vreg(*rhs),
+                kind: adapt_cmp(*kind),
+                true_val: adapt_vreg(*true_val),
+                false_val: adapt_vreg(*false_val),
+            },
+            L::CmpImmSelect {
+                dst,
+                lhs,
+                imm,
+                kind,
+                true_val,
+                false_val,
+            } => A::CmpImmSelect {
+                dst: adapt_vreg(*dst),
+                lhs: adapt_vreg(*lhs),
+                imm: *imm,
+                kind: adapt_cmp(*kind),
+                true_val: adapt_vreg(*true_val),
+                false_val: adapt_vreg(*false_val),
+            },
+            L::GuardedCmpSelect {
+                dst,
+                guard,
+                lhs,
+                rhs,
+                kind,
+                true_val,
+                false_val,
+            } => A::GuardedCmpSelect {
+                dst: adapt_vreg(*dst),
+                guard: adapt_vreg(*guard),
+                lhs: adapt_vreg(*lhs),
+                rhs: adapt_vreg(*rhs),
+                kind: adapt_cmp(*kind),
+                true_val: adapt_vreg(*true_val),
+                false_val: adapt_vreg(*false_val),
+            },
+            L::Branch {
+                cond,
+                true_bb,
+                false_bb,
+            } => A::Branch {
+                cond: adapt_vreg(*cond),
+                true_bb: adapt_block(*true_bb),
+                false_bb: adapt_block(*false_bb),
+            },
+            L::BranchPred {
+                predicate,
+                true_bb,
+                false_bb,
+            } => A::BranchPred {
+                predicate: adapt_predicate(*predicate),
+                true_bb: adapt_block(*true_bb),
+                false_bb: adapt_block(*false_bb),
+            },
+            L::JumpTable { index, targets, .. } => A::JumpTable {
+                index: adapt_vreg(*index),
+                targets: targets.iter().copied().map(adapt_block).collect(),
+            },
+            L::Jump { target } => A::Jump {
+                target: adapt_block(*target),
+            },
+            L::Return => A::Return,
+            L::ReturnError { code } => A::ReturnError { code: *code },
+        };
+    Ok(instruction)
+}
+
+fn adapt_binary(
+    dst: legacy_mir::VReg,
+    lhs: legacy_mir::VReg,
+    rhs: legacy_mir::VReg,
+    make: impl FnOnce(mir::VReg, mir::VReg, mir::VReg) -> mir::MInst,
+) -> mir::MInst {
+    make(adapt_vreg(dst), adapt_vreg(lhs), adapt_vreg(rhs))
+}
+
+fn adapt_unary(
+    dst: legacy_mir::VReg,
+    src: legacy_mir::VReg,
+    make: impl FnOnce(mir::VReg, mir::VReg) -> mir::MInst,
+) -> mir::MInst {
+    make(adapt_vreg(dst), adapt_vreg(src))
 }
 
 fn adapt_register(register: PhysReg) -> Arm64Reg {
@@ -106,6 +751,47 @@ fn adapt_source(source: ParallelCopySource) -> CopySource {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lowers_semantic_operands_into_aarch64_owned_types() {
+        let lowered = adapt_instruction(&legacy_mir::MInst::LoadIndexed {
+            dst: legacy_mir::VReg(3),
+            base: legacy_mir::BaseReg::StackFrame,
+            offset: -24,
+            index: legacy_mir::VReg(7),
+            scale: 8,
+            size: legacy_mir::OpSize::S32,
+            alias_range: None,
+        })
+        .unwrap();
+
+        assert_eq!(
+            lowered,
+            mir::MInst::LoadIndexed {
+                dst: mir::VReg(3),
+                base: mir::BaseReg::StackFrame,
+                offset: -24,
+                index: mir::VReg(7),
+                scale: 8,
+                size: mir::OpSize::S32,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_x86_only_opcodes_at_the_legacy_boundary() {
+        let error = adapt_instruction(&legacy_mir::MInst::X86Simd(
+            legacy_mir::X86SimdInst::Zero128 {
+                dst: legacy_mir::X86VecReg(0),
+            },
+        ))
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            LegacyLoweringError::Unsupported("x86 SIMD MIR")
+        ));
+    }
 
     #[test]
     fn legacy_colors_map_to_distinct_non_reserved_aarch64_registers() {

--- a/crates/celox-backend-arm64/src/legacy_allocation.rs
+++ b/crates/celox-backend-arm64/src/legacy_allocation.rs
@@ -1,8 +1,9 @@
-//! Transitional lowering from the established x86 MIR and allocator result.
+//! Transitional lowering from the established x86 MIR.
 //!
 //! No AArch64 emitter code should interpret x86 opcodes or register colors
-//! directly. This module is deleted once AArch64 instruction selection and
-//! allocation produce the target-owned MIR without a legacy input.
+//! directly. The production path lowers pre-allocation MIR and delegates all
+//! allocation to the AArch64 backend. This module is deleted once AArch64
+//! instruction selection produces the target-owned MIR without a legacy input.
 
 use std::fmt;
 
@@ -58,6 +59,15 @@ pub(crate) fn adapt(
 
     // The legacy plan proves that every pre-existing spill home and phi source
     // is complete. Physical register colors are deliberately discarded below.
+    let mut target = crate::regalloc::allocate_without_spills(lower(function)?)?;
+    target.edge_copies = rebuild_legacy_home_copies(function, assignment, &target)?;
+    Ok(target)
+}
+
+/// Lower optimized scalar MIR before any legacy allocation has modified it.
+pub(crate) fn lower(
+    function: &legacy_mir::MFunction,
+) -> Result<mir::MFunction, LegacyLoweringError> {
     let blocks = function
         .blocks
         .iter()
@@ -86,12 +96,10 @@ pub(crate) fn adapt(
             })
         })
         .collect::<Result<_, LegacyLoweringError>>()?;
-    let mut target = crate::regalloc::allocate_without_spills(mir::MFunction::new(
+    Ok(mir::MFunction::new(
         blocks,
         function.constant_tables().to_vec(),
-    ))?;
-    target.edge_copies = rebuild_legacy_home_copies(function, assignment, &target)?;
-    Ok(target)
+    ))
 }
 
 fn rebuild_legacy_home_copies(

--- a/crates/celox-backend-arm64/src/legacy_allocation.rs
+++ b/crates/celox-backend-arm64/src/legacy_allocation.rs
@@ -1,0 +1,149 @@
+//! Transitional adapter from the established x86 allocator result.
+//!
+//! No AArch64 emitter code should interpret x86 register colors directly.
+//! This module is deleted once the production AArch64 MIR uses its own target
+//! driver with the shared opcode-free allocation facts.
+
+use celox_backend_x86::native::mir::{BlockId, MFunction, VReg};
+use celox_backend_x86::native::regalloc::AssignmentMap as LegacyAssignment;
+use celox_backend_x86::native::regalloc::assignment::PhysReg;
+use celox_backend_x86::native::ssa_destroy::{
+    ParallelCopyDestination, ParallelCopyOperation, ParallelCopySource, SsaDestructionError,
+    SsaDestructionPlan,
+};
+
+use crate::Arm64Reg;
+use crate::allocation::{Assignment, CopyDestination, CopyOperation, CopySource, EdgeCopyPlan};
+
+pub(crate) fn adapt(
+    function: &MFunction,
+    assignment: &LegacyAssignment,
+    spill_frame_size: u32,
+) -> Result<(Assignment<VReg>, EdgeCopyPlan<BlockId>), SsaDestructionError> {
+    let legacy_plan = SsaDestructionPlan::build(function, assignment)?;
+    legacy_plan.verify(function, assignment, spill_frame_size)?;
+
+    let mut target_assignment = Assignment::default();
+    for (value, register) in assignment.sorted_entries() {
+        target_assignment.set(value, adapt_register(register));
+    }
+
+    let mut target_plan = EdgeCopyPlan::default();
+    for block in &function.blocks {
+        for successor in block.successors() {
+            let Some(edge) = legacy_plan.edge(block.id, successor) else {
+                continue;
+            };
+            target_plan.insert(
+                block.id,
+                successor,
+                edge.operations.iter().copied().map(adapt_copy).collect(),
+            );
+        }
+    }
+    Ok((target_assignment, target_plan))
+}
+
+fn adapt_register(register: PhysReg) -> Arm64Reg {
+    match register {
+        PhysReg::RAX => Arm64Reg::new(1),
+        PhysReg::RCX => Arm64Reg::new(2),
+        PhysReg::RDX => Arm64Reg::new(3),
+        PhysReg::RBX => Arm64Reg::new(4),
+        PhysReg::RBP => Arm64Reg::new(5),
+        PhysReg::RSI => Arm64Reg::new(6),
+        PhysReg::RDI => Arm64Reg::new(7),
+        PhysReg::R8 => Arm64Reg::new(8),
+        PhysReg::R9 => Arm64Reg::new(9),
+        PhysReg::R10 => Arm64Reg::new(10),
+        PhysReg::R11 => Arm64Reg::new(11),
+        PhysReg::R12 => Arm64Reg::new(12),
+        PhysReg::R13 => Arm64Reg::new(13),
+        PhysReg::R14 => Arm64Reg::new(14),
+        PhysReg::R15 => Arm64Reg::new(15),
+    }
+}
+
+fn adapt_copy(operation: ParallelCopyOperation) -> CopyOperation {
+    match operation {
+        ParallelCopyOperation::Move {
+            destination,
+            source,
+        } => CopyOperation::Move {
+            destination: adapt_destination(destination),
+            source: adapt_source(source),
+        },
+        ParallelCopyOperation::SwapRegisters { left, right } => CopyOperation::SwapRegisters {
+            left: adapt_register(left),
+            right: adapt_register(right),
+        },
+        ParallelCopyOperation::SaveTemporary(destination) => {
+            CopyOperation::SaveTemporary(adapt_destination(destination))
+        }
+        ParallelCopyOperation::RestoreTemporary(destination) => {
+            CopyOperation::RestoreTemporary(adapt_destination(destination))
+        }
+    }
+}
+
+fn adapt_destination(destination: ParallelCopyDestination) -> CopyDestination {
+    match destination {
+        ParallelCopyDestination::Register(register) => {
+            CopyDestination::Register(adapt_register(register))
+        }
+        ParallelCopyDestination::Stack(offset) => CopyDestination::Stack(offset),
+    }
+}
+
+fn adapt_source(source: ParallelCopySource) -> CopySource {
+    match source {
+        ParallelCopySource::Register(register) => CopySource::Register(adapt_register(register)),
+        ParallelCopySource::Stack(offset) => CopySource::Stack(offset),
+        ParallelCopySource::Immediate(value) => CopySource::Immediate(value),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_colors_map_to_distinct_non_reserved_aarch64_registers() {
+        let colors = [
+            PhysReg::RAX,
+            PhysReg::RCX,
+            PhysReg::RDX,
+            PhysReg::RBX,
+            PhysReg::RBP,
+            PhysReg::RSI,
+            PhysReg::RDI,
+            PhysReg::R8,
+            PhysReg::R9,
+            PhysReg::R10,
+            PhysReg::R11,
+            PhysReg::R12,
+            PhysReg::R13,
+            PhysReg::R14,
+            PhysReg::R15,
+        ];
+        let mut registers = colors.map(adapt_register).map(Arm64Reg::number);
+        registers.sort_unstable();
+
+        assert_eq!(
+            registers,
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        );
+        assert!(
+            !registers.contains(&0),
+            "x0 is the simulator-state register"
+        );
+        assert!(
+            !registers.contains(&16),
+            "x16 is an emitter scratch register"
+        );
+        assert!(
+            !registers.contains(&17),
+            "x17 is an emitter scratch register"
+        );
+    }
+}

--- a/crates/celox-backend-arm64/src/legacy_allocation.rs
+++ b/crates/celox-backend-arm64/src/legacy_allocation.rs
@@ -21,6 +21,7 @@ use crate::mir::{self, AllocatedFunction};
 #[derive(Debug)]
 pub(crate) enum LegacyLoweringError {
     Ssa(SsaDestructionError),
+    TargetAllocation(crate::regalloc::TargetRegallocError),
     Unsupported(&'static str),
 }
 
@@ -28,6 +29,7 @@ impl fmt::Display for LegacyLoweringError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Ssa(error) => error.fmt(formatter),
+            Self::TargetAllocation(error) => error.fmt(formatter),
             Self::Unsupported(instruction) => {
                 write!(formatter, "AArch64 lowering does not support {instruction}")
             }
@@ -40,6 +42,12 @@ impl std::error::Error for LegacyLoweringError {}
 impl From<SsaDestructionError> for LegacyLoweringError {
     fn from(error: SsaDestructionError) -> Self {
         Self::Ssa(error)
+    }
+}
+
+impl From<crate::regalloc::TargetRegallocError> for LegacyLoweringError {
+    fn from(error: crate::regalloc::TargetRegallocError) -> Self {
+        Self::TargetAllocation(error)
     }
 }
 
@@ -75,6 +83,20 @@ pub(crate) fn adapt(
         .map(|block| {
             Ok(mir::MBlock {
                 id: adapt_block(block.id),
+                phis: block
+                    .phis
+                    .iter()
+                    .map(|phi| mir::PhiNode {
+                        dst: adapt_vreg(phi.dst),
+                        sources: phi
+                            .sources
+                            .iter()
+                            .map(|&(predecessor, value)| {
+                                (adapt_block(predecessor), adapt_vreg(value))
+                            })
+                            .collect(),
+                    })
+                    .collect(),
                 insts: block
                     .insts
                     .iter()
@@ -83,11 +105,13 @@ pub(crate) fn adapt(
             })
         })
         .collect::<Result<_, LegacyLoweringError>>()?;
-    Ok(AllocatedFunction {
+    let allocated = AllocatedFunction {
         function: mir::MFunction::new(blocks, function.constant_tables().to_vec()),
         assignment: target_assignment,
         edge_copies: target_plan,
-    })
+    };
+    crate::regalloc::verify_allocated(&allocated)?;
+    Ok(allocated)
 }
 
 fn adapt_vreg(value: legacy_mir::VReg) -> mir::VReg {

--- a/crates/celox-backend-arm64/src/lib.rs
+++ b/crates/celox-backend-arm64/src/lib.rs
@@ -15,6 +15,7 @@ use std::fmt;
 mod allocation;
 pub mod jit_mem;
 mod legacy_allocation;
+pub mod mir;
 pub mod scalar;
 
 /// Virtual general-purpose register in bootstrap ARM64 MIR.

--- a/crates/celox-backend-arm64/src/lib.rs
+++ b/crates/celox-backend-arm64/src/lib.rs
@@ -12,7 +12,9 @@ use celox_backend_common::regalloc::{
 use std::collections::HashMap;
 use std::fmt;
 
+mod allocation;
 pub mod jit_mem;
+mod legacy_allocation;
 pub mod scalar;
 
 /// Virtual general-purpose register in bootstrap ARM64 MIR.
@@ -26,6 +28,11 @@ pub struct Arm64Reg(u8);
 impl Arm64Reg {
     pub const X0: Self = Self(0);
 
+    pub(crate) const fn new(number: u8) -> Self {
+        assert!(number <= 30, "AArch64 GPR number must be at most 30");
+        Self(number)
+    }
+
     pub const fn number(self) -> u8 {
         self.0
     }
@@ -38,13 +45,13 @@ impl MachineRegister for Arm64Reg {
 }
 
 const ALLOCATABLE_REGS: [Arm64Reg; 7] = [
-    Arm64Reg(9),
-    Arm64Reg(10),
-    Arm64Reg(11),
-    Arm64Reg(12),
-    Arm64Reg(13),
-    Arm64Reg(14),
-    Arm64Reg(15),
+    Arm64Reg::new(9),
+    Arm64Reg::new(10),
+    Arm64Reg::new(11),
+    Arm64Reg::new(12),
+    Arm64Reg::new(13),
+    Arm64Reg::new(14),
+    Arm64Reg::new(15),
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/celox-backend-arm64/src/lib.rs
+++ b/crates/celox-backend-arm64/src/lib.rs
@@ -16,6 +16,7 @@ mod allocation;
 pub mod jit_mem;
 mod legacy_allocation;
 pub mod mir;
+mod regalloc;
 pub mod scalar;
 
 /// Virtual general-purpose register in bootstrap ARM64 MIR.

--- a/crates/celox-backend-arm64/src/lib.rs
+++ b/crates/celox-backend-arm64/src/lib.rs
@@ -1,0 +1,456 @@
+//! Bootstrap AArch64 backend.
+//!
+//! The initial pipeline deliberately covers a small, executable subset:
+//! parameters, 64-bit immediates, integer addition, and return. It establishes
+//! the target boundary and exercises the shared register allocator before SIR
+//! lowering and spill support are added.
+
+use celox_backend_common::regalloc::{
+    Allocation, LinearScanError, LiveRange, MachineRegister, allocate_linear_scan,
+};
+use std::collections::HashMap;
+use std::fmt;
+
+/// Virtual general-purpose register in bootstrap ARM64 MIR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct VReg(u32);
+
+/// AArch64 general-purpose register number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Arm64Reg(u8);
+
+impl Arm64Reg {
+    pub const X0: Self = Self(0);
+
+    pub const fn number(self) -> u8 {
+        self.0
+    }
+}
+
+impl MachineRegister for Arm64Reg {
+    fn index(self) -> u8 {
+        self.0
+    }
+}
+
+const ALLOCATABLE_REGS: [Arm64Reg; 7] = [
+    Arm64Reg(9),
+    Arm64Reg(10),
+    Arm64Reg(11),
+    Arm64Reg(12),
+    Arm64Reg(13),
+    Arm64Reg(14),
+    Arm64Reg(15),
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Inst {
+    Parameter { dst: VReg, index: u8 },
+    LoadImm { dst: VReg, value: u64 },
+    Add { dst: VReg, lhs: VReg, rhs: VReg },
+    Return { value: VReg },
+}
+
+impl Inst {
+    fn def(self) -> Option<VReg> {
+        match self {
+            Self::Parameter { dst, .. } | Self::LoadImm { dst, .. } | Self::Add { dst, .. } => {
+                Some(dst)
+            }
+            Self::Return { .. } => None,
+        }
+    }
+
+    fn uses(self) -> [Option<VReg>; 2] {
+        match self {
+            Self::Parameter { .. } | Self::LoadImm { .. } => [None, None],
+            Self::Add { lhs, rhs, .. } => [Some(lhs), Some(rhs)],
+            Self::Return { value } => [Some(value), None],
+        }
+    }
+}
+
+/// Verified bootstrap machine function.
+#[derive(Debug, Clone)]
+pub struct Function {
+    instructions: Vec<Inst>,
+    vreg_count: u32,
+}
+
+impl Function {
+    pub fn builder() -> FunctionBuilder {
+        FunctionBuilder::default()
+    }
+}
+
+/// Builder which assigns every definition a fresh SSA identity.
+#[derive(Debug, Default)]
+pub struct FunctionBuilder {
+    instructions: Vec<Inst>,
+    next_vreg: u32,
+}
+
+impl FunctionBuilder {
+    fn alloc(&mut self) -> VReg {
+        let value = VReg(self.next_vreg);
+        self.next_vreg = self
+            .next_vreg
+            .checked_add(1)
+            .expect("bootstrap ARM64 VReg namespace exhausted");
+        value
+    }
+
+    pub fn parameter(&mut self, index: u8) -> VReg {
+        let dst = self.alloc();
+        self.instructions.push(Inst::Parameter { dst, index });
+        dst
+    }
+
+    pub fn load_imm(&mut self, value: u64) -> VReg {
+        let dst = self.alloc();
+        self.instructions.push(Inst::LoadImm { dst, value });
+        dst
+    }
+
+    pub fn add(&mut self, lhs: VReg, rhs: VReg) -> VReg {
+        let dst = self.alloc();
+        self.instructions.push(Inst::Add { dst, lhs, rhs });
+        dst
+    }
+
+    pub fn return_value(&mut self, value: VReg) {
+        self.instructions.push(Inst::Return { value });
+    }
+
+    pub fn finish(self) -> Function {
+        Function {
+            instructions: self.instructions,
+            vreg_count: self.next_vreg,
+        }
+    }
+}
+
+/// Failure from bootstrap MIR verification or allocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompileError {
+    InvalidMir(String),
+    Regalloc(LinearScanError<VReg>),
+}
+
+impl fmt::Display for CompileError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidMir(message) => write!(formatter, "invalid ARM64 MIR: {message}"),
+            Self::Regalloc(error) => write!(formatter, "ARM64 register allocation failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for CompileError {}
+
+impl From<LinearScanError<VReg>> for CompileError {
+    fn from(error: LinearScanError<VReg>) -> Self {
+        Self::Regalloc(error)
+    }
+}
+
+/// Compiled AArch64 function and its physical assignment.
+#[derive(Debug, Clone)]
+pub struct CompiledFunction {
+    code: Vec<u8>,
+    allocation: Allocation<VReg, Arm64Reg>,
+}
+
+impl CompiledFunction {
+    pub fn code(&self) -> &[u8] {
+        &self.code
+    }
+
+    pub fn assigned_register(&self, value: VReg) -> Option<Arm64Reg> {
+        self.allocation.get(value)
+    }
+}
+
+/// Verify, allocate, and emit one bootstrap AArch64 function.
+pub fn compile(function: &Function) -> Result<CompiledFunction, CompileError> {
+    verify(function)?;
+    let ranges = live_ranges(function)?;
+    let allocation = allocate_linear_scan(&ranges, &ALLOCATABLE_REGS)?;
+    let code = emit(function, &allocation);
+    Ok(CompiledFunction { code, allocation })
+}
+
+fn verify(function: &Function) -> Result<(), CompileError> {
+    let mut defined = vec![false; function.vreg_count as usize];
+    let mut saw_return = false;
+    for (index, instruction) in function.instructions.iter().copied().enumerate() {
+        if saw_return {
+            return Err(CompileError::InvalidMir(format!(
+                "instruction {index} follows return"
+            )));
+        }
+        if let Inst::Parameter {
+            index: parameter, ..
+        } = instruction
+            && parameter >= 8
+        {
+            return Err(CompileError::InvalidMir(format!(
+                "parameter {parameter} is outside the AAPCS64 register argument set"
+            )));
+        }
+        for used in instruction.uses().into_iter().flatten() {
+            let Some(is_defined) = defined.get(used.0 as usize) else {
+                return Err(CompileError::InvalidMir(format!(
+                    "instruction {index} uses unallocated {used:?}"
+                )));
+            };
+            if !is_defined {
+                return Err(CompileError::InvalidMir(format!(
+                    "instruction {index} uses {used:?} before its definition"
+                )));
+            }
+        }
+        if let Some(dst) = instruction.def() {
+            let Some(slot) = defined.get_mut(dst.0 as usize) else {
+                return Err(CompileError::InvalidMir(format!(
+                    "instruction {index} defines unallocated {dst:?}"
+                )));
+            };
+            if std::mem::replace(slot, true) {
+                return Err(CompileError::InvalidMir(format!(
+                    "instruction {index} redefines {dst:?}"
+                )));
+            }
+        }
+        saw_return = matches!(instruction, Inst::Return { .. });
+    }
+    if !saw_return {
+        return Err(CompileError::InvalidMir("function has no return".into()));
+    }
+    if defined.into_iter().any(|is_defined| !is_defined) {
+        return Err(CompileError::InvalidMir(
+            "allocated virtual register has no definition".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn live_ranges(function: &Function) -> Result<Vec<LiveRange<VReg>>, CompileError> {
+    let mut ranges = HashMap::<VReg, LiveRange<VReg>>::new();
+    for (index, instruction) in function.instructions.iter().copied().enumerate() {
+        let index = u32::try_from(index)
+            .map_err(|_| CompileError::InvalidMir("too many instructions".into()))?;
+        let use_point = index
+            .checked_mul(2)
+            .ok_or_else(|| CompileError::InvalidMir("program point overflow".into()))?;
+        let def_point = use_point
+            .checked_add(1)
+            .ok_or_else(|| CompileError::InvalidMir("program point overflow".into()))?;
+        for used in instruction.uses().into_iter().flatten() {
+            let range = ranges.get_mut(&used).ok_or_else(|| {
+                CompileError::InvalidMir(format!("missing live range for {used:?}"))
+            })?;
+            range.end = use_point;
+        }
+        if let Some(dst) = instruction.def() {
+            ranges.insert(
+                dst,
+                LiveRange {
+                    value: dst,
+                    start: def_point,
+                    end: def_point,
+                },
+            );
+        }
+    }
+    let mut result = ranges.into_values().collect::<Vec<_>>();
+    result.sort_unstable_by_key(|range| range.value);
+    Ok(result)
+}
+
+fn emit(function: &Function, allocation: &Allocation<VReg, Arm64Reg>) -> Vec<u8> {
+    let mut code = Vec::new();
+    for instruction in &function.instructions {
+        match *instruction {
+            Inst::Parameter { dst, index } => {
+                let destination = assigned(allocation, dst);
+                push_mov_reg(&mut code, destination, Arm64Reg(index));
+            }
+            Inst::LoadImm { dst, value } => {
+                push_load_imm(&mut code, assigned(allocation, dst), value);
+            }
+            Inst::Add { dst, lhs, rhs } => push_word(
+                &mut code,
+                encode_add(
+                    assigned(allocation, dst),
+                    assigned(allocation, lhs),
+                    assigned(allocation, rhs),
+                ),
+            ),
+            Inst::Return { value } => {
+                push_mov_reg(&mut code, Arm64Reg::X0, assigned(allocation, value));
+                push_word(&mut code, 0xd65f_03c0);
+            }
+        }
+    }
+    code
+}
+
+fn assigned(allocation: &Allocation<VReg, Arm64Reg>, value: VReg) -> Arm64Reg {
+    allocation
+        .get(value)
+        .expect("verified ARM64 MIR value must have an assignment")
+}
+
+fn push_mov_reg(code: &mut Vec<u8>, destination: Arm64Reg, source: Arm64Reg) {
+    if destination != source {
+        push_word(code, encode_mov_reg(destination, source));
+    }
+}
+
+fn push_load_imm(code: &mut Vec<u8>, destination: Arm64Reg, value: u64) {
+    let halves = [
+        value as u16,
+        (value >> 16) as u16,
+        (value >> 32) as u16,
+        (value >> 48) as u16,
+    ];
+    let first = halves.iter().position(|half| *half != 0).unwrap_or(0);
+    push_word(code, encode_movz(destination, halves[first], first as u8));
+    for (index, half) in halves.into_iter().enumerate() {
+        if index != first && half != 0 {
+            push_word(code, encode_movk(destination, half, index as u8));
+        }
+    }
+}
+
+fn push_word(code: &mut Vec<u8>, instruction: u32) {
+    code.extend_from_slice(&instruction.to_le_bytes());
+}
+
+fn encode_mov_reg(destination: Arm64Reg, source: Arm64Reg) -> u32 {
+    0xaa00_03e0 | (u32::from(source.0) << 16) | u32::from(destination.0)
+}
+
+fn encode_add(destination: Arm64Reg, lhs: Arm64Reg, rhs: Arm64Reg) -> u32 {
+    0x8b00_0000 | (u32::from(rhs.0) << 16) | (u32::from(lhs.0) << 5) | u32::from(destination.0)
+}
+
+fn encode_movz(destination: Arm64Reg, immediate: u16, halfword: u8) -> u32 {
+    0xd280_0000
+        | (u32::from(halfword) << 21)
+        | (u32::from(immediate) << 5)
+        | u32::from(destination.0)
+}
+
+fn encode_movk(destination: Arm64Reg, immediate: u16, halfword: u8) -> u32 {
+    0xf280_0000
+        | (u32::from(halfword) << 21)
+        | (u32::from(immediate) << 5)
+        | u32::from(destination.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn words(code: &[u8]) -> Vec<u32> {
+        code.chunks_exact(4)
+            .map(|bytes| u32::from_le_bytes(bytes.try_into().unwrap()))
+            .collect()
+    }
+
+    fn add_function() -> Function {
+        let mut builder = Function::builder();
+        let lhs = builder.parameter(0);
+        let rhs = builder.parameter(1);
+        let sum = builder.add(lhs, rhs);
+        builder.return_value(sum);
+        builder.finish()
+    }
+
+    #[test]
+    fn emits_aapcs64_add_leaf() {
+        let compiled = compile(&add_function()).unwrap();
+        assert_eq!(
+            words(compiled.code()),
+            vec![
+                0xaa00_03e9, // mov x9, x0
+                0xaa01_03ea, // mov x10, x1
+                0x8b0a_0129, // add x9, x9, x10
+                0xaa09_03e0, // mov x0, x9
+                0xd65f_03c0, // ret
+            ]
+        );
+    }
+
+    #[test]
+    fn materializes_every_nonzero_immediate_halfword() {
+        let mut builder = Function::builder();
+        let value = builder.load_imm(0x1234_5678_9abc_def0);
+        builder.return_value(value);
+        let compiled = compile(&builder.finish()).unwrap();
+        assert_eq!(compiled.code().len(), 6 * 4);
+        assert_eq!(words(compiled.code()).last(), Some(&0xd65f_03c0));
+    }
+
+    #[test]
+    fn reports_bootstrap_register_pressure() {
+        let mut builder = Function::builder();
+        let parameters = (0..8)
+            .map(|index| builder.parameter(index))
+            .collect::<Vec<_>>();
+        let mut sum = parameters[0];
+        for parameter in &parameters[1..] {
+            sum = builder.add(sum, *parameter);
+        }
+        builder.return_value(sum);
+        assert!(matches!(
+            compile(&builder.finish()),
+            Err(CompileError::Regalloc(
+                LinearScanError::RegisterPressure { .. }
+            ))
+        ));
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    unsafe fn execute_binary(function: &CompiledFunction, lhs: u64, rhs: u64) -> u64 {
+        let length = function.code().len();
+        let memory = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                length,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        assert_ne!(memory, libc::MAP_FAILED);
+        unsafe {
+            std::ptr::copy_nonoverlapping(function.code().as_ptr(), memory.cast(), length);
+            clear_cache(memory.cast(), memory.cast::<u8>().add(length));
+        }
+        assert_eq!(
+            unsafe { libc::mprotect(memory, length, libc::PROT_READ | libc::PROT_EXEC) },
+            0
+        );
+        let entry: extern "C" fn(u64, u64) -> u64 = unsafe { std::mem::transmute(memory) };
+        let result = entry(lhs, rhs);
+        assert_eq!(unsafe { libc::munmap(memory, length) }, 0);
+        result
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    unsafe extern "C" {
+        #[link_name = "__clear_cache"]
+        fn clear_cache(begin: *mut u8, end: *mut u8);
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    #[test]
+    fn executes_generated_add_under_aapcs64() {
+        let compiled = compile(&add_function()).unwrap();
+        assert_eq!(unsafe { execute_binary(&compiled, 19, 23) }, 42);
+    }
+}

--- a/crates/celox-backend-arm64/src/lib.rs
+++ b/crates/celox-backend-arm64/src/lib.rs
@@ -6,7 +6,8 @@
 //! lowering and spill support are added.
 
 use celox_backend_common::regalloc::{
-    Allocation, LinearScanError, LiveRange, MachineRegister, allocate_linear_scan,
+    Allocation, BlockAllocationFacts, FunctionAllocationFacts, InstructionAllocationFacts,
+    LinearScanError, LiveRange, MachineRegister, allocate_linear_scan,
 };
 use std::collections::HashMap;
 use std::fmt;
@@ -84,6 +85,32 @@ impl Function {
     pub fn builder() -> FunctionBuilder {
         FunctionBuilder::default()
     }
+
+    /// Project target-owned AArch64 MIR into opcode-free allocator facts.
+    ///
+    /// Keeping this adapter on the target side lets the allocator evolve
+    /// without teaching it the AArch64 instruction enum.
+    fn allocation_facts(&self) -> FunctionAllocationFacts<VReg, Arm64Reg> {
+        let instructions = self
+            .instructions
+            .iter()
+            .copied()
+            .map(|instruction| InstructionAllocationFacts {
+                uses: instruction.uses().into_iter().flatten().collect(),
+                defs: instruction.def().into_iter().collect(),
+                is_copy: false,
+                ..InstructionAllocationFacts::default()
+            })
+            .collect();
+        FunctionAllocationFacts {
+            entry: 0,
+            blocks: vec![BlockAllocationFacts {
+                successors: Vec::new(),
+                phis: Vec::new(),
+                instructions,
+            }],
+        }
+    }
 }
 
 /// Builder which assigns every definition a fresh SSA identity.
@@ -137,6 +164,7 @@ impl FunctionBuilder {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CompileError {
     InvalidMir(String),
+    InvalidAllocationFacts(String),
     Regalloc(LinearScanError<VReg>),
 }
 
@@ -144,6 +172,9 @@ impl fmt::Display for CompileError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::InvalidMir(message) => write!(formatter, "invalid ARM64 MIR: {message}"),
+            Self::InvalidAllocationFacts(message) => {
+                write!(formatter, "invalid ARM64 allocation facts: {message}")
+            }
             Self::Regalloc(error) => write!(formatter, "ARM64 register allocation failed: {error}"),
         }
     }
@@ -177,7 +208,11 @@ impl CompiledFunction {
 /// Verify, allocate, and emit one bootstrap AArch64 function.
 pub fn compile(function: &Function) -> Result<CompiledFunction, CompileError> {
     verify(function)?;
-    let ranges = live_ranges(function)?;
+    let facts = function.allocation_facts();
+    facts
+        .verify()
+        .map_err(|error| CompileError::InvalidAllocationFacts(error.to_string()))?;
+    let ranges = live_ranges(&facts)?;
     let allocation = allocate_linear_scan(&ranges, &ALLOCATABLE_REGS)?;
     let code = emit(function, &allocation);
     Ok(CompiledFunction { code, allocation })
@@ -238,9 +273,12 @@ fn verify(function: &Function) -> Result<(), CompileError> {
     Ok(())
 }
 
-fn live_ranges(function: &Function) -> Result<Vec<LiveRange<VReg>>, CompileError> {
+fn live_ranges(
+    facts: &FunctionAllocationFacts<VReg, Arm64Reg>,
+) -> Result<Vec<LiveRange<VReg>>, CompileError> {
+    let instructions = &facts.blocks[0].instructions;
     let mut ranges = HashMap::<VReg, LiveRange<VReg>>::new();
-    for (index, instruction) in function.instructions.iter().copied().enumerate() {
+    for (index, instruction) in instructions.iter().enumerate() {
         let index = u32::try_from(index)
             .map_err(|_| CompileError::InvalidMir("too many instructions".into()))?;
         let use_point = index
@@ -249,13 +287,13 @@ fn live_ranges(function: &Function) -> Result<Vec<LiveRange<VReg>>, CompileError
         let def_point = use_point
             .checked_add(1)
             .ok_or_else(|| CompileError::InvalidMir("program point overflow".into()))?;
-        for used in instruction.uses().into_iter().flatten() {
+        for &used in &instruction.uses {
             let range = ranges.get_mut(&used).ok_or_else(|| {
                 CompileError::InvalidMir(format!("missing live range for {used:?}"))
             })?;
             range.end = use_point;
         }
-        if let Some(dst) = instruction.def() {
+        for &dst in &instruction.defs {
             ranges.insert(
                 dst,
                 LiveRange {

--- a/crates/celox-backend-arm64/src/lib.rs
+++ b/crates/celox-backend-arm64/src/lib.rs
@@ -11,6 +11,9 @@ use celox_backend_common::regalloc::{
 use std::collections::HashMap;
 use std::fmt;
 
+pub mod jit_mem;
+pub mod scalar;
+
 /// Virtual general-purpose register in bootstrap ARM64 MIR.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct VReg(u32);

--- a/crates/celox-backend-arm64/src/mir.rs
+++ b/crates/celox-backend-arm64/src/mir.rs
@@ -489,10 +489,238 @@ pub(crate) enum MInst {
     },
 }
 
+impl MInst {
+    pub(crate) fn def(&self) -> Option<VReg> {
+        match self {
+            Self::Mov { dst, .. }
+            | Self::Mov32 { dst, .. }
+            | Self::LoadImm { dst, .. }
+            | Self::Scratch { dst }
+            | Self::LoadConstantTableAddr { dst, .. }
+            | Self::Load { dst, .. }
+            | Self::LoadPtr { dst, .. }
+            | Self::LoadIndexed { dst, .. }
+            | Self::PackedLaneCompare { dst, .. }
+            | Self::PackedByteAffineCompare { dst, .. }
+            | Self::LoadPtrIndexed { dst, .. }
+            | Self::Add { dst, .. }
+            | Self::Add32 { dst, .. }
+            | Self::Sub { dst, .. }
+            | Self::Sub32 { dst, .. }
+            | Self::Mul { dst, .. }
+            | Self::Mul32 { dst, .. }
+            | Self::UMulHi { dst, .. }
+            | Self::And { dst, .. }
+            | Self::And32 { dst, .. }
+            | Self::Or { dst, .. }
+            | Self::Or32 { dst, .. }
+            | Self::Xor { dst, .. }
+            | Self::Xor32 { dst, .. }
+            | Self::Shr { dst, .. }
+            | Self::Shl { dst, .. }
+            | Self::Sar { dst, .. }
+            | Self::AndImm { dst, .. }
+            | Self::AndImm32 { dst, .. }
+            | Self::OrImm { dst, .. }
+            | Self::ShrImm { dst, .. }
+            | Self::ShlImm { dst, .. }
+            | Self::SarImm { dst, .. }
+            | Self::AddImm { dst, .. }
+            | Self::SubImm { dst, .. }
+            | Self::Cmp { dst, .. }
+            | Self::CmpImm { dst, .. }
+            | Self::UDiv { dst, .. }
+            | Self::URem { dst, .. }
+            | Self::SDiv { dst, .. }
+            | Self::SRem { dst, .. }
+            | Self::BitNot { dst, .. }
+            | Self::Neg { dst, .. }
+            | Self::Popcnt { dst, .. }
+            | Self::Bsf { dst, .. }
+            | Self::Bsr { dst, .. }
+            | Self::BsrOr { dst, .. }
+            | Self::Pext { dst, .. }
+            | Self::Pdep { dst, .. }
+            | Self::Select { dst, .. }
+            | Self::CmpSelect { dst, .. }
+            | Self::CmpImmSelect { dst, .. }
+            | Self::GuardedCmpSelect { dst, .. } => Some(*dst),
+            Self::Store { .. }
+            | Self::AndStoreImm { .. }
+            | Self::OrStoreImm { .. }
+            | Self::StorePtr { .. }
+            | Self::ReleaseStorePtr { .. }
+            | Self::StoreIndexed { .. }
+            | Self::OrStoreIndexed { .. }
+            | Self::StorePtrIndexed { .. }
+            | Self::ReleaseStorePtrIndexed { .. }
+            | Self::MemCopy { .. }
+            | Self::MemFill { .. }
+            | Self::SparseCommit { .. }
+            | Self::SparseMarkActive { .. }
+            | Self::SparseCommitWorklist { .. }
+            | Self::Branch { .. }
+            | Self::BranchPred { .. }
+            | Self::JumpTable { .. }
+            | Self::Jump { .. }
+            | Self::Return
+            | Self::ReturnError { .. } => None,
+        }
+    }
+
+    pub(crate) fn uses(&self) -> Vec<VReg> {
+        match self {
+            Self::Mov { src, .. } | Self::Mov32 { src, .. } => vec![*src],
+            Self::LoadImm { .. }
+            | Self::Scratch { .. }
+            | Self::LoadConstantTableAddr { .. }
+            | Self::Load { .. }
+            | Self::AndStoreImm { .. }
+            | Self::OrStoreImm { .. }
+            | Self::MemCopy { .. }
+            | Self::MemFill { .. }
+            | Self::SparseCommit { .. }
+            | Self::SparseMarkActive { .. }
+            | Self::SparseCommitWorklist { .. } => Vec::new(),
+            Self::Store { src, .. } => vec![*src],
+            Self::LoadPtr { ptr, .. } => vec![*ptr],
+            Self::StorePtr { ptr, src, .. } | Self::ReleaseStorePtr { ptr, src, .. } => {
+                vec![*ptr, *src]
+            }
+            Self::LoadIndexed { index, .. } => vec![*index],
+            Self::PackedLaneCompare {
+                rhs: PackedLaneCompareRhs::Scalar(value),
+                ..
+            } => vec![*value],
+            Self::PackedLaneCompare {
+                rhs: PackedLaneCompareRhs::Memory { .. },
+                ..
+            } => Vec::new(),
+            Self::PackedByteAffineCompare { base, rhs, .. } => vec![*base, *rhs],
+            Self::StoreIndexed { index, src, .. } | Self::OrStoreIndexed { index, src, .. } => {
+                vec![*index, *src]
+            }
+            Self::LoadPtrIndexed { ptr, index, .. } => vec![*ptr, *index],
+            Self::StorePtrIndexed {
+                ptr, index, src, ..
+            }
+            | Self::ReleaseStorePtrIndexed {
+                ptr, index, src, ..
+            } => vec![*ptr, *index, *src],
+            Self::Add { lhs, rhs, .. }
+            | Self::Add32 { lhs, rhs, .. }
+            | Self::Sub { lhs, rhs, .. }
+            | Self::Sub32 { lhs, rhs, .. }
+            | Self::Mul { lhs, rhs, .. }
+            | Self::Mul32 { lhs, rhs, .. }
+            | Self::UMulHi { lhs, rhs, .. }
+            | Self::And { lhs, rhs, .. }
+            | Self::And32 { lhs, rhs, .. }
+            | Self::Or { lhs, rhs, .. }
+            | Self::Or32 { lhs, rhs, .. }
+            | Self::Xor { lhs, rhs, .. }
+            | Self::Xor32 { lhs, rhs, .. }
+            | Self::Shr { lhs, rhs, .. }
+            | Self::Shl { lhs, rhs, .. }
+            | Self::Sar { lhs, rhs, .. }
+            | Self::Cmp { lhs, rhs, .. }
+            | Self::UDiv { lhs, rhs, .. }
+            | Self::URem { lhs, rhs, .. }
+            | Self::SDiv { lhs, rhs, .. }
+            | Self::SRem { lhs, rhs, .. } => vec![*lhs, *rhs],
+            Self::AndImm { src, .. }
+            | Self::AndImm32 { src, .. }
+            | Self::OrImm { src, .. }
+            | Self::ShrImm { src, .. }
+            | Self::ShlImm { src, .. }
+            | Self::SarImm { src, .. }
+            | Self::AddImm { src, .. }
+            | Self::SubImm { src, .. }
+            | Self::BitNot { src, .. }
+            | Self::Neg { src, .. }
+            | Self::Popcnt { src, .. }
+            | Self::Bsf { src, .. }
+            | Self::Bsr { src, .. }
+            | Self::BsrOr { src, .. } => vec![*src],
+            Self::CmpImm { lhs, .. } => vec![*lhs],
+            Self::Pext { src, mask, .. } | Self::Pdep { src, mask, .. } => vec![*src, *mask],
+            Self::Select {
+                cond,
+                true_val,
+                false_val,
+                ..
+            } => vec![*cond, *true_val, *false_val],
+            Self::CmpSelect {
+                lhs,
+                rhs,
+                true_val,
+                false_val,
+                ..
+            } => vec![*lhs, *rhs, *true_val, *false_val],
+            Self::CmpImmSelect {
+                lhs,
+                true_val,
+                false_val,
+                ..
+            } => vec![*lhs, *true_val, *false_val],
+            Self::GuardedCmpSelect {
+                guard,
+                lhs,
+                rhs,
+                true_val,
+                false_val,
+                ..
+            } => vec![*guard, *lhs, *rhs, *true_val, *false_val],
+            Self::Branch { cond, .. } => vec![*cond],
+            Self::BranchPred {
+                predicate: BranchPredicate::Compare { lhs, rhs, .. },
+                ..
+            } => vec![*lhs, *rhs],
+            Self::BranchPred {
+                predicate: BranchPredicate::CompareImm { lhs, .. },
+                ..
+            } => vec![*lhs],
+            Self::BranchPred {
+                predicate: BranchPredicate::MemoryNonZero { .. },
+                ..
+            } => Vec::new(),
+            Self::JumpTable { index, .. } => vec![*index],
+            Self::Jump { .. } | Self::Return | Self::ReturnError { .. } => Vec::new(),
+        }
+    }
+
+    pub(crate) fn is_copy(&self) -> bool {
+        matches!(self, Self::Mov { .. })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PhiNode {
+    pub(crate) dst: VReg,
+    pub(crate) sources: Vec<(BlockId, VReg)>,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct MBlock {
     pub(crate) id: BlockId,
+    pub(crate) phis: Vec<PhiNode>,
     pub(crate) insts: Vec<MInst>,
+}
+
+impl MBlock {
+    pub(crate) fn successors(&self) -> Vec<BlockId> {
+        match self.insts.last() {
+            Some(MInst::Branch {
+                true_bb, false_bb, ..
+            })
+            | Some(MInst::BranchPred {
+                true_bb, false_bb, ..
+            }) => vec![*true_bb, *false_bb],
+            Some(MInst::JumpTable { targets, .. }) => targets.to_vec(),
+            Some(MInst::Jump { target }) => vec![*target],
+            _ => Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/celox-backend-arm64/src/mir.rs
+++ b/crates/celox-backend-arm64/src/mir.rs
@@ -1,0 +1,522 @@
+//! AArch64 scalar machine IR.
+//!
+//! This is deliberately owned by the AArch64 backend.  The current production
+//! pipeline lowers the established x86 scalar MIR into this form after
+//! allocation; future AArch64 selection, optimization, and allocation can
+//! target the same boundary without teaching the emitter about x86 opcodes.
+
+use std::fmt;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct VReg(pub(crate) u32);
+
+impl fmt::Debug for VReg {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "v{}", self.0)
+    }
+}
+
+impl fmt::Display for VReg {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "v{}", self.0)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct BlockId(pub u32);
+
+impl fmt::Debug for BlockId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "bb{}", self.0)
+    }
+}
+
+impl fmt::Display for BlockId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "bb{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct ConstantTableId(pub(crate) usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) enum OpSize {
+    S8,
+    S16,
+    S32,
+    S64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum BaseReg {
+    SimState,
+    StackFrame,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum CmpKind {
+    Eq,
+    Ne,
+    LtU,
+    LtS,
+    LeU,
+    LeS,
+    GtU,
+    GtS,
+    GeU,
+    GeS,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum BranchPredicate {
+    Compare {
+        lhs: VReg,
+        rhs: VReg,
+        kind: CmpKind,
+    },
+    CompareImm {
+        lhs: VReg,
+        imm: i32,
+        kind: CmpKind,
+    },
+    MemoryNonZero {
+        base: BaseReg,
+        offset: i32,
+        size: OpSize,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum PackedLaneCompareRhs {
+    Scalar(VReg),
+    Memory { offset: i32 },
+}
+
+pub(crate) const SPARSE_COMMIT_DESCRIPTOR_WORDS: usize = 8;
+
+/// Word-level AArch64 operations before physical-register substitution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MInst {
+    Mov {
+        dst: VReg,
+        src: VReg,
+    },
+    Mov32 {
+        dst: VReg,
+        src: VReg,
+    },
+    LoadImm {
+        dst: VReg,
+        value: u64,
+    },
+    Scratch {
+        dst: VReg,
+    },
+    LoadConstantTableAddr {
+        dst: VReg,
+        table: ConstantTableId,
+    },
+    Load {
+        dst: VReg,
+        base: BaseReg,
+        offset: i32,
+        size: OpSize,
+    },
+    Store {
+        base: BaseReg,
+        offset: i32,
+        src: VReg,
+        size: OpSize,
+    },
+    AndStoreImm {
+        base: BaseReg,
+        offset: i32,
+        size: OpSize,
+        imm: u64,
+    },
+    OrStoreImm {
+        base: BaseReg,
+        offset: i32,
+        size: OpSize,
+        imm: u64,
+    },
+    LoadPtr {
+        dst: VReg,
+        ptr: VReg,
+        offset: i32,
+        size: OpSize,
+    },
+    StorePtr {
+        ptr: VReg,
+        offset: i32,
+        src: VReg,
+        size: OpSize,
+    },
+    ReleaseStorePtr {
+        ptr: VReg,
+        offset: i32,
+        src: VReg,
+        size: OpSize,
+    },
+    LoadIndexed {
+        dst: VReg,
+        base: BaseReg,
+        offset: i32,
+        index: VReg,
+        scale: u8,
+        size: OpSize,
+    },
+    PackedLaneCompare {
+        dst: VReg,
+        rhs: PackedLaneCompareRhs,
+        kind: CmpKind,
+        offset: i32,
+        lane_count: u8,
+        element_stride: u8,
+        bit_offset: u8,
+        field_width: u8,
+    },
+    PackedByteAffineCompare {
+        dst: VReg,
+        base: VReg,
+        rhs: VReg,
+        kind: CmpKind,
+    },
+    StoreIndexed {
+        base: BaseReg,
+        offset: i32,
+        index: VReg,
+        src: VReg,
+        size: OpSize,
+    },
+    OrStoreIndexed {
+        base: BaseReg,
+        offset: i32,
+        index: VReg,
+        src: VReg,
+        size: OpSize,
+    },
+    LoadPtrIndexed {
+        dst: VReg,
+        ptr: VReg,
+        offset: i32,
+        index: VReg,
+        size: OpSize,
+    },
+    StorePtrIndexed {
+        ptr: VReg,
+        offset: i32,
+        index: VReg,
+        src: VReg,
+        size: OpSize,
+    },
+    ReleaseStorePtrIndexed {
+        ptr: VReg,
+        offset: i32,
+        index: VReg,
+        src: VReg,
+        size: OpSize,
+    },
+    MemCopy {
+        src_offset: i32,
+        dst_offset: i32,
+        byte_len: usize,
+    },
+    MemFill {
+        dst_offset: i32,
+        byte_len: usize,
+        value: u8,
+    },
+    SparseCommit {
+        src_offset: i32,
+        dst_offset: i32,
+        byte_size: usize,
+        dirty_words_offset: i32,
+        dirty_word_count: usize,
+        summary_words_offset: i32,
+        summary_word_count: usize,
+        four_state: bool,
+    },
+    SparseMarkActive {
+        active_index: u32,
+        active_bits_offset: i32,
+        active_capacity: usize,
+    },
+    SparseCommitWorklist {
+        descriptor_table: ConstantTableId,
+        active_bits_offset: i32,
+        active_capacity: usize,
+    },
+    Add {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    Add32 {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    Sub {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    Sub32 {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    Mul {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    Mul32 {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    UMulHi {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    And {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    And32 {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    Or {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    Or32 {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    Xor {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    Xor32 {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    Shr {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    Shl {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    Sar {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    AndImm {
+        dst: VReg,
+        src: VReg,
+        imm: u64,
+    },
+    AndImm32 {
+        dst: VReg,
+        src: VReg,
+        imm: u32,
+    },
+    OrImm {
+        dst: VReg,
+        src: VReg,
+        imm: u64,
+    },
+    ShrImm {
+        dst: VReg,
+        src: VReg,
+        imm: u8,
+    },
+    ShlImm {
+        dst: VReg,
+        src: VReg,
+        imm: u8,
+    },
+    SarImm {
+        dst: VReg,
+        src: VReg,
+        imm: u8,
+    },
+    AddImm {
+        dst: VReg,
+        src: VReg,
+        imm: i32,
+    },
+    SubImm {
+        dst: VReg,
+        src: VReg,
+        imm: i32,
+    },
+    Cmp {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+        kind: CmpKind,
+    },
+    CmpImm {
+        dst: VReg,
+        lhs: VReg,
+        imm: i32,
+        kind: CmpKind,
+    },
+    UDiv {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    URem {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    SDiv {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    SRem {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+    },
+    BitNot {
+        dst: VReg,
+        src: VReg,
+    },
+    Neg {
+        dst: VReg,
+        src: VReg,
+    },
+    Popcnt {
+        dst: VReg,
+        src: VReg,
+    },
+    Bsf {
+        dst: VReg,
+        src: VReg,
+    },
+    Bsr {
+        dst: VReg,
+        src: VReg,
+    },
+    BsrOr {
+        dst: VReg,
+        src: VReg,
+        zero_value: u8,
+    },
+    Pext {
+        dst: VReg,
+        src: VReg,
+        mask: VReg,
+    },
+    Pdep {
+        dst: VReg,
+        src: VReg,
+        mask: VReg,
+    },
+    Select {
+        dst: VReg,
+        cond: VReg,
+        true_val: VReg,
+        false_val: VReg,
+    },
+    CmpSelect {
+        dst: VReg,
+        lhs: VReg,
+        rhs: VReg,
+        kind: CmpKind,
+        true_val: VReg,
+        false_val: VReg,
+    },
+    CmpImmSelect {
+        dst: VReg,
+        lhs: VReg,
+        imm: i32,
+        kind: CmpKind,
+        true_val: VReg,
+        false_val: VReg,
+    },
+    GuardedCmpSelect {
+        dst: VReg,
+        guard: VReg,
+        lhs: VReg,
+        rhs: VReg,
+        kind: CmpKind,
+        true_val: VReg,
+        false_val: VReg,
+    },
+    Branch {
+        cond: VReg,
+        true_bb: BlockId,
+        false_bb: BlockId,
+    },
+    BranchPred {
+        predicate: BranchPredicate,
+        true_bb: BlockId,
+        false_bb: BlockId,
+    },
+    JumpTable {
+        index: VReg,
+        targets: Box<[BlockId]>,
+    },
+    Jump {
+        target: BlockId,
+    },
+    Return,
+    ReturnError {
+        code: i64,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MBlock {
+    pub(crate) id: BlockId,
+    pub(crate) insts: Vec<MInst>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MFunction {
+    pub(crate) blocks: Vec<MBlock>,
+    constant_tables: Vec<Vec<u64>>,
+}
+
+impl MFunction {
+    pub(crate) fn new(blocks: Vec<MBlock>, constant_tables: Vec<Vec<u64>>) -> Self {
+        Self {
+            blocks,
+            constant_tables,
+        }
+    }
+
+    pub(crate) fn constant_tables(&self) -> &[Vec<u64>] {
+        &self.constant_tables
+    }
+}
+
+/// Complete codegen-ready artifact produced at the AArch64 MIR boundary.
+pub(crate) struct AllocatedFunction {
+    pub(crate) function: MFunction,
+    pub(crate) assignment: crate::allocation::Assignment<VReg>,
+    pub(crate) edge_copies: crate::allocation::EdgeCopyPlan<BlockId>,
+}

--- a/crates/celox-backend-arm64/src/mir.rs
+++ b/crates/celox-backend-arm64/src/mir.rs
@@ -1,10 +1,12 @@
 //! AArch64 scalar machine IR.
 //!
-//! This is deliberately owned by the AArch64 backend.  The current production
-//! pipeline lowers the established x86 scalar MIR into this form after
-//! allocation; future AArch64 selection, optimization, and allocation can
-//! target the same boundary without teaching the emitter about x86 opcodes.
+//! This is deliberately owned by the AArch64 backend. The current production
+//! pipeline lowers optimized x86 scalar MIR into this form before allocation,
+//! then performs spilling, coloring, and SSA destruction here. Future AArch64
+//! instruction selection can target the same boundary without teaching the
+//! emitter about x86 opcodes.
 
+use std::collections::BTreeMap;
 use std::fmt;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -112,6 +114,10 @@ pub(crate) enum MInst {
     },
     Scratch {
         dst: VReg,
+    },
+    /// Allocation-only edge use. Emission intentionally produces no code.
+    KeepAlive {
+        src: VReg,
     },
     LoadConstantTableAddr {
         dst: VReg,
@@ -546,6 +552,86 @@ impl MInst {
             | Self::CmpImmSelect { dst, .. }
             | Self::GuardedCmpSelect { dst, .. } => Some(*dst),
             Self::Store { .. }
+            | Self::KeepAlive { .. }
+            | Self::AndStoreImm { .. }
+            | Self::OrStoreImm { .. }
+            | Self::StorePtr { .. }
+            | Self::ReleaseStorePtr { .. }
+            | Self::StoreIndexed { .. }
+            | Self::OrStoreIndexed { .. }
+            | Self::StorePtrIndexed { .. }
+            | Self::ReleaseStorePtrIndexed { .. }
+            | Self::MemCopy { .. }
+            | Self::MemFill { .. }
+            | Self::SparseCommit { .. }
+            | Self::SparseMarkActive { .. }
+            | Self::SparseCommitWorklist { .. }
+            | Self::Branch { .. }
+            | Self::BranchPred { .. }
+            | Self::JumpTable { .. }
+            | Self::Jump { .. }
+            | Self::Return
+            | Self::ReturnError { .. } => None,
+        }
+    }
+
+    pub(crate) fn def_mut(&mut self) -> Option<&mut VReg> {
+        match self {
+            Self::Mov { dst, .. }
+            | Self::Mov32 { dst, .. }
+            | Self::LoadImm { dst, .. }
+            | Self::Scratch { dst }
+            | Self::LoadConstantTableAddr { dst, .. }
+            | Self::Load { dst, .. }
+            | Self::LoadPtr { dst, .. }
+            | Self::LoadIndexed { dst, .. }
+            | Self::PackedLaneCompare { dst, .. }
+            | Self::PackedByteAffineCompare { dst, .. }
+            | Self::LoadPtrIndexed { dst, .. }
+            | Self::Add { dst, .. }
+            | Self::Add32 { dst, .. }
+            | Self::Sub { dst, .. }
+            | Self::Sub32 { dst, .. }
+            | Self::Mul { dst, .. }
+            | Self::Mul32 { dst, .. }
+            | Self::UMulHi { dst, .. }
+            | Self::And { dst, .. }
+            | Self::And32 { dst, .. }
+            | Self::Or { dst, .. }
+            | Self::Or32 { dst, .. }
+            | Self::Xor { dst, .. }
+            | Self::Xor32 { dst, .. }
+            | Self::Shr { dst, .. }
+            | Self::Shl { dst, .. }
+            | Self::Sar { dst, .. }
+            | Self::AndImm { dst, .. }
+            | Self::AndImm32 { dst, .. }
+            | Self::OrImm { dst, .. }
+            | Self::ShrImm { dst, .. }
+            | Self::ShlImm { dst, .. }
+            | Self::SarImm { dst, .. }
+            | Self::AddImm { dst, .. }
+            | Self::SubImm { dst, .. }
+            | Self::Cmp { dst, .. }
+            | Self::CmpImm { dst, .. }
+            | Self::UDiv { dst, .. }
+            | Self::URem { dst, .. }
+            | Self::SDiv { dst, .. }
+            | Self::SRem { dst, .. }
+            | Self::BitNot { dst, .. }
+            | Self::Neg { dst, .. }
+            | Self::Popcnt { dst, .. }
+            | Self::Bsf { dst, .. }
+            | Self::Bsr { dst, .. }
+            | Self::BsrOr { dst, .. }
+            | Self::Pext { dst, .. }
+            | Self::Pdep { dst, .. }
+            | Self::Select { dst, .. }
+            | Self::CmpSelect { dst, .. }
+            | Self::CmpImmSelect { dst, .. }
+            | Self::GuardedCmpSelect { dst, .. } => Some(dst),
+            Self::Store { .. }
+            | Self::KeepAlive { .. }
             | Self::AndStoreImm { .. }
             | Self::OrStoreImm { .. }
             | Self::StorePtr { .. }
@@ -570,7 +656,7 @@ impl MInst {
 
     pub(crate) fn uses(&self) -> Vec<VReg> {
         match self {
-            Self::Mov { src, .. } | Self::Mov32 { src, .. } => vec![*src],
+            Self::Mov { src, .. } | Self::Mov32 { src, .. } | Self::KeepAlive { src } => vec![*src],
             Self::LoadImm { .. }
             | Self::Scratch { .. }
             | Self::LoadConstantTableAddr { .. }
@@ -689,6 +775,178 @@ impl MInst {
         }
     }
 
+    pub(crate) fn rewrite_use(&mut self, old: VReg, new: VReg) {
+        let rewrite = |value: &mut VReg| {
+            if *value == old {
+                *value = new;
+            }
+        };
+        match self {
+            Self::Mov { src, .. }
+            | Self::Mov32 { src, .. }
+            | Self::KeepAlive { src }
+            | Self::Store { src, .. } => {
+                rewrite(src);
+            }
+            Self::LoadPtr { ptr, .. } => rewrite(ptr),
+            Self::StorePtr { ptr, src, .. } | Self::ReleaseStorePtr { ptr, src, .. } => {
+                rewrite(ptr);
+                rewrite(src);
+            }
+            Self::LoadIndexed { index, .. } => rewrite(index),
+            Self::PackedLaneCompare {
+                rhs: PackedLaneCompareRhs::Scalar(value),
+                ..
+            } => rewrite(value),
+            Self::PackedByteAffineCompare { base, rhs, .. } => {
+                rewrite(base);
+                rewrite(rhs);
+            }
+            Self::StoreIndexed { index, src, .. } | Self::OrStoreIndexed { index, src, .. } => {
+                rewrite(index);
+                rewrite(src);
+            }
+            Self::LoadPtrIndexed { ptr, index, .. } => {
+                rewrite(ptr);
+                rewrite(index);
+            }
+            Self::StorePtrIndexed {
+                ptr, index, src, ..
+            }
+            | Self::ReleaseStorePtrIndexed {
+                ptr, index, src, ..
+            } => {
+                rewrite(ptr);
+                rewrite(index);
+                rewrite(src);
+            }
+            Self::Add { lhs, rhs, .. }
+            | Self::Add32 { lhs, rhs, .. }
+            | Self::Sub { lhs, rhs, .. }
+            | Self::Sub32 { lhs, rhs, .. }
+            | Self::Mul { lhs, rhs, .. }
+            | Self::Mul32 { lhs, rhs, .. }
+            | Self::UMulHi { lhs, rhs, .. }
+            | Self::And { lhs, rhs, .. }
+            | Self::And32 { lhs, rhs, .. }
+            | Self::Or { lhs, rhs, .. }
+            | Self::Or32 { lhs, rhs, .. }
+            | Self::Xor { lhs, rhs, .. }
+            | Self::Xor32 { lhs, rhs, .. }
+            | Self::Shr { lhs, rhs, .. }
+            | Self::Shl { lhs, rhs, .. }
+            | Self::Sar { lhs, rhs, .. }
+            | Self::Cmp { lhs, rhs, .. }
+            | Self::UDiv { lhs, rhs, .. }
+            | Self::URem { lhs, rhs, .. }
+            | Self::SDiv { lhs, rhs, .. }
+            | Self::SRem { lhs, rhs, .. } => {
+                rewrite(lhs);
+                rewrite(rhs);
+            }
+            Self::AndImm { src, .. }
+            | Self::AndImm32 { src, .. }
+            | Self::OrImm { src, .. }
+            | Self::ShrImm { src, .. }
+            | Self::ShlImm { src, .. }
+            | Self::SarImm { src, .. }
+            | Self::AddImm { src, .. }
+            | Self::SubImm { src, .. }
+            | Self::BitNot { src, .. }
+            | Self::Neg { src, .. }
+            | Self::Popcnt { src, .. }
+            | Self::Bsf { src, .. }
+            | Self::Bsr { src, .. }
+            | Self::BsrOr { src, .. } => rewrite(src),
+            Self::CmpImm { lhs, .. } => rewrite(lhs),
+            Self::Pext { src, mask, .. } | Self::Pdep { src, mask, .. } => {
+                rewrite(src);
+                rewrite(mask);
+            }
+            Self::Select {
+                cond,
+                true_val,
+                false_val,
+                ..
+            } => {
+                rewrite(cond);
+                rewrite(true_val);
+                rewrite(false_val);
+            }
+            Self::CmpSelect {
+                lhs,
+                rhs,
+                true_val,
+                false_val,
+                ..
+            } => {
+                rewrite(lhs);
+                rewrite(rhs);
+                rewrite(true_val);
+                rewrite(false_val);
+            }
+            Self::CmpImmSelect {
+                lhs,
+                true_val,
+                false_val,
+                ..
+            } => {
+                rewrite(lhs);
+                rewrite(true_val);
+                rewrite(false_val);
+            }
+            Self::GuardedCmpSelect {
+                guard,
+                lhs,
+                rhs,
+                true_val,
+                false_val,
+                ..
+            } => {
+                rewrite(guard);
+                rewrite(lhs);
+                rewrite(rhs);
+                rewrite(true_val);
+                rewrite(false_val);
+            }
+            Self::Branch { cond, .. } => rewrite(cond),
+            Self::BranchPred {
+                predicate: BranchPredicate::Compare { lhs, rhs, .. },
+                ..
+            } => {
+                rewrite(lhs);
+                rewrite(rhs);
+            }
+            Self::BranchPred {
+                predicate: BranchPredicate::CompareImm { lhs, .. },
+                ..
+            } => rewrite(lhs),
+            Self::JumpTable { index, .. } => rewrite(index),
+            Self::LoadImm { .. }
+            | Self::Scratch { .. }
+            | Self::LoadConstantTableAddr { .. }
+            | Self::Load { .. }
+            | Self::AndStoreImm { .. }
+            | Self::OrStoreImm { .. }
+            | Self::PackedLaneCompare {
+                rhs: PackedLaneCompareRhs::Memory { .. },
+                ..
+            }
+            | Self::MemCopy { .. }
+            | Self::MemFill { .. }
+            | Self::SparseCommit { .. }
+            | Self::SparseMarkActive { .. }
+            | Self::SparseCommitWorklist { .. }
+            | Self::BranchPred {
+                predicate: BranchPredicate::MemoryNonZero { .. },
+                ..
+            }
+            | Self::Jump { .. }
+            | Self::Return
+            | Self::ReturnError { .. } => {}
+        }
+    }
+
     pub(crate) fn is_copy(&self) -> bool {
         matches!(self, Self::Mov { .. })
     }
@@ -698,6 +956,19 @@ impl MInst {
 pub(crate) struct PhiNode {
     pub(crate) dst: VReg,
     pub(crate) sources: Vec<(BlockId, VReg)>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum SpilledPhiSource {
+    Value(VReg),
+    Stack(i32),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SpilledPhiNode {
+    pub(crate) successor: BlockId,
+    pub(crate) destination: i32,
+    pub(crate) sources: Vec<(BlockId, SpilledPhiSource)>,
 }
 
 #[derive(Debug, Clone)]
@@ -727,6 +998,8 @@ impl MBlock {
 pub(crate) struct MFunction {
     pub(crate) blocks: Vec<MBlock>,
     constant_tables: Vec<Vec<u64>>,
+    pub(crate) spill_homes: BTreeMap<VReg, i32>,
+    pub(crate) spilled_phis: Vec<SpilledPhiNode>,
 }
 
 impl MFunction {
@@ -734,6 +1007,8 @@ impl MFunction {
         Self {
             blocks,
             constant_tables,
+            spill_homes: BTreeMap::new(),
+            spilled_phis: Vec::new(),
         }
     }
 

--- a/crates/celox-backend-arm64/src/regalloc.rs
+++ b/crates/celox-backend-arm64/src/regalloc.rs
@@ -1,11 +1,12 @@
 //! AArch64 register-allocation boundary.
 //!
-//! Target MIR is projected into opcode-free facts consumed by shared analyses.
-//! The production pipeline still imports a mature allocation through the
-//! legacy bridge, but that result is independently checked here against the
-//! AArch64 MIR and register file before emission.
+//! Target MIR is projected into opcode-free facts consumed by shared analyses,
+//! then colored against the AArch64 register file. The legacy bridge still
+//! supplies spill placement while target-native spill insertion is developed;
+//! it no longer supplies physical register colors.
 
-use std::collections::HashMap;
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 
 use celox_backend_common::regalloc::{
@@ -14,6 +15,7 @@ use celox_backend_common::regalloc::{
 };
 
 use crate::Arm64Reg;
+use crate::allocation::{Assignment, CopyDestination, CopyOperation, CopySource, EdgeCopyPlan};
 use crate::mir::{AllocatedFunction, BlockId, MFunction, VReg};
 
 pub(crate) type AllocationFacts = FunctionAllocationFacts<VReg, Arm64Reg>;
@@ -43,6 +45,14 @@ pub(crate) enum TargetRegallocError {
         left: VReg,
         right: VReg,
         register: Arm64Reg,
+    },
+    RegisterPressure {
+        value: VReg,
+    },
+    ParallelCopy {
+        predecessor: BlockId,
+        successor: BlockId,
+        message: String,
     },
 }
 
@@ -87,6 +97,18 @@ impl fmt::Display for TargetRegallocError {
                 formatter,
                 "AArch64 {block} point {instruction} keeps {left} and {right} live in x{}",
                 register.number()
+            ),
+            Self::RegisterPressure { value } => write!(
+                formatter,
+                "AArch64 register pressure cannot assign {value} without spilling"
+            ),
+            Self::ParallelCopy {
+                predecessor,
+                successor,
+                message,
+            } => write!(
+                formatter,
+                "AArch64 parallel copy on {predecessor} -> {successor}: {message}"
             ),
         }
     }
@@ -180,7 +202,8 @@ pub(crate) fn verify_allocated(function: &AllocatedFunction) -> Result<(), Targe
                         value,
                     });
                 };
-                if !(1..=15).contains(&register.number()) {
+                if !(1..=15).contains(&register.number()) && !(19..=28).contains(&register.number())
+                {
                     return Err(TargetRegallocError::ReservedAssignment {
                         block: block.id,
                         instruction: instruction_index,
@@ -192,6 +215,222 @@ pub(crate) fn verify_allocated(function: &AllocatedFunction) -> Result<(), Targe
         }
     }
     verify_interval_registers(function, &intervals)
+}
+
+const ALLOCATABLE_REGISTERS: [Arm64Reg; 25] = [
+    Arm64Reg::new(1),
+    Arm64Reg::new(2),
+    Arm64Reg::new(3),
+    Arm64Reg::new(4),
+    Arm64Reg::new(5),
+    Arm64Reg::new(6),
+    Arm64Reg::new(7),
+    Arm64Reg::new(8),
+    Arm64Reg::new(9),
+    Arm64Reg::new(10),
+    Arm64Reg::new(11),
+    Arm64Reg::new(12),
+    Arm64Reg::new(13),
+    Arm64Reg::new(14),
+    Arm64Reg::new(15),
+    Arm64Reg::new(19),
+    Arm64Reg::new(20),
+    Arm64Reg::new(21),
+    Arm64Reg::new(22),
+    Arm64Reg::new(23),
+    Arm64Reg::new(24),
+    Arm64Reg::new(25),
+    Arm64Reg::new(26),
+    Arm64Reg::new(27),
+    Arm64Reg::new(28),
+];
+
+/// Allocate AArch64-owned target MIR without importing x86 register colors.
+///
+/// This first target-native path intentionally reports pressure instead of
+/// hiding a spill policy. Spill/reload insertion is the next AArch64-owned
+/// layer and can preserve this coloring and edge-copy boundary.
+pub(crate) fn allocate_without_spills(
+    function: MFunction,
+) -> Result<AllocatedFunction, TargetRegallocError> {
+    let facts = build_facts(&function)?;
+    let intervals = analyze_live_intervals(&facts)
+        .map_err(|error| TargetRegallocError::InvalidFacts(error.to_string()))?;
+    let assignment = color_intervals(&function, &intervals)?;
+    let edge_copies = build_edge_copies(&function, &assignment)?;
+    let allocated = AllocatedFunction {
+        function,
+        assignment,
+        edge_copies,
+    };
+    verify_allocated(&allocated)?;
+    Ok(allocated)
+}
+
+fn color_intervals(
+    function: &MFunction,
+    intervals: &celox_backend_common::regalloc::LiveIntervals<VReg>,
+) -> Result<Assignment<VReg>, TargetRegallocError> {
+    let mut interference = intervals
+        .iter()
+        .map(|(&value, _)| (value, BTreeSet::new()))
+        .collect::<BTreeMap<_, _>>();
+    for block in 0..function.blocks.len() {
+        let mut segments = intervals
+            .iter()
+            .filter_map(|(&value, interval)| {
+                interval
+                    .segment_in_block(block)
+                    .map(|segment| (segment.start, segment.end, value))
+            })
+            .collect::<Vec<_>>();
+        segments.sort_unstable();
+        let mut active = Vec::<(u64, VReg)>::new();
+        for (start, end, value) in segments {
+            active.retain(|(active_end, _)| *active_end > start);
+            for &(_, other) in &active {
+                interference.entry(value).or_default().insert(other);
+                interference.entry(other).or_default().insert(value);
+            }
+            active.push((end, value));
+        }
+    }
+
+    let mut affinities = BTreeMap::<VReg, BTreeSet<VReg>>::new();
+    for block in &function.blocks {
+        for phi in &block.phis {
+            for &(_, source) in &phi.sources {
+                affinities.entry(phi.dst).or_default().insert(source);
+                affinities.entry(source).or_default().insert(phi.dst);
+            }
+        }
+    }
+    let mut order = interference
+        .iter()
+        .map(|(&value, neighbors)| (Reverse(neighbors.len()), value))
+        .collect::<Vec<_>>();
+    order.sort_unstable();
+
+    let mut assignment = Assignment::default();
+    for (_, value) in order {
+        let used = interference[&value]
+            .iter()
+            .filter_map(|neighbor| assignment.get(neighbor))
+            .collect::<BTreeSet<_>>();
+        let preferred = affinities
+            .get(&value)
+            .into_iter()
+            .flatten()
+            .filter_map(|neighbor| assignment.get(neighbor))
+            .find(|register| !used.contains(register));
+        let register = preferred
+            .or_else(|| {
+                ALLOCATABLE_REGISTERS
+                    .iter()
+                    .copied()
+                    .find(|register| !used.contains(register))
+            })
+            .ok_or(TargetRegallocError::RegisterPressure { value })?;
+        assignment.set(value, register);
+    }
+    Ok(assignment)
+}
+
+fn build_edge_copies(
+    function: &MFunction,
+    assignment: &Assignment<VReg>,
+) -> Result<EdgeCopyPlan<BlockId>, TargetRegallocError> {
+    use celox_backend_common::regalloc as common;
+
+    let mut plan = EdgeCopyPlan::default();
+    for successor in &function.blocks {
+        let mut rows_by_predecessor =
+            BTreeMap::<BlockId, Vec<common::ParallelCopy<Arm64Reg>>>::new();
+        for phi in &successor.phis {
+            let destination =
+                assignment
+                    .get(&phi.dst)
+                    .ok_or(TargetRegallocError::MissingAssignment {
+                        block: successor.id,
+                        instruction: 0,
+                        value: phi.dst,
+                    })?;
+            for &(predecessor, source_value) in &phi.sources {
+                let source = assignment.get(&source_value).ok_or(
+                    TargetRegallocError::MissingAssignment {
+                        block: predecessor,
+                        instruction: 0,
+                        value: source_value,
+                    },
+                )?;
+                rows_by_predecessor
+                    .entry(predecessor)
+                    .or_default()
+                    .push(common::ParallelCopy {
+                        destination: common::CopyDestination::Register(destination),
+                        source: common::CopySource::Register(source),
+                    });
+            }
+        }
+        for (predecessor, rows) in rows_by_predecessor {
+            let resolution = common::resolve_parallel_copies(&rows).map_err(|error| {
+                TargetRegallocError::ParallelCopy {
+                    predecessor,
+                    successor: successor.id,
+                    message: error.to_string(),
+                }
+            })?;
+            let operations = resolution
+                .operations
+                .into_iter()
+                .map(|operation| match operation {
+                    common::CopyOperation::Move {
+                        destination,
+                        source,
+                    } => CopyOperation::Move {
+                        destination: adapt_copy_destination(destination),
+                        source: adapt_copy_source(source),
+                    },
+                    common::CopyOperation::SwapRegisters { left, right } => {
+                        CopyOperation::SwapRegisters { left, right }
+                    }
+                    common::CopyOperation::SaveTemporary(destination) => {
+                        CopyOperation::SaveTemporary(adapt_copy_destination(destination))
+                    }
+                    common::CopyOperation::RestoreTemporary(destination) => {
+                        CopyOperation::RestoreTemporary(adapt_copy_destination(destination))
+                    }
+                })
+                .collect();
+            plan.insert(predecessor, successor.id, operations);
+        }
+    }
+    Ok(plan)
+}
+
+fn adapt_copy_destination(
+    destination: celox_backend_common::regalloc::CopyDestination<Arm64Reg>,
+) -> CopyDestination {
+    match destination {
+        celox_backend_common::regalloc::CopyDestination::Register(register) => {
+            CopyDestination::Register(register)
+        }
+        celox_backend_common::regalloc::CopyDestination::Stack(offset) => {
+            CopyDestination::Stack(offset)
+        }
+    }
+}
+
+fn adapt_copy_source(source: celox_backend_common::regalloc::CopySource<Arm64Reg>) -> CopySource {
+    match source {
+        celox_backend_common::regalloc::CopySource::Register(register) => {
+            CopySource::Register(register)
+        }
+        celox_backend_common::regalloc::CopySource::Stack(offset) => CopySource::Stack(offset),
+        celox_backend_common::regalloc::CopySource::Immediate(value) => {
+            CopySource::Immediate(value)
+        }
+    }
 }
 
 fn verify_interval_registers(
@@ -239,7 +478,7 @@ fn verify_interval_registers(
 mod tests {
     use super::*;
     use crate::allocation::{Assignment, EdgeCopyPlan};
-    use crate::mir::{MBlock, MInst, PhiNode};
+    use crate::mir::{BaseReg, MBlock, MInst, OpSize, PhiNode};
 
     fn diamond_function() -> MFunction {
         let entry = MBlock {
@@ -376,5 +615,121 @@ mod tests {
                 ..
             }) if register == Arm64Reg::new(1)
         ));
+    }
+
+    #[test]
+    fn allocates_target_owned_mir_without_legacy_colors() {
+        let allocated = allocate_without_spills(diamond_function()).unwrap();
+
+        for value in [VReg(0), VReg(1), VReg(2), VReg(3)] {
+            let register = allocated.assignment.get(&value).unwrap();
+            assert!(
+                (1..=15).contains(&register.number()) || (19..=28).contains(&register.number())
+            );
+        }
+        verify_allocated(&allocated).unwrap();
+    }
+
+    #[test]
+    fn lowers_target_phi_rows_with_the_common_copy_resolver() {
+        let predecessor = MBlock {
+            id: BlockId(0),
+            phis: Vec::new(),
+            insts: vec![
+                MInst::LoadImm {
+                    dst: VReg(0),
+                    value: 7,
+                },
+                MInst::Jump { target: BlockId(1) },
+            ],
+        };
+        let successor = MBlock {
+            id: BlockId(1),
+            phis: vec![PhiNode {
+                dst: VReg(1),
+                sources: vec![(BlockId(0), VReg(0))],
+            }],
+            insts: vec![MInst::Return],
+        };
+        let function = MFunction::new(vec![predecessor, successor], Vec::new());
+        let mut assignment = Assignment::default();
+        assignment.set(VReg(0), Arm64Reg::new(1));
+        assignment.set(VReg(1), Arm64Reg::new(2));
+
+        let copies = build_edge_copies(&function, &assignment).unwrap();
+
+        assert_eq!(
+            copies.edge(BlockId(0), BlockId(1)),
+            Some(
+                [CopyOperation::Move {
+                    destination: CopyDestination::Register(Arm64Reg::new(2)),
+                    source: CopySource::Register(Arm64Reg::new(1)),
+                }]
+                .as_slice()
+            )
+        );
+    }
+
+    #[test]
+    fn reports_pressure_before_spill_support_is_enabled() {
+        let mut instructions = (0..26)
+            .map(|value| MInst::LoadImm {
+                dst: VReg(value),
+                value: u64::from(value),
+            })
+            .collect::<Vec<_>>();
+        instructions.extend((0..26).map(|value| MInst::Store {
+            base: BaseReg::SimState,
+            offset: value * 8,
+            src: VReg(value as u32),
+            size: OpSize::S64,
+        }));
+        instructions.push(MInst::Return);
+        let function = MFunction::new(
+            vec![MBlock {
+                id: BlockId(0),
+                phis: Vec::new(),
+                insts: instructions,
+            }],
+            Vec::new(),
+        );
+
+        assert!(matches!(
+            allocate_without_spills(function),
+            Err(TargetRegallocError::RegisterPressure { .. })
+        ));
+    }
+
+    #[test]
+    fn uses_preserved_registers_above_caller_saved_pressure() {
+        let mut instructions = (0..16)
+            .map(|value| MInst::LoadImm {
+                dst: VReg(value),
+                value: u64::from(value),
+            })
+            .collect::<Vec<_>>();
+        instructions.extend((0..16).map(|value| MInst::Store {
+            base: BaseReg::SimState,
+            offset: value * 8,
+            src: VReg(value as u32),
+            size: OpSize::S64,
+        }));
+        instructions.push(MInst::Return);
+        let allocated = allocate_without_spills(MFunction::new(
+            vec![MBlock {
+                id: BlockId(0),
+                phis: Vec::new(),
+                insts: instructions,
+            }],
+            Vec::new(),
+        ))
+        .unwrap();
+
+        assert!(
+            allocated
+                .assignment
+                .iter()
+                .any(|(_, register)| (19..=28).contains(&register.number()))
+        );
     }
 }

--- a/crates/celox-backend-arm64/src/regalloc.rs
+++ b/crates/celox-backend-arm64/src/regalloc.rs
@@ -1,9 +1,9 @@
 //! AArch64 register-allocation boundary.
 //!
 //! Target MIR is projected into opcode-free facts consumed by shared analyses,
-//! then colored against the AArch64 register file. The legacy bridge still
-//! supplies spill placement while target-native spill insertion is developed;
-//! it no longer supplies physical register colors.
+//! then spilled and colored against the AArch64 register file. Phi lowering and
+//! edge-copy scheduling also remain target-owned; only opcode-free allocation
+//! analyses and algorithms are shared.
 
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -16,7 +16,7 @@ use celox_backend_common::regalloc::{
 
 use crate::Arm64Reg;
 use crate::allocation::{Assignment, CopyDestination, CopyOperation, CopySource, EdgeCopyPlan};
-use crate::mir::{AllocatedFunction, BlockId, MFunction, VReg};
+use crate::mir::{AllocatedFunction, BlockId, MFunction, MInst, VReg};
 
 pub(crate) type AllocationFacts = FunctionAllocationFacts<VReg, Arm64Reg>;
 
@@ -54,6 +54,10 @@ pub(crate) enum TargetRegallocError {
         successor: BlockId,
         message: String,
     },
+    UnspillablePressure {
+        value: VReg,
+    },
+    SpillFrameOverflow,
 }
 
 impl fmt::Display for TargetRegallocError {
@@ -110,6 +114,13 @@ impl fmt::Display for TargetRegallocError {
                 formatter,
                 "AArch64 parallel copy on {predecessor} -> {successor}: {message}"
             ),
+            Self::UnspillablePressure { value } => write!(
+                formatter,
+                "AArch64 register pressure at {value} involves only unspillable scratch values"
+            ),
+            Self::SpillFrameOverflow => {
+                formatter.write_str("AArch64 spill frame exceeds the supported i32 offset range")
+            }
         }
     }
 }
@@ -245,6 +256,370 @@ const ALLOCATABLE_REGISTERS: [Arm64Reg; 25] = [
     Arm64Reg::new(28),
 ];
 
+pub(crate) struct TargetAllocation {
+    pub(crate) allocated: AllocatedFunction,
+    pub(crate) spill_frame_size: u32,
+}
+
+/// Allocate target MIR, inserting simple AArch64-owned stack spills when the
+/// interference graph does not fit the register file.
+///
+/// SSA values are split into one stack home, short definition temporaries, and
+/// per-instruction reload temporaries. Spilled phis become target edge copies
+/// whose sources and destinations may be stack slots; register sources receive
+/// allocation-only edge uses to keep them live until the copy. This keeps spill
+/// policy and rewriting on the target side.
+pub(crate) fn allocate_with_spills(
+    mut function: MFunction,
+) -> Result<TargetAllocation, TargetRegallocError> {
+    let initial_facts = build_facts(&function)?;
+    let mut candidates = initial_facts
+        .blocks
+        .iter()
+        .flat_map(|block| {
+            block.phis.iter().map(|phi| phi.destination).chain(
+                block
+                    .instructions
+                    .iter()
+                    .flat_map(|instruction| instruction.defs.iter().copied()),
+            )
+        })
+        .collect::<BTreeSet<_>>();
+    for block in &function.blocks {
+        for instruction in &block.insts {
+            if let MInst::Scratch { dst } = instruction {
+                candidates.remove(dst);
+            }
+        }
+    }
+
+    let mut next_value = function
+        .blocks
+        .iter()
+        .flat_map(|block| {
+            block
+                .phis
+                .iter()
+                .flat_map(|phi| std::iter::once(phi.dst).chain(phi.sources.iter().map(|row| row.1)))
+                .chain(block.insts.iter().flat_map(|instruction| {
+                    instruction.uses().into_iter().chain(instruction.def())
+                }))
+        })
+        .map(|value| value.0)
+        .max()
+        .map_or(0, |value| value.saturating_add(1));
+    let mut spill_frame_size = 0_u32;
+
+    loop {
+        let facts = build_facts(&function)?;
+        let intervals = analyze_live_intervals(&facts)
+            .map_err(|error| TargetRegallocError::InvalidFacts(error.to_string()))?;
+        let proactive = close_phi_spill_set(
+            &function,
+            select_spill_batch(&function, &intervals, &candidates, false),
+        );
+        if !proactive.is_empty() {
+            insert_spill_batch(
+                &mut function,
+                &mut candidates,
+                proactive,
+                &mut spill_frame_size,
+                &mut next_value,
+            )?;
+            continue;
+        }
+        match allocate_without_spills(function.clone()) {
+            Ok(allocated) => {
+                return Ok(TargetAllocation {
+                    allocated,
+                    spill_frame_size,
+                });
+            }
+            Err(TargetRegallocError::RegisterPressure { value }) => {
+                let spilled = close_phi_spill_set(
+                    &function,
+                    select_spill_batch(&function, &intervals, &candidates, true),
+                );
+                if spilled.is_empty() {
+                    return Err(TargetRegallocError::UnspillablePressure { value });
+                }
+                insert_spill_batch(
+                    &mut function,
+                    &mut candidates,
+                    spilled,
+                    &mut spill_frame_size,
+                    &mut next_value,
+                )?;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn close_phi_spill_set(function: &MFunction, spilled: Vec<VReg>) -> Vec<VReg> {
+    let mut all_spilled = function
+        .spill_homes
+        .keys()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let mut newly_spilled = spilled.into_iter().collect::<BTreeSet<_>>();
+    all_spilled.extend(newly_spilled.iter().copied());
+    loop {
+        let mut changed = false;
+        for block in &function.blocks {
+            for phi in &block.phis {
+                let touches_spill = all_spilled.contains(&phi.dst)
+                    || phi
+                        .sources
+                        .iter()
+                        .any(|&(_, source)| all_spilled.contains(&source));
+                if touches_spill && all_spilled.insert(phi.dst) {
+                    newly_spilled.insert(phi.dst);
+                    changed = true;
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    newly_spilled.into_iter().collect()
+}
+
+fn select_spill_batch(
+    function: &MFunction,
+    intervals: &celox_backend_common::regalloc::LiveIntervals<VReg>,
+    candidates: &BTreeSet<VReg>,
+    force: bool,
+) -> Vec<VReg> {
+    let live_lengths = intervals
+        .iter()
+        .map(|(&value, interval)| {
+            let length = interval
+                .segments
+                .iter()
+                .map(|segment| segment.end.saturating_sub(segment.start))
+                .sum::<u64>();
+            (value, length)
+        })
+        .collect::<BTreeMap<_, _>>();
+    let live_length = |value: VReg| live_lengths.get(&value).copied().unwrap_or(0);
+    // The widest target instruction has five uses and one definition. Keep
+    // that many registers free so a spilled row's local reload/definition
+    // temporaries do not immediately create a second pressure wave.
+    let target_capacity = ALLOCATABLE_REGISTERS.len().saturating_sub(6);
+    let mut selected = BTreeSet::new();
+    let mut peak = Vec::new();
+    for block in 0..function.blocks.len() {
+        let mut segments = intervals
+            .iter()
+            .filter_map(|(&value, interval)| {
+                interval
+                    .segment_in_block(block)
+                    .map(|segment| (segment.start, segment.end, value))
+            })
+            .collect::<Vec<_>>();
+        segments.sort_unstable();
+        let mut active = Vec::<(u64, VReg)>::new();
+        for (start, end, value) in segments {
+            active.retain(|(active_end, active_value)| {
+                *active_end > start && !selected.contains(active_value)
+            });
+            if !selected.contains(&value) {
+                active.push((end, value));
+            }
+            if active.len() > peak.len() {
+                peak = active.iter().map(|&(_, value)| value).collect();
+            }
+            while active.len() > target_capacity {
+                let Some(spilled) = active
+                    .iter()
+                    .filter(|(_, value)| candidates.contains(value))
+                    .max_by_key(|(_, value)| (live_length(*value), Reverse(*value)))
+                    .map(|&(_, value)| value)
+                else {
+                    break;
+                };
+                selected.insert(spilled);
+                active.retain(|&(_, value)| value != spilled);
+            }
+        }
+    }
+
+    if !selected.is_empty() {
+        return selected.into_iter().collect();
+    }
+    if !force {
+        return Vec::new();
+    }
+    peak.into_iter()
+        .filter(|value| candidates.contains(value))
+        .max_by_key(|value| (live_length(*value), Reverse(*value)))
+        .into_iter()
+        .collect()
+}
+
+fn insert_spill_batch(
+    function: &mut MFunction,
+    candidates: &mut BTreeSet<VReg>,
+    spilled: Vec<VReg>,
+    spill_frame_size: &mut u32,
+    next_value: &mut u32,
+) -> Result<(), TargetRegallocError> {
+    let mut homes = BTreeMap::new();
+    for spilled in spilled {
+        candidates.remove(&spilled);
+        let offset = i32::try_from(*spill_frame_size)
+            .map_err(|_| TargetRegallocError::SpillFrameOverflow)?;
+        homes.insert(spilled, offset);
+        *spill_frame_size = spill_frame_size
+            .checked_add(8)
+            .ok_or(TargetRegallocError::SpillFrameOverflow)?;
+    }
+    function
+        .spill_homes
+        .extend(homes.iter().map(|(&value, &offset)| (value, offset)));
+    spill_values(function, &homes, next_value)
+}
+
+fn spill_values(
+    function: &mut MFunction,
+    homes: &BTreeMap<VReg, i32>,
+    next_value: &mut u32,
+) -> Result<(), TargetRegallocError> {
+    let fresh = |next_value: &mut u32| {
+        let value = VReg(*next_value);
+        *next_value = next_value
+            .checked_add(1)
+            .ok_or(TargetRegallocError::SpillFrameOverflow)?;
+        Ok(value)
+    };
+    let mut rewritten_definitions = BTreeSet::new();
+    let all_homes = function.spill_homes.clone();
+    let mut external_phis = Vec::new();
+    let mut edge_keep_alives = BTreeMap::<BlockId, BTreeSet<VReg>>::new();
+    for block in &mut function.blocks {
+        let mut retained = Vec::with_capacity(block.phis.len());
+        for phi in std::mem::take(&mut block.phis) {
+            if let Some(&destination) = all_homes.get(&phi.dst) {
+                let spilled = phi.dst;
+                external_phis.push(crate::mir::SpilledPhiNode {
+                    successor: block.id,
+                    destination,
+                    sources: phi
+                        .sources
+                        .into_iter()
+                        .map(|(predecessor, source)| {
+                            let source = if let Some(&offset) = all_homes.get(&source) {
+                                crate::mir::SpilledPhiSource::Stack(offset)
+                            } else {
+                                edge_keep_alives
+                                    .entry(predecessor)
+                                    .or_default()
+                                    .insert(source);
+                                crate::mir::SpilledPhiSource::Value(source)
+                            };
+                            (predecessor, source)
+                        })
+                        .collect(),
+                });
+                rewritten_definitions.insert(spilled);
+            } else {
+                debug_assert!(
+                    phi.sources
+                        .iter()
+                        .all(|&(_, source)| !all_homes.contains_key(&source)),
+                    "phi spill closure must externalize a destination with a spilled source"
+                );
+                retained.push(phi);
+            }
+        }
+        block.phis = retained;
+    }
+    for phi in &mut function.spilled_phis {
+        for (_, source) in &mut phi.sources {
+            if let crate::mir::SpilledPhiSource::Value(value) = *source
+                && let Some(&offset) = all_homes.get(&value)
+            {
+                *source = crate::mir::SpilledPhiSource::Stack(offset);
+            }
+        }
+    }
+    function.spilled_phis.extend(external_phis);
+    for block in &mut function.blocks {
+        let original = std::mem::take(&mut block.insts);
+        let existing_keep_alives = original
+            .iter()
+            .filter_map(|instruction| match instruction {
+                MInst::KeepAlive { src } if !homes.contains_key(src) => Some(*src),
+                _ => None,
+            })
+            .collect::<BTreeSet<_>>();
+        let new_keep_alives = edge_keep_alives
+            .remove(&block.id)
+            .unwrap_or_default()
+            .difference(&existing_keep_alives)
+            .copied()
+            .collect::<Vec<_>>();
+        let terminator_index = original.len().saturating_sub(1);
+        let mut rewritten = Vec::with_capacity(original.len() + new_keep_alives.len());
+        for (index, mut instruction) in original.into_iter().enumerate() {
+            if matches!(instruction, MInst::KeepAlive { src } if homes.contains_key(&src)) {
+                continue;
+            }
+            if index == terminator_index {
+                rewritten.extend(
+                    new_keep_alives
+                        .iter()
+                        .copied()
+                        .map(|src| MInst::KeepAlive { src }),
+                );
+            }
+            let spilled_uses = instruction
+                .uses()
+                .into_iter()
+                .filter(|value| homes.contains_key(value))
+                .collect::<BTreeSet<_>>();
+            for spilled in spilled_uses {
+                let reload = fresh(next_value)?;
+                rewritten.push(MInst::Load {
+                    dst: reload,
+                    base: crate::mir::BaseReg::StackFrame,
+                    offset: homes[&spilled],
+                    size: crate::mir::OpSize::S64,
+                });
+                instruction.rewrite_use(spilled, reload);
+            }
+            if let Some(spilled) = instruction.def().filter(|value| homes.contains_key(value)) {
+                let temporary = fresh(next_value)?;
+                *instruction
+                    .def_mut()
+                    .expect("the matching spill definition has a mutable destination") = temporary;
+                rewritten.push(instruction);
+                rewritten.push(MInst::Store {
+                    base: crate::mir::BaseReg::StackFrame,
+                    offset: homes[&spilled],
+                    src: temporary,
+                    size: crate::mir::OpSize::S64,
+                });
+                rewritten_definitions.insert(spilled);
+            } else {
+                rewritten.push(instruction);
+            }
+        }
+        block.insts = rewritten;
+    }
+    if let Some(spilled) = homes
+        .keys()
+        .find(|value| !rewritten_definitions.contains(value))
+    {
+        return Err(TargetRegallocError::InvalidFacts(format!(
+            "spill candidate {spilled} has no instruction definition"
+        )));
+    }
+    Ok(())
+}
+
 /// Allocate AArch64-owned target MIR without importing x86 register colors.
 ///
 /// This first target-native path intentionally reports pressure instead of
@@ -369,6 +744,35 @@ fn build_edge_copies(
                     .push(common::ParallelCopy {
                         destination: common::CopyDestination::Register(destination),
                         source: common::CopySource::Register(source),
+                    });
+            }
+        }
+        for phi in function
+            .spilled_phis
+            .iter()
+            .filter(|phi| phi.successor == successor.id)
+        {
+            for &(predecessor, source) in &phi.sources {
+                let source = match source {
+                    crate::mir::SpilledPhiSource::Value(value) => {
+                        common::CopySource::Register(assignment.get(&value).ok_or(
+                            TargetRegallocError::MissingAssignment {
+                                block: predecessor,
+                                instruction: 0,
+                                value,
+                            },
+                        )?)
+                    }
+                    crate::mir::SpilledPhiSource::Stack(offset) => {
+                        common::CopySource::Stack(offset)
+                    }
+                };
+                rows_by_predecessor
+                    .entry(predecessor)
+                    .or_default()
+                    .push(common::ParallelCopy {
+                        destination: common::CopyDestination::Stack(phi.destination),
+                        source,
                     });
             }
         }
@@ -698,6 +1102,139 @@ mod tests {
             allocate_without_spills(function),
             Err(TargetRegallocError::RegisterPressure { .. })
         ));
+    }
+
+    #[test]
+    fn inserts_target_owned_spill_and_reload_instructions() {
+        let mut instructions = (0..26)
+            .map(|value| MInst::LoadImm {
+                dst: VReg(value),
+                value: u64::from(value),
+            })
+            .collect::<Vec<_>>();
+        instructions.extend((0..26).map(|value| MInst::Store {
+            base: BaseReg::SimState,
+            offset: value * 8,
+            src: VReg(value as u32),
+            size: OpSize::S64,
+        }));
+        instructions.push(MInst::Return);
+        let allocation = allocate_with_spills(MFunction::new(
+            vec![MBlock {
+                id: BlockId(0),
+                phis: Vec::new(),
+                insts: instructions,
+            }],
+            Vec::new(),
+        ))
+        .unwrap();
+
+        assert!(allocation.spill_frame_size >= 8);
+        assert_eq!(allocation.spill_frame_size % 8, 0);
+        assert!(
+            allocation.allocated.function.blocks[0]
+                .insts
+                .iter()
+                .any(|instruction| matches!(
+                    instruction,
+                    MInst::Load {
+                        base: BaseReg::StackFrame,
+                        offset: 0,
+                        size: OpSize::S64,
+                        ..
+                    }
+                ))
+        );
+        assert!(
+            allocation.allocated.function.blocks[0]
+                .insts
+                .iter()
+                .any(|instruction| matches!(
+                    instruction,
+                    MInst::Store {
+                        base: BaseReg::StackFrame,
+                        offset: 0,
+                        size: OpSize::S64,
+                        ..
+                    }
+                ))
+        );
+        verify_allocated(&allocation.allocated).unwrap();
+    }
+
+    #[test]
+    fn keeps_external_phi_register_sources_live_to_the_edge() {
+        let mut function = MFunction::new(
+            vec![
+                MBlock {
+                    id: BlockId(0),
+                    phis: Vec::new(),
+                    insts: vec![
+                        MInst::LoadImm {
+                            dst: VReg(0),
+                            value: 42,
+                        },
+                        MInst::Jump { target: BlockId(1) },
+                    ],
+                },
+                MBlock {
+                    id: BlockId(1),
+                    phis: vec![PhiNode {
+                        dst: VReg(1),
+                        sources: vec![(BlockId(0), VReg(0))],
+                    }],
+                    insts: vec![
+                        MInst::Store {
+                            base: BaseReg::SimState,
+                            offset: 0,
+                            src: VReg(1),
+                            size: OpSize::S64,
+                        },
+                        MInst::Return,
+                    ],
+                },
+            ],
+            Vec::new(),
+        );
+        let homes = [(VReg(1), 8)].into_iter().collect();
+        let mut next_value = 2;
+        function.spill_homes.insert(VReg(1), 8);
+
+        spill_values(&mut function, &homes, &mut next_value).unwrap();
+
+        let facts = build_facts(&function).unwrap();
+        let intervals = analyze_live_intervals(&facts).unwrap();
+        assert!(intervals.get(&VReg(0)).is_some());
+        assert!(intervals.get(&VReg(1)).is_none());
+        assert!(matches!(
+            function.blocks[0].insts.as_slice(),
+            [
+                MInst::LoadImm { .. },
+                MInst::KeepAlive { src: VReg(0) },
+                MInst::Jump { .. }
+            ]
+        ));
+        assert!(matches!(
+            function.blocks[1].insts.first(),
+            Some(MInst::Load {
+                base: BaseReg::StackFrame,
+                offset: 8,
+                ..
+            })
+        ));
+        assert_eq!(function.spilled_phis.len(), 1);
+        let allocated = allocate_without_spills(function).unwrap();
+        let source = allocated.assignment.get(&VReg(0)).unwrap();
+        assert_eq!(
+            allocated.edge_copies.edge(BlockId(0), BlockId(1)),
+            Some(
+                [CopyOperation::Move {
+                    destination: CopyDestination::Stack(8),
+                    source: CopySource::Register(source),
+                }]
+                .as_slice()
+            )
+        );
     }
 
     #[test]

--- a/crates/celox-backend-arm64/src/regalloc.rs
+++ b/crates/celox-backend-arm64/src/regalloc.rs
@@ -1,0 +1,382 @@
+//! AArch64 register-allocation boundary.
+//!
+//! Target MIR is projected into opcode-free facts consumed by shared analyses.
+//! The production pipeline still imports a mature allocation through the
+//! legacy bridge, but that result is independently checked here against the
+//! AArch64 MIR and register file before emission.
+
+use std::collections::{BTreeSet, HashMap};
+use std::fmt;
+
+use celox_backend_common::regalloc::{
+    BlockAllocationFacts, FunctionAllocationFacts, InstructionAllocationFacts, PhiAllocationFacts,
+    PhiSource, analyze_next_uses,
+};
+
+use crate::Arm64Reg;
+use crate::mir::{AllocatedFunction, BlockId, MFunction, VReg};
+
+pub(crate) type AllocationFacts = FunctionAllocationFacts<VReg, Arm64Reg>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TargetRegallocError {
+    EmptyFunction,
+    MissingBlock {
+        block: BlockId,
+        target: BlockId,
+    },
+    InvalidFacts(String),
+    MissingAssignment {
+        block: BlockId,
+        instruction: usize,
+        value: VReg,
+    },
+    ReservedAssignment {
+        block: BlockId,
+        instruction: usize,
+        value: VReg,
+        register: Arm64Reg,
+    },
+    RegisterConflict {
+        block: BlockId,
+        instruction: usize,
+        left: VReg,
+        right: VReg,
+        register: Arm64Reg,
+    },
+}
+
+impl fmt::Display for TargetRegallocError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyFunction => formatter.write_str("AArch64 allocation has no entry block"),
+            Self::MissingBlock { block, target } => {
+                write!(
+                    formatter,
+                    "AArch64 block {block} targets missing block {target}"
+                )
+            }
+            Self::InvalidFacts(error) => {
+                write!(formatter, "invalid AArch64 allocation facts: {error}")
+            }
+            Self::MissingAssignment {
+                block,
+                instruction,
+                value,
+            } => write!(
+                formatter,
+                "AArch64 {block} instruction {instruction} value {value} has no register assignment"
+            ),
+            Self::ReservedAssignment {
+                block,
+                instruction,
+                value,
+                register,
+            } => write!(
+                formatter,
+                "AArch64 {block} instruction {instruction} value {value} uses reserved x{}",
+                register.number()
+            ),
+            Self::RegisterConflict {
+                block,
+                instruction,
+                left,
+                right,
+                register,
+            } => write!(
+                formatter,
+                "AArch64 {block} point {instruction} keeps {left} and {right} live in x{}",
+                register.number()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TargetRegallocError {}
+
+pub(crate) fn build_facts(function: &MFunction) -> Result<AllocationFacts, TargetRegallocError> {
+    if function.blocks.is_empty() {
+        return Err(TargetRegallocError::EmptyFunction);
+    }
+    let indices = function
+        .blocks
+        .iter()
+        .enumerate()
+        .map(|(index, block)| (block.id, index))
+        .collect::<HashMap<_, _>>();
+    let blocks = function
+        .blocks
+        .iter()
+        .map(|block| {
+            let block_target = |target: BlockId| {
+                indices
+                    .get(&target)
+                    .copied()
+                    .ok_or(TargetRegallocError::MissingBlock {
+                        block: block.id,
+                        target,
+                    })
+            };
+            let successors = block
+                .successors()
+                .into_iter()
+                .map(block_target)
+                .collect::<Result<_, _>>()?;
+            let phis = block
+                .phis
+                .iter()
+                .map(|phi| {
+                    Ok(PhiAllocationFacts {
+                        destination: phi.dst,
+                        sources: phi
+                            .sources
+                            .iter()
+                            .map(|&(predecessor, value)| {
+                                Ok(PhiSource {
+                                    predecessor: block_target(predecessor)?,
+                                    value,
+                                })
+                            })
+                            .collect::<Result<_, TargetRegallocError>>()?,
+                    })
+                })
+                .collect::<Result<_, TargetRegallocError>>()?;
+            let instructions = block
+                .insts
+                .iter()
+                .map(|instruction| InstructionAllocationFacts {
+                    uses: instruction.uses(),
+                    defs: instruction.def().into_iter().collect(),
+                    is_copy: instruction.is_copy(),
+                    ..InstructionAllocationFacts::default()
+                })
+                .collect();
+            Ok(BlockAllocationFacts {
+                successors,
+                phis,
+                instructions,
+            })
+        })
+        .collect::<Result<_, TargetRegallocError>>()?;
+    let facts = FunctionAllocationFacts { entry: 0, blocks };
+    facts
+        .verify()
+        .map_err(|error| TargetRegallocError::InvalidFacts(error.to_string()))?;
+    Ok(facts)
+}
+
+pub(crate) fn verify_allocated(function: &AllocatedFunction) -> Result<(), TargetRegallocError> {
+    let facts = build_facts(&function.function)?;
+    let next_use = analyze_next_uses(&facts)
+        .map_err(|error| TargetRegallocError::InvalidFacts(error.to_string()))?;
+
+    for block in &function.function.blocks {
+        for (instruction_index, instruction) in block.insts.iter().enumerate() {
+            for value in instruction.uses().into_iter().chain(instruction.def()) {
+                let Some(register) = function.assignment.get(&value) else {
+                    return Err(TargetRegallocError::MissingAssignment {
+                        block: block.id,
+                        instruction: instruction_index,
+                        value,
+                    });
+                };
+                if !(1..=15).contains(&register.number()) {
+                    return Err(TargetRegallocError::ReservedAssignment {
+                        block: block.id,
+                        instruction: instruction_index,
+                        value,
+                        register,
+                    });
+                }
+            }
+        }
+    }
+    for (block_index, block) in function.function.blocks.iter().enumerate() {
+        let mut live = next_use.exit_distances[block_index]
+            .keys()
+            .copied()
+            .collect::<BTreeSet<_>>();
+        verify_live_registers(function, block.id, block.insts.len(), live.iter().copied())?;
+        for (instruction_index, instruction) in block.insts.iter().enumerate().rev() {
+            if let Some(definition) = instruction.def() {
+                live.remove(&definition);
+            }
+            live.extend(instruction.uses());
+            verify_live_registers(function, block.id, instruction_index, live.iter().copied())?;
+        }
+    }
+    Ok(())
+}
+
+fn verify_live_registers(
+    function: &AllocatedFunction,
+    block: BlockId,
+    instruction: usize,
+    live: impl IntoIterator<Item = VReg>,
+) -> Result<(), TargetRegallocError> {
+    let mut occupants = HashMap::<Arm64Reg, VReg>::new();
+    for value in live {
+        let Some(register) = function.assignment.get(&value) else {
+            // A phi edge may be materialized directly from stack or an
+            // immediate and therefore have no resident register at the block
+            // boundary. Instruction operands were checked separately above.
+            continue;
+        };
+        if let Some(left) = occupants.insert(register, value)
+            && left != value
+        {
+            return Err(TargetRegallocError::RegisterConflict {
+                block,
+                instruction,
+                left,
+                right: value,
+                register,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::allocation::{Assignment, EdgeCopyPlan};
+    use crate::mir::{MBlock, MInst, PhiNode};
+
+    fn diamond_function() -> MFunction {
+        let entry = MBlock {
+            id: BlockId(10),
+            phis: Vec::new(),
+            insts: vec![
+                MInst::LoadImm {
+                    dst: VReg(0),
+                    value: 1,
+                },
+                MInst::Branch {
+                    cond: VReg(0),
+                    true_bb: BlockId(20),
+                    false_bb: BlockId(30),
+                },
+            ],
+        };
+        let left = MBlock {
+            id: BlockId(20),
+            phis: Vec::new(),
+            insts: vec![
+                MInst::LoadImm {
+                    dst: VReg(1),
+                    value: 2,
+                },
+                MInst::Jump {
+                    target: BlockId(40),
+                },
+            ],
+        };
+        let right = MBlock {
+            id: BlockId(30),
+            phis: Vec::new(),
+            insts: vec![
+                MInst::LoadImm {
+                    dst: VReg(2),
+                    value: 3,
+                },
+                MInst::Jump {
+                    target: BlockId(40),
+                },
+            ],
+        };
+        let join = MBlock {
+            id: BlockId(40),
+            phis: vec![PhiNode {
+                dst: VReg(3),
+                sources: vec![(BlockId(20), VReg(1)), (BlockId(30), VReg(2))],
+            }],
+            insts: vec![MInst::Return],
+        };
+        MFunction::new(vec![entry, left, right, join], Vec::new())
+    }
+
+    #[test]
+    fn exports_normalized_cfg_phi_and_instruction_facts() {
+        let facts = build_facts(&diamond_function()).unwrap();
+
+        assert_eq!(facts.blocks[0].successors, vec![1, 2]);
+        assert_eq!(facts.blocks[0].instructions[0].defs, vec![VReg(0)]);
+        assert_eq!(facts.blocks[0].instructions[1].uses, vec![VReg(0)]);
+        assert_eq!(facts.blocks[3].phis[0].destination, VReg(3));
+        assert_eq!(facts.blocks[3].phis[0].sources[0].predecessor, 1);
+        assert_eq!(facts.blocks[3].phis[0].sources[1].predecessor, 2);
+        analyze_next_uses(&facts).unwrap();
+    }
+
+    #[test]
+    fn rejects_missing_and_reserved_instruction_assignments() {
+        let function = diamond_function();
+        let mut allocated = AllocatedFunction {
+            function,
+            assignment: Assignment::default(),
+            edge_copies: EdgeCopyPlan::default(),
+        };
+        assert!(matches!(
+            verify_allocated(&allocated),
+            Err(TargetRegallocError::MissingAssignment { value: VReg(0), .. })
+        ));
+
+        for (value, register) in [
+            (VReg(0), Arm64Reg::new(1)),
+            (VReg(1), Arm64Reg::new(2)),
+            (VReg(2), Arm64Reg::new(3)),
+        ] {
+            allocated.assignment.set(value, register);
+        }
+        allocated.assignment.set(VReg(0), Arm64Reg::new(16));
+        assert!(matches!(
+            verify_allocated(&allocated),
+            Err(TargetRegallocError::ReservedAssignment { value: VReg(0), .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_interfering_values_assigned_to_one_register() {
+        let function = MFunction::new(
+            vec![MBlock {
+                id: BlockId(0),
+                phis: Vec::new(),
+                insts: vec![
+                    MInst::LoadImm {
+                        dst: VReg(0),
+                        value: 1,
+                    },
+                    MInst::LoadImm {
+                        dst: VReg(1),
+                        value: 2,
+                    },
+                    MInst::Add {
+                        dst: VReg(2),
+                        lhs: VReg(0),
+                        rhs: VReg(1),
+                    },
+                    MInst::Return,
+                ],
+            }],
+            Vec::new(),
+        );
+        let mut assignment = Assignment::default();
+        assignment.set(VReg(0), Arm64Reg::new(1));
+        assignment.set(VReg(1), Arm64Reg::new(1));
+        assignment.set(VReg(2), Arm64Reg::new(2));
+        let allocated = AllocatedFunction {
+            function,
+            assignment,
+            edge_copies: EdgeCopyPlan::default(),
+        };
+
+        assert!(matches!(
+            verify_allocated(&allocated),
+            Err(TargetRegallocError::RegisterConflict {
+                register,
+                ..
+            }) if register == Arm64Reg::new(1)
+        ));
+    }
+}

--- a/crates/celox-backend-arm64/src/regalloc.rs
+++ b/crates/celox-backend-arm64/src/regalloc.rs
@@ -5,12 +5,12 @@
 //! legacy bridge, but that result is independently checked here against the
 //! AArch64 MIR and register file before emission.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 use std::fmt;
 
 use celox_backend_common::regalloc::{
     BlockAllocationFacts, FunctionAllocationFacts, InstructionAllocationFacts, PhiAllocationFacts,
-    PhiSource, analyze_next_uses,
+    PhiSource, analyze_live_intervals,
 };
 
 use crate::Arm64Reg;
@@ -167,7 +167,7 @@ pub(crate) fn build_facts(function: &MFunction) -> Result<AllocationFacts, Targe
 
 pub(crate) fn verify_allocated(function: &AllocatedFunction) -> Result<(), TargetRegallocError> {
     let facts = build_facts(&function.function)?;
-    let next_use = analyze_next_uses(&facts)
+    let intervals = analyze_live_intervals(&facts)
         .map_err(|error| TargetRegallocError::InvalidFacts(error.to_string()))?;
 
     for block in &function.function.blocks {
@@ -191,48 +191,46 @@ pub(crate) fn verify_allocated(function: &AllocatedFunction) -> Result<(), Targe
             }
         }
     }
-    for (block_index, block) in function.function.blocks.iter().enumerate() {
-        let mut live = next_use.exit_distances[block_index]
-            .keys()
-            .copied()
-            .collect::<BTreeSet<_>>();
-        verify_live_registers(function, block.id, block.insts.len(), live.iter().copied())?;
-        for (instruction_index, instruction) in block.insts.iter().enumerate().rev() {
-            if let Some(definition) = instruction.def() {
-                live.remove(&definition);
-            }
-            live.extend(instruction.uses());
-            verify_live_registers(function, block.id, instruction_index, live.iter().copied())?;
-        }
-    }
-    Ok(())
+    verify_interval_registers(function, &intervals)
 }
 
-fn verify_live_registers(
+fn verify_interval_registers(
     function: &AllocatedFunction,
-    block: BlockId,
-    instruction: usize,
-    live: impl IntoIterator<Item = VReg>,
+    intervals: &celox_backend_common::regalloc::LiveIntervals<VReg>,
 ) -> Result<(), TargetRegallocError> {
-    let mut occupants = HashMap::<Arm64Reg, VReg>::new();
-    for value in live {
+    let mut segments = Vec::new();
+    for (&value, interval) in intervals.iter() {
         let Some(register) = function.assignment.get(&value) else {
-            // A phi edge may be materialized directly from stack or an
-            // immediate and therefore have no resident register at the block
-            // boundary. Instruction operands were checked separately above.
+            // Legacy edge values may reside in a stack home or immediate.
             continue;
         };
-        if let Some(left) = occupants.insert(register, value)
+        segments.extend(
+            interval
+                .segments
+                .iter()
+                .map(|segment| (segment.block, register, segment.start, segment.end, value)),
+        );
+    }
+    segments.sort_unstable_by_key(|&(block, register, start, end, value)| {
+        (block, register, start, end, value)
+    });
+    let mut previous = None;
+    for (block, register, start, end, value) in segments {
+        if let Some((left_block, left_register, _, left_end, left)) = previous
+            && left_block == block
+            && left_register == register
+            && start < left_end
             && left != value
         {
             return Err(TargetRegallocError::RegisterConflict {
-                block,
-                instruction,
+                block: function.function.blocks[block].id,
+                instruction: usize::try_from(start / 3).unwrap_or(usize::MAX),
                 left,
                 right: value,
                 register,
             });
         }
+        previous = Some((block, register, start, end, value));
     }
     Ok(())
 }
@@ -306,7 +304,7 @@ mod tests {
         assert_eq!(facts.blocks[3].phis[0].destination, VReg(3));
         assert_eq!(facts.blocks[3].phis[0].sources[0].predecessor, 1);
         assert_eq!(facts.blocks[3].phis[0].sources[1].predecessor, 2);
-        analyze_next_uses(&facts).unwrap();
+        analyze_live_intervals(&facts).unwrap();
     }
 
     #[test]

--- a/crates/celox-backend-arm64/src/regalloc.rs
+++ b/crates/celox-backend-arm64/src/regalloc.rs
@@ -10,8 +10,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 
 use celox_backend_common::regalloc::{
-    BlockAllocationFacts, FunctionAllocationFacts, InstructionAllocationFacts, PhiAllocationFacts,
-    PhiSource, analyze_live_intervals,
+    BlockAllocationFacts, FunctionAllocationFacts, InstructionAllocationFacts, LiveIntervals,
+    PhiAllocationFacts, PhiSource, analyze_live_intervals, color_stack_slots,
 };
 
 use crate::Arm64Reg;
@@ -265,9 +265,10 @@ pub(crate) struct TargetAllocation {
 /// interference graph does not fit the register file.
 ///
 /// SSA values are split into one stack home, short definition temporaries, and
-/// per-instruction reload temporaries. Spilled phis become target edge copies
-/// whose sources and destinations may be stack slots; register sources receive
-/// allocation-only edge uses to keep them live until the copy. This keeps spill
+/// reload ranges shared only across adjacent instructions. Spilled phis become
+/// target edge copies whose sources and destinations may be stack slots;
+/// register sources receive allocation-only edge uses to keep them live until
+/// the copy. Noninterfering homes share colored frame slots. This keeps spill
 /// policy and rewriting on the target side.
 pub(crate) fn allocate_with_spills(
     mut function: MFunction,
@@ -323,6 +324,7 @@ pub(crate) fn allocate_with_spills(
                 &mut function,
                 &mut candidates,
                 proactive,
+                &intervals,
                 &mut spill_frame_size,
                 &mut next_value,
             )?;
@@ -347,6 +349,7 @@ pub(crate) fn allocate_with_spills(
                     &mut function,
                     &mut candidates,
                     spilled,
+                    &intervals,
                     &mut spill_frame_size,
                     &mut next_value,
                 )?;
@@ -463,18 +466,46 @@ fn insert_spill_batch(
     function: &mut MFunction,
     candidates: &mut BTreeSet<VReg>,
     spilled: Vec<VReg>,
+    intervals: &LiveIntervals<VReg>,
     spill_frame_size: &mut u32,
     next_value: &mut u32,
 ) -> Result<(), TargetRegallocError> {
+    // Instruction insertion changes the numeric interval coordinate system
+    // between spill iterations. Color values selected from this one immutable
+    // analysis together, and keep separate batches in disjoint frame regions.
+    let batch_base = *spill_frame_size;
+    let spill_intervals = spilled
+        .iter()
+        .map(|value| {
+            intervals.get(value).ok_or_else(|| {
+                TargetRegallocError::InvalidFacts(format!(
+                    "spill candidate {value} has no exact live interval"
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let stack_coloring = color_stack_slots(spill_intervals)
+        .map_err(|error| TargetRegallocError::InvalidFacts(error.to_string()))?;
     let mut homes = BTreeMap::new();
     for spilled in spilled {
         candidates.remove(&spilled);
-        let offset = i32::try_from(*spill_frame_size)
-            .map_err(|_| TargetRegallocError::SpillFrameOverflow)?;
-        homes.insert(spilled, offset);
-        *spill_frame_size = spill_frame_size
-            .checked_add(8)
+        let slot = stack_coloring
+            .get(&spilled)
+            .expect("each selected spill candidate has a colored stack slot");
+        let local_offset = slot
+            .checked_mul(8)
             .ok_or(TargetRegallocError::SpillFrameOverflow)?;
+        let offset = batch_base
+            .checked_add(local_offset)
+            .and_then(|offset| i32::try_from(offset).ok())
+            .ok_or(TargetRegallocError::SpillFrameOverflow)?;
+        homes.insert(spilled, offset);
+        *spill_frame_size = (*spill_frame_size).max(
+            batch_base
+                .checked_add(local_offset)
+                .and_then(|offset| offset.checked_add(8))
+                .ok_or(TargetRegallocError::SpillFrameOverflow)?,
+        );
     }
     function
         .spill_homes
@@ -548,6 +579,21 @@ fn spill_values(
     function.spilled_phis.extend(external_phis);
     for block in &mut function.blocks {
         let original = std::mem::take(&mut block.insts);
+        let spill_uses = original
+            .iter()
+            .map(|instruction| {
+                if matches!(instruction, MInst::KeepAlive { src } if homes.contains_key(src)) {
+                    BTreeSet::new()
+                } else {
+                    instruction
+                        .uses()
+                        .into_iter()
+                        .filter(|value| homes.contains_key(value))
+                        .collect()
+                }
+            })
+            .collect::<Vec<BTreeSet<_>>>();
+        let mut reload_cache = BTreeMap::<VReg, VReg>::new();
         let existing_keep_alives = original
             .iter()
             .filter_map(|instruction| match instruction {
@@ -575,21 +621,23 @@ fn spill_values(
                         .map(|src| MInst::KeepAlive { src }),
                 );
             }
-            let spilled_uses = instruction
-                .uses()
-                .into_iter()
-                .filter(|value| homes.contains_key(value))
-                .collect::<BTreeSet<_>>();
-            for spilled in spilled_uses {
-                let reload = fresh(next_value)?;
-                rewritten.push(MInst::Load {
-                    dst: reload,
-                    base: crate::mir::BaseReg::StackFrame,
-                    offset: homes[&spilled],
-                    size: crate::mir::OpSize::S64,
-                });
+            for spilled in spill_uses[index].iter().copied() {
+                let reload = if let Some(&reload) = reload_cache.get(&spilled) {
+                    reload
+                } else {
+                    let reload = fresh(next_value)?;
+                    rewritten.push(MInst::Load {
+                        dst: reload,
+                        base: crate::mir::BaseReg::StackFrame,
+                        offset: homes[&spilled],
+                        size: crate::mir::OpSize::S64,
+                    });
+                    reload_cache.insert(spilled, reload);
+                    reload
+                };
                 instruction.rewrite_use(spilled, reload);
             }
+            let mut definition_cache = None;
             if let Some(spilled) = instruction.def().filter(|value| homes.contains_key(value)) {
                 let temporary = fresh(next_value)?;
                 *instruction
@@ -603,8 +651,17 @@ fn spill_values(
                     size: crate::mir::OpSize::S64,
                 });
                 rewritten_definitions.insert(spilled);
+                definition_cache = Some((spilled, temporary));
             } else {
                 rewritten.push(instruction);
+            }
+            let next_uses = spill_uses.get(index + 1);
+            reload_cache
+                .retain(|value, _| next_uses.is_some_and(|next_uses| next_uses.contains(value)));
+            if let Some((spilled, temporary)) = definition_cache
+                && next_uses.is_some_and(|next_uses| next_uses.contains(&spilled))
+            {
+                reload_cache.insert(spilled, temporary);
             }
         }
         block.insts = rewritten;
@@ -1131,20 +1188,21 @@ mod tests {
 
         assert!(allocation.spill_frame_size >= 8);
         assert_eq!(allocation.spill_frame_size % 8, 0);
-        assert!(
-            allocation.allocated.function.blocks[0]
-                .insts
-                .iter()
-                .any(|instruction| matches!(
+        let reload_count = allocation.allocated.function.blocks[0]
+            .insts
+            .iter()
+            .filter(|instruction| {
+                matches!(
                     instruction,
                     MInst::Load {
                         base: BaseReg::StackFrame,
-                        offset: 0,
                         size: OpSize::S64,
                         ..
                     }
-                ))
-        );
+                )
+            })
+            .count();
+        assert!(reload_count > 0);
         assert!(
             allocation.allocated.function.blocks[0]
                 .insts
@@ -1159,6 +1217,90 @@ mod tests {
                     }
                 ))
         );
+        verify_allocated(&allocation.allocated).unwrap();
+    }
+
+    #[test]
+    fn reuses_one_reload_across_adjacent_uses() {
+        let mut function = MFunction::new(
+            vec![MBlock {
+                id: BlockId(0),
+                phis: Vec::new(),
+                insts: vec![
+                    MInst::LoadImm {
+                        dst: VReg(0),
+                        value: 42,
+                    },
+                    MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 0,
+                        src: VReg(0),
+                        size: OpSize::S64,
+                    },
+                    MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 8,
+                        src: VReg(0),
+                        size: OpSize::S64,
+                    },
+                    MInst::Return,
+                ],
+            }],
+            Vec::new(),
+        );
+        let homes = [(VReg(0), 0)].into_iter().collect();
+        function.spill_homes.insert(VReg(0), 0);
+        let mut next_value = 1;
+
+        spill_values(&mut function, &homes, &mut next_value).unwrap();
+
+        assert_eq!(
+            function.blocks[0]
+                .insts
+                .iter()
+                .filter(|instruction| matches!(
+                    instruction,
+                    MInst::Load {
+                        base: BaseReg::StackFrame,
+                        ..
+                    }
+                ))
+                .count(),
+            0
+        );
+        allocate_without_spills(function).unwrap();
+    }
+
+    #[test]
+    fn colors_disjoint_pressure_waves_into_shared_stack_slots() {
+        let mut instructions = Vec::new();
+        for wave in 0..2_u32 {
+            let first = wave * 26;
+            instructions.extend((0..26).map(|value| MInst::LoadImm {
+                dst: VReg(first + value),
+                value: u64::from(first + value),
+            }));
+            instructions.extend((0..26).map(|value| MInst::Store {
+                base: BaseReg::SimState,
+                offset: i32::try_from((first + value) * 8).unwrap(),
+                src: VReg(first + value),
+                size: OpSize::S64,
+            }));
+        }
+        instructions.push(MInst::Return);
+        let allocation = allocate_with_spills(MFunction::new(
+            vec![MBlock {
+                id: BlockId(0),
+                phis: Vec::new(),
+                insts: instructions,
+            }],
+            Vec::new(),
+        ))
+        .unwrap();
+
+        let spill_count = allocation.allocated.function.spill_homes.len();
+        let slot_count = allocation.spill_frame_size / 8;
+        assert!(spill_count > usize::try_from(slot_count).unwrap());
         verify_allocated(&allocation.allocated).unwrap();
     }
 

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -261,11 +261,21 @@ fn emit_function(
     let tick_success = tick_loop.then(|| ops.new_dynamic_label());
     let tick_entry = tick_loop.then(|| block_labels[&function.blocks[0].id]);
     let mut block_offsets = Vec::with_capacity(function.blocks.len());
+    let mut callee_saved = assignment
+        .iter()
+        .map(|(_, register)| register.number())
+        .filter(|register| (19..=28).contains(register))
+        .collect::<Vec<_>>();
+    callee_saved.sort_unstable();
+    callee_saved.dedup();
 
     dynasm!(ops
         ; .arch aarch64
         ; str x30, [sp, #-16]!
     );
+    for &register in &callee_saved {
+        dynasm!(ops ; .arch aarch64 ; str X(register), [sp, #-16]!);
+    }
     if tick_loop {
         // d29 retains the simulator-state pointer across success/error return
         // values. d31 carries the remaining tick count between body entries.
@@ -347,6 +357,9 @@ fn emit_function(
             STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET as u64,
         );
         dynasm!(ops ; .arch aarch64 ; add x17, x17, x30 ; str x16, [x17]);
+    }
+    for &register in callee_saved.iter().rev() {
+        dynasm!(ops ; .arch aarch64 ; ldr X(register), [sp], #16);
     }
     dynasm!(ops ; .arch aarch64 ; ldr x30, [sp], #16 ; ret);
     let text_size = ops.offset().0;

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -320,7 +320,6 @@ fn emit_function(
             emit_store(&mut ops, 30, SCRATCH0, OpSize::S64);
         }
     }
-
     for block in &function.blocks {
         let label = block_labels[&block.id];
         block_offsets.push((block.id, ops.offset().0 as u64));
@@ -1812,8 +1811,11 @@ fn emit_edge_copies(
             }
             ParallelCopyOperation::SaveTemporary(destination) => {
                 read_copy_destination(ops, destination, spill_base, SCRATCH1)?;
+                // Address materialization uses x17 for the offset. Preserve
+                // the value being saved before computing the temporary slot.
+                dynasm!(ops ; .arch aarch64 ; mov x30, x17);
                 emit_address(ops, STATE_REG, temporary_offset as i64);
-                emit_store(ops, SCRATCH1, SCRATCH0, OpSize::S64);
+                emit_store(ops, 30, SCRATCH0, OpSize::S64);
             }
             ParallelCopyOperation::RestoreTemporary(destination) => {
                 emit_address(ops, STATE_REG, temporary_offset as i64);
@@ -1878,6 +1880,15 @@ fn write_copy_destination(
             dynasm!(ops ; .arch aarch64 ; mov X(register), X(source));
         }
         ParallelCopyDestination::Stack(offset) => {
+            let source = if source == SCRATCH1 {
+                // emit_address reserves x17 for large/immediate offsets.
+                // Stack-to-stack and temporary restores arrive in x17, so
+                // retain their payload in the other fixed scratch register.
+                dynasm!(ops ; .arch aarch64 ; mov x30, x17);
+                30
+            } else {
+                source
+            };
             emit_address(ops, STATE_REG, spill_base as i64 + i64::from(offset));
             emit_store(ops, source, SCRATCH0, OpSize::S64);
         }
@@ -1899,7 +1910,11 @@ pub fn disassemble(code: &[u8], base_addr: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_arch = "aarch64")]
+    use celox_backend_x86::native::mir::PhiNode;
     use celox_backend_x86::native::mir::{MBlock, SpillDesc, VRegAllocator};
+    #[cfg(target_arch = "aarch64")]
+    use celox_backend_x86::native::regalloc::assignment::EdgeLocation;
 
     fn state_update() -> (MFunction, AssignmentMap) {
         let mut vregs = VRegAllocator::new();
@@ -2225,6 +2240,123 @@ mod tests {
         let mut state = [0_u8; 24];
         assert_eq!(unsafe { code.call(&mut state) }, 0);
         assert_eq!(u64::from_le_bytes(state[16..].try_into().unwrap()), 8);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn executes_stack_parallel_copy_cycle_without_clobbering_payloads() {
+        let mut vregs = VRegAllocator::new();
+        let first = vregs.alloc();
+        let second = vregs.alloc();
+        let immediate = vregs.alloc();
+        let dst_first = vregs.alloc();
+        let dst_second = vregs.alloc();
+        let dst_copy = vregs.alloc();
+        let dst_immediate = vregs.alloc();
+        let out_first = vregs.alloc();
+        let out_second = vregs.alloc();
+        let out_copy = vregs.alloc();
+        let out_immediate = vregs.alloc();
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 11]);
+
+        let mut predecessor = MBlock::new(BlockId(0));
+        predecessor.push(MInst::LoadImm {
+            dst: first,
+            value: 33,
+        });
+        predecessor.push(MInst::Store {
+            base: BaseReg::StackFrame,
+            offset: 0,
+            src: first,
+            size: OpSize::S64,
+        });
+        predecessor.push(MInst::LoadImm {
+            dst: second,
+            value: 44,
+        });
+        predecessor.push(MInst::Store {
+            base: BaseReg::StackFrame,
+            offset: 8,
+            src: second,
+            size: OpSize::S64,
+        });
+        predecessor.push(MInst::LoadImm {
+            dst: immediate,
+            value: 55,
+        });
+        predecessor.push(MInst::Jump { target: BlockId(1) });
+
+        let mut successor = MBlock::new(BlockId(1));
+        successor.phis = vec![
+            PhiNode {
+                dst: dst_first,
+                sources: vec![(BlockId(0), second)],
+            },
+            PhiNode {
+                dst: dst_second,
+                sources: vec![(BlockId(0), first)],
+            },
+            PhiNode {
+                dst: dst_copy,
+                sources: vec![(BlockId(0), first)],
+            },
+            PhiNode {
+                dst: dst_immediate,
+                sources: vec![(BlockId(0), immediate)],
+            },
+        ];
+        for (stack_offset, state_offset, output) in [
+            (0, 0, out_first),
+            (8, 8, out_second),
+            (16, 16, out_copy),
+            (24, 24, out_immediate),
+        ] {
+            successor.push(MInst::Load {
+                dst: output,
+                base: BaseReg::StackFrame,
+                offset: stack_offset,
+                size: OpSize::S64,
+            });
+            successor.push(MInst::Store {
+                base: BaseReg::SimState,
+                offset: state_offset,
+                src: output,
+                size: OpSize::S64,
+            });
+        }
+        successor.push(MInst::Return);
+        function.push_block(predecessor);
+        function.push_block(successor);
+
+        let mut assignment = AssignmentMap::default();
+        for (value, register) in [
+            (first, PhysReg::RAX),
+            (second, PhysReg::RDX),
+            (immediate, PhysReg::RSI),
+            (out_first, PhysReg::RAX),
+            (out_second, PhysReg::RAX),
+            (out_copy, PhysReg::RAX),
+            (out_immediate, PhysReg::RAX),
+        ] {
+            assignment.set(value, register);
+        }
+        assignment.set_edge_location(BlockId(0), first, EdgeLocation::Stack(0));
+        assignment.set_edge_location(BlockId(0), second, EdgeLocation::Stack(8));
+        assignment.set_edge_location(BlockId(0), immediate, EdgeLocation::Immediate(77));
+        assignment.set_edge_spill_slot(dst_first, 0);
+        assignment.set_edge_spill_slot(dst_second, 8);
+        assignment.set_edge_spill_slot(dst_copy, 16);
+        assignment.set_edge_spill_slot(dst_immediate, 24);
+
+        let emitted = emit(&function, &assignment, 32).unwrap();
+        let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
+        let mut state = vec![0_u8; 32];
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        let actual = state
+            .chunks_exact(8)
+            .map(|bytes| u64::from_le_bytes(bytes.try_into().unwrap()))
+            .collect::<Vec<_>>();
+        assert_eq!(actual, [44, 33, 33, 77]);
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -1,0 +1,2423 @@
+//! AArch64 emission for the shared scalar native MIR pipeline.
+
+use std::collections::HashMap;
+use std::fmt;
+
+use celox_backend_x86::native::mir::{
+    BaseReg, BlockId, BranchPredicate, CmpKind, MFunction, MInst, OpSize, PackedLaneCompareRhs,
+    SparseCommitDescriptor, VReg,
+};
+use celox_backend_x86::native::regalloc::AssignmentMap;
+use celox_backend_x86::native::regalloc::assignment::PhysReg;
+use celox_backend_x86::native::scalar_pipeline::{
+    PreparedScalarFunction, ScalarPrepareError as PrepareError, prepare_scalar_eu,
+};
+use celox_backend_x86::native::ssa_destroy::{
+    ParallelCopyDestination, ParallelCopyOperation, ParallelCopySource, SsaDestructionPlan,
+};
+use celox_state_layout::{
+    STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET, STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET,
+    STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET,
+};
+use dynasmrt::aarch64::Aarch64Relocation;
+use dynasmrt::{DynamicLabel, DynasmApi, DynasmError, DynasmLabelApi, VecAssembler, dynasm};
+
+const STATE_REG: u8 = 0;
+const SCRATCH0: u8 = 16;
+const SCRATCH1: u8 = 17;
+const TEMPORARY_BYTES: usize = 16;
+
+/// Result of scalar AArch64 emission.
+pub struct EmitResult {
+    pub code: Vec<u8>,
+    pub text_size: usize,
+    pub frame_size: u32,
+    pub required_state_size: u32,
+    pub block_offsets: Vec<(BlockId, u64)>,
+}
+
+/// Exact intermediate forms captured by the native runtime.
+#[derive(Default)]
+pub struct NativeFunctionTrace {
+    pub optimized_sir: String,
+    pub reactive_graph: String,
+    pub state_layout: String,
+    pub mir_before_regalloc: String,
+    pub mir_after_late_memory_folds: String,
+    pub mir_after_scheduling: String,
+    pub mir_after_regalloc: String,
+    pub register_assignment: String,
+    pub spill_frame_size: u32,
+    pub disassembly: String,
+}
+
+#[derive(Debug)]
+pub enum EmitError {
+    Assembly(DynasmError),
+    MissingAssignment(VReg),
+    Range(&'static str),
+    Unsupported(&'static str),
+    Ssa(celox_backend_x86::native::ssa_destroy::SsaDestructionError),
+}
+
+impl fmt::Display for EmitError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Assembly(error) => error.fmt(formatter),
+            Self::MissingAssignment(value) => {
+                write!(
+                    formatter,
+                    "ARM64 MIR value {value} has no physical assignment"
+                )
+            }
+            Self::Range(message) => write!(formatter, "ARM64 emission range error: {message}"),
+            Self::Unsupported(instruction) => {
+                write!(
+                    formatter,
+                    "ARM64 emission does not yet support {instruction}"
+                )
+            }
+            Self::Ssa(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for EmitError {}
+
+impl From<DynasmError> for EmitError {
+    fn from(error: DynasmError) -> Self {
+        Self::Assembly(error)
+    }
+}
+
+impl From<celox_backend_x86::native::ssa_destroy::SsaDestructionError> for EmitError {
+    fn from(error: celox_backend_x86::native::ssa_destroy::SsaDestructionError) -> Self {
+        Self::Ssa(error)
+    }
+}
+
+#[derive(Debug)]
+pub enum ChainedEmitError {
+    Prepare(PrepareError),
+    Emit(EmitError),
+}
+
+impl fmt::Display for ChainedEmitError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Prepare(error) => error.fmt(formatter),
+            Self::Emit(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for ChainedEmitError {}
+
+impl From<PrepareError> for ChainedEmitError {
+    fn from(error: PrepareError) -> Self {
+        Self::Prepare(error)
+    }
+}
+
+impl From<EmitError> for ChainedEmitError {
+    fn from(error: EmitError) -> Self {
+        Self::Emit(error)
+    }
+}
+
+/// Lower one prepared SIR execution unit through scalar MIR and AArch64 codegen.
+pub fn emit_prepared_eu(
+    sir_eu: &celox_backend_x86::ExecutionUnit<celox_backend_x86::RegionedAbsoluteAddr>,
+    layout: &celox_backend_x86::MemoryLayout,
+    four_state: bool,
+    label: &str,
+    _x86_options: &celox_backend_x86::X86BackendOptions,
+    mut trace: Option<&mut NativeFunctionTrace>,
+) -> Result<EmitResult, ChainedEmitError> {
+    let tick_loop =
+        label == "eval_comb_apply_ff" && celox_backend_x86::native::native_tick_loop_enabled();
+    let check_runtime_events = tick_loop
+        && sir_eu.blocks.values().any(|block| {
+            block.instructions.iter().any(|instruction| {
+                matches!(
+                    instruction,
+                    celox_backend_x86::SIRInstruction::RuntimeEvent { .. }
+                        | celox_backend_x86::SIRInstruction::CombCaptureEvent { .. }
+                )
+            })
+        });
+    if let Some(trace) = trace.as_deref_mut() {
+        trace.optimized_sir = sir_eu.to_string();
+    }
+    let prepared = prepare_scalar_eu(sir_eu, layout, four_state, label)?;
+    if let Some(trace) = trace.as_deref_mut() {
+        trace.mir_after_regalloc = prepared.function.to_string();
+        trace.register_assignment = prepared
+            .allocation
+            .sorted_entries()
+            .into_iter()
+            .map(|(value, register)| format!("  {value} -> {register}\n"))
+            .collect();
+        trace.spill_frame_size = prepared.spill_frame_size;
+    }
+    let result = emit_prepared(&prepared, tick_loop, check_runtime_events)?;
+    if let Some(trace) = trace {
+        trace.disassembly = disassemble(&result.code[..result.text_size], 0);
+    }
+    Ok(result)
+}
+
+/// Emit an already allocated MIR function. Primarily used by focused tests.
+pub fn emit(
+    function: &MFunction,
+    assignment: &AssignmentMap,
+    spill_frame_size: u32,
+) -> Result<EmitResult, EmitError> {
+    let plan = SsaDestructionPlan::build(function, assignment)?;
+    plan.verify(function, assignment, spill_frame_size)?;
+    emit_function(
+        function,
+        assignment,
+        spill_frame_size,
+        4096,
+        &plan,
+        false,
+        false,
+    )
+}
+
+fn emit_prepared(
+    prepared: &PreparedScalarFunction,
+    tick_loop: bool,
+    check_runtime_events: bool,
+) -> Result<EmitResult, EmitError> {
+    let plan = SsaDestructionPlan::build(&prepared.function, &prepared.allocation)?;
+    plan.verify(
+        &prepared.function,
+        &prepared.allocation,
+        prepared.spill_frame_size,
+    )?;
+    emit_function(
+        &prepared.function,
+        &prepared.allocation,
+        prepared.spill_frame_size,
+        prepared.state_size(),
+        &plan,
+        tick_loop,
+        check_runtime_events,
+    )
+}
+
+fn resolve(assignment: &AssignmentMap, value: VReg) -> Result<u8, EmitError> {
+    assignment
+        .get(value)
+        .map(physical_register)
+        .ok_or(EmitError::MissingAssignment(value))
+}
+
+/// The established allocator has fifteen colors. AArch64 exposes exactly
+/// fifteen volatile registers x1..x15 after reserving x0 for simulator state.
+fn physical_register(register: PhysReg) -> u8 {
+    match register {
+        PhysReg::RAX => 1,
+        PhysReg::RCX => 2,
+        PhysReg::RDX => 3,
+        PhysReg::RBX => 4,
+        PhysReg::RBP => 5,
+        PhysReg::RSI => 6,
+        PhysReg::RDI => 7,
+        PhysReg::R8 => 8,
+        PhysReg::R9 => 9,
+        PhysReg::R10 => 10,
+        PhysReg::R11 => 11,
+        PhysReg::R12 => 12,
+        PhysReg::R13 => 13,
+        PhysReg::R14 => 14,
+        PhysReg::R15 => 15,
+    }
+}
+
+fn align16(value: usize) -> Result<usize, EmitError> {
+    value
+        .checked_add(15)
+        .map(|value| value & !15)
+        .ok_or(EmitError::Range("native arena alignment overflow"))
+}
+
+fn emit_function(
+    function: &MFunction,
+    assignment: &AssignmentMap,
+    spill_frame_size: u32,
+    state_size: usize,
+    plan: &SsaDestructionPlan,
+    tick_loop: bool,
+    check_runtime_events: bool,
+) -> Result<EmitResult, EmitError> {
+    let spill_base = align16(state_size)?;
+    let temporary_offset = spill_base
+        .checked_add(spill_frame_size as usize)
+        .and_then(|value| value.checked_add(15))
+        .map(|value| value & !15)
+        .ok_or(EmitError::Range("spill arena overflow"))?;
+    let required_state_size = temporary_offset
+        .checked_add(TEMPORARY_BYTES)
+        .ok_or(EmitError::Range("native arena size overflow"))?;
+    let required_state_size = u32::try_from(required_state_size)
+        .map_err(|_| EmitError::Range("native arena exceeds u32"))?;
+
+    let mut ops = VecAssembler::<Aarch64Relocation>::new(0);
+    let block_labels = function
+        .blocks
+        .iter()
+        .map(|block| (block.id, ops.new_dynamic_label()))
+        .collect::<HashMap<_, _>>();
+    let table_labels = function
+        .constant_tables()
+        .iter()
+        .map(|_| ops.new_dynamic_label())
+        .collect::<Vec<_>>();
+    let epilogue = ops.new_dynamic_label();
+    let tick_success = tick_loop.then(|| ops.new_dynamic_label());
+    let tick_entry = tick_loop.then(|| block_labels[&function.blocks[0].id]);
+    let mut block_offsets = Vec::with_capacity(function.blocks.len());
+
+    dynasm!(ops
+        ; .arch aarch64
+        ; str x30, [sp, #-16]!
+    );
+    if tick_loop {
+        // d29 retains the simulator-state pointer across success/error return
+        // values. d31 carries the remaining tick count between body entries.
+        dynasm!(ops ; .arch aarch64 ; fmov d29, x0);
+        emit_address(
+            &mut ops,
+            STATE_REG,
+            STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET as i64,
+        );
+        emit_load(&mut ops, SCRATCH0, SCRATCH0, OpSize::S64);
+        let count_ready = ops.new_dynamic_label();
+        dynasm!(ops
+            ; .arch aarch64
+            ; cbnz x16, =>count_ready
+            ; mov x16, #1
+            ; =>count_ready
+            ; fmov d31, x16
+        );
+        if check_runtime_events {
+            emit_address(
+                &mut ops,
+                STATE_REG,
+                STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET as i64,
+            );
+            emit_load(&mut ops, SCRATCH0, SCRATCH0, OpSize::S64);
+            emit_load(&mut ops, SCRATCH0, SCRATCH0, OpSize::S64);
+            dynasm!(ops ; .arch aarch64 ; mov x30, x16);
+            emit_address(
+                &mut ops,
+                STATE_REG,
+                STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET as i64,
+            );
+            emit_store(&mut ops, 30, SCRATCH0, OpSize::S64);
+        }
+    }
+
+    for block in &function.blocks {
+        let label = block_labels[&block.id];
+        block_offsets.push((block.id, ops.offset().0 as u64));
+        dynasm!(ops
+            ; .arch aarch64
+            ; =>label
+        );
+        for instruction in &block.insts {
+            emit_instruction(
+                &mut ops,
+                instruction,
+                block.id,
+                assignment,
+                spill_base,
+                temporary_offset,
+                plan,
+                &block_labels,
+                &table_labels,
+                function.constant_tables(),
+                epilogue,
+                tick_entry,
+                tick_success,
+                check_runtime_events,
+            )?;
+        }
+    }
+
+    if let Some(success) = tick_success {
+        dynasm!(ops ; .arch aarch64 ; =>success ; mov x0, xzr);
+    }
+    dynasm!(ops
+        ; .arch aarch64
+        ; =>epilogue
+    );
+    if tick_loop {
+        dynasm!(ops
+            ; .arch aarch64
+            ; fmov x16, d31
+            ; fmov x17, d29
+        );
+        emit_load_imm(
+            &mut ops,
+            30,
+            STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET as u64,
+        );
+        dynasm!(ops ; .arch aarch64 ; add x17, x17, x30 ; str x16, [x17]);
+    }
+    dynasm!(ops ; .arch aarch64 ; ldr x30, [sp], #16 ; ret);
+    let text_size = ops.offset().0;
+    for (index, table) in function.constant_tables().iter().enumerate() {
+        let label = table_labels[index];
+        dynasm!(ops
+            ; .arch aarch64
+            ; .align 8
+            ; =>label
+        );
+        for &word in table {
+            dynasm!(ops
+                ; .arch aarch64
+                ; .u64 word
+            );
+        }
+    }
+    let code = ops.finalize()?;
+    Ok(EmitResult {
+        code,
+        text_size,
+        frame_size: spill_frame_size,
+        required_state_size,
+        block_offsets,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_instruction(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    instruction: &MInst,
+    block: BlockId,
+    assignment: &AssignmentMap,
+    spill_base: usize,
+    temporary_offset: usize,
+    plan: &SsaDestructionPlan,
+    labels: &HashMap<BlockId, DynamicLabel>,
+    table_labels: &[DynamicLabel],
+    constant_tables: &[Vec<u64>],
+    epilogue: DynamicLabel,
+    tick_entry: Option<DynamicLabel>,
+    tick_success: Option<DynamicLabel>,
+    check_runtime_events: bool,
+) -> Result<(), EmitError> {
+    match instruction {
+        MInst::Mov { dst, src } => {
+            let (dst, src) = (resolve(assignment, *dst)?, resolve(assignment, *src)?);
+            dynasm!(ops ; .arch aarch64 ; mov X(dst), X(src));
+        }
+        MInst::Mov32 { dst, src } => {
+            let (dst, src) = (resolve(assignment, *dst)?, resolve(assignment, *src)?);
+            dynasm!(ops ; .arch aarch64 ; mov W(dst), W(src));
+        }
+        MInst::LoadImm { dst, value } => emit_load_imm(ops, resolve(assignment, *dst)?, *value),
+        MInst::Scratch { .. } => {}
+        MInst::LoadConstantTableAddr { dst, table } => {
+            let dst = resolve(assignment, *dst)?;
+            let label = *table_labels
+                .get(table.0)
+                .ok_or(EmitError::Range("constant table identity out of range"))?;
+            dynasm!(ops ; .arch aarch64 ; adr X(dst), =>label);
+        }
+        MInst::Load {
+            dst,
+            base,
+            offset,
+            size,
+        } => {
+            emit_base_address(ops, *base, *offset, spill_base)?;
+            emit_load(ops, resolve(assignment, *dst)?, SCRATCH0, *size);
+        }
+        MInst::Store {
+            base,
+            offset,
+            src,
+            size,
+        } => {
+            emit_base_address(ops, *base, *offset, spill_base)?;
+            emit_store(ops, resolve(assignment, *src)?, SCRATCH0, *size);
+        }
+        MInst::LoadPtr {
+            dst,
+            ptr,
+            offset,
+            size,
+        } => {
+            emit_address(ops, resolve(assignment, *ptr)?, i64::from(*offset));
+            emit_load(ops, resolve(assignment, *dst)?, SCRATCH0, *size);
+        }
+        MInst::StorePtr {
+            ptr,
+            offset,
+            src,
+            size,
+        } => {
+            emit_address(ops, resolve(assignment, *ptr)?, i64::from(*offset));
+            emit_store(ops, resolve(assignment, *src)?, SCRATCH0, *size);
+        }
+        MInst::ReleaseStorePtr {
+            ptr,
+            offset,
+            src,
+            size,
+        } => {
+            emit_address(ops, resolve(assignment, *ptr)?, i64::from(*offset));
+            emit_release_store(ops, resolve(assignment, *src)?, SCRATCH0, *size);
+        }
+        MInst::LoadIndexed {
+            dst,
+            base,
+            offset,
+            index,
+            scale,
+            size,
+            ..
+        } => {
+            let base = base_register(*base);
+            let index = resolve(assignment, *index)?;
+            let shift = scale.trailing_zeros();
+            dynasm!(ops ; .arch aarch64 ; add x16, X(base), X(index), LSL #shift);
+            emit_add_offset(ops, i64::from(*offset));
+            emit_load(ops, resolve(assignment, *dst)?, SCRATCH0, *size);
+        }
+        MInst::StoreIndexed {
+            base,
+            offset,
+            index,
+            src,
+            size,
+            ..
+        }
+        | MInst::OrStoreIndexed {
+            base,
+            offset,
+            index,
+            src,
+            size,
+            ..
+        } => {
+            let base = base_register(*base);
+            let index = resolve(assignment, *index)?;
+            dynasm!(ops ; .arch aarch64 ; add x16, X(base), X(index));
+            emit_add_offset(ops, i64::from(*offset));
+            if matches!(instruction, MInst::OrStoreIndexed { .. }) {
+                emit_load(ops, SCRATCH1, SCRATCH0, *size);
+                let src = resolve(assignment, *src)?;
+                dynasm!(ops ; .arch aarch64 ; orr x17, x17, X(src));
+                emit_store(ops, SCRATCH1, SCRATCH0, *size);
+            } else {
+                emit_store(ops, resolve(assignment, *src)?, SCRATCH0, *size);
+            }
+        }
+        MInst::LoadPtrIndexed {
+            dst,
+            ptr,
+            offset,
+            index,
+            size,
+        } => {
+            let (ptr, index) = (resolve(assignment, *ptr)?, resolve(assignment, *index)?);
+            dynasm!(ops ; .arch aarch64 ; add x16, X(ptr), X(index));
+            emit_add_offset(ops, i64::from(*offset));
+            emit_load(ops, resolve(assignment, *dst)?, SCRATCH0, *size);
+        }
+        MInst::StorePtrIndexed {
+            ptr,
+            offset,
+            index,
+            src,
+            size,
+        }
+        | MInst::ReleaseStorePtrIndexed {
+            ptr,
+            offset,
+            index,
+            src,
+            size,
+        } => {
+            let (ptr, index) = (resolve(assignment, *ptr)?, resolve(assignment, *index)?);
+            dynasm!(ops ; .arch aarch64 ; add x16, X(ptr), X(index));
+            emit_add_offset(ops, i64::from(*offset));
+            let src = resolve(assignment, *src)?;
+            if matches!(instruction, MInst::ReleaseStorePtrIndexed { .. }) {
+                emit_release_store(ops, src, SCRATCH0, *size);
+            } else {
+                emit_store(ops, src, SCRATCH0, *size);
+            }
+        }
+        MInst::AndStoreImm {
+            base,
+            offset,
+            size,
+            imm,
+        }
+        | MInst::OrStoreImm {
+            base,
+            offset,
+            size,
+            imm,
+        } => {
+            emit_base_address(ops, *base, *offset, spill_base)?;
+            emit_load(ops, SCRATCH1, SCRATCH0, *size);
+            emit_load_imm(ops, SCRATCH0, *imm);
+            if matches!(instruction, MInst::AndStoreImm { .. }) {
+                dynasm!(ops ; .arch aarch64 ; and x30, x17, x16);
+            } else {
+                dynasm!(ops ; .arch aarch64 ; orr x30, x17, x16);
+            }
+            emit_base_address(ops, *base, *offset, spill_base)?;
+            emit_store(ops, 30, SCRATCH0, *size);
+        }
+        MInst::Add { dst, lhs, rhs }
+        | MInst::Sub { dst, lhs, rhs }
+        | MInst::Mul { dst, lhs, rhs }
+        | MInst::And { dst, lhs, rhs }
+        | MInst::Or { dst, lhs, rhs }
+        | MInst::Xor { dst, lhs, rhs }
+        | MInst::Shr { dst, lhs, rhs }
+        | MInst::Shl { dst, lhs, rhs }
+        | MInst::Sar { dst, lhs, rhs } => {
+            let (dst, lhs, rhs) = (
+                resolve(assignment, *dst)?,
+                resolve(assignment, *lhs)?,
+                resolve(assignment, *rhs)?,
+            );
+            match instruction {
+                MInst::Add { .. } => dynasm!(ops ; .arch aarch64 ; add X(dst), X(lhs), X(rhs)),
+                MInst::Sub { .. } => dynasm!(ops ; .arch aarch64 ; sub X(dst), X(lhs), X(rhs)),
+                MInst::Mul { .. } => dynasm!(ops ; .arch aarch64 ; mul X(dst), X(lhs), X(rhs)),
+                MInst::And { .. } => dynasm!(ops ; .arch aarch64 ; and X(dst), X(lhs), X(rhs)),
+                MInst::Or { .. } => dynasm!(ops ; .arch aarch64 ; orr X(dst), X(lhs), X(rhs)),
+                MInst::Xor { .. } => dynasm!(ops ; .arch aarch64 ; eor X(dst), X(lhs), X(rhs)),
+                MInst::Shr { .. } => dynasm!(ops ; .arch aarch64 ; lsrv X(dst), X(lhs), X(rhs)),
+                MInst::Shl { .. } => dynasm!(ops ; .arch aarch64 ; lslv X(dst), X(lhs), X(rhs)),
+                MInst::Sar { .. } => dynasm!(ops ; .arch aarch64 ; asrv X(dst), X(lhs), X(rhs)),
+                _ => unreachable!(),
+            }
+        }
+        MInst::Add32 { dst, lhs, rhs }
+        | MInst::Sub32 { dst, lhs, rhs }
+        | MInst::Mul32 { dst, lhs, rhs }
+        | MInst::And32 { dst, lhs, rhs }
+        | MInst::Or32 { dst, lhs, rhs }
+        | MInst::Xor32 { dst, lhs, rhs } => {
+            let (dst, lhs, rhs) = (
+                resolve(assignment, *dst)?,
+                resolve(assignment, *lhs)?,
+                resolve(assignment, *rhs)?,
+            );
+            match instruction {
+                MInst::Add32 { .. } => dynasm!(ops ; .arch aarch64 ; add W(dst), W(lhs), W(rhs)),
+                MInst::Sub32 { .. } => dynasm!(ops ; .arch aarch64 ; sub W(dst), W(lhs), W(rhs)),
+                MInst::Mul32 { .. } => dynasm!(ops ; .arch aarch64 ; mul W(dst), W(lhs), W(rhs)),
+                MInst::And32 { .. } => dynasm!(ops ; .arch aarch64 ; and W(dst), W(lhs), W(rhs)),
+                MInst::Or32 { .. } => dynasm!(ops ; .arch aarch64 ; orr W(dst), W(lhs), W(rhs)),
+                MInst::Xor32 { .. } => dynasm!(ops ; .arch aarch64 ; eor W(dst), W(lhs), W(rhs)),
+                _ => unreachable!(),
+            }
+        }
+        MInst::UMulHi { dst, lhs, rhs } => {
+            let (dst, lhs, rhs) = (
+                resolve(assignment, *dst)?,
+                resolve(assignment, *lhs)?,
+                resolve(assignment, *rhs)?,
+            );
+            dynasm!(ops ; .arch aarch64 ; umulh X(dst), X(lhs), X(rhs));
+        }
+        MInst::AndImm { dst, src, imm } | MInst::OrImm { dst, src, imm } => {
+            let (dst, src) = (resolve(assignment, *dst)?, resolve(assignment, *src)?);
+            emit_load_imm(ops, SCRATCH0, *imm);
+            if matches!(instruction, MInst::AndImm { .. }) {
+                dynasm!(ops ; .arch aarch64 ; and X(dst), X(src), x16);
+            } else {
+                dynasm!(ops ; .arch aarch64 ; orr X(dst), X(src), x16);
+            }
+        }
+        MInst::AndImm32 { dst, src, imm } => {
+            let (dst, src) = (resolve(assignment, *dst)?, resolve(assignment, *src)?);
+            emit_load_imm(ops, SCRATCH0, u64::from(*imm));
+            dynasm!(ops ; .arch aarch64 ; and W(dst), W(src), w16);
+        }
+        MInst::ShrImm { dst, src, imm }
+        | MInst::ShlImm { dst, src, imm }
+        | MInst::SarImm { dst, src, imm } => {
+            let (dst, src, imm) = (
+                resolve(assignment, *dst)?,
+                resolve(assignment, *src)?,
+                u32::from(*imm),
+            );
+            match instruction {
+                MInst::ShrImm { .. } => dynasm!(ops ; .arch aarch64 ; lsr X(dst), X(src), #imm),
+                MInst::ShlImm { .. } => dynasm!(ops ; .arch aarch64 ; lsl X(dst), X(src), #imm),
+                MInst::SarImm { .. } => dynasm!(ops ; .arch aarch64 ; asr X(dst), X(src), #imm),
+                _ => unreachable!(),
+            }
+        }
+        MInst::AddImm { dst, src, imm } | MInst::SubImm { dst, src, imm } => {
+            let (dst, src) = (resolve(assignment, *dst)?, resolve(assignment, *src)?);
+            emit_load_imm(ops, SCRATCH0, i64::from(*imm).unsigned_abs());
+            let subtract = matches!(instruction, MInst::SubImm { .. }) ^ (*imm < 0);
+            if subtract {
+                dynasm!(ops ; .arch aarch64 ; sub X(dst), X(src), x16);
+            } else {
+                dynasm!(ops ; .arch aarch64 ; add X(dst), X(src), x16);
+            }
+        }
+        MInst::Cmp {
+            dst,
+            lhs,
+            rhs,
+            kind,
+        } => {
+            let (dst, lhs, rhs) = (
+                resolve(assignment, *dst)?,
+                resolve(assignment, *lhs)?,
+                resolve(assignment, *rhs)?,
+            );
+            dynasm!(ops ; .arch aarch64 ; cmp X(lhs), X(rhs));
+            emit_cset(ops, dst, *kind);
+        }
+        MInst::CmpImm {
+            dst,
+            lhs,
+            imm,
+            kind,
+        } => {
+            let (dst, lhs) = (resolve(assignment, *dst)?, resolve(assignment, *lhs)?);
+            emit_load_imm(ops, SCRATCH0, *imm as i64 as u64);
+            dynasm!(ops ; .arch aarch64 ; cmp X(lhs), x16);
+            emit_cset(ops, dst, *kind);
+        }
+        MInst::UDiv { dst, lhs, rhs }
+        | MInst::URem { dst, lhs, rhs }
+        | MInst::SDiv { dst, lhs, rhs }
+        | MInst::SRem { dst, lhs, rhs } => {
+            let (dst, lhs, rhs) = (
+                resolve(assignment, *dst)?,
+                resolve(assignment, *lhs)?,
+                resolve(assignment, *rhs)?,
+            );
+            if matches!(instruction, MInst::UDiv { .. } | MInst::URem { .. }) {
+                dynasm!(ops ; .arch aarch64 ; udiv x16, X(lhs), X(rhs));
+            } else {
+                dynasm!(ops ; .arch aarch64 ; sdiv x16, X(lhs), X(rhs));
+            }
+            if matches!(instruction, MInst::URem { .. } | MInst::SRem { .. }) {
+                dynasm!(ops ; .arch aarch64 ; msub X(dst), x16, X(rhs), X(lhs));
+            } else {
+                dynasm!(ops ; .arch aarch64 ; mov X(dst), x16);
+            }
+        }
+        MInst::BitNot { dst, src } | MInst::Neg { dst, src } => {
+            let (dst, src) = (resolve(assignment, *dst)?, resolve(assignment, *src)?);
+            if matches!(instruction, MInst::BitNot { .. }) {
+                dynasm!(ops ; .arch aarch64 ; mvn X(dst), X(src));
+            } else {
+                dynasm!(ops ; .arch aarch64 ; neg X(dst), X(src));
+            }
+        }
+        MInst::Popcnt { dst, src } => {
+            let (dst, src) = (resolve(assignment, *dst)?, resolve(assignment, *src)?);
+            dynasm!(ops
+                ; .arch aarch64
+                ; fmov d0, X(src)
+                ; cnt v0.b8, v0.b8
+                ; addv b0, v0.b8
+                ; umov W(dst), v0.b[0]
+            );
+        }
+        MInst::Bsf { dst, src } => {
+            let (dst, src) = (resolve(assignment, *dst)?, resolve(assignment, *src)?);
+            dynasm!(ops ; .arch aarch64 ; rbit x16, X(src) ; clz X(dst), x16);
+        }
+        MInst::Bsr { dst, src } | MInst::BsrOr { dst, src, .. } => {
+            let (dst, src) = (resolve(assignment, *dst)?, resolve(assignment, *src)?);
+            dynasm!(ops ; .arch aarch64 ; clz x16, X(src));
+            emit_load_imm(ops, SCRATCH1, 63);
+            dynasm!(ops ; .arch aarch64 ; sub x16, x17, x16);
+            if let MInst::BsrOr { zero_value, .. } = instruction {
+                emit_load_imm(ops, SCRATCH1, u64::from(*zero_value));
+                dynasm!(ops ; .arch aarch64 ; cmp XSP(src), #0 ; csel X(dst), x16, x17, ne);
+            } else {
+                dynasm!(ops ; .arch aarch64 ; mov X(dst), x16);
+            }
+        }
+        MInst::Select {
+            dst,
+            cond,
+            true_val,
+            false_val,
+        } => {
+            let (dst, cond, true_val, false_val) = (
+                resolve(assignment, *dst)?,
+                resolve(assignment, *cond)?,
+                resolve(assignment, *true_val)?,
+                resolve(assignment, *false_val)?,
+            );
+            dynasm!(ops
+                ; .arch aarch64
+                ; cmp XSP(cond), #0
+                ; csel X(dst), X(true_val), X(false_val), ne
+            );
+        }
+        MInst::CmpSelect {
+            dst,
+            lhs,
+            rhs,
+            kind,
+            true_val,
+            false_val,
+        } => {
+            let (dst, lhs, rhs, true_val, false_val) = (
+                resolve(assignment, *dst)?,
+                resolve(assignment, *lhs)?,
+                resolve(assignment, *rhs)?,
+                resolve(assignment, *true_val)?,
+                resolve(assignment, *false_val)?,
+            );
+            dynasm!(ops ; .arch aarch64 ; cmp X(lhs), X(rhs));
+            emit_csel(ops, dst, true_val, false_val, *kind);
+        }
+        MInst::CmpImmSelect {
+            dst,
+            lhs,
+            imm,
+            kind,
+            true_val,
+            false_val,
+        } => {
+            let (dst, lhs, true_val, false_val) = (
+                resolve(assignment, *dst)?,
+                resolve(assignment, *lhs)?,
+                resolve(assignment, *true_val)?,
+                resolve(assignment, *false_val)?,
+            );
+            emit_load_imm(ops, SCRATCH0, *imm as i64 as u64);
+            dynasm!(ops ; .arch aarch64 ; cmp X(lhs), x16);
+            emit_csel(ops, dst, true_val, false_val, *kind);
+        }
+        MInst::JumpTable { index, targets, .. } => {
+            let Some((&default_target, compared_targets)) = targets.split_last() else {
+                return Err(EmitError::Range("jump table has no targets"));
+            };
+            let index = resolve(assignment, *index)?;
+            let paths = compared_targets
+                .iter()
+                .map(|_| ops.new_dynamic_label())
+                .collect::<Vec<_>>();
+            for (table_index, path) in paths.iter().copied().enumerate() {
+                emit_load_imm(ops, SCRATCH0, table_index as u64);
+                dynasm!(ops ; .arch aarch64 ; cmp X(index), x16 ; b.eq =>path);
+            }
+            emit_edge_copies(
+                ops,
+                plan,
+                block,
+                default_target,
+                spill_base,
+                temporary_offset,
+            )?;
+            let default_label = labels[&default_target];
+            dynasm!(ops ; .arch aarch64 ; b =>default_label);
+            for (&target, path) in compared_targets.iter().zip(paths) {
+                dynasm!(ops ; .arch aarch64 ; =>path);
+                emit_edge_copies(ops, plan, block, target, spill_base, temporary_offset)?;
+                let target_label = labels[&target];
+                dynasm!(ops ; .arch aarch64 ; b =>target_label);
+            }
+        }
+        MInst::Branch {
+            cond,
+            true_bb,
+            false_bb,
+        } => {
+            let true_path = ops.new_dynamic_label();
+            let cond = resolve(assignment, *cond)?;
+            dynasm!(ops ; .arch aarch64 ; cbnz X(cond), =>true_path);
+            emit_edge_copies(ops, plan, block, *false_bb, spill_base, temporary_offset)?;
+            let false_label = labels[false_bb];
+            dynasm!(ops ; .arch aarch64 ; b =>false_label ; =>true_path);
+            emit_edge_copies(ops, plan, block, *true_bb, spill_base, temporary_offset)?;
+            let true_label = labels[true_bb];
+            dynasm!(ops ; .arch aarch64 ; b =>true_label);
+        }
+        MInst::BranchPred {
+            predicate,
+            true_bb,
+            false_bb,
+        } => {
+            emit_branch_predicate(ops, *predicate, assignment, spill_base)?;
+            let true_path = ops.new_dynamic_label();
+            emit_conditional_branch(ops, true_path, predicate_kind(*predicate));
+            emit_edge_copies(ops, plan, block, *false_bb, spill_base, temporary_offset)?;
+            let false_label = labels[false_bb];
+            dynasm!(ops ; .arch aarch64 ; b =>false_label ; =>true_path);
+            emit_edge_copies(ops, plan, block, *true_bb, spill_base, temporary_offset)?;
+            let true_label = labels[true_bb];
+            dynasm!(ops ; .arch aarch64 ; b =>true_label);
+        }
+        MInst::Jump { target } => {
+            emit_edge_copies(ops, plan, block, *target, spill_base, temporary_offset)?;
+            let label = labels[target];
+            dynasm!(ops ; .arch aarch64 ; b =>label);
+        }
+        MInst::Return => {
+            if let (Some(entry), Some(success)) = (tick_entry, tick_success) {
+                dynasm!(ops
+                    ; .arch aarch64
+                    ; fmov x16, d31
+                    ; subs x16, x16, #1
+                    ; fmov d31, x16
+                    ; b.eq =>success
+                );
+                if check_runtime_events {
+                    emit_address(
+                        ops,
+                        STATE_REG,
+                        STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET as i64,
+                    );
+                    emit_load(ops, SCRATCH0, SCRATCH0, OpSize::S64);
+                    emit_load(ops, SCRATCH0, SCRATCH0, OpSize::S64);
+                    dynasm!(ops ; .arch aarch64 ; mov x30, x16);
+                    emit_address(
+                        ops,
+                        STATE_REG,
+                        STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET as i64,
+                    );
+                    emit_load(ops, SCRATCH1, SCRATCH0, OpSize::S64);
+                    dynasm!(ops ; .arch aarch64 ; cmp x30, x17 ; b.ne =>success);
+                }
+                dynasm!(ops ; .arch aarch64 ; b =>entry);
+            } else {
+                dynasm!(ops ; .arch aarch64 ; mov x0, xzr ; b =>epilogue);
+            }
+        }
+        MInst::ReturnError { code } => {
+            if tick_entry.is_some() {
+                dynasm!(ops
+                    ; .arch aarch64
+                    ; fmov x16, d31
+                    ; sub x16, x16, #1
+                    ; fmov d31, x16
+                );
+            }
+            emit_load_imm(ops, STATE_REG, *code as u64);
+            dynasm!(ops ; .arch aarch64 ; b =>epilogue);
+        }
+        MInst::X86Simd(_) => return Err(EmitError::Unsupported("x86 SIMD MIR")),
+        MInst::PackedLaneCompare {
+            dst,
+            rhs,
+            kind,
+            offset,
+            lane_count,
+            element_stride,
+            bit_offset,
+            field_width,
+            ..
+        } => emit_packed_lane_compare(
+            ops,
+            resolve(assignment, *dst)?,
+            *rhs,
+            *kind,
+            *offset,
+            *lane_count,
+            *element_stride,
+            *bit_offset,
+            *field_width,
+            assignment,
+        )?,
+        MInst::PackedByteAffineCompare {
+            dst,
+            base,
+            rhs,
+            kind,
+        } => emit_packed_byte_affine_compare(
+            ops,
+            resolve(assignment, *dst)?,
+            resolve(assignment, *base)?,
+            resolve(assignment, *rhs)?,
+            *kind,
+        ),
+        MInst::MemCopy {
+            src_offset,
+            dst_offset,
+            byte_len,
+        } => emit_mem_copy(ops, *src_offset, *dst_offset, *byte_len),
+        MInst::MemFill {
+            dst_offset,
+            byte_len,
+            value,
+        } => emit_mem_fill(ops, *dst_offset, *byte_len, *value),
+        MInst::SparseCommit {
+            src_offset,
+            dst_offset,
+            byte_size,
+            dirty_words_offset,
+            dirty_word_count,
+            summary_words_offset,
+            summary_word_count,
+            four_state,
+        } => emit_sparse_commit(
+            ops,
+            *src_offset,
+            *dst_offset,
+            *byte_size,
+            *dirty_words_offset,
+            *dirty_word_count,
+            *summary_words_offset,
+            *summary_word_count,
+            *four_state,
+        ),
+        MInst::SparseMarkActive {
+            active_index,
+            active_bits_offset,
+            ..
+        } => {
+            let word_offset = i32::try_from((*active_index as usize / 64) * 8)
+                .map_err(|_| EmitError::Range("sparse active bitmap offset exceeds i32"))?;
+            let offset = active_bits_offset
+                .checked_add(word_offset)
+                .ok_or(EmitError::Range("sparse active bitmap offset overflow"))?;
+            emit_base_address(ops, BaseReg::SimState, offset, spill_base)?;
+            emit_load(ops, SCRATCH1, SCRATCH0, OpSize::S64);
+            emit_load_imm(ops, SCRATCH0, 1_u64 << (*active_index % 64));
+            dynasm!(ops ; .arch aarch64 ; orr x30, x17, x16);
+            emit_base_address(ops, BaseReg::SimState, offset, spill_base)?;
+            emit_store(ops, 30, SCRATCH0, OpSize::S64);
+        }
+        MInst::SparseCommitWorklist {
+            descriptor_table,
+            active_bits_offset,
+            active_capacity,
+        } => emit_sparse_commit_worklist(
+            ops,
+            constant_tables
+                .get(descriptor_table.0)
+                .ok_or(EmitError::Range("sparse descriptor table is missing"))?,
+            *active_bits_offset,
+            *active_capacity,
+        )?,
+        MInst::Pext { dst, src, mask } | MInst::Pdep { dst, src, mask } => {
+            emit_parallel_bits(
+                ops,
+                resolve(assignment, *dst)?,
+                resolve(assignment, *src)?,
+                resolve(assignment, *mask)?,
+                matches!(instruction, MInst::Pdep { .. }),
+            );
+        }
+        MInst::GuardedCmpSelect {
+            dst,
+            guard,
+            lhs,
+            rhs,
+            kind,
+            true_val,
+            false_val,
+        } => {
+            let (dst, guard, lhs, rhs, true_val, false_val) = (
+                resolve(assignment, *dst)?,
+                resolve(assignment, *guard)?,
+                resolve(assignment, *lhs)?,
+                resolve(assignment, *rhs)?,
+                resolve(assignment, *true_val)?,
+                resolve(assignment, *false_val)?,
+            );
+            // Materialize the comparison before testing the guard because both
+            // operations write NZCV. x16 is reserved from the allocator.
+            dynasm!(ops ; .arch aarch64 ; cmp X(lhs), X(rhs));
+            emit_cset(ops, SCRATCH0, *kind);
+            dynasm!(ops
+                ; .arch aarch64
+                ; cmp XSP(guard), #0
+                ; csel x16, x16, xzr, ne
+                ; cmp x16, #0
+                ; csel X(dst), X(true_val), X(false_val), ne
+            );
+        }
+    }
+    Ok(())
+}
+
+fn emit_mem_copy(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    src_offset: i32,
+    dst_offset: i32,
+    byte_len: usize,
+) {
+    if byte_len == 0 || src_offset == dst_offset {
+        return;
+    }
+    let src_end = i64::from(src_offset) + byte_len as i64;
+    let dst_end = i64::from(dst_offset) + byte_len as i64;
+    let copy_backward = src_end > i64::from(dst_offset)
+        && dst_end > i64::from(src_offset)
+        && dst_offset > src_offset;
+    let qwords = byte_len / 8;
+    let remainder = byte_len % 8;
+
+    if copy_backward {
+        emit_load_imm(ops, SCRATCH0, src_end as u64);
+        dynasm!(ops ; .arch aarch64 ; add x16, x0, x16);
+        emit_load_imm(ops, SCRATCH1, dst_end as u64);
+        dynasm!(ops ; .arch aarch64 ; add x17, x0, x17);
+        if remainder >= 4 {
+            dynasm!(ops
+                ; .arch aarch64
+                ; ldr w30, [x16, #-4]!
+                ; str w30, [x17, #-4]!
+            );
+        }
+        if remainder % 4 >= 2 {
+            dynasm!(ops
+                ; .arch aarch64
+                ; ldrh w30, [x16, #-2]!
+                ; strh w30, [x17, #-2]!
+            );
+        }
+        if remainder % 2 == 1 {
+            dynasm!(ops
+                ; .arch aarch64
+                ; ldrb w30, [x16, #-1]!
+                ; strb w30, [x17, #-1]!
+            );
+        }
+        if qwords != 0 {
+            let loop_label = ops.new_dynamic_label();
+            let done = ops.new_dynamic_label();
+            emit_load_imm(ops, 30, dst_offset as i64 as u64);
+            dynasm!(ops
+                ; .arch aarch64
+                ; add x30, x0, x30
+                ; =>loop_label
+                ; cmp x17, x30
+                ; b.ls =>done
+                ; ldr d0, [x16, #-8]!
+                ; str d0, [x17, #-8]!
+                ; b =>loop_label
+                ; =>done
+            );
+        }
+        return;
+    }
+
+    emit_load_imm(ops, SCRATCH0, src_offset as i64 as u64);
+    dynasm!(ops ; .arch aarch64 ; add x16, x0, x16);
+    emit_load_imm(ops, SCRATCH1, dst_offset as i64 as u64);
+    dynasm!(ops ; .arch aarch64 ; add x17, x0, x17);
+    if qwords != 0 {
+        let loop_label = ops.new_dynamic_label();
+        let done = ops.new_dynamic_label();
+        emit_load_imm(
+            ops,
+            30,
+            (i64::from(dst_offset) + (qwords * 8) as i64) as u64,
+        );
+        dynasm!(ops
+            ; .arch aarch64
+            ; add x30, x0, x30
+            ; =>loop_label
+            ; cmp x17, x30
+            ; b.hs =>done
+            ; ldr d0, [x16], #8
+            ; str d0, [x17], #8
+            ; b =>loop_label
+            ; =>done
+        );
+    }
+    if remainder >= 4 {
+        dynasm!(ops ; .arch aarch64 ; ldr w30, [x16], #4 ; str w30, [x17], #4);
+    }
+    if remainder % 4 >= 2 {
+        dynasm!(ops ; .arch aarch64 ; ldrh w30, [x16], #2 ; strh w30, [x17], #2);
+    }
+    if remainder % 2 == 1 {
+        dynasm!(ops ; .arch aarch64 ; ldrb w30, [x16] ; strb w30, [x17]);
+    }
+}
+
+fn emit_parallel_bits(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: u8,
+    source: u8,
+    mask: u8,
+    deposit: bool,
+) {
+    // Save both inputs before defining the result: allocation may coalesce a
+    // dying input with the destination. The fixed unroll avoids a hidden GPR
+    // clobber while matching BMI2 semantics on baseline ARMv8-A.
+    dynasm!(ops
+        ; .arch aarch64
+        ; fmov d6, X(source)
+        ; fmov d7, X(mask)
+        ; mov x17, xzr
+        ; mov x30, xzr
+    );
+    for bit in 0..64_u32 {
+        let skip = ops.new_dynamic_label();
+        dynasm!(ops ; .arch aarch64 ; fmov x16, d7 ; tbz x16, bit, =>skip ; fmov x16, d6);
+        if deposit {
+            dynasm!(ops ; .arch aarch64 ; lsr x16, x16, x17 ; and x16, x16, #1);
+            if bit != 0 {
+                dynasm!(ops ; .arch aarch64 ; lsl x16, x16, bit);
+            }
+        } else {
+            if bit != 0 {
+                dynasm!(ops ; .arch aarch64 ; lsr x16, x16, bit);
+            }
+            dynasm!(ops ; .arch aarch64 ; and x16, x16, #1 ; lsl x16, x16, x17);
+        }
+        dynasm!(ops
+            ; .arch aarch64
+            ; orr x30, x30, x16
+            ; add x17, x17, #1
+            ; =>skip
+        );
+    }
+    dynasm!(ops ; .arch aarch64 ; mov X(destination), x30);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_packed_lane_compare(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: u8,
+    rhs: PackedLaneCompareRhs,
+    kind: CmpKind,
+    offset: i32,
+    lane_count: u8,
+    element_stride: u8,
+    bit_offset: u8,
+    field_width: u8,
+    assignment: &AssignmentMap,
+) -> Result<(), EmitError> {
+    let size = match element_stride {
+        1 => OpSize::S8,
+        2 => OpSize::S16,
+        4 => OpSize::S32,
+        _ => return Err(EmitError::Range("packed lane stride must be 1, 2, or 4")),
+    };
+    if let PackedLaneCompareRhs::Scalar(value) = rhs {
+        let register = resolve(assignment, value)?;
+        dynasm!(ops ; .arch aarch64 ; fmov d6, X(register));
+    }
+    dynasm!(ops ; .arch aarch64 ; mov x30, xzr);
+    let field_mask = if field_width == 64 {
+        u64::MAX
+    } else {
+        (1_u64 << field_width) - 1
+    };
+    for lane in 0..lane_count {
+        let lane_delta = i32::from(lane)
+            .checked_mul(i32::from(element_stride))
+            .and_then(|delta| offset.checked_add(delta))
+            .ok_or(EmitError::Range("packed lane offset overflow"))?;
+        emit_address(ops, STATE_REG, i64::from(lane_delta));
+        emit_load(ops, SCRATCH0, SCRATCH0, size);
+        match rhs {
+            PackedLaneCompareRhs::Scalar(_) => {
+                dynasm!(ops ; .arch aarch64 ; fmov x17, d6);
+            }
+            PackedLaneCompareRhs::Memory { offset, .. } => {
+                dynasm!(ops ; .arch aarch64 ; fmov d7, x16);
+                let rhs_offset = i32::from(lane)
+                    .checked_mul(i32::from(element_stride))
+                    .and_then(|delta| offset.checked_add(delta))
+                    .ok_or(EmitError::Range("packed lane RHS offset overflow"))?;
+                emit_address(ops, STATE_REG, i64::from(rhs_offset));
+                emit_load(ops, SCRATCH1, SCRATCH0, size);
+                dynasm!(ops ; .arch aarch64 ; fmov x16, d7);
+            }
+        }
+        if bit_offset != 0 {
+            let shift = u32::from(bit_offset);
+            dynasm!(ops
+                ; .arch aarch64
+                ; lsr x16, x16, shift
+                ; lsr x17, x17, shift
+            );
+        }
+        let storage_width = element_stride * 8;
+        if field_width != storage_width {
+            dynasm!(ops ; .arch aarch64 ; fmov d5, x30);
+            emit_load_imm(ops, 30, field_mask);
+            dynasm!(ops
+                ; .arch aarch64
+                ; and x16, x16, x30
+                ; and x17, x17, x30
+                ; fmov x30, d5
+            );
+        }
+        if matches!(
+            kind,
+            CmpKind::LtS | CmpKind::LeS | CmpKind::GtS | CmpKind::GeS
+        ) {
+            match storage_width {
+                8 => dynasm!(ops ; .arch aarch64 ; sxtb x16, w16 ; sxtb x17, w17),
+                16 => dynasm!(ops ; .arch aarch64 ; sxth x16, w16 ; sxth x17, w17),
+                32 => dynasm!(ops ; .arch aarch64 ; sxtw x16, w16 ; sxtw x17, w17),
+                _ => unreachable!(),
+            }
+        }
+        dynasm!(ops ; .arch aarch64 ; cmp x16, x17);
+        emit_cset(ops, SCRATCH0, kind);
+        if lane != 0 {
+            let shift = u32::from(lane);
+            dynasm!(ops ; .arch aarch64 ; lsl x16, x16, shift);
+        }
+        dynasm!(ops ; .arch aarch64 ; orr x30, x30, x16);
+    }
+    dynasm!(ops ; .arch aarch64 ; mov X(destination), x30);
+    Ok(())
+}
+
+fn emit_packed_byte_affine_compare(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: u8,
+    base: u8,
+    rhs: u8,
+    kind: CmpKind,
+) {
+    dynasm!(ops
+        ; .arch aarch64
+        ; fmov d6, X(base)
+        ; fmov d7, X(rhs)
+        ; mov x30, xzr
+    );
+    for lane in 0..16_u32 {
+        dynasm!(ops ; .arch aarch64 ; fmov x16, d6);
+        if lane != 0 {
+            emit_load_imm(ops, SCRATCH1, u64::from(lane));
+            dynasm!(ops ; .arch aarch64 ; add x16, x16, x17);
+        }
+        dynasm!(ops ; .arch aarch64 ; fmov x17, d7 ; fmov d5, x30);
+        emit_load_imm(ops, 30, 0xff);
+        dynasm!(ops
+            ; .arch aarch64
+            ; and x16, x16, x30
+            ; and x17, x17, x30
+            ; fmov x30, d5
+        );
+        if matches!(
+            kind,
+            CmpKind::LtS | CmpKind::LeS | CmpKind::GtS | CmpKind::GeS
+        ) {
+            dynasm!(ops ; .arch aarch64 ; sxtb x16, w16 ; sxtb x17, w17);
+        }
+        dynasm!(ops ; .arch aarch64 ; cmp x16, x17);
+        emit_cset(ops, SCRATCH0, kind);
+        if lane != 0 {
+            dynasm!(ops ; .arch aarch64 ; lsl x16, x16, lane);
+        }
+        dynasm!(ops ; .arch aarch64 ; orr x30, x30, x16);
+    }
+    dynasm!(ops ; .arch aarch64 ; mov X(destination), x30);
+}
+
+fn emit_sparse_commit_worklist(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    descriptors: &[u64],
+    active_bits_offset: i32,
+    active_capacity: usize,
+) -> Result<(), EmitError> {
+    for word_index in 0..active_capacity.div_ceil(64) {
+        let word_offset = i32::try_from(word_index * 8)
+            .map_err(|_| EmitError::Range("sparse active bitmap offset exceeds i32"))?;
+        let offset = active_bits_offset
+            .checked_add(word_offset)
+            .ok_or(EmitError::Range("sparse active bitmap offset overflow"))?;
+        let word_done = ops.new_dynamic_label();
+        emit_address(ops, STATE_REG, i64::from(offset));
+        dynasm!(ops
+            ; .arch aarch64
+            ; ldr x17, [x16]
+            ; str xzr, [x16]
+            ; cbz x17, =>word_done
+        );
+        let first_index = word_index * 64;
+        let end_index = active_capacity.min(first_index + 64);
+        for active_index in first_index..end_index {
+            let row_start = active_index
+                .checked_mul(SparseCommitDescriptor::WORDS)
+                .ok_or(EmitError::Range("sparse descriptor index overflow"))?;
+            let row = descriptors
+                .get(row_start..row_start + SparseCommitDescriptor::WORDS)
+                .ok_or(EmitError::Range("sparse descriptor row is missing"))?;
+            let skip = ops.new_dynamic_label();
+            let mask = 1_u64 << (active_index % 64);
+            emit_load_imm(ops, SCRATCH0, mask);
+            dynasm!(ops
+                ; .arch aarch64
+                ; and x16, x17, x16
+                ; cbz x16, =>skip
+                ; fmov d5, x17
+            );
+            emit_sparse_commit(
+                ops,
+                i32::try_from(row[0])
+                    .map_err(|_| EmitError::Range("sparse source offset exceeds i32"))?,
+                i32::try_from(row[1])
+                    .map_err(|_| EmitError::Range("sparse destination offset exceeds i32"))?,
+                usize::try_from(row[2])
+                    .map_err(|_| EmitError::Range("sparse byte size exceeds usize"))?,
+                i32::try_from(row[3])
+                    .map_err(|_| EmitError::Range("sparse dirty offset exceeds i32"))?,
+                usize::try_from(row[4])
+                    .map_err(|_| EmitError::Range("sparse dirty count exceeds usize"))?,
+                i32::try_from(row[5])
+                    .map_err(|_| EmitError::Range("sparse summary offset exceeds i32"))?,
+                usize::try_from(row[6])
+                    .map_err(|_| EmitError::Range("sparse summary count exceeds usize"))?,
+                row[7] != 0,
+            );
+            dynasm!(ops ; .arch aarch64 ; fmov x17, d5 ; =>skip);
+        }
+        dynasm!(ops ; .arch aarch64 ; =>word_done);
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_sparse_commit(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    src_offset: i32,
+    dst_offset: i32,
+    byte_size: usize,
+    dirty_words_offset: i32,
+    dirty_word_count: usize,
+    summary_words_offset: i32,
+    summary_word_count: usize,
+    four_state: bool,
+) {
+    let chunk_count = byte_size.div_ceil(8);
+    let last_chunk = chunk_count.saturating_sub(1);
+    let last_len = byte_size.saturating_sub(last_chunk * 8);
+    let plane_count = if four_state { 2 } else { 1 };
+
+    for summary_index in 0..summary_word_count {
+        let summary_loop = ops.new_dynamic_label();
+        let summary_done = ops.new_dynamic_label();
+        let summary_next = ops.new_dynamic_label();
+        let dirty_loop = ops.new_dynamic_label();
+        let dirty_restore = ops.new_dynamic_label();
+        let summary_offset = i64::from(summary_words_offset) + (summary_index * 8) as i64;
+        emit_address(ops, STATE_REG, summary_offset);
+        dynasm!(ops
+            ; .arch aarch64
+            ; ldr x17, [x16]
+            ; str xzr, [x16]
+            ; mov x16, x17
+            ; =>summary_loop
+            ; cbz x16, =>summary_done
+            ; rbit x17, x16
+            ; clz x17, x17
+            ; sub x30, x16, #1
+            ; and x16, x16, x30
+        );
+        if summary_index != 0 {
+            emit_load_imm(ops, 30, (summary_index * 64) as u64);
+            dynasm!(ops ; .arch aarch64 ; add x17, x17, x30);
+        }
+        emit_load_imm(ops, 30, dirty_word_count as u64);
+        dynasm!(ops
+            ; .arch aarch64
+            ; cmp x17, x30
+            ; b.hs =>summary_loop
+            ; fmov d0, x16
+            ; fmov d1, x17
+            ; lsl x17, x17, #3
+        );
+        emit_load_imm(ops, SCRATCH0, dirty_words_offset as i64 as u64);
+        dynasm!(ops
+            ; .arch aarch64
+            ; add x16, x0, x16
+            ; add x16, x16, x17
+            ; ldr x30, [x16]
+            ; str xzr, [x16]
+            ; =>dirty_loop
+            ; cbz x30, =>summary_next
+            ; rbit x17, x30
+            ; clz x17, x17
+            ; sub x16, x30, #1
+            ; and x30, x30, x16
+            ; fmov d2, x30
+            ; fmov x16, d1
+            ; lsl x16, x16, #6
+            ; add x17, x16, x17
+        );
+        emit_load_imm(ops, SCRATCH0, chunk_count as u64);
+        dynasm!(ops
+            ; .arch aarch64
+            ; cmp x17, x16
+            ; b.hs =>dirty_restore
+            ; lsl x17, x17, #3
+            ; fmov d4, x17
+        );
+
+        if last_len != 8 {
+            let full_chunk = ops.new_dynamic_label();
+            let copy_done = ops.new_dynamic_label();
+            emit_load_imm(ops, SCRATCH0, (last_chunk * 8) as u64);
+            dynasm!(ops ; .arch aarch64 ; cmp x17, x16 ; b.ne =>full_chunk);
+            for plane in 0..plane_count {
+                let delta = (plane * byte_size) as i32;
+                emit_sparse_chunk_copy(ops, src_offset + delta, dst_offset + delta, last_len);
+            }
+            dynasm!(ops ; .arch aarch64 ; b =>copy_done ; =>full_chunk);
+            for plane in 0..plane_count {
+                let delta = (plane * byte_size) as i32;
+                emit_sparse_chunk_copy(ops, src_offset + delta, dst_offset + delta, 8);
+            }
+            dynasm!(ops ; .arch aarch64 ; =>copy_done);
+        } else {
+            for plane in 0..plane_count {
+                let delta = (plane * byte_size) as i32;
+                emit_sparse_chunk_copy(ops, src_offset + delta, dst_offset + delta, 8);
+            }
+        }
+        dynasm!(ops
+            ; .arch aarch64
+            ; =>dirty_restore
+            ; fmov x30, d2
+            ; b =>dirty_loop
+            ; =>summary_next
+            ; fmov x16, d0
+            ; b =>summary_loop
+            ; =>summary_done
+        );
+    }
+}
+
+fn emit_sparse_chunk_copy(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    src_offset: i32,
+    dst_offset: i32,
+    byte_len: usize,
+) {
+    dynasm!(ops ; .arch aarch64 ; fmov x17, d4);
+    emit_load_imm(ops, SCRATCH0, src_offset as i64 as u64);
+    dynasm!(ops ; .arch aarch64 ; add x16, x0, x16 ; add x16, x16, x17);
+    emit_load_imm(ops, 30, dst_offset as i64 as u64);
+    dynasm!(ops ; .arch aarch64 ; add x30, x0, x30 ; add x30, x30, x17);
+    if byte_len == 8 {
+        dynasm!(ops ; .arch aarch64 ; ldr d3, [x16] ; str d3, [x30]);
+        return;
+    }
+    if byte_len >= 4 {
+        dynasm!(ops ; .arch aarch64 ; ldr w17, [x16], #4 ; str w17, [x30], #4);
+    }
+    if byte_len % 4 >= 2 {
+        dynasm!(ops ; .arch aarch64 ; ldrh w17, [x16], #2 ; strh w17, [x30], #2);
+    }
+    if byte_len % 2 == 1 {
+        dynasm!(ops ; .arch aarch64 ; ldrb w17, [x16] ; strb w17, [x30]);
+    }
+}
+
+fn emit_mem_fill(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    dst_offset: i32,
+    byte_len: usize,
+    value: u8,
+) {
+    if byte_len == 0 {
+        return;
+    }
+    let qwords = byte_len / 8;
+    let remainder = byte_len % 8;
+    let pattern = u64::from(value) * 0x0101_0101_0101_0101;
+    emit_load_imm(ops, SCRATCH0, dst_offset as i64 as u64);
+    dynasm!(ops ; .arch aarch64 ; add x16, x0, x16);
+    emit_load_imm(ops, 30, pattern);
+    if qwords != 0 {
+        let loop_label = ops.new_dynamic_label();
+        let done = ops.new_dynamic_label();
+        emit_load_imm(
+            ops,
+            SCRATCH1,
+            (i64::from(dst_offset) + (qwords * 8) as i64) as u64,
+        );
+        dynasm!(ops
+            ; .arch aarch64
+            ; add x17, x0, x17
+            ; =>loop_label
+            ; cmp x16, x17
+            ; b.hs =>done
+            ; str x30, [x16], #8
+            ; b =>loop_label
+            ; =>done
+        );
+    }
+    if remainder >= 4 {
+        dynasm!(ops ; .arch aarch64 ; str w30, [x16], #4);
+    }
+    if remainder % 4 >= 2 {
+        dynasm!(ops ; .arch aarch64 ; strh w30, [x16], #2);
+    }
+    if remainder % 2 == 1 {
+        dynasm!(ops ; .arch aarch64 ; strb w30, [x16]);
+    }
+}
+
+fn base_register(base: BaseReg) -> u8 {
+    match base {
+        BaseReg::SimState => STATE_REG,
+        BaseReg::StackFrame => STATE_REG,
+    }
+}
+
+fn emit_base_address(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    base: BaseReg,
+    offset: i32,
+    spill_base: usize,
+) -> Result<(), EmitError> {
+    let offset = match base {
+        BaseReg::SimState => i64::from(offset),
+        BaseReg::StackFrame => i64::try_from(spill_base)
+            .ok()
+            .and_then(|base| base.checked_add(i64::from(offset)))
+            .ok_or(EmitError::Range("stack-frame address overflow"))?,
+    };
+    emit_address(ops, STATE_REG, offset);
+    Ok(())
+}
+
+fn emit_address(ops: &mut VecAssembler<Aarch64Relocation>, base: u8, offset: i64) {
+    if offset == 0 {
+        dynasm!(ops ; .arch aarch64 ; mov x16, X(base));
+    } else {
+        emit_load_imm(ops, SCRATCH1, offset as u64);
+        dynasm!(ops ; .arch aarch64 ; add x16, X(base), x17);
+    }
+}
+
+fn emit_add_offset(ops: &mut VecAssembler<Aarch64Relocation>, offset: i64) {
+    if offset != 0 {
+        emit_load_imm(ops, SCRATCH1, offset as u64);
+        dynasm!(ops ; .arch aarch64 ; add x16, x16, x17);
+    }
+}
+
+fn emit_load_imm(ops: &mut VecAssembler<Aarch64Relocation>, register: u8, value: u64) {
+    let halves = [
+        value as u16,
+        (value >> 16) as u16,
+        (value >> 32) as u16,
+        (value >> 48) as u16,
+    ];
+    let first = halves.iter().position(|half| *half != 0).unwrap_or(0);
+    let half = u32::from(halves[first]);
+    match first {
+        0 => dynasm!(ops ; .arch aarch64 ; movz X(register), half),
+        1 => dynasm!(ops ; .arch aarch64 ; movz X(register), half, LSL #16),
+        2 => dynasm!(ops ; .arch aarch64 ; movz X(register), half, LSL #32),
+        3 => dynasm!(ops ; .arch aarch64 ; movz X(register), half, LSL #48),
+        _ => unreachable!(),
+    }
+    for (index, half) in halves.into_iter().enumerate() {
+        if index == first || half == 0 {
+            continue;
+        }
+        let half = u32::from(half);
+        match index {
+            0 => dynasm!(ops ; .arch aarch64 ; movk X(register), half),
+            1 => dynasm!(ops ; .arch aarch64 ; movk X(register), half, LSL #16),
+            2 => dynasm!(ops ; .arch aarch64 ; movk X(register), half, LSL #32),
+            3 => dynasm!(ops ; .arch aarch64 ; movk X(register), half, LSL #48),
+            _ => unreachable!(),
+        }
+    }
+}
+
+fn emit_load(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: u8,
+    address: u8,
+    size: OpSize,
+) {
+    match size {
+        OpSize::S8 => dynasm!(ops ; .arch aarch64 ; ldrb W(destination), [X(address)]),
+        OpSize::S16 => dynasm!(ops ; .arch aarch64 ; ldrh W(destination), [X(address)]),
+        OpSize::S32 => dynasm!(ops ; .arch aarch64 ; ldr W(destination), [X(address)]),
+        OpSize::S64 => dynasm!(ops ; .arch aarch64 ; ldr X(destination), [X(address)]),
+    }
+}
+
+fn emit_store(ops: &mut VecAssembler<Aarch64Relocation>, source: u8, address: u8, size: OpSize) {
+    match size {
+        OpSize::S8 => dynasm!(ops ; .arch aarch64 ; strb W(source), [X(address)]),
+        OpSize::S16 => dynasm!(ops ; .arch aarch64 ; strh W(source), [X(address)]),
+        OpSize::S32 => dynasm!(ops ; .arch aarch64 ; str W(source), [X(address)]),
+        OpSize::S64 => dynasm!(ops ; .arch aarch64 ; str X(source), [X(address)]),
+    }
+}
+
+fn emit_release_store(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    source: u8,
+    address: u8,
+    size: OpSize,
+) {
+    match size {
+        OpSize::S8 => dynasm!(ops ; .arch aarch64 ; stlrb W(source), [X(address)]),
+        OpSize::S16 => dynasm!(ops ; .arch aarch64 ; stlrh W(source), [X(address)]),
+        OpSize::S32 => dynasm!(ops ; .arch aarch64 ; stlr W(source), [X(address)]),
+        OpSize::S64 => dynasm!(ops ; .arch aarch64 ; stlr X(source), [X(address)]),
+    }
+}
+
+fn emit_cset(ops: &mut VecAssembler<Aarch64Relocation>, destination: u8, kind: CmpKind) {
+    match kind {
+        CmpKind::Eq => dynasm!(ops ; .arch aarch64 ; cset X(destination), eq),
+        CmpKind::Ne => dynasm!(ops ; .arch aarch64 ; cset X(destination), ne),
+        CmpKind::LtU => dynasm!(ops ; .arch aarch64 ; cset X(destination), lo),
+        CmpKind::LtS => dynasm!(ops ; .arch aarch64 ; cset X(destination), lt),
+        CmpKind::LeU => dynasm!(ops ; .arch aarch64 ; cset X(destination), ls),
+        CmpKind::LeS => dynasm!(ops ; .arch aarch64 ; cset X(destination), le),
+        CmpKind::GtU => dynasm!(ops ; .arch aarch64 ; cset X(destination), hi),
+        CmpKind::GtS => dynasm!(ops ; .arch aarch64 ; cset X(destination), gt),
+        CmpKind::GeU => dynasm!(ops ; .arch aarch64 ; cset X(destination), hs),
+        CmpKind::GeS => dynasm!(ops ; .arch aarch64 ; cset X(destination), ge),
+    }
+}
+
+fn emit_csel(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: u8,
+    true_value: u8,
+    false_value: u8,
+    kind: CmpKind,
+) {
+    match kind {
+        CmpKind::Eq => {
+            dynasm!(ops ; .arch aarch64 ; csel X(destination), X(true_value), X(false_value), eq)
+        }
+        CmpKind::Ne => {
+            dynasm!(ops ; .arch aarch64 ; csel X(destination), X(true_value), X(false_value), ne)
+        }
+        CmpKind::LtU => {
+            dynasm!(ops ; .arch aarch64 ; csel X(destination), X(true_value), X(false_value), lo)
+        }
+        CmpKind::LtS => {
+            dynasm!(ops ; .arch aarch64 ; csel X(destination), X(true_value), X(false_value), lt)
+        }
+        CmpKind::LeU => {
+            dynasm!(ops ; .arch aarch64 ; csel X(destination), X(true_value), X(false_value), ls)
+        }
+        CmpKind::LeS => {
+            dynasm!(ops ; .arch aarch64 ; csel X(destination), X(true_value), X(false_value), le)
+        }
+        CmpKind::GtU => {
+            dynasm!(ops ; .arch aarch64 ; csel X(destination), X(true_value), X(false_value), hi)
+        }
+        CmpKind::GtS => {
+            dynasm!(ops ; .arch aarch64 ; csel X(destination), X(true_value), X(false_value), gt)
+        }
+        CmpKind::GeU => {
+            dynasm!(ops ; .arch aarch64 ; csel X(destination), X(true_value), X(false_value), hs)
+        }
+        CmpKind::GeS => {
+            dynasm!(ops ; .arch aarch64 ; csel X(destination), X(true_value), X(false_value), ge)
+        }
+    }
+}
+
+fn emit_branch_predicate(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    predicate: BranchPredicate,
+    assignment: &AssignmentMap,
+    spill_base: usize,
+) -> Result<(), EmitError> {
+    match predicate {
+        BranchPredicate::Compare { lhs, rhs, .. } => {
+            let (lhs, rhs) = (resolve(assignment, lhs)?, resolve(assignment, rhs)?);
+            dynasm!(ops ; .arch aarch64 ; cmp X(lhs), X(rhs));
+        }
+        BranchPredicate::CompareImm { lhs, imm, .. } => {
+            let lhs = resolve(assignment, lhs)?;
+            emit_load_imm(ops, SCRATCH0, imm as i64 as u64);
+            dynasm!(ops ; .arch aarch64 ; cmp X(lhs), x16);
+        }
+        BranchPredicate::MemoryNonZero { base, offset, size } => {
+            emit_base_address(ops, base, offset, spill_base)?;
+            emit_load(ops, SCRATCH0, SCRATCH0, size);
+            dynasm!(ops ; .arch aarch64 ; cmp x16, #0);
+        }
+    }
+    Ok(())
+}
+
+fn predicate_kind(predicate: BranchPredicate) -> CmpKind {
+    match predicate {
+        BranchPredicate::Compare { kind, .. } | BranchPredicate::CompareImm { kind, .. } => kind,
+        BranchPredicate::MemoryNonZero { .. } => CmpKind::Ne,
+    }
+}
+
+fn emit_conditional_branch(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    label: DynamicLabel,
+    kind: CmpKind,
+) {
+    match kind {
+        CmpKind::Eq => dynasm!(ops ; .arch aarch64 ; b.eq =>label),
+        CmpKind::Ne => dynasm!(ops ; .arch aarch64 ; b.ne =>label),
+        CmpKind::LtU => dynasm!(ops ; .arch aarch64 ; b.lo =>label),
+        CmpKind::LtS => dynasm!(ops ; .arch aarch64 ; b.lt =>label),
+        CmpKind::LeU => dynasm!(ops ; .arch aarch64 ; b.ls =>label),
+        CmpKind::LeS => dynasm!(ops ; .arch aarch64 ; b.le =>label),
+        CmpKind::GtU => dynasm!(ops ; .arch aarch64 ; b.hi =>label),
+        CmpKind::GtS => dynasm!(ops ; .arch aarch64 ; b.gt =>label),
+        CmpKind::GeU => dynasm!(ops ; .arch aarch64 ; b.hs =>label),
+        CmpKind::GeS => dynasm!(ops ; .arch aarch64 ; b.ge =>label),
+    }
+}
+
+fn emit_edge_copies(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    plan: &SsaDestructionPlan,
+    predecessor: BlockId,
+    successor: BlockId,
+    spill_base: usize,
+    temporary_offset: usize,
+) -> Result<(), EmitError> {
+    let Some(edge) = plan.edge(predecessor, successor) else {
+        return Ok(());
+    };
+    for operation in &edge.operations {
+        match *operation {
+            ParallelCopyOperation::Move {
+                destination,
+                source,
+            } => emit_copy(ops, destination, source, spill_base)?,
+            ParallelCopyOperation::SwapRegisters { left, right } => {
+                let (left, right) = (physical_register(left), physical_register(right));
+                dynasm!(ops
+                    ; .arch aarch64
+                    ; mov x16, X(left)
+                    ; mov X(left), X(right)
+                    ; mov X(right), x16
+                );
+            }
+            ParallelCopyOperation::SaveTemporary(destination) => {
+                read_copy_destination(ops, destination, spill_base, SCRATCH1)?;
+                emit_address(ops, STATE_REG, temporary_offset as i64);
+                emit_store(ops, SCRATCH1, SCRATCH0, OpSize::S64);
+            }
+            ParallelCopyOperation::RestoreTemporary(destination) => {
+                emit_address(ops, STATE_REG, temporary_offset as i64);
+                emit_load(ops, SCRATCH1, SCRATCH0, OpSize::S64);
+                write_copy_destination(ops, destination, spill_base, SCRATCH1)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn emit_copy(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: ParallelCopyDestination,
+    source: ParallelCopySource,
+    spill_base: usize,
+) -> Result<(), EmitError> {
+    match source {
+        ParallelCopySource::Register(register) => {
+            write_copy_destination(ops, destination, spill_base, physical_register(register))
+        }
+        ParallelCopySource::Stack(offset) => {
+            emit_address(ops, STATE_REG, spill_base as i64 + i64::from(offset));
+            emit_load(ops, SCRATCH1, SCRATCH0, OpSize::S64);
+            write_copy_destination(ops, destination, spill_base, SCRATCH1)
+        }
+        ParallelCopySource::Immediate(value) => {
+            emit_load_imm(ops, SCRATCH1, value);
+            write_copy_destination(ops, destination, spill_base, SCRATCH1)
+        }
+    }
+}
+
+fn read_copy_destination(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: ParallelCopyDestination,
+    spill_base: usize,
+    output: u8,
+) -> Result<(), EmitError> {
+    match destination {
+        ParallelCopyDestination::Register(register) => {
+            let register = physical_register(register);
+            dynasm!(ops ; .arch aarch64 ; mov X(output), X(register));
+        }
+        ParallelCopyDestination::Stack(offset) => {
+            emit_address(ops, STATE_REG, spill_base as i64 + i64::from(offset));
+            emit_load(ops, output, SCRATCH0, OpSize::S64);
+        }
+    }
+    Ok(())
+}
+
+fn write_copy_destination(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: ParallelCopyDestination,
+    spill_base: usize,
+    source: u8,
+) -> Result<(), EmitError> {
+    match destination {
+        ParallelCopyDestination::Register(register) => {
+            let register = physical_register(register);
+            dynasm!(ops ; .arch aarch64 ; mov X(register), X(source));
+        }
+        ParallelCopyDestination::Stack(offset) => {
+            emit_address(ops, STATE_REG, spill_base as i64 + i64::from(offset));
+            emit_store(ops, source, SCRATCH0, OpSize::S64);
+        }
+    }
+    Ok(())
+}
+
+/// Hex-word fallback used in traces until an AArch64 disassembler is added.
+pub fn disassemble(code: &[u8], base_addr: u64) -> String {
+    code.chunks_exact(4)
+        .enumerate()
+        .map(|(index, bytes)| {
+            let word = u32::from_le_bytes(bytes.try_into().expect("four-byte chunk"));
+            format!("{:08x}: {word:08x}\n", base_addr + (index * 4) as u64)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use celox_backend_x86::native::mir::{MBlock, SpillDesc, VRegAllocator};
+
+    fn state_update() -> (MFunction, AssignmentMap) {
+        let mut vregs = VRegAllocator::new();
+        let loaded = vregs.alloc();
+        let increment = vregs.alloc();
+        let result = vregs.alloc();
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 3]);
+        let mut block = MBlock::new(BlockId(0));
+        block.push(MInst::Load {
+            dst: loaded,
+            base: BaseReg::SimState,
+            offset: 0,
+            size: OpSize::S64,
+        });
+        block.push(MInst::LoadImm {
+            dst: increment,
+            value: 5,
+        });
+        block.push(MInst::Add {
+            dst: result,
+            lhs: loaded,
+            rhs: increment,
+        });
+        block.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 8,
+            src: result,
+            size: OpSize::S64,
+        });
+        block.push(MInst::Return);
+        function.push_block(block);
+        let mut assignment = AssignmentMap::default();
+        assignment.set(loaded, PhysReg::RAX);
+        assignment.set(increment, PhysReg::RDX);
+        assignment.set(result, PhysReg::RSI);
+        (function, assignment)
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn guarded_select() -> (MFunction, AssignmentMap) {
+        let mut vregs = VRegAllocator::new();
+        let guard = vregs.alloc();
+        let lhs = vregs.alloc();
+        let rhs = vregs.alloc();
+        let true_value = vregs.alloc();
+        let false_value = vregs.alloc();
+        let result = vregs.alloc();
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 6]);
+        let mut block = MBlock::new(BlockId(0));
+        for (dst, offset) in [(guard, 0), (lhs, 8), (rhs, 16)] {
+            block.push(MInst::Load {
+                dst,
+                base: BaseReg::SimState,
+                offset,
+                size: OpSize::S64,
+            });
+        }
+        block.push(MInst::LoadImm {
+            dst: true_value,
+            value: 0xaa,
+        });
+        block.push(MInst::LoadImm {
+            dst: false_value,
+            value: 0x55,
+        });
+        block.push(MInst::GuardedCmpSelect {
+            dst: result,
+            guard,
+            lhs,
+            rhs,
+            kind: CmpKind::LtU,
+            true_val: true_value,
+            false_val: false_value,
+        });
+        block.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 24,
+            src: result,
+            size: OpSize::S64,
+        });
+        block.push(MInst::Return);
+        function.push_block(block);
+        let mut assignment = AssignmentMap::default();
+        for (value, register) in [
+            (guard, PhysReg::RAX),
+            (lhs, PhysReg::RDX),
+            (rhs, PhysReg::RSI),
+            (true_value, PhysReg::RDI),
+            (false_value, PhysReg::R8),
+            (result, PhysReg::R9),
+        ] {
+            assignment.set(value, register);
+        }
+        (function, assignment)
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn bulk_memory_ops() -> (MFunction, AssignmentMap) {
+        let mut function = MFunction::new(VRegAllocator::new(), Vec::new());
+        let mut block = MBlock::new(BlockId(0));
+        block.push(MInst::MemCopy {
+            src_offset: 0,
+            dst_offset: 4,
+            byte_len: 12,
+        });
+        block.push(MInst::MemFill {
+            dst_offset: 20,
+            byte_len: 13,
+            value: 0xa5,
+        });
+        block.push(MInst::Return);
+        function.push_block(block);
+        (function, AssignmentMap::default())
+    }
+
+    #[test]
+    fn emits_allocated_scalar_mir() {
+        let (function, assignment) = state_update();
+        let result = emit(&function, &assignment, 0).unwrap();
+        assert!(!result.code.is_empty());
+        assert!(result.text_size <= result.code.len());
+        assert_eq!(result.block_offsets, vec![(BlockId(0), 4)]);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn executes_allocated_scalar_mir() {
+        let (function, assignment) = state_update();
+        let result = emit(&function, &assignment, 0).unwrap();
+        let code = crate::jit_mem::JitCode::new(&result.code).unwrap();
+        let mut state = vec![0_u8; 16];
+        state[..8].copy_from_slice(&37_u64.to_le_bytes());
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        assert_eq!(u64::from_le_bytes(state[8..].try_into().unwrap()), 42);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn executes_guarded_compare_select() {
+        let (function, assignment) = guarded_select();
+        let result = emit(&function, &assignment, 0).unwrap();
+        let code = crate::jit_mem::JitCode::new(&result.code).unwrap();
+        let mut state = vec![0_u8; 32];
+        state[..8].copy_from_slice(&1_u64.to_le_bytes());
+        state[8..16].copy_from_slice(&3_u64.to_le_bytes());
+        state[16..24].copy_from_slice(&7_u64.to_le_bytes());
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        assert_eq!(u64::from_le_bytes(state[24..].try_into().unwrap()), 0xaa);
+
+        state[..8].copy_from_slice(&0_u64.to_le_bytes());
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        assert_eq!(u64::from_le_bytes(state[24..].try_into().unwrap()), 0x55);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn executes_overlap_copy_and_fill() {
+        let (function, assignment) = bulk_memory_ops();
+        let result = emit(&function, &assignment, 0).unwrap();
+        let code = crate::jit_mem::JitCode::new(&result.code).unwrap();
+        let mut state = vec![0_u8; 40];
+        for (index, byte) in state[..16].iter_mut().enumerate() {
+            *byte = index as u8;
+        }
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        assert_eq!(&state[4..16], &(0_u8..12).collect::<Vec<_>>());
+        assert_eq!(&state[20..33], &[0xa5; 13]);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn executes_every_jump_table_target() {
+        let mut vregs = VRegAllocator::new();
+        let loaded = vregs.alloc();
+        let index = vregs.alloc();
+        let table_base = vregs.alloc();
+        let target = vregs.alloc();
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 4]);
+        let mut entry = MBlock::new(BlockId(0));
+        entry.push(MInst::Load {
+            dst: loaded,
+            base: BaseReg::SimState,
+            offset: 0,
+            size: OpSize::S8,
+        });
+        entry.push(MInst::AndImm32 {
+            dst: index,
+            src: loaded,
+            imm: 3,
+        });
+        entry.push(MInst::Scratch { dst: table_base });
+        entry.push(MInst::Scratch { dst: target });
+        entry.push(MInst::JumpTable {
+            index,
+            table_base,
+            target,
+            targets: (1..=4).map(BlockId).collect(),
+        });
+        function.push_block(entry);
+        for code in 1..=4 {
+            let mut arm = MBlock::new(BlockId(code));
+            arm.push(MInst::ReturnError {
+                code: i64::from(code),
+            });
+            function.push_block(arm);
+        }
+        let mut assignment = AssignmentMap::default();
+        assignment.set(loaded, PhysReg::RAX);
+        assignment.set(index, PhysReg::RCX);
+        assignment.set(table_base, PhysReg::RDX);
+        assignment.set(target, PhysReg::RBX);
+        let emitted = emit(&function, &assignment, 0).unwrap();
+        let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
+        for index in 0..4_u8 {
+            let mut state = [0xfc | index];
+            assert_eq!(unsafe { code.call(&mut state) }, i64::from(index) + 1);
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn executes_sparse_commit_tail_chunk() {
+        const STABLE: usize = 0;
+        const SPARSE: usize = 16;
+        const DIRTY: usize = 32;
+        const SUMMARY: usize = 40;
+        let mut function = MFunction::new(VRegAllocator::new(), Vec::new());
+        let mut block = MBlock::new(BlockId(0));
+        block.push(MInst::SparseCommit {
+            src_offset: SPARSE as i32,
+            dst_offset: STABLE as i32,
+            byte_size: 13,
+            dirty_words_offset: DIRTY as i32,
+            dirty_word_count: 1,
+            summary_words_offset: SUMMARY as i32,
+            summary_word_count: 1,
+            four_state: false,
+        });
+        block.push(MInst::Return);
+        function.push_block(block);
+        let emitted = emit(&function, &AssignmentMap::default(), 0).unwrap();
+        let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
+        let mut state = vec![0x11_u8; 64];
+        state[SPARSE..SPARSE + 13].copy_from_slice(&[0xa5; 13]);
+        state[DIRTY..DIRTY + 8].copy_from_slice(&2_u64.to_le_bytes());
+        state[SUMMARY..SUMMARY + 8].copy_from_slice(&1_u64.to_le_bytes());
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        assert_eq!(&state[STABLE..STABLE + 8], &[0x11; 8]);
+        assert_eq!(&state[STABLE + 8..STABLE + 13], &[0xa5; 5]);
+        assert_eq!(&state[DIRTY..DIRTY + 8], &[0; 8]);
+        assert_eq!(&state[SUMMARY..SUMMARY + 8], &[0; 8]);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn executes_sparse_worklist_commit() {
+        const BYTE_SIZE: usize = 13;
+        const STABLE: usize = 0;
+        const SPARSE: usize = 32;
+        const DIRTY: usize = 64;
+        const SUMMARY: usize = 72;
+        const ACTIVE: usize = 80;
+        let mut function = MFunction::new(VRegAllocator::new(), Vec::new());
+        let table = function.intern_constant_table(
+            SparseCommitDescriptor {
+                src_offset: SPARSE as u64,
+                dst_offset: STABLE as u64,
+                byte_size: BYTE_SIZE as u64,
+                dirty_words_offset: DIRTY as u64,
+                dirty_word_count: 1,
+                summary_words_offset: SUMMARY as u64,
+                summary_word_count: 1,
+                four_state: 1,
+            }
+            .words()
+            .to_vec(),
+        );
+        let mut block = MBlock::new(BlockId(0));
+        block.push(MInst::SparseMarkActive {
+            active_index: 0,
+            active_bits_offset: ACTIVE as i32,
+            active_capacity: 1,
+        });
+        block.push(MInst::SparseCommitWorklist {
+            descriptor_table: table,
+            active_bits_offset: ACTIVE as i32,
+            active_capacity: 1,
+        });
+        block.push(MInst::Return);
+        function.push_block(block);
+        let emitted = emit(&function, &AssignmentMap::default(), 0).unwrap();
+        let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
+        let mut state = vec![0_u8; 128];
+        for index in 0..BYTE_SIZE * 2 {
+            state[SPARSE + index] = index as u8 ^ 0x6d;
+        }
+        state[DIRTY..DIRTY + 8].copy_from_slice(&3_u64.to_le_bytes());
+        state[SUMMARY..SUMMARY + 8].copy_from_slice(&1_u64.to_le_bytes());
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        assert_eq!(&state[ACTIVE..ACTIVE + 8], &[0; 8]);
+        assert_eq!(&state[SUMMARY..SUMMARY + 8], &[0; 8]);
+        assert_eq!(&state[DIRTY..DIRTY + 8], &[0; 8]);
+        assert_eq!(
+            &state[STABLE..STABLE + BYTE_SIZE * 2],
+            &state[SPARSE..SPARSE + BYTE_SIZE * 2]
+        );
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn executes_sparse_active_mark() {
+        let mut function = MFunction::new(VRegAllocator::new(), Vec::new());
+        let mut block = MBlock::new(BlockId(0));
+        block.push(MInst::SparseMarkActive {
+            active_index: 3,
+            active_bits_offset: 16,
+            active_capacity: 4,
+        });
+        block.push(MInst::Return);
+        function.push_block(block);
+        let emitted = emit(&function, &AssignmentMap::default(), 0).unwrap();
+        let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
+        let mut state = [0_u8; 24];
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        assert_eq!(u64::from_le_bytes(state[16..].try_into().unwrap()), 8);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn executes_packed_compare_fallbacks() {
+        let mut vregs = VRegAllocator::new();
+        let rhs = vregs.alloc();
+        let lanes = vregs.alloc();
+        let base = vregs.alloc();
+        let affine_rhs = vregs.alloc();
+        let affine = vregs.alloc();
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 5]);
+        let mut block = MBlock::new(BlockId(0));
+        block.push(MInst::LoadImm { dst: rhs, value: 5 });
+        block.push(MInst::PackedLaneCompare {
+            dst: lanes,
+            rhs: PackedLaneCompareRhs::Scalar(rhs),
+            kind: CmpKind::Eq,
+            offset: 0,
+            lane_count: 16,
+            element_stride: 1,
+            bit_offset: 0,
+            field_width: 8,
+            alias_range: None,
+        });
+        block.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 24,
+            src: lanes,
+            size: OpSize::S64,
+        });
+        block.push(MInst::LoadImm {
+            dst: base,
+            value: 250,
+        });
+        block.push(MInst::LoadImm {
+            dst: affine_rhs,
+            value: 2,
+        });
+        block.push(MInst::PackedByteAffineCompare {
+            dst: affine,
+            base,
+            rhs: affine_rhs,
+            kind: CmpKind::Eq,
+        });
+        block.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 32,
+            src: affine,
+            size: OpSize::S64,
+        });
+        block.push(MInst::Return);
+        function.push_block(block);
+        let mut assignment = AssignmentMap::default();
+        for (value, register) in [
+            (rhs, PhysReg::RAX),
+            (lanes, PhysReg::RDX),
+            (base, PhysReg::RSI),
+            (affine_rhs, PhysReg::RDI),
+            (affine, PhysReg::R8),
+        ] {
+            assignment.set(value, register);
+        }
+        let emitted = emit(&function, &assignment, 0).unwrap();
+        let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
+        let mut state = vec![0_u8; 40];
+        state[..16].copy_from_slice(&[5, 1, 5, 2, 3, 5, 4, 5, 6, 7, 8, 9, 5, 5, 0, 5]);
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        assert_eq!(
+            u64::from_le_bytes(state[24..32].try_into().unwrap()),
+            0b1011_0000_1010_0101
+        );
+        assert_eq!(
+            u64::from_le_bytes(state[32..40].try_into().unwrap()),
+            1 << 8
+        );
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn executes_parallel_bit_extract_and_deposit() {
+        let mut vregs = VRegAllocator::new();
+        let source = vregs.alloc();
+        let mask = vregs.alloc();
+        let extracted = vregs.alloc();
+        let deposited_source = vregs.alloc();
+        let deposited = vregs.alloc();
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 5]);
+        let mut block = MBlock::new(BlockId(0));
+        block.push(MInst::LoadImm {
+            dst: source,
+            value: 0b110101,
+        });
+        block.push(MInst::LoadImm {
+            dst: mask,
+            value: 0b101010,
+        });
+        block.push(MInst::Pext {
+            dst: extracted,
+            src: source,
+            mask,
+        });
+        block.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 0,
+            src: extracted,
+            size: OpSize::S64,
+        });
+        block.push(MInst::LoadImm {
+            dst: deposited_source,
+            value: 0b101,
+        });
+        block.push(MInst::Pdep {
+            dst: deposited,
+            src: deposited_source,
+            mask,
+        });
+        block.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 8,
+            src: deposited,
+            size: OpSize::S64,
+        });
+        block.push(MInst::Return);
+        function.push_block(block);
+        let mut assignment = AssignmentMap::default();
+        for (value, register) in [
+            (source, PhysReg::RAX),
+            (mask, PhysReg::RDX),
+            (extracted, PhysReg::RSI),
+            (deposited_source, PhysReg::RDI),
+            (deposited, PhysReg::R8),
+        ] {
+            assignment.set(value, register);
+        }
+        let emitted = emit(&function, &assignment, 0).unwrap();
+        let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
+        let mut state = [0_u8; 16];
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        assert_eq!(u64::from_le_bytes(state[..8].try_into().unwrap()), 0b100);
+        assert_eq!(u64::from_le_bytes(state[8..].try_into().unwrap()), 0b100010);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn executes_native_tick_loop_inside_one_jit_call() {
+        let mut vregs = VRegAllocator::new();
+        let current = vregs.alloc();
+        let one = vregs.alloc();
+        let next = vregs.alloc();
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 3]);
+        let mut block = MBlock::new(BlockId(0));
+        block.push(MInst::Load {
+            dst: current,
+            base: BaseReg::SimState,
+            offset: 32,
+            size: OpSize::S64,
+        });
+        block.push(MInst::LoadImm { dst: one, value: 1 });
+        block.push(MInst::Add {
+            dst: next,
+            lhs: current,
+            rhs: one,
+        });
+        block.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 32,
+            src: next,
+            size: OpSize::S64,
+        });
+        block.push(MInst::Return);
+        function.push_block(block);
+        let mut assignment = AssignmentMap::default();
+        assignment.set(current, PhysReg::RAX);
+        assignment.set(one, PhysReg::RDX);
+        assignment.set(next, PhysReg::RSI);
+        let plan = SsaDestructionPlan::build(&function, &assignment).unwrap();
+        let emitted = emit_function(&function, &assignment, 0, 64, &plan, true, false).unwrap();
+        let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
+        let mut state = [0_u8; 40];
+        state[STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET
+            ..STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET + 8]
+            .copy_from_slice(&5_u64.to_le_bytes());
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        assert_eq!(
+            u64::from_le_bytes(
+                state[STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET
+                    ..STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET + 8]
+                    .try_into()
+                    .unwrap()
+            ),
+            0
+        );
+        assert_eq!(u64::from_le_bytes(state[32..].try_into().unwrap()), 5);
+    }
+}

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -3,10 +3,7 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use celox_backend_x86::native::mir::{
-    BaseReg, BlockId, BranchPredicate, CmpKind, MFunction, MInst, OpSize, PackedLaneCompareRhs,
-    SparseCommitDescriptor, VReg,
-};
+use celox_backend_x86::native::mir::MFunction as LegacyFunction;
 use celox_backend_x86::native::regalloc::AssignmentMap as LegacyAssignment;
 use celox_backend_x86::native::scalar_pipeline::{
     PreparedScalarFunction, ScalarPrepareError as PrepareError, prepare_scalar_eu,
@@ -20,6 +17,10 @@ use dynasmrt::{DynamicLabel, DynasmApi, DynasmError, DynasmLabelApi, VecAssemble
 
 use crate::Arm64Reg;
 use crate::allocation::{Assignment, CopyDestination, CopyOperation, CopySource, EdgeCopyPlan};
+use crate::mir::{
+    BaseReg, BlockId, BranchPredicate, CmpKind, MFunction, MInst, OpSize, PackedLaneCompareRhs,
+    SPARSE_COMMIT_DESCRIPTOR_WORDS, VReg,
+};
 
 const STATE_REG: u8 = 0;
 const SCRATCH0: u8 = 16;
@@ -53,10 +54,10 @@ pub struct NativeFunctionTrace {
 #[derive(Debug)]
 pub enum EmitError {
     Assembly(DynasmError),
-    MissingAssignment(VReg),
+    MissingAssignment(u32),
     Range(&'static str),
     Unsupported(&'static str),
-    Ssa(celox_backend_x86::native::ssa_destroy::SsaDestructionError),
+    LegacyLowering(String),
 }
 
 impl fmt::Display for EmitError {
@@ -66,7 +67,7 @@ impl fmt::Display for EmitError {
             Self::MissingAssignment(value) => {
                 write!(
                     formatter,
-                    "ARM64 MIR value {value} has no physical assignment"
+                    "ARM64 MIR value v{value} has no physical assignment"
                 )
             }
             Self::Range(message) => write!(formatter, "ARM64 emission range error: {message}"),
@@ -76,7 +77,7 @@ impl fmt::Display for EmitError {
                     "ARM64 emission does not yet support {instruction}"
                 )
             }
-            Self::Ssa(error) => error.fmt(formatter),
+            Self::LegacyLowering(error) => error.fmt(formatter),
         }
     }
 }
@@ -89,9 +90,14 @@ impl From<DynasmError> for EmitError {
     }
 }
 
-impl From<celox_backend_x86::native::ssa_destroy::SsaDestructionError> for EmitError {
-    fn from(error: celox_backend_x86::native::ssa_destroy::SsaDestructionError) -> Self {
-        Self::Ssa(error)
+impl From<crate::legacy_allocation::LegacyLoweringError> for EmitError {
+    fn from(error: crate::legacy_allocation::LegacyLoweringError) -> Self {
+        match error {
+            crate::legacy_allocation::LegacyLoweringError::Unsupported(instruction) => {
+                Self::Unsupported(instruction)
+            }
+            error => Self::LegacyLowering(error.to_string()),
+        }
     }
 }
 
@@ -168,18 +174,17 @@ pub fn emit_prepared_eu(
 
 /// Emit an already allocated MIR function. Primarily used by focused tests.
 pub fn emit(
-    function: &MFunction,
+    function: &LegacyFunction,
     assignment: &LegacyAssignment,
     spill_frame_size: u32,
 ) -> Result<EmitResult, EmitError> {
-    let (assignment, plan) =
-        crate::legacy_allocation::adapt(function, assignment, spill_frame_size)?;
+    let allocated = crate::legacy_allocation::adapt(function, assignment, spill_frame_size)?;
     emit_function(
-        function,
-        &assignment,
+        &allocated.function,
+        &allocated.assignment,
         spill_frame_size,
         4096,
-        &plan,
+        &allocated.edge_copies,
         false,
         false,
     )
@@ -190,17 +195,17 @@ fn emit_prepared(
     tick_loop: bool,
     check_runtime_events: bool,
 ) -> Result<EmitResult, EmitError> {
-    let (assignment, plan) = crate::legacy_allocation::adapt(
+    let allocated = crate::legacy_allocation::adapt(
         &prepared.function,
         &prepared.allocation,
         prepared.spill_frame_size,
     )?;
     emit_function(
-        &prepared.function,
-        &assignment,
+        &allocated.function,
+        &allocated.assignment,
         prepared.spill_frame_size,
         prepared.state_size(),
-        &plan,
+        &allocated.edge_copies,
         tick_loop,
         check_runtime_events,
     )
@@ -210,7 +215,7 @@ fn resolve(assignment: &Assignment<VReg>, value: VReg) -> Result<u8, EmitError> 
     assignment
         .get(&value)
         .map(Arm64Reg::number)
-        .ok_or(EmitError::MissingAssignment(value))
+        .ok_or(EmitError::MissingAssignment(value.0))
 }
 
 fn align16(value: usize) -> Result<usize, EmitError> {
@@ -889,7 +894,6 @@ fn emit_instruction(
             emit_load_imm(ops, STATE_REG, *code as u64);
             dynasm!(ops ; .arch aarch64 ; b =>epilogue);
         }
-        MInst::X86Simd(_) => return Err(EmitError::Unsupported("x86 SIMD MIR")),
         MInst::PackedLaneCompare {
             dst,
             rhs,
@@ -1323,10 +1327,10 @@ fn emit_sparse_commit_worklist(
         let end_index = active_capacity.min(first_index + 64);
         for active_index in first_index..end_index {
             let row_start = active_index
-                .checked_mul(SparseCommitDescriptor::WORDS)
+                .checked_mul(SPARSE_COMMIT_DESCRIPTOR_WORDS)
                 .ok_or(EmitError::Range("sparse descriptor index overflow"))?;
             let row = descriptors
-                .get(row_start..row_start + SparseCommitDescriptor::WORDS)
+                .get(row_start..row_start + SPARSE_COMMIT_DESCRIPTOR_WORDS)
                 .ok_or(EmitError::Range("sparse descriptor row is missing"))?;
             let skip = ops.new_dynamic_label();
             let mask = 1_u64 << (active_index % 64);
@@ -1886,9 +1890,13 @@ pub fn disassemble(code: &[u8], base_addr: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use celox_backend_x86::native::mir::{
+        BaseReg, BlockId, MBlock, MFunction, MInst, OpSize, SpillDesc, VRegAllocator,
+    };
     #[cfg(target_arch = "aarch64")]
-    use celox_backend_x86::native::mir::PhiNode;
-    use celox_backend_x86::native::mir::{MBlock, SpillDesc, VRegAllocator};
+    use celox_backend_x86::native::mir::{
+        CmpKind, PackedLaneCompareRhs, PhiNode, SparseCommitDescriptor,
+    };
     use celox_backend_x86::native::regalloc::AssignmentMap;
     #[cfg(target_arch = "aarch64")]
     use celox_backend_x86::native::regalloc::assignment::EdgeLocation;
@@ -2014,7 +2022,7 @@ mod tests {
         let result = emit(&function, &assignment, 0).unwrap();
         assert!(!result.code.is_empty());
         assert!(result.text_size <= result.code.len());
-        assert_eq!(result.block_offsets, vec![(BlockId(0), 4)]);
+        assert_eq!(result.block_offsets, vec![(crate::mir::BlockId(0), 4)]);
     }
 
     #[cfg(target_arch = "aarch64")]
@@ -2511,9 +2519,17 @@ mod tests {
         assignment.set(current, PhysReg::RAX);
         assignment.set(one, PhysReg::RDX);
         assignment.set(next, PhysReg::RSI);
-        let (assignment, plan) =
-            crate::legacy_allocation::adapt(&function, &assignment, 0).unwrap();
-        let emitted = emit_function(&function, &assignment, 0, 64, &plan, true, false).unwrap();
+        let allocated = crate::legacy_allocation::adapt(&function, &assignment, 0).unwrap();
+        let emitted = emit_function(
+            &allocated.function,
+            &allocated.assignment,
+            0,
+            64,
+            &allocated.edge_copies,
+            true,
+            false,
+        )
+        .unwrap();
         let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
         let mut state = [0_u8; 40];
         state[STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use celox_backend_x86::native::mir::MFunction as LegacyFunction;
 use celox_backend_x86::native::regalloc::AssignmentMap as LegacyAssignment;
 use celox_backend_x86::native::scalar_pipeline::{
-    PreparedScalarFunction, ScalarPrepareError as PrepareError, prepare_scalar_eu,
+    ScalarPrepareError as PrepareError, prepare_scalar_mir,
 };
 use celox_state_layout::{
     STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET, STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET,
@@ -154,18 +154,36 @@ pub fn emit_prepared_eu(
     if let Some(trace) = trace.as_deref_mut() {
         trace.optimized_sir = sir_eu.to_string();
     }
-    let prepared = prepare_scalar_eu(sir_eu, layout, four_state, label)?;
+    let prepared = prepare_scalar_mir(sir_eu, layout, four_state)?;
+    let state_size = prepared.state_size();
+    let function = crate::legacy_allocation::lower(&prepared.function).map_err(EmitError::from)?;
+    let allocation = crate::regalloc::allocate_with_spills(function)
+        .map_err(|error| EmitError::LegacyLowering(error.to_string()))?;
     if let Some(trace) = trace.as_deref_mut() {
-        trace.mir_after_regalloc = prepared.function.to_string();
-        trace.register_assignment = prepared
-            .allocation
-            .sorted_entries()
+        trace.mir_before_regalloc = prepared.function.to_string();
+        trace.mir_after_regalloc = format!("{:#?}", allocation.allocated.function);
+        let mut assignments = allocation
+            .allocated
+            .assignment
+            .iter()
+            .map(|(&value, register)| (value, register.number()))
+            .collect::<Vec<_>>();
+        assignments.sort_unstable();
+        trace.register_assignment = assignments
             .into_iter()
-            .map(|(value, register)| format!("  {value} -> {register}\n"))
+            .map(|(value, register)| format!("  {value} -> x{register}\n"))
             .collect();
-        trace.spill_frame_size = prepared.spill_frame_size;
+        trace.spill_frame_size = allocation.spill_frame_size;
     }
-    let result = emit_prepared(&prepared, tick_loop, check_runtime_events)?;
+    let result = emit_function(
+        &allocation.allocated.function,
+        &allocation.allocated.assignment,
+        allocation.spill_frame_size,
+        state_size,
+        &allocation.allocated.edge_copies,
+        tick_loop,
+        check_runtime_events,
+    )?;
     if let Some(trace) = trace {
         trace.disassembly = disassemble(&result.code[..result.text_size], 0);
     }
@@ -187,27 +205,6 @@ pub fn emit(
         &allocated.edge_copies,
         false,
         false,
-    )
-}
-
-fn emit_prepared(
-    prepared: &PreparedScalarFunction,
-    tick_loop: bool,
-    check_runtime_events: bool,
-) -> Result<EmitResult, EmitError> {
-    let allocated = crate::legacy_allocation::adapt(
-        &prepared.function,
-        &prepared.allocation,
-        prepared.spill_frame_size,
-    )?;
-    emit_function(
-        &allocated.function,
-        &allocated.assignment,
-        prepared.spill_frame_size,
-        prepared.state_size(),
-        &allocated.edge_copies,
-        tick_loop,
-        check_runtime_events,
     )
 }
 
@@ -414,7 +411,7 @@ fn emit_instruction(
             dynasm!(ops ; .arch aarch64 ; mov W(dst), W(src));
         }
         MInst::LoadImm { dst, value } => emit_load_imm(ops, resolve(assignment, *dst)?, *value),
-        MInst::Scratch { .. } => {}
+        MInst::Scratch { .. } | MInst::KeepAlive { .. } => {}
         MInst::LoadConstantTableAddr { dst, table } => {
             let dst = resolve(assignment, *dst)?;
             let label = *table_labels
@@ -1903,6 +1900,8 @@ pub fn disassemble(code: &[u8], base_addr: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_arch = "aarch64")]
+    use crate::mir as arm_mir;
     use celox_backend_x86::native::mir::{
         BaseReg, BlockId, MBlock, MFunction, MInst, OpSize, SpillDesc, VRegAllocator,
     };
@@ -2048,6 +2047,54 @@ mod tests {
         state[..8].copy_from_slice(&37_u64.to_le_bytes());
         assert_eq!(unsafe { code.call(&mut state) }, 0);
         assert_eq!(u64::from_le_bytes(state[8..].try_into().unwrap()), 42);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn executes_target_owned_spills_and_reloads() {
+        let mut instructions = (0..26)
+            .map(|value| arm_mir::MInst::LoadImm {
+                dst: arm_mir::VReg(value),
+                value: u64::from(value) + 100,
+            })
+            .collect::<Vec<_>>();
+        instructions.extend((0..26).map(|value| arm_mir::MInst::Store {
+            base: arm_mir::BaseReg::SimState,
+            offset: value * 8,
+            src: arm_mir::VReg(value as u32),
+            size: arm_mir::OpSize::S64,
+        }));
+        instructions.push(arm_mir::MInst::Return);
+        let allocation = crate::regalloc::allocate_with_spills(arm_mir::MFunction::new(
+            vec![arm_mir::MBlock {
+                id: arm_mir::BlockId(0),
+                phis: Vec::new(),
+                insts: instructions,
+            }],
+            Vec::new(),
+        ))
+        .unwrap();
+        assert!(allocation.spill_frame_size > 0);
+        let emitted = emit_function(
+            &allocation.allocated.function,
+            &allocation.allocated.assignment,
+            allocation.spill_frame_size,
+            26 * 8,
+            &allocation.allocated.edge_copies,
+            false,
+            false,
+        )
+        .unwrap();
+        let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
+        let mut state = vec![0_u8; 512];
+
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        for value in 0..26_usize {
+            assert_eq!(
+                u64::from_le_bytes(state[value * 8..value * 8 + 8].try_into().unwrap()),
+                value as u64 + 100
+            );
+        }
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -1,4 +1,4 @@
-//! AArch64 emission for the shared scalar native MIR pipeline.
+//! AArch64 emission for the transitional scalar MIR pipeline.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -7,13 +7,9 @@ use celox_backend_x86::native::mir::{
     BaseReg, BlockId, BranchPredicate, CmpKind, MFunction, MInst, OpSize, PackedLaneCompareRhs,
     SparseCommitDescriptor, VReg,
 };
-use celox_backend_x86::native::regalloc::AssignmentMap;
-use celox_backend_x86::native::regalloc::assignment::PhysReg;
+use celox_backend_x86::native::regalloc::AssignmentMap as LegacyAssignment;
 use celox_backend_x86::native::scalar_pipeline::{
     PreparedScalarFunction, ScalarPrepareError as PrepareError, prepare_scalar_eu,
-};
-use celox_backend_x86::native::ssa_destroy::{
-    ParallelCopyDestination, ParallelCopyOperation, ParallelCopySource, SsaDestructionPlan,
 };
 use celox_state_layout::{
     STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET, STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET,
@@ -21,6 +17,9 @@ use celox_state_layout::{
 };
 use dynasmrt::aarch64::Aarch64Relocation;
 use dynasmrt::{DynamicLabel, DynasmApi, DynasmError, DynasmLabelApi, VecAssembler, dynasm};
+
+use crate::Arm64Reg;
+use crate::allocation::{Assignment, CopyDestination, CopyOperation, CopySource, EdgeCopyPlan};
 
 const STATE_REG: u8 = 0;
 const SCRATCH0: u8 = 16;
@@ -170,14 +169,14 @@ pub fn emit_prepared_eu(
 /// Emit an already allocated MIR function. Primarily used by focused tests.
 pub fn emit(
     function: &MFunction,
-    assignment: &AssignmentMap,
+    assignment: &LegacyAssignment,
     spill_frame_size: u32,
 ) -> Result<EmitResult, EmitError> {
-    let plan = SsaDestructionPlan::build(function, assignment)?;
-    plan.verify(function, assignment, spill_frame_size)?;
+    let (assignment, plan) =
+        crate::legacy_allocation::adapt(function, assignment, spill_frame_size)?;
     emit_function(
         function,
-        assignment,
+        &assignment,
         spill_frame_size,
         4096,
         &plan,
@@ -191,15 +190,14 @@ fn emit_prepared(
     tick_loop: bool,
     check_runtime_events: bool,
 ) -> Result<EmitResult, EmitError> {
-    let plan = SsaDestructionPlan::build(&prepared.function, &prepared.allocation)?;
-    plan.verify(
+    let (assignment, plan) = crate::legacy_allocation::adapt(
         &prepared.function,
         &prepared.allocation,
         prepared.spill_frame_size,
     )?;
     emit_function(
         &prepared.function,
-        &prepared.allocation,
+        &assignment,
         prepared.spill_frame_size,
         prepared.state_size(),
         &plan,
@@ -208,33 +206,11 @@ fn emit_prepared(
     )
 }
 
-fn resolve(assignment: &AssignmentMap, value: VReg) -> Result<u8, EmitError> {
+fn resolve(assignment: &Assignment<VReg>, value: VReg) -> Result<u8, EmitError> {
     assignment
-        .get(value)
-        .map(physical_register)
+        .get(&value)
+        .map(Arm64Reg::number)
         .ok_or(EmitError::MissingAssignment(value))
-}
-
-/// The established allocator has fifteen colors. AArch64 exposes exactly
-/// fifteen volatile registers x1..x15 after reserving x0 for simulator state.
-fn physical_register(register: PhysReg) -> u8 {
-    match register {
-        PhysReg::RAX => 1,
-        PhysReg::RCX => 2,
-        PhysReg::RDX => 3,
-        PhysReg::RBX => 4,
-        PhysReg::RBP => 5,
-        PhysReg::RSI => 6,
-        PhysReg::RDI => 7,
-        PhysReg::R8 => 8,
-        PhysReg::R9 => 9,
-        PhysReg::R10 => 10,
-        PhysReg::R11 => 11,
-        PhysReg::R12 => 12,
-        PhysReg::R13 => 13,
-        PhysReg::R14 => 14,
-        PhysReg::R15 => 15,
-    }
 }
 
 fn align16(value: usize) -> Result<usize, EmitError> {
@@ -246,10 +222,10 @@ fn align16(value: usize) -> Result<usize, EmitError> {
 
 fn emit_function(
     function: &MFunction,
-    assignment: &AssignmentMap,
+    assignment: &Assignment<VReg>,
     spill_frame_size: u32,
     state_size: usize,
-    plan: &SsaDestructionPlan,
+    plan: &EdgeCopyPlan<BlockId>,
     tick_loop: bool,
     check_runtime_events: bool,
 ) -> Result<EmitResult, EmitError> {
@@ -398,10 +374,10 @@ fn emit_instruction(
     ops: &mut VecAssembler<Aarch64Relocation>,
     instruction: &MInst,
     block: BlockId,
-    assignment: &AssignmentMap,
+    assignment: &Assignment<VReg>,
     spill_base: usize,
     temporary_offset: usize,
-    plan: &SsaDestructionPlan,
+    plan: &EdgeCopyPlan<BlockId>,
     labels: &HashMap<BlockId, DynamicLabel>,
     table_labels: &[DynamicLabel],
     constant_tables: &[Vec<u64>],
@@ -1198,7 +1174,7 @@ fn emit_packed_lane_compare(
     element_stride: u8,
     bit_offset: u8,
     field_width: u8,
-    assignment: &AssignmentMap,
+    assignment: &Assignment<VReg>,
 ) -> Result<(), EmitError> {
     let size = match element_stride {
         1 => OpSize::S8,
@@ -1735,7 +1711,7 @@ fn emit_csel(
 fn emit_branch_predicate(
     ops: &mut VecAssembler<Aarch64Relocation>,
     predicate: BranchPredicate,
-    assignment: &AssignmentMap,
+    assignment: &Assignment<VReg>,
     spill_base: usize,
 ) -> Result<(), EmitError> {
     match predicate {
@@ -1785,23 +1761,23 @@ fn emit_conditional_branch(
 
 fn emit_edge_copies(
     ops: &mut VecAssembler<Aarch64Relocation>,
-    plan: &SsaDestructionPlan,
+    plan: &EdgeCopyPlan<BlockId>,
     predecessor: BlockId,
     successor: BlockId,
     spill_base: usize,
     temporary_offset: usize,
 ) -> Result<(), EmitError> {
-    let Some(edge) = plan.edge(predecessor, successor) else {
+    let Some(operations) = plan.edge(predecessor, successor) else {
         return Ok(());
     };
-    for operation in &edge.operations {
+    for operation in operations {
         match *operation {
-            ParallelCopyOperation::Move {
+            CopyOperation::Move {
                 destination,
                 source,
             } => emit_copy(ops, destination, source, spill_base)?,
-            ParallelCopyOperation::SwapRegisters { left, right } => {
-                let (left, right) = (physical_register(left), physical_register(right));
+            CopyOperation::SwapRegisters { left, right } => {
+                let (left, right) = (left.number(), right.number());
                 dynasm!(ops
                     ; .arch aarch64
                     ; mov x16, X(left)
@@ -1809,7 +1785,7 @@ fn emit_edge_copies(
                     ; mov X(right), x16
                 );
             }
-            ParallelCopyOperation::SaveTemporary(destination) => {
+            CopyOperation::SaveTemporary(destination) => {
                 read_copy_destination(ops, destination, spill_base, SCRATCH1)?;
                 // Address materialization uses x17 for the offset. Preserve
                 // the value being saved before computing the temporary slot.
@@ -1817,7 +1793,7 @@ fn emit_edge_copies(
                 emit_address(ops, STATE_REG, temporary_offset as i64);
                 emit_store(ops, 30, SCRATCH0, OpSize::S64);
             }
-            ParallelCopyOperation::RestoreTemporary(destination) => {
+            CopyOperation::RestoreTemporary(destination) => {
                 emit_address(ops, STATE_REG, temporary_offset as i64);
                 emit_load(ops, SCRATCH1, SCRATCH0, OpSize::S64);
                 write_copy_destination(ops, destination, spill_base, SCRATCH1)?;
@@ -1829,20 +1805,20 @@ fn emit_edge_copies(
 
 fn emit_copy(
     ops: &mut VecAssembler<Aarch64Relocation>,
-    destination: ParallelCopyDestination,
-    source: ParallelCopySource,
+    destination: CopyDestination,
+    source: CopySource,
     spill_base: usize,
 ) -> Result<(), EmitError> {
     match source {
-        ParallelCopySource::Register(register) => {
-            write_copy_destination(ops, destination, spill_base, physical_register(register))
+        CopySource::Register(register) => {
+            write_copy_destination(ops, destination, spill_base, register.number())
         }
-        ParallelCopySource::Stack(offset) => {
+        CopySource::Stack(offset) => {
             emit_address(ops, STATE_REG, spill_base as i64 + i64::from(offset));
             emit_load(ops, SCRATCH1, SCRATCH0, OpSize::S64);
             write_copy_destination(ops, destination, spill_base, SCRATCH1)
         }
-        ParallelCopySource::Immediate(value) => {
+        CopySource::Immediate(value) => {
             emit_load_imm(ops, SCRATCH1, value);
             write_copy_destination(ops, destination, spill_base, SCRATCH1)
         }
@@ -1851,16 +1827,16 @@ fn emit_copy(
 
 fn read_copy_destination(
     ops: &mut VecAssembler<Aarch64Relocation>,
-    destination: ParallelCopyDestination,
+    destination: CopyDestination,
     spill_base: usize,
     output: u8,
 ) -> Result<(), EmitError> {
     match destination {
-        ParallelCopyDestination::Register(register) => {
-            let register = physical_register(register);
+        CopyDestination::Register(register) => {
+            let register = register.number();
             dynasm!(ops ; .arch aarch64 ; mov X(output), X(register));
         }
-        ParallelCopyDestination::Stack(offset) => {
+        CopyDestination::Stack(offset) => {
             emit_address(ops, STATE_REG, spill_base as i64 + i64::from(offset));
             emit_load(ops, output, SCRATCH0, OpSize::S64);
         }
@@ -1870,16 +1846,16 @@ fn read_copy_destination(
 
 fn write_copy_destination(
     ops: &mut VecAssembler<Aarch64Relocation>,
-    destination: ParallelCopyDestination,
+    destination: CopyDestination,
     spill_base: usize,
     source: u8,
 ) -> Result<(), EmitError> {
     match destination {
-        ParallelCopyDestination::Register(register) => {
-            let register = physical_register(register);
+        CopyDestination::Register(register) => {
+            let register = register.number();
             dynasm!(ops ; .arch aarch64 ; mov X(register), X(source));
         }
-        ParallelCopyDestination::Stack(offset) => {
+        CopyDestination::Stack(offset) => {
             let source = if source == SCRATCH1 {
                 // emit_address reserves x17 for large/immediate offsets.
                 // Stack-to-stack and temporary restores arrive in x17, so
@@ -1913,8 +1889,10 @@ mod tests {
     #[cfg(target_arch = "aarch64")]
     use celox_backend_x86::native::mir::PhiNode;
     use celox_backend_x86::native::mir::{MBlock, SpillDesc, VRegAllocator};
+    use celox_backend_x86::native::regalloc::AssignmentMap;
     #[cfg(target_arch = "aarch64")]
     use celox_backend_x86::native::regalloc::assignment::EdgeLocation;
+    use celox_backend_x86::native::regalloc::assignment::PhysReg;
 
     fn state_update() -> (MFunction, AssignmentMap) {
         let mut vregs = VRegAllocator::new();
@@ -2533,7 +2511,8 @@ mod tests {
         assignment.set(current, PhysReg::RAX);
         assignment.set(one, PhysReg::RDX);
         assignment.set(next, PhysReg::RSI);
-        let plan = SsaDestructionPlan::build(&function, &assignment).unwrap();
+        let (assignment, plan) =
+            crate::legacy_allocation::adapt(&function, &assignment, 0).unwrap();
         let emitted = emit_function(&function, &assignment, 0, 64, &plan, true, false).unwrap();
         let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
         let mut state = [0_u8; 40];

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -136,11 +136,10 @@ pub fn emit_prepared_eu(
     layout: &celox_backend_x86::MemoryLayout,
     four_state: bool,
     label: &str,
-    _x86_options: &celox_backend_x86::X86BackendOptions,
+    x86_options: &celox_backend_x86::X86BackendOptions,
     mut trace: Option<&mut NativeFunctionTrace>,
 ) -> Result<EmitResult, ChainedEmitError> {
-    let tick_loop =
-        label == "eval_comb_apply_ff" && celox_backend_x86::native::native_tick_loop_enabled();
+    let tick_loop = label == "eval_comb_apply_ff" && x86_options.native_tick_loop;
     let check_runtime_events = tick_loop
         && sir_eu.blocks.values().any(|block| {
             block.instructions.iter().any(|instruction| {

--- a/crates/celox-backend-common/Cargo.toml
+++ b/crates/celox-backend-common/Cargo.toml
@@ -9,3 +9,6 @@ edition.workspace = true
 
 [lints]
 workspace = true
+
+[dependencies]
+fxhash = { workspace = true }

--- a/crates/celox-backend-common/Cargo.toml
+++ b/crates/celox-backend-common/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "celox-backend-common"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+description = "Target-independent machine-code backend primitives for Celox"
+edition.workspace = true
+
+[lints]
+workspace = true

--- a/crates/celox-backend-common/src/lib.rs
+++ b/crates/celox-backend-common/src/lib.rs
@@ -1,0 +1,3 @@
+//! Target-independent building blocks shared by native machine-code backends.
+
+pub mod regalloc;

--- a/crates/celox-backend-common/src/regalloc.rs
+++ b/crates/celox-backend-common/src/regalloc.rs
@@ -8,9 +8,14 @@ use std::hash::Hash;
 use fxhash::{FxHashMap, FxHashSet};
 
 mod live_interval;
+mod parallel_copy;
 
 pub use live_interval::{
     LiveInterval, LiveIntervalError, LiveIntervals, LiveSegment, analyze_live_intervals,
+};
+pub use parallel_copy::{
+    CopyDestination, CopyOperation, CopyResolution, CopyResolutionError, CopyResolutionWork,
+    CopySource, ParallelCopy, resolve_parallel_copies,
 };
 
 /// A physical register that can be stored in a compact register set.

--- a/crates/celox-backend-common/src/regalloc.rs
+++ b/crates/celox-backend-common/src/regalloc.rs
@@ -9,6 +9,7 @@ use fxhash::{FxHashMap, FxHashSet};
 
 mod live_interval;
 mod parallel_copy;
+mod stack_color;
 
 pub use live_interval::{
     LiveInterval, LiveIntervalError, LiveIntervals, LiveSegment, analyze_live_intervals,
@@ -17,6 +18,7 @@ pub use parallel_copy::{
     CopyDestination, CopyOperation, CopyResolution, CopyResolutionError, CopyResolutionWork,
     CopySource, ParallelCopy, resolve_parallel_copies,
 };
+pub use stack_color::{StackColorError, StackSlotColoring, color_stack_slots};
 
 /// A physical register that can be stored in a compact register set.
 pub trait MachineRegister: Copy + Eq + Hash + Ord + fmt::Debug {

--- a/crates/celox-backend-common/src/regalloc.rs
+++ b/crates/celox-backend-common/src/regalloc.rs
@@ -7,6 +7,12 @@ use std::hash::Hash;
 
 use fxhash::{FxHashMap, FxHashSet};
 
+mod live_interval;
+
+pub use live_interval::{
+    LiveInterval, LiveIntervalError, LiveIntervals, LiveSegment, analyze_live_intervals,
+};
+
 /// A physical register that can be stored in a compact register set.
 pub trait MachineRegister: Copy + Eq + Hash + Ord + fmt::Debug {
     /// Stable target-defined register number in the range `0..64`.

--- a/crates/celox-backend-common/src/regalloc.rs
+++ b/crates/celox-backend-common/src/regalloc.rs
@@ -1,8 +1,11 @@
 //! Register-allocation data types and target-independent allocation helpers.
 
+use std::collections::VecDeque;
 use std::collections::{BTreeSet, HashMap};
 use std::fmt;
 use std::hash::Hash;
+
+use fxhash::{FxHashMap, FxHashSet};
 
 /// A physical register that can be stored in a compact register set.
 pub trait MachineRegister: Copy + Eq + Hash + Ord + fmt::Debug {
@@ -58,9 +61,10 @@ pub enum ValueLocation<R> {
 }
 
 /// Target constraints attached to one instruction after legalization.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InstructionConstraints<V, R> {
     pub fixed_uses: Vec<(V, R)>,
+    pub fixed_defs: Vec<(V, R)>,
     pub clobbers: Vec<R>,
 }
 
@@ -68,9 +72,453 @@ impl<V, R> Default for InstructionConstraints<V, R> {
     fn default() -> Self {
         Self {
             fixed_uses: Vec::new(),
+            fixed_defs: Vec::new(),
             clobbers: Vec::new(),
         }
     }
+}
+
+/// Register-allocation facts for one target-owned machine instruction.
+///
+/// This deliberately contains no opcode. Backends lower their own MIR into
+/// these facts so allocation algorithms do not need a common machine IR or a
+/// target instruction enum.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstructionAllocationFacts<V, R> {
+    pub uses: Vec<V>,
+    pub defs: Vec<V>,
+    pub constraints: InstructionConstraints<V, R>,
+    /// Hint used by allocators which perform copy coalescing.
+    pub is_copy: bool,
+}
+
+impl<V, R> Default for InstructionAllocationFacts<V, R> {
+    fn default() -> Self {
+        Self {
+            uses: Vec::new(),
+            defs: Vec::new(),
+            constraints: InstructionConstraints::default(),
+            is_copy: false,
+        }
+    }
+}
+
+/// One source of a target-MIR phi node, identified by normalized predecessor
+/// block index rather than a backend-specific block identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PhiSource<V> {
+    pub predecessor: usize,
+    pub value: V,
+}
+
+/// Register-allocation facts for one target-MIR phi node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PhiAllocationFacts<V> {
+    pub destination: V,
+    pub sources: Vec<PhiSource<V>>,
+}
+
+/// Register-allocation facts for one normalized target-MIR basic block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockAllocationFacts<V, R> {
+    pub successors: Vec<usize>,
+    pub phis: Vec<PhiAllocationFacts<V>>,
+    pub instructions: Vec<InstructionAllocationFacts<V, R>>,
+}
+
+/// Target-independent input boundary for register-allocation analyses.
+///
+/// x86 and AArch64 retain separate MIR instruction types and optimization
+/// pipelines. Each backend projects its final virtual-register MIR into this
+/// representation immediately before allocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FunctionAllocationFacts<V, R> {
+    pub entry: usize,
+    pub blocks: Vec<BlockAllocationFacts<V, R>>,
+}
+
+/// Structural error in backend-provided register-allocation facts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AllocationFactsError<V> {
+    MissingEntry {
+        entry: usize,
+        block_count: usize,
+    },
+    MissingSuccessor {
+        block: usize,
+        successor: usize,
+        block_count: usize,
+    },
+    MissingPhiPredecessor {
+        block: usize,
+        predecessor: usize,
+        value: V,
+    },
+    FixedUseIsNotUse {
+        block: usize,
+        instruction: usize,
+        value: V,
+    },
+    FixedDefIsNotDef {
+        block: usize,
+        instruction: usize,
+        value: V,
+    },
+}
+
+impl<V> fmt::Display for AllocationFactsError<V>
+where
+    V: fmt::Debug,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingEntry { entry, block_count } => write!(
+                formatter,
+                "allocation entry block {entry} is outside {block_count} blocks"
+            ),
+            Self::MissingSuccessor {
+                block,
+                successor,
+                block_count,
+            } => write!(
+                formatter,
+                "allocation block {block} has successor {successor} outside {block_count} blocks"
+            ),
+            Self::MissingPhiPredecessor {
+                block,
+                predecessor,
+                value,
+            } => write!(
+                formatter,
+                "allocation phi for {value:?} in block {block} names non-predecessor block {predecessor}"
+            ),
+            Self::FixedUseIsNotUse {
+                block,
+                instruction,
+                value,
+            } => write!(
+                formatter,
+                "fixed-use value {value:?} is not a use of allocation block {block} instruction {instruction}"
+            ),
+            Self::FixedDefIsNotDef {
+                block,
+                instruction,
+                value,
+            } => write!(
+                formatter,
+                "fixed-def value {value:?} is not a definition of allocation block {block} instruction {instruction}"
+            ),
+        }
+    }
+}
+
+impl<V> std::error::Error for AllocationFactsError<V> where V: fmt::Debug {}
+
+impl<V, R> FunctionAllocationFacts<V, R>
+where
+    V: Copy + Eq + fmt::Debug,
+{
+    /// Verify only target-independent shape invariants. Opcode legality and
+    /// register-class rules remain the responsibility of the owning backend.
+    pub fn verify(&self) -> Result<(), AllocationFactsError<V>> {
+        let block_count = self.blocks.len();
+        if self.entry >= block_count {
+            return Err(AllocationFactsError::MissingEntry {
+                entry: self.entry,
+                block_count,
+            });
+        }
+
+        let mut predecessors = vec![Vec::new(); block_count];
+        for (block_index, block) in self.blocks.iter().enumerate() {
+            for &successor in &block.successors {
+                let Some(successor_predecessors) = predecessors.get_mut(successor) else {
+                    return Err(AllocationFactsError::MissingSuccessor {
+                        block: block_index,
+                        successor,
+                        block_count,
+                    });
+                };
+                successor_predecessors.push(block_index);
+            }
+        }
+
+        for (block_index, block) in self.blocks.iter().enumerate() {
+            for phi in &block.phis {
+                for source in &phi.sources {
+                    if !predecessors[block_index].contains(&source.predecessor) {
+                        return Err(AllocationFactsError::MissingPhiPredecessor {
+                            block: block_index,
+                            predecessor: source.predecessor,
+                            value: source.value,
+                        });
+                    }
+                }
+            }
+            for (instruction_index, instruction) in block.instructions.iter().enumerate() {
+                for &(value, _) in &instruction.constraints.fixed_uses {
+                    if !instruction.uses.contains(&value) {
+                        return Err(AllocationFactsError::FixedUseIsNotUse {
+                            block: block_index,
+                            instruction: instruction_index,
+                            value,
+                        });
+                    }
+                }
+                for &(value, _) in &instruction.constraints.fixed_defs {
+                    if !instruction.defs.contains(&value) {
+                        return Err(AllocationFactsError::FixedDefIsNotDef {
+                            block: block_index,
+                            instruction: instruction_index,
+                            value,
+                        });
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Next-use distances at target-MIR block boundaries.
+///
+/// Distances are measured in target instructions. Loop-exit paths receive a
+/// deliberately large penalty so an allocator prefers uses within the loop.
+#[derive(Debug, Clone)]
+pub struct NextUseAnalysis<V> {
+    pub entry_distances: Vec<FxHashMap<V, u32>>,
+    pub exit_distances: Vec<FxHashMap<V, u32>>,
+    pub predecessors: Vec<Vec<usize>>,
+    pub backedge_successors: Vec<Vec<usize>>,
+}
+
+/// Large edge length for a DFS backedge. This matches the established native
+/// allocator's heuristic and keeps a use behind a loop farther away than uses
+/// in the loop body.
+const LOOP_EXIT_LENGTH: u32 = 100_000;
+
+/// Compute liveness and global next-use distances solely from allocator facts.
+pub fn analyze_next_uses<V, R>(
+    facts: &FunctionAllocationFacts<V, R>,
+) -> Result<NextUseAnalysis<V>, AllocationFactsError<V>>
+where
+    V: Copy + Eq + Hash + Ord + fmt::Debug,
+{
+    facts.verify()?;
+    let block_count = facts.blocks.len();
+    let successors = facts
+        .blocks
+        .iter()
+        .map(|block| block.successors.clone())
+        .collect::<Vec<_>>();
+    let mut predecessors = vec![Vec::new(); block_count];
+    for (block, block_successors) in successors.iter().enumerate() {
+        for &successor in block_successors {
+            predecessors[successor].push(block);
+        }
+    }
+    let backedge_successors = compute_backedge_successors(&successors);
+    let backedge_edges = successors
+        .iter()
+        .enumerate()
+        .map(|(block, block_successors)| {
+            block_successors
+                .iter()
+                .map(|successor| backedge_successors[block].contains(successor))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let phi_edge_uses = compute_phi_edge_uses(facts, &successors);
+    let transfers = compute_block_transfers(facts);
+
+    let mut entry_distances = vec![FxHashMap::default(); block_count];
+    let mut exit_distances = vec![FxHashMap::default(); block_count];
+    let mut worklist = (0..block_count).rev().collect::<VecDeque<_>>();
+    let mut in_worklist = vec![true; block_count];
+    while let Some(block) = worklist.pop_front() {
+        in_worklist[block] = false;
+        let (new_entry, new_exit) = compute_block_distances(
+            block,
+            &successors,
+            &backedge_edges,
+            &phi_edge_uses,
+            &transfers,
+            &entry_distances,
+        );
+        if new_entry != entry_distances[block] || new_exit != exit_distances[block] {
+            entry_distances[block] = new_entry;
+            exit_distances[block] = new_exit;
+            for &predecessor in &predecessors[block] {
+                if !in_worklist[predecessor] {
+                    worklist.push_back(predecessor);
+                    in_worklist[predecessor] = true;
+                }
+            }
+        }
+    }
+
+    Ok(NextUseAnalysis {
+        entry_distances,
+        exit_distances,
+        predecessors,
+        backedge_successors,
+    })
+}
+
+struct BlockTransfer<V> {
+    block_len: u32,
+    defs: FxHashSet<V>,
+    local_uses: Vec<(V, u32)>,
+}
+
+fn compute_block_transfers<V, R>(facts: &FunctionAllocationFacts<V, R>) -> Vec<BlockTransfer<V>>
+where
+    V: Copy + Eq + Hash + Ord,
+{
+    facts
+        .blocks
+        .iter()
+        .map(|block| {
+            let mut defs = FxHashSet::default();
+            defs.reserve(block.phis.len() + block.instructions.len());
+            defs.extend(block.phis.iter().map(|phi| phi.destination));
+            let mut local_uses = FxHashMap::default();
+            for (instruction_index, instruction) in block.instructions.iter().enumerate() {
+                for &definition in &instruction.defs {
+                    defs.insert(definition);
+                }
+                let position = instruction_index as u32;
+                for &used in &instruction.uses {
+                    if !defs.contains(&used) {
+                        local_uses.entry(used).or_insert(position);
+                    }
+                }
+            }
+            let mut local_uses = local_uses.into_iter().collect::<Vec<_>>();
+            local_uses.sort_by_key(|(value, _)| *value);
+            BlockTransfer {
+                block_len: block.instructions.len() as u32,
+                defs,
+                local_uses,
+            }
+        })
+        .collect()
+}
+
+fn compute_phi_edge_uses<V, R>(
+    facts: &FunctionAllocationFacts<V, R>,
+    successors: &[Vec<usize>],
+) -> Vec<Vec<Vec<V>>>
+where
+    V: Copy,
+{
+    successors
+        .iter()
+        .enumerate()
+        .map(|(predecessor, block_successors)| {
+            block_successors
+                .iter()
+                .map(|&successor| {
+                    facts.blocks[successor]
+                        .phis
+                        .iter()
+                        .flat_map(|phi| {
+                            phi.sources
+                                .iter()
+                                .filter(move |source| source.predecessor == predecessor)
+                                .map(|source| source.value)
+                        })
+                        .collect()
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn compute_block_distances<V>(
+    block: usize,
+    successors: &[Vec<usize>],
+    backedge_edges: &[Vec<bool>],
+    phi_edge_uses: &[Vec<Vec<V>>],
+    transfers: &[BlockTransfer<V>],
+    entry_distances: &[FxHashMap<V, u32>],
+) -> (FxHashMap<V, u32>, FxHashMap<V, u32>)
+where
+    V: Copy + Eq + Hash,
+{
+    let transfer = &transfers[block];
+    let mut new_exit = FxHashMap::default();
+    let exit_capacity = successors[block]
+        .iter()
+        .map(|&successor| entry_distances[successor].len())
+        .sum::<usize>()
+        + phi_edge_uses[block].iter().map(Vec::len).sum::<usize>();
+    new_exit.reserve(exit_capacity);
+    for (edge, &successor) in successors[block].iter().enumerate() {
+        let edge_length = if backedge_edges[block][edge] {
+            LOOP_EXIT_LENGTH
+        } else {
+            0
+        };
+        for (&value, &distance) in &entry_distances[successor] {
+            let distance = distance.saturating_add(edge_length);
+            let entry = new_exit.entry(value).or_insert(u32::MAX);
+            *entry = (*entry).min(distance);
+        }
+        for &value in &phi_edge_uses[block][edge] {
+            let entry = new_exit.entry(value).or_insert(u32::MAX);
+            *entry = (*entry).min(edge_length);
+        }
+    }
+
+    let mut new_entry = FxHashMap::default();
+    new_entry.reserve(new_exit.len() + transfer.local_uses.len());
+    for (&value, &distance) in &new_exit {
+        if !transfer.defs.contains(&value) {
+            new_entry.insert(value, transfer.block_len.saturating_add(distance));
+        }
+    }
+    for &(value, position) in &transfer.local_uses {
+        new_entry.insert(value, position);
+    }
+    (new_entry, new_exit)
+}
+
+fn compute_backedge_successors(successors: &[Vec<usize>]) -> Vec<Vec<usize>> {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Color {
+        White,
+        Gray,
+        Black,
+    }
+
+    let mut colors = vec![Color::White; successors.len()];
+    let mut backedges = vec![Vec::new(); successors.len()];
+    for root in 0..successors.len() {
+        if colors[root] != Color::White {
+            continue;
+        }
+        colors[root] = Color::Gray;
+        let mut stack = vec![(root, 0usize)];
+        while let Some((node, next_successor)) = stack.last_mut() {
+            if *next_successor == successors[*node].len() {
+                colors[*node] = Color::Black;
+                stack.pop();
+                continue;
+            }
+            let successor = successors[*node][*next_successor];
+            *next_successor += 1;
+            match colors[successor] {
+                Color::White => {
+                    colors[successor] = Color::Gray;
+                    stack.push((successor, 0));
+                }
+                Color::Gray => backedges[*node].push(successor),
+                Color::Black => {}
+            }
+        }
+    }
+    backedges
 }
 
 /// One inclusive live range in a linearized machine function.
@@ -233,6 +681,74 @@ mod tests {
         assert_eq!(
             allocate_linear_scan(&ranges, &[Reg(9)]),
             Err(LinearScanError::RegisterPressure { value: 1, point: 1 })
+        );
+    }
+
+    #[test]
+    fn allocation_facts_verify_without_knowing_target_opcodes() {
+        let facts = FunctionAllocationFacts {
+            entry: 0,
+            blocks: vec![
+                BlockAllocationFacts {
+                    successors: vec![1],
+                    phis: Vec::new(),
+                    instructions: vec![InstructionAllocationFacts {
+                        uses: vec![0],
+                        defs: vec![1],
+                        constraints: InstructionConstraints {
+                            fixed_uses: vec![(0, Reg(3))],
+                            fixed_defs: vec![(1, Reg(4))],
+                            clobbers: vec![Reg(5)],
+                        },
+                        is_copy: false,
+                    }],
+                },
+                BlockAllocationFacts {
+                    successors: Vec::new(),
+                    phis: vec![PhiAllocationFacts {
+                        destination: 2,
+                        sources: vec![PhiSource {
+                            predecessor: 0,
+                            value: 1,
+                        }],
+                    }],
+                    instructions: Vec::new(),
+                },
+            ],
+        };
+
+        assert_eq!(facts.verify(), Ok(()));
+        let analysis = analyze_next_uses(&facts).unwrap();
+        assert_eq!(analysis.exit_distances[0].get(&1), Some(&0));
+        assert_eq!(analysis.entry_distances[0].get(&0), Some(&0));
+    }
+
+    #[test]
+    fn allocation_facts_reject_constraints_detached_from_operands() {
+        let facts = FunctionAllocationFacts {
+            entry: 0,
+            blocks: vec![BlockAllocationFacts {
+                successors: Vec::new(),
+                phis: Vec::new(),
+                instructions: vec![InstructionAllocationFacts {
+                    uses: vec![0],
+                    defs: Vec::new(),
+                    constraints: InstructionConstraints {
+                        fixed_uses: vec![(1, Reg(3))],
+                        ..InstructionConstraints::default()
+                    },
+                    is_copy: false,
+                }],
+            }],
+        };
+
+        assert_eq!(
+            facts.verify(),
+            Err(AllocationFactsError::FixedUseIsNotUse {
+                block: 0,
+                instruction: 0,
+                value: 1,
+            })
         );
     }
 }

--- a/crates/celox-backend-common/src/regalloc.rs
+++ b/crates/celox-backend-common/src/regalloc.rs
@@ -1,0 +1,238 @@
+//! Register-allocation data types and target-independent allocation helpers.
+
+use std::collections::{BTreeSet, HashMap};
+use std::fmt;
+use std::hash::Hash;
+
+/// A physical register that can be stored in a compact register set.
+pub trait MachineRegister: Copy + Eq + Hash + Ord + fmt::Debug {
+    /// Stable target-defined register number in the range `0..64`.
+    fn index(self) -> u8;
+}
+
+/// Compact set for targets with at most 64 physical registers per class.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RegisterSet(u64);
+
+impl RegisterSet {
+    pub const fn new() -> Self {
+        Self(0)
+    }
+
+    pub fn insert<R: MachineRegister>(&mut self, register: R) {
+        self.0 |= register_bit(register);
+    }
+
+    pub fn remove<R: MachineRegister>(&mut self, register: R) {
+        self.0 &= !register_bit(register);
+    }
+
+    pub fn contains<R: MachineRegister>(&self, register: &R) -> bool {
+        self.0 & register_bit(*register) != 0
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+}
+
+fn register_bit<R: MachineRegister>(register: R) -> u64 {
+    1_u64
+        .checked_shl(u32::from(register.index()))
+        .expect("physical register index must be below 64")
+}
+
+/// Constraint on one machine-instruction operand.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegConstraint<R> {
+    Any,
+    Fixed(R),
+}
+
+/// Physical location used while lowering SSA edge transfers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValueLocation<R> {
+    Register(R),
+    Stack(i32),
+    Immediate(u64),
+}
+
+/// Target constraints attached to one instruction after legalization.
+#[derive(Debug, Clone)]
+pub struct InstructionConstraints<V, R> {
+    pub fixed_uses: Vec<(V, R)>,
+    pub clobbers: Vec<R>,
+}
+
+impl<V, R> Default for InstructionConstraints<V, R> {
+    fn default() -> Self {
+        Self {
+            fixed_uses: Vec::new(),
+            clobbers: Vec::new(),
+        }
+    }
+}
+
+/// One inclusive live range in a linearized machine function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LiveRange<V> {
+    pub value: V,
+    pub start: u32,
+    pub end: u32,
+}
+
+/// Register assignment returned by [`allocate_linear_scan`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Allocation<V: Eq + Hash, R> {
+    assignments: HashMap<V, R>,
+}
+
+impl<V: Eq + Hash, R: Copy> Allocation<V, R> {
+    pub fn get(&self, value: V) -> Option<R> {
+        self.assignments.get(&value).copied()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&V, &R)> {
+        self.assignments.iter()
+    }
+}
+
+/// Failure from target-independent linear-scan allocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LinearScanError<V> {
+    EmptyRegisterFile,
+    DuplicateValue(V),
+    InvalidRange(LiveRange<V>),
+    RegisterPressure { value: V, point: u32 },
+}
+
+impl<V: fmt::Debug> fmt::Display for LinearScanError<V> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyRegisterFile => formatter.write_str("target has no allocatable registers"),
+            Self::DuplicateValue(value) => write!(formatter, "duplicate live range for {value:?}"),
+            Self::InvalidRange(range) => write!(
+                formatter,
+                "invalid live range {:?}: {}..{}",
+                range.value, range.start, range.end
+            ),
+            Self::RegisterPressure { value, point } => write!(
+                formatter,
+                "no register available for {value:?} at program point {point}"
+            ),
+        }
+    }
+}
+
+impl<V: fmt::Debug> std::error::Error for LinearScanError<V> {}
+
+/// Allocate non-spilling live ranges using a deterministic linear scan.
+///
+/// This is the bootstrap allocator for new native targets. The mature SSA
+/// splitter remains available to x86 while its target hooks are separated;
+/// both allocators share the physical-register and constraint model here.
+pub fn allocate_linear_scan<V, R>(
+    ranges: &[LiveRange<V>],
+    allocatable: &[R],
+) -> Result<Allocation<V, R>, LinearScanError<V>>
+where
+    V: Copy + Eq + Hash + Ord + fmt::Debug,
+    R: MachineRegister,
+{
+    if allocatable.is_empty() {
+        return Err(LinearScanError::EmptyRegisterFile);
+    }
+
+    let mut ordered = ranges.to_vec();
+    ordered.sort_unstable_by_key(|range| (range.start, range.end, range.value));
+    let mut seen = BTreeSet::new();
+    for range in &ordered {
+        if range.start > range.end {
+            return Err(LinearScanError::InvalidRange(*range));
+        }
+        if !seen.insert(range.value) {
+            return Err(LinearScanError::DuplicateValue(range.value));
+        }
+    }
+
+    let mut active = Vec::<(u32, V, R)>::new();
+    let mut assignments = HashMap::with_capacity(ordered.len());
+    for range in ordered {
+        active.retain(|(end, _, _)| *end >= range.start);
+        let register = allocatable
+            .iter()
+            .copied()
+            .find(|candidate| active.iter().all(|(_, _, used)| used != candidate))
+            .ok_or(LinearScanError::RegisterPressure {
+                value: range.value,
+                point: range.start,
+            })?;
+        assignments.insert(range.value, register);
+        active.push((range.end, range.value, register));
+        active.sort_unstable_by_key(|(end, value, register)| (*end, *value, register.index()));
+    }
+
+    Ok(Allocation { assignments })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+    struct Reg(u8);
+
+    impl MachineRegister for Reg {
+        fn index(self) -> u8 {
+            self.0
+        }
+    }
+
+    #[test]
+    fn register_set_supports_registers_above_x86s_range() {
+        let mut set = RegisterSet::new();
+        set.insert(Reg(30));
+        assert!(set.contains(&Reg(30)));
+        set.remove(Reg(30));
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn linear_scan_reuses_register_after_last_use() {
+        let ranges = [
+            LiveRange {
+                value: 0,
+                start: 0,
+                end: 1,
+            },
+            LiveRange {
+                value: 1,
+                start: 2,
+                end: 3,
+            },
+        ];
+        let allocation = allocate_linear_scan(&ranges, &[Reg(9)]).unwrap();
+        assert_eq!(allocation.get(0), Some(Reg(9)));
+        assert_eq!(allocation.get(1), Some(Reg(9)));
+    }
+
+    #[test]
+    fn linear_scan_reports_pressure_without_hidden_spills() {
+        let ranges = [
+            LiveRange {
+                value: 0,
+                start: 0,
+                end: 2,
+            },
+            LiveRange {
+                value: 1,
+                start: 1,
+                end: 2,
+            },
+        ];
+        assert_eq!(
+            allocate_linear_scan(&ranges, &[Reg(9)]),
+            Err(LinearScanError::RegisterPressure { value: 1, point: 1 })
+        );
+    }
+}

--- a/crates/celox-backend-common/src/regalloc/live_interval.rs
+++ b/crates/celox-backend-common/src/regalloc/live_interval.rs
@@ -1,0 +1,805 @@
+//! Exact sparse live intervals over opcode-free allocation facts.
+//!
+//! Backends retain their own machine IR. This module only sees the normalized
+//! control-flow, SSA definitions, uses, and phi edges exported at the
+//! allocation boundary.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fmt;
+use std::hash::Hash;
+
+use super::FunctionAllocationFacts;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct DefinitionSite {
+    block: usize,
+    instruction: Option<usize>,
+    slot: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct UseSite {
+    block: usize,
+    instruction: Option<usize>,
+    slot: u64,
+}
+
+/// One half-open live segment within a normalized basic block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LiveSegment {
+    pub block: usize,
+    pub start: u64,
+    pub end: u64,
+}
+
+impl LiveSegment {
+    pub fn contains(self, point: u64) -> bool {
+        self.start <= point && point < self.end
+    }
+
+    pub fn overlaps(self, other: Self) -> bool {
+        self.block == other.block && self.start < other.end && other.start < self.end
+    }
+}
+
+/// Sparse per-block live interval for one target-owned virtual register.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveInterval<V> {
+    pub value: V,
+    pub segments: Vec<LiveSegment>,
+}
+
+impl<V> LiveInterval<V> {
+    pub fn segment_in_block(&self, block: usize) -> Option<LiveSegment> {
+        self.segments
+            .binary_search_by_key(&block, |segment| segment.block)
+            .ok()
+            .map(|index| self.segments[index])
+    }
+
+    pub fn interferes(&self, other: &Self) -> bool {
+        let mut left = 0;
+        let mut right = 0;
+        while left < self.segments.len() && right < other.segments.len() {
+            let a = self.segments[left];
+            let b = other.segments[right];
+            if a.overlaps(b) {
+                return true;
+            }
+            if (a.block, a.end) <= (b.block, b.end) {
+                left += 1;
+            } else {
+                right += 1;
+            }
+        }
+        false
+    }
+}
+
+/// Exact SSA liveness reconstructed from allocation facts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveIntervals<V> {
+    intervals: BTreeMap<V, LiveInterval<V>>,
+    live_in: Vec<BTreeSet<V>>,
+    live_out: Vec<BTreeSet<V>>,
+}
+
+impl<V: Ord> LiveIntervals<V> {
+    pub fn get(&self, value: &V) -> Option<&LiveInterval<V>> {
+        self.intervals.get(value)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&V, &LiveInterval<V>)> {
+        self.intervals.iter()
+    }
+
+    pub fn live_in(&self, block: usize) -> Option<&BTreeSet<V>> {
+        self.live_in.get(block)
+    }
+
+    pub fn live_out(&self, block: usize) -> Option<&BTreeSet<V>> {
+        self.live_out.get(block)
+    }
+}
+
+/// Failure while constructing strict-SSA live intervals.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveIntervalError<V> {
+    pub rule: &'static str,
+    pub block: Option<usize>,
+    pub instruction: Option<usize>,
+    pub values: Vec<V>,
+    pub message: String,
+}
+
+impl<V> LiveIntervalError<V> {
+    fn new(
+        rule: &'static str,
+        block: Option<usize>,
+        instruction: Option<usize>,
+        values: Vec<V>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            rule,
+            block,
+            instruction,
+            values,
+            message: message.into(),
+        }
+    }
+}
+
+impl<V: fmt::Debug> fmt::Display for LiveIntervalError<V> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.rule)?;
+        if let Some(block) = self.block {
+            write!(formatter, " at block {block}")?;
+        }
+        if let Some(instruction) = self.instruction {
+            write!(formatter, "/i{instruction}")?;
+        }
+        if !self.values.is_empty() {
+            write!(formatter, " values={:?}", self.values)?;
+        }
+        write!(formatter, ": {}", self.message)
+    }
+}
+
+impl<V: fmt::Debug> std::error::Error for LiveIntervalError<V> {}
+
+struct BlockFacts<V> {
+    definitions: BTreeSet<V>,
+    upward_uses: BTreeSet<V>,
+    last_use: BTreeMap<V, u64>,
+}
+
+impl<V> Default for BlockFacts<V> {
+    fn default() -> Self {
+        Self {
+            definitions: BTreeSet::new(),
+            upward_uses: BTreeSet::new(),
+            last_use: BTreeMap::new(),
+        }
+    }
+}
+
+struct ModelFacts<V> {
+    definitions: BTreeMap<V, DefinitionSite>,
+    uses: BTreeMap<V, Vec<UseSite>>,
+    blocks: Vec<BlockFacts<V>>,
+    edge_uses: BTreeMap<(usize, usize), BTreeSet<V>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct BlockSlots {
+    phi_def: u64,
+    exit: u64,
+}
+
+fn instruction_use_slot(instruction: usize) -> Option<u64> {
+    u64::try_from(instruction)
+        .ok()?
+        .checked_mul(3)?
+        .checked_add(2)
+}
+
+fn instruction_def_slot(instruction: usize) -> Option<u64> {
+    instruction_use_slot(instruction)?.checked_add(2)
+}
+
+fn block_slots<V, R>(
+    facts: &FunctionAllocationFacts<V, R>,
+) -> Result<Vec<BlockSlots>, LiveIntervalError<V>> {
+    facts
+        .blocks
+        .iter()
+        .enumerate()
+        .map(|(block, facts)| {
+            let exit = u64::try_from(facts.instructions.len())
+                .ok()
+                .and_then(|count| count.checked_mul(3))
+                .and_then(|slot| slot.checked_add(2))
+                .ok_or_else(|| {
+                    LiveIntervalError::new(
+                        "LIVE_INTERVAL.SLOT_RANGE",
+                        Some(block),
+                        None,
+                        Vec::new(),
+                        "block exit is outside the program-point domain",
+                    )
+                })?;
+            Ok(BlockSlots { phi_def: 1, exit })
+        })
+        .collect()
+}
+
+fn record_definition<V: Copy + Ord>(
+    definitions: &mut BTreeMap<V, DefinitionSite>,
+    value: V,
+    site: DefinitionSite,
+) -> Result<(), LiveIntervalError<V>> {
+    if let Some(previous) = definitions.insert(value, site) {
+        return Err(LiveIntervalError::new(
+            "LIVE_INTERVAL.MULTIPLE_DEFINITIONS",
+            Some(site.block),
+            site.instruction,
+            vec![value],
+            format!("value was already defined at {previous:?}"),
+        ));
+    }
+    Ok(())
+}
+
+fn collect_model<V, R>(
+    facts: &FunctionAllocationFacts<V, R>,
+    predecessors: &[Vec<usize>],
+    slots: &[BlockSlots],
+) -> Result<ModelFacts<V>, LiveIntervalError<V>>
+where
+    V: Copy + Ord,
+{
+    let mut definitions = BTreeMap::new();
+    let mut uses = BTreeMap::<V, Vec<UseSite>>::new();
+    let mut blocks = (0..facts.blocks.len())
+        .map(|_| BlockFacts::default())
+        .collect::<Vec<_>>();
+
+    for (block_index, block) in facts.blocks.iter().enumerate() {
+        for phi in &block.phis {
+            let site = DefinitionSite {
+                block: block_index,
+                instruction: None,
+                slot: slots[block_index].phi_def,
+            };
+            record_definition(&mut definitions, phi.destination, site)?;
+            blocks[block_index].definitions.insert(phi.destination);
+        }
+
+        let mut seen_definitions = blocks[block_index].definitions.clone();
+        for (instruction_index, instruction) in block.instructions.iter().enumerate() {
+            let use_slot = instruction_use_slot(instruction_index).ok_or_else(|| {
+                LiveIntervalError::new(
+                    "LIVE_INTERVAL.SLOT_RANGE",
+                    Some(block_index),
+                    Some(instruction_index),
+                    Vec::new(),
+                    "instruction use is outside the program-point domain",
+                )
+            })?;
+            let mut instruction_uses = instruction.uses.clone();
+            instruction_uses.sort_unstable();
+            instruction_uses.dedup();
+            for value in instruction_uses {
+                let site = UseSite {
+                    block: block_index,
+                    instruction: Some(instruction_index),
+                    slot: use_slot,
+                };
+                uses.entry(value).or_default().push(site);
+                if !seen_definitions.contains(&value) {
+                    blocks[block_index].upward_uses.insert(value);
+                }
+                blocks[block_index]
+                    .last_use
+                    .entry(value)
+                    .and_modify(|current| *current = (*current).max(use_slot))
+                    .or_insert(use_slot);
+            }
+            let def_slot = instruction_def_slot(instruction_index).ok_or_else(|| {
+                LiveIntervalError::new(
+                    "LIVE_INTERVAL.SLOT_RANGE",
+                    Some(block_index),
+                    Some(instruction_index),
+                    Vec::new(),
+                    "instruction definition is outside the program-point domain",
+                )
+            })?;
+            for &value in &instruction.defs {
+                let site = DefinitionSite {
+                    block: block_index,
+                    instruction: Some(instruction_index),
+                    slot: def_slot,
+                };
+                record_definition(&mut definitions, value, site)?;
+                blocks[block_index].definitions.insert(value);
+                seen_definitions.insert(value);
+            }
+        }
+    }
+
+    let mut edge_uses = BTreeMap::<(usize, usize), BTreeSet<V>>::new();
+    for (successor, block) in facts.blocks.iter().enumerate() {
+        for phi in &block.phis {
+            let mut seen_predecessors = BTreeSet::new();
+            for source in &phi.sources {
+                if !seen_predecessors.insert(source.predecessor) {
+                    return Err(LiveIntervalError::new(
+                        "LIVE_INTERVAL.PHI_PREDECESSOR",
+                        Some(successor),
+                        None,
+                        vec![source.value],
+                        "phi predecessor appears more than once",
+                    ));
+                }
+                let site = UseSite {
+                    block: source.predecessor,
+                    instruction: None,
+                    slot: slots[source.predecessor].exit,
+                };
+                uses.entry(source.value).or_default().push(site);
+                edge_uses
+                    .entry((source.predecessor, successor))
+                    .or_default()
+                    .insert(source.value);
+                blocks[source.predecessor]
+                    .last_use
+                    .entry(source.value)
+                    .and_modify(|current| *current = (*current).max(site.slot))
+                    .or_insert(site.slot);
+            }
+            if seen_predecessors.len() != predecessors[successor].len() {
+                return Err(LiveIntervalError::new(
+                    "LIVE_INTERVAL.PHI_PREDECESSOR",
+                    Some(successor),
+                    None,
+                    vec![phi.destination],
+                    "phi does not provide exactly one source for every predecessor",
+                ));
+            }
+        }
+    }
+    for sites in uses.values_mut() {
+        sites.sort_unstable();
+        sites.dedup();
+    }
+
+    Ok(ModelFacts {
+        definitions,
+        uses,
+        blocks,
+        edge_uses,
+    })
+}
+
+fn solve_liveness<V: Copy + Ord, R>(
+    facts: &FunctionAllocationFacts<V, R>,
+    predecessors: &[Vec<usize>],
+    model: &ModelFacts<V>,
+) -> (Vec<BTreeSet<V>>, Vec<BTreeSet<V>>) {
+    let mut live_in = vec![BTreeSet::new(); facts.blocks.len()];
+    let mut live_out = live_in.clone();
+    let mut queue = (0..facts.blocks.len()).rev().collect::<VecDeque<_>>();
+    let mut queued = vec![true; facts.blocks.len()];
+    while let Some(block) = queue.pop_front() {
+        queued[block] = false;
+        let mut next_out = BTreeSet::new();
+        for &successor in &facts.blocks[block].successors {
+            next_out.extend(live_in[successor].iter().copied());
+            if let Some(edge) = model.edge_uses.get(&(block, successor)) {
+                next_out.extend(edge.iter().copied());
+            }
+        }
+        let mut next_in = model.blocks[block].upward_uses.clone();
+        next_in.extend(
+            next_out
+                .iter()
+                .copied()
+                .filter(|value| !model.blocks[block].definitions.contains(value)),
+        );
+        if next_in != live_in[block] || next_out != live_out[block] {
+            live_in[block] = next_in;
+            live_out[block] = next_out;
+            for &predecessor in &predecessors[block] {
+                if !queued[predecessor] {
+                    queued[predecessor] = true;
+                    queue.push_back(predecessor);
+                }
+            }
+        }
+    }
+    (live_in, live_out)
+}
+
+struct DominatorTree {
+    enter: Vec<usize>,
+    exit: Vec<usize>,
+}
+
+impl DominatorTree {
+    fn dominates(&self, dominator: usize, block: usize) -> bool {
+        self.enter[dominator] <= self.enter[block] && self.exit[block] <= self.exit[dominator]
+    }
+}
+
+fn compute_dominators<V>(
+    entry: usize,
+    successors: &[Vec<usize>],
+    predecessors: &[Vec<usize>],
+) -> Result<DominatorTree, LiveIntervalError<V>> {
+    let mut reachable = vec![false; successors.len()];
+    let mut postorder = Vec::with_capacity(successors.len());
+    let mut stack = vec![(entry, 0usize)];
+    reachable[entry] = true;
+    while let Some((block, next_successor)) = stack.last_mut() {
+        if *next_successor == successors[*block].len() {
+            postorder.push(*block);
+            stack.pop();
+        } else {
+            let successor = successors[*block][*next_successor];
+            *next_successor += 1;
+            if !reachable[successor] {
+                reachable[successor] = true;
+                stack.push((successor, 0));
+            }
+        }
+    }
+    if let Some(block) = reachable.iter().position(|reachable| !reachable) {
+        return Err(LiveIntervalError::new(
+            "LIVE_INTERVAL.UNREACHABLE_BLOCK",
+            Some(block),
+            None,
+            Vec::new(),
+            "allocation facts contain a block unreachable from the entry",
+        ));
+    }
+
+    postorder.reverse();
+    let mut rpo_position = vec![0; successors.len()];
+    for (position, &block) in postorder.iter().enumerate() {
+        rpo_position[block] = position;
+    }
+    let mut idom = vec![None; successors.len()];
+    idom[entry] = Some(entry);
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for &block in postorder.iter().skip(1) {
+            let mut processed = predecessors[block]
+                .iter()
+                .copied()
+                .filter(|predecessor| idom[*predecessor].is_some());
+            let mut next = processed.next().ok_or_else(|| {
+                LiveIntervalError::new(
+                    "LIVE_INTERVAL.DOMINATOR_TREE",
+                    Some(block),
+                    None,
+                    Vec::new(),
+                    "reachable block has no processed predecessor",
+                )
+            })?;
+            for predecessor in processed {
+                next = intersect_dominators(next, predecessor, &idom, &rpo_position);
+            }
+            if idom[block] != Some(next) {
+                idom[block] = Some(next);
+                changed = true;
+            }
+        }
+    }
+    idom[entry] = None;
+
+    let mut children = vec![Vec::new(); successors.len()];
+    for (block, parent) in idom.iter().copied().enumerate() {
+        if let Some(parent) = parent {
+            children[parent].push(block);
+        }
+    }
+    let mut enter = vec![0; successors.len()];
+    let mut exit = vec![0; successors.len()];
+    let mut clock = 0usize;
+    let mut stack = vec![(entry, false)];
+    while let Some((block, leaving)) = stack.pop() {
+        if leaving {
+            exit[block] = clock;
+            clock += 1;
+        } else {
+            enter[block] = clock;
+            clock += 1;
+            stack.push((block, true));
+            stack.extend(children[block].iter().rev().map(|&child| (child, false)));
+        }
+    }
+    Ok(DominatorTree { enter, exit })
+}
+
+fn intersect_dominators(
+    mut left: usize,
+    mut right: usize,
+    idom: &[Option<usize>],
+    rpo_position: &[usize],
+) -> usize {
+    while left != right {
+        while rpo_position[left] > rpo_position[right] {
+            left = idom[left].expect("processed dominator must have a parent");
+        }
+        while rpo_position[right] > rpo_position[left] {
+            right = idom[right].expect("processed dominator must have a parent");
+        }
+    }
+    left
+}
+
+/// Build exact block-sparse live intervals for a strict-SSA target program.
+pub fn analyze_live_intervals<V, R>(
+    facts: &FunctionAllocationFacts<V, R>,
+) -> Result<LiveIntervals<V>, LiveIntervalError<V>>
+where
+    V: Copy + Eq + Hash + Ord + fmt::Debug,
+{
+    facts.verify().map_err(|error| {
+        LiveIntervalError::new(
+            "LIVE_INTERVAL.ALLOCATION_FACTS",
+            None,
+            None,
+            Vec::new(),
+            error.to_string(),
+        )
+    })?;
+    let mut predecessors = vec![Vec::new(); facts.blocks.len()];
+    for (block, facts) in facts.blocks.iter().enumerate() {
+        for &successor in &facts.successors {
+            predecessors[successor].push(block);
+        }
+    }
+    let successors = facts
+        .blocks
+        .iter()
+        .map(|block| block.successors.clone())
+        .collect::<Vec<_>>();
+    let dominators = compute_dominators(facts.entry, &successors, &predecessors)?;
+    let slots = block_slots(facts)?;
+    let model = collect_model(facts, &predecessors, &slots)?;
+    let (live_in, live_out) = solve_liveness(facts, &predecessors, &model);
+    let mut segments = BTreeMap::<V, Vec<LiveSegment>>::new();
+
+    for block in 0..facts.blocks.len() {
+        let mut values = BTreeSet::new();
+        values.extend(live_in[block].iter().copied());
+        values.extend(live_out[block].iter().copied());
+        values.extend(model.blocks[block].definitions.iter().copied());
+        values.extend(model.blocks[block].last_use.keys().copied());
+        for value in values {
+            let Some(definition) = model.definitions.get(&value).copied() else {
+                return Err(LiveIntervalError::new(
+                    "LIVE_INTERVAL.MISSING_DEFINITION",
+                    Some(block),
+                    None,
+                    vec![value],
+                    "live or used value has no target-MIR definition",
+                ));
+            };
+            if definition.block == block && live_in[block].contains(&value) {
+                return Err(LiveIntervalError::new(
+                    "LIVE_INTERVAL.USE_BEFORE_DEFINITION",
+                    Some(block),
+                    definition.instruction,
+                    vec![value],
+                    "value is live at entry of its defining block",
+                ));
+            }
+            let start = if definition.block == block {
+                definition.slot
+            } else {
+                0
+            };
+            let end = if live_out[block].contains(&value) {
+                slots[block].exit.checked_add(1)
+            } else if let Some(last_use) = model.blocks[block].last_use.get(&value) {
+                last_use.checked_add(1)
+            } else if definition.block == block {
+                definition.slot.checked_add(1)
+            } else {
+                None
+            }
+            .ok_or_else(|| {
+                LiveIntervalError::new(
+                    "LIVE_INTERVAL.SLOT_RANGE",
+                    Some(block),
+                    None,
+                    vec![value],
+                    "live segment end overflows or has no local reason to exist",
+                )
+            })?;
+            if start >= end {
+                return Err(LiveIntervalError::new(
+                    "LIVE_INTERVAL.EMPTY_SEGMENT",
+                    Some(block),
+                    None,
+                    vec![value],
+                    format!("segment {start}..{end} is empty or reversed"),
+                ));
+            }
+            segments
+                .entry(value)
+                .or_default()
+                .push(LiveSegment { block, start, end });
+        }
+    }
+
+    let mut intervals = BTreeMap::new();
+    for (&value, &definition) in &model.definitions {
+        let mut value_segments = segments.remove(&value).unwrap_or_default();
+        value_segments.sort_unstable_by_key(|segment| (segment.block, segment.start));
+        let interval = LiveInterval {
+            value,
+            segments: value_segments,
+        };
+        if !interval
+            .segment_in_block(definition.block)
+            .is_some_and(|segment| segment.contains(definition.slot))
+        {
+            return Err(LiveIntervalError::new(
+                "LIVE_INTERVAL.DEFINITION_COVERAGE",
+                Some(definition.block),
+                definition.instruction,
+                vec![value],
+                "definition is not covered by its live interval",
+            ));
+        }
+        for site in model.uses.get(&value).into_iter().flatten() {
+            let covered = interval
+                .segment_in_block(site.block)
+                .is_some_and(|segment| segment.contains(site.slot));
+            let dominated = if definition.block == site.block {
+                definition.slot < site.slot
+            } else {
+                dominators.dominates(definition.block, site.block)
+            };
+            if !covered || !dominated {
+                return Err(LiveIntervalError::new(
+                    "LIVE_INTERVAL.DEFINITION_DOMINANCE",
+                    Some(site.block),
+                    site.instruction,
+                    vec![value],
+                    "definition does not dominate the target-MIR use",
+                ));
+            }
+        }
+        intervals.insert(value, interval);
+    }
+    if let Some((&value, sites)) = model
+        .uses
+        .iter()
+        .find(|(value, _)| !model.definitions.contains_key(value))
+    {
+        return Err(LiveIntervalError::new(
+            "LIVE_INTERVAL.MISSING_DEFINITION",
+            sites.first().map(|site| site.block),
+            sites.first().and_then(|site| site.instruction),
+            vec![value],
+            "used value has no target-MIR definition",
+        ));
+    }
+
+    Ok(LiveIntervals {
+        intervals,
+        live_in,
+        live_out,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::regalloc::{
+        BlockAllocationFacts, InstructionAllocationFacts, InstructionConstraints,
+        PhiAllocationFacts, PhiSource,
+    };
+
+    fn instruction(uses: Vec<u32>, defs: Vec<u32>) -> InstructionAllocationFacts<u32, ()> {
+        InstructionAllocationFacts {
+            uses,
+            defs,
+            constraints: InstructionConstraints::default(),
+            is_copy: false,
+        }
+    }
+
+    #[test]
+    fn diamond_arms_remain_non_interfering() {
+        let facts = FunctionAllocationFacts {
+            entry: 0,
+            blocks: vec![
+                BlockAllocationFacts {
+                    successors: vec![1, 2],
+                    phis: Vec::new(),
+                    instructions: vec![instruction(Vec::new(), vec![0])],
+                },
+                BlockAllocationFacts {
+                    successors: vec![3],
+                    phis: Vec::new(),
+                    instructions: vec![instruction(vec![0], vec![1])],
+                },
+                BlockAllocationFacts {
+                    successors: vec![3],
+                    phis: Vec::new(),
+                    instructions: vec![instruction(vec![0], vec![2])],
+                },
+                BlockAllocationFacts {
+                    successors: Vec::new(),
+                    phis: vec![PhiAllocationFacts {
+                        destination: 3,
+                        sources: vec![
+                            PhiSource {
+                                predecessor: 1,
+                                value: 1,
+                            },
+                            PhiSource {
+                                predecessor: 2,
+                                value: 2,
+                            },
+                        ],
+                    }],
+                    instructions: vec![instruction(vec![3], Vec::new())],
+                },
+            ],
+        };
+
+        let intervals = analyze_live_intervals(&facts).unwrap();
+        assert!(
+            !intervals
+                .get(&1)
+                .unwrap()
+                .interferes(intervals.get(&2).unwrap())
+        );
+        assert!(intervals.live_out(1).unwrap().contains(&1));
+        assert!(intervals.live_out(2).unwrap().contains(&2));
+        assert!(!intervals.live_in(3).unwrap().contains(&1));
+    }
+
+    #[test]
+    fn rejects_missing_phi_source() {
+        let facts = FunctionAllocationFacts::<u32, ()> {
+            entry: 0,
+            blocks: vec![
+                BlockAllocationFacts {
+                    successors: vec![1, 2],
+                    phis: Vec::new(),
+                    instructions: vec![instruction(Vec::new(), vec![0])],
+                },
+                BlockAllocationFacts {
+                    successors: vec![2],
+                    phis: Vec::new(),
+                    instructions: vec![instruction(Vec::new(), vec![1])],
+                },
+                BlockAllocationFacts {
+                    successors: Vec::new(),
+                    phis: vec![PhiAllocationFacts {
+                        destination: 2,
+                        sources: vec![PhiSource {
+                            predecessor: 0,
+                            value: 0,
+                        }],
+                    }],
+                    instructions: Vec::new(),
+                },
+            ],
+        };
+
+        assert_eq!(
+            analyze_live_intervals(&facts).unwrap_err().rule,
+            "LIVE_INTERVAL.PHI_PREDECESSOR"
+        );
+    }
+
+    #[test]
+    fn rejects_use_before_definition() {
+        let facts = FunctionAllocationFacts::<u32, ()> {
+            entry: 0,
+            blocks: vec![BlockAllocationFacts {
+                successors: Vec::new(),
+                phis: Vec::new(),
+                instructions: vec![
+                    instruction(vec![0], Vec::new()),
+                    instruction(Vec::new(), vec![0]),
+                ],
+            }],
+        };
+
+        assert_eq!(
+            analyze_live_intervals(&facts).unwrap_err().rule,
+            "LIVE_INTERVAL.USE_BEFORE_DEFINITION"
+        );
+    }
+}

--- a/crates/celox-backend-common/src/regalloc/parallel_copy.rs
+++ b/crates/celox-backend-common/src/regalloc/parallel_copy.rs
@@ -1,0 +1,426 @@
+//! Target-independent scheduling of edge-local parallel copies.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fmt;
+
+/// Writable physical location in a parallel assignment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CopyDestination<R> {
+    Register(R),
+    Stack(i32),
+}
+
+/// Readable physical location or constant in a parallel assignment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CopySource<R> {
+    Register(R),
+    Stack(i32),
+    Immediate(u64),
+}
+
+/// One simultaneous assignment row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParallelCopy<R> {
+    pub destination: CopyDestination<R>,
+    pub source: CopySource<R>,
+}
+
+impl<R: PartialEq> ParallelCopy<R> {
+    pub fn is_identity(&self) -> bool {
+        matches!(
+            (&self.destination, &self.source),
+            (
+                CopyDestination::Register(destination),
+                CopySource::Register(source)
+            ) if destination == source
+        ) || matches!(
+            (&self.destination, &self.source),
+            (CopyDestination::Stack(destination), CopySource::Stack(source))
+                if destination == source
+        )
+    }
+}
+
+/// One sequential operation implementing a parallel assignment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CopyOperation<R> {
+    Move {
+        destination: CopyDestination<R>,
+        source: CopySource<R>,
+    },
+    SwapRegisters {
+        left: R,
+        right: R,
+    },
+    SaveTemporary(CopyDestination<R>),
+    RestoreTemporary(CopyDestination<R>),
+}
+
+/// Work counters retained for allocator diagnostics and regression tests.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CopyResolutionWork {
+    pub effective_copies: usize,
+    pub direct_moves: usize,
+    pub register_swaps: usize,
+    pub cycle_breaks: usize,
+    pub temporary_cycle_breaks: usize,
+    pub ready_queue_pops: usize,
+    pub dependency_releases: usize,
+}
+
+/// Dependency-ordered realization of one parallel assignment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CopyResolution<R> {
+    pub operations: Vec<CopyOperation<R>>,
+    pub work: CopyResolutionWork,
+}
+
+/// Malformed copy rows or an inconsistent resolver state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CopyResolutionError<R> {
+    pub rule: &'static str,
+    pub destination: Option<CopyDestination<R>>,
+    pub message: String,
+}
+
+impl<R> CopyResolutionError<R> {
+    fn new(rule: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            rule,
+            destination: None,
+            message: message.into(),
+        }
+    }
+
+    fn at(mut self, destination: CopyDestination<R>) -> Self {
+        self.destination = Some(destination);
+        self
+    }
+}
+
+impl<R: fmt::Debug> fmt::Display for CopyResolutionError<R> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "parallel copy [{}]", self.rule)?;
+        if let Some(destination) = &self.destination {
+            write!(formatter, " at {destination:?}")?;
+        }
+        write!(formatter, ": {}", self.message)
+    }
+}
+
+impl<R: fmt::Debug> std::error::Error for CopyResolutionError<R> {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingSource<R> {
+    Value(CopySource<R>),
+    Temporary,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PendingCopy<R> {
+    destination: CopyDestination<R>,
+    source: PendingSource<R>,
+    pending: bool,
+}
+
+fn source_as_destination<R: Copy>(source: CopySource<R>) -> Option<CopyDestination<R>> {
+    match source {
+        CopySource::Register(register) => Some(CopyDestination::Register(register)),
+        CopySource::Stack(slot) => Some(CopyDestination::Stack(slot)),
+        CopySource::Immediate(_) => None,
+    }
+}
+
+fn register_cycle<R>(
+    copies: &[PendingCopy<R>],
+    destination_index: &BTreeMap<CopyDestination<R>, usize>,
+    start: usize,
+) -> Option<(Vec<usize>, Vec<(R, R)>)>
+where
+    R: Copy + Ord,
+{
+    let CopyDestination::Register(start_register) = copies.get(start)?.destination else {
+        return None;
+    };
+    let mut current = start_register;
+    let mut members = Vec::new();
+    let mut swaps = Vec::new();
+    let mut visited = BTreeSet::new();
+    loop {
+        if !visited.insert(current) {
+            return None;
+        }
+        let destination = CopyDestination::Register(current);
+        let &index = destination_index.get(&destination)?;
+        let copy = copies.get(index)?;
+        if !copy.pending {
+            return None;
+        }
+        let PendingSource::Value(CopySource::Register(source)) = copy.source else {
+            return None;
+        };
+        members.push(index);
+        if source == start_register {
+            return (members.len() >= 2).then_some((members, swaps));
+        }
+        swaps.push((current, source));
+        current = source;
+    }
+}
+
+/// Schedule copies without clobbering any still-needed source.
+///
+/// Acyclic rows become direct moves, two-register cycles become one swap, and
+/// longer or stack cycles use one target-provided temporary location.
+pub fn resolve_parallel_copies<R>(
+    rows: &[ParallelCopy<R>],
+) -> Result<CopyResolution<R>, CopyResolutionError<R>>
+where
+    R: Copy + Ord + fmt::Debug,
+{
+    let mut destination_owner = BTreeSet::new();
+    for row in rows {
+        if !destination_owner.insert(row.destination) {
+            return Err(CopyResolutionError::new(
+                "PARALLEL_COPY.NON_UNIQUE_DESTINATION",
+                "parallel assignment writes one destination more than once",
+            )
+            .at(row.destination));
+        }
+    }
+
+    let mut copies = rows
+        .iter()
+        .filter(|row| !row.is_identity())
+        .map(|row| PendingCopy {
+            destination: row.destination,
+            source: PendingSource::Value(row.source),
+            pending: true,
+        })
+        .collect::<Vec<_>>();
+    let mut work = CopyResolutionWork {
+        effective_copies: copies.len(),
+        ..CopyResolutionWork::default()
+    };
+    if copies.is_empty() {
+        return Ok(CopyResolution {
+            operations: Vec::new(),
+            work,
+        });
+    }
+
+    let destination_index = copies
+        .iter()
+        .enumerate()
+        .map(|(index, copy)| (copy.destination, index))
+        .collect::<BTreeMap<_, _>>();
+    let mut readers = BTreeMap::<CopyDestination<R>, BTreeSet<usize>>::new();
+    for (index, copy) in copies.iter().enumerate() {
+        let PendingSource::Value(source) = copy.source else {
+            continue;
+        };
+        if let Some(location) = source_as_destination(source) {
+            readers.entry(location).or_default().insert(index);
+        }
+    }
+
+    let mut ready = VecDeque::new();
+    let mut queued = vec![false; copies.len()];
+    for (index, copy) in copies.iter().enumerate() {
+        if !readers.contains_key(&copy.destination) {
+            ready.push_back(index);
+            queued[index] = true;
+        }
+    }
+
+    let mut operations = Vec::with_capacity(copies.len());
+    let mut remaining = copies.len();
+    let mut temporary_live = false;
+    let mut cycle_search_start = 0usize;
+    while remaining != 0 {
+        while let Some(index) = ready.pop_front() {
+            queued[index] = false;
+            if !copies[index].pending {
+                continue;
+            }
+            work.ready_queue_pops += 1;
+            match copies[index].source {
+                PendingSource::Value(source) => {
+                    operations.push(CopyOperation::Move {
+                        destination: copies[index].destination,
+                        source,
+                    });
+                    work.direct_moves += 1;
+                    if let Some(location) = source_as_destination(source) {
+                        let released = readers.get_mut(&location).is_some_and(|location_readers| {
+                            location_readers.remove(&index);
+                            location_readers.is_empty()
+                        });
+                        if released {
+                            readers.remove(&location);
+                            work.dependency_releases += 1;
+                            if let Some(&writer) = destination_index.get(&location)
+                                && copies[writer].pending
+                                && !queued[writer]
+                            {
+                                ready.push_back(writer);
+                                queued[writer] = true;
+                            }
+                        }
+                    }
+                }
+                PendingSource::Temporary => {
+                    if !temporary_live {
+                        return Err(CopyResolutionError::new(
+                            "PARALLEL_COPY.TEMPORARY_STATE",
+                            "resolver attempted to restore an inactive temporary",
+                        )
+                        .at(copies[index].destination));
+                    }
+                    operations.push(CopyOperation::RestoreTemporary(copies[index].destination));
+                    temporary_live = false;
+                }
+            }
+            copies[index].pending = false;
+            remaining -= 1;
+        }
+
+        if remaining == 0 {
+            break;
+        }
+        if temporary_live {
+            return Err(CopyResolutionError::new(
+                "PARALLEL_COPY.TEMPORARY_STATE",
+                "resolver stalled while a temporary was live",
+            ));
+        }
+        let Some(cycle) = copies
+            .iter()
+            .enumerate()
+            .skip(cycle_search_start)
+            .find_map(|(index, copy)| copy.pending.then_some(index))
+        else {
+            return Err(CopyResolutionError::new(
+                "PARALLEL_COPY.RESOLVER_STATE",
+                "nonzero pending count has no pending row",
+            ));
+        };
+        cycle_search_start = cycle + 1;
+
+        if let Some((members, swaps)) = register_cycle(&copies, &destination_index, cycle)
+            && members.len() == 2
+        {
+            for (left, right) in swaps.iter().copied() {
+                operations.push(CopyOperation::SwapRegisters { left, right });
+            }
+            for &member in &members {
+                readers.remove(&copies[member].destination);
+                copies[member].pending = false;
+                queued[member] = false;
+            }
+            remaining -= members.len();
+            work.register_swaps += swaps.len();
+            work.cycle_breaks += 1;
+            work.dependency_releases += members.len();
+            continue;
+        }
+
+        let saved = copies[cycle].destination;
+        let saved_readers = readers.remove(&saved).unwrap_or_default();
+        if saved_readers.len() != 1 {
+            return Err(CopyResolutionError::new(
+                "PARALLEL_COPY.CYCLE_SHAPE",
+                format!("stalled cycle location has {} readers", saved_readers.len()),
+            )
+            .at(saved));
+        }
+        let reader = *saved_readers
+            .iter()
+            .next()
+            .expect("one cycle reader was checked above");
+        copies[reader].source = PendingSource::Temporary;
+        operations.push(CopyOperation::SaveTemporary(saved));
+        work.cycle_breaks += 1;
+        work.temporary_cycle_breaks += 1;
+        work.dependency_releases += 1;
+        temporary_live = true;
+        if !queued[cycle] {
+            ready.push_back(cycle);
+            queued[cycle] = true;
+        }
+    }
+
+    if temporary_live {
+        return Err(CopyResolutionError::new(
+            "PARALLEL_COPY.TEMPORARY_STATE",
+            "resolver left its temporary live",
+        ));
+    }
+    Ok(CopyResolution { operations, work })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn register_copy(destination: u8, source: u8) -> ParallelCopy<u8> {
+        ParallelCopy {
+            destination: CopyDestination::Register(destination),
+            source: CopySource::Register(source),
+        }
+    }
+
+    #[test]
+    fn orders_an_acyclic_chain_backwards() {
+        let result = resolve_parallel_copies(&[register_copy(0, 1), register_copy(2, 0)]).unwrap();
+        assert_eq!(
+            result.operations,
+            vec![
+                CopyOperation::Move {
+                    destination: CopyDestination::Register(2),
+                    source: CopySource::Register(0),
+                },
+                CopyOperation::Move {
+                    destination: CopyDestination::Register(0),
+                    source: CopySource::Register(1),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn swaps_a_two_register_cycle() {
+        let result = resolve_parallel_copies(&[register_copy(0, 1), register_copy(1, 0)]).unwrap();
+        assert_eq!(result.work.register_swaps, 1);
+        assert!(matches!(
+            result.operations.as_slice(),
+            [CopyOperation::SwapRegisters { .. }]
+        ));
+    }
+
+    #[test]
+    fn breaks_a_long_cycle_with_one_temporary() {
+        let result = resolve_parallel_copies(&[
+            register_copy(0, 1),
+            register_copy(1, 2),
+            register_copy(2, 0),
+        ])
+        .unwrap();
+        assert_eq!(result.work.temporary_cycle_breaks, 1);
+        assert!(matches!(
+            result.operations.first(),
+            Some(CopyOperation::SaveTemporary(_))
+        ));
+        assert!(matches!(
+            result.operations.last(),
+            Some(CopyOperation::RestoreTemporary(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_duplicate_destinations_even_when_one_row_is_identity() {
+        let error =
+            resolve_parallel_copies(&[register_copy(0, 0), register_copy(0, 1)]).unwrap_err();
+        assert_eq!(error.rule, "PARALLEL_COPY.NON_UNIQUE_DESTINATION");
+    }
+}

--- a/crates/celox-backend-common/src/regalloc/stack_color.rs
+++ b/crates/celox-backend-common/src/regalloc/stack_color.rs
@@ -1,0 +1,171 @@
+//! Opcode-free stack-slot coloring over exact sparse live intervals.
+
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
+use std::fmt;
+
+use super::LiveInterval;
+
+/// Failure while assigning target-owned spill homes to reusable frame slots.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StackColorError<V> {
+    DuplicateValue(V),
+    EmptyInterval(V),
+    SlotCountOverflow,
+}
+
+impl<V: fmt::Debug> fmt::Display for StackColorError<V> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DuplicateValue(value) => {
+                write!(formatter, "stack interval for {value:?} was colored twice")
+            }
+            Self::EmptyInterval(value) => {
+                write!(
+                    formatter,
+                    "stack interval for {value:?} has no live segments"
+                )
+            }
+            Self::SlotCountOverflow => formatter.write_str("stack-slot count exceeds u32"),
+        }
+    }
+}
+
+impl<V: fmt::Debug> std::error::Error for StackColorError<V> {}
+
+/// Deterministic stack-slot assignment for target-owned spill homes.
+///
+/// Backends retain responsibility for choosing spill values and translating a
+/// slot number into their frame layout. This helper conservatively projects
+/// each exact sparse interval to a linear block-order envelope, then reuses
+/// slots with a sweep. Envelope overlap may miss a legal reuse across a sparse
+/// gap, but cannot make interfering homes alias. The algorithm is independent
+/// of target MIR and opcode semantics and runs in O(n log n).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StackSlotColoring<V> {
+    assignments: BTreeMap<V, u32>,
+    slot_count: u32,
+}
+
+impl<V> StackSlotColoring<V>
+where
+    V: Ord,
+{
+    pub fn get(&self, value: &V) -> Option<u32> {
+        self.assignments.get(value).copied()
+    }
+
+    pub fn slot_count(&self) -> u32 {
+        self.slot_count
+    }
+}
+
+/// Color a complete target spill batch using conservative linear envelopes.
+pub fn color_stack_slots<'a, V, I>(intervals: I) -> Result<StackSlotColoring<V>, StackColorError<V>>
+where
+    V: 'a + Copy + Ord,
+    I: IntoIterator<Item = &'a LiveInterval<V>>,
+{
+    let mut seen = BTreeSet::new();
+    let mut ordered = Vec::new();
+    for interval in intervals {
+        if !seen.insert(interval.value) {
+            return Err(StackColorError::DuplicateValue(interval.value));
+        }
+        let Some(first) = interval.segments.first() else {
+            return Err(StackColorError::EmptyInterval(interval.value));
+        };
+        let last = interval
+            .segments
+            .last()
+            .expect("a nonempty interval has a last segment");
+        ordered.push((
+            (first.block, first.start),
+            (last.block, last.end),
+            interval.value,
+        ));
+    }
+    ordered.sort_unstable();
+
+    let mut active = BinaryHeap::<Reverse<((usize, u64), u32, V)>>::new();
+    let mut available = BinaryHeap::<Reverse<u32>>::new();
+    let mut next_slot = 0_u32;
+    let mut assignments = BTreeMap::new();
+    for (start, end, value) in ordered {
+        while active
+            .peek()
+            .is_some_and(|Reverse((active_end, _, _))| *active_end <= start)
+        {
+            let Reverse((_, slot, _)) = active.pop().expect("peeked active interval exists");
+            available.push(Reverse(slot));
+        }
+        let slot = if let Some(Reverse(slot)) = available.pop() {
+            slot
+        } else {
+            let slot = next_slot;
+            next_slot = next_slot
+                .checked_add(1)
+                .ok_or(StackColorError::SlotCountOverflow)?;
+            slot
+        };
+        assignments.insert(value, slot);
+        active.push(Reverse((end, slot, value)));
+    }
+    Ok(StackSlotColoring {
+        assignments,
+        slot_count: next_slot,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::regalloc::LiveSegment;
+
+    fn interval(value: u32, segments: &[(usize, u64, u64)]) -> LiveInterval<u32> {
+        LiveInterval {
+            value,
+            segments: segments
+                .iter()
+                .map(|&(block, start, end)| LiveSegment { block, start, end })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn reuses_a_slot_for_disjoint_sparse_intervals() {
+        let intervals = [
+            interval(0, &[(0, 0, 4)]),
+            interval(1, &[(0, 4, 8)]),
+            interval(2, &[(1, 0, 8)]),
+        ];
+        let coloring = color_stack_slots(&intervals).unwrap();
+
+        assert_eq!(coloring.get(&0), Some(0));
+        assert_eq!(coloring.get(&1), Some(0));
+        assert_eq!(coloring.get(&2), Some(0));
+        assert_eq!(coloring.slot_count(), 1);
+    }
+
+    #[test]
+    fn separates_any_pair_with_an_overlapping_segment() {
+        let intervals = [
+            interval(0, &[(0, 0, 2), (2, 0, 8)]),
+            interval(1, &[(1, 0, 2), (2, 7, 9)]),
+        ];
+        let coloring = color_stack_slots(&intervals).unwrap();
+
+        assert_eq!(coloring.get(&0), Some(0));
+        assert_eq!(coloring.get(&1), Some(1));
+    }
+
+    #[test]
+    fn rejects_duplicate_values() {
+        let value = interval(7, &[(0, 0, 1)]);
+
+        assert_eq!(
+            color_stack_slots([&value, &value]),
+            Err(StackColorError::DuplicateValue(7))
+        );
+    }
+}

--- a/crates/celox-backend-x86/Cargo.toml
+++ b/crates/celox-backend-x86/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 [dependencies]
 tracing = { workspace = true }
 celox-analysis = { path = "../celox-analysis" }
+celox-backend-common = { path = "../celox-backend-common" }
 celox-design = { path = "../celox-design" }
 celox-sir = { path = "../celox-sir" }
 celox-state-layout = { path = "../celox-state-layout" }

--- a/crates/celox-backend-x86/src/backend/native/mod.rs
+++ b/crates/celox-backend-x86/src/backend/native/mod.rs
@@ -1,15 +1,22 @@
 //! x86-64 backend pipeline: SIR → MIR → allocation → machine code.
 
+#[cfg(target_arch = "x86_64")]
 pub mod emit;
+#[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
 pub mod features;
 pub mod isel;
+#[cfg(target_arch = "x86_64")]
 pub mod jit_mem;
 pub mod memory_effect;
 pub mod mir;
 pub mod mir_legalize;
 pub mod mir_opt;
 pub mod mir_verify;
+#[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
 pub mod regalloc;
+pub mod scalar_pipeline;
 mod sparse_write_state;
+#[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
 pub mod ssa_destroy;
+#[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
 pub mod x86_slp;

--- a/crates/celox-backend-x86/src/backend/native/regalloc.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc.rs
@@ -11,6 +11,7 @@ mod cfg;
 mod color;
 mod constraints;
 mod cost;
+mod facts;
 mod home_verify;
 mod interval_union;
 mod legalize;

--- a/crates/celox-backend-x86/src/backend/native/regalloc/analysis.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/analysis.rs
@@ -1,47 +1,30 @@
-//! Liveness analysis and global next-use distance computation.
+//! Target-independent liveness and next-use analysis adapter.
 //!
-//! Implements the augmented liveness analysis from Braun & Hack Section 4.1:
-//! instead of computing live-in/live-out sets, we compute next-use distance
-//! maps. The join operation takes the minimum distance per variable.
+//! The x86 backend owns its MIR and exports opcode-free facts. The fixed-point
+//! algorithm lives in `celox-backend-common`, where AArch64 can use it without
+//! importing x86 instruction types.
 
-use std::collections::VecDeque;
+use celox_backend_common::regalloc::{NextUseAnalysis, analyze_next_uses};
 
-use crate::native::mir::*;
-use crate::{HashMap, HashSet};
+use crate::HashSet;
+use crate::native::mir::{MFunction, VReg};
 
 use super::assignment::{AssignmentMap, EdgeLocation};
 
-/// Large constant used as edge length for loop-exit edges.
-/// Ensures that uses behind loops have larger distances than uses inside loops.
-const LOOP_EXIT_LENGTH: u32 = 100_000;
+pub(super) type AnalysisResult = NextUseAnalysis<VReg>;
 
-/// Analysis result for the entire function.
-pub struct AnalysisResult {
-    /// For each block, the next-use distances at block entry.
-    /// `entry_distances[block_idx][vreg] = distance`
-    pub entry_distances: Vec<HashMap<VReg, u32>>,
-    /// For each block, the next-use distances at block exit.
-    pub exit_distances: Vec<HashMap<VReg, u32>>,
-    /// Predecessor list for each block (by index).
-    #[cfg(test)]
-    pub predecessors: Vec<Vec<usize>>,
-    /// Successor indices that are real DFS backedges for each block.
-    #[cfg(test)]
-    pub backedge_successors: Vec<Vec<usize>>,
-}
-
-/// Compute liveness and next-use distances for the entire MFunction.
-pub fn analyze(func: &MFunction) -> AnalysisResult {
-    analyze_ignoring_phi_sources(func, &HashSet::default(), &HashSet::default())
+/// Compute ordinary target-MIR liveness and next-use distances.
+pub(super) fn analyze(function: &MFunction) -> AnalysisResult {
+    let facts = super::facts::build(function, |_| Default::default())
+        .expect("verified x86 MIR must export valid allocation facts");
+    analyze_next_uses(&facts).expect("verified allocation facts must support next-use analysis")
 }
 
 /// Rebuild verifier liveness from destination-qualified phi locations.
 /// Semantic source VRegs remain in MIR for out-of-SSA identity, but an exact
-/// stack/immediate row is not a register use on that edge. A stack-resident
-/// phi value likewise remains a location value until an explicit reload
-/// defines a new machine VReg.
+/// stack/immediate row is not a register use on that edge.
 pub(super) fn analyze_for_assignment(
-    func: &MFunction,
+    function: &MFunction,
     assignment: &AssignmentMap,
 ) -> AnalysisResult {
     let mut ignored_phi_sources = assignment
@@ -51,7 +34,7 @@ pub(super) fn analyze_for_assignment(
             (!matches!(location, EdgeLocation::Register(_))).then_some(edge)
         })
         .collect::<HashSet<_>>();
-    for block in &func.blocks {
+    for block in &function.blocks {
         for phi in &block.phis {
             if assignment.is_semantic_phi_definition(phi.dst) {
                 ignored_phi_sources.extend(
@@ -68,271 +51,37 @@ pub(super) fn analyze_for_assignment(
         .copied()
         .filter(|value| assignment.get(*value).is_none())
         .collect::<HashSet<_>>();
-    analyze_ignoring_phi_sources(func, &ignored_phi_sources, &stack_values)
-}
 
-fn analyze_ignoring_phi_sources(
-    func: &MFunction,
-    ignored_phi_sources: &HashSet<(BlockId, BlockId, VReg, VReg)>,
-    stack_values: &HashSet<VReg>,
-) -> AnalysisResult {
-    let num_blocks = func.blocks.len();
-
-    // Build block_order and block_index
-    let block_order: Vec<BlockId> = func.blocks.iter().map(|b| b.id).collect();
-    let mut block_index = HashMap::default();
-    for (i, &bid) in block_order.iter().enumerate() {
-        block_index.insert(bid, i);
-    }
-
-    // Build predecessor and successor lists
-    let mut predecessors = vec![Vec::new(); num_blocks];
-    let mut successors = vec![Vec::new(); num_blocks];
-    for (i, block) in func.blocks.iter().enumerate() {
-        for succ_bid in block.successors() {
-            if let Some(&succ_idx) = block_index.get(&succ_bid) {
-                successors[i].push(succ_idx);
-                predecessors[succ_idx].push(i);
-            }
+    let mut facts = super::facts::build(function, |_| Default::default())
+        .expect("verified x86 MIR must export valid allocation facts");
+    for (successor_index, block) in facts.blocks.iter_mut().enumerate() {
+        let successor = function.blocks[successor_index].id;
+        for phi in &mut block.phis {
+            phi.sources.retain(|source| {
+                let predecessor = function.blocks[source.predecessor].id;
+                !ignored_phi_sources.contains(&(
+                    predecessor,
+                    successor,
+                    phi.destination,
+                    source.value,
+                )) && !stack_values.contains(&source.value)
+            });
         }
     }
-    let backedge_successors = compute_backedge_successors(&successors);
-    let backedge_successor_edges =
-        compute_backedge_successor_edges(&successors, &backedge_successors);
-    let phi_edge_uses = compute_phi_edge_uses(
-        func,
-        &block_order,
-        &successors,
-        ignored_phi_sources,
-        stack_values,
-    );
-    let block_transfers = compute_block_transfers(func);
-
-    // Initialize next-use distance maps
-    let mut entry_distances: Vec<HashMap<VReg, u32>> = vec![HashMap::default(); num_blocks];
-    let mut exit_distances: Vec<HashMap<VReg, u32>> = vec![HashMap::default(); num_blocks];
-
-    let mut worklist: VecDeque<usize> = (0..num_blocks).rev().collect();
-    let mut in_worklist = vec![true; num_blocks];
-    while let Some(bi) = worklist.pop_front() {
-        in_worklist[bi] = false;
-        let (new_entry, new_exit) = compute_block_distances(
-            bi,
-            &successors,
-            &backedge_successor_edges,
-            &phi_edge_uses,
-            &block_transfers,
-            &entry_distances,
-        );
-
-        if new_entry != entry_distances[bi] || new_exit != exit_distances[bi] {
-            entry_distances[bi] = new_entry;
-            exit_distances[bi] = new_exit;
-            for &pred in &predecessors[bi] {
-                if !in_worklist[pred] {
-                    worklist.push_back(pred);
-                    in_worklist[pred] = true;
-                }
-            }
-        }
-    }
-
-    AnalysisResult {
-        entry_distances,
-        exit_distances,
-        #[cfg(test)]
-        predecessors,
-        #[cfg(test)]
-        backedge_successors,
-    }
-}
-
-fn compute_block_distances(
-    bi: usize,
-    successors: &[Vec<usize>],
-    backedge_successor_edges: &[Vec<bool>],
-    phi_edge_uses: &[Vec<Vec<VReg>>],
-    block_transfers: &[BlockTransfer],
-    entry_distances: &[HashMap<VReg, u32>],
-) -> (HashMap<VReg, u32>, HashMap<VReg, u32>) {
-    let transfer = &block_transfers[bi];
-
-    // Join successor entry distances. Phi sources are edge uses from this
-    // predecessor into the successor, so they are live at this block's exit.
-    let mut new_exit: HashMap<VReg, u32> = HashMap::default();
-    let exit_capacity = successors[bi]
-        .iter()
-        .map(|&succ_idx| entry_distances[succ_idx].len())
-        .sum::<usize>()
-        + phi_edge_uses[bi]
-            .iter()
-            .map(|sources| sources.len())
-            .sum::<usize>();
-    new_exit.reserve(exit_capacity);
-    for (edge_idx, &succ_idx) in successors[bi].iter().enumerate() {
-        let edge_len = if backedge_successor_edges[bi][edge_idx] {
-            LOOP_EXIT_LENGTH
-        } else {
-            0
-        };
-        for (&vreg, &dist) in &entry_distances[succ_idx] {
-            let new_dist = dist.saturating_add(edge_len);
-            let entry = new_exit.entry(vreg).or_insert(u32::MAX);
-            *entry = (*entry).min(new_dist);
-        }
-        for &src_vreg in &phi_edge_uses[bi][edge_idx] {
-            let entry = new_exit.entry(src_vreg).or_insert(u32::MAX);
-            *entry = (*entry).min(edge_len);
-        }
-    }
-
-    let mut new_entry: HashMap<VReg, u32> = HashMap::default();
-    new_entry.reserve(new_exit.len() + transfer.local_uses.len());
-    for (&vreg, &dist) in &new_exit {
-        if !transfer.defs.contains(&vreg) {
-            new_entry.insert(vreg, transfer.block_len.saturating_add(dist));
-        }
-    }
-    for &(vreg, pos) in &transfer.local_uses {
-        new_entry.insert(vreg, pos);
-    }
-
-    (new_entry, new_exit)
-}
-
-struct BlockTransfer {
-    block_len: u32,
-    defs: HashSet<VReg>,
-    local_uses: Vec<(VReg, u32)>,
-}
-
-fn compute_block_transfers(func: &MFunction) -> Vec<BlockTransfer> {
-    func.blocks
-        .iter()
-        .map(|block| {
-            let mut defs = HashSet::default();
-            defs.reserve(block.phis.len() + block.insts.len());
-            for phi in &block.phis {
-                defs.insert(phi.dst);
-            }
-
-            let mut local_uses: HashMap<VReg, u32> = HashMap::default();
-            for (inst_idx, inst) in block.insts.iter().enumerate() {
-                if let Some(def) = inst.def() {
-                    defs.insert(def);
-                }
-                let pos = inst_idx as u32;
-                for vreg in inst.uses() {
-                    if !defs.contains(&vreg) {
-                        local_uses.entry(vreg).or_insert(pos);
-                    }
-                }
-            }
-
-            let mut local_uses = local_uses.into_iter().collect::<Vec<_>>();
-            local_uses.sort_by_key(|(vreg, _)| *vreg);
-            BlockTransfer {
-                block_len: block.insts.len() as u32,
-                defs,
-                local_uses,
-            }
-        })
-        .collect()
-}
-
-fn compute_backedge_successor_edges(
-    successors: &[Vec<usize>],
-    backedge_successors: &[Vec<usize>],
-) -> Vec<Vec<bool>> {
-    successors
-        .iter()
-        .enumerate()
-        .map(|(idx, succs)| {
-            succs
-                .iter()
-                .map(|succ| backedge_successors[idx].contains(succ))
-                .collect()
-        })
-        .collect()
-}
-
-fn compute_phi_edge_uses(
-    func: &MFunction,
-    block_order: &[BlockId],
-    successors: &[Vec<usize>],
-    ignored: &HashSet<(BlockId, BlockId, VReg, VReg)>,
-    stack_values: &HashSet<VReg>,
-) -> Vec<Vec<Vec<VReg>>> {
-    let mut phi_edge_uses = successors
-        .iter()
-        .map(|succs| vec![Vec::new(); succs.len()])
-        .collect::<Vec<_>>();
-
-    for (pred_idx, succs) in successors.iter().enumerate() {
-        let pred_id = block_order[pred_idx];
-        for (edge_idx, &succ_idx) in succs.iter().enumerate() {
-            let succ_block = &func.blocks[succ_idx];
-            for phi in &succ_block.phis {
-                for (source_pred, source) in &phi.sources {
-                    if *source_pred == pred_id
-                        && !ignored.contains(&(pred_id, succ_block.id, phi.dst, *source))
-                        && !stack_values.contains(source)
-                    {
-                        phi_edge_uses[pred_idx][edge_idx].push(*source);
-                    }
-                }
-            }
-        }
-    }
-
-    phi_edge_uses
-}
-
-fn compute_backedge_successors(successors: &[Vec<usize>]) -> Vec<Vec<usize>> {
-    #[derive(Clone, Copy, PartialEq, Eq)]
-    enum Color {
-        White,
-        Gray,
-        Black,
-    }
-
-    let mut colors = vec![Color::White; successors.len()];
-    let mut backedges = vec![Vec::new(); successors.len()];
-    for root in 0..successors.len() {
-        if colors[root] != Color::White {
-            continue;
-        }
-        colors[root] = Color::Gray;
-        let mut stack = vec![(root, 0usize)];
-        while let Some((node, next_successor)) = stack.last_mut() {
-            if *next_successor == successors[*node].len() {
-                colors[*node] = Color::Black;
-                stack.pop();
-                continue;
-            }
-            let successor = successors[*node][*next_successor];
-            *next_successor += 1;
-            match colors[successor] {
-                Color::White => {
-                    colors[successor] = Color::Gray;
-                    stack.push((successor, 0));
-                }
-                Color::Gray => backedges[*node].push(successor),
-                Color::Black => {}
-            }
-        }
-    }
-    backedges
+    analyze_next_uses(&facts).expect("filtered allocation facts must remain structurally valid")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::native::mir::{
+        BaseReg, BlockId, MBlock, MInst, OpSize, PhiNode, SpillDesc, VRegAllocator,
+    };
 
     fn empty_func(blocks: Vec<MBlock>) -> MFunction {
-        let mut func = MFunction::new(VRegAllocator::new(), Vec::new());
-        func.blocks = blocks;
-        func
+        let mut function = MFunction::new(VRegAllocator::new(), Vec::new());
+        function.blocks = blocks;
+        function
     }
 
     #[test]
@@ -346,8 +95,6 @@ mod tests {
         let mut b1 = MBlock::new(BlockId(1));
         b1.push(MInst::Jump { target: BlockId(2) });
 
-        // Layout order is intentionally not topological: b1 jumps to b2,
-        // whose layout index is lower. This must not be treated as a loop.
         let analysis = analyze(&empty_func(vec![b0, b2, b1]));
         assert!(analysis.backedge_successors[2].is_empty());
     }
@@ -370,9 +117,9 @@ mod tests {
         let live = VReg(0);
         let mut blocks = Vec::new();
 
-        for i in (0..block_count).rev() {
-            let mut block = MBlock::new(BlockId(i as u32));
-            if i + 1 == block_count {
+        for index in (0..block_count).rev() {
+            let mut block = MBlock::new(BlockId(index as u32));
+            if index + 1 == block_count {
                 block.push(MInst::Store {
                     base: BaseReg::SimState,
                     offset: 0,
@@ -382,7 +129,7 @@ mod tests {
                 block.push(MInst::Return);
             } else {
                 block.push(MInst::Jump {
-                    target: BlockId((i + 1) as u32),
+                    target: BlockId((index + 1) as u32),
                 });
             }
             blocks.push(block);

--- a/crates/celox-backend-x86/src/backend/native/regalloc/assignment.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/assignment.rs
@@ -6,6 +6,10 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 
+use celox_backend_common::regalloc::{
+    MachineRegister, RegConstraint as CommonRegConstraint, RegisterSet, ValueLocation,
+};
+
 use crate::native::features::VariableShiftEncoding;
 use crate::native::mir::*;
 
@@ -31,6 +35,12 @@ pub enum PhysReg {
     R13 = 13,
     R14 = 14,
     R15 = 15,
+}
+
+impl MachineRegister for PhysReg {
+    fn index(self) -> u8 {
+        self as u8
+    }
 }
 
 /// Physical register in the x86 128-bit vector class.
@@ -66,27 +76,7 @@ impl fmt::Display for PhysReg {
     }
 }
 
-// ────────────────────────────────────────────────────────────────
-// PhysRegSet: u16 bitset for small PhysReg sets
-// ────────────────────────────────────────────────────────────────
-
-#[derive(Clone, Copy, Default)]
-pub struct PhysRegSet(u16);
-
-impl PhysRegSet {
-    pub fn new() -> Self {
-        Self(0)
-    }
-    pub fn insert(&mut self, r: PhysReg) {
-        self.0 |= 1 << (r as u16);
-    }
-    pub fn contains(&self, r: &PhysReg) -> bool {
-        self.0 & (1 << (*r as u16)) != 0
-    }
-    pub fn is_empty(&self) -> bool {
-        self.0 == 0
-    }
-}
+pub type PhysRegSet = RegisterSet;
 
 pub const ALLOCATABLE_REGS: &[PhysReg] = &[
     PhysReg::RAX,
@@ -110,19 +100,10 @@ pub const ALLOCATABLE_REGS: &[PhysReg] = &[
 // Register constraints
 // ────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RegConstraint {
-    Any,
-    Fixed(PhysReg),
-}
+pub type RegConstraint = CommonRegConstraint<PhysReg>;
 
 /// Physical location of a phi source at one predecessor edge.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum EdgeLocation {
-    Register(PhysReg),
-    Stack(i32),
-    Immediate(u64),
-}
+pub type EdgeLocation = ValueLocation<PhysReg>;
 
 pub(super) fn use_constraints(
     inst: &MInst,

--- a/crates/celox-backend-x86/src/backend/native/regalloc/assignment.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/assignment.rs
@@ -109,6 +109,12 @@ pub(super) fn use_constraints(
     inst: &MInst,
     shift_encoding: VariableShiftEncoding,
 ) -> Vec<RegConstraint> {
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        let _ = shift_encoding;
+        return inst.uses().iter().map(|_| RegConstraint::Any).collect();
+    }
+    #[cfg(target_arch = "x86_64")]
     match inst {
         // BMI2's three-operand shifts accept the count in any GPR. Baseline
         // x86 shifts require it in CL (the low byte of RCX).
@@ -126,6 +132,12 @@ pub(super) fn use_constraints(
 
 /// Returns physical registers clobbered by this instruction (besides dst).
 pub fn clobbers(inst: &MInst) -> &'static [PhysReg] {
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        let _ = inst;
+        return &[];
+    }
+    #[cfg(target_arch = "x86_64")]
     match inst {
         MInst::UDiv { .. }
         | MInst::URem { .. }

--- a/crates/celox-backend-x86/src/backend/native/regalloc/constraints.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/constraints.rs
@@ -1,15 +1,12 @@
 //! Stable machine-constraint facts after legalization.
 
 use crate::native::mir::{BlockId, MFunction, VReg};
+use celox_backend_common::regalloc::InstructionConstraints as CommonInstructionConstraints;
 
 use super::assignment::{PhysReg, RegConstraint, clobbers, use_constraints};
 use super::cfg::NormalizedCfg;
 
-#[derive(Debug, Clone, Default)]
-pub(super) struct InstructionConstraints {
-    pub fixed_uses: Vec<(VReg, PhysReg)>,
-    pub clobbers: Vec<PhysReg>,
-}
+pub(super) type InstructionConstraints = CommonInstructionConstraints<VReg, PhysReg>;
 
 #[derive(Debug)]
 pub(super) struct ConstraintModel {

--- a/crates/celox-backend-x86/src/backend/native/regalloc/constraints.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/constraints.rs
@@ -101,6 +101,15 @@ impl ConstraintModel {
                 error.to_string(),
             )
         })?;
+        celox_backend_common::regalloc::analyze_live_intervals(&facts).map_err(|error| {
+            ConstraintError::new(
+                "CONSTRAINT.LIVE_INTERVALS",
+                error.block.map(|block| func.blocks[block].id),
+                error.instruction,
+                error.values,
+                error.message,
+            )
+        })?;
         let instructions = facts
             .blocks
             .iter()

--- a/crates/celox-backend-x86/src/backend/native/regalloc/constraints.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/constraints.rs
@@ -11,6 +11,11 @@ pub(super) type InstructionConstraints = CommonInstructionConstraints<VReg, Phys
 #[derive(Debug)]
 pub(super) struct ConstraintModel {
     pub instructions: Vec<Vec<InstructionConstraints>>,
+    /// Opcode-free scalar facts exported by the x86-owned MIR. The mature
+    /// allocator still consumes some MIR details directly while it is split
+    /// into target driver and common algorithm, but new common analyses use
+    /// this boundary instead of matching `MInst`.
+    pub facts: super::facts::ScalarAllocationFacts,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -55,32 +60,62 @@ impl ConstraintModel {
                 ),
             ));
         }
-        let instructions: Vec<Vec<InstructionConstraints>> = func
+        let mut facts = super::facts::build(func, |inst| InstructionConstraints {
+            fixed_uses: inst
+                .uses()
+                .into_iter()
+                .zip(use_constraints(
+                    inst,
+                    func.target_features.variable_shift_encoding(),
+                ))
+                .filter_map(|(value, constraint)| match constraint {
+                    RegConstraint::Any => None,
+                    RegConstraint::Fixed(register) => Some((value, register)),
+                })
+                .collect(),
+            fixed_defs: Vec::new(),
+            clobbers: clobbers(inst).to_vec(),
+        })
+        .map_err(|error| {
+            ConstraintError::new(
+                "CONSTRAINT.ALLOCATION_FACTS",
+                error.block,
+                None,
+                error.value.into_iter().collect(),
+                error.message,
+            )
+        })?;
+        // Jump tables may name the same destination more than once. MIR
+        // liveness preserves those semantic edges, while the mature allocator
+        // operates on a CFG which has already coalesced duplicate successors.
+        // Constraint facts belong to that normalized allocation view.
+        for (facts_block, successors) in facts.blocks.iter_mut().zip(&cfg.successors) {
+            facts_block.successors.clone_from(successors);
+        }
+        facts.verify().map_err(|error| {
+            ConstraintError::new(
+                "CONSTRAINT.ALLOCATION_FACTS",
+                None,
+                None,
+                Vec::new(),
+                error.to_string(),
+            )
+        })?;
+        let instructions = facts
             .blocks
             .iter()
             .map(|block| {
                 block
-                    .insts
+                    .instructions
                     .iter()
-                    .map(|inst| InstructionConstraints {
-                        fixed_uses: inst
-                            .uses()
-                            .into_iter()
-                            .zip(use_constraints(
-                                inst,
-                                func.target_features.variable_shift_encoding(),
-                            ))
-                            .filter_map(|(value, constraint)| match constraint {
-                                RegConstraint::Any => None,
-                                RegConstraint::Fixed(register) => Some((value, register)),
-                            })
-                            .collect(),
-                        clobbers: clobbers(inst).to_vec(),
-                    })
+                    .map(|instruction| instruction.constraints.clone())
                     .collect()
             })
             .collect();
-        Ok(Self { instructions })
+        Ok(Self {
+            instructions,
+            facts,
+        })
     }
 
     pub(super) fn verify(&self, func: &MFunction) -> Result<(), ConstraintError> {
@@ -97,6 +132,15 @@ impl ConstraintModel {
                 ),
             ));
         }
+        self.facts.verify().map_err(|error| {
+            ConstraintError::new(
+                "CONSTRAINT.ALLOCATION_FACTS",
+                None,
+                None,
+                Vec::new(),
+                error.to_string(),
+            )
+        })?;
         for (block_index, block) in func.blocks.iter().enumerate() {
             if self.instructions[block_index].len() != block.insts.len() {
                 return Err(ConstraintError::new(
@@ -174,5 +218,38 @@ mod tests {
 
         assert_eq!(error.rule, "CONSTRAINT.INSTRUCTION_COVERAGE");
         assert_eq!(error.block, Some(BlockId(0)));
+    }
+
+    #[test]
+    fn allocation_facts_use_normalized_jump_table_successors() {
+        let mut vregs = VRegAllocator::new();
+        let index = vregs.alloc();
+        let table_base = vregs.alloc();
+        let target = vregs.alloc();
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 3]);
+        let mut entry = MBlock::new(BlockId(0));
+        entry.push(MInst::LoadImm {
+            dst: index,
+            value: 0,
+        });
+        entry.push(MInst::LoadImm {
+            dst: table_base,
+            value: 0,
+        });
+        entry.push(MInst::Scratch { dst: target });
+        entry.push(MInst::JumpTable {
+            index,
+            table_base,
+            target,
+            targets: vec![BlockId(1), BlockId(1)].into_boxed_slice(),
+        });
+        let mut exit = MBlock::new(BlockId(1));
+        exit.push(MInst::Return);
+        function.blocks = vec![entry, exit];
+
+        let cfg = super::super::cfg::normalize(&mut function).unwrap();
+        let model = ConstraintModel::build(&function, &cfg).unwrap();
+
+        assert_eq!(model.facts.blocks[0].successors, vec![1]);
     }
 }

--- a/crates/celox-backend-x86/src/backend/native/regalloc/facts.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/facts.rs
@@ -1,0 +1,103 @@
+//! Projection from x86-owned MIR into opcode-free allocation facts.
+
+use celox_backend_common::regalloc::{
+    BlockAllocationFacts, FunctionAllocationFacts, InstructionAllocationFacts,
+    InstructionConstraints, PhiAllocationFacts, PhiSource,
+};
+
+use crate::HashMap;
+use crate::native::mir::{BlockId, MFunction, MInst, VReg};
+
+use super::assignment::PhysReg;
+
+pub(super) type ScalarAllocationFacts = FunctionAllocationFacts<VReg, PhysReg>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct FactsError {
+    pub block: Option<BlockId>,
+    pub value: Option<VReg>,
+    pub message: String,
+}
+
+/// Export scalar GPR facts from x86 MIR. Target-specific vector allocation is
+/// intentionally a separate x86 pass and therefore not represented here.
+pub(super) fn build(
+    function: &MFunction,
+    mut constraints: impl FnMut(&MInst) -> InstructionConstraints<VReg, PhysReg>,
+) -> Result<ScalarAllocationFacts, FactsError> {
+    let block_indices = function
+        .blocks
+        .iter()
+        .enumerate()
+        .map(|(index, block)| (block.id, index))
+        .collect::<HashMap<_, _>>();
+    let blocks = function
+        .blocks
+        .iter()
+        .map(|block| {
+            let successors = block
+                .successors()
+                .into_iter()
+                .map(|successor| {
+                    block_indices
+                        .get(&successor)
+                        .copied()
+                        .ok_or_else(|| FactsError {
+                            block: Some(block.id),
+                            value: None,
+                            message: format!("terminator targets missing block {successor}"),
+                        })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let phis = block
+                .phis
+                .iter()
+                .map(|phi| {
+                    let sources = phi
+                        .sources
+                        .iter()
+                        .map(|&(predecessor, value)| {
+                            block_indices
+                                .get(&predecessor)
+                                .copied()
+                                .map(|predecessor| PhiSource { predecessor, value })
+                                .ok_or_else(|| FactsError {
+                                    block: Some(block.id),
+                                    value: Some(value),
+                                    message: format!(
+                                        "phi source names missing block {predecessor}"
+                                    ),
+                                })
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    Ok(PhiAllocationFacts {
+                        destination: phi.dst,
+                        sources,
+                    })
+                })
+                .collect::<Result<Vec<_>, FactsError>>()?;
+            let instructions = block
+                .insts
+                .iter()
+                .map(|instruction| InstructionAllocationFacts {
+                    uses: instruction.uses().into_iter().collect(),
+                    defs: instruction.def().into_iter().collect(),
+                    constraints: constraints(instruction),
+                    is_copy: matches!(instruction, MInst::Mov { .. }),
+                })
+                .collect();
+            Ok(BlockAllocationFacts {
+                successors,
+                phis,
+                instructions,
+            })
+        })
+        .collect::<Result<Vec<_>, FactsError>>()?;
+    let facts = FunctionAllocationFacts { entry: 0, blocks };
+    facts.verify().map_err(|error| FactsError {
+        block: None,
+        value: None,
+        message: error.to_string(),
+    })?;
+    Ok(facts)
+}

--- a/crates/celox-backend-x86/src/backend/native/scalar_pipeline.rs
+++ b/crates/celox-backend-x86/src/backend/native/scalar_pipeline.rs
@@ -1,8 +1,10 @@
-//! Scalar native middle-end shared temporarily by machine-code emitters.
+//! Transitional scalar pipeline implemented by the x86 backend.
 //!
-//! This module exposes the target-independent portion of the established x86
-//! pipeline while it is migrated into `celox-backend-common`. New targets can
-//! consume verified, allocated scalar MIR without duplicating SIR lowering.
+//! AArch64 temporarily consumes this allocated x86 MIR while its complete
+//! target-owned instruction selection and allocation driver are brought up.
+//! This is a compatibility bridge, not a shared-MIR architecture: reusable
+//! allocation algorithms move to `celox-backend-common` behind opcode-free
+//! facts, while target MIR and machine optimizations remain in each backend.
 
 use std::fmt;
 
@@ -77,9 +79,9 @@ impl PreparedScalarFunction {
     }
 }
 
-/// Lower, optimize, allocate, and destroy SSA for architecture-neutral scalar
-/// MIR. Target-specific SIMD selection and final emission are intentionally
-/// excluded.
+/// Lower, optimize, allocate, and destroy SSA through the transitional scalar
+/// x86 pipeline. Target-specific SIMD selection and final emission are
+/// intentionally excluded.
 pub fn prepare_scalar_eu(
     sir_eu: &crate::ExecutionUnit<crate::RegionedAbsoluteAddr>,
     layout: &crate::MemoryLayout,

--- a/crates/celox-backend-x86/src/backend/native/scalar_pipeline.rs
+++ b/crates/celox-backend-x86/src/backend/native/scalar_pipeline.rs
@@ -1,7 +1,7 @@
 //! Transitional scalar pipeline implemented by the x86 backend.
 //!
-//! AArch64 temporarily consumes this allocated x86 MIR while its complete
-//! target-owned instruction selection and allocation driver are brought up.
+//! AArch64 temporarily consumes the optimized, pre-allocation x86 MIR while
+//! its complete target-owned instruction selection is brought up.
 //! This is a compatibility bridge, not a shared-MIR architecture: reusable
 //! allocation algorithms move to `celox-backend-common` behind opcode-free
 //! facts, while target MIR and machine optimizations remain in each backend.
@@ -61,6 +61,24 @@ pub struct PreparedScalarFunction {
     ssa_destruction: SsaDestructionPlan,
 }
 
+/// Verified and optimized scalar MIR before any target register allocation.
+///
+/// A target backend may consume this boundary directly and own spilling,
+/// coloring, and SSA destruction. The x86 allocation driver remains available
+/// through [`allocate_scalar_mir`] for the native x86 path and compatibility
+/// fallbacks.
+pub struct PreparedScalarMir {
+    pub function: MFunction,
+    state_size: usize,
+}
+
+impl PreparedScalarMir {
+    /// Total byte size of the simulator-owned state preceding backend scratch.
+    pub fn state_size(&self) -> usize {
+        self.state_size
+    }
+}
+
 impl PreparedScalarFunction {
     /// Total byte size of the simulator-owned state preceding backend scratch.
     pub fn state_size(&self) -> usize {
@@ -79,15 +97,26 @@ impl PreparedScalarFunction {
     }
 }
 
-/// Lower, optimize, allocate, and destroy SSA through the transitional scalar
-/// x86 pipeline. Target-specific SIMD selection and final emission are
-/// intentionally excluded.
+/// Lower, optimize, allocate, and destroy SSA through the scalar x86 pipeline.
+/// Target-specific SIMD selection and final emission are intentionally
+/// excluded.
 pub fn prepare_scalar_eu(
     sir_eu: &crate::ExecutionUnit<crate::RegionedAbsoluteAddr>,
     layout: &crate::MemoryLayout,
     four_state: bool,
     label: &str,
 ) -> Result<PreparedScalarFunction, ScalarPrepareError> {
+    let prepared = prepare_scalar_mir(sir_eu, layout, four_state)?;
+    allocate_scalar_mir(prepared, label)
+}
+
+/// Lower and optimize scalar MIR without performing target register
+/// allocation or SSA destruction.
+pub fn prepare_scalar_mir(
+    sir_eu: &crate::ExecutionUnit<crate::RegionedAbsoluteAddr>,
+    layout: &crate::MemoryLayout,
+    four_state: bool,
+) -> Result<PreparedScalarMir, ScalarPrepareError> {
     sir_eu
         .verify_result()
         .map_err(|error| ScalarPrepareError::Sir {
@@ -118,33 +147,46 @@ pub fn prepare_scalar_eu(
             error,
         })?;
 
+    let state_size = layout
+        .merged_total_size
+        .checked_add(layout.triggered_bits_total_size)
+        .expect("native simulation-state size overflow");
+    Ok(PreparedScalarMir {
+        function,
+        state_size,
+    })
+}
+
+/// Run the mature x86 allocation and out-of-SSA pipeline from the shared
+/// pre-allocation scalar MIR boundary.
+pub fn allocate_scalar_mir(
+    mut prepared: PreparedScalarMir,
+    label: &str,
+) -> Result<PreparedScalarFunction, ScalarPrepareError> {
     let RegallocResult {
         assignment,
         spill_frame_size,
-    } = super::regalloc::run_regalloc_with_label(&mut function, label)?;
-    super::mir_opt::post_regalloc_peephole(&mut function);
-    super::mir_opt::post_regalloc_cleanup(&mut function);
-    super::mir_opt::post_regalloc_direct_load_cse(&mut function, &assignment);
-    super::regalloc::verify_assignment(&function, &assignment)?;
-    function
+    } = super::regalloc::run_regalloc_with_label(&mut prepared.function, label)?;
+    super::mir_opt::post_regalloc_peephole(&mut prepared.function);
+    super::mir_opt::post_regalloc_cleanup(&mut prepared.function);
+    super::mir_opt::post_regalloc_direct_load_cse(&mut prepared.function, &assignment);
+    super::regalloc::verify_assignment(&prepared.function, &assignment)?;
+    prepared
+        .function
         .verify_result()
         .map_err(|error| ScalarPrepareError::Mir {
             phase: "after scalar post-allocation cleanup",
             error,
         })?;
 
-    let ssa_destruction = SsaDestructionPlan::build(&function, &assignment)?;
-    ssa_destruction.verify(&function, &assignment, spill_frame_size)?;
-    let state_size = layout
-        .merged_total_size
-        .checked_add(layout.triggered_bits_total_size)
-        .expect("native simulation-state size overflow");
+    let ssa_destruction = SsaDestructionPlan::build(&prepared.function, &assignment)?;
+    ssa_destruction.verify(&prepared.function, &assignment, spill_frame_size)?;
 
     Ok(PreparedScalarFunction {
-        function,
+        function: prepared.function,
         allocation: assignment,
         spill_frame_size,
-        state_size,
+        state_size: prepared.state_size,
         ssa_destruction,
     })
 }

--- a/crates/celox-backend-x86/src/backend/native/scalar_pipeline.rs
+++ b/crates/celox-backend-x86/src/backend/native/scalar_pipeline.rs
@@ -1,0 +1,148 @@
+//! Scalar native middle-end shared temporarily by machine-code emitters.
+//!
+//! This module exposes the target-independent portion of the established x86
+//! pipeline while it is migrated into `celox-backend-common`. New targets can
+//! consume verified, allocated scalar MIR without duplicating SIR lowering.
+
+use std::fmt;
+
+use super::mir::{BlockId, MFunction};
+use super::regalloc::{AssignmentMap, RegallocResult};
+use super::ssa_destroy::{ParallelCopyOperation, SsaDestructionError, SsaDestructionPlan};
+
+/// Failure while preparing scalar native MIR for a target emitter.
+#[derive(Debug)]
+pub enum ScalarPrepareError {
+    Sir {
+        phase: &'static str,
+        error: crate::verify::SirVerifyError,
+    },
+    Mir {
+        phase: &'static str,
+        error: super::mir_verify::MirVerifyError,
+    },
+    Regalloc(super::regalloc::RegallocError),
+    SsaDestruction(SsaDestructionError),
+}
+
+impl fmt::Display for ScalarPrepareError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Sir { phase, error } => write!(formatter, "{phase}: {error}"),
+            Self::Mir { phase, error } => write!(formatter, "{phase}: {error}"),
+            Self::Regalloc(error) => error.fmt(formatter),
+            Self::SsaDestruction(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for ScalarPrepareError {}
+
+impl From<super::regalloc::RegallocError> for ScalarPrepareError {
+    fn from(error: super::regalloc::RegallocError) -> Self {
+        Self::Regalloc(error)
+    }
+}
+
+impl From<SsaDestructionError> for ScalarPrepareError {
+    fn from(error: SsaDestructionError) -> Self {
+        Self::SsaDestruction(error)
+    }
+}
+
+/// Verified scalar MIR plus allocation and out-of-SSA edge copies.
+pub struct PreparedScalarFunction {
+    pub function: MFunction,
+    pub allocation: AssignmentMap,
+    pub spill_frame_size: u32,
+    state_size: usize,
+    ssa_destruction: SsaDestructionPlan,
+}
+
+impl PreparedScalarFunction {
+    /// Total byte size of the simulator-owned state preceding backend scratch.
+    pub fn state_size(&self) -> usize {
+        self.state_size
+    }
+
+    /// Dependency-ordered copies required on one CFG edge.
+    pub fn edge_operations(
+        &self,
+        predecessor: BlockId,
+        successor: BlockId,
+    ) -> Option<&[ParallelCopyOperation]> {
+        self.ssa_destruction
+            .edge(predecessor, successor)
+            .map(|edge| edge.operations.as_slice())
+    }
+}
+
+/// Lower, optimize, allocate, and destroy SSA for architecture-neutral scalar
+/// MIR. Target-specific SIMD selection and final emission are intentionally
+/// excluded.
+pub fn prepare_scalar_eu(
+    sir_eu: &crate::ExecutionUnit<crate::RegionedAbsoluteAddr>,
+    layout: &crate::MemoryLayout,
+    four_state: bool,
+    label: &str,
+) -> Result<PreparedScalarFunction, ScalarPrepareError> {
+    sir_eu
+        .verify_result()
+        .map_err(|error| ScalarPrepareError::Sir {
+            phase: "at scalar native backend boundary",
+            error,
+        })?;
+
+    let mut function = super::isel::lower_execution_unit(sir_eu, layout, four_state);
+    function
+        .verify_result()
+        .map_err(|error| ScalarPrepareError::Mir {
+            phase: "after scalar instruction selection",
+            error,
+        })?;
+    super::mir_legalize::legalize(&mut function);
+    function
+        .verify_result()
+        .map_err(|error| ScalarPrepareError::Mir {
+            phase: "after scalar MIR legalization",
+            error,
+        })?;
+    super::mir_opt::optimize(&mut function);
+    super::mir_opt::compact_vregs(&mut function);
+    function
+        .verify_result()
+        .map_err(|error| ScalarPrepareError::Mir {
+            phase: "after scalar MIR optimization",
+            error,
+        })?;
+
+    let RegallocResult {
+        assignment,
+        spill_frame_size,
+    } = super::regalloc::run_regalloc_with_label(&mut function, label)?;
+    super::mir_opt::post_regalloc_peephole(&mut function);
+    super::mir_opt::post_regalloc_cleanup(&mut function);
+    super::mir_opt::post_regalloc_direct_load_cse(&mut function, &assignment);
+    super::regalloc::verify_assignment(&function, &assignment)?;
+    function
+        .verify_result()
+        .map_err(|error| ScalarPrepareError::Mir {
+            phase: "after scalar post-allocation cleanup",
+            error,
+        })?;
+
+    let ssa_destruction = SsaDestructionPlan::build(&function, &assignment)?;
+    ssa_destruction.verify(&function, &assignment, spill_frame_size)?;
+    let state_size = layout
+        .merged_total_size
+        .checked_add(layout.triggered_bits_total_size)
+        .expect("native simulation-state size overflow");
+
+    Ok(PreparedScalarFunction {
+        function,
+        allocation: assignment,
+        spill_frame_size,
+        state_size,
+        ssa_destruction,
+    })
+}

--- a/crates/celox-backend-x86/src/backend/native/ssa_destroy.rs
+++ b/crates/celox-backend-x86/src/backend/native/ssa_destroy.rs
@@ -1,6 +1,6 @@
 //! Verified destruction of MIR SSA phi nodes into edge-local parallel copies.
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 use super::mir::{BlockId, MFunction, MInst, VReg};
@@ -25,24 +25,6 @@ pub(crate) struct ParallelCopy {
     pub source_value: VReg,
     pub destination: ParallelCopyDestination,
     pub source: ParallelCopySource,
-}
-
-impl ParallelCopy {
-    pub(crate) fn is_identity(self) -> bool {
-        matches!(
-            (self.destination, self.source),
-            (
-                ParallelCopyDestination::Register(destination),
-                ParallelCopySource::Register(source)
-            ) if destination == source
-        ) || matches!(
-            (self.destination, self.source),
-            (
-                ParallelCopyDestination::Stack(destination),
-                ParallelCopySource::Stack(source)
-            ) if destination == source
-        )
-    }
 }
 
 /// A dependency-ordered lowering step for one edge's parallel assignment.
@@ -615,66 +597,6 @@ fn exit_register_values(
     result
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PendingSource {
-    Value(ParallelCopySource),
-    Temporary,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct PendingCopy {
-    phi_destination: VReg,
-    source_value: VReg,
-    destination: ParallelCopyDestination,
-    source: PendingSource,
-    pending: bool,
-}
-
-fn source_as_destination(source: ParallelCopySource) -> Option<ParallelCopyDestination> {
-    match source {
-        ParallelCopySource::Register(register) => Some(ParallelCopyDestination::Register(register)),
-        ParallelCopySource::Stack(slot) => Some(ParallelCopyDestination::Stack(slot)),
-        ParallelCopySource::Immediate(_) => None,
-    }
-}
-
-/// Return a register-only cycle starting at `start`, together with the
-/// exchanges which realize its parallel assignment.  For
-/// `A <- B, B <- C, C <- A`, the result is `xchg A, B; xchg B, C`.
-fn register_cycle(
-    copies: &[PendingCopy],
-    destination_index: &BTreeMap<ParallelCopyDestination, usize>,
-    start: usize,
-) -> Option<(Vec<usize>, Vec<(PhysReg, PhysReg)>)> {
-    let ParallelCopyDestination::Register(start_register) = copies.get(start)?.destination else {
-        return None;
-    };
-    let mut current = start_register;
-    let mut members = Vec::new();
-    let mut swaps = Vec::new();
-    let mut visited = BTreeSet::new();
-    loop {
-        if !visited.insert(current) {
-            return None;
-        }
-        let destination = ParallelCopyDestination::Register(current);
-        let &index = destination_index.get(&destination)?;
-        let copy = copies.get(index)?;
-        if !copy.pending {
-            return None;
-        }
-        let PendingSource::Value(ParallelCopySource::Register(source)) = copy.source else {
-            return None;
-        };
-        members.push(index);
-        if source == start_register {
-            return (members.len() >= 2).then_some((members, swaps));
-        }
-        swaps.push((current, source));
-        current = source;
-    }
-}
-
 /// Schedule one parallel assignment without snapshotting acyclic rows.
 ///
 /// A row is ready once overwriting its destination cannot destroy a source of
@@ -701,214 +623,76 @@ fn resolve_parallel_copies(
         }
     }
 
-    let mut copies = rows
+    use celox_backend_common::regalloc as common;
+
+    let common_destination = |destination| match destination {
+        ParallelCopyDestination::Register(register) => common::CopyDestination::Register(register),
+        ParallelCopyDestination::Stack(offset) => common::CopyDestination::Stack(offset),
+    };
+    let common_source = |source| match source {
+        ParallelCopySource::Register(register) => common::CopySource::Register(register),
+        ParallelCopySource::Stack(offset) => common::CopySource::Stack(offset),
+        ParallelCopySource::Immediate(value) => common::CopySource::Immediate(value),
+    };
+    let common_rows = rows
         .iter()
-        .copied()
-        .filter(|row| !row.is_identity())
-        .map(|row| PendingCopy {
-            phi_destination: row.phi_destination,
-            source_value: row.source_value,
-            destination: row.destination,
-            source: PendingSource::Value(row.source),
-            pending: true,
+        .map(|row| common::ParallelCopy {
+            destination: common_destination(row.destination),
+            source: common_source(row.source),
         })
         .collect::<Vec<_>>();
-    let mut work = ParallelCopyWork {
-        effective_copies: copies.len(),
-        ..ParallelCopyWork::default()
+    let resolution = common::resolve_parallel_copies(&common_rows).map_err(|error| {
+        SsaDestructionError::new(error.rule, error.message).edge(predecessor, successor)
+    })?;
+    let local_destination = |destination| match destination {
+        common::CopyDestination::Register(register) => ParallelCopyDestination::Register(register),
+        common::CopyDestination::Stack(offset) => ParallelCopyDestination::Stack(offset),
     };
-    if copies.is_empty() {
-        return Ok((Vec::new(), work));
-    }
-
-    let destination_index = copies
-        .iter()
-        .enumerate()
-        .map(|(index, copy)| (copy.destination, index))
-        .collect::<BTreeMap<_, _>>();
-    let mut readers = BTreeMap::<ParallelCopyDestination, BTreeSet<usize>>::new();
-    for (index, copy) in copies.iter().enumerate() {
-        let PendingSource::Value(source) = copy.source else {
-            continue;
-        };
-        if let Some(location) = source_as_destination(source) {
-            readers.entry(location).or_default().insert(index);
-        }
-    }
-
-    let mut ready = VecDeque::new();
-    let mut queued = vec![false; copies.len()];
-    for (index, copy) in copies.iter().enumerate() {
-        if !readers.contains_key(&copy.destination) {
-            ready.push_back(index);
-            queued[index] = true;
-        }
-    }
-
-    let mut operations = Vec::with_capacity(copies.len());
-    let mut remaining = copies.len();
-    let mut temporary_live = false;
-    // Each completed cycle contains the lowest still-pending row selected
-    // below. Resume after it so disjoint cycles do not repeatedly rescan an
-    // already completed prefix.
-    let mut cycle_search_start = 0usize;
-    while remaining != 0 {
-        while let Some(index) = ready.pop_front() {
-            queued[index] = false;
-            if !copies[index].pending {
-                continue;
+    let local_source = |source| match source {
+        common::CopySource::Register(register) => ParallelCopySource::Register(register),
+        common::CopySource::Stack(offset) => ParallelCopySource::Stack(offset),
+        common::CopySource::Immediate(value) => ParallelCopySource::Immediate(value),
+    };
+    let operations = resolution
+        .operations
+        .into_iter()
+        .map(|operation| match operation {
+            common::CopyOperation::Move {
+                destination,
+                source,
+            } => ParallelCopyOperation::Move {
+                destination: local_destination(destination),
+                source: local_source(source),
+            },
+            common::CopyOperation::SwapRegisters { left, right } => {
+                ParallelCopyOperation::SwapRegisters { left, right }
             }
-            work.ready_queue_pops += 1;
-            match copies[index].source {
-                PendingSource::Value(source) => {
-                    operations.push(ParallelCopyOperation::Move {
-                        destination: copies[index].destination,
-                        source,
-                    });
-                    work.direct_moves += 1;
-                    if let Some(location) = source_as_destination(source) {
-                        let released = if let Some(location_readers) = readers.get_mut(&location) {
-                            location_readers.remove(&index);
-                            location_readers.is_empty()
-                        } else {
-                            false
-                        };
-                        if released {
-                            readers.remove(&location);
-                            work.dependency_releases += 1;
-                            if let Some(&writer) = destination_index.get(&location)
-                                && copies[writer].pending
-                                && !queued[writer]
-                            {
-                                ready.push_back(writer);
-                                queued[writer] = true;
-                            }
-                        }
-                    }
-                }
-                PendingSource::Temporary => {
-                    if !temporary_live {
-                        return Err(SsaDestructionError::new(
-                            "SSA_DEST.RESOLVER_TEMPORARY_STATE",
-                            "parallel-copy resolver attempted to restore an inactive temporary",
-                        )
-                        .edge(predecessor, successor)
-                        .values(
-                            copies[index].phi_destination,
-                            Some(copies[index].source_value),
-                        ));
-                    }
-                    operations.push(ParallelCopyOperation::RestoreTemporary(
-                        copies[index].destination,
-                    ));
-                    temporary_live = false;
-                }
+            common::CopyOperation::SaveTemporary(destination) => {
+                ParallelCopyOperation::SaveTemporary(local_destination(destination))
             }
-            copies[index].pending = false;
-            remaining -= 1;
-        }
-
-        if remaining == 0 {
-            break;
-        }
-        if temporary_live {
-            let Some(copy) = copies.iter().find(|copy| copy.pending).copied() else {
-                return Err(SsaDestructionError::new(
-                    "SSA_DEST.RESOLVER_TEMPORARY_STATE",
-                    "parallel-copy resolver lost its pending temporary consumer",
-                )
-                .edge(predecessor, successor));
-            };
-            return Err(SsaDestructionError::new(
-                "SSA_DEST.RESOLVER_TEMPORARY_STATE",
-                "parallel-copy resolver stalled while a temporary was live",
-            )
-            .edge(predecessor, successor)
-            .values(copy.phi_destination, Some(copy.source_value)));
-        }
-
-        let Some(cycle) = copies
-            .iter()
-            .enumerate()
-            .skip(cycle_search_start)
-            .find_map(|(index, copy)| copy.pending.then_some(index))
-        else {
-            return Err(SsaDestructionError::new(
-                "SSA_DEST.RESOLVER_STATE",
-                "parallel-copy resolver has a nonzero pending count without a pending row",
-            )
-            .edge(predecessor, successor));
-        };
-        cycle_search_start = cycle + 1;
-
-        // One xchg is the compact lowering for a two-cycle. Longer cycles use
-        // the ordinary temporary path below: K+1 simple moves are fewer x86
-        // uops than K-1 register exchanges.
-        if let Some((members, swaps)) = register_cycle(&copies, &destination_index, cycle)
-            && members.len() == 2
-        {
-            for (left, right) in swaps.iter().copied() {
-                operations.push(ParallelCopyOperation::SwapRegisters { left, right });
+            common::CopyOperation::RestoreTemporary(destination) => {
+                ParallelCopyOperation::RestoreTemporary(local_destination(destination))
             }
-            for &member in &members {
-                readers.remove(&copies[member].destination);
-                copies[member].pending = false;
-                queued[member] = false;
-            }
-            remaining -= members.len();
-            work.register_swaps += swaps.len();
-            work.cycle_breaks += 1;
-            work.dependency_releases += members.len();
-            continue;
-        }
-
-        let saved = copies[cycle].destination;
-        let saved_readers = readers.remove(&saved).unwrap_or_default();
-        if saved_readers.len() != 1 {
-            return Err(SsaDestructionError::new(
-                "SSA_DEST.RESOLVER_CYCLE_SHAPE",
-                format!(
-                    "stalled parallel-copy graph has {} readers of cycle location {:?}",
-                    saved_readers.len(),
-                    saved
-                ),
-            )
-            .edge(predecessor, successor)
-            .values(
-                copies[cycle].phi_destination,
-                Some(copies[cycle].source_value),
-            ));
-        }
-        let Some(&reader) = saved_readers.iter().next() else {
-            return Err(SsaDestructionError::new(
-                "SSA_DEST.RESOLVER_CYCLE_SHAPE",
-                "stalled parallel-copy cycle has no reader",
-            )
-            .edge(predecessor, successor)
-            .values(
-                copies[cycle].phi_destination,
-                Some(copies[cycle].source_value),
-            ));
-        };
-        copies[reader].source = PendingSource::Temporary;
-        operations.push(ParallelCopyOperation::SaveTemporary(saved));
-        work.cycle_breaks += 1;
-        work.temporary_cycle_breaks += 1;
-        work.dependency_releases += 1;
-        temporary_live = true;
-        if !queued[cycle] {
-            ready.push_back(cycle);
-            queued[cycle] = true;
-        }
-    }
-
-    if temporary_live {
-        return Err(SsaDestructionError::new(
-            "SSA_DEST.RESOLVER_TEMPORARY_STATE",
-            "parallel-copy resolver left its temporary live",
-        )
-        .edge(predecessor, successor));
-    }
+        })
+        .collect();
+    let common::CopyResolutionWork {
+        effective_copies,
+        direct_moves,
+        register_swaps,
+        cycle_breaks,
+        temporary_cycle_breaks,
+        ready_queue_pops,
+        dependency_releases,
+    } = resolution.work;
+    let work = ParallelCopyWork {
+        effective_copies,
+        direct_moves,
+        register_swaps,
+        cycle_breaks,
+        temporary_cycle_breaks,
+        ready_queue_pops,
+        dependency_releases,
+    };
     Ok((operations, work))
 }
 

--- a/crates/celox-backend-x86/src/backend/native/ssa_destroy.rs
+++ b/crates/celox-backend-x86/src/backend/native/ssa_destroy.rs
@@ -7,13 +7,13 @@ use super::mir::{BlockId, MFunction, MInst, VReg};
 use super::regalloc::assignment::{AssignmentMap, EdgeLocation, PhysReg, clobbers};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) enum ParallelCopyDestination {
+pub enum ParallelCopyDestination {
     Register(PhysReg),
     Stack(i32),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) enum ParallelCopySource {
+pub enum ParallelCopySource {
     Register(PhysReg),
     Stack(i32),
     Immediate(u64),
@@ -53,7 +53,7 @@ impl ParallelCopy {
 /// register `xchg` is multiple uops, so K-1 exchanges are not competitive
 /// with K+1 ordinary moves once K is at least three.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ParallelCopyOperation {
+pub enum ParallelCopyOperation {
     Move {
         destination: ParallelCopyDestination,
         source: ParallelCopySource,
@@ -80,12 +80,12 @@ pub(crate) struct ParallelCopyWork {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct EdgeCopyPlan {
+pub struct EdgeCopyPlan {
     pub predecessor: BlockId,
     pub successor: BlockId,
-    pub rows: Vec<ParallelCopy>,
+    pub(crate) rows: Vec<ParallelCopy>,
     pub operations: Vec<ParallelCopyOperation>,
-    pub work: ParallelCopyWork,
+    pub(crate) work: ParallelCopyWork,
 }
 
 impl EdgeCopyPlan {
@@ -95,7 +95,7 @@ impl EdgeCopyPlan {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub(crate) struct SsaDestructionPlan {
+pub struct SsaDestructionPlan {
     edges: BTreeMap<(BlockId, BlockId), EdgeCopyPlan>,
 }
 
@@ -179,7 +179,7 @@ impl SsaDestructionPlan {
     /// Resolve every semantic phi row to its source and destination location.
     /// Identity rows remain in the plan so the verifier can prove completeness;
     /// lowering alone is allowed to elide them.
-    pub(crate) fn build(
+    pub fn build(
         func: &MFunction,
         assignment: &AssignmentMap,
     ) -> Result<Self, SsaDestructionError> {
@@ -257,7 +257,7 @@ impl SsaDestructionPlan {
 
     /// Independently compare a materialized plan with MIR phi semantics and the
     /// completed assignment before any machine code is emitted.
-    pub(crate) fn verify(
+    pub fn verify(
         &self,
         func: &MFunction,
         assignment: &AssignmentMap,
@@ -427,7 +427,7 @@ impl SsaDestructionPlan {
         Ok(())
     }
 
-    pub(crate) fn edge(&self, predecessor: BlockId, successor: BlockId) -> Option<&EdgeCopyPlan> {
+    pub fn edge(&self, predecessor: BlockId, successor: BlockId) -> Option<&EdgeCopyPlan> {
         self.edges.get(&(predecessor, successor))
     }
 

--- a/crates/celox-bench/Cargo.toml
+++ b/crates/celox-bench/Cargo.toml
@@ -8,6 +8,10 @@ license.workspace     = true
 description           = "Macro-benchmark runners for Celox"
 edition.workspace     = true
 
+[features]
+default = []
+experimental-arm64-backend = ["celox/experimental-arm64-backend"]
+
 [dependencies]
 celox           = { path = "../celox" }
 clap            = { workspace = true }

--- a/crates/celox-bench/src/bin/celox-heliodor.rs
+++ b/crates/celox-bench/src/bin/celox-heliodor.rs
@@ -167,6 +167,15 @@ fn run() -> Result<(), CeloxHeliodorError> {
             message: "--dump-ir-and-run requires --dump-ir-dir",
         });
     }
+    #[cfg(not(any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    )))]
+    if matches!(opts.backend, Backend::Native) {
+        return Err(CeloxHeliodorError::InvalidConfiguration {
+            message: "the custom native backend is unavailable; enable experimental-arm64-backend on AArch64",
+        });
+    }
     let (sources, metadata) = load_sources(&opts.project, &opts.source_files)?;
     let source_refs: Vec<(&str, &Path)> = sources
         .iter()
@@ -309,6 +318,10 @@ fn run() -> Result<(), CeloxHeliodorError> {
         if opts.dump_ir_and_run {
             let testbench =
                 compile_initial_testbench(&sim).ok_or(CeloxHeliodorError::MissingInitialBlock)?;
+            #[cfg(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            ))]
             sim.start_native_execution_timing();
             let execute_cpu_start = process_cpu_time();
             let execute_start = Instant::now();
@@ -318,10 +331,19 @@ fn run() -> Result<(), CeloxHeliodorError> {
             } else {
                 (run_compiled_testbench(&mut sim, &testbench), 0, false)
             };
+            #[cfg(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            ))]
             let jit_execute_elapsed = sim
                 .finish_native_execution_timing()
                 .expect("native execution timing was started")
                 .elapsed();
+            #[cfg(not(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            )))]
+            let jit_execute_elapsed = Duration::ZERO;
             let execute_elapsed = execute_start.elapsed();
             let execute_cpu_elapsed = process_cpu_time()
                 .zip(execute_cpu_start)
@@ -377,9 +399,18 @@ fn run() -> Result<(), CeloxHeliodorError> {
     if opts.compile_only {
         let compile_start = Instant::now();
         match opts.backend {
+            #[cfg(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            ))]
             Backend::Native => {
                 let _sim = builder.build_native()?;
             }
+            #[cfg(not(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            )))]
+            Backend::Native => unreachable!("native backend availability checked above"),
             Backend::Cranelift => {
                 let _sim = builder.build_cranelift()?;
             }
@@ -411,6 +442,10 @@ fn run() -> Result<(), CeloxHeliodorError> {
         jit_execute_elapsed,
         execute_cpu_elapsed,
     ) = match opts.backend {
+        #[cfg(any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        ))]
         Backend::Native => {
             let mut sim = builder.build_native()?;
             let testbench =
@@ -441,6 +476,11 @@ fn run() -> Result<(), CeloxHeliodorError> {
                     .map(|(end, start)| end.saturating_sub(start)),
             )
         }
+        #[cfg(not(any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        )))]
+        Backend::Native => unreachable!("native backend availability checked above"),
         Backend::Cranelift => {
             let mut sim = builder.build_cranelift()?;
             let testbench =

--- a/crates/celox-macros/src/generator.rs
+++ b/crates/celox-macros/src/generator.rs
@@ -64,7 +64,7 @@ pub fn generate_project(ir: &Ir) -> proc_macro2::TokenStream {
             }
 
             if is_clk {
-                fields.extend(quote! { pub #port_ident: celox::NativeEventRef, });
+                fields.extend(quote! { pub #port_ident: celox::DefaultEventRef, });
                 init_ports.extend(quote! { #port_ident: sim.event(#name), });
                 continue; // Do not generate read/write accessors for clk
             } else {

--- a/crates/celox-macros/src/generator/snapshots/celox_macros__generator__test_generator__tests__generate_full_project.snap
+++ b/crates/celox-macros/src/generator/snapshots/celox_macros__generator__test_generator__tests__generate_full_project.snap
@@ -3,7 +3,7 @@ source: crates/celox-macros/src/generator/test_generator.rs
 expression: code
 ---
 pub struct Module04 {
-    pub clk: celox::NativeEventRef,
+    pub clk: celox::DefaultEventRef,
     pub rst: celox::SignalRef,
     pub a: celox::SignalRef,
     pub b: celox::SignalRef,
@@ -209,7 +209,7 @@ impl<'a, 'b> Module04IO<'a, 'b> {
     }
 }
 pub struct SorterCell {
-    pub clk: celox::NativeEventRef,
+    pub clk: celox::DefaultEventRef,
     pub rst: celox::SignalRef,
     pub en: celox::SignalRef,
     pub i_val: celox::SignalRef,
@@ -456,7 +456,7 @@ impl<'a, 'b> SorterCellIO<'a, 'b> {
     }
 }
 pub struct LinearSorter {
-    pub clk: celox::NativeEventRef,
+    pub clk: celox::DefaultEventRef,
     pub rst: celox::SignalRef,
     pub en: celox::SignalRef,
     pub d_in: celox::SignalRef,
@@ -678,7 +678,7 @@ impl<'a, 'b> LinearSorterIO<'a, 'b> {
     }
 }
 pub struct LinearSorterWrapper {
-    pub clk: celox::NativeEventRef,
+    pub clk: celox::DefaultEventRef,
     pub rst: celox::SignalRef,
     pub en: celox::SignalRef,
     pub d_in: celox::SignalRef,
@@ -903,13 +903,13 @@ impl<'a, 'b> LinearSorterWrapperIO<'a, 'b> {
     }
 }
 pub struct async_fifo {
-    pub is_clk: celox::NativeEventRef,
+    pub is_clk: celox::DefaultEventRef,
     pub is_rst: celox::SignalRef,
     pub os_almost_full: celox::SignalRef,
     pub os_full: celox::SignalRef,
     pub is_push: celox::SignalRef,
     pub is_data: celox::SignalRef,
-    pub id_clk: celox::NativeEventRef,
+    pub id_clk: celox::DefaultEventRef,
     pub id_rst: celox::SignalRef,
     pub od_empty: celox::SignalRef,
     pub id_pop: celox::SignalRef,
@@ -1325,10 +1325,10 @@ impl<'a, 'b> async_fifoIO<'a, 'b> {
     }
 }
 pub struct async_fifo_reset_sync {
-    pub is_clk: celox::NativeEventRef,
+    pub is_clk: celox::DefaultEventRef,
     pub is_rst: celox::SignalRef,
     pub os_rst: celox::SignalRef,
-    pub id_clk: celox::NativeEventRef,
+    pub id_clk: celox::DefaultEventRef,
     pub id_rst: celox::SignalRef,
     pub od_rst: celox::SignalRef,
 }
@@ -1542,12 +1542,12 @@ impl<'a, 'b> async_fifo_reset_syncIO<'a, 'b> {
     }
 }
 pub struct async_handshake {
-    pub is_clk: celox::NativeEventRef,
+    pub is_clk: celox::DefaultEventRef,
     pub is_rst: celox::SignalRef,
     pub is_valid: celox::SignalRef,
     pub os_ready: celox::SignalRef,
     pub is_data: celox::SignalRef,
-    pub id_clk: celox::NativeEventRef,
+    pub id_clk: celox::DefaultEventRef,
     pub id_rst: celox::SignalRef,
     pub od_valid: celox::SignalRef,
     pub id_ready: celox::SignalRef,
@@ -2840,7 +2840,7 @@ impl<'a, 'b> linear_sec_encoderIO<'a, 'b> {
     }
 }
 pub struct counter {
-    pub i_clk: celox::NativeEventRef,
+    pub i_clk: celox::DefaultEventRef,
     pub i_rst: celox::SignalRef,
     pub i_clear: celox::SignalRef,
     pub i_set: celox::SignalRef,
@@ -3746,7 +3746,7 @@ impl<'a, 'b> _onehotIO<'a, 'b> {
     }
 }
 pub struct delay {
-    pub i_clk: celox::NativeEventRef,
+    pub i_clk: celox::DefaultEventRef,
     pub i_rst: celox::SignalRef,
     pub i_d: celox::SignalRef,
     pub o_d: celox::SignalRef,
@@ -3911,7 +3911,7 @@ impl<'a, 'b> delayIO<'a, 'b> {
     }
 }
 pub struct edge_detector {
-    pub i_clk: celox::NativeEventRef,
+    pub i_clk: celox::DefaultEventRef,
     pub i_rst: celox::SignalRef,
     pub i_clear: celox::SignalRef,
     pub i_data: celox::SignalRef,
@@ -4205,7 +4205,7 @@ impl<'a, 'b> edge_detectorIO<'a, 'b> {
     }
 }
 pub struct fifo {
-    pub i_clk: celox::NativeEventRef,
+    pub i_clk: celox::DefaultEventRef,
     pub i_rst: celox::SignalRef,
     pub i_clear: celox::SignalRef,
     pub o_empty: celox::SignalRef,
@@ -4675,7 +4675,7 @@ impl<'a, 'b> fifoIO<'a, 'b> {
     }
 }
 pub struct fifo_controller {
-    pub i_clk: celox::NativeEventRef,
+    pub i_clk: celox::DefaultEventRef,
     pub i_rst: celox::SignalRef,
     pub i_clear: celox::SignalRef,
     pub o_empty: celox::SignalRef,
@@ -5363,7 +5363,7 @@ impl<'a, 'b> fifo_controllerIO<'a, 'b> {
     }
 }
 pub struct gray_counter {
-    pub i_clk: celox::NativeEventRef,
+    pub i_clk: celox::DefaultEventRef,
     pub i_rst: celox::SignalRef,
     pub i_clear: celox::SignalRef,
     pub i_set: celox::SignalRef,
@@ -6046,7 +6046,7 @@ impl<'a, 'b> gray_encoderIO<'a, 'b> {
     }
 }
 pub struct lfsr_galois {
-    pub i_clk: celox::NativeEventRef,
+    pub i_clk: celox::DefaultEventRef,
     pub i_en: celox::SignalRef,
     pub i_set: celox::SignalRef,
     pub i_setval: celox::SignalRef,
@@ -6498,7 +6498,7 @@ pub struct test_utils_clog2_clippedIO<'a, 'b> {
 }
 impl<'a, 'b> test_utils_clog2_clippedIO<'a, 'b> {}
 pub struct ram {
-    pub i_clk: celox::NativeEventRef,
+    pub i_clk: celox::DefaultEventRef,
     pub i_rst: celox::SignalRef,
     pub i_clr: celox::SignalRef,
     pub i_mea: celox::SignalRef,
@@ -7353,7 +7353,7 @@ pub struct test_onehot_muxIO<'a, 'b> {
 }
 impl<'a, 'b> test_onehot_muxIO<'a, 'b> {}
 pub struct slicer {
-    pub i_clk: celox::NativeEventRef,
+    pub i_clk: celox::DefaultEventRef,
     pub i_rst: celox::SignalRef,
     pub o_ready: celox::SignalRef,
     pub i_valid: celox::SignalRef,
@@ -7682,7 +7682,7 @@ impl<'a, 'b> slicerIO<'a, 'b> {
     }
 }
 pub struct slicer_unit_fb {
-    pub i_clk: celox::NativeEventRef,
+    pub i_clk: celox::DefaultEventRef,
     pub i_rst: celox::SignalRef,
     pub o_ready: celox::SignalRef,
     pub i_valid: celox::SignalRef,
@@ -8017,7 +8017,7 @@ impl<'a, 'b> slicer_unit_fbIO<'a, 'b> {
     }
 }
 pub struct slicer_unit_hb {
-    pub i_clk: celox::NativeEventRef,
+    pub i_clk: celox::DefaultEventRef,
     pub i_rst: celox::SignalRef,
     pub o_ready: celox::SignalRef,
     pub i_valid: celox::SignalRef,
@@ -8352,7 +8352,7 @@ impl<'a, 'b> slicer_unit_hbIO<'a, 'b> {
     }
 }
 pub struct synchronizer_basic {
-    pub i_clk: celox::NativeEventRef,
+    pub i_clk: celox::DefaultEventRef,
     pub i_rst: celox::SignalRef,
     pub i_d: celox::SignalRef,
     pub o_d: celox::SignalRef,

--- a/crates/celox-state-layout/src/lib.rs
+++ b/crates/celox-state-layout/src/lib.rs
@@ -14,6 +14,12 @@ pub const RUNTIME_EVENT_CAPACITY: usize = 1024;
 pub const RUNTIME_EVENT_WRITING: u64 = u64::MAX;
 pub const STATE_HEADER_SIZE: usize = 32;
 pub const STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET: usize = 0;
+/// Remaining iterations for an in-function native tick loop.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub const STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET: usize = 8;
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+pub const STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET: usize = 24;
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub const STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET: usize = 16;
 /// Runtime-event write sequence observed when a native tick batch starts.
 pub const RUNTIME_EVENT_HEADER_SIZE: usize = 8;
@@ -610,5 +616,25 @@ mod tests {
         assert_eq!(expanded.offsets, base.offsets);
         assert_eq!(expanded.working_offsets, base.working_offsets);
         assert_eq!(expanded.triggered_bits_offset, base.triggered_bits_offset);
+    }
+
+    #[test]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    fn state_header_fields_do_not_overlap() {
+        const {
+            assert!(
+                STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET + 8
+                    <= STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET
+            );
+            assert!(
+                STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET + 8
+                    <= STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET
+            );
+            assert!(
+                STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET + 8
+                    <= STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET
+            );
+            assert!(STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET + 8 <= STATE_HEADER_SIZE);
+        }
     }
 }

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -49,9 +49,14 @@ celox-macros          = { path = "../celox-macros", optional = true }
 celox-backend-cranelift = { path = "../celox-backend-cranelift", optional = true }
 wasmtime              = { version = "47", optional = true }
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 celox-backend-x86     = { path = "../celox-backend-x86", optional = true }
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
 celox-sir-opt         = { path = "../celox-sir-opt", default-features = false, features = ["wide-native-memory"] }
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+celox-backend-arm64   = { path = "../celox-backend-arm64" }
 
 [dev-dependencies]
 insta      = "1.46"

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -17,6 +17,7 @@ host-runtime = [
     "dep:wasmtime",
     "celox-sir-opt/timing",
 ]
+experimental-arm64-backend = ["host-runtime", "dep:celox-backend-arm64"]
 
 [dependencies]
 toml                  = { workspace = true }
@@ -56,7 +57,7 @@ celox-backend-x86     = { path = "../celox-backend-x86", optional = true }
 celox-sir-opt         = { path = "../celox-sir-opt", default-features = false, features = ["wide-native-memory"] }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
-celox-backend-arm64   = { path = "../celox-backend-arm64" }
+celox-backend-arm64   = { path = "../celox-backend-arm64", optional = true }
 
 [dev-dependencies]
 insta      = "1.46"

--- a/crates/celox/src/backend.rs
+++ b/crates/celox/src/backend.rs
@@ -1,7 +1,10 @@
 pub(crate) mod memory_layout;
 #[cfg(all(
     feature = "host-runtime",
-    any(target_arch = "x86_64", target_arch = "aarch64")
+    any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    )
 ))]
 pub(crate) mod native;
 #[cfg(feature = "host-runtime")]
@@ -24,7 +27,10 @@ mod host {
         CraneliftDiagnostics, CraneliftOptLevel, CraneliftOptions, RegallocAlgorithm,
     };
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    ))]
     pub use celox_backend_x86::{NativeDiagnostics, NativeDumpOptions, X86BackendOptions};
 }
 

--- a/crates/celox/src/backend.rs
+++ b/crates/celox/src/backend.rs
@@ -1,5 +1,8 @@
 pub(crate) mod memory_layout;
-#[cfg(all(feature = "host-runtime", target_arch = "x86_64"))]
+#[cfg(all(
+    feature = "host-runtime",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 pub(crate) mod native;
 #[cfg(feature = "host-runtime")]
 mod runtime;
@@ -21,7 +24,7 @@ mod host {
         CraneliftDiagnostics, CraneliftOptLevel, CraneliftOptions, RegallocAlgorithm,
     };
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub use celox_backend_x86::{NativeDiagnostics, NativeDumpOptions, X86BackendOptions};
 }
 

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -5,7 +5,10 @@ use crate::ir::{
 };
 #[cfg(all(
     feature = "host-runtime",
-    any(target_arch = "x86_64", target_arch = "aarch64")
+    any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    )
 ))]
 pub use celox_state_layout::STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET;
 pub use celox_state_layout::{

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -3,8 +3,11 @@ use crate::ir::{
     AbsoluteAddr, OptimizedSir, RegisterId, SIRInstruction, SIROffset, STABLE_REGION,
     collect_exact_zero_registers,
 };
-#[cfg(all(feature = "host-runtime", target_arch = "x86_64"))]
-pub use celox_backend_x86::STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET;
+#[cfg(all(
+    feature = "host-runtime",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
+pub use celox_state_layout::STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET;
 pub use celox_state_layout::{
     LayoutInput, LayoutRequirements, LayoutSource, MemoryLayoutMode, StateObjectLayout,
     UnpackedArrayLayout, get_byte_size,

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -25,7 +25,7 @@ use super::{emit, jit_mem, regalloc};
 /// JIT function type: `fn(state: *mut u8) -> i64`
 #[cfg(target_arch = "x86_64")]
 pub type NativeSimFunc = unsafe extern "sysv64" fn(*mut u8) -> i64;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "experimental-arm64-backend"))]
 pub type NativeSimFunc = unsafe extern "C" fn(*mut u8) -> i64;
 
 /// Time spent inside generated native simulator functions.

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -1,7 +1,7 @@
-//! NativeBackend: SimBackend implementation using the custom x86-64 backend.
+//! NativeBackend: SimBackend implementation using a custom host backend.
 //!
 //! Mirrors the structure of JitBackend but compiles through
-//! ISel → MIR → regalloc → x86-64 emit instead of Cranelift.
+//! ISel → scalar MIR → regalloc → host emission instead of Cranelift.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -23,7 +23,10 @@ use super::{emit, jit_mem, regalloc};
 // ────────────────────────────────────────────────────────────────
 
 /// JIT function type: `fn(state: *mut u8) -> i64`
+#[cfg(target_arch = "x86_64")]
 pub type NativeSimFunc = unsafe extern "sysv64" fn(*mut u8) -> i64;
+#[cfg(target_arch = "aarch64")]
+pub type NativeSimFunc = unsafe extern "C" fn(*mut u8) -> i64;
 
 /// Time spent inside generated native simulator functions.
 ///

--- a/crates/celox/src/backend/native/mod.rs
+++ b/crates/celox/src/backend/native/mod.rs
@@ -1,3 +1,5 @@
 pub mod backend;
 pub use backend::{NativeBackend, NativeExecutionTiming, SharedNativeCode};
+#[cfg(target_arch = "aarch64")]
+pub use celox_backend_arm64::{jit_mem, scalar as emit};
 pub use celox_backend_x86::native::*;

--- a/crates/celox/src/backend/native/mod.rs
+++ b/crates/celox/src/backend/native/mod.rs
@@ -1,5 +1,5 @@
 pub mod backend;
 pub use backend::{NativeBackend, NativeExecutionTiming, SharedNativeCode};
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "experimental-arm64-backend"))]
 pub use celox_backend_arm64::{jit_mem, scalar as emit};
 pub use celox_backend_x86::native::*;

--- a/crates/celox/src/diagnostics.rs
+++ b/crates/celox/src/diagnostics.rs
@@ -23,9 +23,15 @@ mod host {
         pub runtime: RuntimeDiagnostics,
         pub sir: crate::optimizer::SirDiagnostics,
         pub cranelift: crate::backend::CraneliftDiagnostics,
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        ))]
         pub native: crate::backend::NativeDiagnostics,
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        ))]
         pub native_tick_loop: Option<bool>,
     }
 
@@ -91,7 +97,10 @@ mod host {
                 effect_case_dispatch: enabled("CELOX_EFFECT_CASE_DISPATCH"),
             };
             let cranelift = crate::backend::CraneliftDiagnostics { pass_timing };
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            ))]
             let (native, native_tick_loop) = {
                 let native_tick_loop = variables
                     .get(OsStr::new("CELOX_NATIVE_TICK_LOOP"))
@@ -136,9 +145,15 @@ mod host {
                 runtime,
                 sir,
                 cranelift,
-                #[cfg(target_arch = "x86_64")]
+                #[cfg(any(
+                    target_arch = "x86_64",
+                    all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                ))]
                 native,
-                #[cfg(target_arch = "x86_64")]
+                #[cfg(any(
+                    target_arch = "x86_64",
+                    all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                ))]
                 native_tick_loop,
             }
         }
@@ -159,7 +174,10 @@ mod host {
             assert!(options.sir.pass_timing);
             assert_eq!(options.sir.branchify_trace_reg, Some(42));
             assert_eq!(options.runtime.tick_timing_every, Some(100));
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            ))]
             assert!(options.native.verify_regalloc);
         }
 

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -128,7 +128,10 @@ impl OptimizedSir {
         }
     }
 
-    #[cfg(all(feature = "host-runtime", target_arch = "x86_64"))]
+    #[cfg(all(
+        feature = "host-runtime",
+        any(target_arch = "x86_64", target_arch = "aarch64")
+    ))]
     pub(crate) fn into_runtime(self) -> RuntimeProgram {
         self.runtime
     }
@@ -497,7 +500,10 @@ pub(crate) mod verify {
 pub use celox_slt::{GlueAddrBase, GlueBlockBase};
 
 pub use celox_frontend_veryl::SimModule;
-#[cfg(all(feature = "host-runtime", target_arch = "x86_64"))]
+#[cfg(all(
+    feature = "host-runtime",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 pub(crate) use celox_runtime::SignalArrayLayout;
 pub use celox_runtime::SignalRef;
 

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -130,7 +130,10 @@ impl OptimizedSir {
 
     #[cfg(all(
         feature = "host-runtime",
-        any(target_arch = "x86_64", target_arch = "aarch64")
+        any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        )
     ))]
     pub(crate) fn into_runtime(self) -> RuntimeProgram {
         self.runtime
@@ -502,7 +505,10 @@ pub use celox_slt::{GlueAddrBase, GlueBlockBase};
 pub use celox_frontend_veryl::SimModule;
 #[cfg(all(
     feature = "host-runtime",
-    any(target_arch = "x86_64", target_arch = "aarch64")
+    any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    )
 ))]
 pub(crate) use celox_runtime::SignalArrayLayout;
 pub use celox_runtime::SignalRef;

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -79,24 +79,45 @@ mod host_api {
         }
     }
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    ))]
     pub mod native_backend {
         //! Re-exports for the custom native backend (for testing/integration).
         pub use crate::backend::native::*;
     }
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    ))]
     pub use crate::backend::native::backend::NativeEventRef;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    ))]
     pub use crate::backend::native::{NativeBackend, SharedNativeCode};
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    ))]
     pub use crate::backend::{NativeDiagnostics, NativeDumpOptions};
 
-    /// Default simulation backend: custom native on x86-64/AArch64, Cranelift elsewhere.
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    /// Default simulation backend: custom native on x86-64 and opt-in AArch64,
+    /// Cranelift elsewhere.
+    #[cfg(any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    ))]
     pub type DefaultBackend = NativeBackend;
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    #[cfg(not(any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    )))]
     pub type DefaultBackend = JitBackend;
+
+    pub type DefaultEventRef = <DefaultBackend as SimBackend>::Event;
 }
 
 #[cfg(feature = "host-runtime")]

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -79,23 +79,23 @@ mod host_api {
         }
     }
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub mod native_backend {
-        //! Re-exports for the native x86-64 backend (for testing/integration).
+        //! Re-exports for the custom native backend (for testing/integration).
         pub use crate::backend::native::*;
     }
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub use crate::backend::native::backend::NativeEventRef;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub use crate::backend::native::{NativeBackend, SharedNativeCode};
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub use crate::backend::{NativeDiagnostics, NativeDumpOptions};
 
-    /// Default simulation backend: NativeBackend on x86-64, JitBackend (Cranelift) elsewhere.
-    #[cfg(target_arch = "x86_64")]
+    /// Default simulation backend: custom native on x86-64/AArch64, Cranelift elsewhere.
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     pub type DefaultBackend = NativeBackend;
-    #[cfg(not(target_arch = "x86_64"))]
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     pub type DefaultBackend = JitBackend;
 }
 

--- a/crates/celox/src/optimizer/sir.rs
+++ b/crates/celox/src/optimizer/sir.rs
@@ -1,6 +1,9 @@
 #[cfg(all(
     feature = "host-runtime",
-    any(target_arch = "x86_64", target_arch = "aarch64")
+    any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    )
 ))]
 use std::sync::Arc;
 
@@ -9,7 +12,10 @@ use crate::ir::LaidOutProgram;
 use crate::ir::{AbsoluteAddr, OptimizedSir};
 #[cfg(all(
     feature = "host-runtime",
-    any(target_arch = "x86_64", target_arch = "aarch64")
+    any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    )
 ))]
 use crate::ir::{
     ExecutionUnit, RegionedAbsoluteAddr, SPARSE_WORKING_REGION, STABLE_REGION, WORKING_REGION,
@@ -17,7 +23,10 @@ use crate::ir::{
 
 #[cfg(all(
     feature = "host-runtime",
-    any(target_arch = "x86_64", target_arch = "aarch64")
+    any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    )
 ))]
 pub use celox_sir_opt::optimizer::pass_eliminate_working_round_trip;
 pub(crate) use celox_sir_opt::optimizer::{
@@ -26,7 +35,10 @@ pub(crate) use celox_sir_opt::optimizer::{
 };
 #[cfg(all(
     feature = "host-runtime",
-    any(target_arch = "x86_64", target_arch = "aarch64")
+    any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    )
 ))]
 pub(crate) use celox_sir_opt::optimizer::{
     eliminate_unobserved_comb_state_stores, promote_eval_apply_working_round_trips,
@@ -65,7 +77,10 @@ pub(crate) fn optimize_rooted_comb_memory(
 
 #[cfg(all(
     feature = "host-runtime",
-    any(target_arch = "x86_64", target_arch = "aarch64")
+    any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    )
 ))]
 pub(crate) fn optimize_native_merged_chain(
     eu: &mut ExecutionUnit<RegionedAbsoluteAddr>,
@@ -107,7 +122,10 @@ pub(crate) fn optimize_native_merged_chain(
 
 #[cfg(all(
     feature = "host-runtime",
-    any(target_arch = "x86_64", target_arch = "aarch64")
+    any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    )
 ))]
 fn packed_range_is_physically_contiguous(
     layout: &crate::backend::MemoryLayout,

--- a/crates/celox/src/optimizer/sir.rs
+++ b/crates/celox/src/optimizer/sir.rs
@@ -1,21 +1,33 @@
-#[cfg(all(feature = "host-runtime", target_arch = "x86_64"))]
+#[cfg(all(
+    feature = "host-runtime",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 use std::sync::Arc;
 
 #[cfg(feature = "host-runtime")]
 use crate::ir::LaidOutProgram;
 use crate::ir::{AbsoluteAddr, OptimizedSir};
-#[cfg(all(feature = "host-runtime", target_arch = "x86_64"))]
+#[cfg(all(
+    feature = "host-runtime",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 use crate::ir::{
     ExecutionUnit, RegionedAbsoluteAddr, SPARSE_WORKING_REGION, STABLE_REGION, WORKING_REGION,
 };
 
-#[cfg(all(feature = "host-runtime", target_arch = "x86_64"))]
+#[cfg(all(
+    feature = "host-runtime",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 pub use celox_sir_opt::optimizer::pass_eliminate_working_round_trip;
 pub(crate) use celox_sir_opt::optimizer::{
     eliminate_shared_comb_state_stores, promote_fused_comb_static_slots,
     remove_dead_sir_definitions,
 };
-#[cfg(all(feature = "host-runtime", target_arch = "x86_64"))]
+#[cfg(all(
+    feature = "host-runtime",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 pub(crate) use celox_sir_opt::optimizer::{
     eliminate_unobserved_comb_state_stores, promote_eval_apply_working_round_trips,
 };
@@ -51,7 +63,10 @@ pub(crate) fn optimize_rooted_comb_memory(
     });
 }
 
-#[cfg(all(feature = "host-runtime", target_arch = "x86_64"))]
+#[cfg(all(
+    feature = "host-runtime",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 pub(crate) fn optimize_native_merged_chain(
     eu: &mut ExecutionUnit<RegionedAbsoluteAddr>,
     layout: &crate::backend::MemoryLayout,
@@ -90,7 +105,10 @@ pub(crate) fn optimize_native_merged_chain(
     )
 }
 
-#[cfg(all(feature = "host-runtime", target_arch = "x86_64"))]
+#[cfg(all(
+    feature = "host-runtime",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 fn packed_range_is_physically_contiguous(
     layout: &crate::backend::MemoryLayout,
     destination: RegionedAbsoluteAddr,

--- a/crates/celox/src/simulation.rs
+++ b/crates/celox/src/simulation.rs
@@ -10,8 +10,7 @@ use celox_runtime::{EventInfo, SimulationExecutor, SimulationState};
 ///
 /// Manages simulation time, periodic clocks, and an event queue.
 ///
-/// The default type parameter `B = NativeBackend` means that bare `Simulation`
-/// is equivalent to `Simulation<JitBackend>` for backward compatibility.
+/// The default type parameter uses the host's [`crate::DefaultBackend`].
 pub struct Simulation<B: SimBackend = crate::DefaultBackend> {
     pub(crate) simulator: Simulator<B>,
     pub(crate) state: SimulationState<B>,

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -14,7 +14,10 @@ mod host {
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
     use crate::backend::RuntimeEventBuffer;
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    ))]
     use crate::backend::native::{NativeBackend, SharedNativeCode};
     use crate::{
         IOContext, RuntimeErrorCode,
@@ -59,7 +62,7 @@ mod host {
     /// and an optional VCD writer. Provides low-level, event-driven control.
     ///
     /// The default type parameter `B = DefaultBackend` means that bare `Simulator`
-    /// uses the custom native backend on x86-64/AArch64 and Cranelift elsewhere.
+    /// uses the custom native backend on x86-64 and opt-in AArch64, and Cranelift elsewhere.
     pub struct Simulator<B: SimBackend = crate::DefaultBackend> {
         pub(crate) backend: B,
         pub(crate) program: RuntimeProgram,
@@ -1450,7 +1453,10 @@ mod host {
         }
     }
 
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    ))]
     impl Simulator<NativeBackend> {
         /// Returns the shared compiled native code, allowing it to be reused
         /// for creating additional simulator instances without recompilation.

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -14,7 +14,7 @@ mod host {
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
     use crate::backend::RuntimeEventBuffer;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     use crate::backend::native::{NativeBackend, SharedNativeCode};
     use crate::{
         IOContext, RuntimeErrorCode,
@@ -59,7 +59,7 @@ mod host {
     /// and an optional VCD writer. Provides low-level, event-driven control.
     ///
     /// The default type parameter `B = DefaultBackend` means that bare `Simulator`
-    /// uses the native x86-64 backend on x86-64 and Cranelift elsewhere.
+    /// uses the custom native backend on x86-64/AArch64 and Cranelift elsewhere.
     pub struct Simulator<B: SimBackend = crate::DefaultBackend> {
         pub(crate) backend: B,
         pub(crate) program: RuntimeProgram,
@@ -1450,7 +1450,7 @@ mod host {
         }
     }
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     impl Simulator<NativeBackend> {
         /// Returns the shared compiled native code, allowing it to be reused
         /// for creating additional simulator instances without recompilation.

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -233,7 +233,7 @@ mod host {
         pub optimize_options: crate::optimizer::OptimizeOptions,
         /// Fine-grained Cranelift backend options.
         pub cranelift_options: crate::backend::CraneliftOptions,
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
         pub x86_options: crate::backend::X86BackendOptions,
         pub trace: crate::debug::TraceOptions,
         pub diagnostics: crate::RuntimeDiagnostics,
@@ -251,7 +251,7 @@ mod host {
                 four_state: false,
                 optimize_options: opt,
                 cranelift_options: crate::backend::CraneliftOptions::default(),
-                #[cfg(target_arch = "x86_64")]
+                #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
                 x86_options: crate::backend::X86BackendOptions::default(),
                 trace: Default::default(),
                 diagnostics: Default::default(),
@@ -389,10 +389,18 @@ mod host {
             self
         }
 
-        #[cfg(target_arch = "x86_64")]
-        pub fn x86_slp(mut self, enable: bool) -> Self {
-            self.options.x86_options.slp = enable;
-            self
+        pub fn x86_slp(self, enable: bool) -> Self {
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            {
+                let mut this = self;
+                this.options.x86_options.slp = enable;
+                return this;
+            }
+            #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+            {
+                let _ = enable;
+                self
+            }
         }
 
         /// Set fine-grained Cranelift backend options.
@@ -446,7 +454,7 @@ mod host {
             self.options.diagnostics = diagnostics.runtime;
             self.options.optimize_options.diagnostics = diagnostics.sir;
             self.options.cranelift_options.diagnostics = diagnostics.cranelift;
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
             {
                 self.options.x86_options.diagnostics = diagnostics.native;
                 if let Some(enabled) = diagnostics.native_tick_loop {
@@ -663,13 +671,13 @@ mod host {
         }
 
         /// Compiles the Veryl source and constructs the simulator.
-        /// Uses the native x86-64 backend on x86-64, Cranelift elsewhere.
+        /// Uses a custom native backend on x86-64/AArch64, Cranelift elsewhere.
         pub fn build(self) -> Result<Simulator<crate::DefaultBackend>, SimulatorError> {
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
             {
                 self.build_native()
             }
-            #[cfg(not(target_arch = "x86_64"))]
+            #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
             {
                 self.build_cranelift()
             }
@@ -721,8 +729,8 @@ mod host {
             Ok(sim)
         }
 
-        /// Compiles using the native x86-64 backend.
-        #[cfg(target_arch = "x86_64")]
+        /// Compiles using the custom native backend for this host architecture.
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
         pub fn build_native(
             self,
         ) -> Result<Simulator<crate::backend::native::NativeBackend>, SimulatorError> {
@@ -796,7 +804,7 @@ mod host {
         }
 
         /// Compiles and runs a testbench using the custom native backend.
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
         pub fn run_test_native(self) -> Result<crate::testbench::TestResult, SimulatorError> {
             run_test_with_sim(self.build_native()?)
         }
@@ -822,9 +830,9 @@ mod host {
         /// while capturing compilation trace data as configured by TraceOptions.
         pub fn build_with_trace(self) -> crate::debug::CompilationTraceResult {
             let mut trace = crate::debug::CompilationTrace::default();
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::ElementStrided;
-            #[cfg(not(target_arch = "x86_64"))]
+            #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::Packed;
             let program_res = compile_to_sir_with_layout_mode(
                 &self.sources,
@@ -851,7 +859,7 @@ mod host {
                     run_dead_store_elimination(&mut laid_out, &self.live_signals, &self.options);
                 }
 
-                #[cfg(target_arch = "x86_64")]
+                #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
                 let backend = if self.options.trace.mir
                     || !self.options.trace.native_profile_blocks.is_empty()
                 {
@@ -868,7 +876,7 @@ mod host {
                 } else {
                     crate::backend::native::NativeBackend::new(&laid_out, &self.options)?
                 };
-                #[cfg(not(target_arch = "x86_64"))]
+                #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
                 let backend = JitBackend::new(&laid_out, &self.options, None)?;
 
                 let mut sim =
@@ -945,9 +953,9 @@ mod host {
         /// Compiles the Veryl source and constructs the timed simulation wrapper.
         pub fn build(mut self) -> Result<crate::Simulation, SimulatorError> {
             self.options.emit_triggers = true;
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::ElementStrided;
-            #[cfg(not(target_arch = "x86_64"))]
+            #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::Packed;
             let (program, warnings) = compile_to_sir_with_layout_mode(
                 &self.sources,
@@ -971,9 +979,9 @@ mod host {
             if self.options.dead_store_policy != DeadStorePolicy::Off {
                 run_dead_store_elimination(&mut laid_out, &self.live_signals, &self.options);
             }
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
             let backend = crate::backend::native::NativeBackend::new(&laid_out, &self.options)?;
-            #[cfg(not(target_arch = "x86_64"))]
+            #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
             let backend = crate::backend::JitBackend::new(&laid_out, &self.options, None)?;
 
             let mut sim =

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -233,7 +233,10 @@ mod host {
         pub optimize_options: crate::optimizer::OptimizeOptions,
         /// Fine-grained Cranelift backend options.
         pub cranelift_options: crate::backend::CraneliftOptions,
-        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        #[cfg(any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        ))]
         pub x86_options: crate::backend::X86BackendOptions,
         pub trace: crate::debug::TraceOptions,
         pub diagnostics: crate::RuntimeDiagnostics,
@@ -251,7 +254,10 @@ mod host {
                 four_state: false,
                 optimize_options: opt,
                 cranelift_options: crate::backend::CraneliftOptions::default(),
-                #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+                #[cfg(any(
+                    target_arch = "x86_64",
+                    all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                ))]
                 x86_options: crate::backend::X86BackendOptions::default(),
                 trace: Default::default(),
                 diagnostics: Default::default(),
@@ -389,18 +395,22 @@ mod host {
             self
         }
 
+        #[cfg(any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        ))]
+        pub fn x86_slp(mut self, enable: bool) -> Self {
+            self.options.x86_options.slp = enable;
+            self
+        }
+
+        #[cfg(not(any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        )))]
         pub fn x86_slp(self, enable: bool) -> Self {
-            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-            {
-                let mut this = self;
-                this.options.x86_options.slp = enable;
-                return this;
-            }
-            #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
-            {
-                let _ = enable;
-                self
-            }
+            let _ = enable;
+            self
         }
 
         /// Set fine-grained Cranelift backend options.
@@ -454,7 +464,10 @@ mod host {
             self.options.diagnostics = diagnostics.runtime;
             self.options.optimize_options.diagnostics = diagnostics.sir;
             self.options.cranelift_options.diagnostics = diagnostics.cranelift;
-            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            #[cfg(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            ))]
             {
                 self.options.x86_options.diagnostics = diagnostics.native;
                 if let Some(enabled) = diagnostics.native_tick_loop {
@@ -671,13 +684,19 @@ mod host {
         }
 
         /// Compiles the Veryl source and constructs the simulator.
-        /// Uses a custom native backend on x86-64/AArch64, Cranelift elsewhere.
+        /// Uses a custom native backend on x86-64 and opt-in AArch64, Cranelift elsewhere.
         pub fn build(self) -> Result<Simulator<crate::DefaultBackend>, SimulatorError> {
-            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            #[cfg(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            ))]
             {
                 self.build_native()
             }
-            #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+            #[cfg(not(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            )))]
             {
                 self.build_cranelift()
             }
@@ -730,7 +749,10 @@ mod host {
         }
 
         /// Compiles using the custom native backend for this host architecture.
-        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        #[cfg(any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        ))]
         pub fn build_native(
             self,
         ) -> Result<Simulator<crate::backend::native::NativeBackend>, SimulatorError> {
@@ -804,7 +826,10 @@ mod host {
         }
 
         /// Compiles and runs a testbench using the custom native backend.
-        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        #[cfg(any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        ))]
         pub fn run_test_native(self) -> Result<crate::testbench::TestResult, SimulatorError> {
             run_test_with_sim(self.build_native()?)
         }
@@ -830,9 +855,15 @@ mod host {
         /// while capturing compilation trace data as configured by TraceOptions.
         pub fn build_with_trace(self) -> crate::debug::CompilationTraceResult {
             let mut trace = crate::debug::CompilationTrace::default();
-            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            #[cfg(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            ))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::ElementStrided;
-            #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+            #[cfg(not(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            )))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::Packed;
             let program_res = compile_to_sir_with_layout_mode(
                 &self.sources,
@@ -859,7 +890,10 @@ mod host {
                     run_dead_store_elimination(&mut laid_out, &self.live_signals, &self.options);
                 }
 
-                #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+                #[cfg(any(
+                    target_arch = "x86_64",
+                    all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                ))]
                 let backend = if self.options.trace.mir
                     || !self.options.trace.native_profile_blocks.is_empty()
                 {
@@ -876,7 +910,10 @@ mod host {
                 } else {
                     crate::backend::native::NativeBackend::new(&laid_out, &self.options)?
                 };
-                #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+                #[cfg(not(any(
+                    target_arch = "x86_64",
+                    all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                )))]
                 let backend = JitBackend::new(&laid_out, &self.options, None)?;
 
                 let mut sim =
@@ -953,9 +990,15 @@ mod host {
         /// Compiles the Veryl source and constructs the timed simulation wrapper.
         pub fn build(mut self) -> Result<crate::Simulation, SimulatorError> {
             self.options.emit_triggers = true;
-            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            #[cfg(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            ))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::ElementStrided;
-            #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+            #[cfg(not(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            )))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::Packed;
             let (program, warnings) = compile_to_sir_with_layout_mode(
                 &self.sources,
@@ -979,9 +1022,15 @@ mod host {
             if self.options.dead_store_policy != DeadStorePolicy::Off {
                 run_dead_store_elimination(&mut laid_out, &self.live_signals, &self.options);
             }
-            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            #[cfg(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            ))]
             let backend = crate::backend::native::NativeBackend::new(&laid_out, &self.options)?;
-            #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+            #[cfg(not(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            )))]
             let backend = crate::backend::JitBackend::new(&laid_out, &self.options, None)?;
 
             let mut sim =

--- a/crates/celox/src/simulator/error.rs
+++ b/crates/celox/src/simulator/error.rs
@@ -72,21 +72,39 @@ pub enum CodegenError {
         source: celox_sir::verify::SirVerifyError,
     },
 
-    #[cfg(all(feature = "host-runtime", target_arch = "x86_64"))]
+    #[cfg(all(
+        feature = "host-runtime",
+        any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        )
+    ))]
     #[error("native emission failed: {source}")]
     NativePipeline {
         #[source]
-        source: celox_backend_x86::native::emit::ChainedEmitError,
+        source: crate::backend::native::emit::ChainedEmitError,
     },
 
-    #[cfg(all(feature = "host-runtime", target_arch = "x86_64"))]
+    #[cfg(all(
+        feature = "host-runtime",
+        any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        )
+    ))]
     #[error("native emission failed: {source}")]
     NativeEmission {
         #[source]
-        source: celox_backend_x86::native::emit::EmitError,
+        source: crate::backend::native::emit::EmitError,
     },
 
-    #[cfg(all(feature = "host-runtime", target_arch = "x86_64"))]
+    #[cfg(all(
+        feature = "host-runtime",
+        any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        )
+    ))]
     #[error("failed to allocate executable native memory: {source}")]
     NativeMemory {
         #[source]

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -2518,6 +2518,10 @@ fn test_ff_dynamic_store_sir() {
 }
 
 #[test]
+#[cfg(any(
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+))]
 fn test_ff_packed_bit_select_writes_regression() {
     let code = r#"
     module Top (

--- a/crates/celox/tests/native_exec.rs
+++ b/crates/celox/tests/native_exec.rs
@@ -1,5 +1,8 @@
 //! Integration tests: execute native backend output and verify correctness.
-#![cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#![cfg(any(
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+))]
 
 use celox::{MemoryLayout, MemoryLayoutMode, OptimizedSir, Simulator, SimulatorBuilder};
 

--- a/crates/celox/tests/native_exec.rs
+++ b/crates/celox/tests/native_exec.rs
@@ -1,9 +1,8 @@
 //! Integration tests: execute native backend output and verify correctness.
-#![cfg(target_arch = "x86_64")]
+#![cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 
 use celox::{MemoryLayout, MemoryLayoutMode, OptimizedSir, Simulator, SimulatorBuilder};
 
-#[cfg(target_arch = "x86_64")]
 fn run_single_block_mir(insts: Vec<celox::native_backend::mir::MInst>, vreg_count: usize) -> u64 {
     use celox::native_backend::emit;
     use celox::native_backend::jit_mem;

--- a/crates/celox/tests/native_shift_boundaries.rs
+++ b/crates/celox/tests/native_shift_boundaries.rs
@@ -1,3 +1,8 @@
+#![cfg(any(
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+))]
+
 use celox::{BigUint, Simulator};
 
 #[test]

--- a/crates/celox/tests/test_utils/mod.rs
+++ b/crates/celox/tests/test_utils/mod.rs
@@ -92,6 +92,10 @@ macro_rules! all_backends {
             use super::*;
 
             #[test]
+            #[cfg(any(
+                target_arch = "x86_64",
+                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+            ))]
             $(#[$meta])*
             $(#[$na])*
             #[allow(unused_mut, unused_variables)]

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -22,6 +22,7 @@ Simulator IR (SIR) and backend-independent optimization
 physical state layout
     │
     ├──► native x86-64 code
+    ├──► native AArch64 code
     ├──► Cranelift JIT code
     └──► WebAssembly
              │
@@ -84,6 +85,14 @@ The default x86-64 backend lowers SIR to a private machine IR, performs
 machine-level optimization and register allocation, and emits executable code.
 Its instruction selection, allocation data, and executable-memory management are
 not part of the shared compiler model.
+
+### Native AArch64
+
+The AArch64 backend owns its register policy, ABI lowering, and executable code
+emission. Its machine IR and machine-level optimizations are intentionally
+separate from x86. Both native backends may export opcode-free control-flow,
+use/def, and register-constraint facts to shared allocation algorithms; those
+facts are not a common machine IR.
 
 ### Cranelift
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -94,6 +94,10 @@ separate from x86. Both native backends may export opcode-free control-flow,
 use/def, and register-constraint facts to shared allocation algorithms; those
 facts are not a common machine IR.
 
+The backend is experimental and disabled by default. Enable the
+`experimental-arm64-backend` feature on the `celox` crate to select it as the
+default backend on AArch64; without the feature, AArch64 uses Cranelift.
+
 ### Cranelift
 
 The Cranelift backend translates SIR to Cranelift IR and uses Cranelift's JIT. It

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -40,10 +40,38 @@ not depend on the facade. `celox-backend-x86` and `celox-backend-arm64` depend o
 `celox-backend-common` for allocation machinery; that crate is a compile-time
 library, not another pipeline artifact.
 
-`celox-backend-arm64` is currently a bootstrap backend. It verifies AAPCS64
-calling-convention handling, allocation, and executable instruction emission for
-a small integer MIR, but does not yet lower a complete `LaidOutProgram` or plug
-into the facade's backend selection.
+`celox-backend-arm64` is wired into native backend selection and emits complete
+scalar simulation kernels. Its production path temporarily uses the established
+x86-owned scalar lowering and allocation pipeline as a compatibility bridge.
+The migration target is separate x86 and AArch64 MIR pipelines which export only
+opcode-free allocation facts to `celox-backend-common`.
+
+## Native MIR and allocation boundary
+
+Native backends do not share an instruction enum. Each target owns instruction
+selection, machine optimization, legalization, register classes, ABI rules,
+spill/reload construction, and post-allocation rewriting:
+
+```text
+                         x86 instruction selection -> X86 MIR -> x86 passes
+LaidOutProgram -> SIR --<                                           |
+                         A64 instruction selection -> A64 MIR -> A64 passes
+                                                                     |
+                                      opcode-free allocation facts <-+
+                                                                     |
+                                      shared allocation algorithms
+```
+
+Immediately before a reusable allocation analysis, a backend projects its MIR
+into normalized facts: CFG successors, phi edges, virtual-register uses and
+definitions, fixed operands, clobbers, and copy hints. Shared code must consume
+these facts instead of matching target opcodes. Target drivers remain responsible
+for turning allocation decisions into legal machine instructions.
+
+Optimizations which are genuinely independent of machine instruction shape
+belong in `celox-sir-opt`. DCE or CFG algorithms may be shared over allocation
+facts when their required semantics are fully represented, but common MIR
+opcodes must not be introduced merely to reuse a pass.
 
 The facade's default `host-runtime` feature owns host execution, Cranelift,
 Wasmtime, the x86 backend, and the test macro. WebAssembly bindings disable that

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -40,8 +40,9 @@ not depend on the facade. `celox-backend-x86` and `celox-backend-arm64` depend o
 `celox-backend-common` for allocation machinery; that crate is a compile-time
 library, not another pipeline artifact.
 
-`celox-backend-arm64` is wired into native backend selection and emits complete
-scalar simulation kernels. Its production path temporarily uses the established
+`celox-backend-arm64` is wired into native backend selection behind the
+default-off `experimental-arm64-backend` feature and emits complete scalar
+simulation kernels. Its production path temporarily uses the established
 x86-owned scalar lowering and allocation pipeline as a compatibility bridge.
 The migration target is separate x86 and AArch64 MIR pipelines which export only
 opcode-free allocation facts to `celox-backend-common`.

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -36,7 +36,14 @@ celox-frontend-veryl ──► SymbolicRtl ──► ScheduledRtl
 
 The `celox` crate is the public facade and compiler driver. It wires these phases
 together, selects a backend, and exposes the simulator API. Lower-level crates do
-not depend on the facade.
+not depend on the facade. `celox-backend-x86` and `celox-backend-arm64` depend on
+`celox-backend-common` for allocation machinery; that crate is a compile-time
+library, not another pipeline artifact.
+
+`celox-backend-arm64` is currently a bootstrap backend. It verifies AAPCS64
+calling-convention handling, allocation, and executable instruction emission for
+a small integer MIR, but does not yet lower a complete `LaidOutProgram` or plug
+into the facade's backend selection.
 
 The facade's default `host-runtime` feature owns host execution, Cranelift,
 Wasmtime, the x86 backend, and the test macro. WebAssembly bindings disable that
@@ -56,7 +63,9 @@ for.
 | `celox-sir` | Backend-independent simulator IR and control-flow structures | Target instructions or runtime scheduling |
 | `celox-sir-opt` | Backend-independent SIR analyses and transformation passes | Veryl ASTs or target MIR |
 | `celox-state-layout` | Semantic-to-physical state mapping and layout validation | Optimization policy or executable memory |
-| `celox-backend-x86` | x86 MIR, instruction selection, register allocation, and machine-code emission | Frontend or runtime policy |
+| `celox-backend-common` | Target-independent register sets, constraints, locations, and allocation mechanisms | Target registers, ABI rules, or instruction encodings |
+| `celox-backend-arm64` | AArch64 MIR, register policy, AAPCS64 lowering, and machine-code emission | x86 constraints or frontend policy |
+| `celox-backend-x86` | x86 MIR, instruction selection, target allocation policy, and machine-code emission | Frontend or runtime policy |
 | `celox-backend-cranelift` | Cranelift translation and JIT construction | Frontend or x86-specific MIR |
 | `celox-backend-wasm` | WebAssembly module generation | Host runtime behavior |
 | `celox-testbench` | Source-independent testbench bytecode and values | Veryl AST traversal or simulator memory ownership |
@@ -112,7 +121,9 @@ The following rules define the intended architecture:
 2. Semantic state identities remain distinct from physical memory offsets until
    layout finalization.
 3. SIR optimizations are independent of any concrete backend.
-4. Target MIR, register allocation, and emission remain private to their backend.
+4. Target MIR, allocation policy, ABI handling, and emission remain private to
+   their backend; target-independent allocation mechanisms belong in
+   `celox-backend-common`.
 5. Runtime code depends on backend contracts, not concrete compiler pipelines.
 6. Testbench execution uses source-independent bytecode; only the frontend parses
    Veryl testbench syntax.
@@ -130,6 +141,10 @@ is therefore an architectural change, not a convenient shortcut.
 - A backend-independent instruction or CFG rule belongs in `celox-sir`.
 - A backend-independent transformation belongs in `celox-sir-opt`.
 - A memory-region or address-placement rule belongs in `celox-state-layout`.
+- A target-independent register-allocation mechanism or constraint data type
+  belongs in `celox-backend-common`.
+- An AArch64 instruction, register constraint, or emission rule belongs in
+  `celox-backend-arm64`.
 - An x86 instruction, register constraint, or emission rule belongs in
   `celox-backend-x86`.
 - Event ordering, timed execution, or VCD behavior belongs in `celox-runtime`.

--- a/scripts/setup-arm64-backend-dev.sh
+++ b/scripts/setup-arm64-backend-dev.sh
@@ -37,9 +37,10 @@ Options:
 After setup:
   source target/arm64-dev/activate
   cargo test -p celox-backend-arm64
+  cargo test -p celox --features experimental-arm64-backend
 
-The ARM64 backend crate does not exist yet, so the final command becomes useful
-after it has been scaffolded. For real ARM64 Linux CI, use ubuntu-24.04-arm.
+The facade feature is disabled by default. For real ARM64 Linux CI, use
+ubuntu-24.04-arm.
 EOF
 }
 
@@ -272,7 +273,8 @@ fi
 
 log "current checkout is ready for ARM64 development"
 printf '\n  source %q\n' "$ACTIVATION"
-printf '  cargo test -p celox-backend-arm64\n\n'
+printf '  cargo test -p celox-backend-arm64\n'
+printf '  cargo test -p celox --features experimental-arm64-backend\n\n'
 if [[ "$TARGET" == aarch64-apple-darwin ]]; then
     log "note: this validates macOS ARM64; use ubuntu-24.04-arm for the Linux ABI"
 elif [[ "$EXECUTION" == qemu ]]; then

--- a/scripts/setup-arm64-backend-dev.sh
+++ b/scripts/setup-arm64-backend-dev.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# Prepare the current checkout for native or QEMU-based ARM64 development.
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
+EXECUTION="auto"
+QEMU_CPU_MODEL="cortex-a53"
+INSTALL_DEPS=1
+UPDATE_SUBMODULES=1
+RUN_PROBE=1
+DRY_RUN=0
+OPEN_SHELL=0
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/setup-arm64-backend-dev.sh [options]
+
+Prepare the current Git checkout for ARM64 backend work. On ARM64 Linux/macOS
+the generated code runs natively. On x86-64 Linux the script installs an
+AArch64 cross toolchain and runs target binaries through QEMU user-mode.
+
+This script never creates, switches, updates, or deletes Git branches and
+worktrees. Create the desired development branch before invoking it.
+
+Options:
+  --execution MODE       auto, native, or qemu (default: auto)
+  --qemu-cpu CPU         QEMU CPU model (default: cortex-a53 / ARMv8-A)
+  --no-install-deps      Do not install missing Debian/Ubuntu QEMU packages
+  --no-submodules        Do not initialize submodules in the current checkout
+  --no-probe             Skip compiling and executing the ARM64 smoke test
+  --shell                Enter an interactive target-configured shell afterward
+  --dry-run              Print mutating commands without running them
+  -h, --help             Show this help
+
+After setup:
+  source target/arm64-dev/activate
+  cargo test -p celox-backend-arm64
+
+The ARM64 backend crate does not exist yet, so the final command becomes useful
+after it has been scaffolded. For real ARM64 Linux CI, use ubuntu-24.04-arm.
+EOF
+}
+
+log() {
+    printf '[arm64-dev] %s\n' "$1"
+}
+
+die() {
+    printf '[arm64-dev] error: %s\n' "$1" >&2
+    exit 1
+}
+
+print_command() {
+    local argument
+    printf '[arm64-dev] +'
+    for argument in "$@"; do
+        printf ' %q' "$argument"
+    done
+    printf '\n'
+}
+
+run() {
+    if (( DRY_RUN )); then
+        print_command "$@"
+    else
+        "$@"
+    fi
+}
+
+run_in_repo() {
+    if (( DRY_RUN )); then
+        printf '[arm64-dev] + (cd %q &&' "$REPO_ROOT"
+        local argument
+        for argument in "$@"; do
+            printf ' %q' "$argument"
+        done
+        printf ')\n'
+    else
+        (
+            cd "$REPO_ROOT"
+            "$@"
+        )
+    fi
+}
+
+while (( $# > 0 )); do
+    case "$1" in
+        --execution)
+            (( $# >= 2 )) || die "--execution requires a value"
+            EXECUTION="$2"
+            shift 2
+            ;;
+        --qemu-cpu)
+            (( $# >= 2 )) || die "--qemu-cpu requires a value"
+            QEMU_CPU_MODEL="$2"
+            shift 2
+            ;;
+        --no-install-deps)
+            INSTALL_DEPS=0
+            shift
+            ;;
+        --no-submodules)
+            UPDATE_SUBMODULES=0
+            shift
+            ;;
+        --no-probe)
+            RUN_PROBE=0
+            shift
+            ;;
+        --shell)
+            OPEN_SHELL=1
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown option: $1"
+            ;;
+    esac
+done
+
+case "$EXECUTION" in
+    auto|native|qemu) ;;
+    *) die "--execution must be auto, native, or qemu" ;;
+esac
+
+[[ -n "$QEMU_CPU_MODEL" && "$QEMU_CPU_MODEL" != *[[:space:]]* ]] \
+    || die "--qemu-cpu must be one non-empty CPU model name"
+
+HOST_OS="$(uname -s)"
+HOST_ARCH="$(uname -m)"
+TARGET=""
+QEMU_SYSROOT="/usr/aarch64-linux-gnu"
+
+if [[ "$EXECUTION" == auto ]]; then
+    case "$HOST_OS:$HOST_ARCH" in
+        Linux:aarch64|Linux:arm64|Darwin:arm64)
+            EXECUTION="native"
+            ;;
+        Linux:x86_64|Linux:amd64)
+            EXECUTION="qemu"
+            ;;
+        *)
+            die "cannot run ARM64 on $HOST_OS/$HOST_ARCH; use an ARM64 host or x86-64 Linux with QEMU"
+            ;;
+    esac
+fi
+
+case "$EXECUTION:$HOST_OS:$HOST_ARCH" in
+    native:Linux:aarch64|native:Linux:arm64)
+        TARGET="aarch64-unknown-linux-gnu"
+        ;;
+    native:Darwin:arm64)
+        TARGET="aarch64-apple-darwin"
+        ;;
+    qemu:Linux:x86_64|qemu:Linux:amd64)
+        TARGET="aarch64-unknown-linux-gnu"
+        ;;
+    native:*)
+        die "native execution requires an ARM64 Linux or macOS host"
+        ;;
+    qemu:*)
+        die "the supported QEMU setup requires an x86-64 Debian/Ubuntu Linux host"
+        ;;
+esac
+
+ensure_qemu_dependencies() {
+    local -a missing=()
+    command -v qemu-aarch64 >/dev/null 2>&1 || missing+=(qemu-user)
+    command -v aarch64-linux-gnu-gcc >/dev/null 2>&1 || missing+=(gcc-aarch64-linux-gnu)
+    [[ -e "$QEMU_SYSROOT/lib/ld-linux-aarch64.so.1" ]] || missing+=(libc6-dev-arm64-cross)
+
+    if (( ${#missing[@]} == 0 )); then
+        log "QEMU and the AArch64 GNU sysroot are available"
+        return
+    fi
+    if (( ! INSTALL_DEPS )); then
+        die "missing QEMU dependencies: ${missing[*]}"
+    fi
+    command -v apt-get >/dev/null 2>&1 \
+        || die "missing ${missing[*]}; automatic installation requires apt-get"
+
+    local -a elevate=()
+    if (( EUID != 0 )); then
+        command -v sudo >/dev/null 2>&1 \
+            || die "missing ${missing[*]}; rerun as root or install them manually"
+        elevate=(sudo)
+    fi
+    log "installing QEMU dependencies: ${missing[*]}"
+    run "${elevate[@]}" apt-get update
+    run "${elevate[@]}" apt-get install -y --no-install-recommends "${missing[@]}"
+}
+
+if [[ "$EXECUTION" == qemu ]]; then
+    ensure_qemu_dependencies
+fi
+
+if (( UPDATE_SUBMODULES )); then
+    log "initializing submodules"
+    run_in_repo git submodule update --init --recursive
+fi
+
+command -v rustup >/dev/null 2>&1 || die "rustup is required"
+log "installing Rust target $TARGET"
+run_in_repo rustup target add "$TARGET"
+
+ACTIVATION_DIR="$REPO_ROOT/target/arm64-dev"
+ACTIVATION="$ACTIVATION_DIR/activate"
+
+write_activation() {
+    if (( DRY_RUN )); then
+        log "would write $ACTIVATION"
+        return
+    fi
+
+    mkdir -p "$ACTIVATION_DIR"
+    {
+        printf '# Generated by scripts/setup-arm64-backend-dev.sh\n'
+        printf 'export CELOX_ARM64_EXECUTION=%q\n' "$EXECUTION"
+        printf 'export CELOX_ARM64_TARGET=%q\n' "$TARGET"
+        printf 'export CARGO_BUILD_TARGET=%q\n' "$TARGET"
+        if [[ "$EXECUTION" == qemu ]]; then
+            printf 'export QEMU_CPU=%q\n' "$QEMU_CPU_MODEL"
+            printf 'export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=%q\n' \
+                'aarch64-linux-gnu-gcc'
+            printf 'export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER=%q\n' \
+                "qemu-aarch64 -L $QEMU_SYSROOT"
+        fi
+    } > "$ACTIVATION"
+}
+
+write_activation
+
+run_probe() {
+    local probe_source="$ACTIVATION_DIR/probe.rs"
+    local probe_binary="$ACTIVATION_DIR/probe"
+
+    if (( DRY_RUN )); then
+        log "would compile and run an $TARGET smoke-test binary"
+        return
+    fi
+
+    cat > "$probe_source" <<'EOF'
+fn main() {
+    assert_eq!(std::env::consts::ARCH, "aarch64");
+    println!("ARM64 execution probe passed");
+}
+EOF
+
+    if [[ "$EXECUTION" == qemu ]]; then
+        run_in_repo rustc --target "$TARGET" \
+            -C linker=aarch64-linux-gnu-gcc "$probe_source" -o "$probe_binary"
+        run env QEMU_CPU="$QEMU_CPU_MODEL" \
+            qemu-aarch64 -L "$QEMU_SYSROOT" "$probe_binary"
+    else
+        run_in_repo rustc --target "$TARGET" "$probe_source" -o "$probe_binary"
+        run "$probe_binary"
+    fi
+}
+
+if (( RUN_PROBE )); then
+    run_probe
+fi
+
+log "current checkout is ready for ARM64 development"
+printf '\n  source %q\n' "$ACTIVATION"
+printf '  cargo test -p celox-backend-arm64\n\n'
+if [[ "$TARGET" == aarch64-apple-darwin ]]; then
+    log "note: this validates macOS ARM64; use ubuntu-24.04-arm for the Linux ABI"
+elif [[ "$EXECUTION" == qemu ]]; then
+    log "QEMU CPU model: $QEMU_CPU_MODEL"
+    log "note: use ubuntu-24.04-arm CI for final execution on real ARM64 hardware"
+fi
+
+if (( OPEN_SHELL )); then
+    if (( DRY_RUN )); then
+        log "would open an interactive target-configured shell in $REPO_ROOT"
+    else
+        # shellcheck disable=SC1090
+        source "$ACTIVATION"
+        cd "$REPO_ROOT"
+        exec "${SHELL:-/bin/bash}" -i
+    fi
+fi


### PR DESCRIPTION
## Summary

- add an experimental AArch64 native backend with target-owned MIR, register policy, spilling, coloring, ABI lowering, and machine-code emission
- extract opcode-free allocation facts and reusable register-allocation algorithms into `celox-backend-common` while keeping target-specific MIR and optimization in each backend
- integrate the backend into the simulator behind the default-off `experimental-arm64-backend` feature
- add native/QEMU ARM64 development setup, documentation, benchmark feature forwarding, and ARM64 CI coverage

The AArch64 production path remains explicitly experimental. Without the feature, AArch64 continues to use the Cranelift fallback.

## x86-64 compatibility

The final branch was compared with master using the Heliodor Linux boot design at O2. All six compiler trace artifacts were byte-identical, including the 57,366,625-byte MIR/disassembly dump.

- MIR SHA-256 on both master and this branch: `713b01ca04ba2ec20bee9877408680eb25a83dfbf7a9f1752bf81339c45ae20e`
- compile-only median: master 84.04 s, branch 79.76 s
- no x86-64 generated-code or compile-time regression was observed

## Validation

- booted the Heliodor Linux workload through the ARM64 backend: `cy=aedda0 x3=aa pass=1`
- AArch64/QEMU feature-off facade tests: 28 passed
- AArch64/QEMU feature-on facade tests: 28 passed
- AArch64/QEMU native execution tests: 17 passed
- linked the full Celox integration-test suite on AArch64 with the feature both off and on
- `cargo test --locked -p celox --test native_mir`: 6 passed
- `cargo test --locked -p celox-macros`: 2 passed
- `cargo test --locked -p celox --test macro_test`: 2 passed
- checked `celox` and `celox-bench` on AArch64 with the feature both off and on
- ran scoped host and AArch64 clippy checks
- pre-push hook passed formatting, Cargo checks, Biome, submodule validation, and clean-tree validation
