### PR TITLE
feat(frontend)!: diagnose mutable for loop bounds

### DIFF
--- a/crates/celox-frontend-veryl/src/dynamic_for_check.rs
+++ b/crates/celox-frontend-veryl/src/dynamic_for_check.rs
@@ -128,9 +128,7 @@ impl Effects {
 pub fn check_dynamic_for_bounds(ir: &Ir) -> Vec<FrontendDiagnostic> {
     let mut diagnostics = Vec::new();
     for component in &ir.components {
-        if let Component::Module(module) = component
-            && !module.suppress_unassigned
-        {
+        if let Component::Module(module) = component {
             check_module(module, &mut diagnostics);
         }
     }
@@ -267,8 +265,9 @@ fn check_elaborated_for(
             .iter()
             .any(|write| accesses_conflict(read, write))
     });
-    let bound_has_visible_effect =
-        bound_effects.observable || bound_effects.writes.iter().any(|write| !write.deferred);
+    let bound_has_visible_effect = bound_effects.observable
+        || !bound_effects.state_changes.is_empty()
+        || bound_effects.writes.iter().any(|write| !write.deferred);
     if immediate_conflict || bound_has_visible_effect {
         return;
     }
@@ -1004,8 +1003,9 @@ fn check_for(
             .iter()
             .any(|write| accesses_conflict(read, write))
     });
-    let bound_has_visible_effect =
-        bound_effects.observable || bound_effects.writes.iter().any(|write| !write.deferred);
+    let bound_has_visible_effect = bound_effects.observable
+        || !bound_effects.state_changes.is_empty()
+        || bound_effects.writes.iter().any(|write| !write.deferred);
 
     if body_conflict || bound_has_visible_effect {
         diagnostics.push(FrontendDiagnostic::mutable_for_bound(
@@ -1186,12 +1186,16 @@ fn collect_statement_effects(
                         clock: *clock,
                     });
                 }
-                TbMethod::FileOpen { name, .. } => effects.append(collect_expression_effects(
-                    &name.0,
-                    module,
-                    active_functions,
-                )),
+                TbMethod::FileOpen { name, .. } => {
+                    effects.observable = true;
+                    effects.append(collect_expression_effects(
+                        &name.0,
+                        module,
+                        active_functions,
+                    ));
+                }
                 TbMethod::FileWrite { args } => {
+                    effects.observable = true;
                     for argument in args {
                         effects.append(collect_expression_effects(
                             &argument.0,
@@ -1200,7 +1204,7 @@ fn collect_statement_effects(
                         ));
                     }
                 }
-                TbMethod::FileClose | TbMethod::FileFlush => {}
+                TbMethod::FileClose | TbMethod::FileFlush => effects.observable = true,
             },
             Statement::Unsupported(_) => {
                 effects.mark_unknown("unsupported statement has unknown effects")
@@ -1612,6 +1616,82 @@ mod tests {
         assert!(matches!(
             diagnostics.as_slice(),
             [FrontendDiagnostic::UnknownForBoundEffect { .. }]
+        ));
+    }
+
+    #[test]
+    fn suppress_unassigned_does_not_skip_mutable_bound_checks() {
+        let token = TokenRange::default();
+        let bound_id = VarId::from_raw(1);
+        let mut bound_type = Type::new(TypeKind::Logic);
+        bound_type.set_concrete_width(Shape::new(vec![Some(8)]));
+        let bound_comptime = Comptime {
+            r#type: bound_type.clone(),
+            ..Default::default()
+        };
+        let bound = Expression::Term(Box::new(Factor::Variable(
+            bound_id,
+            VarIndex::default(),
+            VarSelect::default(),
+            bound_comptime.clone(),
+        )));
+        let body_write = Statement::Assign(veryl_analyzer::ir::AssignStatement {
+            dst: vec![AssignDestination {
+                id: bound_id,
+                path: VarPath::default(),
+                index: VarIndex::default(),
+                select: VarSelect::default(),
+                comptime: bound_comptime,
+                token,
+            }],
+            width: Some(8),
+            expr: bound.clone(),
+            token,
+        });
+        let statement = Statement::For(ForStatement {
+            var_id: VarId::default(),
+            var_name: StrId::default(),
+            var_type: Type::default(),
+            range: ForRange::Forward {
+                start: ForBound::Const(0),
+                end: ForBound::Expression(Box::new(bound)),
+                inclusive: false,
+                step: 1,
+            },
+            body: vec![body_write],
+            token,
+        });
+        let variable = Variable {
+            id: bound_id,
+            path: VarPath::default(),
+            kind: VarKind::Variable,
+            r#type: bound_type,
+            value: Vec::new(),
+            assigned: Vec::new(),
+            affiliation: Affiliation::Module,
+            token,
+        };
+        let module = Module {
+            name: StrId::default(),
+            token,
+            ports: HashMap::default(),
+            port_types: HashMap::default(),
+            variables: [(bound_id, variable)].into_iter().collect(),
+            functions: HashMap::default(),
+            declarations: vec![Declaration::new_comb(vec![statement])],
+            suppress_unassigned: true,
+            per_decl_refs: HashMap::default(),
+            assign_tokens: HashMap::default(),
+            ff_table: FfTable::default(),
+        };
+        let ir = Ir {
+            components: vec![Component::Module(module)],
+        };
+
+        let diagnostics = check_dynamic_for_bounds(&ir);
+        assert!(matches!(
+            diagnostics.as_slice(),
+            [FrontendDiagnostic::MutableForBound { .. }]
         ));
     }
 }

--- a/crates/celox-frontend-veryl/src/dynamic_for_check.rs
+++ b/crates/celox-frontend-veryl/src/dynamic_for_check.rs
@@ -1,0 +1,1607 @@
+//! Detects dynamic `for` loops whose continuation bound may be affected while
+//! the loop is executing.
+//!
+//! # Analysis contract
+//!
+//! This is a Celox frontend rule, not a definition of Veryl language
+//! semantics. Its purpose is to reject programs that could observe the
+//! difference between capturing a continuation bound before a loop and
+//! re-evaluating it before every iteration.
+//!
+//! The checker uses a structural, bit-level may-dependency relation. It does
+//! not attempt to prove runtime value equality, branch reachability, event-edge
+//! feasibility, or program termination:
+//!
+//! - selects, slices, concatenations, and fixed shifts preserve their known bit
+//!   mapping;
+//! - bitwise operators relate corresponding operand and result bits;
+//! - arithmetic, dynamic shifts, and other non-local operators conservatively
+//!   affect their whole result;
+//! - a tainted branch condition may affect every write controlled by it;
+//! - a dynamic index may address the whole underlying object; and
+//! - time-advancing operations close transitively over combinational logic,
+//!   generated or gated events, and the FF domains those events may activate.
+//!
+//! The relation is conservative rather than canonical. A sound simplification
+//! may prove that an apparent dependency, such as `x & 0`, cannot affect the
+//! result and remove it. Dependencies which remain after such simplification
+//! may still include algebraically redundant cases. The guarantee below
+//! depends on never discarding a possible influence merely because it is hard
+//! to analyze; those cases must remain dependent or become unknown.
+//!
+//! A known overlap between the continuation-bound reads and the loop body's
+//! immediate or event-mediated write closure is an error. An opaque or
+//! otherwise unresolvable effect is a warning. Therefore, a program accepted
+//! without either diagnostic is guaranteed not to contain such an influence
+//! within Celox's closed-world elaborated execution model.
+//!
+//! Opaque SystemVerilog components, DPI/VPI callbacks, `force`/`release`,
+//! `bind`, and other external mechanisms are outside that guarantee. If Celox
+//! can see an opaque boundary but cannot derive its effects, the checker must
+//! warn rather than silently treating it as pure.
+//!
+//! The analyzer-IR pass runs before lowering captures a bound into a pre-loop
+//! value. It preserves statement provenance, expands known Veryl functions,
+//! uses flattened bit accesses for alias checks, and distinguishes immediate
+//! procedural writes from FF/NBA writes. A second pass after hierarchy
+//! elaboration resolves event-mediated effects to concrete state identities.
+
+use celox_design::{BinaryOp, BitAccess, STABLE_REGION, StateAddr, UnaryOp};
+use celox_sir::{BlockId, ExecutionUnit, RegisterId, SIRInstruction, SIRTerminator};
+use num_traits::ToPrimitive as _;
+use veryl_analyzer::ir::{
+    ArrayLiteralItem, AssignDestination, CasePattern, Component, Declaration, Expression, Factor,
+    ForBound, ForRange, ForStatement, FunctionCall, Ir, Module, Statement, SystemFunctionCall,
+    SystemFunctionKind, TbMethod, VarId, VarIndex, VarSelect,
+};
+use veryl_analyzer::symbol::Affiliation;
+use veryl_parser::resource_table::StrId;
+
+use crate::{
+    FrontendDiagnostic, FusedSirOptimizationHints, HashMap, HashSet, ScheduledRtl,
+    bitaccess::eval_var_select,
+};
+
+#[derive(Clone, Copy)]
+struct Access {
+    id: VarId,
+    bits: BitAccess,
+    /// The write is committed after the enclosing always_ff activation and is
+    /// therefore invisible to the loop's continuation test.
+    deferred: bool,
+}
+
+#[derive(Clone, Copy)]
+enum StateChange {
+    Clock(StrId),
+    Reset { reset: StrId, clock: StrId },
+}
+
+#[derive(Default)]
+struct Effects {
+    reads: Vec<Access>,
+    writes: Vec<Access>,
+    state_changes: Vec<StateChange>,
+    observable: bool,
+    unknown: Option<String>,
+}
+
+impl Effects {
+    fn mark_unknown(&mut self, detail: impl Into<String>) {
+        if self.unknown.is_none() {
+            self.unknown = Some(detail.into());
+        }
+    }
+
+    fn append(&mut self, mut other: Effects) {
+        self.reads.append(&mut other.reads);
+        self.writes.append(&mut other.writes);
+        self.state_changes.append(&mut other.state_changes);
+        self.observable |= other.observable;
+        if self.unknown.is_none() {
+            self.unknown = other.unknown;
+        }
+    }
+
+    fn discard_function_locals(&mut self, module: &Module) {
+        let is_function_local = |id: VarId| {
+            module
+                .variables
+                .get(&id)
+                .is_some_and(|variable| variable.affiliation == Affiliation::Function)
+        };
+        self.reads.retain(|access| !is_function_local(access.id));
+        self.writes.retain(|access| !is_function_local(access.id));
+    }
+}
+
+pub fn check_dynamic_for_bounds(ir: &Ir) -> Vec<FrontendDiagnostic> {
+    let mut diagnostics = Vec::new();
+    for component in &ir.components {
+        if let Component::Module(module) = component
+            && !module.suppress_unassigned
+        {
+            check_module(module, &mut diagnostics);
+        }
+    }
+    diagnostics
+}
+
+/// Resolves testbench time-advancing effects after hierarchy flattening.
+///
+/// At this point every root variable and event domain has a concrete state
+/// identity, and the scheduled SIR contains the transitive FF/comb work for
+/// each event. This lets a loop that advances time be classified as an error
+/// or a pass instead of conservatively warning about every `clock.next()`.
+pub fn check_elaborated_dynamic_for_bounds(
+    scheduled: &ScheduledRtl,
+    module: &Module,
+    hints: &FusedSirOptimizationHints,
+) -> Vec<FrontendDiagnostic> {
+    let source = &scheduled.testbench_source;
+    let Some(statements) = &source.initial_statements else {
+        return Vec::new();
+    };
+    let mut diagnostics = Vec::new();
+    check_elaborated_statements(statements, module, scheduled, hints, &mut diagnostics);
+    for function in module.functions.values() {
+        for body in &function.functions {
+            check_elaborated_statements(
+                &body.statements,
+                module,
+                scheduled,
+                hints,
+                &mut diagnostics,
+            );
+        }
+    }
+    diagnostics
+}
+
+fn check_elaborated_statements(
+    statements: &[Statement],
+    module: &Module,
+    scheduled: &ScheduledRtl,
+    hints: &FusedSirOptimizationHints,
+    diagnostics: &mut Vec<FrontendDiagnostic>,
+) {
+    for statement in statements {
+        match statement {
+            Statement::If(statement) => {
+                check_elaborated_statements(
+                    &statement.true_side,
+                    module,
+                    scheduled,
+                    hints,
+                    diagnostics,
+                );
+                check_elaborated_statements(
+                    &statement.false_side,
+                    module,
+                    scheduled,
+                    hints,
+                    diagnostics,
+                );
+            }
+            Statement::IfReset(statement) => {
+                check_elaborated_statements(
+                    &statement.true_side,
+                    module,
+                    scheduled,
+                    hints,
+                    diagnostics,
+                );
+                check_elaborated_statements(
+                    &statement.false_side,
+                    module,
+                    scheduled,
+                    hints,
+                    diagnostics,
+                );
+            }
+            Statement::Case(statement) => {
+                for arm in &statement.arms {
+                    check_elaborated_statements(&arm.body, module, scheduled, hints, diagnostics);
+                }
+                check_elaborated_statements(
+                    &statement.default,
+                    module,
+                    scheduled,
+                    hints,
+                    diagnostics,
+                );
+            }
+            Statement::For(statement) => {
+                check_elaborated_for(statement, module, scheduled, hints, diagnostics);
+                check_elaborated_statements(&statement.body, module, scheduled, hints, diagnostics);
+            }
+            Statement::Assign(_)
+            | Statement::FunctionCall(_)
+            | Statement::SystemFunctionCall(_)
+            | Statement::TbMethodCall(_)
+            | Statement::Break
+            | Statement::Unsupported(_)
+            | Statement::Null => {}
+        }
+    }
+}
+
+fn check_elaborated_for(
+    statement: &ForStatement,
+    module: &Module,
+    scheduled: &ScheduledRtl,
+    hints: &FusedSirOptimizationHints,
+    diagnostics: &mut Vec<FrontendDiagnostic>,
+) {
+    let continuation_bound = match &statement.range {
+        ForRange::Forward { end, .. } | ForRange::Stepped { end, .. } => end,
+        ForRange::Reverse { start, .. } => start,
+    };
+    let ForBound::Expression(bound) = continuation_bound else {
+        return;
+    };
+
+    let mut active_functions = HashSet::default();
+    let bound_effects = collect_expression_effects(bound, module, &mut active_functions);
+    let mut active_functions = HashSet::default();
+    let body_effects =
+        collect_statement_effects(&statement.body, module, &mut active_functions, false);
+    if body_effects.state_changes.is_empty() {
+        return;
+    }
+
+    // Immediate conflicts were already diagnosed by the analyzer-IR pass.
+    let immediate_conflict = bound_effects.reads.iter().any(|read| {
+        body_effects
+            .writes
+            .iter()
+            .any(|write| accesses_conflict(read, write))
+    });
+    let bound_has_visible_effect =
+        bound_effects.observable || bound_effects.writes.iter().any(|write| !write.deferred);
+    if immediate_conflict || bound_has_visible_effect {
+        return;
+    }
+
+    let mut unknown = bound_effects.unknown.or(body_effects.unknown);
+    let writes =
+        collect_state_change_writes(&body_effects.state_changes, scheduled, hints, &mut unknown);
+    let mut conflict = false;
+    for read in &bound_effects.reads {
+        let Some((address, _)) = scheduled.frontend_lookup.root_variable(read.id) else {
+            unknown.get_or_insert_with(|| {
+                format!(
+                    "bound variable `{}` could not be projected after elaboration",
+                    read.id
+                )
+            });
+            continue;
+        };
+        if writes.iter().any(|write| {
+            write.address == address
+                && write
+                    .bits
+                    .is_none_or(|write_bits| write_bits.overlaps(&read.bits))
+        }) {
+            conflict = true;
+            break;
+        }
+    }
+
+    if conflict {
+        diagnostics.push(FrontendDiagnostic::mutable_for_bound(
+            &statement.token,
+            "the loop body advances an event that may update state read by the continuation bound",
+        ));
+    } else if let Some(detail) = unknown {
+        diagnostics.push(FrontendDiagnostic::unknown_for_bound_effect(
+            &statement.token,
+            detail,
+        ));
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct StateWrite {
+    address: StateAddr,
+    /// `None` denotes a dynamic or otherwise non-static range of this object.
+    bits: Option<BitAccess>,
+}
+
+fn collect_state_change_writes(
+    changes: &[StateChange],
+    scheduled: &ScheduledRtl,
+    hints: &FusedSirOptimizationHints,
+    unknown: &mut Option<String>,
+) -> Vec<StateWrite> {
+    let mut writes = Vec::new();
+    for change in changes {
+        match *change {
+            StateChange::Clock(clock) => {
+                let Some((event, info)) = scheduled.frontend_lookup.root_named_variable(clock)
+                else {
+                    unknown.get_or_insert_with(|| {
+                        format!("clock `{clock}` could not be resolved after elaboration")
+                    });
+                    continue;
+                };
+                push_whole_state_write(event, info.width, &mut writes);
+                push_direct_event_writes(event, scheduled, hints, &mut writes);
+            }
+            StateChange::Reset { reset, clock } => {
+                let Some((reset_signal, reset_info)) =
+                    scheduled.frontend_lookup.root_named_variable(reset)
+                else {
+                    unknown.get_or_insert_with(|| {
+                        format!("reset `{reset}` could not be resolved after elaboration")
+                    });
+                    continue;
+                };
+                push_whole_state_write(reset_signal, reset_info.width, &mut writes);
+
+                let Some((clock_event, clock_info)) =
+                    scheduled.frontend_lookup.root_named_variable(clock)
+                else {
+                    unknown.get_or_insert_with(|| {
+                        format!("reset clock `{clock}` could not be resolved after elaboration")
+                    });
+                    continue;
+                };
+                push_whole_state_write(clock_event, clock_info.width, &mut writes);
+                push_direct_event_writes(clock_event, scheduled, hints, &mut writes);
+            }
+        }
+    }
+    // Advancing one event can update a generated/gated clock through comb
+    // logic, which in turn activates another FF domain in the same timed
+    // step. Mirror the runtime's event-discovery loop and close over both
+    // comb propagation and newly reached event domains.
+    loop {
+        let before = writes.clone();
+        propagate_comb_writes(&scheduled.sir.eval_comb, &mut writes);
+        for event in &scheduled.design.events.ordered_events {
+            if writes
+                .iter()
+                .any(|write| scheduled.design.events.canonical(write.address) == *event)
+            {
+                push_direct_event_writes(*event, scheduled, hints, &mut writes);
+            }
+        }
+        if writes == before {
+            break;
+        }
+    }
+    writes
+}
+
+fn push_whole_state_write(address: StateAddr, width: usize, writes: &mut Vec<StateWrite>) {
+    writes.push(StateWrite {
+        address,
+        bits: width.checked_sub(1).map(|msb| BitAccess::new(0, msb)),
+    });
+}
+
+fn push_direct_event_writes(
+    event: StateAddr,
+    scheduled: &ScheduledRtl,
+    hints: &FusedSirOptimizationHints,
+    writes: &mut Vec<StateWrite>,
+) {
+    let event = scheduled.design.events.canonical(event);
+    if let Some(direct) = hints.direct_ff_writes.get(&event) {
+        for atom in direct {
+            add_state_write(
+                writes,
+                StateWrite {
+                    address: atom.id.absolute_addr(),
+                    bits: Some(atom.access),
+                },
+            );
+        }
+    }
+    for units in [
+        scheduled.sir.eval_apply_ffs.get(&event),
+        scheduled.sir.apply_ffs.get(&event),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        for unit in units {
+            push_unit_stable_writes(unit, writes);
+        }
+    }
+}
+
+fn push_unit_stable_writes(
+    unit: &ExecutionUnit<celox_design::RegionedStateAddr>,
+    writes: &mut Vec<StateWrite>,
+) {
+    for block in unit.blocks.values() {
+        for instruction in &block.instructions {
+            let (address, offset, width) = match instruction {
+                SIRInstruction::Store(address, offset, width, ..)
+                    if address.region == STABLE_REGION =>
+                {
+                    (address.absolute_addr(), offset, *width)
+                }
+                SIRInstruction::Commit(_, address, offset, width, _)
+                    if address.region == STABLE_REGION =>
+                {
+                    (address.absolute_addr(), offset, *width)
+                }
+                _ => continue,
+            };
+            add_state_write(
+                writes,
+                StateWrite {
+                    address,
+                    bits: offset
+                        .constant_bit_offset()
+                        .and_then(|lsb| access_from_offset(lsb, width)),
+                },
+            );
+        }
+    }
+}
+
+fn propagate_comb_writes(
+    units: &[ExecutionUnit<celox_design::RegionedStateAddr>],
+    writes: &mut Vec<StateWrite>,
+) {
+    // A later unit may feed an earlier one when a conservative scheduler path
+    // was retained. Iterate to a fixed point rather than relying on unit order.
+    loop {
+        let before = writes.clone();
+        for unit in units {
+            propagate_comb_unit(unit, writes);
+        }
+        if *writes == before {
+            break;
+        }
+    }
+}
+
+fn propagate_comb_unit(
+    unit: &ExecutionUnit<celox_design::RegionedStateAddr>,
+    writes: &mut Vec<StateWrite>,
+) {
+    let mut registers: HashMap<RegisterId, Vec<BitAccess>> = HashMap::default();
+    let mut control_tainted: HashSet<BlockId> = HashSet::default();
+    let constants = known_usize_constants(unit);
+
+    loop {
+        let mut changed = false;
+        for block in unit.blocks.values() {
+            let block_control = control_tainted.contains(&block.id);
+            for instruction in &block.instructions {
+                match instruction {
+                    SIRInstruction::Imm(..) => {}
+                    SIRInstruction::Load(dst, address, offset, width) => {
+                        let mut taint = load_taint(address.absolute_addr(), offset, *width, writes);
+                        if offset
+                            .dynamic_registers()
+                            .into_iter()
+                            .flatten()
+                            .any(|register| register_is_tainted(&registers, register))
+                        {
+                            taint = whole_register_taint(unit, *dst);
+                        }
+                        changed |= extend_register_taint(&mut registers, *dst, taint);
+                    }
+                    SIRInstruction::Unary(dst, operation, source) => {
+                        let source_taint = registers.get(source).cloned().unwrap_or_default();
+                        let taint = match operation {
+                            UnaryOp::Ident | UnaryOp::ToTwoState | UnaryOp::BitNot
+                                if register_width(unit, *dst) == register_width(unit, *source) =>
+                            {
+                                source_taint
+                            }
+                            _ if !source_taint.is_empty() => whole_register_taint(unit, *dst),
+                            _ => Vec::new(),
+                        };
+                        changed |= extend_register_taint(&mut registers, *dst, taint);
+                    }
+                    SIRInstruction::Binary(dst, lhs, operation, rhs) => {
+                        let lhs_taint = registers.get(lhs).cloned().unwrap_or_default();
+                        let rhs_taint = registers.get(rhs).cloned().unwrap_or_default();
+                        let taint = match operation {
+                            BinaryOp::Shl if rhs_taint.is_empty() => {
+                                constants.get(rhs).map_or_else(
+                                    || {
+                                        if lhs_taint.is_empty() {
+                                            Vec::new()
+                                        } else {
+                                            whole_register_taint(unit, *dst)
+                                        }
+                                    },
+                                    |shift| {
+                                        shift_taint_left(
+                                            &lhs_taint,
+                                            *shift,
+                                            register_width(unit, *dst),
+                                        )
+                                    },
+                                )
+                            }
+                            BinaryOp::Shr if rhs_taint.is_empty() => {
+                                constants.get(rhs).map_or_else(
+                                    || {
+                                        if lhs_taint.is_empty() {
+                                            Vec::new()
+                                        } else {
+                                            whole_register_taint(unit, *dst)
+                                        }
+                                    },
+                                    |shift| {
+                                        shift_taint_right(
+                                            &lhs_taint,
+                                            *shift,
+                                            register_width(unit, *dst),
+                                        )
+                                    },
+                                )
+                            }
+                            BinaryOp::And | BinaryOp::Or | BinaryOp::Xor
+                                if register_width(unit, *dst) == register_width(unit, *lhs)
+                                    && register_width(unit, *dst) == register_width(unit, *rhs) =>
+                            {
+                                lhs_taint.into_iter().chain(rhs_taint).collect()
+                            }
+                            _ if !lhs_taint.is_empty() || !rhs_taint.is_empty() => {
+                                whole_register_taint(unit, *dst)
+                            }
+                            _ => Vec::new(),
+                        };
+                        changed |= extend_register_taint(&mut registers, *dst, taint);
+                    }
+                    SIRInstruction::Concat(dst, sources) => {
+                        let total_width = sources
+                            .iter()
+                            .map(|source| register_width(unit, *source))
+                            .sum::<usize>();
+                        let mut cursor = total_width;
+                        let mut taint = Vec::new();
+                        for source in sources {
+                            let width = register_width(unit, *source);
+                            cursor = cursor.saturating_sub(width);
+                            taint.extend(
+                                registers
+                                    .get(source)
+                                    .into_iter()
+                                    .flatten()
+                                    .filter_map(|bits| shift_access(*bits, cursor)),
+                            );
+                        }
+                        changed |= extend_register_taint(&mut registers, *dst, taint);
+                    }
+                    SIRInstruction::Slice(dst, source, offset, width) => {
+                        let selected = access_from_offset(*offset, *width);
+                        let taint = selected.map_or_else(Vec::new, |selected| {
+                            registers
+                                .get(source)
+                                .into_iter()
+                                .flatten()
+                                .filter_map(|bits| intersect_access(*bits, selected))
+                                .filter_map(|bits| shift_access_down(bits, *offset))
+                                .collect()
+                        });
+                        changed |= extend_register_taint(&mut registers, *dst, taint);
+                    }
+                    SIRInstruction::Mux(dst, condition, then_value, else_value) => {
+                        let taint = if register_is_tainted(&registers, *condition) {
+                            whole_register_taint(unit, *dst)
+                        } else {
+                            registers
+                                .get(then_value)
+                                .into_iter()
+                                .flatten()
+                                .chain(registers.get(else_value).into_iter().flatten())
+                                .copied()
+                                .collect()
+                        };
+                        changed |= extend_register_taint(&mut registers, *dst, taint);
+                    }
+                    SIRInstruction::Store(address, offset, width, source, ..) => {
+                        let address_tainted = offset
+                            .dynamic_registers()
+                            .into_iter()
+                            .flatten()
+                            .any(|register| register_is_tainted(&registers, register));
+                        let source_taint = registers.get(source).cloned().unwrap_or_default();
+                        let state_taint = store_taint(
+                            address.absolute_addr(),
+                            offset,
+                            *width,
+                            &source_taint,
+                            block_control || address_tainted,
+                        );
+                        for write in state_taint {
+                            changed |= add_state_write(writes, write);
+                        }
+                    }
+                    SIRInstruction::Commit(source, destination, offset, width, _) => {
+                        let source_taint =
+                            load_taint(source.absolute_addr(), offset, *width, writes);
+                        let state_taint = store_taint(
+                            destination.absolute_addr(),
+                            offset,
+                            *width,
+                            &source_taint,
+                            block_control,
+                        );
+                        for write in state_taint {
+                            changed |= add_state_write(writes, write);
+                        }
+                    }
+                    SIRInstruction::RuntimeEvent { .. }
+                    | SIRInstruction::CombCaptureEvent { .. }
+                    | SIRInstruction::CombCaptureEnableIfChanged { .. } => {}
+                }
+            }
+
+            match &block.terminator {
+                SIRTerminator::Jump(target, args) => {
+                    let source_registers = registers.clone();
+                    changed |= propagate_block_args(
+                        unit,
+                        &source_registers,
+                        *target,
+                        args,
+                        &mut registers,
+                    );
+                    if block_control {
+                        changed |= control_tainted.insert(*target);
+                    }
+                }
+                SIRTerminator::Branch {
+                    cond,
+                    true_block,
+                    false_block,
+                } => {
+                    for (target, args) in [true_block, false_block] {
+                        let target = *target;
+                        changed |= propagate_block_args(
+                            unit,
+                            &registers.clone(),
+                            target,
+                            args,
+                            &mut registers,
+                        );
+                        if block_control || register_is_tainted(&registers, *cond) {
+                            changed |= control_tainted.insert(target);
+                        }
+                    }
+                }
+                SIRTerminator::Switch {
+                    selector,
+                    cases,
+                    default,
+                } => {
+                    if block_control || register_is_tainted(&registers, *selector) {
+                        for target in cases
+                            .iter()
+                            .map(|case| case.target)
+                            .chain(std::iter::once(*default))
+                        {
+                            changed |= control_tainted.insert(target);
+                        }
+                    }
+                }
+                SIRTerminator::Return | SIRTerminator::Error(_) => {}
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+}
+
+fn known_usize_constants(
+    unit: &ExecutionUnit<celox_design::RegionedStateAddr>,
+) -> HashMap<RegisterId, usize> {
+    unit.blocks
+        .values()
+        .flat_map(|block| &block.instructions)
+        .filter_map(|instruction| match instruction {
+            SIRInstruction::Imm(register, value) if value.mask == 0u8.into() => {
+                value.payload.to_usize().map(|value| (*register, value))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn shift_taint_left(taint: &[BitAccess], shift: usize, width: usize) -> Vec<BitAccess> {
+    let Some(result) = access_from_offset(0, width) else {
+        return Vec::new();
+    };
+    taint
+        .iter()
+        .filter_map(|bits| shift_access(*bits, shift))
+        .filter_map(|bits| intersect_access(bits, result))
+        .collect()
+}
+
+fn shift_taint_right(taint: &[BitAccess], shift: usize, width: usize) -> Vec<BitAccess> {
+    let Some(source) = access_from_offset(shift, width) else {
+        return Vec::new();
+    };
+    taint
+        .iter()
+        .filter_map(|bits| intersect_access(*bits, source))
+        .filter_map(|bits| shift_access_down(bits, shift))
+        .collect()
+}
+
+fn register_width(
+    unit: &ExecutionUnit<celox_design::RegionedStateAddr>,
+    register: RegisterId,
+) -> usize {
+    unit.register_map
+        .get(&register)
+        .map(|r#type| r#type.width())
+        .unwrap_or(0)
+}
+
+fn whole_register_taint(
+    unit: &ExecutionUnit<celox_design::RegionedStateAddr>,
+    register: RegisterId,
+) -> Vec<BitAccess> {
+    access_from_offset(0, register_width(unit, register))
+        .into_iter()
+        .collect()
+}
+
+fn register_is_tainted(
+    registers: &HashMap<RegisterId, Vec<BitAccess>>,
+    register: RegisterId,
+) -> bool {
+    registers
+        .get(&register)
+        .is_some_and(|bits| !bits.is_empty())
+}
+
+fn extend_register_taint(
+    registers: &mut HashMap<RegisterId, Vec<BitAccess>>,
+    register: RegisterId,
+    taint: Vec<BitAccess>,
+) -> bool {
+    let target = registers.entry(register).or_default();
+    let before = target.len();
+    for bits in taint {
+        if !target
+            .iter()
+            .any(|known| known.lsb <= bits.lsb && known.msb >= bits.msb)
+        {
+            target.push(bits);
+        }
+    }
+    target.len() != before
+}
+
+fn propagate_block_args(
+    unit: &ExecutionUnit<celox_design::RegionedStateAddr>,
+    source_registers: &HashMap<RegisterId, Vec<BitAccess>>,
+    target: BlockId,
+    args: &[RegisterId],
+    registers: &mut HashMap<RegisterId, Vec<BitAccess>>,
+) -> bool {
+    let Some(block) = unit.blocks.get(&target) else {
+        return false;
+    };
+    let mut changed = false;
+    for (parameter, argument) in block.params.iter().zip(args) {
+        changed |= extend_register_taint(
+            registers,
+            *parameter,
+            source_registers.get(argument).cloned().unwrap_or_default(),
+        );
+    }
+    changed
+}
+
+fn load_taint(
+    address: StateAddr,
+    offset: &celox_sir::SIROffset,
+    width: usize,
+    writes: &[StateWrite],
+) -> Vec<BitAccess> {
+    let Some(load_bits) = offset
+        .constant_bit_offset()
+        .and_then(|offset| access_from_offset(offset, width))
+    else {
+        return writes
+            .iter()
+            .any(|write| write.address == address)
+            .then(|| access_from_offset(0, width))
+            .flatten()
+            .into_iter()
+            .collect();
+    };
+    writes
+        .iter()
+        .filter(|write| write.address == address)
+        .filter_map(|write| {
+            write
+                .bits
+                .and_then(|bits| intersect_access(bits, load_bits))
+                .or(write.bits.is_none().then_some(load_bits))
+        })
+        .filter_map(|bits| shift_access_down(bits, load_bits.lsb))
+        .collect()
+}
+
+fn store_taint(
+    address: StateAddr,
+    offset: &celox_sir::SIROffset,
+    width: usize,
+    source_taint: &[BitAccess],
+    whole_write: bool,
+) -> Vec<StateWrite> {
+    let Some(lsb) = offset.constant_bit_offset() else {
+        return (whole_write || !source_taint.is_empty())
+            .then_some(StateWrite {
+                address,
+                bits: None,
+            })
+            .into_iter()
+            .collect();
+    };
+    if whole_write {
+        return vec![StateWrite {
+            address,
+            bits: access_from_offset(lsb, width),
+        }];
+    }
+    let source_width = access_from_offset(0, width);
+    source_taint
+        .iter()
+        .filter_map(|bits| source_width.and_then(|range| intersect_access(*bits, range)))
+        .filter_map(|bits| shift_access(bits, lsb))
+        .map(|bits| StateWrite {
+            address,
+            bits: Some(bits),
+        })
+        .collect()
+}
+
+fn add_state_write(writes: &mut Vec<StateWrite>, write: StateWrite) -> bool {
+    if writes.iter().any(|known| {
+        known.address == write.address
+            && match (known.bits, write.bits) {
+                (None, _) => true,
+                (Some(_), None) => false,
+                (Some(known), Some(new)) => known.lsb <= new.lsb && known.msb >= new.msb,
+            }
+    }) {
+        return false;
+    }
+    if write.bits.is_none() {
+        writes.retain(|known| known.address != write.address);
+    }
+    writes.push(write);
+    true
+}
+
+fn access_from_offset(offset: usize, width: usize) -> Option<BitAccess> {
+    width
+        .checked_sub(1)
+        .and_then(|tail| offset.checked_add(tail))
+        .map(|msb| BitAccess::new(offset, msb))
+}
+
+fn intersect_access(lhs: BitAccess, rhs: BitAccess) -> Option<BitAccess> {
+    let lsb = lhs.lsb.max(rhs.lsb);
+    let msb = lhs.msb.min(rhs.msb);
+    (lsb <= msb).then(|| BitAccess::new(lsb, msb))
+}
+
+fn shift_access(bits: BitAccess, offset: usize) -> Option<BitAccess> {
+    Some(BitAccess::new(
+        bits.lsb.checked_add(offset)?,
+        bits.msb.checked_add(offset)?,
+    ))
+}
+
+fn shift_access_down(bits: BitAccess, offset: usize) -> Option<BitAccess> {
+    Some(BitAccess::new(
+        bits.lsb.checked_sub(offset)?,
+        bits.msb.checked_sub(offset)?,
+    ))
+}
+
+fn check_module(module: &Module, diagnostics: &mut Vec<FrontendDiagnostic>) {
+    for declaration in &module.declarations {
+        let statements = match declaration {
+            Declaration::Comb(declaration) => Some((declaration.statements.as_slice(), false)),
+            Declaration::Ff(declaration) => Some((declaration.statements.as_slice(), true)),
+            Declaration::Initial(declaration) => Some((declaration.statements.as_slice(), false)),
+            Declaration::Final(declaration) => Some((declaration.statements.as_slice(), false)),
+            Declaration::Inst(_) | Declaration::Unsupported(_) | Declaration::Null => None,
+        };
+        if let Some((statements, from_ff)) = statements {
+            check_statements(statements, module, diagnostics, from_ff);
+        }
+    }
+
+    for function in module.functions.values() {
+        for body in &function.functions {
+            check_statements(&body.statements, module, diagnostics, false);
+        }
+    }
+}
+
+fn check_statements(
+    statements: &[Statement],
+    module: &Module,
+    diagnostics: &mut Vec<FrontendDiagnostic>,
+    from_ff: bool,
+) {
+    for statement in statements {
+        match statement {
+            Statement::If(statement) => {
+                check_statements(&statement.true_side, module, diagnostics, from_ff);
+                check_statements(&statement.false_side, module, diagnostics, from_ff);
+            }
+            Statement::IfReset(statement) => {
+                check_statements(&statement.true_side, module, diagnostics, from_ff);
+                check_statements(&statement.false_side, module, diagnostics, from_ff);
+            }
+            Statement::Case(statement) => {
+                for arm in &statement.arms {
+                    check_statements(&arm.body, module, diagnostics, from_ff);
+                }
+                check_statements(&statement.default, module, diagnostics, from_ff);
+            }
+            Statement::For(statement) => {
+                check_for(statement, module, diagnostics, from_ff);
+                check_statements(&statement.body, module, diagnostics, from_ff);
+            }
+            Statement::Assign(_)
+            | Statement::FunctionCall(_)
+            | Statement::SystemFunctionCall(_)
+            | Statement::TbMethodCall(_)
+            | Statement::Break
+            | Statement::Unsupported(_)
+            | Statement::Null => {}
+        }
+    }
+}
+
+fn check_for(
+    statement: &ForStatement,
+    module: &Module,
+    diagnostics: &mut Vec<FrontendDiagnostic>,
+    from_ff: bool,
+) {
+    let continuation_bound = match &statement.range {
+        ForRange::Forward { end, .. } | ForRange::Stepped { end, .. } => end,
+        ForRange::Reverse { start, .. } => start,
+    };
+    let ForBound::Expression(bound) = continuation_bound else {
+        return;
+    };
+
+    let mut active_functions = HashSet::default();
+    let bound_effects = collect_expression_effects(bound, module, &mut active_functions);
+    let mut active_functions = HashSet::default();
+    let body_effects =
+        collect_statement_effects(&statement.body, module, &mut active_functions, from_ff);
+
+    let body_conflict = bound_effects.reads.iter().any(|read| {
+        body_effects
+            .writes
+            .iter()
+            .any(|write| accesses_conflict(read, write))
+    });
+    let bound_has_visible_effect =
+        bound_effects.observable || bound_effects.writes.iter().any(|write| !write.deferred);
+
+    if body_conflict || bound_has_visible_effect {
+        diagnostics.push(FrontendDiagnostic::mutable_for_bound(
+            &statement.token,
+            if bound_has_visible_effect {
+                "the continuation bound has an observable effect and would be evaluated a different number of times"
+            } else {
+                "the loop body may immediately modify state read by the continuation bound"
+            },
+        ));
+        return;
+    }
+
+    // Known testbench state transitions are classified after elaboration,
+    // where event and state identities can be compared exactly. Defer any
+    // accompanying unknown effect as well so an exact conflict wins over a
+    // provisional warning.
+    if !body_effects.state_changes.is_empty() {
+        return;
+    }
+
+    let unknown = bound_effects.unknown.or_else(|| {
+        (!bound_effects.reads.is_empty())
+            .then_some(body_effects.unknown)
+            .flatten()
+    });
+    if let Some(detail) = unknown {
+        diagnostics.push(FrontendDiagnostic::unknown_for_bound_effect(
+            &statement.token,
+            detail,
+        ));
+    }
+}
+
+fn accesses_conflict(read: &Access, write: &Access) -> bool {
+    !write.deferred && read.id == write.id && read.bits.overlaps(&write.bits)
+}
+
+fn collect_statement_effects(
+    statements: &[Statement],
+    module: &Module,
+    active_functions: &mut HashSet<VarId>,
+    from_ff: bool,
+) -> Effects {
+    let mut effects = Effects::default();
+    for statement in statements {
+        match statement {
+            Statement::Assign(statement) => {
+                effects.append(collect_expression_effects(
+                    &statement.expr,
+                    module,
+                    active_functions,
+                ));
+                for destination in &statement.dst {
+                    collect_destination_effects(
+                        destination,
+                        module,
+                        active_functions,
+                        &mut effects,
+                        from_ff,
+                    );
+                }
+            }
+            Statement::If(statement) => {
+                effects.append(collect_expression_effects(
+                    &statement.cond,
+                    module,
+                    active_functions,
+                ));
+                effects.append(collect_statement_effects(
+                    &statement.true_side,
+                    module,
+                    active_functions,
+                    from_ff,
+                ));
+                effects.append(collect_statement_effects(
+                    &statement.false_side,
+                    module,
+                    active_functions,
+                    from_ff,
+                ));
+            }
+            Statement::IfReset(statement) => {
+                effects.append(collect_statement_effects(
+                    &statement.true_side,
+                    module,
+                    active_functions,
+                    from_ff,
+                ));
+                effects.append(collect_statement_effects(
+                    &statement.false_side,
+                    module,
+                    active_functions,
+                    from_ff,
+                ));
+            }
+            Statement::Case(statement) => {
+                effects.append(collect_expression_effects(
+                    &statement.case_target,
+                    module,
+                    active_functions,
+                ));
+                for arm in &statement.arms {
+                    for pattern in &arm.patterns {
+                        match pattern {
+                            CasePattern::Eq(expression) => effects.append(
+                                collect_expression_effects(expression, module, active_functions),
+                            ),
+                            CasePattern::Range { lo, hi, .. } => {
+                                effects.append(collect_expression_effects(
+                                    lo,
+                                    module,
+                                    active_functions,
+                                ));
+                                effects.append(collect_expression_effects(
+                                    hi,
+                                    module,
+                                    active_functions,
+                                ));
+                            }
+                        }
+                    }
+                    effects.append(collect_statement_effects(
+                        &arm.body,
+                        module,
+                        active_functions,
+                        from_ff,
+                    ));
+                }
+                effects.append(collect_statement_effects(
+                    &statement.default,
+                    module,
+                    active_functions,
+                    from_ff,
+                ));
+            }
+            Statement::For(statement) => {
+                for bound in dynamic_bounds(&statement.range) {
+                    effects.append(collect_expression_effects(bound, module, active_functions));
+                }
+                effects.append(collect_statement_effects(
+                    &statement.body,
+                    module,
+                    active_functions,
+                    from_ff,
+                ));
+            }
+            Statement::FunctionCall(call) => {
+                collect_call_effects(call, module, active_functions, &mut effects, from_ff);
+            }
+            Statement::SystemFunctionCall(call) => {
+                collect_system_function_effects(call, module, active_functions, &mut effects);
+            }
+            Statement::TbMethodCall(call) => match &call.method {
+                TbMethod::ClockNext { count, period } => {
+                    if let Some(count) = count {
+                        effects.append(collect_expression_effects(count, module, active_functions));
+                    }
+                    if let Some(period) = period {
+                        effects.append(collect_expression_effects(
+                            period,
+                            module,
+                            active_functions,
+                        ));
+                    }
+                    effects.state_changes.push(StateChange::Clock(call.inst));
+                }
+                TbMethod::ResetAssert { clock, duration } => {
+                    if let Some(duration) = duration {
+                        effects.append(collect_expression_effects(
+                            duration,
+                            module,
+                            active_functions,
+                        ));
+                    }
+                    effects.state_changes.push(StateChange::Reset {
+                        reset: call.inst,
+                        clock: *clock,
+                    });
+                }
+                TbMethod::FileOpen { name, .. } => effects.append(collect_expression_effects(
+                    &name.0,
+                    module,
+                    active_functions,
+                )),
+                TbMethod::FileWrite { args } => {
+                    for argument in args {
+                        effects.append(collect_expression_effects(
+                            &argument.0,
+                            module,
+                            active_functions,
+                        ));
+                    }
+                }
+                TbMethod::FileClose | TbMethod::FileFlush => {}
+            },
+            Statement::Unsupported(_) => {
+                effects.mark_unknown("unsupported statement has unknown effects")
+            }
+            Statement::Break | Statement::Null => {}
+        }
+    }
+    effects
+}
+
+fn collect_expression_effects(
+    expression: &Expression,
+    module: &Module,
+    active_functions: &mut HashSet<VarId>,
+) -> Effects {
+    let mut effects = Effects::default();
+    match expression {
+        Expression::Term(factor) => match factor.as_ref() {
+            Factor::Variable(id, index, select, _) => {
+                collect_index_select_effects(index, select, module, active_functions, &mut effects);
+                push_access(module, *id, index, select, false, true, &mut effects);
+            }
+            Factor::FunctionCall(call) => {
+                collect_call_effects(call, module, active_functions, &mut effects, false)
+            }
+            Factor::SystemFunctionCall(call) => {
+                collect_system_function_effects(call, module, active_functions, &mut effects)
+            }
+            Factor::Unknown(_) => {
+                effects.mark_unknown("bound expression contains an unknown value")
+            }
+            Factor::Value(_) | Factor::Anonymous(_) => {}
+        },
+        Expression::Unary(_, expression, _) => {
+            effects.append(collect_expression_effects(
+                expression,
+                module,
+                active_functions,
+            ));
+        }
+        Expression::Binary(lhs, _, rhs, _) => {
+            effects.append(collect_expression_effects(lhs, module, active_functions));
+            effects.append(collect_expression_effects(rhs, module, active_functions));
+        }
+        Expression::Ternary(cond, lhs, rhs, _) => {
+            effects.append(collect_expression_effects(cond, module, active_functions));
+            effects.append(collect_expression_effects(lhs, module, active_functions));
+            effects.append(collect_expression_effects(rhs, module, active_functions));
+        }
+        Expression::Concatenation(elements, _) => {
+            for (expression, repeat) in elements {
+                effects.append(collect_expression_effects(
+                    expression,
+                    module,
+                    active_functions,
+                ));
+                if let Some(repeat) = repeat {
+                    effects.append(collect_expression_effects(repeat, module, active_functions));
+                }
+            }
+        }
+        Expression::StructConstructor(_, fields, _) => {
+            for (_, expression) in fields {
+                effects.append(collect_expression_effects(
+                    expression,
+                    module,
+                    active_functions,
+                ));
+            }
+        }
+        Expression::ArrayLiteral(items, _) => {
+            for item in items {
+                match item {
+                    ArrayLiteralItem::Value(expression, repeat) => {
+                        effects.append(collect_expression_effects(
+                            expression,
+                            module,
+                            active_functions,
+                        ));
+                        if let Some(repeat) = repeat {
+                            effects.append(collect_expression_effects(
+                                repeat,
+                                module,
+                                active_functions,
+                            ));
+                        }
+                    }
+                    ArrayLiteralItem::Defaul(expression) => effects.append(
+                        collect_expression_effects(expression, module, active_functions),
+                    ),
+                }
+            }
+        }
+    }
+    effects
+}
+
+fn collect_call_effects(
+    call: &FunctionCall,
+    module: &Module,
+    active_functions: &mut HashSet<VarId>,
+    effects: &mut Effects,
+    outputs_deferred: bool,
+) {
+    for input in call.inputs.values() {
+        effects.append(collect_expression_effects(input, module, active_functions));
+    }
+    for destinations in call.outputs.values() {
+        for destination in destinations {
+            collect_destination_effects(
+                destination,
+                module,
+                active_functions,
+                effects,
+                outputs_deferred,
+            );
+        }
+    }
+
+    if !active_functions.insert(call.id) {
+        effects.mark_unknown(format!(
+            "recursive function `{}` has unknown effects",
+            call.id
+        ));
+        return;
+    }
+    let body = module.functions.get(&call.id).and_then(|function| {
+        call.index
+            .as_deref()
+            .and_then(|index| function.get_function(index))
+            .or_else(|| function.get_function(&[]))
+    });
+    if let Some(body) = body {
+        let mut function_effects =
+            collect_statement_effects(&body.statements, module, active_functions, false);
+        function_effects.discard_function_locals(module);
+        effects.append(function_effects);
+    } else {
+        effects.mark_unknown(format!("function `{}` could not be resolved", call.id));
+    }
+    active_functions.remove(&call.id);
+}
+
+fn collect_system_function_effects(
+    call: &SystemFunctionCall,
+    module: &Module,
+    active_functions: &mut HashSet<VarId>,
+    effects: &mut Effects,
+) {
+    match &call.kind {
+        SystemFunctionKind::Bits(input)
+        | SystemFunctionKind::Size(input)
+        | SystemFunctionKind::Clog2(input)
+        | SystemFunctionKind::Onehot(input)
+        | SystemFunctionKind::Signed(input)
+        | SystemFunctionKind::Unsigned(input) => effects.append(collect_expression_effects(
+            &input.0,
+            module,
+            active_functions,
+        )),
+        SystemFunctionKind::Readmemh(filename, output) => {
+            effects.append(collect_expression_effects(
+                &filename.0,
+                module,
+                active_functions,
+            ));
+            for destination in &output.0 {
+                collect_destination_effects(destination, module, active_functions, effects, false);
+            }
+        }
+        SystemFunctionKind::Display(arguments) | SystemFunctionKind::Write(arguments) => {
+            effects.observable = true;
+            for argument in arguments {
+                effects.append(collect_expression_effects(
+                    &argument.0,
+                    module,
+                    active_functions,
+                ));
+            }
+        }
+        SystemFunctionKind::Assert { cond, args, .. } => {
+            effects.observable = true;
+            effects.append(collect_expression_effects(
+                &cond.0,
+                module,
+                active_functions,
+            ));
+            for argument in args {
+                effects.append(collect_expression_effects(
+                    &argument.0,
+                    module,
+                    active_functions,
+                ));
+            }
+        }
+        SystemFunctionKind::Finish => effects.observable = true,
+    }
+}
+
+fn collect_destination_effects(
+    destination: &AssignDestination,
+    module: &Module,
+    active_functions: &mut HashSet<VarId>,
+    effects: &mut Effects,
+    from_ff: bool,
+) {
+    collect_index_select_effects(
+        &destination.index,
+        &destination.select,
+        module,
+        active_functions,
+        effects,
+    );
+    let deferred = from_ff
+        && module
+            .variables
+            .get(&destination.id)
+            .is_some_and(|variable| {
+                variable.kind != veryl_analyzer::ir::VarKind::Let
+                    && variable.affiliation != Affiliation::AlwaysFf
+            });
+    push_access(
+        module,
+        destination.id,
+        &destination.index,
+        &destination.select,
+        deferred,
+        false,
+        effects,
+    );
+}
+
+fn collect_index_select_effects(
+    index: &VarIndex,
+    select: &VarSelect,
+    module: &Module,
+    active_functions: &mut HashSet<VarId>,
+    effects: &mut Effects,
+) {
+    for expression in &index.0 {
+        effects.append(collect_expression_effects(
+            expression,
+            module,
+            active_functions,
+        ));
+    }
+    for expression in &select.0 {
+        effects.append(collect_expression_effects(
+            expression,
+            module,
+            active_functions,
+        ));
+    }
+    if let Some((_, expression)) = &select.1 {
+        effects.append(collect_expression_effects(
+            expression,
+            module,
+            active_functions,
+        ));
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn push_access(
+    module: &Module,
+    id: VarId,
+    index: &VarIndex,
+    select: &VarSelect,
+    deferred: bool,
+    read: bool,
+    effects: &mut Effects,
+) {
+    match eval_var_select(module, id, index, select) {
+        Ok(bits) => {
+            let access = Access { id, bits, deferred };
+            if read {
+                effects.reads.push(access);
+            } else {
+                effects.writes.push(access);
+            }
+        }
+        Err(error) => effects.mark_unknown(format!(
+            "the access range of `{id}` could not be resolved: {error}"
+        )),
+    }
+}
+
+fn dynamic_bounds(range: &ForRange) -> impl Iterator<Item = &Expression> {
+    let (start, end) = match range {
+        ForRange::Forward { start, end, .. }
+        | ForRange::Reverse { start, end, .. }
+        | ForRange::Stepped { start, end, .. } => (start, end),
+    };
+    [start, end].into_iter().filter_map(|bound| match bound {
+        ForBound::Expression(expression) => Some(expression.as_ref()),
+        ForBound::Const(_) => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use veryl_analyzer::ir::{
+        Comptime, FfTable, Shape, Type, TypeKind, VarKind, VarPath, Variable,
+    };
+    use veryl_parser::token_range::TokenRange;
+
+    #[test]
+    fn unknown_bound_ir_is_reported_as_a_warning() {
+        // The pinned Veryl analyzer rejects source constructs that currently
+        // lower to Unknown before Celox receives the IR. Build that boundary
+        // state directly so the fail-open warning policy remains covered.
+        let token = TokenRange::default();
+        let statement = Statement::For(ForStatement {
+            var_id: VarId::default(),
+            var_name: StrId::default(),
+            var_type: Type::default(),
+            range: ForRange::Forward {
+                start: ForBound::Const(0),
+                end: ForBound::Expression(Box::new(Expression::Term(Box::new(Factor::Unknown(
+                    Comptime::default(),
+                ))))),
+                inclusive: false,
+                step: 1,
+            },
+            body: Vec::new(),
+            token,
+        });
+        let module = Module {
+            name: StrId::default(),
+            token,
+            ports: HashMap::default(),
+            port_types: HashMap::default(),
+            variables: HashMap::default(),
+            functions: HashMap::default(),
+            declarations: vec![Declaration::new_comb(vec![statement])],
+            suppress_unassigned: false,
+            per_decl_refs: HashMap::default(),
+            assign_tokens: HashMap::default(),
+            ff_table: FfTable::default(),
+        };
+        let ir = Ir {
+            components: vec![Component::Module(module)],
+        };
+
+        let diagnostics = check_dynamic_for_bounds(&ir);
+        assert!(matches!(
+            diagnostics.as_slice(),
+            [FrontendDiagnostic::UnknownForBoundEffect { .. }]
+        ));
+    }
+
+    #[test]
+    fn unknown_body_effect_ir_is_reported_as_a_warning_for_a_mutable_bound() {
+        let token = TokenRange::default();
+        let bound_id = VarId::from_raw(1);
+        let mut bound_type = Type::new(TypeKind::Logic);
+        bound_type.set_concrete_width(Shape::new(vec![Some(8)]));
+        let bound = Expression::Term(Box::new(Factor::Variable(
+            bound_id,
+            VarIndex::default(),
+            VarSelect::default(),
+            Comptime {
+                r#type: bound_type.clone(),
+                ..Default::default()
+            },
+        )));
+        let statement = Statement::For(ForStatement {
+            var_id: VarId::default(),
+            var_name: StrId::default(),
+            var_type: Type::default(),
+            range: ForRange::Forward {
+                start: ForBound::Const(0),
+                end: ForBound::Expression(Box::new(bound)),
+                inclusive: false,
+                step: 1,
+            },
+            body: vec![Statement::Unsupported(token)],
+            token,
+        });
+        let variable = Variable {
+            id: bound_id,
+            path: VarPath::default(),
+            kind: VarKind::Variable,
+            r#type: bound_type,
+            value: Vec::new(),
+            assigned: Vec::new(),
+            affiliation: Affiliation::Module,
+            token,
+        };
+        let module = Module {
+            name: StrId::default(),
+            token,
+            ports: HashMap::default(),
+            port_types: HashMap::default(),
+            variables: [(bound_id, variable)].into_iter().collect(),
+            functions: HashMap::default(),
+            declarations: vec![Declaration::new_comb(vec![statement])],
+            suppress_unassigned: false,
+            per_decl_refs: HashMap::default(),
+            assign_tokens: HashMap::default(),
+            ff_table: FfTable::default(),
+        };
+        let ir = Ir {
+            components: vec![Component::Module(module)],
+        };
+
+        let diagnostics = check_dynamic_for_bounds(&ir);
+        assert!(matches!(
+            diagnostics.as_slice(),
+            [FrontendDiagnostic::UnknownForBoundEffect { .. }]
+        ));
+    }
+}

--- a/crates/celox-frontend-veryl/src/dynamic_for_check.rs
+++ b/crates/celox-frontend-veryl/src/dynamic_for_check.rs
@@ -3,10 +3,20 @@
 //!
 //! # Analysis contract
 //!
-//! This is a Celox frontend rule, not a definition of Veryl language
-//! semantics. Its purpose is to reject programs that could observe the
-//! difference between capturing a continuation bound before a loop and
-//! re-evaluating it before every iteration.
+//! This is a Celox frontend rule, not a choice between capture-on-entry and
+//! per-iteration evaluation as Veryl language semantics. Celox may capture a
+//! continuation bound while emitted synthesizable SystemVerilog evaluates its
+//! loop condition on every iteration. An immediate body write that makes this
+//! difference observable is therefore an error.
+//!
+//! Testbench loops have a different compatibility requirement. Celox currently
+//! executes them only through its native testbench compiler, which captures
+//! the bound before entering the loop; it does not emit a SystemVerilog
+//! testbench. A time-advancing body is consequently not rejected. Instead, the
+//! checker warns only when the advanced event's write closure reaches state
+//! read by the original bound. This identifies fragile code without warning on
+//! unrelated clocks or writes to disjoint state. A procedural `let` can be
+//! used when an explicit snapshot is intended.
 //!
 //! The checker uses a structural, bit-level may-dependency relation. It does
 //! not attempt to prove runtime value equality, branch reachability, event-edge
@@ -29,11 +39,11 @@
 //! depends on never discarding a possible influence merely because it is hard
 //! to analyze; those cases must remain dependent or become unknown.
 //!
-//! A known overlap between the continuation-bound reads and the loop body's
-//! immediate or event-mediated write closure is an error. An opaque or
-//! otherwise unresolvable effect is a warning. Therefore, a program accepted
-//! without either diagnostic is guaranteed not to contain such an influence
-//! within Celox's closed-world elaborated execution model.
+//! A known overlap between continuation-bound reads and immediate body writes
+//! is an error. Event-mediated overlap is a warning, as is an opaque or
+//! otherwise unresolvable effect. More precise event analysis can therefore
+//! turn a conservative warning into a clean pass, but never changes an
+//! immediate-write error.
 //!
 //! Opaque SystemVerilog components, DPI/VPI callbacks, `force`/`release`,
 //! `bind`, and other external mechanisms are outside that guarantee. If Celox
@@ -131,8 +141,8 @@ pub fn check_dynamic_for_bounds(ir: &Ir) -> Vec<FrontendDiagnostic> {
 ///
 /// At this point every root variable and event domain has a concrete state
 /// identity, and the scheduled SIR contains the transitive FF/comb work for
-/// each event. This lets a loop that advances time be classified as an error
-/// or a pass instead of conservatively warning about every `clock.next()`.
+/// each event. This lets a loop that advances time either receive a targeted
+/// warning or pass cleanly instead of warning about every `clock.next()`.
 pub fn check_elaborated_dynamic_for_bounds(
     scheduled: &ScheduledRtl,
     module: &Module,
@@ -289,7 +299,7 @@ fn check_elaborated_for(
     }
 
     if conflict {
-        diagnostics.push(FrontendDiagnostic::mutable_for_bound(
+        diagnostics.push(FrontendDiagnostic::time_advancing_for_bound(
             &statement.token,
             "the loop body advances an event that may update state read by the continuation bound",
         ));

--- a/crates/celox-frontend-veryl/src/error.rs
+++ b/crates/celox-frontend-veryl/src/error.rs
@@ -31,6 +31,96 @@ impl SourceLocation {
     }
 }
 
+/// Celox-specific source diagnostics produced after Veryl analysis but before
+/// source identities are discarded by lowering.
+#[derive(Error, Debug)]
+pub enum FrontendDiagnostic {
+    #[error("Loop continuation bound is not stable: {detail}")]
+    MutableForBound {
+        detail: String,
+        source_location: SourceLocation,
+    },
+
+    #[error("Unable to prove that the loop continuation bound remains unchanged: {detail}")]
+    UnknownForBoundEffect {
+        detail: String,
+        source_location: SourceLocation,
+    },
+}
+
+impl FrontendDiagnostic {
+    pub fn mutable_for_bound(token: &TokenRange, detail: impl Into<String>) -> Self {
+        Self::MutableForBound {
+            detail: detail.into(),
+            source_location: SourceLocation::from_token(token),
+        }
+    }
+
+    pub fn unknown_for_bound_effect(token: &TokenRange, detail: impl Into<String>) -> Self {
+        Self::UnknownForBoundEffect {
+            detail: detail.into(),
+            source_location: SourceLocation::from_token(token),
+        }
+    }
+
+    pub fn is_error(&self) -> bool {
+        matches!(self, Self::MutableForBound { .. })
+    }
+
+    fn source_location(&self) -> &SourceLocation {
+        match self {
+            Self::MutableForBound {
+                source_location, ..
+            }
+            | Self::UnknownForBoundEffect {
+                source_location, ..
+            } => source_location,
+        }
+    }
+}
+
+impl miette::Diagnostic for FrontendDiagnostic {
+    fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        Some(Box::new(match self {
+            Self::MutableForBound { .. } => "mutable_for_bound",
+            Self::UnknownForBoundEffect { .. } => "unknown_for_bound_effect",
+        }))
+    }
+
+    fn severity(&self) -> Option<miette::Severity> {
+        Some(if self.is_error() {
+            miette::Severity::Error
+        } else {
+            miette::Severity::Warning
+        })
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        Some(Box::new(match self {
+            Self::MutableForBound { .. } => {
+                "copy the bound to a value that is not modified by the loop body"
+            }
+            Self::UnknownForBoundEffect { .. } => {
+                "avoid opaque or time-advancing calls in the loop, or make the bound independent of mutable state"
+            }
+        }))
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(&self.source_location().source)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+        let location = self.source_location();
+        Some(Box::new(std::iter::once(
+            miette::LabeledSpan::new_with_span(
+                Some("loop with an unstable continuation bound".to_string()),
+                location.span,
+            ),
+        )))
+    }
+}
+
 /// The compilation phase where an unsupported feature was encountered.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LoweringPhase {

--- a/crates/celox-frontend-veryl/src/error.rs
+++ b/crates/celox-frontend-veryl/src/error.rs
@@ -41,6 +41,12 @@ pub enum FrontendDiagnostic {
         source_location: SourceLocation,
     },
 
+    #[error("Loop continuation bound may change while simulation time advances: {detail}")]
+    TimeAdvancingForBound {
+        detail: String,
+        source_location: SourceLocation,
+    },
+
     #[error("Unable to prove that the loop continuation bound remains unchanged: {detail}")]
     UnknownForBoundEffect {
         detail: String,
@@ -63,6 +69,13 @@ impl FrontendDiagnostic {
         }
     }
 
+    pub fn time_advancing_for_bound(token: &TokenRange, detail: impl Into<String>) -> Self {
+        Self::TimeAdvancingForBound {
+            detail: detail.into(),
+            source_location: SourceLocation::from_token(token),
+        }
+    }
+
     pub fn is_error(&self) -> bool {
         matches!(self, Self::MutableForBound { .. })
     }
@@ -70,6 +83,9 @@ impl FrontendDiagnostic {
     fn source_location(&self) -> &SourceLocation {
         match self {
             Self::MutableForBound {
+                source_location, ..
+            }
+            | Self::TimeAdvancingForBound {
                 source_location, ..
             }
             | Self::UnknownForBoundEffect {
@@ -83,6 +99,7 @@ impl miette::Diagnostic for FrontendDiagnostic {
     fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
         Some(Box::new(match self {
             Self::MutableForBound { .. } => "mutable_for_bound",
+            Self::TimeAdvancingForBound { .. } => "time_advancing_for_bound",
             Self::UnknownForBoundEffect { .. } => "unknown_for_bound_effect",
         }))
     }
@@ -99,6 +116,9 @@ impl miette::Diagnostic for FrontendDiagnostic {
         Some(Box::new(match self {
             Self::MutableForBound { .. } => {
                 "copy the bound to a value that is not modified by the loop body"
+            }
+            Self::TimeAdvancingForBound { .. } => {
+                "copy the bound to a procedural let before entering the loop"
             }
             Self::UnknownForBoundEffect { .. } => {
                 "avoid opaque or time-advancing calls in the loop, or make the bound independent of mutable state"

--- a/crates/celox-frontend-veryl/src/lib.rs
+++ b/crates/celox-frontend-veryl/src/lib.rs
@@ -10,6 +10,7 @@ pub mod case;
 mod config;
 pub mod context_width;
 mod design_assembly;
+mod dynamic_for_check;
 mod error;
 pub mod ff;
 pub mod flattening;
@@ -26,7 +27,8 @@ mod types;
 
 pub use config::BuildConfig;
 pub use design_assembly::schedule_symbolic_rtl;
-pub use error::{LoweringPhase, ParserError, SourceLocation};
+pub use dynamic_for_check::{check_dynamic_for_bounds, check_elaborated_dynamic_for_bounds};
+pub use error::{FrontendDiagnostic, LoweringPhase, ParserError, SourceLocation};
 pub use global_ff::{
     FfClockRecipe, FfRuntimeRelocation, SharedClockLowering, build_ff_clock_recipes,
 };

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -600,11 +600,11 @@ fn load_project_sources(
     Ok((sources, metadata, celox_cfg))
 }
 
-/// Format analyzer warnings as a JSON array of strings.
+/// Format compilation warnings as a JSON array of strings.
 ///
 /// Uses `render_diagnostic` to include source location and span information,
 /// matching the format used for error messages.
-fn format_warnings_json(warnings: &[veryl_analyzer::AnalyzerError]) -> String {
+fn format_warnings_json(warnings: &[celox::CompilationWarning]) -> String {
     let msgs: Vec<String> = warnings
         .iter()
         .map(|w| celox::render_diagnostic(w))
@@ -1030,7 +1030,7 @@ impl NativeSimulatorHandle {
         self.hierarchy_json.clone()
     }
 
-    /// Returns analyzer warnings as a JSON array of strings.
+    /// Returns compilation warnings as a JSON array of strings.
     #[napi(getter)]
     pub fn warnings_json(&self) -> String {
         self.warnings_json.clone()
@@ -1283,7 +1283,7 @@ impl NativeSimulationHandle {
         self.hierarchy_json.clone()
     }
 
-    /// Returns analyzer warnings as a JSON array of strings.
+    /// Returns compilation warnings as a JSON array of strings.
     #[napi(getter)]
     pub fn warnings_json(&self) -> String {
         self.warnings_json.clone()
@@ -1587,7 +1587,7 @@ impl NativeSimulatorHandle {
         self.hierarchy_json.clone()
     }
 
-    /// Returns analyzer warnings as a JSON array of strings.
+    /// Returns compilation warnings as a JSON array of strings.
     #[napi(getter)]
     pub fn warnings_json(&self) -> String {
         self.warnings_json.clone()

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -17,7 +17,7 @@ pub use backend::{
     EventHandle, LayoutRequirements, MemoryLayout, MemoryLayoutMode, SimBackend, get_byte_size,
 };
 pub use celox_design::{ElaboratedDesign, EventTopology, RuntimeSchema};
-pub use celox_frontend_veryl::{LoweringPhase, ParserError};
+pub use celox_frontend_veryl::{FrontendDiagnostic, LoweringPhase, ParserError};
 pub use celox_slt::scheduler::SchedulerError;
 pub use debug::{CompilationTrace, NativeProfileBlock, TraceOptions};
 pub use diagnostics::RuntimeDiagnostics;
@@ -34,7 +34,7 @@ pub use optimizer::OptimizeOptions;
 pub use optimizer::SirDiagnostics;
 pub use optimizer::SirPass;
 pub use simulator::render_diagnostic;
-pub use simulator::{CodegenError, SimulatorError, SimulatorErrorKind};
+pub use simulator::{CodegenError, CompilationWarning, SimulatorError, SimulatorErrorKind};
 pub use veryl_metadata::{ClockType, ResetType};
 
 #[cfg(feature = "host-runtime")]

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -307,7 +307,13 @@ pub fn parse(
     optimize_options: &crate::optimizer::OptimizeOptions,
     diagnostics: &crate::RuntimeDiagnostics,
     preserve_element_storage_layout: bool,
-) -> Result<crate::ir::OptimizedSir, ParserError> {
+) -> Result<
+    (
+        crate::ir::OptimizedSir,
+        Vec<celox_frontend_veryl::FrontendDiagnostic>,
+    ),
+    ParserError,
+> {
     debug_assert!(
         loop_provenance.is_consistent_with(ir),
         "loop provenance must describe the analyzer IR passed to the parser"
@@ -354,6 +360,37 @@ pub fn parse(
         trace.absorb_frontend(frontend_trace);
     }
     let mut scheduled = scheduled?;
+    let root_module_name = scheduled
+        .scheduled
+        .frontend_lookup
+        .root_instance_and_module()
+        .and_then(|(_, module)| {
+            scheduled
+                .scheduled
+                .frontend_lookup
+                .module_names
+                .get(&module)
+                .copied()
+        });
+    let dynamic_for_diagnostics = root_module_name
+        .and_then(|root_module_name| {
+            ir.components.iter().find_map(|component| match component {
+                veryl_analyzer::ir::Component::Module(module)
+                    if module.name == root_module_name =>
+                {
+                    Some(module)
+                }
+                _ => None,
+            })
+        })
+        .map(|module| {
+            celox_frontend_veryl::check_elaborated_dynamic_for_bounds(
+                &scheduled.scheduled,
+                module,
+                &scheduled.fused_optimization_hints,
+            )
+        })
+        .unwrap_or_default();
     apply_fused_optimization_hints(&mut scheduled.scheduled, scheduled.fused_optimization_hints)?;
     scheduled.scheduled.inject_triggers();
     let scheduled = scheduled.scheduled;
@@ -401,5 +438,5 @@ pub fn parse(
         t.post_optimized_sir = Some(program.clone());
     }
 
-    Ok(program)
+    Ok((program, dynamic_for_diagnostics))
 }

--- a/crates/celox/src/simulation.rs
+++ b/crates/celox/src/simulation.rs
@@ -152,8 +152,8 @@ impl<B: SimBackend> Simulation<B> {
         Self { simulator, state }
     }
 
-    /// Returns analyzer warnings emitted during compilation.
-    pub fn warnings(&self) -> &[veryl_analyzer::AnalyzerError] {
+    /// Returns warnings emitted during compilation.
+    pub fn warnings(&self) -> &[crate::CompilationWarning] {
         self.simulator.warnings()
     }
 

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -5,7 +5,7 @@ pub use builder::compile_to_sir;
 #[cfg(feature = "host-runtime")]
 pub use builder::{DeadStorePolicy, SimulatorBuilder, SimulatorOptions};
 pub use error::render_diagnostic;
-pub use error::{CodegenError, SimulatorError, SimulatorErrorKind};
+pub use error::{CodegenError, CompilationWarning, SimulatorError, SimulatorErrorKind};
 
 #[cfg(feature = "host-runtime")]
 mod host {
@@ -68,7 +68,7 @@ mod host {
         pub(crate) program: RuntimeProgram,
         pub(crate) vcd_writer: Option<crate::VcdWriter>,
         pub(crate) dirty: bool,
-        pub(crate) warnings: Vec<veryl_analyzer::AnalyzerError>,
+        pub(crate) warnings: Vec<CompilationWarning>,
         runtime_event_read_seq: Arc<AtomicU64>,
         runtime_event_drain_active: Arc<AtomicBool>,
         comb_observer_snapshots: Vec<Vec<(BigUint, BigUint)>>,
@@ -495,7 +495,7 @@ mod host {
         pub fn with_backend_and_program(
             backend: B,
             program: RuntimeProgram,
-            warnings: Vec<veryl_analyzer::AnalyzerError>,
+            warnings: Vec<CompilationWarning>,
         ) -> Self {
             let mut sim = Self {
                 backend,
@@ -780,8 +780,8 @@ mod host {
             &self.backend
         }
 
-        /// Returns analyzer warnings emitted during compilation.
-        pub fn warnings(&self) -> &[veryl_analyzer::AnalyzerError] {
+        /// Returns warnings emitted during compilation.
+        pub fn warnings(&self) -> &[CompilationWarning] {
             &self.warnings
         }
 

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -8,7 +8,10 @@ use veryl_parser::Parser;
 use veryl_parser::resource_table;
 
 use crate::parser::BuildConfig;
-use crate::{ParserError, SimulatorError, SimulatorErrorKind, ir::OptimizedSir, parser};
+use crate::{
+    CompilationWarning, FrontendDiagnostic, ParserError, SimulatorError, SimulatorErrorKind,
+    ir::OptimizedSir, parser,
+};
 
 fn analyze(
     sources: &[(&str, &Path)],
@@ -32,7 +35,11 @@ fn analyze(
     optimize_options: &crate::optimizer::OptimizeOptions,
     diagnostics: &crate::RuntimeDiagnostics,
     preserve_element_storage_layout: bool,
-) -> (Result<OptimizedSir, ParserError>, Vec<AnalyzerError>) {
+) -> (
+    Result<OptimizedSir, ParserError>,
+    Vec<AnalyzerError>,
+    Vec<FrontendDiagnostic>,
+) {
     symbol_table::clear();
     attribute_table::clear();
 
@@ -81,6 +88,11 @@ fn analyze(
         ));
     }
     errors.append(&mut Analyzer::analyze_post_pass2(&ir));
+    let mut frontend_diagnostics = if errors.iter().any(AnalyzerError::is_error) {
+        Vec::new()
+    } else {
+        celox_frontend_veryl::check_dynamic_for_bounds(&ir)
+    };
     let loop_provenance = loop_sources.match_unrolled(&ir);
 
     let top = veryl_parser::resource_table::insert_str(top);
@@ -104,14 +116,18 @@ fn analyze(
         optimize_options,
         diagnostics,
         preserve_element_storage_layout,
-    );
-    (sir, errors)
+    )
+    .map(|(sir, mut elaborated_diagnostics)| {
+        frontend_diagnostics.append(&mut elaborated_diagnostics);
+        sir
+    });
+    (sir, errors, frontend_diagnostics)
 }
 
 /// Compile Veryl source code to the SIR (Simulation IR) representation.
 ///
 /// This is the shared compilation pipeline used by all backends.
-/// Returns verified optimized SIR and any analyzer warnings on success.
+/// Returns verified optimized SIR and any compilation warnings on success.
 pub fn compile_to_sir(
     sources: &[(&str, &Path)],
     top: &str,
@@ -132,7 +148,7 @@ pub fn compile_to_sir(
     reset_type: Option<ResetType>,
     param_overrides: &[(String, u64)],
     optimize_options: &crate::optimizer::OptimizeOptions,
-) -> Result<(OptimizedSir, Vec<AnalyzerError>), SimulatorError> {
+) -> Result<(OptimizedSir, Vec<CompilationWarning>), SimulatorError> {
     compile_to_sir_with_layout_mode(
         sources,
         top,
@@ -173,8 +189,8 @@ fn compile_to_sir_with_layout_mode(
     optimize_options: &crate::optimizer::OptimizeOptions,
     diagnostics: &crate::RuntimeDiagnostics,
     layout_mode: crate::backend::memory_layout::MemoryLayoutMode,
-) -> Result<(OptimizedSir, Vec<AnalyzerError>), SimulatorError> {
-    let (sir, errors) = analyze(
+) -> Result<(OptimizedSir, Vec<CompilationWarning>), SimulatorError> {
+    let (sir, errors, frontend_diagnostics) = analyze(
         sources,
         top,
         ignored_loops,
@@ -190,10 +206,29 @@ fn compile_to_sir_with_layout_mode(
         diagnostics,
         layout_mode == crate::backend::memory_layout::MemoryLayoutMode::ElementStrided,
     );
-    let (real_errors, warnings): (Vec<_>, Vec<_>) = errors.into_iter().partition(|e| e.is_error());
+    let (real_errors, analyzer_warnings): (Vec<_>, Vec<_>) =
+        errors.into_iter().partition(AnalyzerError::is_error);
+    let (frontend_errors, frontend_warnings): (Vec<_>, Vec<_>) = frontend_diagnostics
+        .into_iter()
+        .partition(FrontendDiagnostic::is_error);
+    let warnings = analyzer_warnings
+        .into_iter()
+        .map(CompilationWarning::Analyzer)
+        .chain(
+            frontend_warnings
+                .into_iter()
+                .map(CompilationWarning::Frontend),
+        )
+        .collect::<Vec<_>>();
     if !real_errors.is_empty() {
         return Err(
             SimulatorError::new(SimulatorErrorKind::Analyzer(real_errors)).with_warnings(warnings),
+        );
+    }
+    if !frontend_errors.is_empty() {
+        return Err(
+            SimulatorError::new(SimulatorErrorKind::Frontend(frontend_errors))
+                .with_warnings(warnings),
         );
     }
     match sir {
@@ -633,7 +668,7 @@ mod host {
         ) -> Result<
             (
                 crate::ir::LaidOutProgram,
-                Vec<veryl_analyzer::AnalyzerError>,
+                Vec<CompilationWarning>,
                 SimulatorOptions,
                 Option<std::path::PathBuf>,
             ),

--- a/crates/celox/src/simulator/error.rs
+++ b/crates/celox/src/simulator/error.rs
@@ -37,11 +37,74 @@ fn render_analyzer_error(error: &veryl_analyzer::AnalyzerError) -> String {
     rendered
 }
 
+/// A non-fatal source diagnostic retained by a successfully built simulator.
+#[derive(Debug)]
+pub enum CompilationWarning {
+    Analyzer(veryl_analyzer::AnalyzerError),
+    Frontend(celox_frontend_veryl::FrontendDiagnostic),
+}
+
+impl fmt::Display for CompilationWarning {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Analyzer(diagnostic) => diagnostic.fmt(f),
+            Self::Frontend(diagnostic) => diagnostic.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for CompilationWarning {}
+
+impl miette::Diagnostic for CompilationWarning {
+    fn code<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
+        match self {
+            Self::Analyzer(diagnostic) => miette::Diagnostic::code(diagnostic),
+            Self::Frontend(diagnostic) => miette::Diagnostic::code(diagnostic),
+        }
+    }
+
+    fn severity(&self) -> Option<miette::Severity> {
+        match self {
+            Self::Analyzer(diagnostic) => miette::Diagnostic::severity(diagnostic),
+            Self::Frontend(diagnostic) => miette::Diagnostic::severity(diagnostic),
+        }
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
+        match self {
+            Self::Analyzer(diagnostic) => miette::Diagnostic::help(diagnostic),
+            Self::Frontend(diagnostic) => miette::Diagnostic::help(diagnostic),
+        }
+    }
+
+    fn url<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
+        match self {
+            Self::Analyzer(diagnostic) => miette::Diagnostic::url(diagnostic),
+            Self::Frontend(diagnostic) => miette::Diagnostic::url(diagnostic),
+        }
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        match self {
+            Self::Analyzer(diagnostic) => miette::Diagnostic::source_code(diagnostic),
+            Self::Frontend(diagnostic) => miette::Diagnostic::source_code(diagnostic),
+        }
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+        match self {
+            Self::Analyzer(diagnostic) => miette::Diagnostic::labels(diagnostic),
+            Self::Frontend(diagnostic) => miette::Diagnostic::labels(diagnostic),
+        }
+    }
+}
+
 /// The specific kind of simulator error.
 #[derive(Debug)]
 pub enum SimulatorErrorKind {
     SIRParser(crate::ParserError),
     Analyzer(Vec<veryl_analyzer::AnalyzerError>),
+    Frontend(Vec<celox_frontend_veryl::FrontendDiagnostic>),
     Runtime(crate::RuntimeErrorCode),
     Codegen(CodegenError),
 }
@@ -133,11 +196,11 @@ impl CodegenError {
     }
 }
 
-/// A simulator error that may also carry accumulated analyzer warnings.
+/// A simulator error that may also carry accumulated compilation warnings.
 #[derive(Debug)]
 pub struct SimulatorError {
     kind: Box<SimulatorErrorKind>,
-    warnings: Vec<veryl_analyzer::AnalyzerError>,
+    warnings: Vec<CompilationWarning>,
 }
 
 impl SimulatorError {
@@ -150,7 +213,7 @@ impl SimulatorError {
     }
 
     /// Attach warnings to this error.
-    pub fn with_warnings(mut self, warnings: Vec<veryl_analyzer::AnalyzerError>) -> Self {
+    pub fn with_warnings(mut self, warnings: Vec<CompilationWarning>) -> Self {
         self.warnings = warnings;
         self
     }
@@ -160,8 +223,8 @@ impl SimulatorError {
         &self.kind
     }
 
-    /// Returns accumulated analyzer warnings.
-    pub fn warnings(&self) -> &[veryl_analyzer::AnalyzerError] {
+    /// Returns accumulated compilation warnings.
+    pub fn warnings(&self) -> &[CompilationWarning] {
         &self.warnings
     }
 }
@@ -176,6 +239,14 @@ impl fmt::Display for SimulatorError {
                         f.write_str("\n")?;
                     }
                     f.write_str(&render_analyzer_error(e))?;
+                }
+            }
+            SimulatorErrorKind::Frontend(diagnostics) => {
+                for (i, diagnostic) in diagnostics.iter().enumerate() {
+                    if i > 0 {
+                        f.write_str("\n")?;
+                    }
+                    f.write_str(&render_diagnostic(diagnostic))?;
                 }
             }
             SimulatorErrorKind::Runtime(e) => write!(f, "Runtime error: {e}")?,

--- a/crates/celox/tests/error_readability.rs
+++ b/crates/celox/tests/error_readability.rs
@@ -134,3 +134,49 @@ fn test_sv_module_unsupported_error_readability() {
     let err = res.unwrap_err().to_string();
     assert_snapshot!(err);
 }
+
+#[test]
+fn test_mutable_for_bound_error_readability() {
+    let code = r#"
+        module Top {
+            var limit: logic<8>;
+            always_comb {
+                limit = 4;
+                for _i in 0..limit {
+                    limit = 1;
+                }
+            }
+        }
+    "#;
+    let error = Simulator::builder(code, "Top").build().unwrap_err();
+    assert_snapshot!(error.to_string());
+}
+
+#[test]
+fn test_elaborated_mutable_for_bound_error_readability() {
+    let code = r#"
+        module Counter (
+            clk: input clock,
+            count: output logic<8>,
+        ) {
+            always_ff {
+                count += 1;
+            }
+        }
+
+        #[test(t)]
+        module t {
+            inst clk: $tb::clock_gen;
+            var count: logic<8>;
+            inst dut: Counter (clk, count);
+            initial {
+                for _i in 0..count {
+                    clk.next();
+                }
+                $finish();
+            }
+        }
+    "#;
+    let error = Simulator::builder(code, "t").build().unwrap_err();
+    assert_snapshot!(error.to_string());
+}

--- a/crates/celox/tests/error_readability.rs
+++ b/crates/celox/tests/error_readability.rs
@@ -1,4 +1,6 @@
-use celox::{Simulator, SimulatorBuilder};
+use celox::{
+    CompilationWarning, FrontendDiagnostic, Simulator, SimulatorBuilder, render_diagnostic,
+};
 use insta::assert_snapshot;
 
 #[test]
@@ -153,7 +155,7 @@ fn test_mutable_for_bound_error_readability() {
 }
 
 #[test]
-fn test_elaborated_mutable_for_bound_error_readability() {
+fn test_time_advancing_for_bound_warning_readability() {
     let code = r#"
         module Counter (
             clk: input clock,
@@ -177,6 +179,16 @@ fn test_elaborated_mutable_for_bound_error_readability() {
             }
         }
     "#;
-    let error = Simulator::builder(code, "t").build().unwrap_err();
-    assert_snapshot!(error.to_string());
+    let simulator = Simulator::builder(code, "t").build().unwrap();
+    let warning = simulator
+        .warnings()
+        .iter()
+        .find(|warning| {
+            matches!(
+                warning,
+                CompilationWarning::Frontend(FrontendDiagnostic::TimeAdvancingForBound { .. })
+            )
+        })
+        .expect("expected a time-advancing continuation-bound warning");
+    assert_snapshot!(render_diagnostic(warning));
 }

--- a/crates/celox/tests/mutable_for_bound.rs
+++ b/crates/celox/tests/mutable_for_bound.rs
@@ -17,6 +17,19 @@ fn expect_mutable_bound_error(code: &str, top: &str) {
     );
 }
 
+fn expect_time_advancing_bound_warning(code: &str, top: &str) {
+    let simulator = Simulator::builder(code, top)
+        .build()
+        .expect("time-advancing continuation bounds are warnings, not errors");
+    assert!(
+        simulator.warnings().iter().any(|warning| matches!(
+            warning,
+            CompilationWarning::Frontend(FrontendDiagnostic::TimeAdvancingForBound { .. })
+        )),
+        "expected a time-advancing continuation-bound warning"
+    );
+}
+
 #[test]
 fn direct_and_nested_body_writes_are_errors() {
     expect_mutable_bound_error(
@@ -250,7 +263,7 @@ module Top (
 }
 
 #[test]
-fn time_advancing_body_effects_are_errors_when_the_bound_is_in_the_event_write_closure() {
+fn time_advancing_body_effects_warn_when_the_bound_is_in_the_event_write_closure() {
     let code = r#"
 module Counter (
     clk: input clock,
@@ -280,7 +293,7 @@ module t {
     }
 }
 "#;
-    expect_mutable_bound_error(code, "t");
+    expect_time_advancing_bound_warning(code, "t");
 }
 
 #[test]
@@ -360,7 +373,7 @@ module t {
 }
 
 #[test]
-fn event_write_closure_propagates_through_comb_logic_and_testbench_functions() {
+fn event_write_closure_warning_propagates_through_comb_logic_and_testbench_functions() {
     let code = r#"
 module Counter (
     clk: input clock,
@@ -394,11 +407,11 @@ module t {
     }
 }
 "#;
-    expect_mutable_bound_error(code, "t");
+    expect_time_advancing_bound_warning(code, "t");
 }
 
 #[test]
-fn event_calls_hidden_in_testbench_helpers_are_errors() {
+fn event_calls_hidden_in_testbench_helpers_warn() {
     let code = r#"
 module Counter (
     clk: input clock,
@@ -427,11 +440,11 @@ module t {
     }
 }
 "#;
-    expect_mutable_bound_error(code, "t");
+    expect_time_advancing_bound_warning(code, "t");
 }
 
 #[test]
-fn asynchronous_reset_write_closure_is_an_error() {
+fn asynchronous_reset_write_closure_is_a_warning() {
     let code = r#"
 module Counter (
     clk: input clock,
@@ -460,25 +473,21 @@ module t {
     }
 }
 "#;
-    let error = Simulator::builder(code, "t")
+    let simulator = Simulator::builder(code, "t")
         .reset_type(ResetType::AsyncHigh)
         .build()
-        .expect_err("an asynchronous reset may update the continuation bound");
+        .expect("an asynchronous reset conflict is a warning");
     assert!(
-        matches!(
-            error.kind(),
-            SimulatorErrorKind::Frontend(diagnostics)
-                if diagnostics.iter().any(|diagnostic| matches!(
-                    diagnostic,
-                    FrontendDiagnostic::MutableForBound { .. }
-                ))
-        ),
-        "unexpected diagnostic: {error}"
+        simulator.warnings().iter().any(|warning| matches!(
+            warning,
+            CompilationWarning::Frontend(FrontendDiagnostic::TimeAdvancingForBound { .. })
+        )),
+        "expected an asynchronous reset continuation-bound warning"
     );
 }
 
 #[test]
-fn event_write_closure_follows_cascaded_clock_domains() {
+fn event_write_closure_warning_follows_cascaded_clock_domains() {
     let code = r#"
 module Counter (
     clk: input clock,
@@ -508,11 +517,11 @@ module t {
     }
 }
 "#;
-    expect_mutable_bound_error(code, "t");
+    expect_time_advancing_bound_warning(code, "t");
 }
 
 #[test]
-fn event_write_closure_tracks_concat_slice_and_mux_bits() {
+fn event_write_closure_warning_tracks_concat_slice_and_mux_bits() {
     let code = r#"
 module Counter (
     clk: input clock,
@@ -548,7 +557,7 @@ module t {
     }
 }
 "#;
-    expect_mutable_bound_error(code, "t");
+    expect_time_advancing_bound_warning(code, "t");
 }
 
 #[test]
@@ -591,7 +600,7 @@ module t {
 }
 
 #[test]
-fn event_write_closure_handles_dynamic_unpacked_array_writes_conservatively() {
+fn event_write_closure_warns_for_dynamic_unpacked_array_writes_conservatively() {
     let code = r#"
 module Counter (
     clk: input clock,
@@ -619,7 +628,7 @@ module t {
     }
 }
 "#;
-    expect_mutable_bound_error(code, "t");
+    expect_time_advancing_bound_warning(code, "t");
 }
 
 #[test]

--- a/crates/celox/tests/mutable_for_bound.rs
+++ b/crates/celox/tests/mutable_for_bound.rs
@@ -1,0 +1,654 @@
+use celox::{CompilationWarning, FrontendDiagnostic, ResetType, Simulator, SimulatorErrorKind};
+
+fn expect_mutable_bound_error(code: &str, top: &str) {
+    let error = Simulator::builder(code, top)
+        .build()
+        .expect_err("mutable continuation bound must be rejected");
+    assert!(
+        matches!(
+            error.kind(),
+            SimulatorErrorKind::Frontend(diagnostics)
+                if diagnostics.iter().any(|diagnostic| matches!(
+                    diagnostic,
+                    FrontendDiagnostic::MutableForBound { .. }
+                ))
+        ),
+        "unexpected diagnostic: {error}"
+    );
+}
+
+#[test]
+fn direct_and_nested_body_writes_are_errors() {
+    expect_mutable_bound_error(
+        r#"
+module Top {
+    var limit: logic<8>;
+    var count: logic<8>;
+
+    always_comb {
+        limit = 4;
+        count = 0;
+        for _i in 0..limit {
+            for _j in 0..1 {
+                limit = 1;
+            }
+            count += 1;
+        }
+    }
+}
+"#,
+        "Top",
+    );
+}
+
+#[test]
+fn writes_hidden_in_rhs_functions_are_errors() {
+    expect_mutable_bound_error(
+        r#"
+module Top {
+    var limit: logic<8>;
+    var sink: logic<8>;
+
+    function shrink() -> logic<8> {
+        limit = 1;
+        return 0;
+    }
+
+    always_comb {
+        limit = 4;
+        sink = 0;
+        for _i in 0..limit {
+            sink = shrink();
+        }
+    }
+}
+"#,
+        "Top",
+    );
+}
+
+#[test]
+fn function_output_writeback_to_the_bound_is_an_error() {
+    expect_mutable_bound_error(
+        r#"
+module Top {
+    var limit: logic<8>;
+
+    function shrink (
+        value: output logic<8>,
+    ) {
+        value = 1;
+    }
+
+    always_comb {
+        limit = 4;
+        for _i in 0..limit {
+            shrink(limit);
+        }
+    }
+}
+"#,
+        "Top",
+    );
+}
+
+#[test]
+fn effects_in_the_bound_itself_are_errors() {
+    expect_mutable_bound_error(
+        r#"
+module Top {
+    var limit: logic<8>;
+    var evaluations: logic<8>;
+
+    function get_limit() -> logic<8> {
+        evaluations += 1;
+        return limit;
+    }
+
+    always_comb {
+        limit = 4;
+        evaluations = 0;
+        for _i in 0..get_limit() {
+        }
+    }
+}
+"#,
+        "Top",
+    );
+}
+
+#[test]
+fn only_the_continuation_side_of_the_range_is_protected() {
+    let forward = r#"
+module Top (
+    out: output logic<8>,
+) {
+    var start: logic<8>;
+    always_comb {
+        start = 0;
+        out = 0;
+        for _i in start..4 {
+            start = 3;
+            out += 1;
+        }
+    }
+}
+"#;
+    Simulator::builder(forward, "Top")
+        .build()
+        .expect("a forward loop does not re-evaluate its start bound");
+
+    expect_mutable_bound_error(
+        r#"
+module Top {
+    var start: logic<8>;
+    always_comb {
+        start = 0;
+        for _i in rev start..4 {
+            start = 3;
+        }
+    }
+}
+"#,
+        "Top",
+    );
+}
+
+#[test]
+fn bit_disjoint_and_unrelated_writes_remain_valid() {
+    let code = r#"
+module Top (
+    out: output logic<8>,
+) {
+    var bits: logic<8>;
+    var unrelated: logic<8>;
+
+    always_comb {
+        bits = 4;
+        unrelated = 0;
+        for _i in 0..bits[3:0] {
+            bits[7:4] = 1;
+            unrelated += 1;
+        }
+        out = unrelated;
+    }
+}
+"#;
+    Simulator::builder(code, "Top")
+        .build()
+        .expect("bit-disjoint writes must not conflict");
+}
+
+#[test]
+fn dynamic_indices_are_checked_conservatively() {
+    expect_mutable_bound_error(
+        r#"
+module Top {
+    var limits: logic<8>[4];
+    var index: logic<2>;
+
+    always_comb {
+        limits = '{1, 1, 4, 1};
+        index = 2;
+        for _i in 0..limits[2] {
+            limits[index] = 1;
+        }
+    }
+}
+"#,
+        "Top",
+    );
+}
+
+#[test]
+fn true_ff_writes_are_invisible_but_ff_locals_are_errors() {
+    let ff_state = r#"
+module Top (
+    clk: input clock,
+    rst: input reset,
+) {
+    var limit: logic<8>;
+    var count: logic<8>;
+
+    always_ff {
+        if_reset {
+            limit = 4;
+            count = 0;
+        } else {
+            for _i in 0..limit {
+                limit = 1;
+                count += 1;
+            }
+        }
+    }
+}
+"#;
+    Simulator::builder(ff_state, "Top")
+        .build()
+        .expect("FF/NBA writes are not visible to the running loop");
+
+    expect_mutable_bound_error(
+        r#"
+module Top (
+    clk: input clock,
+    rst: input reset,
+) {
+    always_ff {
+        if_reset {
+        } else {
+            var limit: logic<8>;
+            limit = 4;
+            for _i in 0..limit {
+                limit = 1;
+            }
+        }
+    }
+}
+"#,
+        "Top",
+    );
+}
+
+#[test]
+fn time_advancing_body_effects_are_errors_when_the_bound_is_in_the_event_write_closure() {
+    let code = r#"
+module Counter (
+    clk: input clock,
+    rst: input reset,
+    count: output logic<8>,
+) {
+    always_ff {
+        if_reset { count = 0; }
+        else       { count += 1; }
+    }
+}
+
+#[test(t)]
+module t {
+    inst clk: $tb::clock_gen;
+    inst rst: $tb::reset_gen(clk);
+    var count: logic<8>;
+    inst dut: Counter (clk, rst, count);
+
+    initial {
+        rst.assert(clk);
+        clk.next(2);
+        for _i in 0..count {
+            clk.next();
+        }
+        $finish();
+    }
+}
+"#;
+    expect_mutable_bound_error(code, "t");
+}
+
+#[test]
+fn time_advancing_body_effects_pass_when_the_bound_is_outside_the_event_write_closure() {
+    let code = r#"
+module Counter (
+    clk: input clock,
+    rst: input reset,
+    count: output logic<8>,
+) {
+    always_ff {
+        if_reset { count = 0; }
+        else       { count += 1; }
+    }
+}
+
+#[test(t)]
+module t {
+    inst clk: $tb::clock_gen;
+    inst rst: $tb::reset_gen(clk);
+    var count: logic<8>;
+    var limit: logic<8>;
+    inst dut: Counter (clk, rst, count);
+
+    initial {
+        limit = 2;
+        rst.assert(clk);
+        for _i in 0..limit {
+            clk.next();
+        }
+        $finish();
+    }
+}
+"#;
+    let simulator = Simulator::builder(code, "t")
+        .build()
+        .expect("an unrelated event write closure must not reject the loop");
+    assert!(!simulator.warnings().iter().any(|warning| matches!(
+        warning,
+        CompilationWarning::Frontend(FrontendDiagnostic::UnknownForBoundEffect { .. })
+    )));
+}
+
+#[test]
+fn time_advancing_body_effects_respect_disjoint_bit_ranges() {
+    let code = r#"
+module Counter (
+    clk: input clock,
+    rst: input reset,
+    count: output logic<8>,
+) {
+    always_ff {
+        if_reset { count[3:0] = 0; }
+        else       { count[3:0] += 1; }
+    }
+}
+
+#[test(t)]
+module t {
+    inst clk: $tb::clock_gen;
+    inst rst: $tb::reset_gen(clk);
+    var count: logic<8>;
+    inst dut: Counter (clk, rst, count);
+
+    initial {
+        rst.assert(clk);
+        for _i in 0..count[7:4] {
+            clk.next();
+        }
+        $finish();
+    }
+}
+"#;
+    Simulator::builder(code, "t")
+        .build()
+        .expect("event writes to disjoint bits must not reject the loop");
+}
+
+#[test]
+fn event_write_closure_propagates_through_comb_logic_and_testbench_functions() {
+    let code = r#"
+module Counter (
+    clk: input clock,
+    count: output logic<8>,
+    limit: output logic<8>,
+) {
+    always_ff {
+        count += 1;
+    }
+    always_comb {
+        limit = count + 1;
+    }
+}
+
+#[test(t)]
+module t {
+    inst clk: $tb::clock_gen;
+    var count: logic<8>;
+    var limit: logic<8>;
+    inst dut: Counter (clk, count, limit);
+
+    function run() {
+        for _i in 0..limit {
+            clk.next();
+        }
+    }
+
+    initial {
+        run();
+        $finish();
+    }
+}
+"#;
+    expect_mutable_bound_error(code, "t");
+}
+
+#[test]
+fn event_calls_hidden_in_testbench_helpers_are_errors() {
+    let code = r#"
+module Counter (
+    clk: input clock,
+    count: output logic<8>,
+) {
+    always_ff {
+        count += 1;
+    }
+}
+
+#[test(t)]
+module t {
+    inst clk: $tb::clock_gen;
+    var count: logic<8>;
+    inst dut: Counter (clk, count);
+
+    function tick() {
+        clk.next();
+    }
+
+    initial {
+        for _i in 0..count {
+            tick();
+        }
+        $finish();
+    }
+}
+"#;
+    expect_mutable_bound_error(code, "t");
+}
+
+#[test]
+fn asynchronous_reset_write_closure_is_an_error() {
+    let code = r#"
+module Counter (
+    clk: input clock,
+    rst: input reset,
+    count: output logic<8>,
+) {
+    always_ff {
+        if_reset { count = 0; }
+        else       { count += 1; }
+    }
+}
+
+#[test(t)]
+module t {
+    inst reset_clk: $tb::clock_gen;
+    inst dut_clk: $tb::clock_gen;
+    inst rst: $tb::reset_gen(clk: reset_clk);
+    var count: logic<8>;
+    inst dut: Counter (clk: dut_clk, rst, count);
+
+    initial {
+        for _i in 0..count {
+            rst.assert(reset_clk);
+        }
+        $finish();
+    }
+}
+"#;
+    let error = Simulator::builder(code, "t")
+        .reset_type(ResetType::AsyncHigh)
+        .build()
+        .expect_err("an asynchronous reset may update the continuation bound");
+    assert!(
+        matches!(
+            error.kind(),
+            SimulatorErrorKind::Frontend(diagnostics)
+                if diagnostics.iter().any(|diagnostic| matches!(
+                    diagnostic,
+                    FrontendDiagnostic::MutableForBound { .. }
+                ))
+        ),
+        "unexpected diagnostic: {error}"
+    );
+}
+
+#[test]
+fn event_write_closure_follows_cascaded_clock_domains() {
+    let code = r#"
+module Counter (
+    clk: input clock,
+    enable: input logic,
+    count: output logic<8>,
+) {
+    let gated_clk: '_ clock = clk & enable;
+
+    always_ff (gated_clk) {
+        count += 1;
+    }
+}
+
+#[test(t)]
+module t {
+    inst clk: $tb::clock_gen;
+    var enable: logic;
+    var count: logic<8>;
+    inst dut: Counter (clk, enable, count);
+
+    initial {
+        enable = 1;
+        for _i in 0..count {
+            clk.next();
+        }
+        $finish();
+    }
+}
+"#;
+    expect_mutable_bound_error(code, "t");
+}
+
+#[test]
+fn event_write_closure_tracks_concat_slice_and_mux_bits() {
+    let code = r#"
+module Counter (
+    clk: input clock,
+    select: input logic,
+    count: output logic<8>,
+    limit: output logic<4>,
+) {
+    var combined: logic<12>;
+
+    always_ff {
+        count += 1;
+    }
+    always_comb {
+        combined = {count, 4'h0};
+        limit = if select ? combined[7:4] : 4'h0;
+    }
+}
+
+#[test(t)]
+module t {
+    inst clk: $tb::clock_gen;
+    var select: logic;
+    var count: logic<8>;
+    var limit: logic<4>;
+    inst dut: Counter (clk, select, count, limit);
+
+    initial {
+        select = 1;
+        for _i in 0..limit {
+            clk.next();
+        }
+        $finish();
+    }
+}
+"#;
+    expect_mutable_bound_error(code, "t");
+}
+
+#[test]
+fn event_write_closure_preserves_disjoint_bits_through_concat_and_slice() {
+    let code = r#"
+module Counter (
+    clk: input clock,
+    count: output logic<8>,
+    limit: output logic<4>,
+) {
+    var combined: logic<12>;
+
+    always_ff {
+        count[3:0] += 1;
+    }
+    always_comb {
+        combined = {count, 4'h0};
+        limit = combined[11:8];
+    }
+}
+
+#[test(t)]
+module t {
+    inst clk: $tb::clock_gen;
+    var count: logic<8>;
+    var limit: logic<4>;
+    inst dut: Counter (clk, count, limit);
+
+    initial {
+        for _i in 0..limit {
+            clk.next();
+        }
+        $finish();
+    }
+}
+"#;
+    Simulator::builder(code, "t")
+        .build()
+        .expect("comb propagation must preserve disjoint packed bit ranges");
+}
+
+#[test]
+fn event_write_closure_handles_dynamic_unpacked_array_writes_conservatively() {
+    let code = r#"
+module Counter (
+    clk: input clock,
+    index: input logic<2>,
+    limits: output logic<8>[4],
+) {
+    always_ff {
+        limits[index] += 1;
+    }
+}
+
+#[test(t)]
+module t {
+    inst clk: $tb::clock_gen;
+    var index: logic<2>;
+    var limits: logic<8>[4];
+    inst dut: Counter (clk, index, limits);
+
+    initial {
+        index = 0;
+        for _i in 0..limits[2] {
+            clk.next();
+        }
+        $finish();
+    }
+}
+"#;
+    expect_mutable_bound_error(code, "t");
+}
+
+#[test]
+fn event_write_closure_preserves_disjoint_unpacked_array_elements() {
+    let code = r#"
+module Counter (
+    clk: input clock,
+    limits: output logic<8>[4],
+) {
+    always_ff {
+        limits[0] += 1;
+    }
+}
+
+#[test(t)]
+module t {
+    inst clk: $tb::clock_gen;
+    var limits: logic<8>[4];
+    inst dut: Counter (clk, limits);
+
+    initial {
+        for _i in 0..limits[2] {
+            clk.next();
+        }
+        $finish();
+    }
+}
+"#;
+    Simulator::builder(code, "t")
+        .build()
+        .expect("event writes to another unpacked element must remain valid");
+}

--- a/crates/celox/tests/mutable_for_bound.rs
+++ b/crates/celox/tests/mutable_for_bound.rs
@@ -131,6 +131,57 @@ module Top {
 }
 
 #[test]
+fn time_advancing_effects_in_the_bound_itself_are_errors() {
+    expect_mutable_bound_error(
+        r#"
+#[test(t)]
+module t {
+    inst clk: $tb::clock_gen;
+
+    function get_limit() -> logic<8> {
+        clk.next();
+        return 1;
+    }
+
+    initial {
+        for _i in 0..get_limit() {
+        }
+        $finish();
+    }
+}
+"#,
+        "t",
+    );
+}
+
+#[test]
+fn file_effects_in_the_bound_itself_are_errors() {
+    expect_mutable_bound_error(
+        r#"
+#[test(t)]
+module t {
+    var file: $tb::file;
+
+    function get_limit() -> logic<8> {
+        file.open("mutable_for_bound.txt");
+        file.write("bound");
+        file.flush();
+        file.close();
+        return 1;
+    }
+
+    initial {
+        for _i in 0..get_limit() {
+        }
+        $finish();
+    }
+}
+"#,
+        "t",
+    );
+}
+
+#[test]
 fn only_the_continuation_side_of_the_range_is_protected() {
     let forward = r#"
 module Top (

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -483,11 +483,13 @@ fn test_for_loop_expression_bound_forward() {
             inst clk: $tb::clock_gen;
             inst rst: $tb::reset_gen(clk);
             var cnt: logic<32>;
+            var limit: logic<32>;
             inst dut: Counter (clk, rst, cnt);
             initial {{
                 rst.assert(clk);
                 clk.next(10);
-                for _i in 0..(cnt >> 1) {{
+                limit = cnt >> 1;
+                for _i in 0..limit {{
                     clk.next();
                 }}
                 $assert(cnt == 32'd15);
@@ -541,11 +543,13 @@ fn test_for_loop_expression_bound_inclusive() {
             inst clk: $tb::clock_gen;
             inst rst: $tb::reset_gen(clk);
             var cnt: logic<32>;
+            var limit: logic<32>;
             inst dut: Counter (clk, rst, cnt);
             initial {{
                 rst.assert(clk);
                 clk.next(3);
-                for _i in 0..=(cnt + 32'd2) {{
+                limit = cnt + 32'd2;
+                for _i in 0..=limit {{
                     clk.next();
                 }}
                 $assert(cnt == 32'd9);
@@ -570,11 +574,13 @@ fn test_for_loop_expression_bound_stepped() {
             inst clk: $tb::clock_gen;
             inst rst: $tb::reset_gen(clk);
             var cnt: logic<32>;
+            var limit: logic<32>;
             inst dut: Counter (clk, rst, cnt);
             initial {{
                 rst.assert(clk);
                 clk.next(10);
-                for _i in 1..(cnt >> 1) step *= 2 {{
+                limit = cnt >> 1;
+                for _i in 1..limit step *= 2 {{
                     clk.next();
                 }}
                 $assert(cnt == 32'd13);
@@ -599,11 +605,13 @@ fn test_for_loop_expression_bound_stepped_non_progress_fails() {
             inst clk: $tb::clock_gen;
             inst rst: $tb::reset_gen(clk);
             var cnt: logic<32>;
+            var limit: logic<32>;
             inst dut: Counter (clk, rst, cnt);
             initial {{
                 rst.assert(clk);
                 clk.next(10);
-                for _i in (cnt - cnt)..cnt step *= 2 {{
+                limit = cnt;
+                for _i in (limit - limit)..limit step *= 2 {{
                     clk.next();
                 }}
                 $assert(cnt == 32'd11);
@@ -628,11 +636,13 @@ fn test_for_loop_expression_bound_arith_shift_step() {
             inst clk: $tb::clock_gen;
             inst rst: $tb::reset_gen(clk);
             var cnt: logic<32>;
+            var limit: logic<32>;
             inst dut: Counter (clk, rst, cnt);
             initial {{
                 rst.assert(clk);
                 clk.next(10);
-                for _i in 1..(cnt >> 1) step <<<= 1 {{
+                limit = cnt >> 1;
+                for _i in 1..limit step <<<= 1 {{
                     clk.next();
                 }}
                 $assert(cnt == 32'd13);
@@ -657,11 +667,13 @@ fn test_for_loop_expression_bound_large_arith_shift_reports_non_progress() {
             inst clk: $tb::clock_gen;
             inst rst: $tb::reset_gen(clk);
             var cnt: logic<32>;
+            var limit: logic<32>;
             inst dut: Counter (clk, rst, cnt);
             initial {{
                 rst.assert(clk);
                 clk.next(10);
-                for _i in 1..cnt step <<<= 100 {{
+                limit = cnt;
+                for _i in 1..limit step <<<= 100 {{
                     clk.next();
                 }}
                 $assert(cnt == 32'd11);
@@ -853,11 +865,13 @@ fn test_for_loop_expression_bound_non_progress_reports_failure() {
             inst clk: $tb::clock_gen;
             inst rst: $tb::reset_gen(clk);
             var cnt: logic<32>;
+            var limit: logic<32>;
             inst dut: Counter (clk, rst, cnt);
             initial {{
                 rst.assert(clk);
                 clk.next(10);
-                for _i in (cnt - cnt)..cnt step *= 2 {{
+                limit = cnt;
+                for _i in (limit - limit)..limit step *= 2 {{
                     clk.next();
                 }}
                 $finish();
@@ -881,11 +895,13 @@ fn test_for_loop_expression_bound_terminal_inclusive_mul_reports_non_progress() 
             inst clk: $tb::clock_gen;
             inst rst: $tb::reset_gen(clk);
             var cnt: logic<32>;
+            var limit: logic<32>;
             inst dut: Counter (clk, rst, cnt);
             initial {{
                 rst.assert(clk);
                 clk.next(10);
-                for _i in (cnt - cnt)..=(cnt - cnt) step *= 2 {{
+                limit = cnt;
+                for _i in (limit - limit)..=(limit - limit) step *= 2 {{
                     clk.next();
                 }}
                 $assert(cnt == 32'd11);
@@ -1515,12 +1531,14 @@ fn test_run_test_preserves_runtime_error_after_assert_continue_failures() {
             inst clk: $tb::clock_gen;
             inst rst: $tb::reset_gen(clk);
             var cnt: logic<32>;
+            var limit: logic<32>;
             inst dut: Counter (clk, rst, cnt);
             initial {{
                 rst.assert(clk);
                 $assert_continue(1'b0, "first");
                 clk.next(2);
-                for _i in (cnt - cnt)..cnt step *= 2 {{
+                limit = cnt;
+                for _i in (limit - limit)..limit step *= 2 {{
                     clk.next();
                 }}
                 $finish();

--- a/crates/celox/tests/snapshots/error_readability__elaborated_mutable_for_bound_error_readability.snap
+++ b/crates/celox/tests/snapshots/error_readability__elaborated_mutable_for_bound_error_readability.snap
@@ -1,0 +1,16 @@
+---
+source: crates/celox/tests/error_readability.rs
+expression: error.to_string()
+---
+mutable_for_bound
+
+  × Loop continuation bound is not stable: the loop body advances an event that may update state read by the
+  │ continuation bound
+    ╭─[:17:21]
+ 16 │             initial {
+ 17 │                 for _i in 0..count {
+    ·                     ─┬
+    ·                      ╰── loop with an unstable continuation bound
+ 18 │                     clk.next();
+    ╰────
+  help: copy the bound to a value that is not modified by the loop body

--- a/crates/celox/tests/snapshots/error_readability__mutable_for_bound_error_readability.snap
+++ b/crates/celox/tests/snapshots/error_readability__mutable_for_bound_error_readability.snap
@@ -1,0 +1,15 @@
+---
+source: crates/celox/tests/error_readability.rs
+expression: error.to_string()
+---
+mutable_for_bound
+
+  × Loop continuation bound is not stable: the loop body may immediately modify state read by the continuation bound
+   ╭─[:6:21]
+ 5 │                 limit = 4;
+ 6 │                 for _i in 0..limit {
+   ·                     ─┬
+   ·                      ╰── loop with an unstable continuation bound
+ 7 │                     limit = 1;
+   ╰────
+  help: copy the bound to a value that is not modified by the loop body

--- a/crates/celox/tests/snapshots/error_readability__time_advancing_for_bound_warning_readability.snap
+++ b/crates/celox/tests/snapshots/error_readability__time_advancing_for_bound_warning_readability.snap
@@ -1,11 +1,11 @@
 ---
 source: crates/celox/tests/error_readability.rs
-expression: error.to_string()
+expression: render_diagnostic(warning)
 ---
-mutable_for_bound
+time_advancing_for_bound
 
-  × Loop continuation bound is not stable: the loop body advances an event that may update state read by the
-  │ continuation bound
+  ⚠ Loop continuation bound may change while simulation time advances: the loop body advances an event that may update
+  │ state read by the continuation bound
     ╭─[:17:21]
  16 │             initial {
  17 │                 for _i in 0..count {
@@ -13,4 +13,4 @@ mutable_for_bound
     ·                      ╰── loop with an unstable continuation bound
  18 │                     clk.next();
     ╰────
-  help: copy the bound to a value that is not modified by the loop body
+  help: copy the bound to a procedural let before entering the loop

--- a/crates/celox/tests/synth_dynamic_loop.rs
+++ b/crates/celox/tests/synth_dynamic_loop.rs
@@ -165,35 +165,6 @@ fn test_runtime_bounds_in_synth_for_loops(sim) {
     assert_eq!(sim.get(sum_step), 15u32.into());
 }
 
-fn test_loop_bound_is_evaluated_once_before_body(sim) {
-    @setup { let code = r#"
-        module Top (
-            initial_limit: input logic<32>,
-            count: output logic<32>,
-        ) {
-            var limit: logic<32>;
-
-            always_comb {
-                limit = initial_limit;
-                count = 0;
-
-                for _i in 0..limit {
-                    count += 1;
-                    limit = 1;
-                }
-            }
-        }
-    "#; }
-    @build Simulator::builder(code, "Top");
-
-    let initial_limit = sim.signal("initial_limit");
-    let count = sim.signal("count");
-
-    sim.set(initial_limit, 4u32);
-    sim.eval_comb().unwrap();
-    assert_eq!(sim.get(count), 4u32.into());
-}
-
 fn test_runtime_bitwise_steps_in_synth_for_loops(sim) {
     @setup { let code = r#"
         module Top (


### PR DESCRIPTION
## Summary

Add a Celox frontend diagnostic for dynamic `for` loops whose continuation bound may be affected while the loop is executing.

```veryl
var limit: logic<8>;

always_comb {
    limit = 4;
    for _i in 0..limit {
        limit = 1; // error
    }
}
```

The checker:

- reports a `mutable_for_bound` error when a known immediate or event-mediated write closure overlaps bits read by the continuation bound;
- reports an `unknown_for_bound_effect` warning when an opaque or unresolvable effect prevents proof;
- expands known function effects and function output writebacks;
- distinguishes immediate procedural writes from FF/NBA updates;
- resolves hierarchy and event domains after elaboration;
- follows combinational dependencies, resets, generated/gated clocks, and cascaded event domains to a fixed point; and
- preserves bit-range precision through selects, concatenations, slices, fixed shifts, and static unpacked-array elements while treating dynamic accesses conservatively.

The checker module documents its analysis contract explicitly. A warning-free build guarantees that no modeled loop-body effect reaches state read by the continuation bound within Celox's closed-world elaborated execution model. Opaque SystemVerilog, DPI/VPI, `force`/`release`, `bind`, and other external effects remain outside that guarantee.

## Motivation

Celox's native testbench execution captures loop bounds before entering the loop, while emitted SystemVerilog may re-evaluate the continuation condition before each iteration. A loop that modifies its continuation bound can therefore behave differently between backends and may terminate unexpectedly or fail to terminate.

Diagnosing the pattern avoids observable backend-dependent behavior without committing Veryl to either evaluation model.

## Diagnostics and compatibility

Known overlaps are errors. Unknown effects remain warnings so analyzable programs are rejected precisely without failing closed at opaque boundaries.

This is a breaking compatibility change:

- programs that previously modified a continuation bound may now be rejected; and
- public warning APIs now return `CompilationWarning`, which can contain either an analyzer warning or a Celox frontend warning.

Existing native-testbench cases that intentionally relied on capture semantics now copy their bound explicitly before the loop.

## Validation

- `cargo test -p celox-frontend-veryl --quiet`
- `cargo test -p celox --tests --quiet`
- `cargo check --workspace --all-targets`
- `cargo clippy -p celox-frontend-veryl -p celox -p celox-napi --all-targets -- -D warnings -A clippy::question_mark`
- `cargo fmt --all`
- pre-push hooks: submodule check, Cargo formatting/check, Biome, and clean-tree check

Regression coverage includes immediate and nested writes, function effects, FF visibility, bit-disjoint accesses, dynamic indices, reset closure, helper-mediated events, generated/gated and cascaded clocks, combinational propagation, concat/slice/mux precision, and static/dynamic unpacked-array accesses.