### PR TITLE
feat(veryl): support hierarchical testbench reads

### DIFF
--- a/crates/celox-design/src/lib.rs
+++ b/crates/celox-design/src/lib.rs
@@ -45,6 +45,9 @@ pub struct VariableMetadata {
     /// Per-dimension sizes for array ports (for example, `[4]` for `logic<32>[4]`).
     /// Empty means scalar.
     pub array_dims: Vec<usize>,
+    /// Per-dimension packed widths (for example, `[4, 4]` for `logic<4, 4>`).
+    /// Empty means a scalar one-bit value.
+    pub packed_dims: Vec<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -614,10 +617,12 @@ mod tests {
             kind: DomainKind::Other,
             type_kind: PortTypeKind::Logic,
             array_dims: vec![4],
+            packed_dims: vec![8],
         };
 
         assert_eq!(metadata.width, 32);
         assert_eq!(metadata.array_dims, vec![4]);
+        assert_eq!(metadata.packed_dims, vec![8]);
     }
 
     #[test]
@@ -631,6 +636,7 @@ mod tests {
                 kind: DomainKind::ClockPosedge,
                 type_kind: PortTypeKind::Clock,
                 array_dims: Vec::new(),
+                packed_dims: Vec::new(),
             },
         );
         design.events.aliases.insert(11, 10);

--- a/crates/celox-frontend-veryl/src/design_assembly.rs
+++ b/crates/celox-frontend-veryl/src/design_assembly.rs
@@ -873,6 +873,21 @@ fn module_variables(
                         kind: type_kind_to_domain_kind(&varibale.r#type.kind, config),
                         type_kind: type_kind_to_port_type_kind(&varibale.r#type.kind, config),
                         array_dims: varibale.r#type.array.iter().filter_map(|d| *d).collect(),
+                        packed_dims: {
+                            let mut dimensions = varibale
+                                .r#type
+                                .width()
+                                .iter()
+                                .filter_map(|dimension| *dimension)
+                                .collect::<Vec<_>>();
+                            if dimensions.is_empty()
+                                && let Some(width) = varibale.r#type.kind.width()
+                                && width > 1
+                            {
+                                dimensions.push(width);
+                            }
+                            dimensions
+                        },
                     },
                 },
             );

--- a/crates/celox-frontend-veryl/src/design_assembly.rs
+++ b/crates/celox-frontend-veryl/src/design_assembly.rs
@@ -12,6 +12,7 @@ use celox_slt::{
     scheduler::{self, SchedulerError},
 };
 use veryl_analyzer::ir::{Declaration, Module, VarId, VarPath};
+use veryl_analyzer::symbol::Affiliation;
 use veryl_metadata::{ClockType, ResetType};
 use veryl_parser::resource_table::{self, StrId};
 
