### PR TITLE
feat(testbench): support Veryl random methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,8 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "proptest",
+ "rand 0.10.2",
+ "rand_pcg",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,8 @@ libc            = "0.2"
 miette          = { version = "7.6" }
 num-bigint      = "0.5"
 num-traits      = "0.2.19"
+rand            = { version = "0.10", default-features = false }
+rand_pcg        = "0.10"
 serde           = { version = "1.0", features = ["derive"] }
 serde_json      = "1.0"
 tempfile        = "3.26"

--- a/crates/celox-frontend-veryl/src/testbench.rs
+++ b/crates/celox-frontend-veryl/src/testbench.rs
@@ -1969,7 +1969,7 @@ pub fn compile_semantic_testbench(
     lookup: &VerylFrontendLookup,
     source: &VerylTestbenchSource,
     runtime_event_site_count: usize,
-    random_seed: u64,
+    random_seed: Option<u64>,
 ) -> Result<Option<TestbenchProgram<StateAddr>>, ParserError> {
     let Some(initial_stmts) = source.initial_statements.as_ref() else {
         return Ok(None);
@@ -1978,6 +1978,6 @@ pub fn compile_semantic_testbench(
     let mut builder = SemanticTestbenchBuilder::new(lookup, source, runtime_event_site_count);
     builder.build_event_map(initial_stmts);
     Ok(Some(
-        TestbenchProgram::new(builder.convert(initial_stmts)).with_random_seed(random_seed),
+        TestbenchProgram::new(builder.convert(initial_stmts)).with_random_seed_option(random_seed),
     ))
 }

--- a/crates/celox-frontend-veryl/src/testbench.rs
+++ b/crates/celox-frontend-veryl/src/testbench.rs
@@ -1823,6 +1823,24 @@ fn validate_testbench_system_function(
     }
 }
 
+fn validate_testbench_destination(
+    destination: &veryl_analyzer::ir::AssignDestination,
+) -> Result<(), ParserError> {
+    if !destination.index.0.is_empty()
+        || !destination.select.0.is_empty()
+        || destination.select.1.is_some()
+    {
+        return Err(ParserError::unsupported(
+            478,
+            LoweringPhase::SimulatorParser,
+            "selected native testbench assignment",
+            "selected destinations are not represented by the testbench AIR",
+            Some(&destination.token),
+        ));
+    }
+    Ok(())
+}
+
 fn validate_testbench_statements(
     statements: &[Statement],
     source: &VerylTestbenchSource,
@@ -1831,6 +1849,18 @@ fn validate_testbench_statements(
     for statement in statements {
         match statement {
             Statement::Assign(statement) => {
+                for destination in &statement.dst {
+                    validate_testbench_destination(destination)?;
+                    for expression in &destination.index.0 {
+                        validate_testbench_expression(expression, source, active_functions)?;
+                    }
+                    for expression in &destination.select.0 {
+                        validate_testbench_expression(expression, source, active_functions)?;
+                    }
+                    if let Some((_, expression)) = &destination.select.1 {
+                        validate_testbench_expression(expression, source, active_functions)?;
+                    }
+                }
                 validate_testbench_expression(&statement.expr, source, active_functions)?
             }
             Statement::If(statement) => {
@@ -1883,47 +1913,52 @@ fn validate_testbench_statements(
             Statement::FunctionCall(call) => {
                 validate_testbench_function_call(call, source, active_functions)?;
             }
-            Statement::TbMethodCall(call) => match &call.method {
-                TbMethod::Component { .. } => {
-                    return Err(ParserError::unsupported(
-                        468,
-                        LoweringPhase::SimulatorParser,
-                        "testbench component method",
-                        "component runtime integration is not implemented",
-                        None,
-                    ));
+            Statement::TbMethodCall(call) => {
+                if let Some(destination) = call.ret.as_deref() {
+                    validate_testbench_destination(destination)?;
                 }
-                TbMethod::RandomSeed { value } => {
-                    validate_testbench_expression(value, source, active_functions)?;
-                }
-                TbMethod::RandomGetRange { min, max, .. } => {
-                    validate_testbench_expression(min, source, active_functions)?;
-                    validate_testbench_expression(max, source, active_functions)?;
-                }
-                TbMethod::RandomGet { .. } | TbMethod::RandomGetSeed => {}
-                TbMethod::ClockNext { count, period } => {
-                    if let Some(expression) = count {
-                        validate_testbench_expression(expression, source, active_functions)?;
+                match &call.method {
+                    TbMethod::Component { .. } => {
+                        return Err(ParserError::unsupported(
+                            468,
+                            LoweringPhase::SimulatorParser,
+                            "testbench component method",
+                            "component runtime integration is not implemented",
+                            None,
+                        ));
                     }
-                    if let Some(expression) = period {
-                        validate_testbench_expression(expression, source, active_functions)?;
+                    TbMethod::RandomSeed { value } => {
+                        validate_testbench_expression(value, source, active_functions)?;
                     }
-                }
-                TbMethod::ResetAssert { duration, .. } => {
-                    if let Some(expression) = duration {
-                        validate_testbench_expression(expression, source, active_functions)?;
+                    TbMethod::RandomGetRange { min, max, .. } => {
+                        validate_testbench_expression(min, source, active_functions)?;
+                        validate_testbench_expression(max, source, active_functions)?;
                     }
-                }
-                TbMethod::FileOpen { name, .. } => {
-                    validate_testbench_expression(&name.0, source, active_functions)?
-                }
-                TbMethod::FileWrite { args } => {
-                    for argument in args {
-                        validate_testbench_expression(&argument.0, source, active_functions)?;
+                    TbMethod::RandomGet { .. } | TbMethod::RandomGetSeed => {}
+                    TbMethod::ClockNext { count, period } => {
+                        if let Some(expression) = count {
+                            validate_testbench_expression(expression, source, active_functions)?;
+                        }
+                        if let Some(expression) = period {
+                            validate_testbench_expression(expression, source, active_functions)?;
+                        }
                     }
+                    TbMethod::ResetAssert { duration, .. } => {
+                        if let Some(expression) = duration {
+                            validate_testbench_expression(expression, source, active_functions)?;
+                        }
+                    }
+                    TbMethod::FileOpen { name, .. } => {
+                        validate_testbench_expression(&name.0, source, active_functions)?
+                    }
+                    TbMethod::FileWrite { args } => {
+                        for argument in args {
+                            validate_testbench_expression(&argument.0, source, active_functions)?;
+                        }
+                    }
+                    TbMethod::FileClose | TbMethod::FileFlush => {}
                 }
-                TbMethod::FileClose | TbMethod::FileFlush => {}
-            },
+            }
             Statement::Break | Statement::Unsupported(_) | Statement::Null => {}
         }
     }

--- a/crates/celox-frontend-veryl/src/testbench.rs
+++ b/crates/celox-frontend-veryl/src/testbench.rs
@@ -1549,15 +1549,56 @@ impl<'a> SemanticTestbenchBuilder<'a> {
                     deassert_value,
                 })
             }
+            TbMethod::RandomSeed { value } => Some(GenericTestbenchStatement::RandomSeed {
+                handle: resource_table::get_str_value(tb.inst).unwrap_or_default(),
+                value: ec.compile(value),
+            }),
+            TbMethod::RandomGet { width, signed } => {
+                let ret = match tb.ret.as_deref() {
+                    Some(dst) => Some(ec.resolve_var(&dst.id)?),
+                    None => None,
+                };
+                Some(GenericTestbenchStatement::RandomGet {
+                    handle: resource_table::get_str_value(tb.inst).unwrap_or_default(),
+                    width: *width,
+                    signed: *signed,
+                    ret,
+                })
+            }
+            TbMethod::RandomGetRange {
+                min,
+                max,
+                width,
+                signed,
+            } => {
+                let ret = match tb.ret.as_deref() {
+                    Some(dst) => Some(ec.resolve_var(&dst.id)?),
+                    None => None,
+                };
+                Some(GenericTestbenchStatement::RandomGetRange {
+                    handle: resource_table::get_str_value(tb.inst).unwrap_or_default(),
+                    min: ec.compile(min),
+                    max: ec.compile(max),
+                    width: *width,
+                    signed: *signed,
+                    ret,
+                })
+            }
+            TbMethod::RandomGetSeed => {
+                let ret = match tb.ret.as_deref() {
+                    Some(dst) => Some(ec.resolve_var(&dst.id)?),
+                    None => None,
+                };
+                Some(GenericTestbenchStatement::RandomGetSeed {
+                    handle: resource_table::get_str_value(tb.inst).unwrap_or_default(),
+                    ret,
+                })
+            }
             TbMethod::FileOpen { .. }
             | TbMethod::FileWrite { .. }
             | TbMethod::FileClose
             | TbMethod::FileFlush
-            | TbMethod::Component { .. }
-            | TbMethod::RandomSeed { .. }
-            | TbMethod::RandomGet { .. }
-            | TbMethod::RandomGetRange { .. }
-            | TbMethod::RandomGetSeed => None,
+            | TbMethod::Component { .. } => None,
         }
     }
 
@@ -1853,25 +1894,13 @@ fn validate_testbench_statements(
                     ));
                 }
                 TbMethod::RandomSeed { value } => {
-                    return Err(ParserError::unsupported(
-                        469,
-                        LoweringPhase::SimulatorParser,
-                        "testbench random method",
-                        "random runtime integration is not implemented",
-                        Some(&value.comptime().token),
-                    ));
+                    validate_testbench_expression(value, source, active_functions)?;
                 }
-                TbMethod::RandomGet { .. }
-                | TbMethod::RandomGetRange { .. }
-                | TbMethod::RandomGetSeed => {
-                    return Err(ParserError::unsupported(
-                        469,
-                        LoweringPhase::SimulatorParser,
-                        "testbench random method",
-                        "random runtime integration is not implemented",
-                        None,
-                    ));
+                TbMethod::RandomGetRange { min, max, .. } => {
+                    validate_testbench_expression(min, source, active_functions)?;
+                    validate_testbench_expression(max, source, active_functions)?;
                 }
+                TbMethod::RandomGet { .. } | TbMethod::RandomGetSeed => {}
                 TbMethod::ClockNext { count, period } => {
                     if let Some(expression) = count {
                         validate_testbench_expression(expression, source, active_functions)?;
@@ -1905,6 +1934,7 @@ pub fn compile_semantic_testbench(
     lookup: &VerylFrontendLookup,
     source: &VerylTestbenchSource,
     runtime_event_site_count: usize,
+    random_seed: u64,
 ) -> Result<Option<TestbenchProgram<StateAddr>>, ParserError> {
     let Some(initial_stmts) = source.initial_statements.as_ref() else {
         return Ok(None);
@@ -1912,5 +1942,7 @@ pub fn compile_semantic_testbench(
     validate_testbench_statements(initial_stmts, source, &mut FxHashSet::default())?;
     let mut builder = SemanticTestbenchBuilder::new(lookup, source, runtime_event_site_count);
     builder.build_event_map(initial_stmts);
-    Ok(Some(TestbenchProgram::new(builder.convert(initial_stmts))))
+    Ok(Some(
+        TestbenchProgram::new(builder.convert(initial_stmts)).with_random_seed(random_seed),
+    ))
 }

--- a/crates/celox-runtime/src/testbench.rs
+++ b/crates/celox-runtime/src/testbench.rs
@@ -225,7 +225,7 @@ pub fn bind_testbench_program<B: SimBackend>(
     backend: &B,
     program: TestbenchProgram<AbsoluteAddr>,
 ) -> Option<ExecutableTestbench<B::Event, SignalRef>> {
-    let random_seed = program.random_seed();
+    let random_seed = program.configured_random_seed();
     let statements = program
         .into_statements()
         .into_iter()

--- a/crates/celox-runtime/src/testbench.rs
+++ b/crates/celox-runtime/src/testbench.rs
@@ -178,6 +178,44 @@ fn bind_statement<B: SimBackend>(
                 expr: bind_expr(backend, expr)?,
             })
         }
+        GenericTestbenchStatement::RandomSeed { handle, value } => {
+            Some(GenericTestbenchStatement::RandomSeed {
+                handle,
+                value: bind_expr(backend, value)?,
+            })
+        }
+        GenericTestbenchStatement::RandomGet {
+            handle,
+            width,
+            signed,
+            ret,
+        } => Some(GenericTestbenchStatement::RandomGet {
+            handle,
+            width,
+            signed,
+            ret: ret.map(|signal| backend.resolve_signal(&signal.address)),
+        }),
+        GenericTestbenchStatement::RandomGetRange {
+            handle,
+            min,
+            max,
+            width,
+            signed,
+            ret,
+        } => Some(GenericTestbenchStatement::RandomGetRange {
+            handle,
+            min: bind_expr(backend, min)?,
+            max: bind_expr(backend, max)?,
+            width,
+            signed,
+            ret: ret.map(|signal| backend.resolve_signal(&signal.address)),
+        }),
+        GenericTestbenchStatement::RandomGetSeed { handle, ret } => {
+            Some(GenericTestbenchStatement::RandomGetSeed {
+                handle,
+                ret: ret.map(|signal| backend.resolve_signal(&signal.address)),
+            })
+        }
         GenericTestbenchStatement::Break => Some(GenericTestbenchStatement::Break),
         GenericTestbenchStatement::Finish => Some(GenericTestbenchStatement::Finish),
     }
@@ -187,10 +225,11 @@ pub fn bind_testbench_program<B: SimBackend>(
     backend: &B,
     program: TestbenchProgram<AbsoluteAddr>,
 ) -> Option<ExecutableTestbench<B::Event, SignalRef>> {
+    let random_seed = program.random_seed();
     let statements = program
         .into_statements()
         .into_iter()
         .map(|statement| bind_statement(backend, statement))
         .collect::<Option<Vec<_>>>()?;
-    Some(ExecutableTestbench::new(statements))
+    Some(ExecutableTestbench::new(statements, random_seed))
 }

--- a/crates/celox-runtime/src/testbench.rs
+++ b/crates/celox-runtime/src/testbench.rs
@@ -231,5 +231,8 @@ pub fn bind_testbench_program<B: SimBackend>(
         .into_iter()
         .map(|statement| bind_statement(backend, statement))
         .collect::<Option<Vec<_>>>()?;
-    Some(ExecutableTestbench::new(statements, random_seed))
+    Some(ExecutableTestbench::new_with_random_seed(
+        statements,
+        random_seed,
+    ))
 }

--- a/crates/celox-testbench/src/lib.rs
+++ b/crates/celox-testbench/src/lib.rs
@@ -175,14 +175,14 @@ pub type SemanticStatement<A> =
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TestbenchProgram<A> {
     statements: Vec<SemanticStatement<A>>,
-    random_seed: u64,
+    random_seed: Option<u64>,
 }
 
 impl<A> Default for TestbenchProgram<A> {
     fn default() -> Self {
         Self {
             statements: Vec::new(),
-            random_seed: 0,
+            random_seed: None,
         }
     }
 }
@@ -191,11 +191,16 @@ impl<A> TestbenchProgram<A> {
     pub fn new(statements: Vec<SemanticStatement<A>>) -> Self {
         Self {
             statements,
-            random_seed: 0,
+            random_seed: None,
         }
     }
 
     pub fn with_random_seed(mut self, random_seed: u64) -> Self {
+        self.random_seed = Some(random_seed);
+        self
+    }
+
+    pub fn with_random_seed_option(mut self, random_seed: Option<u64>) -> Self {
         self.random_seed = random_seed;
         self
     }
@@ -208,7 +213,7 @@ impl<A> TestbenchProgram<A> {
         self.statements
     }
 
-    pub fn random_seed(&self) -> u64 {
+    pub fn random_seed(&self) -> Option<u64> {
         self.random_seed
     }
 
@@ -314,11 +319,18 @@ pub type ExecutableStatement<Event, Signal> =
 
 pub struct ExecutableTestbench<Event, Signal> {
     statements: Vec<ExecutableStatement<Event, Signal>>,
-    random_seed: u64,
+    random_seed: Option<u64>,
 }
 
 impl<Event, Signal> ExecutableTestbench<Event, Signal> {
     pub fn new(statements: Vec<ExecutableStatement<Event, Signal>>, random_seed: u64) -> Self {
+        Self::new_with_random_seed(statements, Some(random_seed))
+    }
+
+    pub fn new_with_random_seed(
+        statements: Vec<ExecutableStatement<Event, Signal>>,
+        random_seed: Option<u64>,
+    ) -> Self {
         Self {
             statements,
             random_seed,
@@ -333,7 +345,7 @@ impl<Event, Signal> ExecutableTestbench<Event, Signal> {
         self.statements
     }
 
-    pub fn random_seed(&self) -> u64 {
+    pub fn random_seed(&self) -> Option<u64> {
         self.random_seed
     }
 }

--- a/crates/celox-testbench/src/lib.rs
+++ b/crates/celox-testbench/src/lib.rs
@@ -129,6 +129,28 @@ pub enum TestbenchStatement<Event, Signal, Expression, Argument> {
         dst: Signal,
         expr: Expression,
     },
+    RandomSeed {
+        handle: String,
+        value: Expression,
+    },
+    RandomGet {
+        handle: String,
+        width: u32,
+        signed: bool,
+        ret: Option<Signal>,
+    },
+    RandomGetRange {
+        handle: String,
+        min: Expression,
+        max: Expression,
+        width: u32,
+        signed: bool,
+        ret: Option<Signal>,
+    },
+    RandomGetSeed {
+        handle: String,
+        ret: Option<Signal>,
+    },
     Break,
     Finish,
 }
@@ -153,19 +175,29 @@ pub type SemanticStatement<A> =
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TestbenchProgram<A> {
     statements: Vec<SemanticStatement<A>>,
+    random_seed: u64,
 }
 
 impl<A> Default for TestbenchProgram<A> {
     fn default() -> Self {
         Self {
             statements: Vec::new(),
+            random_seed: 0,
         }
     }
 }
 
 impl<A> TestbenchProgram<A> {
     pub fn new(statements: Vec<SemanticStatement<A>>) -> Self {
-        Self { statements }
+        Self {
+            statements,
+            random_seed: 0,
+        }
+    }
+
+    pub fn with_random_seed(mut self, random_seed: u64) -> Self {
+        self.random_seed = random_seed;
+        self
     }
 
     pub fn statements(&self) -> &[SemanticStatement<A>] {
@@ -174,6 +206,10 @@ impl<A> TestbenchProgram<A> {
 
     pub fn into_statements(self) -> Vec<SemanticStatement<A>> {
         self.statements
+    }
+
+    pub fn random_seed(&self) -> u64 {
+        self.random_seed
     }
 
     pub fn is_empty(&self) -> bool {
@@ -278,11 +314,15 @@ pub type ExecutableStatement<Event, Signal> =
 
 pub struct ExecutableTestbench<Event, Signal> {
     statements: Vec<ExecutableStatement<Event, Signal>>,
+    random_seed: u64,
 }
 
 impl<Event, Signal> ExecutableTestbench<Event, Signal> {
-    pub fn new(statements: Vec<ExecutableStatement<Event, Signal>>) -> Self {
-        Self { statements }
+    pub fn new(statements: Vec<ExecutableStatement<Event, Signal>>, random_seed: u64) -> Self {
+        Self {
+            statements,
+            random_seed,
+        }
     }
 
     pub fn statements(&self) -> &[ExecutableStatement<Event, Signal>] {
@@ -291,6 +331,10 @@ impl<Event, Signal> ExecutableTestbench<Event, Signal> {
 
     pub fn into_statements(self) -> Vec<ExecutableStatement<Event, Signal>> {
         self.statements
+    }
+
+    pub fn random_seed(&self) -> u64 {
+        self.random_seed
     }
 }
 

--- a/crates/celox-testbench/src/lib.rs
+++ b/crates/celox-testbench/src/lib.rs
@@ -213,7 +213,11 @@ impl<A> TestbenchProgram<A> {
         self.statements
     }
 
-    pub fn random_seed(&self) -> Option<u64> {
+    pub fn random_seed(&self) -> u64 {
+        self.random_seed.unwrap_or_default()
+    }
+
+    pub fn configured_random_seed(&self) -> Option<u64> {
         self.random_seed
     }
 
@@ -345,7 +349,11 @@ impl<Event, Signal> ExecutableTestbench<Event, Signal> {
         self.statements
     }
 
-    pub fn random_seed(&self) -> Option<u64> {
+    pub fn random_seed(&self) -> u64 {
+        self.random_seed.unwrap_or_default()
+    }
+
+    pub fn configured_random_seed(&self) -> Option<u64> {
         self.random_seed
     }
 }

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -40,6 +40,8 @@ thiserror             = { workspace = true }
 clap                  = { workspace = true }
 miette                = { workspace = true }
 num-bigint            = "0.5"
+rand                  = { workspace = true }
+rand_pcg              = { workspace = true }
 serde                 = { workspace = true }
 serde_json            = { workspace = true }
 num-traits            = { workspace = true }

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -15,6 +15,7 @@ host-runtime = [
     "dep:celox-backend-x86",
     "dep:celox-macros",
     "dep:wasmtime",
+    "rand/thread_rng",
     "celox-sir-opt/timing",
 ]
 experimental-arm64-backend = ["host-runtime", "dep:celox-backend-arm64"]

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -307,6 +307,7 @@ pub fn parse(
     optimize_options: &crate::optimizer::OptimizeOptions,
     diagnostics: &crate::RuntimeDiagnostics,
     preserve_element_storage_layout: bool,
+    testbench_random_seed: u64,
 ) -> Result<
     (
         crate::ir::OptimizedSir,
@@ -396,8 +397,11 @@ pub fn parse(
     let scheduled = scheduled.scheduled;
     let (sir, mut runtime, testbench_source) = RuntimeProgram::from_scheduled(scheduled);
     crate::testbench_compile::project_observability(&mut runtime, &testbench_source);
-    runtime.testbench =
-        crate::testbench_compile::compile_semantic_testbench(&runtime, &testbench_source)?;
+    runtime.testbench = crate::testbench_compile::compile_semantic_testbench(
+        &runtime,
+        &testbench_source,
+        testbench_random_seed,
+    )?;
     dump_addr_map_if_requested(&runtime, diagnostics);
     let mut program = UnoptimizedSir::new(sir, runtime);
     if let Some(t) = trace.as_deref_mut()

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -307,7 +307,7 @@ pub fn parse(
     optimize_options: &crate::optimizer::OptimizeOptions,
     diagnostics: &crate::RuntimeDiagnostics,
     preserve_element_storage_layout: bool,
-    testbench_random_seed: u64,
+    testbench_random_seed: Option<u64>,
 ) -> Result<
     (
         crate::ir::OptimizedSir,

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -1,5 +1,10 @@
 use std::path::Path;
 
+#[cfg(not(feature = "host-runtime"))]
+use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(not(feature = "host-runtime"))]
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use veryl_analyzer::ir::{Comptime, Expression, VarPath};
 use veryl_analyzer::value::Value;
 use veryl_analyzer::{Analyzer, AnalyzerError, Context, attribute_table, ir::Ir, symbol_table};
@@ -12,6 +17,25 @@ use crate::{
     CompilationWarning, FrontendDiagnostic, ParserError, SimulatorError, SimulatorErrorKind,
     ir::OptimizedSir, parser,
 };
+
+#[cfg(feature = "host-runtime")]
+fn fresh_testbench_seed() -> u64 {
+    rand::random()
+}
+
+#[cfg(not(feature = "host-runtime"))]
+fn fresh_testbench_seed() -> u64 {
+    // The host simulator uses the operating system RNG above. Keep the
+    // portable compiler path independent of getrandom's target-specific
+    // backends while still ensuring that two builds in the same tick receive
+    // distinct seeds.
+    static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+    let time = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos() as u64);
+    let sequence = SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    time ^ sequence.rotate_left(32)
+}
 
 fn analyze(
     sources: &[(&str, &Path)],
@@ -44,7 +68,7 @@ fn analyze(
     attribute_table::clear();
 
     let metadata = metadata.unwrap_or_else(|| Metadata::create_default("prj").unwrap());
-    let testbench_random_seed = metadata.test.seed.unwrap_or_default();
+    let testbench_random_seed = metadata.test.seed.unwrap_or_else(fresh_testbench_seed);
     let analyzer = Analyzer::new(&metadata);
     let project_name = metadata.project.name.clone();
 

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -44,6 +44,7 @@ fn analyze(
     attribute_table::clear();
 
     let metadata = metadata.unwrap_or_else(|| Metadata::create_default("prj").unwrap());
+    let testbench_random_seed = metadata.test.seed.unwrap_or_default();
     let analyzer = Analyzer::new(&metadata);
     let project_name = metadata.project.name.clone();
 
@@ -121,6 +122,7 @@ fn analyze(
         optimize_options,
         diagnostics,
         preserve_element_storage_layout,
+        testbench_random_seed,
     )
     .map(|(sir, mut elaborated_diagnostics)| {
         frontend_diagnostics.append(&mut elaborated_diagnostics);
@@ -886,8 +888,7 @@ mod host {
                 )))
             })?;
             Ok(crate::testbench::run_testbench_detailed(
-                &mut sim,
-                testbench.statements(),
+                &mut sim, &testbench,
             ))
         }
 
@@ -985,7 +986,7 @@ mod host {
                 "no initial block found — this module is not a native testbench",
             )))
         })?;
-        let result = crate::testbench::run_testbench(&mut sim, testbench.statements());
+        let result = crate::testbench::run_testbench(&mut sim, &testbench);
         if let Some(start) = testbench_start {
             tracing::debug!("[phase-timing] testbench: {:?}", start.elapsed());
         }

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -1,10 +1,5 @@
 use std::path::Path;
 
-#[cfg(not(feature = "host-runtime"))]
-use std::sync::atomic::{AtomicU64, Ordering};
-#[cfg(not(feature = "host-runtime"))]
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use veryl_analyzer::ir::{Comptime, Expression, VarPath};
 use veryl_analyzer::value::Value;
 use veryl_analyzer::{Analyzer, AnalyzerError, Context, attribute_table, ir::Ir, symbol_table};
@@ -17,25 +12,6 @@ use crate::{
     CompilationWarning, FrontendDiagnostic, ParserError, SimulatorError, SimulatorErrorKind,
     ir::OptimizedSir, parser,
 };
-
-#[cfg(feature = "host-runtime")]
-fn fresh_testbench_seed() -> u64 {
-    rand::random()
-}
-
-#[cfg(not(feature = "host-runtime"))]
-fn fresh_testbench_seed() -> u64 {
-    // The host simulator uses the operating system RNG above. Keep the
-    // portable compiler path independent of getrandom's target-specific
-    // backends while still ensuring that two builds in the same tick receive
-    // distinct seeds.
-    static SEQUENCE: AtomicU64 = AtomicU64::new(0);
-    let time = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| duration.as_nanos() as u64);
-    let sequence = SEQUENCE.fetch_add(1, Ordering::Relaxed);
-    time ^ sequence.rotate_left(32)
-}
 
 fn analyze(
     sources: &[(&str, &Path)],
@@ -68,7 +44,10 @@ fn analyze(
     attribute_table::clear();
 
     let metadata = metadata.unwrap_or_else(|| Metadata::create_default("prj").unwrap());
-    let testbench_random_seed = metadata.test.seed.unwrap_or_else(fresh_testbench_seed);
+    // Preserve an explicitly configured seed, but defer generating an
+    // implicit seed until testbench execution. This keeps compilation
+    // deterministic and avoids host-only time APIs in the browser compiler.
+    let testbench_random_seed = metadata.test.seed;
     let analyzer = Analyzer::new(&metadata);
     let project_name = metadata.project.name.clone();
 

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -170,6 +170,10 @@ fn sim_set_u64<B: SimBackend>(sim: &mut crate::Simulator<B>, sig: SignalRef, val
     }
 }
 
+fn execution_random_seed(seed: Option<u64>) -> u64 {
+    seed.unwrap_or_else(rand::random)
+}
+
 // Keep the generator, seed derivation, and range sampling byte-for-byte
 // compatible with Veryl's `$tb::random` runtime.
 struct RandomTable {
@@ -855,7 +859,7 @@ fn run_testbench_limited<B: SimBackend>(
         current_time: 0,
         tick_limit,
         tick_limit_reached: false,
-        random: RandomTable::new(testbench.random_seed()),
+        random: RandomTable::new(execution_random_seed(testbench.random_seed())),
     };
     let result = exec_detailed(sim, testbench.statements(), &mut ctx);
     let failed_messages = ctx
@@ -935,7 +939,7 @@ pub(crate) fn run_testbench_detailed<B: SimBackend>(
         current_time: 0,
         tick_limit: None,
         tick_limit_reached: false,
-        random: RandomTable::new(testbench.random_seed()),
+        random: RandomTable::new(execution_random_seed(testbench.random_seed())),
     };
     let result = exec_detailed(sim, testbench.statements(), &mut ctx);
     let passed = !matches!(result, ExecResult::Fail(_)) && ctx.assertions.iter().all(|a| a.passed);

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -471,6 +471,14 @@ fn mask_to_width(value: BigUint, width: usize) -> BigUint {
     }
 }
 
+fn width_mask(width: usize) -> BigUint {
+    if width == 0 {
+        BigUint::from(0u8)
+    } else {
+        (BigUint::from(1u8) << width) - BigUint::from(1u8)
+    }
+}
+
 fn sim_set_i128<B: SimBackend>(
     sim: &mut crate::Simulator<B>,
     sig: SignalRef,
@@ -494,6 +502,39 @@ fn sim_set_biguint<B: SimBackend>(sim: &mut crate::Simulator<B>, sig: SignalRef,
     } else {
         sim.set_wide(sig, mask_to_width(value, sig.width));
     }
+}
+
+fn random_value_for_destination(
+    value: u64,
+    source_width: u32,
+    signed: bool,
+    destination_width: usize,
+) -> BigUint {
+    let source_width = source_width as usize;
+    let source_mask = width_mask(source_width);
+    let source_value = BigUint::from(value) & &source_mask;
+    if destination_width < source_width {
+        source_value & width_mask(destination_width)
+    } else if signed
+        && source_width > 0
+        && source_width <= 64
+        && source_value.bit((source_width - 1) as u64)
+    {
+        source_value | (width_mask(destination_width) ^ source_mask)
+    } else {
+        source_value
+    }
+}
+
+fn sim_set_random<B: SimBackend>(
+    sim: &mut crate::Simulator<B>,
+    sig: SignalRef,
+    value: u64,
+    source_width: u32,
+    signed: bool,
+) {
+    let value = random_value_for_destination(value, source_width, signed, sig.width);
+    sim_set_biguint(sim, sig, value);
 }
 
 fn sim_set_bigint<B: SimBackend>(
@@ -1355,12 +1396,12 @@ fn exec_one_detailed<B: SimBackend>(
         GenericTestbenchStatement::RandomGet {
             handle,
             width,
-            signed: _,
+            signed,
             ret,
         } => {
             let value = ctx.random.get(handle, *width);
             if let Some(ret) = ret {
-                sim_set_u64(sim, *ret, value);
+                sim_set_random(sim, *ret, value, *width, *signed);
             }
             ExecResult::Continue
         }
@@ -1380,7 +1421,7 @@ fn exec_one_detailed<B: SimBackend>(
             let max = max.eval_u64(ptr);
             let value = ctx.random.get_range(handle, min, max, *width, *signed);
             if let Some(ret) = ret {
-                sim_set_u64(sim, *ret, value);
+                sim_set_random(sim, *ret, value, *width, *signed);
             }
             ExecResult::Continue
         }
@@ -1410,6 +1451,22 @@ mod tests {
         };
 
         assert!(error.source().unwrap().is::<RuntimeErrorCode>());
+    }
+
+    #[test]
+    fn random_values_sign_extend_for_wider_destinations() {
+        assert_eq!(
+            random_value_for_destination(0x80, 8, true, 16),
+            BigUint::from(0xff80u16)
+        );
+        assert_eq!(
+            random_value_for_destination(0x7f, 8, true, 16),
+            BigUint::from(0x007fu16)
+        );
+        assert_eq!(
+            random_value_for_destination(0x80, 8, false, 16),
+            BigUint::from(0x0080u16)
+        );
     }
 
     #[test]

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -22,6 +22,9 @@ use celox_testbench::{
 };
 use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::ToPrimitive as _;
+use rand::{RngExt as _, SeedableRng as _};
+use rand_pcg::Pcg64;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 // ── Public types ───────────────────────────────────────────────────────
@@ -164,6 +167,91 @@ fn sim_set_u64<B: SimBackend>(sim: &mut crate::Simulator<B>, sig: SignalRef, val
         17..=32 => sim.set(sig, value as u32),
         33..=64 => sim.set(sig, value),
         _ => sim.set_wide(sig, BigUint::from(value)),
+    }
+}
+
+// Keep the generator, seed derivation, and range sampling byte-for-byte
+// compatible with Veryl's `$tb::random` runtime.
+struct RandomTable {
+    base_seed: u64,
+    rngs: HashMap<String, (Pcg64, u64)>,
+}
+
+impl RandomTable {
+    fn new(base_seed: u64) -> Self {
+        Self {
+            base_seed,
+            rngs: HashMap::new(),
+        }
+    }
+
+    fn derive_seed(base_seed: u64, handle: &str) -> u64 {
+        let mut hash = 0xcbf2_9ce4_8422_2325u64;
+        for byte in base_seed
+            .to_le_bytes()
+            .iter()
+            .copied()
+            .chain(handle.bytes())
+        {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        hash
+    }
+
+    fn entry(&mut self, handle: &str) -> &mut (Pcg64, u64) {
+        let base_seed = self.base_seed;
+        self.rngs.entry(handle.to_owned()).or_insert_with(|| {
+            let seed = Self::derive_seed(base_seed, handle);
+            (Pcg64::seed_from_u64(seed), seed)
+        })
+    }
+
+    fn seed(&mut self, handle: &str, seed: u64) {
+        self.rngs
+            .insert(handle.to_owned(), (Pcg64::seed_from_u64(seed), seed));
+    }
+
+    fn get_seed(&mut self, handle: &str) -> u64 {
+        self.entry(handle).1
+    }
+
+    fn get(&mut self, handle: &str, width: u32) -> u64 {
+        let mask = random_mask(width);
+        self.entry(handle).0.random_range(0..=mask)
+    }
+
+    fn get_range(&mut self, handle: &str, min: u64, max: u64, width: u32, signed: bool) -> u64 {
+        let mask = random_mask(width);
+        if signed {
+            let min = sign_extend_random(min & mask, width);
+            let max = sign_extend_random(max & mask, width);
+            let (lo, hi) = if min <= max { (min, max) } else { (max, min) };
+            let sample: i64 = self.entry(handle).0.random_range(lo..=hi);
+            (sample as u64) & mask
+        } else {
+            let min = min & mask;
+            let max = max & mask;
+            let (lo, hi) = if min <= max { (min, max) } else { (max, min) };
+            self.entry(handle).0.random_range(lo..=hi)
+        }
+    }
+}
+
+fn random_mask(width: u32) -> u64 {
+    if width >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << width) - 1
+    }
+}
+
+fn sign_extend_random(raw: u64, width: u32) -> i64 {
+    if width == 0 || width >= 64 {
+        raw as i64
+    } else {
+        let shift = 64 - width;
+        ((raw << shift) as i64) >> shift
     }
 }
 
@@ -752,14 +840,14 @@ fn exec_for_loop<B: SimBackend>(
 
 pub(crate) fn run_testbench<B: SimBackend>(
     sim: &mut Simulator<B>,
-    stmts: &[TestbenchStatement<B>],
+    testbench: &CompiledTestbench<B>,
 ) -> TestResult {
-    run_testbench_limited(sim, stmts, None).result
+    run_testbench_limited(sim, testbench, None).result
 }
 
 fn run_testbench_limited<B: SimBackend>(
     sim: &mut Simulator<B>,
-    stmts: &[TestbenchStatement<B>],
+    testbench: &CompiledTestbench<B>,
     tick_limit: Option<u64>,
 ) -> LimitedTestbenchResult {
     let mut ctx = DetailedExecContext {
@@ -767,8 +855,9 @@ fn run_testbench_limited<B: SimBackend>(
         current_time: 0,
         tick_limit,
         tick_limit_reached: false,
+        random: RandomTable::new(testbench.random_seed()),
     };
-    let result = exec_detailed(sim, stmts, &mut ctx);
+    let result = exec_detailed(sim, testbench.statements(), &mut ctx);
     let failed_messages = ctx
         .assertions
         .iter()
@@ -820,7 +909,7 @@ pub fn run_compiled_testbench<B: SimBackend>(
     sim: &mut Simulator<B>,
     tb: &CompiledTestbench<B>,
 ) -> TestResult {
-    run_testbench(sim, tb.statements())
+    run_testbench(sim, tb)
 }
 
 /// Execute at most `tick_limit` simulator ticks from a compiled testbench.
@@ -832,22 +921,23 @@ pub fn run_compiled_testbench_with_tick_limit<B: SimBackend>(
     tb: &CompiledTestbench<B>,
     tick_limit: u64,
 ) -> LimitedTestbenchResult {
-    run_testbench_limited(sim, tb.statements(), Some(tick_limit))
+    run_testbench_limited(sim, tb, Some(tick_limit))
 }
 
 /// Run the testbench and return assertion results observed before the test
 /// finishes or stops on a fatal failure.
 pub(crate) fn run_testbench_detailed<B: SimBackend>(
     sim: &mut Simulator<B>,
-    stmts: &[TestbenchStatement<B>],
+    testbench: &CompiledTestbench<B>,
 ) -> TestResultDetailed {
     let mut ctx = DetailedExecContext {
         assertions: Vec::new(),
         current_time: 0,
         tick_limit: None,
         tick_limit_reached: false,
+        random: RandomTable::new(testbench.random_seed()),
     };
-    let result = exec_detailed(sim, stmts, &mut ctx);
+    let result = exec_detailed(sim, testbench.statements(), &mut ctx);
     let passed = !matches!(result, ExecResult::Fail(_)) && ctx.assertions.iter().all(|a| a.passed);
     TestResultDetailed {
         passed,
@@ -860,6 +950,7 @@ struct DetailedExecContext {
     current_time: u64,
     tick_limit: Option<u64>,
     tick_limit_reached: bool,
+    random: RandomTable,
 }
 
 fn assert_event_args(message: &Option<AssertMessage>) -> &[CompiledAssertArg] {
@@ -1246,6 +1337,53 @@ fn exec_one_detailed<B: SimBackend>(
             match val {
                 TbValue::U64(v) => sim_set_u64(sim, *dst, v),
                 TbValue::Wide(v) => sim.set_wide(*dst, v),
+            }
+            ExecResult::Continue
+        }
+        GenericTestbenchStatement::RandomSeed { handle, value } => {
+            if let Err(e) = sim.eval_comb() {
+                return ExecResult::Fail(format!("eval_comb: {e}"));
+            }
+            let (ptr, _) = sim.memory_as_mut_ptr();
+            ctx.random.seed(handle, value.eval_u64(ptr));
+            ExecResult::Continue
+        }
+        GenericTestbenchStatement::RandomGet {
+            handle,
+            width,
+            signed: _,
+            ret,
+        } => {
+            let value = ctx.random.get(handle, *width);
+            if let Some(ret) = ret {
+                sim_set_u64(sim, *ret, value);
+            }
+            ExecResult::Continue
+        }
+        GenericTestbenchStatement::RandomGetRange {
+            handle,
+            min,
+            max,
+            width,
+            signed,
+            ret,
+        } => {
+            if let Err(e) = sim.eval_comb() {
+                return ExecResult::Fail(format!("eval_comb: {e}"));
+            }
+            let (ptr, _) = sim.memory_as_mut_ptr();
+            let min = min.eval_u64(ptr);
+            let max = max.eval_u64(ptr);
+            let value = ctx.random.get_range(handle, min, max, *width, *signed);
+            if let Some(ret) = ret {
+                sim_set_u64(sim, *ret, value);
+            }
+            ExecResult::Continue
+        }
+        GenericTestbenchStatement::RandomGetSeed { handle, ret } => {
+            let seed = ctx.random.get_seed(handle);
+            if let Some(ret) = ret {
+                sim_set_u64(sim, *ret, seed);
             }
             ExecResult::Continue
         }

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -900,7 +900,7 @@ fn run_testbench_limited<B: SimBackend>(
         current_time: 0,
         tick_limit,
         tick_limit_reached: false,
-        random: RandomTable::new(execution_random_seed(testbench.random_seed())),
+        random: RandomTable::new(execution_random_seed(testbench.configured_random_seed())),
     };
     let result = exec_detailed(sim, testbench.statements(), &mut ctx);
     let failed_messages = ctx
@@ -980,7 +980,7 @@ pub(crate) fn run_testbench_detailed<B: SimBackend>(
         current_time: 0,
         tick_limit: None,
         tick_limit_reached: false,
-        random: RandomTable::new(execution_random_seed(testbench.random_seed())),
+        random: RandomTable::new(execution_random_seed(testbench.configured_random_seed())),
     };
     let result = exec_detailed(sim, testbench.statements(), &mut ctx);
     let passed = !matches!(result, ExecResult::Fail(_)) && ctx.assertions.iter().all(|a| a.passed);

--- a/crates/celox/src/testbench_compile.rs
+++ b/crates/celox/src/testbench_compile.rs
@@ -19,7 +19,7 @@ pub(crate) fn project_observability(program: &mut RuntimeProgram, source: &Veryl
 pub(crate) fn compile_semantic_testbench(
     program: &RuntimeProgram,
     source: &VerylTestbenchSource,
-    random_seed: u64,
+    random_seed: Option<u64>,
 ) -> Result<Option<TestbenchProgram<AbsoluteAddr>>, celox_frontend_veryl::ParserError> {
     celox_frontend_veryl::compile_semantic_testbench(
         &program.frontend,

--- a/crates/celox/src/testbench_compile.rs
+++ b/crates/celox/src/testbench_compile.rs
@@ -19,10 +19,12 @@ pub(crate) fn project_observability(program: &mut RuntimeProgram, source: &Veryl
 pub(crate) fn compile_semantic_testbench(
     program: &RuntimeProgram,
     source: &VerylTestbenchSource,
+    random_seed: u64,
 ) -> Result<Option<TestbenchProgram<AbsoluteAddr>>, celox_frontend_veryl::ParserError> {
     celox_frontend_veryl::compile_semantic_testbench(
         &program.frontend,
         source,
         program.runtime_schema.runtime_event_sites.len(),
+        random_seed,
     )
 }

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -1,6 +1,6 @@
 use celox::{
     DeadStorePolicy, ParserError, ResetType, Simulator, SimulatorErrorKind, TestResult,
-    testbench::compile_initial_testbench,
+    testbench::{compile_initial_testbench, run_compiled_testbench},
 };
 use veryl_analyzer::{AnalyzerError, analyzer_error::InvalidForRangeKind};
 use veryl_metadata::Metadata;
@@ -150,23 +150,112 @@ fn test_random_methods_match_veryl_sequence() {
 }
 
 #[test]
-fn test_unset_testbench_seed_is_fresh_per_build() {
+fn test_random_signed_results_sign_extend_on_wider_stores() {
+    let handle = veryl_parser::resource_table::insert_str("r");
+    let get_seed = (0..10_000)
+        .find(|seed| {
+            veryl_simulator::random_table::seed_handle(handle, *seed);
+            let get_value = veryl_simulator::random_table::get(handle, 8, true).payload_u64();
+            get_value & 0x80 != 0
+        })
+        .expect("a signed random result with its sign bit set");
+    let range_seed = (0..10_000)
+        .find(|seed| {
+            veryl_simulator::random_table::seed_handle(handle, *seed);
+            let range_value =
+                veryl_simulator::random_table::get_range(handle, 0x80, 0x7f, 8, true).payload_u64();
+            range_value & 0x80 != 0
+        })
+        .expect("a signed ranged result with its sign bit set");
+    veryl_simulator::random_table::seed_handle(handle, get_seed);
+    let get_value = veryl_simulator::random_table::get(handle, 8, true).payload_u64();
+    veryl_simulator::random_table::seed_handle(handle, range_seed);
+    let range_value =
+        veryl_simulator::random_table::get_range(handle, 0x80, 0x7f, 8, true).payload_u64();
+
+    let code = format!(
+        r#"
+        #[test(t)]
+        module t {{
+            var r: $tb::random::<i8>;
+            var widened_get: logic<16>;
+            var widened_range: logic<16>;
+            initial {{
+                r.seed({get_seed});
+                widened_get = r.get() as i16;
+                r.seed({range_seed});
+                widened_range = r.get_range(-128, 127) as i16;
+                $finish();
+            }}
+        }}
+        "#,
+    );
+    let mut sim = Simulator::builder(&code, "t").build().unwrap();
+    let tb = compile_initial_testbench(&sim).unwrap();
+    assert_eq!(run_compiled_testbench(&mut sim, &tb), TestResult::Pass);
+
+    let widened_get = sim.get_as::<u16>(sim.signal("widened_get"));
+    let widened_range = sim.get_as::<u16>(sim.signal("widened_range"));
+    let expected_get = if get_value & 0x80 != 0 {
+        0xff00 | get_value as u16
+    } else {
+        get_value as u16
+    };
+    let expected_range = if range_value & 0x80 != 0 {
+        0xff00 | range_value as u16
+    } else {
+        range_value as u16
+    };
+    assert_eq!(widened_get, expected_get);
+    assert_eq!(widened_range, expected_range);
+}
+
+#[test]
+fn test_unset_testbench_seed_is_fresh_per_execution() {
     let code = r#"
         #[test(t)]
         module t {
-            initial { $finish(); }
+            var random_seed: u64;
+            var r: $tb::random::<u64>;
+            initial {
+                random_seed = r.get_seed();
+                $finish();
+            }
         }
     "#;
-    let sim_a = Simulator::builder(code, "t").build().unwrap();
-    let sim_b = Simulator::builder(code, "t").build().unwrap();
-    let tb_a = compile_initial_testbench(&sim_a).unwrap();
-    let tb_b = compile_initial_testbench(&sim_b).unwrap();
+    let mut sim = Simulator::builder(code, "t").build().unwrap();
+    let tb = compile_initial_testbench(&sim).unwrap();
+    let random_seed = sim.signal("random_seed");
+
+    assert_eq!(run_compiled_testbench(&mut sim, &tb), TestResult::Pass);
+    let first = sim.get_as::<u64>(random_seed);
+    assert_eq!(run_compiled_testbench(&mut sim, &tb), TestResult::Pass);
+    let second = sim.get_as::<u64>(random_seed);
 
     assert_ne!(
-        tb_a.random_seed(),
-        tb_b.random_seed(),
-        "an omitted metadata seed must not silently become zero",
+        first, second,
+        "an omitted seed must be drawn for each execution"
     );
+
+    let mut metadata = Metadata::create_default("prj").unwrap();
+    metadata.test.seed = Some(42);
+    let mut explicit_sim = Simulator::builder(code, "t")
+        .with_metadata(metadata)
+        .build()
+        .unwrap();
+    let explicit_tb = compile_initial_testbench(&explicit_sim).unwrap();
+    let explicit_seed = explicit_sim.signal("random_seed");
+    assert_eq!(
+        run_compiled_testbench(&mut explicit_sim, &explicit_tb),
+        TestResult::Pass
+    );
+    let explicit_first = explicit_sim.get_as::<u64>(explicit_seed);
+    assert_eq!(
+        run_compiled_testbench(&mut explicit_sim, &explicit_tb),
+        TestResult::Pass
+    );
+    let explicit_second = explicit_sim.get_as::<u64>(explicit_seed);
+    assert_eq!(explicit_first, explicit_second);
 }
 
 #[test]

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -1,4 +1,7 @@
-use celox::{DeadStorePolicy, ResetType, Simulator, SimulatorErrorKind, TestResult};
+use celox::{
+    DeadStorePolicy, ParserError, ResetType, Simulator, SimulatorErrorKind, TestResult,
+    testbench::compile_initial_testbench,
+};
 use veryl_analyzer::{AnalyzerError, analyzer_error::InvalidForRangeKind};
 use veryl_metadata::Metadata;
 
@@ -144,6 +147,62 @@ fn test_random_methods_match_veryl_sequence() {
             .unwrap(),
         TestResult::Pass,
     );
+}
+
+#[test]
+fn test_unset_testbench_seed_is_fresh_per_build() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            initial { $finish(); }
+        }
+    "#;
+    let sim_a = Simulator::builder(code, "t").build().unwrap();
+    let sim_b = Simulator::builder(code, "t").build().unwrap();
+    let tb_a = compile_initial_testbench(&sim_a).unwrap();
+    let tb_b = compile_initial_testbench(&sim_b).unwrap();
+
+    assert_ne!(
+        tb_a.random_seed(),
+        tb_b.random_seed(),
+        "an omitted metadata seed must not silently become zero",
+    );
+}
+
+#[test]
+fn test_selected_testbench_destinations_are_rejected() {
+    for code in [
+        r#"
+            #[test(t)]
+            module t {
+                var values: logic<8>[4];
+                var index: logic<2>;
+                var r: $tb::random::<u8>;
+                initial {
+                    index = 1;
+                    values[index] = r.get();
+                    $finish();
+                }
+            }
+        "#,
+        r#"
+            #[test(t)]
+            module t {
+                var word: logic<8>;
+                initial {
+                    word[3] = 1;
+                    $finish();
+                }
+            }
+        "#,
+    ] {
+        let error = Simulator::builder(code, "t").build().unwrap_err();
+        let SimulatorErrorKind::SIRParser(ParserError::Unsupported { issue, .. }) = error.kind()
+        else {
+            panic!("expected selected destination diagnostic, got {error:?}");
+        };
+        assert_eq!(*issue, 478);
+    }
 }
 
 #[test]

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -77,6 +77,76 @@ fn test_native_testbench_uses_metadata_project_name() {
 }
 
 #[test]
+fn test_random_methods_match_veryl_sequence() {
+    let explicit = veryl_parser::resource_table::insert_str("r");
+    veryl_simulator::random_table::reset(0);
+    veryl_simulator::random_table::seed_handle(explicit, 1234);
+    let exact =
+        veryl_simulator::random_table::get_range(explicit, 100, 100, 8, false).payload_u64();
+    let ranged = veryl_simulator::random_table::get_range(explicit, 0, 7, 8, false).payload_u64();
+    let full0 = veryl_simulator::random_table::get(explicit, 8, false).payload_u64();
+    let full1 = veryl_simulator::random_table::get(explicit, 8, false).payload_u64();
+
+    let signed = veryl_parser::resource_table::insert_str("s");
+    veryl_simulator::random_table::seed_handle(signed, 999);
+    let signed_range =
+        veryl_simulator::random_table::get_range(signed, 251, 5, 8, true).payload_u64();
+
+    let derived = veryl_parser::resource_table::insert_str("derived");
+    veryl_simulator::random_table::reset(42);
+    let derived_seed = veryl_simulator::random_table::get_seed_handle(derived);
+    let derived_value = veryl_simulator::random_table::get(derived, 16, false).payload_u64();
+
+    let code = format!(
+        r#"
+        #[test(t)]
+        module t {{
+            var r      : $tb::random::<u8> ;
+            var s      : $tb::random::<i8> ;
+            var derived: $tb::random::<u16>;
+            var x   : u8 ;
+            var sx  : i8 ;
+            var x16 : u16;
+            var seed: u64;
+            initial {{
+                r.seed(1234);
+                x = r.get_range(100, 100);
+                $assert(x == 8'd{exact});
+                x = r.get_range(0, 7);
+                $assert(x == 8'd{ranged});
+                x = r.get();
+                $assert(x == 8'd{full0});
+                x = r.get();
+                $assert(x == 8'd{full1});
+                seed = r.get_seed();
+                $assert(seed == 64'd1234);
+
+                s.seed(999);
+                sx = s.get_range(-5, 5);
+                $assert((sx as u8) == 8'd{signed_range});
+
+                seed = derived.get_seed();
+                $assert(seed == 64'd{derived_seed});
+                x16 = derived.get();
+                $assert(x16 == 16'd{derived_value});
+                $finish();
+            }}
+        }}
+        "#,
+    );
+    let mut metadata = Metadata::create_default("prj").unwrap();
+    metadata.test.seed = Some(42);
+
+    assert_eq!(
+        Simulator::builder(&code, "t")
+            .with_metadata(metadata)
+            .run_test()
+            .unwrap(),
+        TestResult::Pass,
+    );
+}
+
+#[test]
 fn test_counter_pass() {
     let code = format!(
         r#"


### PR DESCRIPTION
## Summary

- implement Veryl testbench random methods: `seed`, `get`, `get_range`, and `get_seed`
- carry the metadata test seed into the semantic and executable testbench program
- keep random state per testbench execution and per random handle
- add a direct compatibility regression against Veryl 0.20.3's `random_table`

## Compatibility

Celox follows Veryl 0.20.3 exactly for:

- `rand_pcg::Pcg64` seeded with `seed_from_u64`
- FNV-1a derivation from the little-endian base seed followed by the handle name
- `rand 0.10` inclusive range sampling
- unsigned masking and signed two's-complement range interpretation

The regression obtains expected values from Veryl's own random runtime, covering explicit and derived seeds, unsigned and signed ranges, full-width generation, and `get_seed`.

## Validation

- `cargo test -p celox --test native_testbench` — 75 passed, 1 ignored
- `cargo test -p celox-frontend-veryl` — 78 passed
- `cargo test -p celox-testbench` — 4 passed
- `cargo test -p celox-runtime` — passed
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- production clippy targets passed

The full Celox clippy command still reports the pre-existing `needless_range_loop` at `crates/celox-frontend-veryl/src/ff/expression.rs:2011`, outside this change.

Fixes #469
