### PR TITLE
fix(testbench): preserve dynamic resets and clocked child state

### DIFF
--- a/crates/celox-frontend-veryl/src/testbench.rs
+++ b/crates/celox-frontend-veryl/src/testbench.rs
@@ -1236,7 +1236,13 @@ impl<'a> SemanticTestbenchBuilder<'a> {
     fn build_event_map(&mut self, stmts: &[Statement]) {
         let mut clock_insts: Vec<StrId> = Vec::new();
         let mut reset_insts: Vec<StrId> = Vec::new();
-        Self::scan_tb_methods(stmts, &mut clock_insts, &mut reset_insts);
+        let mut active_functions = FxHashSet::default();
+        self.scan_tb_methods(
+            stmts,
+            &mut clock_insts,
+            &mut reset_insts,
+            &mut active_functions,
+        );
         for inst in clock_insts.iter().chain(reset_insts.iter()) {
             if let Some((addr, info)) = self.lookup.root_named_variable(*inst) {
                 self.event_map.insert(*inst, addr);
@@ -1251,7 +1257,13 @@ impl<'a> SemanticTestbenchBuilder<'a> {
         }
     }
 
-    fn scan_tb_methods(stmts: &[Statement], clks: &mut Vec<StrId>, rsts: &mut Vec<StrId>) {
+    fn scan_tb_methods(
+        &self,
+        stmts: &[Statement],
+        clks: &mut Vec<StrId>,
+        rsts: &mut Vec<StrId>,
+        active_functions: &mut FxHashSet<VarId>,
+    ) {
         for stmt in stmts {
             match stmt {
                 Statement::TbMethodCall(tb) => match &tb.method {
@@ -1279,10 +1291,18 @@ impl<'a> SemanticTestbenchBuilder<'a> {
                     | TbMethod::RandomGetSeed => {}
                 },
                 Statement::If(s) => {
-                    Self::scan_tb_methods(&s.true_side, clks, rsts);
-                    Self::scan_tb_methods(&s.false_side, clks, rsts);
+                    self.scan_tb_methods(&s.true_side, clks, rsts, active_functions);
+                    self.scan_tb_methods(&s.false_side, clks, rsts, active_functions);
                 }
-                Statement::For(s) => Self::scan_tb_methods(&s.body, clks, rsts),
+                Statement::For(s) => {
+                    self.scan_tb_methods(&s.body, clks, rsts, active_functions);
+                }
+                Statement::FunctionCall(call) if active_functions.insert(call.id) => {
+                    if let Some(body) = function_body(&self.testbench_source.functions, call) {
+                        self.scan_tb_methods(&body.statements, clks, rsts, active_functions);
+                    }
+                    active_functions.remove(&call.id);
+                }
                 _ => {}
             }
         }
@@ -1512,16 +1532,19 @@ impl<'a> SemanticTestbenchBuilder<'a> {
             TbMethod::ResetAssert { clock, duration } => {
                 let reset_signal = self.signal_map.get(&tb.inst).copied()?;
                 let clock_event = self.event_map.get(clock).copied()?;
-                let dur = duration
-                    .as_ref()
-                    .and_then(try_eval_const)
-                    .unwrap_or(self.default_reset_duration);
+                let duration = match duration {
+                    Some(expr) => match try_eval_const(expr) {
+                        Some(duration) => GenericClockCount::Static(duration),
+                        None => GenericClockCount::Dynamic(ec.compile(expr)),
+                    },
+                    None => GenericClockCount::Static(self.default_reset_duration),
+                };
                 // Determine reset polarity from the variable's DomainKind
                 let (assert_value, deassert_value) = self.resolve_reset_polarity(&tb.inst);
                 Some(GenericTestbenchStatement::ResetAssert {
                     reset_signal,
                     clock_event,
-                    duration: dur,
+                    duration,
                     assert_value,
                     deassert_value,
                 })
@@ -1860,15 +1883,6 @@ fn validate_testbench_statements(
                 TbMethod::ResetAssert { duration, .. } => {
                     if let Some(expression) = duration {
                         validate_testbench_expression(expression, source, active_functions)?;
-                        if try_eval_const(expression).is_none() {
-                            return Err(ParserError::unsupported(
-                                473,
-                                LoweringPhase::SimulatorParser,
-                                "dynamic reset duration",
-                                "runtime reset durations are not implemented",
-                                Some(&expression.comptime().token),
-                            ));
-                        }
                     }
                 }
                 TbMethod::FileOpen { name, .. } => {

--- a/crates/celox-runtime/src/testbench.rs
+++ b/crates/celox-runtime/src/testbench.rs
@@ -104,7 +104,7 @@ fn bind_statement<B: SimBackend>(
         } => Some(GenericTestbenchStatement::ResetAssert {
             reset_signal: backend.resolve_signal(&reset_signal.address),
             clock_event: backend.resolve_event_opt(&clock_event)?,
-            duration,
+            duration: bind_clock_count(backend, duration)?,
             assert_value,
             deassert_value,
         }),

--- a/crates/celox-sir-opt/src/optimizer/passes/analysis/state_ssa.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/analysis/state_ssa.rs
@@ -749,7 +749,12 @@ impl StateSsa {
                 .def_blocks
                 .iter()
                 .any(|block| !cfg.dominance_frontier[cfg.index[block]].is_empty());
-            let needs_liveness = region == WORKING_REGION || may_need_phi;
+            // A single-block STABLE slot can be read before its first local
+            // definition without needing a phi.  It is still live on entry
+            // and must not be promoted as a comb-only temporary.
+            let needs_liveness = region == WORKING_REGION
+                || may_need_phi
+                || !facts[old].upward_use_blocks.is_empty();
             // Placement may query a block which did not contain a load in the
             // original program. Build unpruned MemorySSA for that mode;
             // pruning from only the original upward uses would omit a phi at

--- a/crates/celox-testbench/src/lib.rs
+++ b/crates/celox-testbench/src/lib.rs
@@ -95,7 +95,7 @@ pub enum TestbenchStatement<Event, Signal, Expression, Argument> {
     ResetAssert {
         reset_signal: Signal,
         clock_event: Event,
-        duration: u64,
+        duration: ClockCount<Expression>,
         assert_value: u8,
         deassert_value: u8,
     },

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -1124,37 +1124,40 @@ fn exec_one_detailed<B: SimBackend>(
             duration,
             assert_value,
             deassert_value,
-        } => {
-            sim_set_u64(sim, *reset_signal, (*assert_value).into());
-            let mut remaining = *duration;
-            while remaining != 0 {
-                if tick_limit_reached(ctx) {
-                    return ExecResult::Finished;
-                }
-                let mut batch = remaining;
-                if let Some(limit) = ctx.tick_limit {
-                    batch = batch.min(limit.saturating_sub(ctx.current_time));
-                }
-                let (completed, result) = sim.tick_deferred_comb_many(*clock_event, batch);
-                if completed == 0 || completed > batch {
-                    return ExecResult::Fail(
-                        "backend made invalid progress in a reset tick batch".into(),
-                    );
-                }
-                ctx.current_time = ctx.current_time.saturating_add(completed);
-                remaining -= completed;
-                if let Err(e) = result {
-                    let drained = drain_runtime_assertions(sim, ctx, None);
-                    if let Some(message) = drained.fatal_message {
-                        return ExecResult::Fail(message);
+        } => match eval_clock_count(sim, duration) {
+            Ok(duration) => {
+                sim_set_u64(sim, *reset_signal, (*assert_value).into());
+                let mut remaining = duration;
+                while remaining != 0 {
+                    if tick_limit_reached(ctx) {
+                        return ExecResult::Finished;
                     }
-                    return ExecResult::Fail(format!("reset: {e}"));
+                    let mut batch = remaining;
+                    if let Some(limit) = ctx.tick_limit {
+                        batch = batch.min(limit.saturating_sub(ctx.current_time));
+                    }
+                    let (completed, result) = sim.tick_deferred_comb_many(*clock_event, batch);
+                    if completed == 0 || completed > batch {
+                        return ExecResult::Fail(
+                            "backend made invalid progress in a reset tick batch".into(),
+                        );
+                    }
+                    ctx.current_time = ctx.current_time.saturating_add(completed);
+                    remaining -= completed;
+                    if let Err(e) = result {
+                        let drained = drain_runtime_assertions(sim, ctx, None);
+                        if let Some(message) = drained.fatal_message {
+                            return ExecResult::Fail(message);
+                        }
+                        return ExecResult::Fail(format!("reset: {e}"));
+                    }
+                    drain_runtime_assertions(sim, ctx, None);
                 }
-                drain_runtime_assertions(sim, ctx, None);
+                sim_set_u64(sim, *reset_signal, (*deassert_value).into());
+                ExecResult::Continue
             }
-            sim_set_u64(sim, *reset_signal, (*deassert_value).into());
-            ExecResult::Continue
-        }
+            Err(error) => ExecResult::Fail(error.to_string()),
+        },
         GenericTestbenchStatement::Assert {
             expr,
             site_id,

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -665,43 +665,6 @@ fn test_testbench_helper_hierarchical_read_returns_error_without_panicking() {
 }
 
 #[test]
-fn test_dynamic_reset_duration_returns_unsupported_parser_error() {
-    let code = r#"
-        #[test(t)]
-        module t {
-            inst clk: $tb::clock_gen;
-            inst rst: $tb::reset_gen(clk);
-            var duration: logic<32>;
-
-            initial {
-                duration = 5;
-                rst.assert(duration);
-                $finish();
-            }
-        }
-    "#;
-
-    let result = Simulator::builder(code, "t").build();
-    match result.as_ref().map_err(|error| error.kind()) {
-        Err(SimulatorErrorKind::SIRParser(ParserError::Unsupported {
-            issue,
-            phase: LoweringPhase::SimulatorParser,
-            feature,
-            ..
-        })) => {
-            assert_eq!(*issue, 473);
-            assert_eq!(*feature, "dynamic reset duration");
-        }
-        Err(kind) => {
-            panic!("expected Unsupported(SimulatorParser) for dynamic reset duration, got {kind:?}")
-        }
-        Ok(_) => {
-            panic!("expected Unsupported(SimulatorParser) for dynamic reset duration, got Ok")
-        }
-    }
-}
-
-#[test]
 fn test_reset_compile_time_expression_duration_is_accepted() {
     let code = r#"
         #[test(t)]

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -155,6 +155,38 @@ fn test_testbench_direct_reads_are_dead_store_roots() {
     );
 }
 
+#[test]
+fn test_clock_only_self_updating_ff_advances_in_native_testbench_instance() {
+    let code = r#"
+        module ClockTickCounter (
+            clk  : input  clock    ,
+            ticks: output logic<32>,
+        ) {
+            always_ff (clk) {
+                ticks += 1;
+            }
+        }
+
+        #[test(t)]
+        module t {
+            inst clk: $tb::clock_gen;
+            var ticks: logic<32>;
+            inst dut: ClockTickCounter (clk, ticks);
+
+            initial {
+                clk.next(5);
+                $assert(ticks == 32'd5, "ticks=%d", ticks);
+                $finish();
+            }
+        }
+    "#;
+
+    assert_eq!(
+        Simulator::builder(code, "t").run_test().unwrap(),
+        TestResult::Pass,
+    );
+}
+
 // ── Wide signal (>64 bit) ──────────────────────────────────────────────
 
 #[test]

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -23,6 +23,22 @@ const COUNTER: &str = r#"
     }
 "#;
 
+const CLOCK_TICK_COUNTER: &str = r#"
+    module ClockTickCounter (
+        clk  : input  clock    ,
+        rst  : input  reset    ,
+        ticks: output logic<32>,
+    ) {
+        always_ff {
+            if_reset {
+                ticks += 1;
+            } else {
+                ticks += 1;
+            }
+        }
+    }
+"#;
+
 const BENCH_NATIVE_TB_COUNTER_N1000: &str = concat!(
     include_str!("../../../benches/veryl/top_n1000.veryl"),
     include_str!("../../../benches/veryl/native_tb_counter_n1000.veryl"),
@@ -224,6 +240,93 @@ fn test_reset_explicit_duration() {
                 clk.next  (10);
                 $assert   (cnt == 32'd10);
                 $finish   ();
+            }}
+        }}
+    "#
+    );
+    assert_eq!(
+        Simulator::builder(&code, "t").run_test().unwrap(),
+        TestResult::Pass,
+    );
+}
+
+#[test]
+fn test_reset_dynamic_duration_from_variable() {
+    let code = format!(
+        r#"
+        {CLOCK_TICK_COUNTER}
+        #[test(t)]
+        module t {{
+            inst clk: $tb::clock_gen;
+            inst rst: $tb::reset_gen(clk);
+            var ticks: logic<32>;
+            var duration: logic<32>;
+            inst dut: ClockTickCounter (clk, rst, ticks);
+
+            initial {{
+                duration = 5;
+                rst.assert(duration);
+                $assert(ticks == 32'd5, "ticks=%d", ticks);
+                $finish();
+            }}
+        }}
+    "#
+    );
+    assert_eq!(
+        Simulator::builder(&code, "t").run_test().unwrap(),
+        TestResult::Pass,
+    );
+}
+
+#[test]
+fn test_reset_dynamic_duration_from_loop_variable() {
+    let code = format!(
+        r#"
+        {CLOCK_TICK_COUNTER}
+        #[test(t)]
+        module t {{
+            inst clk: $tb::clock_gen;
+            inst rst: $tb::reset_gen(clk);
+            var ticks: logic<32>;
+            inst dut: ClockTickCounter (clk, rst, ticks);
+
+            initial {{
+                for i in 1..=3 {{
+                    rst.assert(i);
+                }}
+                $assert(ticks == 32'd6, "ticks=%d", ticks);
+                $finish();
+            }}
+        }}
+    "#
+    );
+    assert_eq!(
+        Simulator::builder(&code, "t").run_test().unwrap(),
+        TestResult::Pass,
+    );
+}
+
+#[test]
+fn test_reset_dynamic_duration_from_function_argument() {
+    let code = format!(
+        r#"
+        {CLOCK_TICK_COUNTER}
+        #[test(t)]
+        module t {{
+            inst clk: $tb::clock_gen;
+            inst rst: $tb::reset_gen(clk);
+            var ticks: logic<32>;
+            inst dut: ClockTickCounter (clk, rst, ticks);
+
+            function reset_for(duration: input logic<32>) {{
+                rst.assert(duration);
+            }}
+
+            initial {{
+                reset_for(2);
+                reset_for(4);
+                $assert(ticks == 32'd6, "ticks=%d", ticks);
+                $finish();
             }}
         }}
     "#


### PR DESCRIPTION
## Summary

- evaluate runtime reset durations from variables, loop variables, and function arguments instead of silently using the default duration
- scan called native-testbench functions when building the event map so reset assertions in helpers are retained
- preserve entry-live stable state during fused comb/FF optimization
- add focused regressions for dynamic reset sources and a self-updating clock-only child FF

## Why

The Veryl 0.20.3 follow-up review exposed that a nonconstant `rst.assert` duration was treated like an omitted argument, changing requested reset timing to the default.

While validating that path, a separate Celox optimizer bug appeared: native testbench instances using `ticks += 1` in a resetless clock-only `always_ff` stayed at zero. After dead working-store elimination, StateSSA skipped liveness for a single-block stable slot with an upward use because it needed no phi. Fused static-slot promotion then misclassified persistent FF state as a comb-only temporary and erased the update.

## Impact

Native testbenches now:

- honor dynamic reset durations
- retain reset operations placed in called helper functions
- correctly advance instantiated clock-only FF state that depends on its previous value

## Validation

- `cargo test -p celox-sir-opt` — 390 passed; doctest passed
- `cargo test -p celox --test native_testbench` — 78 passed, 1 ignored
- `cargo test -p celox --test flip_flop` — 330 passed, 78 ignored
- `cargo test -p celox --test native_exec` — 17 passed
- `cargo test -p celox --test error_detection` — 39 passed, 1 ignored
- `cargo test -p celox-testbench` — 4 passed
- `cargo fmt --all -- --check`
- `cargo check -p celox -p celox-sir-opt`
- pre-push submodule, Biome, formatting, and workspace checks

`cargo clippy -p celox -p celox-sir-opt --all-targets -- -D warnings` still reports the pre-existing `needless_range_loop` at `crates/celox-frontend-veryl/src/ff/expression.rs:2011`, outside this change.

Fixes #473
Fixes #474