@@ -852,13 +853,18 @@ fn module_variables(
         let mut variables = HashMap::default();
         let mut paths: HashMap<VarPath, Option<VarId>> = HashMap::default();
         for (id, varibale) in &module.variables {
-            match paths.entry(varibale.path.clone()) {
-                std::collections::hash_map::Entry::Vacant(e) => {
-                    e.insert(Some(*id));
-                }
-                std::collections::hash_map::Entry::Occupied(mut e) => {
-                    // Duplicate VarPath — mark as ambiguous
-                    e.insert(None);
+            // Only module-scope variables are externally addressable. Locals
+            // may share the same VarPath, but must not make a legal
+            // hierarchical or public lookup appear ambiguous.
+            if varibale.affiliation == Affiliation::Module {
+                match paths.entry(varibale.path.clone()) {
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        e.insert(Some(*id));
+                    }
+                    std::collections::hash_map::Entry::Occupied(mut e) => {
+                        // Duplicate visible VarPath — mark as ambiguous.
+                        e.insert(None);
+                    }
                 }
             }
             variables.insert(

--- a/crates/celox-frontend-veryl/src/dynamic_for_check.rs
+++ b/crates/celox-frontend-veryl/src/dynamic_for_check.rs
@@ -257,6 +257,24 @@ fn check_elaborated_for(
     let mut active_functions = HashSet::default();
     let body_effects =
         collect_statement_effects(&statement.body, module, &mut active_functions, false);
+    let mut unknown = bound_effects
+        .unknown
+        .clone()
+        .or(body_effects.unknown.clone());
+    let immediate_writes =
+        collect_immediate_state_writes(&body_effects.writes, scheduled, &mut unknown);
+    if hierarchical_reads_conflict(
+        &bound_effects.hierarchical_reads,
+        &immediate_writes,
+        scheduled,
+        &mut unknown,
+    ) {
+        diagnostics.push(FrontendDiagnostic::mutable_for_bound(
+            &statement.token,
+            "the loop body may immediately modify state read by the continuation bound",
+        ));
+        return;
+    }
     if body_effects.state_changes.is_empty() {
         return;
     }
@@ -275,7 +293,6 @@ fn check_elaborated_for(
         return;
     }
 
-    let mut unknown = bound_effects.unknown.or(body_effects.unknown);
     let writes =
         collect_state_change_writes(&body_effects.state_changes, scheduled, hints, &mut unknown);
     let mut conflict = false;
@@ -299,33 +316,13 @@ fn check_elaborated_for(
             break;
         }
     }
-    for reference in &bound_effects.hierarchical_reads {
-        match crate::testbench::resolve_hierarchical_reference(
-            &scheduled.frontend_lookup,
-            reference,
-        ) {
-            Ok((address, info)) => {
-                match crate::testbench::hierarchical_reference_bits(info, reference) {
-                    Ok(read_bits) => {
-                        if writes.iter().any(|write| {
-                            write.address == address
-                                && write
-                                    .bits
-                                    .is_none_or(|write_bits| write_bits.overlaps(&read_bits))
-                        }) {
-                            conflict = true;
-                            break;
-                        }
-                    }
-                    Err(error) => {
-                        unknown.get_or_insert_with(|| error.to_string());
-                    }
-                }
-            }
-            Err(error) => {
-                unknown.get_or_insert_with(|| error.to_string());
-            }
-        }
+    if hierarchical_reads_conflict(
+        &bound_effects.hierarchical_reads,
+        &writes,
+        scheduled,
+        &mut unknown,
+    ) {
+        conflict = true;
     }
 
     if conflict {
@@ -346,6 +343,70 @@ struct StateWrite {
     address: StateAddr,
     /// `None` denotes a dynamic or otherwise non-static range of this object.
     bits: Option<BitAccess>,
+}
+
+fn collect_immediate_state_writes(
+    accesses: &[Access],
+    scheduled: &ScheduledRtl,
+    unknown: &mut Option<String>,
+) -> Vec<StateWrite> {
+    let mut writes = Vec::new();
+    for access in accesses.iter().filter(|access| !access.deferred) {
+        let Some((address, _)) = scheduled.frontend_lookup.root_variable(access.id) else {
+            unknown.get_or_insert_with(|| {
+                format!(
+                    "body variable `{}` could not be projected after elaboration",
+                    access.id
+                )
+            });
+            continue;
+        };
+        add_state_write(
+            &mut writes,
+            StateWrite {
+                address,
+                bits: Some(access.bits),
+            },
+        );
+    }
+    propagate_comb_writes(&scheduled.sir.eval_comb, &mut writes);
+    writes
+}
+
+fn hierarchical_reads_conflict(
+    references: &[veryl_analyzer::ir::HierVarRef],
+    writes: &[StateWrite],
+    scheduled: &ScheduledRtl,
+    unknown: &mut Option<String>,
+) -> bool {
+    for reference in references {
+        let (address, info) = match crate::testbench::resolve_hierarchical_reference(
+            &scheduled.frontend_lookup,
+            reference,
+        ) {
+            Ok(resolved) => resolved,
+            Err(error) => {
+                unknown.get_or_insert_with(|| error.to_string());
+                continue;
+            }
+        };
+        let read_bits = match crate::testbench::hierarchical_reference_bits(info, reference) {
+            Ok(bits) => bits,
+            Err(error) => {
+                unknown.get_or_insert_with(|| error.to_string());
+                continue;
+            }
+        };
+        if writes.iter().any(|write| {
+            write.address == address
+                && write
+                    .bits
+                    .is_none_or(|write_bits| write_bits.overlaps(&read_bits))
+        }) {
+            return true;
+        }
+    }
+    false
 }
 
 fn collect_state_change_writes(

--- a/crates/celox-frontend-veryl/src/dynamic_for_check.rs
+++ b/crates/celox-frontend-veryl/src/dynamic_for_check.rs
@@ -90,6 +90,7 @@ enum StateChange {
 #[derive(Default)]
 struct Effects {
     reads: Vec<Access>,
+    hierarchical_reads: Vec<veryl_analyzer::ir::HierVarRef>,
     writes: Vec<Access>,
     state_changes: Vec<StateChange>,
     observable: bool,
@@ -105,6 +106,8 @@ impl Effects {
 
     fn append(&mut self, mut other: Effects) {
         self.reads.append(&mut other.reads);
+        self.hierarchical_reads
+            .append(&mut other.hierarchical_reads);
         self.writes.append(&mut other.writes);
         self.state_changes.append(&mut other.state_changes);
         self.observable |= other.observable;
@@ -294,6 +297,22 @@ fn check_elaborated_for(
         }) {
             conflict = true;
             break;
+        }
+    }
+    for reference in &bound_effects.hierarchical_reads {
+        match crate::testbench::resolve_hierarchical_reference(
+            &scheduled.frontend_lookup,
+            reference,
+        ) {
+            Ok((address, _)) => {
+                if writes.iter().any(|write| write.address == address) {
+                    conflict = true;
+                    break;
+                }
+            }
+            Err(error) => {
+                unknown.get_or_insert_with(|| error.to_string());
+            }
         }
     }
 
@@ -1259,8 +1278,15 @@ fn collect_expression_effects(
             Factor::Unknown(_) => {
                 effects.mark_unknown("bound expression contains an unknown value")
             }
-            Factor::HierVariable(_) => {
-                effects.mark_unknown("bound expression contains an unsupported hierarchical read")
+            Factor::HierVariable(reference) => {
+                collect_index_select_effects(
+                    &reference.index,
+                    &reference.select,
+                    module,
+                    active_functions,
+                    &mut effects,
+                );
+                effects.hierarchical_reads.push((**reference).clone());
             }
             Factor::Value(_) | Factor::Anonymous(_) => {}
         },

--- a/crates/celox-frontend-veryl/src/dynamic_for_check.rs
+++ b/crates/celox-frontend-veryl/src/dynamic_for_check.rs
@@ -304,10 +304,22 @@ fn check_elaborated_for(
             &scheduled.frontend_lookup,
             reference,
         ) {
-            Ok((address, _)) => {
-                if writes.iter().any(|write| write.address == address) {
-                    conflict = true;
-                    break;
+            Ok((address, info)) => {
+                match crate::testbench::hierarchical_reference_bits(info, reference) {
+                    Ok(read_bits) => {
+                        if writes.iter().any(|write| {
+                            write.address == address
+                                && write
+                                    .bits
+                                    .is_none_or(|write_bits| write_bits.overlaps(&read_bits))
+                        }) {
+                            conflict = true;
+                            break;
+                        }
+                    }
+                    Err(error) => {
+                        unknown.get_or_insert_with(|| error.to_string());
+                    }
                 }
             }
             Err(error) => {
@@ -1050,7 +1062,7 @@ fn check_for(
     }
 
     let unknown = bound_effects.unknown.or_else(|| {
-        (!bound_effects.reads.is_empty())
+        (!bound_effects.reads.is_empty() || !bound_effects.hierarchical_reads.is_empty())
             .then_some(body_effects.unknown)
             .flatten()
     });
@@ -1653,6 +1665,55 @@ mod tests {
             ports: HashMap::default(),
             port_types: HashMap::default(),
             variables: [(bound_id, variable)].into_iter().collect(),
+            functions: HashMap::default(),
+            declarations: vec![Declaration::new_comb(vec![statement])],
+            suppress_unassigned: false,
+            per_decl_refs: HashMap::default(),
+            assign_tokens: HashMap::default(),
+            ff_table: FfTable::default(),
+        };
+        let ir = Ir {
+            components: vec![Component::Module(module)],
+        };
+
+        let diagnostics = check_dynamic_for_bounds(&ir);
+        assert!(matches!(
+            diagnostics.as_slice(),
+            [FrontendDiagnostic::UnknownForBoundEffect { .. }]
+        ));
+    }
+
+    #[test]
+    fn unknown_body_effect_ir_is_reported_for_a_hierarchical_bound() {
+        let token = TokenRange::default();
+        let bound = Expression::Term(Box::new(Factor::HierVariable(Box::new(
+            veryl_analyzer::ir::HierVarRef {
+                inst_path: vec![StrId::default()],
+                var_path: VarPath(vec![StrId::default()]),
+                index: VarIndex::default(),
+                select: VarSelect::default(),
+                comptime: Comptime::default(),
+            },
+        ))));
+        let statement = Statement::For(Box::new(ForStatement {
+            var_id: VarId::default(),
+            var_name: StrId::default(),
+            var_type: Type::default(),
+            range: ForRange::Forward {
+                start: ForBound::Const(0),
+                end: ForBound::Expression(Box::new(bound)),
+                inclusive: false,
+                step: 1,
+            },
+            body: vec![Statement::Unsupported(token)],
+            token,
+        }));
+        let module = Module {
+            name: StrId::default(),
+            token,
+            ports: HashMap::default(),
+            port_types: HashMap::default(),
+            variables: HashMap::default(),
             functions: HashMap::default(),
             declarations: vec![Declaration::new_comb(vec![statement])],
             suppress_unassigned: false,

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -3593,11 +3593,12 @@ impl<'a> FfParser<'a> {
                 }
             }
             Factor::HierVariable(reference) => {
-                return Err(ParserError::unsupported(
-                    467,
-                    LoweringPhase::FfLowering,
+                return Err(ParserError::illegal_context(
                     "hierarchical variable reference",
-                    format!("{}", reference.var_path),
+                    format!(
+                        "`{}` is only valid in a native testbench block",
+                        reference.var_path
+                    ),
                     Some(&reference.comptime.token),
                 ));
             }

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -1705,11 +1705,12 @@ pub(super) fn collect_written_expression(
                 }
                 Ok(())
             }
-            Factor::HierVariable(reference) => Err(ParserError::unsupported(
-                467,
-                LoweringPhase::CombLowering,
+            Factor::HierVariable(reference) => Err(ParserError::illegal_context(
                 "hierarchical variable reference",
-                format!("{}", reference.var_path),
+                format!(
+                    "`{}` is only valid in a native testbench block",
+                    reference.var_path
+                ),
                 Some(&reference.comptime.token),
             )),
             Factor::SystemFunctionCall(call) => {

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -1120,11 +1120,12 @@ fn collect_factor_effects(
             }
             Ok(())
         }
-        Factor::HierVariable(reference) => Err(ParserError::unsupported(
-            467,
-            crate::LoweringPhase::CombLowering,
+        Factor::HierVariable(reference) => Err(ParserError::illegal_context(
             "hierarchical variable reference",
-            format!("{}", reference.var_path),
+            format!(
+                "`{}` is only valid in a native testbench block",
+                reference.var_path
+            ),
             Some(&reference.comptime.token),
         )),
         Factor::FunctionCall(call) => {
@@ -2577,11 +2578,12 @@ fn collect_factor_position_inputs(
             }
             Ok(())
         }
-        Factor::HierVariable(reference) => Err(ParserError::unsupported(
-            467,
-            crate::LoweringPhase::CombLowering,
+        Factor::HierVariable(reference) => Err(ParserError::illegal_context(
             "hierarchical variable reference",
-            format!("{}", reference.var_path),
+            format!(
+                "`{}` is only valid in a native testbench block",
+                reference.var_path
+            ),
             Some(&reference.comptime.token),
         )),
         Factor::Value(_) => Ok(()),

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -3181,11 +3181,12 @@ fn eval_factor(
                 Ok(((extracted_expr, all_sources), all_bounds))
             }
         }
-        Factor::HierVariable(reference) => Err(ParserError::unsupported(
-            467,
-            LoweringPhase::CombLowering,
+        Factor::HierVariable(reference) => Err(ParserError::illegal_context(
             "hierarchical variable reference",
-            format!("{}", reference.var_path),
+            format!(
+                "`{}` is only valid in a native testbench block",
+                reference.var_path
+            ),
             Some(&reference.comptime.token),
         )),
         Factor::Value(v) => {

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -558,11 +558,12 @@ fn collect_parent_output_address_sources(
                 }
                 Ok(())
             }
-            Factor::HierVariable(reference) => Err(ParserError::unsupported(
-                467,
-                LoweringPhase::SimulatorParser,
+            Factor::HierVariable(reference) => Err(ParserError::illegal_context(
                 "hierarchical variable reference",
-                format!("{}", reference.var_path),
+                format!(
+                    "`{}` is only valid in a native testbench block",
+                    reference.var_path
+                ),
                 Some(&reference.comptime.token),
             )),
             Factor::SystemFunctionCall(call) => {

--- a/crates/celox-frontend-veryl/src/testbench.rs
+++ b/crates/celox-frontend-veryl/src/testbench.rs
@@ -10,7 +10,7 @@ use num_traits::ToPrimitive as _;
 use veryl_analyzer::ir::{
     ArrayLiteralItem, AssertKind, CasePattern, Expression, Factor, ForBound, ForRange, Function,
     FunctionCall, HierVarRef, Op as VerylOp, Statement, SystemFunctionInput, SystemFunctionKind,
-    TbMethod, TbMethodCall, VarId,
+    TbMethod, TbMethodCall, VarId, VarIndex, VarSelect, VarSelectOp,
 };
 use veryl_analyzer::value::byte_value_to_string;
 use veryl_parser::resource_table::{self, StrId};
@@ -442,6 +442,46 @@ fn checked_reference_bits(
         ));
     }
     Ok(BitAccess::new(lsb, msb))
+}
+
+fn variable_access_width(
+    info: &VariableInfo,
+    index: &VarIndex,
+    select: &VarSelect,
+) -> Option<usize> {
+    let array_total = info
+        .array_dims
+        .iter()
+        .try_fold(1usize, |total, dimension| total.checked_mul(*dimension))?;
+    if array_total == 0 || !info.width.is_multiple_of(array_total) {
+        return None;
+    }
+    let consumed = index.0.len();
+    if consumed > info.array_dims.len() {
+        return None;
+    }
+    let element_width = info.width / array_total;
+    let accessed_width = info.array_dims[consumed..]
+        .iter()
+        .try_fold(element_width, |width, dimension| {
+            width.checked_mul(*dimension)
+        })?;
+
+    if let Some((op, range_expression)) = &select.1 {
+        let range = eval_constexpr(range_expression)?.to_usize()?;
+        return match op {
+            VarSelectOp::Colon => {
+                let anchor = eval_constexpr(select.0.last()?)?.to_usize()?;
+                anchor.checked_sub(range)?.checked_add(1)
+            }
+            VarSelectOp::PlusColon | VarSelectOp::MinusColon | VarSelectOp::Step => Some(range),
+        };
+    }
+    if select.0.is_empty() {
+        Some(accessed_width)
+    } else {
+        Some(1)
+    }
 }
 
 enum TestbenchRead {
@@ -1230,7 +1270,7 @@ impl ExprCompiler<'_> {
 
         // Process unpacked array indices
         let mut static_bit_offset: usize = 0;
-        let mut dynamic_emitted = false;
+        let mut dynamic_terms = 0usize;
 
         for (i, idx_expr) in index.0.iter().enumerate() {
             if i >= info.array_dims.len() {
@@ -1242,33 +1282,22 @@ impl ExprCompiler<'_> {
                 // Static index: accumulate into offset
                 static_bit_offset += idx_val * stride;
             } else {
-                // Dynamic index: emit the index expression, then LoadIndexed
-                let base_byte_offset = static_bit_offset / 8;
-                let stride_bytes = get_byte_size(stride);
-                let elem_byte_size = get_byte_size(element_width);
+                // Keep the dynamic flattened bit offset on the stack. All
+                // dimensions are consumed before the selected subarray is
+                // loaded, so a dynamic outer index does not discard inner
+                // indices or force the result down to one scalar element.
                 self.emit(idx_expr, ops);
-                ops.push(TbOpcode::LoadIndexed {
-                    location: Self::state_location_at(address, base_byte_offset),
-                    stride_bytes,
-                    element_byte_size: elem_byte_size,
-                    element_width,
-                });
-                dynamic_emitted = true;
-                // After a dynamic index, remaining indices would need chaining.
-                // For now, only single dynamic index is supported.
-                break;
+                if stride != 1 {
+                    ops.push(TbOpcode::ConstU64(stride as u64));
+                    ops.push(TbOpcode::BinOp(Op::Mul));
+                }
+                if dynamic_terms != 0 {
+                    ops.push(TbOpcode::BinOp(Op::Add));
+                }
+                dynamic_terms += 1;
             }
         }
 
-        if dynamic_emitted {
-            // Apply bit select on top of dynamic result if present
-            if select.1.is_some() || !select.0.is_empty() {
-                self.emit_post_select(select, element_width, ops);
-            }
-            return;
-        }
-
-        // All indices were static — apply bit select
         let accessed_width = if index.0.len() >= info.array_dims.len() {
             element_width
         } else if index.0.is_empty() {
@@ -1277,6 +1306,21 @@ impl ExprCompiler<'_> {
             strides_bits[index.0.len() - 1]
         };
 
+        if dynamic_terms != 0 {
+            ops.push(TbOpcode::LoadIndexed {
+                location: Self::state_location_at(address, 0),
+                stride_bits: 1,
+                base_bit_offset: static_bit_offset,
+                element_width: accessed_width,
+            });
+            // Apply bit select on top of dynamic result if present
+            if select.1.is_some() || !select.0.is_empty() {
+                self.emit_post_select(select, accessed_width, ops);
+            }
+            return;
+        }
+
+        // All indices were static — apply bit select
         if select.0.is_empty() && select.1.is_none() {
             // No bit select, just load the element
             let byte_offset = static_bit_offset / 8;
@@ -1345,7 +1389,9 @@ impl ExprCompiler<'_> {
                 let (lsb, msb) = match op {
                     veryl_analyzer::ir::VarSelectOp::Colon => (v, a),
                     veryl_analyzer::ir::VarSelectOp::PlusColon => (a, a + v - 1),
-                    veryl_analyzer::ir::VarSelectOp::MinusColon => (a.saturating_sub(v) + 1, a),
+                    veryl_analyzer::ir::VarSelectOp::MinusColon => {
+                        (a.saturating_add(1).saturating_sub(v), a)
+                    }
                     veryl_analyzer::ir::VarSelectOp::Step => (a * v, (a + 1) * v - 1),
                 };
                 return (lsb, msb - lsb + 1, false);
@@ -1483,14 +1529,15 @@ impl ExprCompiler<'_> {
         // For terms, look up variable info
         if let Expression::Term(f) = expr {
             match f.as_ref() {
-                Factor::Variable(var_id, _, _, _) => {
+                Factor::Variable(var_id, index, select, _) => {
                     if let Some((_, info)) = self.lookup.root_variable(*var_id) {
-                        return info.width;
+                        return variable_access_width(info, index, select).unwrap_or(info.width);
                     }
                 }
                 Factor::HierVariable(reference) => {
                     if let Ok((_, info)) = resolve_hierarchical_reference(self.lookup, reference) {
-                        return info.width;
+                        return variable_access_width(info, &reference.index, &reference.select)
+                            .unwrap_or(info.width);
                     }
                 }
                 Factor::Value(c) => {

--- a/crates/celox-frontend-veryl/src/testbench.rs
+++ b/crates/celox-frontend-veryl/src/testbench.rs
@@ -1,4 +1,4 @@
-use celox_design::{PortTypeKind, RuntimeEventKind, RuntimeEventSite, StateAddr};
+use celox_design::{BitAccess, PortTypeKind, RuntimeEventKind, RuntimeEventSite, StateAddr};
 use celox_testbench::{
     AssertMessage as GenericAssertMessage, ClockCount as GenericClockCount, ExprBytecode,
     ExprOpcode as TbOpcode, LoopBound as GenericLoopBound, SemanticArgument, SemanticSignal,
@@ -6,6 +6,7 @@ use celox_testbench::{
     TestbenchStatement as GenericTestbenchStatement,
 };
 use fxhash::FxHashSet;
+use num_traits::ToPrimitive as _;
 use veryl_analyzer::ir::{
     ArrayLiteralItem, AssertKind, CasePattern, Expression, Factor, ForBound, ForRange, Function,
     FunctionCall, HierVarRef, Op as VerylOp, Statement, SystemFunctionInput, SystemFunctionKind,
@@ -17,6 +18,7 @@ use veryl_parser::resource_table::{self, StrId};
 use crate::{
     AbsoluteAddr, InstancePath, LoweringPhase, ParserError, VariableInfo, VerylFrontendLookup,
     VerylTestbenchSource,
+    bitaccess::eval_constexpr,
     context_width::{
         ValueContext, binary_semantics, cast_semantics, expression_signed, get_expr_width,
     },
@@ -294,6 +296,152 @@ pub(crate) fn resolve_hierarchical_reference<'a>(
             )
         })?;
     Ok((address, info))
+}
+
+/// Resolve the flattened state bits read by a hierarchical reference.
+///
+/// Metadata intentionally does not retain source-level packed dimensions, so
+/// multi-dimensional packed selects conservatively cover the current slice.
+/// Static unpacked indices and ordinary bit/part selects retain their precise
+/// range, matching the testbench bytecode layout.
+pub(crate) fn hierarchical_reference_bits(
+    info: &VariableInfo,
+    reference: &HierVarRef,
+) -> Result<BitAccess, ParserError> {
+    let invalid = |detail| invalid_hierarchical_reference(reference, detail);
+    let array_total = info
+        .array_dims
+        .iter()
+        .try_fold(1usize, |total, dimension| total.checked_mul(*dimension))
+        .ok_or_else(|| invalid("array dimensions overflow usize"))?;
+    if array_total == 0 || info.width == 0 || !info.width.is_multiple_of(array_total) {
+        return Err(invalid(
+            "the target variable has invalid flattened dimensions",
+        ));
+    }
+    let element_width = info.width / array_total;
+    let mut strides = vec![element_width; info.array_dims.len()];
+    let mut stride = element_width;
+    for (dimension, size) in info.array_dims.iter().enumerate().rev() {
+        strides[dimension] = stride;
+        stride = stride
+            .checked_mul(*size)
+            .ok_or_else(|| invalid("array stride overflows usize"))?;
+    }
+
+    let mut base = 0usize;
+    let mut consumed = 0usize;
+    for (dimension, expression) in reference.index.0.iter().enumerate() {
+        let Some(&dimension_stride) = strides.get(dimension) else {
+            return Err(invalid("too many unpacked array indices"));
+        };
+        let Some(index) = eval_constexpr(expression).and_then(|value| value.to_usize()) else {
+            let width = if dimension == 0 {
+                info.width
+            } else {
+                strides[dimension - 1]
+            };
+            return checked_reference_bits(reference, base, width, info.width);
+        };
+        if index >= info.array_dims[dimension] {
+            return Err(invalid_hierarchical_reference(
+                reference,
+                format!(
+                    "array index {index} is outside dimension width {}",
+                    info.array_dims[dimension]
+                ),
+            ));
+        }
+        base = base
+            .checked_add(
+                index
+                    .checked_mul(dimension_stride)
+                    .ok_or_else(|| invalid("array index offset overflows usize"))?,
+            )
+            .ok_or_else(|| invalid("array index offset overflows usize"))?;
+        consumed += 1;
+    }
+
+    let accessed_width = if consumed == 0 {
+        info.width
+    } else if consumed == info.array_dims.len() {
+        element_width
+    } else {
+        strides[consumed - 1]
+    };
+    if reference.select.0.is_empty() && reference.select.1.is_none() {
+        return checked_reference_bits(reference, base, accessed_width, info.width);
+    }
+    if reference.select.0.len() != 1 {
+        return checked_reference_bits(reference, base, accessed_width, info.width);
+    }
+
+    let anchor_expression = &reference.select.0[0];
+    let Some(anchor) = eval_constexpr(anchor_expression).and_then(|value| value.to_usize()) else {
+        return checked_reference_bits(reference, base, accessed_width, info.width);
+    };
+    let (relative_lsb, selected_width) = if let Some((op, range_expression)) = &reference.select.1 {
+        let Some(range) = eval_constexpr(range_expression).and_then(|value| value.to_usize())
+        else {
+            return checked_reference_bits(reference, base, accessed_width, info.width);
+        };
+        match op {
+            veryl_analyzer::ir::VarSelectOp::Colon => {
+                let width = anchor
+                    .checked_sub(range)
+                    .and_then(|width| width.checked_add(1))
+                    .ok_or_else(|| invalid("part-select range underflows"))?;
+                (range, width)
+            }
+            veryl_analyzer::ir::VarSelectOp::PlusColon => (anchor, range),
+            veryl_analyzer::ir::VarSelectOp::MinusColon => {
+                let lsb = anchor
+                    .checked_add(1)
+                    .and_then(|end| end.checked_sub(range))
+                    .ok_or_else(|| invalid("part-select range underflows"))?;
+                (lsb, range)
+            }
+            veryl_analyzer::ir::VarSelectOp::Step => {
+                let lsb = anchor
+                    .checked_mul(range)
+                    .ok_or_else(|| invalid("part-select offset overflows usize"))?;
+                (lsb, range)
+            }
+        }
+    } else {
+        (anchor, 1)
+    };
+    if selected_width == 0
+        || relative_lsb
+            .checked_add(selected_width)
+            .is_none_or(|end| end > accessed_width)
+    {
+        return Err(invalid("bit select is outside the selected variable slice"));
+    }
+    let absolute_lsb = base
+        .checked_add(relative_lsb)
+        .ok_or_else(|| invalid("bit-select offset overflows usize"))?;
+    checked_reference_bits(reference, absolute_lsb, selected_width, info.width)
+}
+
+fn checked_reference_bits(
+    reference: &HierVarRef,
+    lsb: usize,
+    width: usize,
+    total_width: usize,
+) -> Result<BitAccess, ParserError> {
+    let msb = lsb
+        .checked_add(width.checked_sub(1).ok_or_else(|| {
+            invalid_hierarchical_reference(reference, "selected width must be nonzero")
+        })?)
+        .ok_or_else(|| invalid_hierarchical_reference(reference, "bit range overflows usize"))?;
+    if msb >= total_width {
+        return Err(invalid_hierarchical_reference(
+            reference,
+            "selected bit range is outside the target variable",
+        ));
+    }
+    Ok(BitAccess::new(lsb, msb))
 }
 
 enum TestbenchRead {
@@ -1357,13 +1505,7 @@ impl ExprCompiler<'_> {
     }
 
     fn try_const_usize(expr: &Expression) -> Option<usize> {
-        match expr {
-            Expression::Term(f) => match f.as_ref() {
-                Factor::Value(c) => c.get_value().ok().map(|v| v.payload_u64() as usize),
-                _ => None,
-            },
-            _ => None,
-        }
+        eval_constexpr(expr).and_then(|value| value.to_usize())
     }
 
     fn resolve_var(&self, var_id: &VarId) -> Option<SemanticSignal<StateAddr>> {

--- a/crates/celox-frontend-veryl/src/testbench.rs
+++ b/crates/celox-frontend-veryl/src/testbench.rs
@@ -300,10 +300,8 @@ pub(crate) fn resolve_hierarchical_reference<'a>(
 
 /// Resolve the flattened state bits read by a hierarchical reference.
 ///
-/// Metadata intentionally does not retain source-level packed dimensions, so
-/// multi-dimensional packed selects conservatively cover the current slice.
-/// Static unpacked indices and ordinary bit/part selects retain their precise
-/// range, matching the testbench bytecode layout.
+/// Static unpacked and packed indices retain their precise range. A dynamic
+/// index conservatively covers the remaining slice at that dimension.
 pub(crate) fn hierarchical_reference_bits(
     info: &VariableInfo,
     reference: &HierVarRef,
@@ -372,26 +370,76 @@ pub(crate) fn hierarchical_reference_bits(
     if reference.select.0.is_empty() && reference.select.1.is_none() {
         return checked_reference_bits(reference, base, accessed_width, info.width);
     }
-    if reference.select.0.len() != 1 {
-        return checked_reference_bits(reference, base, accessed_width, info.width);
+
+    let packed_dimensions = if info.packed_dims.is_empty() {
+        vec![element_width]
+    } else {
+        info.packed_dims.clone()
+    };
+    let mut packed_strides = vec![1usize; packed_dimensions.len()];
+    let mut packed_stride = 1usize;
+    for (dimension, size) in packed_dimensions.iter().enumerate().rev() {
+        packed_strides[dimension] = packed_stride;
+        packed_stride = packed_stride
+            .checked_mul(*size)
+            .ok_or_else(|| invalid("packed stride overflows usize"))?;
     }
 
-    let anchor_expression = &reference.select.0[0];
-    let Some(anchor) = eval_constexpr(anchor_expression).and_then(|value| value.to_usize()) else {
-        return checked_reference_bits(reference, base, accessed_width, info.width);
+    let prefix_count = if reference.select.1.is_some() {
+        reference.select.0.len().saturating_sub(1)
+    } else {
+        reference.select.0.len()
     };
-    let (relative_lsb, selected_width) = if let Some((op, range_expression)) = &reference.select.1 {
+    for (dimension, expression) in reference.select.0[..prefix_count].iter().enumerate() {
+        let Some(&scale) = packed_strides.get(dimension) else {
+            return Err(invalid("too many packed indices"));
+        };
+        let Some(index) = eval_constexpr(expression).and_then(|value| value.to_usize()) else {
+            let width = if dimension == 0 {
+                accessed_width
+            } else {
+                packed_strides[dimension - 1]
+            };
+            return checked_reference_bits(reference, base, width, info.width);
+        };
+        base = base
+            .checked_add(
+                index
+                    .checked_mul(scale)
+                    .ok_or_else(|| invalid("packed index offset overflows usize"))?,
+            )
+            .ok_or_else(|| invalid("packed index offset overflows usize"))?;
+    }
+
+    let selected_width = if let Some((op, range_expression)) = &reference.select.1 {
+        let anchor_expression = reference
+            .select
+            .0
+            .last()
+            .ok_or_else(|| invalid("part select is missing its anchor"))?;
+        let current_width = if prefix_count == 0 {
+            accessed_width
+        } else {
+            packed_strides[prefix_count - 1]
+        };
+        let Some(anchor) = eval_constexpr(anchor_expression).and_then(|value| value.to_usize())
+        else {
+            return checked_reference_bits(reference, base, current_width, info.width);
+        };
         let Some(range) = eval_constexpr(range_expression).and_then(|value| value.to_usize())
         else {
-            return checked_reference_bits(reference, base, accessed_width, info.width);
+            return checked_reference_bits(reference, base, current_width, info.width);
         };
-        match op {
+        let scale = *packed_strides
+            .get(prefix_count)
+            .ok_or_else(|| invalid("part select exceeds packed dimensions"))?;
+        let (relative_lsb, elements) = match op {
             veryl_analyzer::ir::VarSelectOp::Colon => {
-                let width = anchor
+                let elements = anchor
                     .checked_sub(range)
                     .and_then(|width| width.checked_add(1))
                     .ok_or_else(|| invalid("part-select range underflows"))?;
-                (range, width)
+                (range, elements)
             }
             veryl_analyzer::ir::VarSelectOp::PlusColon => (anchor, range),
             veryl_analyzer::ir::VarSelectOp::MinusColon => {
@@ -407,21 +455,23 @@ pub(crate) fn hierarchical_reference_bits(
                     .ok_or_else(|| invalid("part-select offset overflows usize"))?;
                 (lsb, range)
             }
-        }
+        };
+        base = base
+            .checked_add(
+                relative_lsb
+                    .checked_mul(scale)
+                    .ok_or_else(|| invalid("part-select offset overflows usize"))?,
+            )
+            .ok_or_else(|| invalid("part-select offset overflows usize"))?;
+        elements
+            .checked_mul(scale)
+            .ok_or_else(|| invalid("part-select width overflows usize"))?
     } else {
-        (anchor, 1)
+        *packed_strides
+            .get(reference.select.0.len() - 1)
+            .ok_or_else(|| invalid("packed select exceeds variable dimensions"))?
     };
-    if selected_width == 0
-        || relative_lsb
-            .checked_add(selected_width)
-            .is_none_or(|end| end > accessed_width)
-    {
-        return Err(invalid("bit select is outside the selected variable slice"));
-    }
-    let absolute_lsb = base
-        .checked_add(relative_lsb)
-        .ok_or_else(|| invalid("bit-select offset overflows usize"))?;
-    checked_reference_bits(reference, absolute_lsb, selected_width, info.width)
+    checked_reference_bits(reference, base, selected_width, info.width)
 }
 
 fn checked_reference_bits(
@@ -467,20 +517,35 @@ fn variable_access_width(
             width.checked_mul(*dimension)
         })?;
 
+    let packed_dimensions = if info.packed_dims.is_empty() {
+        vec![element_width]
+    } else {
+        info.packed_dims.clone()
+    };
+    let mut packed_strides = vec![1usize; packed_dimensions.len()];
+    let mut stride = 1usize;
+    for (dimension, size) in packed_dimensions.iter().enumerate().rev() {
+        packed_strides[dimension] = stride;
+        stride = stride.checked_mul(*size)?;
+    }
+
     if let Some((op, range_expression)) = &select.1 {
         let range = eval_constexpr(range_expression)?.to_usize()?;
-        return match op {
+        let dimension = select.0.len().checked_sub(1)?;
+        let stride = *packed_strides.get(dimension)?;
+        let elements = match op {
             VarSelectOp::Colon => {
                 let anchor = eval_constexpr(select.0.last()?)?.to_usize()?;
                 anchor.checked_sub(range)?.checked_add(1)
             }
             VarSelectOp::PlusColon | VarSelectOp::MinusColon | VarSelectOp::Step => Some(range),
-        };
+        }?;
+        return elements.checked_mul(stride);
     }
     if select.0.is_empty() {
         Some(accessed_width)
     } else {
-        Some(1)
+        packed_strides.get(select.0.len() - 1).copied()
     }
 }
 
@@ -1268,7 +1333,8 @@ impl ExprCompiler<'_> {
             }
         }
 
-        // Process unpacked array indices
+        // Build one flattened bit offset for all unpacked and packed indices.
+        // Dynamic terms remain on the expression stack until the final load.
         let mut static_bit_offset: usize = 0;
         let mut dynamic_terms = 0usize;
 
@@ -1287,14 +1353,7 @@ impl ExprCompiler<'_> {
                 // loaded, so a dynamic outer index does not discard inner
                 // indices or force the result down to one scalar element.
                 self.emit(idx_expr, ops);
-                if stride != 1 {
-                    ops.push(TbOpcode::ConstU64(stride as u64));
-                    ops.push(TbOpcode::BinOp(Op::Mul));
-                }
-                if dynamic_terms != 0 {
-                    ops.push(TbOpcode::BinOp(Op::Add));
-                }
-                dynamic_terms += 1;
+                Self::finish_dynamic_offset_term(stride, ops, &mut dynamic_terms);
             }
         }
 
@@ -1306,146 +1365,146 @@ impl ExprCompiler<'_> {
             strides_bits[index.0.len() - 1]
         };
 
+        let (select_offset, selected_width) =
+            self.emit_select_offset(info, select, accessed_width, ops, &mut dynamic_terms);
+        static_bit_offset += select_offset;
+
         if dynamic_terms != 0 {
             ops.push(TbOpcode::LoadIndexed {
                 location: Self::state_location_at(address, 0),
                 stride_bits: 1,
                 base_bit_offset: static_bit_offset,
-                element_width: accessed_width,
-            });
-            // Apply bit select on top of dynamic result if present
-            if select.1.is_some() || !select.0.is_empty() {
-                self.emit_post_select(select, accessed_width, ops);
-            }
-            return;
-        }
-
-        // All indices were static — apply bit select
-        if select.0.is_empty() && select.1.is_none() {
-            // No bit select, just load the element
-            let byte_offset = static_bit_offset / 8;
-            let sub = static_bit_offset % 8;
-            if sub == 0 {
-                self.emit_load_at(address, byte_offset, accessed_width, ops);
-            } else {
-                let load_width = accessed_width + sub;
-                self.emit_load_at(address, byte_offset, load_width, ops);
-                ops.push(TbOpcode::ConstU64(sub as u64));
-                ops.push(TbOpcode::BinOp(Op::LogicShiftR));
-                if accessed_width < 64 {
-                    ops.push(TbOpcode::ConstU64((1u64 << accessed_width) - 1));
-                    ops.push(TbOpcode::BinOp(Op::BitAnd));
-                }
-            }
-            return;
-        }
-
-        // Static bit select
-        let (sel_lsb, sel_width, is_dynamic_select) = self.resolve_select(select, ops);
-
-        if is_dynamic_select {
-            // Dynamic bit select: load full value, shift by dynamic amount, mask
-            let byte_offset = static_bit_offset / 8;
-            let total_byte_size = get_byte_size(accessed_width);
-            ops.push(TbOpcode::LoadBitSelect {
-                location: Self::state_location_at(address, byte_offset),
-                base_byte_size: total_byte_size,
-                select_width: sel_width,
+                element_width: selected_width,
             });
             return;
         }
 
-        let bit_offset = static_bit_offset + sel_lsb;
+        let bit_offset = static_bit_offset;
         let byte_offset = bit_offset / 8;
         let sub = bit_offset % 8;
         if sub == 0 {
-            self.emit_load_at(address, byte_offset, sel_width, ops);
+            self.emit_load_at(address, byte_offset, selected_width, ops);
         } else {
-            let load_width = sel_width + sub;
+            let load_width = selected_width + sub;
             self.emit_load_at(address, byte_offset, load_width, ops);
             ops.push(TbOpcode::ConstU64(sub as u64));
             ops.push(TbOpcode::BinOp(Op::LogicShiftR));
-            if sel_width < 64 {
-                ops.push(TbOpcode::ConstU64((1u64 << sel_width) - 1));
+            if selected_width < 64 {
+                ops.push(TbOpcode::ConstU64((1u64 << selected_width) - 1));
                 ops.push(TbOpcode::BinOp(Op::BitAnd));
             }
         }
     }
 
-    /// Resolve a VarSelect to `(lsb, width, is_dynamic)`.
-    /// If any index is dynamic, emits the dynamic index expression to `ops`
-    /// and returns `is_dynamic = true`.
-    fn resolve_select(
-        &self,
-        select: &veryl_analyzer::ir::VarSelect,
+    fn finish_dynamic_offset_term(
+        multiplier: usize,
         ops: &mut Vec<UnboundTbOpcode>,
-    ) -> (usize, usize, bool) {
-        if let Some((op, range_expr)) = &select.1 {
-            let anchor_expr = select.0.last();
-            let anchor = anchor_expr.and_then(Self::try_const_usize);
-            let range_val = Self::try_const_usize(range_expr);
-
-            if let (Some(a), Some(v)) = (anchor, range_val) {
-                let (lsb, msb) = match op {
-                    veryl_analyzer::ir::VarSelectOp::Colon => (v, a),
-                    veryl_analyzer::ir::VarSelectOp::PlusColon => (a, a + v - 1),
-                    veryl_analyzer::ir::VarSelectOp::MinusColon => {
-                        (a.saturating_add(1).saturating_sub(v), a)
-                    }
-                    veryl_analyzer::ir::VarSelectOp::Step => (a * v, (a + 1) * v - 1),
-                };
-                return (lsb, msb - lsb + 1, false);
-            }
-
-            // Dynamic select: emit the anchor expression
-            if let Some(anchor_expr) = anchor_expr {
-                self.emit(anchor_expr, ops);
-            } else {
-                ops.push(TbOpcode::ConstU64(0));
-            }
-            let width = range_val.unwrap_or(1);
-            return (0, width, true);
-        }
-
-        // Simple bit index (no range)
-        if let Some(first) = select.0.first() {
-            if let Some(idx) = Self::try_const_usize(first) {
-                return (idx, 1, false);
-            }
-            // Dynamic single bit select
-            self.emit(first, ops);
-            return (0, 1, true);
-        }
-
-        (0, 0, false)
-    }
-
-    /// Emit post-load bit select operations on a value already on the stack
-    /// (for dynamic array element access followed by bit select).
-    fn emit_post_select(
-        &self,
-        select: &veryl_analyzer::ir::VarSelect,
-        _base_width: usize,
-        ops: &mut Vec<UnboundTbOpcode>,
+        dynamic_terms: &mut usize,
     ) {
-        let (lsb, width, is_dynamic) = self.resolve_select(select, ops);
-        if is_dynamic {
-            // Stack: [value, bit_index]
-            ops.push(TbOpcode::BinOp(Op::LogicShiftR));
-            if width < 64 {
-                ops.push(TbOpcode::ConstU64((1u64 << width) - 1));
-                ops.push(TbOpcode::BinOp(Op::BitAnd));
-            }
-        } else if lsb > 0 || width > 0 {
-            if lsb > 0 {
-                ops.push(TbOpcode::ConstU64(lsb as u64));
-                ops.push(TbOpcode::BinOp(Op::LogicShiftR));
-            }
-            if width > 0 && width < 64 {
-                ops.push(TbOpcode::ConstU64((1u64 << width) - 1));
-                ops.push(TbOpcode::BinOp(Op::BitAnd));
+        if multiplier != 1 {
+            ops.push(TbOpcode::ConstU64(multiplier as u64));
+            ops.push(TbOpcode::BinOp(Op::Mul));
+        }
+        if *dynamic_terms != 0 {
+            ops.push(TbOpcode::BinOp(Op::Add));
+        }
+        *dynamic_terms += 1;
+    }
+
+    /// Append packed indices to the flattened bit offset and return the
+    /// remaining static offset plus the selected result width.
+    fn emit_select_offset(
+        &self,
+        info: &VariableInfo,
+        select: &VarSelect,
+        accessed_width: usize,
+        ops: &mut Vec<UnboundTbOpcode>,
+        dynamic_terms: &mut usize,
+    ) -> (usize, usize) {
+        if select.0.is_empty() && select.1.is_none() {
+            return (0, accessed_width);
+        }
+
+        let packed_dimensions = if info.packed_dims.is_empty() {
+            vec![accessed_width]
+        } else {
+            info.packed_dims.clone()
+        };
+        let mut strides = vec![1usize; packed_dimensions.len()];
+        let mut stride = 1usize;
+        for (dimension, size) in packed_dimensions.iter().enumerate().rev() {
+            strides[dimension] = stride;
+            stride = stride.saturating_mul(*size);
+        }
+
+        let prefix_count = if select.1.is_some() {
+            select.0.len().saturating_sub(1)
+        } else {
+            select.0.len()
+        };
+        let mut static_offset = 0usize;
+        for (dimension, expression) in select.0[..prefix_count].iter().enumerate() {
+            let scale = strides[dimension];
+            if let Some(index) = Self::try_const_usize(expression) {
+                static_offset += index * scale;
+            } else {
+                self.emit(expression, ops);
+                Self::finish_dynamic_offset_term(scale, ops, dynamic_terms);
             }
         }
+
+        let Some((op, range_expression)) = &select.1 else {
+            let selected_width = strides[select.0.len() - 1];
+            return (static_offset, selected_width);
+        };
+        let anchor_expression = select
+            .0
+            .last()
+            .expect("validated part select has an anchor");
+        let range = Self::try_const_usize(range_expression)
+            .expect("validated part-select range is compile-time constant");
+        let scale = strides[prefix_count];
+        let elements = match op {
+            VarSelectOp::Colon => {
+                let anchor = Self::try_const_usize(anchor_expression)
+                    .expect("validated colon-select anchor is compile-time constant");
+                static_offset += range * scale;
+                anchor - range + 1
+            }
+            VarSelectOp::PlusColon => {
+                if let Some(anchor) = Self::try_const_usize(anchor_expression) {
+                    static_offset += anchor * scale;
+                } else {
+                    self.emit(anchor_expression, ops);
+                    Self::finish_dynamic_offset_term(scale, ops, dynamic_terms);
+                }
+                range
+            }
+            VarSelectOp::MinusColon => {
+                if let Some(anchor) = Self::try_const_usize(anchor_expression) {
+                    static_offset += (anchor + 1 - range) * scale;
+                } else {
+                    self.emit(anchor_expression, ops);
+                    ops.push(TbOpcode::ConstU64(1));
+                    ops.push(TbOpcode::BinOp(Op::Add));
+                    ops.push(TbOpcode::ConstU64(range as u64));
+                    ops.push(TbOpcode::BinOp(Op::Sub));
+                    Self::finish_dynamic_offset_term(scale, ops, dynamic_terms);
+                }
+                range
+            }
+            VarSelectOp::Step => {
+                let multiplier = range.saturating_mul(scale);
+                if let Some(anchor) = Self::try_const_usize(anchor_expression) {
+                    static_offset += anchor * multiplier;
+                } else {
+                    self.emit(anchor_expression, ops);
+                    Self::finish_dynamic_offset_term(multiplier, ops, dynamic_terms);
+                }
+                range
+            }
+        };
+        (static_offset, elements * scale)
     }
 
     /// Emit a LoadU64 or LoadWide opcode for the given byte offset and bit width.
@@ -2387,6 +2446,7 @@ mod tests {
                 kind: DomainKind::Other,
                 type_kind: PortTypeKind::Logic,
                 array_dims: Vec::new(),
+                packed_dims: vec![8],
             },
         };
 

--- a/crates/celox-frontend-veryl/src/testbench.rs
+++ b/crates/celox-frontend-veryl/src/testbench.rs
@@ -43,21 +43,9 @@ fn compile_assert_arg(
     ec: &ExprCompiler<'_>,
 ) -> SemanticArgument<StateAddr> {
     let expr = &input.0;
-    let width = {
-        let ctx_width = expr.comptime().expr_context.width;
-        if ctx_width > 0 {
-            ctx_width
-        } else if let Some(type_width) = expr.comptime().r#type.total_width() {
-            type_width
-        } else if let Ok(value) = expr.comptime().get_value() {
-            value.width()
-        } else {
-            0
-        }
-    };
     SemanticArgument {
         expr: ec.compile(expr),
-        width,
+        width: ec.natural_width(expr),
         signed: expression_signed(expr),
         is_string: expr.comptime().r#type.is_string(),
     }
@@ -933,9 +921,30 @@ impl ExprCompiler<'_> {
     }
 
     fn natural_width(&self, expr: &Expression) -> usize {
-        get_expr_width(expr)
+        self.resolved_variable_access_width(expr)
+            .or_else(|| get_expr_width(expr))
             .filter(|width| *width != 0)
             .unwrap_or_else(|| self.infer_expr_width(expr).max(1))
+    }
+
+    fn resolved_variable_access_width(&self, expr: &Expression) -> Option<usize> {
+        let Expression::Term(factor) = expr else {
+            return None;
+        };
+        match factor.as_ref() {
+            Factor::Variable(var_id, index, select, _) => {
+                let (_, info) = self.lookup.root_variable(*var_id)?;
+                Some(variable_access_width(info, index, select).unwrap_or(info.width))
+            }
+            Factor::HierVariable(reference) => {
+                let (_, info) = resolve_hierarchical_reference(self.lookup, reference).ok()?;
+                Some(
+                    variable_access_width(info, &reference.index, &reference.select)
+                        .unwrap_or(info.width),
+                )
+            }
+            _ => None,
+        }
     }
 
     fn root_context(&self, expr: &Expression) -> ValueContext {
@@ -1575,6 +1584,9 @@ impl ExprCompiler<'_> {
     /// Infer the bit width of an expression. Falls back to comptime if available,
     /// otherwise resolves from VariableInfo for variables.
     fn infer_expr_width(&self, expr: &Expression) -> usize {
+        if let Some(width) = self.resolved_variable_access_width(expr) {
+            return width;
+        }
         let ctx_width = expr.comptime().expr_context.width;
         if ctx_width > 0 {
             return ctx_width;
@@ -1585,26 +1597,12 @@ impl ExprCompiler<'_> {
                 return w;
             }
         }
-        // For terms, look up variable info
+        // For terms, use constant value widths as a final fallback.
         if let Expression::Term(f) = expr {
-            match f.as_ref() {
-                Factor::Variable(var_id, index, select, _) => {
-                    if let Some((_, info)) = self.lookup.root_variable(*var_id) {
-                        return variable_access_width(info, index, select).unwrap_or(info.width);
-                    }
-                }
-                Factor::HierVariable(reference) => {
-                    if let Ok((_, info)) = resolve_hierarchical_reference(self.lookup, reference) {
-                        return variable_access_width(info, &reference.index, &reference.select)
-                            .unwrap_or(info.width);
-                    }
-                }
-                Factor::Value(c) => {
-                    if let Ok(v) = c.get_value() {
-                        return v.width();
-                    }
-                }
-                _ => {}
+            if let Factor::Value(c) = f.as_ref()
+                && let Ok(v) = c.get_value()
+            {
+                return v.width();
             }
         }
         0
@@ -2510,5 +2508,22 @@ mod tests {
         };
         assert_eq!(feature, "hierarchical variable reference");
         assert!(detail.contains("variable `missing` was not found"));
+    }
+
+    #[test]
+    fn hierarchical_message_argument_width_uses_resolved_variable_metadata() {
+        let dut = resource_table::insert_str("dut");
+        let q = resource_table::insert_str("q");
+        let lookup = lookup_with_child(dut, q);
+        let source = VerylTestbenchSource::default();
+        let compiler = ExprCompiler {
+            lookup: &lookup,
+            testbench_source: &source,
+        };
+        let input = SystemFunctionInput(Expression::Term(Box::new(Factor::HierVariable(
+            Box::new(reference(vec![dut], VarPath(vec![q]))),
+        ))));
+
+        assert_eq!(compile_assert_arg(&input, &compiler).width, 8);
     }
 }

--- a/crates/celox-frontend-veryl/src/testbench.rs
+++ b/crates/celox-frontend-veryl/src/testbench.rs
@@ -8,14 +8,15 @@ use celox_testbench::{
 use fxhash::FxHashSet;
 use veryl_analyzer::ir::{
     ArrayLiteralItem, AssertKind, CasePattern, Expression, Factor, ForBound, ForRange, Function,
-    FunctionCall, Op as VerylOp, Statement, SystemFunctionInput, SystemFunctionKind, TbMethod,
-    TbMethodCall, VarId,
+    FunctionCall, HierVarRef, Op as VerylOp, Statement, SystemFunctionInput, SystemFunctionKind,
+    TbMethod, TbMethodCall, VarId,
 };
 use veryl_analyzer::value::byte_value_to_string;
 use veryl_parser::resource_table::{self, StrId};
 
 use crate::{
-    LoweringPhase, ParserError, VerylFrontendLookup, VerylTestbenchSource,
+    AbsoluteAddr, InstancePath, LoweringPhase, ParserError, VariableInfo, VerylFrontendLookup,
+    VerylTestbenchSource,
     context_width::{
         ValueContext, binary_semantics, cast_semantics, expression_signed, get_expr_width,
     },
@@ -175,25 +176,170 @@ fn count_assert_statements(
     count
 }
 
+fn source_name(id: StrId) -> String {
+    resource_table::get_str_value(id).unwrap_or_else(|| format!("{id}"))
+}
+
+fn hierarchical_reference_name(reference: &HierVarRef) -> String {
+    reference
+        .inst_path
+        .iter()
+        .copied()
+        .chain(reference.var_path.0.iter().copied())
+        .map(source_name)
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+fn invalid_hierarchical_reference(
+    reference: &HierVarRef,
+    detail: impl Into<String>,
+) -> ParserError {
+    ParserError::illegal_context(
+        "hierarchical variable reference",
+        format!(
+            "`{}`: {}",
+            hierarchical_reference_name(reference),
+            detail.into()
+        ),
+        Some(&reference.comptime.token),
+    )
+}
+
+pub(crate) fn resolve_hierarchical_reference<'a>(
+    lookup: &'a VerylFrontendLookup,
+    reference: &HierVarRef,
+) -> Result<(StateAddr, &'a VariableInfo), ParserError> {
+    let mut resolved_path = Vec::with_capacity(reference.inst_path.len());
+    for &segment in &reference.inst_path {
+        let candidates = lookup
+            .instance_ids
+            .keys()
+            .filter(|candidate| {
+                candidate.0.len() == resolved_path.len() + 1
+                    && candidate.0.starts_with(&resolved_path)
+                    && candidate.0[resolved_path.len()].0 == segment
+            })
+            .map(|candidate| candidate.0[resolved_path.len()])
+            .collect::<Vec<_>>();
+        match candidates.as_slice() {
+            [part] => resolved_path.push(*part),
+            [] => {
+                return Err(invalid_hierarchical_reference(
+                    reference,
+                    format!("instance `{}` was not found", source_name(segment)),
+                ));
+            }
+            _ => {
+                return Err(invalid_hierarchical_reference(
+                    reference,
+                    format!(
+                        "instance `{}` is ambiguous because it elaborates to multiple array elements",
+                        source_name(segment)
+                    ),
+                ));
+            }
+        }
+    }
+
+    let instance_id = lookup
+        .instance_ids
+        .get(&InstancePath(resolved_path))
+        .copied()
+        .ok_or_else(|| {
+            invalid_hierarchical_reference(reference, "the elaborated instance path was not found")
+        })?;
+    let module_id = lookup
+        .instance_module
+        .get(&instance_id)
+        .copied()
+        .ok_or_else(|| {
+            invalid_hierarchical_reference(reference, "the target instance has no module")
+        })?;
+    let var_id = match lookup
+        .module_var_path_index
+        .get(&module_id)
+        .and_then(|variables| variables.get(&reference.var_path))
+    {
+        Some(Some(var_id)) => *var_id,
+        Some(None) => {
+            return Err(invalid_hierarchical_reference(
+                reference,
+                format!("variable `{}` is ambiguous", reference.var_path),
+            ));
+        }
+        None => {
+            return Err(invalid_hierarchical_reference(
+                reference,
+                format!("variable `{}` was not found", reference.var_path),
+            ));
+        }
+    };
+    let info = lookup
+        .module_variables
+        .get(&module_id)
+        .and_then(|variables| variables.get(&var_id))
+        .ok_or_else(|| {
+            invalid_hierarchical_reference(reference, "the target variable has no metadata")
+        })?;
+    let address = lookup
+        .state_address(&AbsoluteAddr {
+            instance_id,
+            var_id,
+        })
+        .ok_or_else(|| {
+            invalid_hierarchical_reference(
+                reference,
+                "the target variable has no elaborated state address",
+            )
+        })?;
+    Ok((address, info))
+}
+
+enum TestbenchRead {
+    Root(VarId),
+    Hierarchical(Box<HierVarRef>),
+}
+
 pub fn collect_testbench_observability(
+    lookup: &VerylFrontendLookup,
     source: &VerylTestbenchSource,
-) -> (Vec<RuntimeEventSite>, FxHashSet<VarId>) {
+) -> Result<(Vec<RuntimeEventSite>, FxHashSet<StateAddr>), ParserError> {
     let Some(stmts) = source.initial_statements.as_ref() else {
-        return Default::default();
+        return Ok(Default::default());
     };
     let mut sites = Vec::new();
     collect_runtime_event_sites(stmts, &source.functions, &mut sites);
-    let mut reads = FxHashSet::default();
+    let mut read_references = Vec::new();
     let mut active_functions = FxHashSet::default();
-    collect_statement_reads(stmts, &source.functions, &mut active_functions, &mut reads);
-    (sites, reads)
+    collect_statement_reads(
+        stmts,
+        &source.functions,
+        &mut active_functions,
+        &mut read_references,
+    );
+    let mut reads = FxHashSet::default();
+    for reference in read_references {
+        match reference {
+            TestbenchRead::Root(var_id) => {
+                if let Some((address, _)) = lookup.root_variable(var_id) {
+                    reads.insert(address);
+                }
+            }
+            TestbenchRead::Hierarchical(reference) => {
+                let (address, _) = resolve_hierarchical_reference(lookup, &reference)?;
+                reads.insert(address);
+            }
+        }
+    }
+    Ok((sites, reads))
 }
 
 fn collect_statement_reads(
     stmts: &[Statement],
     funcs: &fxhash::FxHashMap<VarId, Function>,
     active_functions: &mut FxHashSet<VarId>,
-    reads: &mut FxHashSet<VarId>,
+    reads: &mut Vec<TestbenchRead>,
 ) {
     for stmt in stmts {
         match stmt {
@@ -289,7 +435,7 @@ fn collect_for_bound_reads(
     range: &ForRange,
     funcs: &fxhash::FxHashMap<VarId, Function>,
     active_functions: &mut FxHashSet<VarId>,
-    reads: &mut FxHashSet<VarId>,
+    reads: &mut Vec<TestbenchRead>,
 ) {
     let (start, end) = match range {
         ForRange::Forward { start, end, .. }
@@ -307,12 +453,12 @@ fn collect_expression_reads(
     expr: &Expression,
     funcs: &fxhash::FxHashMap<VarId, Function>,
     active_functions: &mut FxHashSet<VarId>,
-    reads: &mut FxHashSet<VarId>,
+    reads: &mut Vec<TestbenchRead>,
 ) {
     match expr {
         Expression::Term(factor) => match factor.as_ref() {
             Factor::Variable(var_id, index, select, _) => {
-                reads.insert(*var_id);
+                reads.push(TestbenchRead::Root(*var_id));
                 for expr in &index.0 {
                     collect_expression_reads(expr, funcs, active_functions, reads);
                 }
@@ -324,7 +470,13 @@ fn collect_expression_reads(
             Factor::FunctionCall(call) => {
                 collect_function_call_reads(call, funcs, active_functions, reads);
             }
-            Factor::HierVariable(_) => {}
+            Factor::HierVariable(reference) => {
+                reads.push(TestbenchRead::Hierarchical(reference.clone()));
+                for expr in &reference.index.0 {
+                    collect_expression_reads(expr, funcs, active_functions, reads);
+                }
+                collect_select_reads(&reference.select, funcs, active_functions, reads);
+            }
             Factor::Value(_) | Factor::Anonymous(_) | Factor::Unknown(_) => {}
         },
         Expression::Unary(_, inner, _) => {
@@ -374,7 +526,7 @@ fn collect_select_reads(
     select: &veryl_analyzer::ir::VarSelect,
     funcs: &fxhash::FxHashMap<VarId, Function>,
     active_functions: &mut FxHashSet<VarId>,
-    reads: &mut FxHashSet<VarId>,
+    reads: &mut Vec<TestbenchRead>,
 ) {
     for expr in &select.0 {
         collect_expression_reads(expr, funcs, active_functions, reads);
@@ -388,7 +540,7 @@ fn collect_system_function_reads(
     kind: &SystemFunctionKind,
     funcs: &fxhash::FxHashMap<VarId, Function>,
     active_functions: &mut FxHashSet<VarId>,
-    reads: &mut FxHashSet<VarId>,
+    reads: &mut Vec<TestbenchRead>,
 ) {
     let mut collect_input = |input: &SystemFunctionInput| {
         collect_expression_reads(&input.0, funcs, active_functions, reads);
@@ -420,7 +572,7 @@ fn collect_function_call_reads(
     call: &FunctionCall,
     funcs: &fxhash::FxHashMap<VarId, Function>,
     active_functions: &mut FxHashSet<VarId>,
-    reads: &mut FxHashSet<VarId>,
+    reads: &mut Vec<TestbenchRead>,
 ) {
     for expr in call.inputs.values() {
         collect_expression_reads(expr, funcs, active_functions, reads);
@@ -761,8 +913,8 @@ impl ExprCompiler<'_> {
                     && let Ok(value) = comptime.get_value()
                 {
                     self.emit_constant_value(value, ops);
-                } else if let Some(sig) = self.resolve_var(var_id) {
-                    self.emit_var_access(var_id, sig, index, select, ops);
+                } else if let Some((address, info)) = self.lookup.root_variable(*var_id) {
+                    self.emit_var_access(address, info, index, select, ops);
                 } else if let Ok(value) = comptime.get_value() {
                     self.emit_constant_value(value, ops);
                 } else {
@@ -779,10 +931,10 @@ impl ExprCompiler<'_> {
             Factor::FunctionCall(fc) => {
                 self.emit_function_call(fc, ops);
             }
-            Factor::HierVariable(_) => {
-                unreachable!(
-                    "hierarchical testbench references are rejected before bytecode emission"
-                )
+            Factor::HierVariable(reference) => {
+                let (address, info) = resolve_hierarchical_reference(self.lookup, reference)
+                    .expect("hierarchical testbench references are validated before emission");
+                self.emit_var_access(address, info, &reference.index, &reference.select, ops);
             }
             Factor::SystemFunctionCall(call) => match &call.kind {
                 SystemFunctionKind::Signed(input) | SystemFunctionKind::Unsigned(input) => {
@@ -903,23 +1055,15 @@ impl ExprCompiler<'_> {
     /// array indices and bit selects.
     fn emit_var_access(
         &self,
-        var_id: &VarId,
-        sig: SemanticSignal<StateAddr>,
+        address: StateAddr,
+        info: &VariableInfo,
         index: &veryl_analyzer::ir::VarIndex,
         select: &veryl_analyzer::ir::VarSelect,
         ops: &mut Vec<UnboundTbOpcode>,
     ) {
-        let info = match self.lookup.root_variable(*var_id) {
-            Some((_, info)) => info,
-            None => {
-                self.emit_load(*var_id, 0, sig.width, ops);
-                return;
-            }
-        };
-
         // No index or select → whole variable
         if index.0.is_empty() && select.0.is_empty() && select.1.is_none() {
-            self.emit_load(*var_id, 0, sig.width, ops);
+            self.emit_load_at(address, 0, info.width, ops);
             return;
         }
 
@@ -956,7 +1100,7 @@ impl ExprCompiler<'_> {
                 let elem_byte_size = get_byte_size(element_width);
                 self.emit(idx_expr, ops);
                 ops.push(TbOpcode::LoadIndexed {
-                    location: self.state_location(*var_id, base_byte_offset),
+                    location: Self::state_location_at(address, base_byte_offset),
                     stride_bytes,
                     element_byte_size: elem_byte_size,
                     element_width,
@@ -990,10 +1134,10 @@ impl ExprCompiler<'_> {
             let byte_offset = static_bit_offset / 8;
             let sub = static_bit_offset % 8;
             if sub == 0 {
-                self.emit_load(*var_id, byte_offset, accessed_width, ops);
+                self.emit_load_at(address, byte_offset, accessed_width, ops);
             } else {
                 let load_width = accessed_width + sub;
-                self.emit_load(*var_id, byte_offset, load_width, ops);
+                self.emit_load_at(address, byte_offset, load_width, ops);
                 ops.push(TbOpcode::ConstU64(sub as u64));
                 ops.push(TbOpcode::BinOp(Op::LogicShiftR));
                 if accessed_width < 64 {
@@ -1012,7 +1156,7 @@ impl ExprCompiler<'_> {
             let byte_offset = static_bit_offset / 8;
             let total_byte_size = get_byte_size(accessed_width);
             ops.push(TbOpcode::LoadBitSelect {
-                location: self.state_location(*var_id, byte_offset),
+                location: Self::state_location_at(address, byte_offset),
                 base_byte_size: total_byte_size,
                 select_width: sel_width,
             });
@@ -1023,10 +1167,10 @@ impl ExprCompiler<'_> {
         let byte_offset = bit_offset / 8;
         let sub = bit_offset % 8;
         if sub == 0 {
-            self.emit_load(*var_id, byte_offset, sel_width, ops);
+            self.emit_load_at(address, byte_offset, sel_width, ops);
         } else {
             let load_width = sel_width + sub;
-            self.emit_load(*var_id, byte_offset, load_width, ops);
+            self.emit_load_at(address, byte_offset, load_width, ops);
             ops.push(TbOpcode::ConstU64(sub as u64));
             ops.push(TbOpcode::BinOp(Op::LogicShiftR));
             if sel_width < 64 {
@@ -1118,6 +1262,21 @@ impl ExprCompiler<'_> {
         width: usize,
         ops: &mut Vec<UnboundTbOpcode>,
     ) {
+        let address = self
+            .lookup
+            .root_variable(var_id)
+            .map(|(address, _)| address)
+            .expect("frontend state projection is complete");
+        self.emit_load_at(address, byte_offset, width, ops);
+    }
+
+    fn emit_load_at(
+        &self,
+        address: StateAddr,
+        byte_offset: usize,
+        width: usize,
+        ops: &mut Vec<UnboundTbOpcode>,
+    ) {
         let byte_size = get_byte_size(width);
         if byte_size <= 8 {
             let mask = if width >= 64 {
@@ -1126,13 +1285,13 @@ impl ExprCompiler<'_> {
                 (1u64 << width) - 1
             };
             ops.push(TbOpcode::LoadU64 {
-                location: self.state_location(var_id, byte_offset),
+                location: Self::state_location_at(address, byte_offset),
                 byte_size,
                 mask,
             });
         } else {
             ops.push(TbOpcode::LoadWide {
-                location: self.state_location(var_id, byte_offset),
+                location: Self::state_location_at(address, byte_offset),
                 byte_size,
                 width,
             });
@@ -1140,12 +1299,17 @@ impl ExprCompiler<'_> {
     }
 
     fn state_location(&self, var_id: VarId, byte_offset: usize) -> StateLocation<StateAddr> {
+        let address = self
+            .lookup
+            .root_variable(var_id)
+            .map(|(address, _)| address)
+            .expect("frontend state projection is complete");
+        Self::state_location_at(address, byte_offset)
+    }
+
+    fn state_location_at(address: StateAddr, byte_offset: usize) -> StateLocation<StateAddr> {
         StateLocation {
-            address: self
-                .lookup
-                .root_variable(var_id)
-                .map(|(address, _)| address)
-                .expect("frontend state projection is complete"),
+            address,
             byte_offset,
         }
     }
@@ -1173,6 +1337,11 @@ impl ExprCompiler<'_> {
             match f.as_ref() {
                 Factor::Variable(var_id, _, _, _) => {
                     if let Some((_, info)) = self.lookup.root_variable(*var_id) {
+                        return info.width;
+                    }
+                }
+                Factor::HierVariable(reference) => {
+                    if let Ok((_, info)) = resolve_hierarchical_reference(self.lookup, reference) {
                         return info.width;
                     }
                 }
@@ -1694,13 +1863,15 @@ fn validate_testbench_expression(
 ) -> Result<(), ParserError> {
     match expression {
         Expression::Term(factor) => match factor.as_ref() {
-            Factor::HierVariable(reference) => Err(ParserError::unsupported(
-                467,
-                LoweringPhase::SimulatorParser,
-                "hierarchical variable reference",
-                format!("{}", reference.var_path),
-                Some(&reference.comptime.token),
-            )),
+            Factor::HierVariable(reference) => {
+                for expression in reference.index.0.iter().chain(reference.select.0.iter()) {
+                    validate_testbench_expression(expression, source, active_functions)?;
+                }
+                if let Some((_, expression)) = &reference.select.1 {
+                    validate_testbench_expression(expression, source, active_functions)?;
+                }
+                Ok(())
+            }
             Factor::Variable(_, index, select, _) => {
                 for expression in index.0.iter().chain(select.0.iter()) {
                     validate_testbench_expression(expression, source, active_functions)?;
@@ -1725,11 +1896,9 @@ fn validate_testbench_expression(
                 let end = (token.end.pos + token.end.length) as usize;
                 let factor_text = source.get(start..end).unwrap_or_default();
                 if factor_text.contains('.') {
-                    Err(ParserError::unsupported(
-                        467,
-                        LoweringPhase::SimulatorParser,
+                    Err(ParserError::illegal_context(
                         "hierarchical variable reference",
-                        factor_text,
+                        format!("`{factor_text}` was not resolved by the analyzer"),
                         Some(token),
                     ))
                 } else {
@@ -1974,10 +2143,123 @@ pub fn compile_semantic_testbench(
     let Some(initial_stmts) = source.initial_statements.as_ref() else {
         return Ok(None);
     };
+    // Resolve every hierarchical read before the infallible bytecode emitter
+    // runs. The same walk also guarantees direct callers get path diagnostics,
+    // even when observability projection is not invoked separately.
+    let _ = collect_testbench_observability(lookup, source)?;
     validate_testbench_statements(initial_stmts, source, &mut FxHashSet::default())?;
     let mut builder = SemanticTestbenchBuilder::new(lookup, source, runtime_event_site_count);
     builder.build_event_map(initial_stmts);
     Ok(Some(
         TestbenchProgram::new(builder.convert(initial_stmts)).with_random_seed_option(random_seed),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use celox_design::{
+        DomainKind, InstanceId, ModuleId, PortTypeKind, StateObjectId, VariableMetadata,
+    };
+    use veryl_analyzer::ir::{Comptime, VarIndex, VarKind, VarPath, VarSelect};
+
+    fn reference(inst_path: Vec<StrId>, var_path: VarPath) -> HierVarRef {
+        HierVarRef {
+            inst_path,
+            var_path,
+            index: VarIndex::default(),
+            select: VarSelect::default(),
+            comptime: Comptime::default(),
+        }
+    }
+
+    fn lookup_with_child(child_name: StrId, variable_name: StrId) -> VerylFrontendLookup {
+        let root_instance = InstanceId(0);
+        let child_instance = InstanceId(1);
+        let root_module = ModuleId(0);
+        let child_module = ModuleId(1);
+        let var_id = VarId::from_raw(0);
+        let source_address = AbsoluteAddr {
+            instance_id: child_instance,
+            var_id,
+        };
+        let state_address = StateAddr {
+            instance_id: child_instance,
+            var_id: StateObjectId(0),
+        };
+        let path = VarPath(vec![variable_name]);
+        let info = VariableInfo {
+            id: var_id,
+            path: path.clone(),
+            var_kind: VarKind::Variable,
+            metadata: VariableMetadata {
+                width: 8,
+                is_4state: true,
+                kind: DomainKind::Other,
+                type_kind: PortTypeKind::Logic,
+                array_dims: Vec::new(),
+            },
+        };
+
+        let mut lookup = VerylFrontendLookup::default();
+        lookup
+            .instance_ids
+            .insert(InstancePath(Vec::new()), root_instance);
+        lookup
+            .instance_ids
+            .insert(InstancePath(vec![(child_name, 0)]), child_instance);
+        lookup.instance_module.insert(root_instance, root_module);
+        lookup.instance_module.insert(child_instance, child_module);
+        lookup
+            .module_variables
+            .entry(child_module)
+            .or_default()
+            .insert(var_id, info);
+        lookup
+            .module_var_path_index
+            .entry(child_module)
+            .or_default()
+            .insert(path, Some(var_id));
+        lookup.source_to_state.insert(source_address, state_address);
+        lookup.state_to_source.insert(state_address, source_address);
+        lookup
+    }
+
+    #[test]
+    fn hierarchical_reference_reports_missing_instance_segment() {
+        let dut = resource_table::insert_str("dut");
+        let missing = resource_table::insert_str("missing");
+        let q = resource_table::insert_str("q");
+        let lookup = lookup_with_child(dut, q);
+        let reference = reference(vec![missing], VarPath(vec![q]));
+
+        let error = resolve_hierarchical_reference(&lookup, &reference).unwrap_err();
+        let ParserError::IllegalContext {
+            feature, detail, ..
+        } = error
+        else {
+            panic!("expected invalid hierarchical path diagnostic");
+        };
+        assert_eq!(feature, "hierarchical variable reference");
+        assert!(detail.contains("instance `missing` was not found"));
+    }
+
+    #[test]
+    fn hierarchical_reference_reports_missing_target_variable() {
+        let dut = resource_table::insert_str("dut");
+        let q = resource_table::insert_str("q");
+        let missing = resource_table::insert_str("missing");
+        let lookup = lookup_with_child(dut, q);
+        let reference = reference(vec![dut], VarPath(vec![missing]));
+
+        let error = resolve_hierarchical_reference(&lookup, &reference).unwrap_err();
+        let ParserError::IllegalContext {
+            feature, detail, ..
+        } = error
+        else {
+            panic!("expected invalid hierarchical variable diagnostic");
+        };
+        assert_eq!(feature, "hierarchical variable reference");
+        assert!(detail.contains("variable `missing` was not found"));
+    }
 }

--- a/crates/celox-testbench/src/lib.rs
+++ b/crates/celox-testbench/src/lib.rs
@@ -269,8 +269,8 @@ pub enum ExprOpcode<L = usize> {
     },
     LoadIndexed {
         location: L,
-        stride_bytes: usize,
-        element_byte_size: usize,
+        stride_bits: usize,
+        base_bit_offset: usize,
         element_width: usize,
     },
     LoadBitSelect {
@@ -432,13 +432,13 @@ impl<A> ExprBytecode<StateLocation<A>> {
                 }
                 ExprOpcode::LoadIndexed {
                     location,
-                    stride_bytes,
-                    element_byte_size,
+                    stride_bits,
+                    base_bit_offset,
                     element_width,
                 } => ExprOpcode::LoadIndexed {
                     location: bind_location(location, &mut resolve)?,
-                    stride_bytes,
-                    element_byte_size,
+                    stride_bits,
+                    base_bit_offset,
                     element_width,
                 },
                 ExprOpcode::LoadBitSelect {

--- a/crates/celox-testbench/src/vm.rs
+++ b/crates/celox-testbench/src/vm.rs
@@ -252,13 +252,20 @@ impl CompiledExpr {
                 });
                 let i = idx.to_u64() as usize;
                 let offset = location + i * stride_bytes;
-                let mask = if *element_width >= 64 {
-                    u64::MAX
+                if *element_byte_size <= 8 {
+                    let mask = if *element_width >= 64 {
+                        u64::MAX
+                    } else {
+                        (1u64 << element_width) - 1
+                    };
+                    let val = unsafe { read_le_u64(memory.add(offset), *element_byte_size) } & mask;
+                    stack.push(TestbenchValue::U64(val));
                 } else {
-                    (1u64 << element_width) - 1
-                };
-                let val = unsafe { read_le_u64(memory.add(offset), *element_byte_size) } & mask;
-                stack.push(TestbenchValue::U64(val));
+                    let val = unsafe {
+                        read_le_wide(memory.add(offset), *element_byte_size, *element_width)
+                    };
+                    stack.push(TestbenchValue::Wide(val));
+                }
                 *pc += 1;
             }
             TbOpcode::LoadBitSelect {
@@ -271,14 +278,21 @@ impl CompiledExpr {
                     TestbenchValue::U64(0)
                 });
                 let shift = bit_idx.to_u64() as usize;
-                let full_val = unsafe { read_le_u64(memory.add(*location), *base_byte_size) };
-                let mask = if *select_width >= 64 {
-                    u64::MAX
+                if *base_byte_size <= 8 && *select_width <= 64 {
+                    let full_val = unsafe { read_le_u64(memory.add(*location), *base_byte_size) };
+                    let mask = if *select_width == 64 {
+                        u64::MAX
+                    } else {
+                        (1u64 << select_width) - 1
+                    };
+                    stack.push(TestbenchValue::U64((full_val >> shift) & mask));
                 } else {
-                    (1u64 << select_width) - 1
-                };
-                let val = (full_val >> shift) & mask;
-                stack.push(TestbenchValue::U64(val));
+                    let full_width = base_byte_size.saturating_mul(8);
+                    let full_val =
+                        unsafe { read_le_wide(memory.add(*location), *base_byte_size, full_width) };
+                    let val = (full_val >> shift) & width_mask(*select_width);
+                    stack.push(tb_value_from_bits(val, *select_width));
+                }
                 *pc += 1;
             }
             TbOpcode::StoreU64 {

--- a/crates/celox-testbench/src/vm.rs
+++ b/crates/celox-testbench/src/vm.rs
@@ -242,8 +242,8 @@ impl CompiledExpr {
             }
             TbOpcode::LoadIndexed {
                 location,
-                stride_bytes,
-                element_byte_size,
+                stride_bits,
+                base_bit_offset,
                 element_width,
             } => {
                 let idx = stack.pop().unwrap_or_else(|| {
@@ -251,21 +251,9 @@ impl CompiledExpr {
                     TestbenchValue::U64(0)
                 });
                 let i = idx.to_u64() as usize;
-                let offset = location + i * stride_bytes;
-                if *element_byte_size <= 8 {
-                    let mask = if *element_width >= 64 {
-                        u64::MAX
-                    } else {
-                        (1u64 << element_width) - 1
-                    };
-                    let val = unsafe { read_le_u64(memory.add(offset), *element_byte_size) } & mask;
-                    stack.push(TestbenchValue::U64(val));
-                } else {
-                    let val = unsafe {
-                        read_le_wide(memory.add(offset), *element_byte_size, *element_width)
-                    };
-                    stack.push(TestbenchValue::Wide(val));
-                }
+                let bit_offset = base_bit_offset.saturating_add(i.saturating_mul(*stride_bits));
+                let val = unsafe { read_bits(memory.add(*location), bit_offset, *element_width) };
+                stack.push(val);
                 *pc += 1;
             }
             TbOpcode::LoadBitSelect {
@@ -339,6 +327,22 @@ unsafe fn read_le_wide(ptr: *const u8, byte_size: usize, width: usize) -> BigUin
         val &= (BigUint::from(1u32) << width) - BigUint::from(1u32);
     }
     val
+}
+
+/// # Safety
+/// `ptr` must be valid for the byte span containing `bit_offset..bit_offset + width`.
+unsafe fn read_bits(ptr: *const u8, bit_offset: usize, width: usize) -> TestbenchValue {
+    let byte_offset = bit_offset / 8;
+    let sub = bit_offset % 8;
+    let span_width = sub.saturating_add(width);
+    let byte_size = span_width.div_ceil(8);
+    if span_width <= 64 {
+        let value = unsafe { read_le_u64(ptr.add(byte_offset), byte_size) } >> sub;
+        TestbenchValue::U64(value & width_mask_u64(width))
+    } else {
+        let value = unsafe { read_le_wide(ptr.add(byte_offset), byte_size, span_width) } >> sub;
+        tb_value_from_bits(value & width_mask(width), width)
+    }
 }
 
 // ── Typed evaluation ───────────────────────────────────────────────────

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -134,6 +134,16 @@ pub(crate) fn collect_strided_array_layouts(
 ) -> HashMap<AbsoluteAddr, UnpackedArrayLayout> {
     let mut candidates = declared_strided_array_layouts(program);
 
+    // Testbench bytecode addresses state through packed logical bit offsets.
+    // Keep every directly observed array packed so dynamic indices do not
+    // accidentally address element padding in an element-strided layout.
+    candidates.retain(|address, _| {
+        !program
+            .runtime_schema
+            .testbench_read_roots
+            .contains(address)
+    });
+
     let mut inspect = |inst: &SIRInstruction<crate::ir::RegionedAbsoluteAddr>,
                        exact_zeros: &crate::HashSet<RegisterId>| {
         let mut check = |addr: &crate::ir::RegionedAbsoluteAddr,

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -396,7 +396,7 @@ pub fn parse(
     scheduled.scheduled.inject_triggers();
     let scheduled = scheduled.scheduled;
     let (sir, mut runtime, testbench_source) = RuntimeProgram::from_scheduled(scheduled);
-    crate::testbench_compile::project_observability(&mut runtime, &testbench_source);
+    crate::testbench_compile::project_observability(&mut runtime, &testbench_source)?;
     runtime.testbench = crate::testbench_compile::compile_semantic_testbench(
         &runtime,
         &testbench_source,

--- a/crates/celox/src/testbench_compile.rs
+++ b/crates/celox/src/testbench_compile.rs
@@ -2,18 +2,15 @@ use crate::ir::{AbsoluteAddr, RuntimeProgram};
 use celox_frontend_veryl::VerylTestbenchSource;
 use celox_testbench::TestbenchProgram;
 
-pub(crate) fn project_observability(program: &mut RuntimeProgram, source: &VerylTestbenchSource) {
-    let (sites, read_variables) = celox_frontend_veryl::collect_testbench_observability(source);
+pub(crate) fn project_observability(
+    program: &mut RuntimeProgram,
+    source: &VerylTestbenchSource,
+) -> Result<(), celox_frontend_veryl::ParserError> {
+    let (sites, read_variables) =
+        celox_frontend_veryl::collect_testbench_observability(&program.frontend, source)?;
     program.runtime_schema.runtime_event_sites.extend(sites);
-    program.runtime_schema.testbench_read_roots = read_variables
-        .into_iter()
-        .filter_map(|var_id| {
-            program
-                .frontend
-                .root_variable(var_id)
-                .map(|(address, _)| address)
-        })
-        .collect();
+    program.runtime_schema.testbench_read_roots = read_variables;
+    Ok(())
 }
 
 pub(crate) fn compile_semantic_testbench(

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -646,20 +646,14 @@ fn test_testbench_helper_hierarchical_read_returns_error_without_panicking() {
             )),
             "expected Veryl InvisibleIndentifier for helper's hierarchical read, got {errors:?}"
         ),
-        Err(SimulatorErrorKind::SIRParser(ParserError::Unsupported {
-            issue,
-            phase: LoweringPhase::SimulatorParser,
-            feature,
-            ..
-        })) => {
-            assert_eq!(*issue, 467);
+        Err(SimulatorErrorKind::SIRParser(ParserError::IllegalContext { feature, .. })) => {
             assert_eq!(*feature, "hierarchical variable reference");
         }
         Err(kind) => panic!(
-            "expected InvisibleIndentifier or Unsupported(SimulatorParser) for helper's hierarchical read, got {kind:?}"
+            "expected InvisibleIndentifier or IllegalContext for helper's hierarchical read, got {kind:?}"
         ),
         Ok(_) => panic!(
-            "expected InvisibleIndentifier or Unsupported(SimulatorParser) for helper's hierarchical read, got Ok"
+            "expected InvisibleIndentifier or IllegalContext for helper's hierarchical read, got Ok"
         ),
     }
 }

--- a/crates/celox/tests/mutable_for_bound.rs
+++ b/crates/celox/tests/mutable_for_bound.rs
@@ -348,6 +348,40 @@ module t {
 }
 
 #[test]
+fn hierarchical_bound_warns_when_clock_advances_the_target_state() {
+    let code = r#"
+module Counter (
+    clk: input clock,
+    rst: input reset,
+) {
+    var count: logic<8>;
+
+    always_ff {
+        if_reset { count = 0; }
+        else       { count += 1; }
+    }
+}
+
+#[test(t)]
+module t {
+    inst clk: $tb::clock_gen;
+    inst rst: $tb::reset_gen(clk);
+    inst dut: Counter (clk, rst);
+
+    initial {
+        rst.assert();
+        clk.next(2);
+        for _i in 0..dut.count {
+            clk.next();
+        }
+        $finish();
+    }
+}
+"#;
+    expect_time_advancing_bound_warning(code, "t");
+}
+
+#[test]
 fn time_advancing_body_effects_pass_when_the_bound_is_outside_the_event_write_closure() {
     let code = r#"
 module Counter (

--- a/crates/celox/tests/mutable_for_bound.rs
+++ b/crates/celox/tests/mutable_for_bound.rs
@@ -371,7 +371,7 @@ module t {
     initial {
         rst.assert();
         clk.next(2);
-        for _i in 0..dut.count {
+        for _i in 0..dut.count[3:0] {
             clk.next();
         }
         $finish();
@@ -379,6 +379,45 @@ module t {
 }
 "#;
     expect_time_advancing_bound_warning(code, "t");
+}
+
+#[test]
+fn hierarchical_bound_respects_disjoint_bit_ranges() {
+    let code = r#"
+module Counter (
+    clk: input clock,
+    rst: input reset,
+) {
+    var count: logic<8>;
+
+    always_ff {
+        if_reset { count[3:0] = 0; }
+        else       { count[3:0] += 1; }
+    }
+}
+
+#[test(t)]
+module t {
+    inst clk: $tb::clock_gen;
+    inst rst: $tb::reset_gen(clk);
+    inst dut: Counter (clk, rst);
+
+    initial {
+        rst.assert();
+        for _i in 0..dut.count[7:4] {
+            clk.next();
+        }
+        $finish();
+    }
+}
+"#;
+    let simulator = Simulator::builder(code, "t")
+        .build()
+        .expect("hierarchical reads of disjoint bits must not conflict");
+    assert!(!simulator.warnings().iter().any(|warning| matches!(
+        warning,
+        CompilationWarning::Frontend(FrontendDiagnostic::TimeAdvancingForBound { .. })
+    )));
 }
 
 #[test]

--- a/crates/celox/tests/mutable_for_bound.rs
+++ b/crates/celox/tests/mutable_for_bound.rs
@@ -421,6 +421,63 @@ module t {
 }
 
 #[test]
+fn hierarchical_bound_connected_to_immediately_written_root_is_an_error() {
+    let code = r#"
+module Limit (
+    limit: input logic<8>,
+) {}
+
+#[test(t)]
+module t {
+    var limit: logic<8>;
+    inst dut: Limit (limit);
+
+    initial {
+        limit = 2;
+        for _i in 0..dut.limit {
+            limit = 0;
+        }
+        $finish();
+    }
+}
+"#;
+    expect_mutable_bound_error(code, "t");
+}
+
+#[test]
+fn hierarchical_bound_connected_to_disjoint_root_bits_is_allowed() {
+    let code = r#"
+module Limit (
+    limit: input logic<8>,
+) {}
+
+#[test(t)]
+module t {
+    var upper: logic<4>;
+    var lower: logic<4>;
+    var limit: logic<8>;
+    inst dut: Limit (limit);
+
+    always_comb {
+        limit = {upper, lower};
+    }
+
+    initial {
+        upper = 2;
+        lower = 0;
+        for _i in 0..dut.limit[7:4] {
+            lower = 1;
+        }
+        $finish();
+    }
+}
+"#;
+    Simulator::builder(code, "t")
+        .build()
+        .expect("writes to disjoint connected bits must not conflict");
+}
+
+#[test]
 fn time_advancing_body_effects_pass_when_the_bound_is_outside_the_event_write_closure() {
     let code = r#"
 module Counter (

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -374,6 +374,44 @@ fn test_testbench_direct_reads_are_dead_store_roots() {
 }
 
 #[test]
+fn test_hierarchical_testbench_read_resolves_nested_instance_index_and_select() {
+    let code = r#"
+        module Core () {
+            var words: logic<16>[2];
+
+            always_comb {
+                words[0] = 16'h1234;
+                words[1] = 16'habcd;
+            }
+        }
+
+        module Dut () {
+            inst u_core: Core ();
+        }
+
+        #[test(t)]
+        module t {
+            inst dut: Dut ();
+            var index: u32;
+
+            initial {
+                index = 1;
+                $assert(dut.u_core.words[index][11:4] == 8'hbc);
+                $finish();
+            }
+        }
+    "#;
+
+    assert_eq!(
+        Simulator::builder(code, "t")
+            .dead_store_policy(DeadStorePolicy::PreserveListedSignals)
+            .run_test()
+            .unwrap(),
+        TestResult::Pass,
+    );
+}
+
+#[test]
 fn test_clock_only_self_updating_ff_advances_in_native_testbench_instance() {
     let code = r#"
         module ClockTickCounter (

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -449,6 +449,43 @@ fn test_hierarchical_dynamic_reads_preserve_wide_values() {
 }
 
 #[test]
+fn test_hierarchical_read_ignores_same_named_function_local() {
+    let code = r#"
+        module Dut () {
+            var q: logic<8>;
+
+            function shadow() -> logic<8> {
+                var q: logic<8>;
+                q = 8'h11;
+                return q;
+            }
+
+            always_comb {
+                q = 8'h42;
+            }
+        }
+
+        #[test(t)]
+        module t {
+            inst dut: Dut ();
+
+            initial {
+                $assert(dut.q == 8'h42);
+                $finish();
+            }
+        }
+    "#;
+
+    assert_eq!(
+        Simulator::builder(code, "t")
+            .dead_store_policy(DeadStorePolicy::PreserveListedSignals)
+            .run_test()
+            .unwrap(),
+        TestResult::Pass,
+    );
+}
+
+#[test]
 fn test_hierarchical_select_widths_and_multidimensional_dynamic_indices() {
     let code = r#"
         module Dut () {

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -412,6 +412,43 @@ fn test_hierarchical_testbench_read_resolves_nested_instance_index_and_select() 
 }
 
 #[test]
+fn test_hierarchical_dynamic_reads_preserve_wide_values() {
+    let code = r#"
+        module Dut () {
+            var words: logic<128>[2];
+
+            always_comb {
+                words[0] = 128'h0123_4567_89ab_cdef_fedc_ba98_7654_3210;
+                words[1] = 128'hffff_eeee_dddd_cccc_bbbb_aaaa_9999_8888;
+            }
+        }
+
+        #[test(t)]
+        module t {
+            inst dut: Dut ();
+            var index: u32;
+            var bit_index: u32;
+
+            initial {
+                index = 1;
+                bit_index = 68;
+                $assert(dut.words[index] == 128'hffff_eeee_dddd_cccc_bbbb_aaaa_9999_8888, "wide indexed read");
+                $assert(dut.words[0][bit_index +: 8] == 8'hde, "wide dynamic select");
+                $finish();
+            }
+        }
+    "#;
+
+    assert_eq!(
+        Simulator::builder(code, "t")
+            .dead_store_policy(DeadStorePolicy::PreserveListedSignals)
+            .run_test()
+            .unwrap(),
+        TestResult::Pass,
+    );
+}
+
+#[test]
 fn test_clock_only_self_updating_ff_advances_in_native_testbench_instance() {
     let code = r#"
         module ClockTickCounter (

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -449,6 +449,55 @@ fn test_hierarchical_dynamic_reads_preserve_wide_values() {
 }
 
 #[test]
+fn test_hierarchical_select_widths_and_multidimensional_dynamic_indices() {
+    let code = r#"
+        module Dut () {
+            var word: logic<8>;
+            var mem: logic<8>[2, 2];
+            var narrow: logic<3>[2, 2];
+
+            always_comb {
+                word = 8'hab;
+                mem[0][0] = 8'h11;
+                mem[0][1] = 8'h12;
+                mem[1][0] = 8'h21;
+                mem[1][1] = 8'h22;
+                narrow[0][0] = 3'h1;
+                narrow[0][1] = 3'h2;
+                narrow[1][0] = 3'h3;
+                narrow[1][1] = 3'h5;
+            }
+        }
+
+        #[test(t)]
+        module t {
+            inst dut: Dut ();
+            var i: u32;
+            var j: u32;
+
+            initial {
+                i = 1;
+                j = 1;
+                $assert(dut.word[3 -: 4] == 4'hb, "minus-colon select");
+                $assert({dut.word[7:4], dut.word[3:0]} == 8'hab, "selected concat widths");
+                $assert(dut.mem[i][1] == 8'h22, "dynamic outer index");
+                $assert(dut.mem[i][j] == 8'h22, "multiple dynamic indices");
+                $assert(dut.narrow[i][j] == 3'h5, "non-byte-aligned dynamic indices");
+                $finish();
+            }
+        }
+    "#;
+
+    assert_eq!(
+        Simulator::builder(code, "t")
+            .dead_store_policy(DeadStorePolicy::PreserveListedSignals)
+            .run_test()
+            .unwrap(),
+        TestResult::Pass,
+    );
+}
+
+#[test]
 fn test_clock_only_self_updating_ff_advances_in_native_testbench_instance() {
     let code = r#"
         module ClockTickCounter (

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -455,6 +455,8 @@ fn test_hierarchical_select_widths_and_multidimensional_dynamic_indices() {
             var word: logic<8>;
             var mem: logic<8>[2, 2];
             var narrow: logic<3>[2, 2];
+            var wide: logic<128>[2];
+            var pix: logic<4, 4>;
 
             always_comb {
                 word = 8'hab;
@@ -466,6 +468,9 @@ fn test_hierarchical_select_widths_and_multidimensional_dynamic_indices() {
                 narrow[0][1] = 3'h2;
                 narrow[1][0] = 3'h3;
                 narrow[1][1] = 3'h5;
+                wide[0] = 0;
+                wide[1] = 128'h0000_0000_0000_0002_0000_0000_0000_0000;
+                pix = 16'h0200;
             }
         }
 
@@ -474,15 +479,25 @@ fn test_hierarchical_select_widths_and_multidimensional_dynamic_indices() {
             inst dut: Dut ();
             var i: u32;
             var j: u32;
+            var anchor: u32;
+            var step_index: u32;
 
             initial {
                 i = 1;
                 j = 1;
+                anchor = 7;
+                step_index = 1;
                 $assert(dut.word[3 -: 4] == 4'hb, "minus-colon select");
+                $assert(dut.word[anchor -: 4] == 4'ha, "dynamic minus-colon select");
+                $assert(dut.word[step_index step 4] == 4'ha, "dynamic step select");
                 $assert({dut.word[7:4], dut.word[3:0]} == 8'hab, "selected concat widths");
                 $assert(dut.mem[i][1] == 8'h22, "dynamic outer index");
                 $assert(dut.mem[i][j] == 8'h22, "multiple dynamic indices");
                 $assert(dut.narrow[i][j] == 3'h5, "non-byte-aligned dynamic indices");
+                $assert(dut.narrow[1][0][j] == 1'b1, "sub-byte static index and dynamic select");
+                $assert(dut.wide[i][64:1] == 64'd0, "wide selected value is masked");
+                $assert(dut.pix[2][1] == 1'b1, "multi-dimensional packed index");
+                $assert(dut.pix[2][0] == 1'b0, "all packed indices are consumed");
                 $finish();
             }
         }

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -448,6 +448,88 @@ fn test_hierarchical_dynamic_reads_preserve_wide_values() {
     );
 }
 
+#[cfg(any(
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+))]
+#[test]
+fn test_hierarchical_dynamic_array_read_uses_native_layout() {
+    let code = r#"
+        module Dut (
+            clk: input clock,
+            narrow: output logic<3>[2],
+        ) {
+            always_ff {
+                narrow[0] = 3'h1;
+                narrow[1] = 3'h5;
+            }
+        }
+
+        #[test(t)]
+        module t {
+            inst clk: $tb::clock_gen;
+            var narrow: logic<3>[2];
+            inst dut: Dut (clk, narrow);
+            var index: u32;
+
+            initial {
+                clk.next();
+                index = 1;
+                $assert(dut.narrow[index] == 3'h5);
+                $finish();
+            }
+        }
+    "#;
+
+    let mut sim = Simulator::builder(code, "t")
+        .dead_store_policy(DeadStorePolicy::PreserveListedSignals)
+        .build_native()
+        .unwrap();
+    assert!(
+        sim.program()
+            .runtime_schema
+            .testbench_read_roots
+            .iter()
+            .all(|address| !sim.layout().unpacked_arrays.contains_key(address))
+    );
+    let testbench = compile_initial_testbench(&sim).unwrap();
+    assert_eq!(
+        run_compiled_testbench(&mut sim, &testbench),
+        TestResult::Pass,
+    );
+}
+
+#[test]
+fn test_hierarchical_assert_message_argument_preserves_selected_width() {
+    let code = r#"
+        module Dut () {
+            var word: logic<8>;
+
+            always_comb {
+                word = 8'hab;
+            }
+        }
+
+        #[test(t)]
+        module t {
+            inst dut: Dut ();
+
+            initial {
+                $assert_continue(1'b0, "got %h", dut.word[3:0]);
+                $finish();
+            }
+        }
+    "#;
+
+    let detailed = Simulator::builder(code, "t")
+        .dead_store_policy(DeadStorePolicy::PreserveListedSignals)
+        .run_test_detailed()
+        .unwrap();
+    assert!(!detailed.passed);
+    assert_eq!(detailed.assertions.len(), 1);
+    assert_eq!(detailed.assertions[0].message.as_deref(), Some("got b"));
+}
+
 #[test]
 fn test_hierarchical_read_ignores_same_named_function_local() {
     let code = r#"


### PR DESCRIPTION
## Summary

- resolve Veryl hierarchical instance and variable paths against elaborated design state
- lower hierarchical testbench reads, including array indices and packed selects, to Celox state locations
- include hierarchical reads in testbench observability and dynamic-loop effect analysis
- report invalid hierarchical contexts and unresolved paths as `IllegalContext` rather than unsupported features
- add success, observability, effect-analysis, and invalid-path diagnostics coverage

## Why

Veryl 0.20.3 emits `Factor::HierVariable` for read-only hierarchical references in native testbench blocks. Celox previously rejected these references and could not preserve their target state through dead-store elimination.

Closes #467

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p celox`
- `cargo test -p celox-frontend-veryl`
- `cargo test -p celox --test native_testbench`
- `cargo test -p celox --test mutable_for_bound`
- `cargo test -p celox --test error_detection`
- `cargo test -p celox --lib`
- pre-push hook: submodule check, cargo fmt, Biome, workspace cargo check, clean tree

## Notes

`cargo clippy -p celox-frontend-veryl -p celox --tests` remains blocked by the pre-existing `clippy::needless_range_loop` diagnostic in `crates/celox-frontend-veryl/src/ff/expression.rs:2011`, outside this change.