### PR TITLE
fix(testbench): preserve selected destinations

### DIFF
--- a/crates/celox-frontend-veryl/src/design_assembly.rs
+++ b/crates/celox-frontend-veryl/src/design_assembly.rs
@@ -20,7 +20,7 @@ use crate::{
     FusedSirOptimizationHints, GlueAddr, HashMap, HashSet, InstancePath, ParserError,
     RegionedAbsoluteAddr, RegionedVarAddr, RelocationModule, ScheduledRtl, ScheduledRtlOutput,
     SharedClockLowering, SimModule, SourceLocation, SymbolicRtl, VariableInfo, VerylFrontendLookup,
-    VerylTestbenchSource, build_ff_clock_recipes, flattening, resolve_total_width,
+    VerylTestbenchSource, bitaccess, build_ff_clock_recipes, flattening, resolve_total_width,
 };
 
 fn flatten_with_trace(
@@ -861,12 +861,18 @@ fn module_variables(
                     e.insert(None);
                 }
             }
+            let (dimensions, _, _) = bitaccess::get_dimensions_and_strides(module, *id)?;
+            let packed_dims = dimensions
+                .into_iter()
+                .skip(varibale.r#type.array.iter().count())
+                .collect();
             variables.insert(
                 *id,
                 VariableInfo {
                     id: *id,
                     path: varibale.path.clone(),
                     var_kind: varibale.kind,
+                    packed_dims,
                     metadata: VariableMetadata {
                         width: resolve_total_width(module, varibale)?,
                         is_4state: is_4state_type(&varibale.r#type.kind),

--- a/crates/celox-frontend-veryl/src/lib.rs
+++ b/crates/celox-frontend-veryl/src/lib.rs
@@ -68,6 +68,13 @@ pub struct VariableInfo {
     pub path: VarPath,
     pub var_kind: veryl_analyzer::ir::VarKind,
     pub metadata: VariableMetadata,
+    /// Per-dimension sizes for the packed shape of the variable.
+    ///
+    /// `VariableMetadata::array_dims` deliberately only describes unpacked
+    /// arrays because that is the source-independent storage shape.  The
+    /// testbench frontend also needs the packed shape to lower a chained
+    /// select such as `logic<4, 4> m; m[2][1]` to one linear bit offset.
+    pub packed_dims: Vec<usize>,
 }
 
 impl std::ops::Deref for VariableInfo {

--- a/crates/celox-frontend-veryl/src/testbench.rs
+++ b/crates/celox-frontend-veryl/src/testbench.rs
@@ -1419,13 +1419,7 @@ impl ExprCompiler<'_> {
     }
 
     fn try_const_usize(expr: &Expression) -> Option<usize> {
-        match expr {
-            Expression::Term(f) => match f.as_ref() {
-                Factor::Value(c) => c.get_value().ok().map(|v| v.payload_u64() as usize),
-                _ => None,
-            },
-            _ => None,
-        }
+        usize::try_from(try_eval_const(expr)?).ok()
     }
 
     fn resolve_var(&self, var_id: &VarId) -> Option<SemanticSignal<StateAddr>> {
@@ -2067,15 +2061,7 @@ fn validate_testbench_statements(
         match statement {
             Statement::Assign(statement) => {
                 for destination in &statement.dst {
-                    for expression in &destination.index.0 {
-                        validate_testbench_expression(expression, source, active_functions)?;
-                    }
-                    for expression in &destination.select.0 {
-                        validate_testbench_expression(expression, source, active_functions)?;
-                    }
-                    if let Some((_, expression)) = &destination.select.1 {
-                        validate_testbench_expression(expression, source, active_functions)?;
-                    }
+                    validate_testbench_destination(destination, source, active_functions)?;
                 }
                 validate_testbench_expression(&statement.expr, source, active_functions)?
             }
@@ -2131,6 +2117,9 @@ fn validate_testbench_statements(
             }
             Statement::TbMethodCall(call) => {
                 // Selected return destinations are lowered together with ordinary assignments.
+                if let Some(destination) = call.ret.as_deref() {
+                    validate_testbench_destination(destination, source, active_functions)?;
+                }
                 match &call.method {
                     TbMethod::Component { .. } => {
                         return Err(ParserError::unsupported(
@@ -2175,6 +2164,23 @@ fn validate_testbench_statements(
             }
             Statement::Break | Statement::Unsupported(_) | Statement::Null => {}
         }
+    }
+    Ok(())
+}
+
+fn validate_testbench_destination(
+    destination: &veryl_analyzer::ir::AssignDestination,
+    source: &VerylTestbenchSource,
+    active_functions: &mut FxHashSet<(VarId, Option<Vec<usize>>)>,
+) -> Result<(), ParserError> {
+    for expression in &destination.index.0 {
+        validate_testbench_expression(expression, source, active_functions)?;
+    }
+    for expression in &destination.select.0 {
+        validate_testbench_expression(expression, source, active_functions)?;
+    }
+    if let Some((_, expression)) = &destination.select.1 {
+        validate_testbench_expression(expression, source, active_functions)?;
     }
     Ok(())
 }

--- a/crates/celox-frontend-veryl/src/testbench.rs
+++ b/crates/celox-frontend-veryl/src/testbench.rs
@@ -3,7 +3,7 @@ use celox_testbench::{
     AssertMessage as GenericAssertMessage, ClockCount as GenericClockCount, ExprBytecode,
     ExprOpcode as TbOpcode, LoopBound as GenericLoopBound, SemanticArgument, SemanticSignal,
     SemanticStatement, SourceLocation, StateLocation, TestbenchOperator as Op, TestbenchProgram,
-    TestbenchStatement as GenericTestbenchStatement,
+    TestbenchSelection, TestbenchStatement as GenericTestbenchStatement, TestbenchTarget,
 };
 use fxhash::FxHashSet;
 use veryl_analyzer::ir::{
@@ -1110,6 +1110,140 @@ impl ExprCompiler<'_> {
         }
     }
 
+    fn append_offset_term(
+        ops: &mut Vec<UnboundTbOpcode>,
+        term: impl FnOnce(&mut Vec<UnboundTbOpcode>),
+    ) {
+        term(ops);
+        ops.push(TbOpcode::BinOp(Op::Add));
+    }
+
+    fn selection_offset(
+        &self,
+        select: &veryl_analyzer::ir::VarSelect,
+    ) -> Option<(Vec<UnboundTbOpcode>, usize)> {
+        let anchor = select.0.last()?;
+        if let Some((op, range)) = &select.1 {
+            let width = Self::try_const_usize(range)?;
+            if width == 0 {
+                return None;
+            }
+            let mut ops = Vec::new();
+            match op {
+                veryl_analyzer::ir::VarSelectOp::Colon => {
+                    let anchor = Self::try_const_usize(anchor)?;
+                    let lsb = width;
+                    let width = anchor.checked_sub(lsb)?.saturating_add(1);
+                    Some((vec![TbOpcode::ConstU64(lsb as u64)], width))
+                }
+                veryl_analyzer::ir::VarSelectOp::PlusColon => {
+                    if let Some(anchor) = Self::try_const_usize(anchor) {
+                        Some((vec![TbOpcode::ConstU64(anchor as u64)], width))
+                    } else {
+                        self.emit(anchor, &mut ops);
+                        Some((ops, width))
+                    }
+                }
+                veryl_analyzer::ir::VarSelectOp::MinusColon => {
+                    if let Some(anchor) = Self::try_const_usize(anchor) {
+                        let lsb = anchor.checked_add(1)?.checked_sub(width)?;
+                        Some((vec![TbOpcode::ConstU64(lsb as u64)], width))
+                    } else {
+                        self.emit(anchor, &mut ops);
+                        ops.push(TbOpcode::ConstU64(1));
+                        ops.push(TbOpcode::BinOp(Op::Add));
+                        ops.push(TbOpcode::ConstU64(width as u64));
+                        ops.push(TbOpcode::BinOp(Op::Sub));
+                        Some((ops, width))
+                    }
+                }
+                veryl_analyzer::ir::VarSelectOp::Step => {
+                    if let Some(anchor) = Self::try_const_usize(anchor) {
+                        Some((vec![TbOpcode::ConstU64((anchor * width) as u64)], width))
+                    } else {
+                        self.emit(anchor, &mut ops);
+                        ops.push(TbOpcode::ConstU64(width as u64));
+                        ops.push(TbOpcode::BinOp(Op::Mul));
+                        Some((ops, width))
+                    }
+                }
+            }
+        } else if let Some(anchor) = Self::try_const_usize(anchor) {
+            Some((vec![TbOpcode::ConstU64(anchor as u64)], 1))
+        } else {
+            let mut ops = Vec::new();
+            self.emit(anchor, &mut ops);
+            Some((ops, 1))
+        }
+    }
+
+    fn resolve_target(
+        &self,
+        destination: &veryl_analyzer::ir::AssignDestination,
+    ) -> Option<TestbenchTarget<SemanticSignal<StateAddr>, ExprBytecode<StateLocation<StateAddr>>>>
+    {
+        let signal = self.resolve_var(&destination.id)?;
+        if destination.index.0.is_empty()
+            && destination.select.0.is_empty()
+            && destination.select.1.is_none()
+        {
+            return Some(TestbenchTarget {
+                signal,
+                selection: None,
+                width: signal.width,
+            });
+        }
+
+        let info = self.lookup.root_variable(destination.id)?.1;
+        let array_total: usize = info.array_dims.iter().product::<usize>().max(1);
+        let element_width = info.width / array_total;
+        let mut strides_bits = vec![element_width; info.array_dims.len()];
+        if !info.array_dims.is_empty() {
+            let mut stride = element_width;
+            for i in (0..info.array_dims.len()).rev() {
+                strides_bits[i] = stride;
+                stride *= info.array_dims[i];
+            }
+        }
+
+        let mut offset_ops = vec![TbOpcode::ConstU64(0)];
+        for (i, index) in destination.index.0.iter().enumerate() {
+            let stride = *strides_bits.get(i)?;
+            Self::append_offset_term(&mut offset_ops, |ops| {
+                if let Some(index) = Self::try_const_usize(index) {
+                    ops.push(TbOpcode::ConstU64((index * stride) as u64));
+                } else {
+                    self.emit(index, ops);
+                    ops.push(TbOpcode::ConstU64(stride as u64));
+                    ops.push(TbOpcode::BinOp(Op::Mul));
+                }
+            });
+        }
+
+        let accessed_width = if destination.index.0.len() >= info.array_dims.len() {
+            element_width
+        } else if destination.index.0.is_empty() {
+            info.width
+        } else {
+            *strides_bits.get(destination.index.0.len() - 1)?
+        };
+        let (select_ops, select_width) = if destination.select.is_empty() {
+            (vec![TbOpcode::ConstU64(0)], accessed_width)
+        } else {
+            self.selection_offset(&destination.select)?
+        };
+        Self::append_offset_term(&mut offset_ops, |ops| ops.extend(select_ops));
+
+        Some(TestbenchTarget {
+            signal,
+            selection: Some(TestbenchSelection {
+                offset: ExprBytecode::new(offset_ops),
+                width: select_width,
+            }),
+            width: select_width,
+        })
+    }
+
     /// Emit a LoadU64 or LoadWide opcode for the given byte offset and bit width.
     fn emit_load(
         &self,
@@ -1439,14 +1573,14 @@ impl<'a> SemanticTestbenchBuilder<'a> {
                     }),
                 }
             }
-            Statement::Assign(a) => a
-                .dst
-                .first()
-                .and_then(|d| ec.resolve_var(&d.id))
-                .map(|dst| GenericTestbenchStatement::Assign {
+            Statement::Assign(a) => a.dst.first().and_then(|destination| {
+                let dst = ec.resolve_target(destination)?;
+                let dst_width = dst.width;
+                Some(GenericTestbenchStatement::Assign {
                     dst,
-                    expr: ec.compile_with_width(&a.expr, dst.width),
-                }),
+                    expr: ec.compile_with_width(&a.expr, dst_width),
+                })
+            }),
             Statement::Break => Some(GenericTestbenchStatement::Break),
             Statement::FunctionCall(fc) => self.convert_function_call(fc, ec, next_assert_site_id),
             _ => None,
@@ -1476,7 +1610,11 @@ impl<'a> SemanticTestbenchBuilder<'a> {
             if let Some(&arg_var_id) = func_body.arg_map.get(arg_path) {
                 if let Some(sig) = ec.resolve_var(&arg_var_id) {
                     stmts.push(GenericTestbenchStatement::Assign {
-                        dst: sig,
+                        dst: TestbenchTarget {
+                            signal: sig,
+                            selection: None,
+                            width: sig.width,
+                        },
                         expr: ec.compile_with_width(arg_expr, sig.width),
                     });
                 }
@@ -1555,7 +1693,7 @@ impl<'a> SemanticTestbenchBuilder<'a> {
             }),
             TbMethod::RandomGet { width, signed } => {
                 let ret = match tb.ret.as_deref() {
-                    Some(dst) => Some(ec.resolve_var(&dst.id)?),
+                    Some(dst) => Some(ec.resolve_target(dst)?),
                     None => None,
                 };
                 Some(GenericTestbenchStatement::RandomGet {
@@ -1572,7 +1710,7 @@ impl<'a> SemanticTestbenchBuilder<'a> {
                 signed,
             } => {
                 let ret = match tb.ret.as_deref() {
-                    Some(dst) => Some(ec.resolve_var(&dst.id)?),
+                    Some(dst) => Some(ec.resolve_target(dst)?),
                     None => None,
                 };
                 Some(GenericTestbenchStatement::RandomGetRange {
@@ -1586,7 +1724,7 @@ impl<'a> SemanticTestbenchBuilder<'a> {
             }
             TbMethod::RandomGetSeed => {
                 let ret = match tb.ret.as_deref() {
-                    Some(dst) => Some(ec.resolve_var(&dst.id)?),
+                    Some(dst) => Some(ec.resolve_target(dst)?),
                     None => None,
                 };
                 Some(GenericTestbenchStatement::RandomGetSeed {
@@ -1823,24 +1961,6 @@ fn validate_testbench_system_function(
     }
 }
 
-fn validate_testbench_destination(
-    destination: &veryl_analyzer::ir::AssignDestination,
-) -> Result<(), ParserError> {
-    if !destination.index.0.is_empty()
-        || !destination.select.0.is_empty()
-        || destination.select.1.is_some()
-    {
-        return Err(ParserError::unsupported(
-            478,
-            LoweringPhase::SimulatorParser,
-            "selected native testbench assignment",
-            "selected destinations are not represented by the testbench AIR",
-            Some(&destination.token),
-        ));
-    }
-    Ok(())
-}
-
 fn validate_testbench_statements(
     statements: &[Statement],
     source: &VerylTestbenchSource,
@@ -1850,7 +1970,6 @@ fn validate_testbench_statements(
         match statement {
             Statement::Assign(statement) => {
                 for destination in &statement.dst {
-                    validate_testbench_destination(destination)?;
                     for expression in &destination.index.0 {
                         validate_testbench_expression(expression, source, active_functions)?;
                     }
@@ -1914,9 +2033,7 @@ fn validate_testbench_statements(
                 validate_testbench_function_call(call, source, active_functions)?;
             }
             Statement::TbMethodCall(call) => {
-                if let Some(destination) = call.ret.as_deref() {
-                    validate_testbench_destination(destination)?;
-                }
+                // Selected return destinations are lowered together with ordinary assignments.
                 match &call.method {
                     TbMethod::Component { .. } => {
                         return Err(ParserError::unsupported(

--- a/crates/celox-frontend-veryl/src/testbench.rs
+++ b/crates/celox-frontend-veryl/src/testbench.rs
@@ -1341,6 +1341,290 @@ impl ExprCompiler<'_> {
         })
     }
 
+    fn validate_target_bounds(
+        &self,
+        destination: &veryl_analyzer::ir::AssignDestination,
+    ) -> Result<(), ParserError> {
+        let Some((_, info)) = self.lookup.root_variable(destination.id) else {
+            return Ok(());
+        };
+
+        for (dimension, index) in destination.index.0.iter().enumerate() {
+            let Some(&size) = info.array_dims.get(dimension) else {
+                return Err(ParserError::illegal_context(
+                    "testbench selected destination",
+                    format!(
+                        "unpacked index dimension {dimension} exceeds the variable's {} dimensions",
+                        info.array_dims.len()
+                    ),
+                    None,
+                ));
+            };
+            if let Some(index) = Self::try_const_usize(index)
+                && index >= size
+            {
+                return Err(ParserError::illegal_context(
+                    "testbench selected destination",
+                    format!(
+                        "unpacked index {index} is outside dimension {dimension} of size {size}"
+                    ),
+                    None,
+                ));
+            }
+        }
+
+        if destination.select.0.is_empty() && destination.select.1.is_none() {
+            return Ok(());
+        }
+
+        let dims = &info.packed_dims;
+        let mut strides = vec![1usize; dims.len()];
+        let mut total_width = 1usize;
+        for i in (0..dims.len()).rev() {
+            strides[i] = total_width;
+            total_width = total_width.checked_mul(dims[i]).ok_or_else(|| {
+                ParserError::illegal_context(
+                    "testbench selected destination",
+                    "packed dimensions overflow the target width",
+                    None,
+                )
+            })?;
+        }
+
+        if let Some((op, range_expr)) = &destination.select.1 {
+            let Some(dimension) = destination.select.0.len().checked_sub(1) else {
+                return Err(ParserError::illegal_context(
+                    "testbench selected destination",
+                    "part select is missing its anchor",
+                    None,
+                ));
+            };
+            let Some(&dimension_size) = dims.get(dimension) else {
+                return Err(ParserError::illegal_context(
+                    "testbench selected destination",
+                    format!("packed part-select dimension {dimension} is out of range"),
+                    None,
+                ));
+            };
+            let scale = strides[dimension];
+            let mut prefix_offset = 0usize;
+            let mut prefix_is_static = true;
+            for (prefix_dimension, index) in destination.select.0[..dimension].iter().enumerate() {
+                if let Some(index) = Self::try_const_usize(index) {
+                    let size = dims[prefix_dimension];
+                    if index >= size {
+                        return Err(ParserError::illegal_context(
+                            "testbench selected destination",
+                            format!(
+                                "packed index {index} is outside dimension {prefix_dimension} of size {size}"
+                            ),
+                            None,
+                        ));
+                    }
+                    prefix_offset = prefix_offset
+                        .checked_add(index.checked_mul(strides[prefix_dimension]).ok_or_else(
+                            || {
+                                ParserError::illegal_context(
+                                    "testbench selected destination",
+                                    "packed index offset overflows usize",
+                                    None,
+                                )
+                            },
+                        )?)
+                        .ok_or_else(|| {
+                            ParserError::illegal_context(
+                                "testbench selected destination",
+                                "packed index offset overflows usize",
+                                None,
+                            )
+                        })?;
+                } else {
+                    prefix_is_static = false;
+                }
+            }
+
+            let Some(range) = Self::try_const_usize(range_expr) else {
+                return Ok(());
+            };
+            let anchor = Self::try_const_usize(destination.select.0.last().unwrap());
+            if !matches!(op, veryl_analyzer::ir::VarSelectOp::Colon) && range == 0 {
+                return Err(ParserError::illegal_context(
+                    "testbench selected destination",
+                    "part-select width must be nonzero",
+                    None,
+                ));
+            }
+            if matches!(op, veryl_analyzer::ir::VarSelectOp::Colon) {
+                if range >= dimension_size {
+                    return Err(ParserError::illegal_context(
+                        "testbench selected destination",
+                        format!(
+                            "colon-select low bound {range} is outside dimension size {dimension_size}"
+                        ),
+                        None,
+                    ));
+                }
+            } else if range > dimension_size {
+                return Err(ParserError::illegal_context(
+                    "testbench selected destination",
+                    format!("part-select width {range} exceeds dimension size {dimension_size}"),
+                    None,
+                ));
+            }
+
+            let Some(anchor) = anchor else {
+                return Ok(());
+            };
+            let (relative_offset, elements) = match op {
+                veryl_analyzer::ir::VarSelectOp::Colon => {
+                    if anchor >= dimension_size || range > anchor {
+                        return Err(ParserError::illegal_context(
+                            "testbench selected destination",
+                            format!(
+                                "colon-select [{anchor}:{range}] is outside dimension size {dimension_size}"
+                            ),
+                            None,
+                        ));
+                    }
+                    (range.checked_mul(scale), anchor - range + 1)
+                }
+                veryl_analyzer::ir::VarSelectOp::PlusColon => {
+                    if anchor >= dimension_size
+                        || anchor
+                            .checked_add(range)
+                            .is_none_or(|end| end > dimension_size)
+                    {
+                        return Err(ParserError::illegal_context(
+                            "testbench selected destination",
+                            format!(
+                                "plus-colon select anchor {anchor} and width {range} are outside dimension size {dimension_size}"
+                            ),
+                            None,
+                        ));
+                    }
+                    (anchor.checked_mul(scale), range)
+                }
+                veryl_analyzer::ir::VarSelectOp::MinusColon => {
+                    if anchor >= dimension_size || anchor + 1 < range {
+                        return Err(ParserError::illegal_context(
+                            "testbench selected destination",
+                            format!(
+                                "minus-colon select anchor {anchor} and width {range} are outside dimension size {dimension_size}"
+                            ),
+                            None,
+                        ));
+                    }
+                    ((anchor + 1 - range).checked_mul(scale), range)
+                }
+                veryl_analyzer::ir::VarSelectOp::Step => {
+                    if anchor
+                        .checked_mul(range)
+                        .and_then(|start| start.checked_add(range))
+                        .is_none_or(|end| end > dimension_size)
+                    {
+                        return Err(ParserError::illegal_context(
+                            "testbench selected destination",
+                            format!(
+                                "step select anchor {anchor} and width {range} are outside dimension size {dimension_size}"
+                            ),
+                            None,
+                        ));
+                    }
+                    (
+                        anchor
+                            .checked_mul(range)
+                            .and_then(|offset| offset.checked_mul(scale)),
+                        range,
+                    )
+                }
+            };
+            let relative_offset = relative_offset.ok_or_else(|| {
+                ParserError::illegal_context(
+                    "testbench selected destination",
+                    "packed part-select offset overflows usize",
+                    None,
+                )
+            })?;
+            let selected_width = elements.checked_mul(scale).ok_or_else(|| {
+                ParserError::illegal_context(
+                    "testbench selected destination",
+                    "packed part-select width overflows usize",
+                    None,
+                )
+            })?;
+            if prefix_is_static
+                && prefix_offset
+                    .checked_add(relative_offset)
+                    .and_then(|offset| offset.checked_add(selected_width))
+                    .is_none_or(|end| end > total_width)
+            {
+                return Err(ParserError::illegal_context(
+                    "testbench selected destination",
+                    "packed part-select exceeds the target width",
+                    None,
+                ));
+            }
+        } else {
+            if destination.select.0.len() > dims.len() {
+                return Err(ParserError::illegal_context(
+                    "testbench selected destination",
+                    "packed index count exceeds the variable's dimensions",
+                    None,
+                ));
+            }
+            let mut offset = 0usize;
+            let mut is_static = true;
+            for (dimension, index) in destination.select.0.iter().enumerate() {
+                if let Some(index) = Self::try_const_usize(index) {
+                    let size = dims[dimension];
+                    if index >= size {
+                        return Err(ParserError::illegal_context(
+                            "testbench selected destination",
+                            format!(
+                                "packed index {index} is outside dimension {dimension} of size {size}"
+                            ),
+                            None,
+                        ));
+                    }
+                    offset = offset
+                        .checked_add(index.checked_mul(strides[dimension]).ok_or_else(|| {
+                            ParserError::illegal_context(
+                                "testbench selected destination",
+                                "packed index offset overflows usize",
+                                None,
+                            )
+                        })?)
+                        .ok_or_else(|| {
+                            ParserError::illegal_context(
+                                "testbench selected destination",
+                                "packed index offset overflows usize",
+                                None,
+                            )
+                        })?;
+                } else {
+                    is_static = false;
+                }
+            }
+            let selected_width = if destination.select.0.is_empty() {
+                total_width
+            } else {
+                strides[destination.select.0.len() - 1]
+            };
+            if is_static
+                && offset
+                    .checked_add(selected_width)
+                    .is_none_or(|end| end > total_width)
+            {
+                return Err(ParserError::illegal_context(
+                    "testbench selected destination",
+                    "packed selection exceeds the target width",
+                    None,
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Emit a LoadU64 or LoadWide opcode for the given byte offset and bit width.
     fn emit_load(
         &self,
@@ -1894,13 +2178,92 @@ fn extract_source_location(
     })
 }
 
-fn validate_testbench_function_call(
+fn has_selected_testbench_destination(destination: &veryl_analyzer::ir::AssignDestination) -> bool {
+    !destination.index.0.is_empty()
+        || !destination.select.0.is_empty()
+        || destination.select.1.is_some()
+}
+
+fn reject_selected_destinations_in_expression_statements(
+    statements: &[Statement],
+) -> Result<(), ParserError> {
+    for statement in statements {
+        match statement {
+            Statement::Assign(statement) => {
+                if statement.dst.iter().any(has_selected_testbench_destination) {
+                    return Err(ParserError::illegal_context(
+                        "selected destination in expression testbench function",
+                        "read-modify-write selected destinations are only supported for statement-level function calls",
+                        None,
+                    ));
+                }
+            }
+            Statement::If(statement) => {
+                reject_selected_destinations_in_expression_statements(&statement.true_side)?;
+                reject_selected_destinations_in_expression_statements(&statement.false_side)?;
+            }
+            Statement::IfReset(statement) => {
+                reject_selected_destinations_in_expression_statements(&statement.true_side)?;
+                reject_selected_destinations_in_expression_statements(&statement.false_side)?;
+            }
+            Statement::Case(statement) => {
+                for arm in &statement.arms {
+                    reject_selected_destinations_in_expression_statements(&arm.body)?;
+                }
+                reject_selected_destinations_in_expression_statements(&statement.default)?;
+            }
+            Statement::For(statement) => {
+                reject_selected_destinations_in_expression_statements(&statement.body)?;
+            }
+            Statement::TbMethodCall(call) => {
+                if call
+                    .ret
+                    .as_deref()
+                    .is_some_and(has_selected_testbench_destination)
+                {
+                    return Err(ParserError::illegal_context(
+                        "selected destination in expression testbench function",
+                        "read-modify-write selected destinations are only supported for statement-level function calls",
+                        None,
+                    ));
+                }
+            }
+            Statement::FunctionCall(_)
+            | Statement::SystemFunctionCall(_)
+            | Statement::Break
+            | Statement::Unsupported(_)
+            | Statement::Null => {}
+        }
+    }
+    Ok(())
+}
+
+fn reject_selected_destinations_in_expression_function_call(
     call: &FunctionCall,
     source: &VerylTestbenchSource,
     active_functions: &mut FxHashSet<(VarId, Option<Vec<usize>>)>,
 ) -> Result<(), ParserError> {
+    let key = (call.id, call.index.clone());
+    if !active_functions.insert(key.clone()) {
+        return Ok(());
+    }
+    let result = if let Some(body) = function_body(&source.functions, call) {
+        reject_selected_destinations_in_expression_statements(&body.statements)
+    } else {
+        Ok(())
+    };
+    active_functions.remove(&key);
+    result
+}
+
+fn validate_testbench_function_call(
+    call: &FunctionCall,
+    lookup: &VerylFrontendLookup,
+    source: &VerylTestbenchSource,
+    active_functions: &mut FxHashSet<(VarId, Option<Vec<usize>>)>,
+) -> Result<(), ParserError> {
     for expression in call.inputs.values() {
-        validate_testbench_expression(expression, source, active_functions)?;
+        validate_testbench_expression(expression, lookup, source, active_functions)?;
     }
 
     let key = (call.id, call.index.clone());
@@ -1908,7 +2271,7 @@ fn validate_testbench_function_call(
         return Ok(());
     }
     let result = if let Some(body) = function_body(&source.functions, call) {
-        validate_testbench_statements(&body.statements, source, active_functions)
+        validate_testbench_statements(&body.statements, lookup, source, active_functions)
     } else {
         Ok(())
     };
@@ -1918,6 +2281,7 @@ fn validate_testbench_function_call(
 
 fn validate_testbench_expression(
     expression: &Expression,
+    lookup: &VerylFrontendLookup,
     source: &VerylTestbenchSource,
     active_functions: &mut FxHashSet<(VarId, Option<Vec<usize>>)>,
 ) -> Result<(), ParserError> {
@@ -1932,18 +2296,23 @@ fn validate_testbench_expression(
             )),
             Factor::Variable(_, index, select, _) => {
                 for expression in index.0.iter().chain(select.0.iter()) {
-                    validate_testbench_expression(expression, source, active_functions)?;
+                    validate_testbench_expression(expression, lookup, source, active_functions)?;
                 }
                 if let Some((_, expression)) = &select.1 {
-                    validate_testbench_expression(expression, source, active_functions)?;
+                    validate_testbench_expression(expression, lookup, source, active_functions)?;
                 }
                 Ok(())
             }
             Factor::FunctionCall(call) => {
-                validate_testbench_function_call(call, source, active_functions)
+                validate_testbench_function_call(call, lookup, source, active_functions)?;
+                reject_selected_destinations_in_expression_function_call(
+                    call,
+                    source,
+                    active_functions,
+                )
             }
             Factor::SystemFunctionCall(call) => {
-                validate_testbench_system_function(&call.kind, source, active_functions)
+                validate_testbench_system_function(&call.kind, lookup, source, active_functions)
             }
             Factor::Anonymous(comptime) | Factor::Unknown(comptime)
                 if comptime.get_value().is_err() =>
@@ -1974,22 +2343,22 @@ fn validate_testbench_expression(
             Factor::Value(_) | Factor::Anonymous(_) | Factor::Unknown(_) => Ok(()),
         },
         Expression::Unary(_, inner, _) => {
-            validate_testbench_expression(inner, source, active_functions)
+            validate_testbench_expression(inner, lookup, source, active_functions)
         }
         Expression::Binary(lhs, _, rhs, _) => {
-            validate_testbench_expression(lhs, source, active_functions)?;
-            validate_testbench_expression(rhs, source, active_functions)
+            validate_testbench_expression(lhs, lookup, source, active_functions)?;
+            validate_testbench_expression(rhs, lookup, source, active_functions)
         }
         Expression::Ternary(condition, then_expression, else_expression, _) => {
-            validate_testbench_expression(condition, source, active_functions)?;
-            validate_testbench_expression(then_expression, source, active_functions)?;
-            validate_testbench_expression(else_expression, source, active_functions)
+            validate_testbench_expression(condition, lookup, source, active_functions)?;
+            validate_testbench_expression(then_expression, lookup, source, active_functions)?;
+            validate_testbench_expression(else_expression, lookup, source, active_functions)
         }
         Expression::Concatenation(items, _) => {
             for (expression, repeat) in items {
-                validate_testbench_expression(expression, source, active_functions)?;
+                validate_testbench_expression(expression, lookup, source, active_functions)?;
                 if let Some(repeat) = repeat {
-                    validate_testbench_expression(repeat, source, active_functions)?;
+                    validate_testbench_expression(repeat, lookup, source, active_functions)?;
                 }
             }
             Ok(())
@@ -1998,13 +2367,28 @@ fn validate_testbench_expression(
             for item in items {
                 match item {
                     ArrayLiteralItem::Value(expression, repeat) => {
-                        validate_testbench_expression(expression, source, active_functions)?;
+                        validate_testbench_expression(
+                            expression,
+                            lookup,
+                            source,
+                            active_functions,
+                        )?;
                         if let Some(repeat) = repeat {
-                            validate_testbench_expression(repeat, source, active_functions)?;
+                            validate_testbench_expression(
+                                repeat,
+                                lookup,
+                                source,
+                                active_functions,
+                            )?;
                         }
                     }
                     ArrayLiteralItem::Defaul(expression) => {
-                        validate_testbench_expression(expression, source, active_functions)?;
+                        validate_testbench_expression(
+                            expression,
+                            lookup,
+                            source,
+                            active_functions,
+                        )?;
                     }
                 }
             }
@@ -2012,7 +2396,7 @@ fn validate_testbench_expression(
         }
         Expression::StructConstructor(_, fields, _) => {
             for (_, expression) in fields {
-                validate_testbench_expression(expression, source, active_functions)?;
+                validate_testbench_expression(expression, lookup, source, active_functions)?;
             }
             Ok(())
         }
@@ -2021,11 +2405,12 @@ fn validate_testbench_expression(
 
 fn validate_testbench_system_function(
     kind: &SystemFunctionKind,
+    lookup: &VerylFrontendLookup,
     source: &VerylTestbenchSource,
     active_functions: &mut FxHashSet<(VarId, Option<Vec<usize>>)>,
 ) -> Result<(), ParserError> {
     let mut validate = |input: &SystemFunctionInput| {
-        validate_testbench_expression(&input.0, source, active_functions)
+        validate_testbench_expression(&input.0, lookup, source, active_functions)
     };
     match kind {
         SystemFunctionKind::Bits(input)
@@ -2054,6 +2439,7 @@ fn validate_testbench_system_function(
 
 fn validate_testbench_statements(
     statements: &[Statement],
+    lookup: &VerylFrontendLookup,
     source: &VerylTestbenchSource,
     active_functions: &mut FxHashSet<(VarId, Option<Vec<usize>>)>,
 ) -> Result<(), ParserError> {
@@ -2061,40 +2447,81 @@ fn validate_testbench_statements(
         match statement {
             Statement::Assign(statement) => {
                 for destination in &statement.dst {
-                    validate_testbench_destination(destination, source, active_functions)?;
+                    validate_testbench_destination(destination, lookup, source, active_functions)?;
                 }
-                validate_testbench_expression(&statement.expr, source, active_functions)?
+                validate_testbench_expression(&statement.expr, lookup, source, active_functions)?
             }
             Statement::If(statement) => {
-                validate_testbench_expression(&statement.cond, source, active_functions)?;
-                validate_testbench_statements(&statement.true_side, source, active_functions)?;
-                validate_testbench_statements(&statement.false_side, source, active_functions)?;
+                validate_testbench_expression(&statement.cond, lookup, source, active_functions)?;
+                validate_testbench_statements(
+                    &statement.true_side,
+                    lookup,
+                    source,
+                    active_functions,
+                )?;
+                validate_testbench_statements(
+                    &statement.false_side,
+                    lookup,
+                    source,
+                    active_functions,
+                )?;
             }
             Statement::IfReset(statement) => {
-                validate_testbench_statements(&statement.true_side, source, active_functions)?;
-                validate_testbench_statements(&statement.false_side, source, active_functions)?;
+                validate_testbench_statements(
+                    &statement.true_side,
+                    lookup,
+                    source,
+                    active_functions,
+                )?;
+                validate_testbench_statements(
+                    &statement.false_side,
+                    lookup,
+                    source,
+                    active_functions,
+                )?;
             }
             Statement::Case(statement) => {
-                validate_testbench_expression(&statement.case_target, source, active_functions)?;
+                validate_testbench_expression(
+                    &statement.case_target,
+                    lookup,
+                    source,
+                    active_functions,
+                )?;
                 for arm in &statement.arms {
                     for pattern in &arm.patterns {
                         match pattern {
                             CasePattern::Eq(expression) => {
                                 validate_testbench_expression(
                                     expression,
+                                    lookup,
                                     source,
                                     active_functions,
                                 )?;
                             }
                             CasePattern::Range { lo, hi, .. } => {
-                                validate_testbench_expression(lo, source, active_functions)?;
-                                validate_testbench_expression(hi, source, active_functions)?;
+                                validate_testbench_expression(
+                                    lo,
+                                    lookup,
+                                    source,
+                                    active_functions,
+                                )?;
+                                validate_testbench_expression(
+                                    hi,
+                                    lookup,
+                                    source,
+                                    active_functions,
+                                )?;
                             }
                         }
                     }
-                    validate_testbench_statements(&arm.body, source, active_functions)?;
+                    validate_testbench_statements(&arm.body, lookup, source, active_functions)?;
                 }
-                validate_testbench_statements(&statement.default, source, active_functions)?;
+                validate_testbench_statements(
+                    &statement.default,
+                    lookup,
+                    source,
+                    active_functions,
+                )?;
             }
             Statement::For(statement) => {
                 let (start, end) = match &statement.range {
@@ -2104,21 +2531,26 @@ fn validate_testbench_statements(
                 };
                 for bound in [start, end] {
                     if let ForBound::Expression(expression) = bound {
-                        validate_testbench_expression(expression, source, active_functions)?;
+                        validate_testbench_expression(
+                            expression,
+                            lookup,
+                            source,
+                            active_functions,
+                        )?;
                     }
                 }
-                validate_testbench_statements(&statement.body, source, active_functions)?;
+                validate_testbench_statements(&statement.body, lookup, source, active_functions)?;
             }
             Statement::SystemFunctionCall(call) => {
-                validate_testbench_system_function(&call.kind, source, active_functions)?;
+                validate_testbench_system_function(&call.kind, lookup, source, active_functions)?;
             }
             Statement::FunctionCall(call) => {
-                validate_testbench_function_call(call, source, active_functions)?;
+                validate_testbench_function_call(call, lookup, source, active_functions)?;
             }
             Statement::TbMethodCall(call) => {
                 // Selected return destinations are lowered together with ordinary assignments.
                 if let Some(destination) = call.ret.as_deref() {
-                    validate_testbench_destination(destination, source, active_functions)?;
+                    validate_testbench_destination(destination, lookup, source, active_functions)?;
                 }
                 match &call.method {
                     TbMethod::Component { .. } => {
@@ -2131,32 +2563,52 @@ fn validate_testbench_statements(
                         ));
                     }
                     TbMethod::RandomSeed { value } => {
-                        validate_testbench_expression(value, source, active_functions)?;
+                        validate_testbench_expression(value, lookup, source, active_functions)?;
                     }
                     TbMethod::RandomGetRange { min, max, .. } => {
-                        validate_testbench_expression(min, source, active_functions)?;
-                        validate_testbench_expression(max, source, active_functions)?;
+                        validate_testbench_expression(min, lookup, source, active_functions)?;
+                        validate_testbench_expression(max, lookup, source, active_functions)?;
                     }
                     TbMethod::RandomGet { .. } | TbMethod::RandomGetSeed => {}
                     TbMethod::ClockNext { count, period } => {
                         if let Some(expression) = count {
-                            validate_testbench_expression(expression, source, active_functions)?;
+                            validate_testbench_expression(
+                                expression,
+                                lookup,
+                                source,
+                                active_functions,
+                            )?;
                         }
                         if let Some(expression) = period {
-                            validate_testbench_expression(expression, source, active_functions)?;
+                            validate_testbench_expression(
+                                expression,
+                                lookup,
+                                source,
+                                active_functions,
+                            )?;
                         }
                     }
                     TbMethod::ResetAssert { duration, .. } => {
                         if let Some(expression) = duration {
-                            validate_testbench_expression(expression, source, active_functions)?;
+                            validate_testbench_expression(
+                                expression,
+                                lookup,
+                                source,
+                                active_functions,
+                            )?;
                         }
                     }
                     TbMethod::FileOpen { name, .. } => {
-                        validate_testbench_expression(&name.0, source, active_functions)?
+                        validate_testbench_expression(&name.0, lookup, source, active_functions)?
                     }
                     TbMethod::FileWrite { args } => {
                         for argument in args {
-                            validate_testbench_expression(&argument.0, source, active_functions)?;
+                            validate_testbench_expression(
+                                &argument.0,
+                                lookup,
+                                source,
+                                active_functions,
+                            )?;
                         }
                     }
                     TbMethod::FileClose | TbMethod::FileFlush => {}
@@ -2170,18 +2622,24 @@ fn validate_testbench_statements(
 
 fn validate_testbench_destination(
     destination: &veryl_analyzer::ir::AssignDestination,
+    lookup: &VerylFrontendLookup,
     source: &VerylTestbenchSource,
     active_functions: &mut FxHashSet<(VarId, Option<Vec<usize>>)>,
 ) -> Result<(), ParserError> {
     for expression in &destination.index.0 {
-        validate_testbench_expression(expression, source, active_functions)?;
+        validate_testbench_expression(expression, lookup, source, active_functions)?;
     }
     for expression in &destination.select.0 {
-        validate_testbench_expression(expression, source, active_functions)?;
+        validate_testbench_expression(expression, lookup, source, active_functions)?;
     }
     if let Some((_, expression)) = &destination.select.1 {
-        validate_testbench_expression(expression, source, active_functions)?;
+        validate_testbench_expression(expression, lookup, source, active_functions)?;
     }
+    ExprCompiler {
+        lookup,
+        testbench_source: source,
+    }
+    .validate_target_bounds(destination)?;
     Ok(())
 }
 
@@ -2194,7 +2652,7 @@ pub fn compile_semantic_testbench(
     let Some(initial_stmts) = source.initial_statements.as_ref() else {
         return Ok(None);
     };
-    validate_testbench_statements(initial_stmts, source, &mut FxHashSet::default())?;
+    validate_testbench_statements(initial_stmts, lookup, source, &mut FxHashSet::default())?;
     let mut builder = SemanticTestbenchBuilder::new(lookup, source, runtime_event_site_count);
     builder.build_event_map(initial_stmts);
     Ok(Some(

--- a/crates/celox-frontend-veryl/src/testbench.rs
+++ b/crates/celox-frontend-veryl/src/testbench.rs
@@ -200,10 +200,7 @@ fn collect_statement_reads(
             Statement::Assign(assign) => {
                 collect_expression_reads(&assign.expr, funcs, active_functions, reads);
                 for dst in &assign.dst {
-                    for expr in &dst.index.0 {
-                        collect_expression_reads(expr, funcs, active_functions, reads);
-                    }
-                    collect_select_reads(&dst.select, funcs, active_functions, reads);
+                    collect_target_reads(dst, funcs, active_functions, reads);
                 }
             }
             Statement::If(stmt) => {
@@ -243,45 +240,72 @@ fn collect_statement_reads(
             Statement::FunctionCall(call) => {
                 collect_function_call_reads(call, funcs, active_functions, reads);
             }
-            Statement::TbMethodCall(call) => match &call.method {
-                TbMethod::ClockNext { count, period } => {
-                    if let Some(expr) = count {
-                        collect_expression_reads(expr, funcs, active_functions, reads);
+            Statement::TbMethodCall(call) => {
+                // A selected random return is a read-modify-write in the
+                // host-side testbench runtime.  Keep both its dynamic
+                // addressing expressions and the old root value observable.
+                if let Some(ret) = call.ret.as_deref() {
+                    collect_target_reads(ret, funcs, active_functions, reads);
+                }
+                match &call.method {
+                    TbMethod::ClockNext { count, period } => {
+                        if let Some(expr) = count {
+                            collect_expression_reads(expr, funcs, active_functions, reads);
+                        }
+                        if let Some(expr) = period {
+                            collect_expression_reads(expr, funcs, active_functions, reads);
+                        }
                     }
-                    if let Some(expr) = period {
-                        collect_expression_reads(expr, funcs, active_functions, reads);
+                    TbMethod::ResetAssert { duration, .. } => {
+                        if let Some(expr) = duration {
+                            collect_expression_reads(expr, funcs, active_functions, reads);
+                        }
                     }
-                }
-                TbMethod::ResetAssert { duration, .. } => {
-                    if let Some(expr) = duration {
-                        collect_expression_reads(expr, funcs, active_functions, reads);
+                    TbMethod::FileOpen { name, .. } => {
+                        collect_expression_reads(&name.0, funcs, active_functions, reads);
                     }
-                }
-                TbMethod::FileOpen { name, .. } => {
-                    collect_expression_reads(&name.0, funcs, active_functions, reads);
-                }
-                TbMethod::FileWrite { args } => {
-                    for arg in args {
-                        collect_expression_reads(&arg.0, funcs, active_functions, reads);
+                    TbMethod::FileWrite { args } => {
+                        for arg in args {
+                            collect_expression_reads(&arg.0, funcs, active_functions, reads);
+                        }
                     }
-                }
-                TbMethod::FileClose | TbMethod::FileFlush => {}
-                TbMethod::Component { args, .. } => {
-                    for arg in args {
-                        collect_expression_reads(&arg.0, funcs, active_functions, reads);
+                    TbMethod::FileClose | TbMethod::FileFlush => {}
+                    TbMethod::Component { args, .. } => {
+                        for arg in args {
+                            collect_expression_reads(&arg.0, funcs, active_functions, reads);
+                        }
                     }
+                    TbMethod::RandomSeed { value } => {
+                        collect_expression_reads(value, funcs, active_functions, reads);
+                    }
+                    TbMethod::RandomGetRange { min, max, .. } => {
+                        collect_expression_reads(min, funcs, active_functions, reads);
+                        collect_expression_reads(max, funcs, active_functions, reads);
+                    }
+                    TbMethod::RandomGet { .. } | TbMethod::RandomGetSeed => {}
                 }
-                TbMethod::RandomSeed { value } => {
-                    collect_expression_reads(value, funcs, active_functions, reads);
-                }
-                TbMethod::RandomGetRange { min, max, .. } => {
-                    collect_expression_reads(min, funcs, active_functions, reads);
-                    collect_expression_reads(max, funcs, active_functions, reads);
-                }
-                TbMethod::RandomGet { .. } | TbMethod::RandomGetSeed => {}
-            },
+            }
             Statement::Break | Statement::Unsupported(_) | Statement::Null => {}
         }
+    }
+}
+
+fn collect_target_reads(
+    target: &veryl_analyzer::ir::AssignDestination,
+    funcs: &fxhash::FxHashMap<VarId, Function>,
+    active_functions: &mut FxHashSet<VarId>,
+    reads: &mut FxHashSet<VarId>,
+) {
+    for expr in &target.index.0 {
+        collect_expression_reads(expr, funcs, active_functions, reads);
+    }
+    collect_select_reads(&target.select, funcs, active_functions, reads);
+
+    // The native selected-target path reads the complete root signal before
+    // merging the new slice.  Model that read as a DSE root; a whole-root
+    // assignment does not need this extra liveness edge.
+    if !target.index.0.is_empty() || !target.select.0.is_empty() || target.select.1.is_some() {
+        reads.insert(target.id);
     }
 }
 
@@ -1121,59 +1145,132 @@ impl ExprCompiler<'_> {
     fn selection_offset(
         &self,
         select: &veryl_analyzer::ir::VarSelect,
+        packed_dims: &[usize],
     ) -> Option<(Vec<UnboundTbOpcode>, usize)> {
-        let anchor = select.0.last()?;
-        if let Some((op, range)) = &select.1 {
-            let width = Self::try_const_usize(range)?;
-            if width == 0 {
-                return None;
+        if packed_dims.is_empty() || select.0.is_empty() {
+            return None;
+        }
+
+        let mut strides = vec![1usize; packed_dims.len()];
+        let mut stride = 1usize;
+        for i in (0..packed_dims.len()).rev() {
+            strides[i] = stride;
+            stride = stride.checked_mul(packed_dims[i])?;
+        }
+
+        let mut ops = vec![TbOpcode::ConstU64(0)];
+        let append_index =
+            |ops: &mut Vec<UnboundTbOpcode>, expr: &Expression, scale: usize| -> Option<()> {
+                if let Some(index) = Self::try_const_usize(expr) {
+                    let offset = index.checked_mul(scale)?;
+                    Self::append_offset_term(ops, |ops| {
+                        ops.push(TbOpcode::ConstU64(offset as u64));
+                    });
+                } else {
+                    Self::append_offset_term(ops, |ops| {
+                        self.emit(expr, ops);
+                        if scale != 1 {
+                            ops.push(TbOpcode::ConstU64(scale as u64));
+                            ops.push(TbOpcode::BinOp(Op::Mul));
+                        }
+                    });
+                }
+                Some(())
+            };
+
+        if let Some((op, range_expr)) = &select.1 {
+            let dimension = select.0.len() - 1;
+            let scale = *strides.get(dimension)?;
+            for (index, expr) in select.0[..dimension].iter().enumerate() {
+                append_index(&mut ops, expr, *strides.get(index)?)?;
             }
-            let mut ops = Vec::new();
-            match op {
+
+            let anchor = select.0.last()?;
+            let range = Self::try_const_usize(range_expr)?;
+            let (part_ops, elements) = match op {
+                // In `base[msb:lsb]`, the second operand is the LSB, not
+                // the selected width.  In particular, `[3:0]` is four bits.
                 veryl_analyzer::ir::VarSelectOp::Colon => {
                     let anchor = Self::try_const_usize(anchor)?;
-                    let lsb = width;
-                    let width = anchor.checked_sub(lsb)?.saturating_add(1);
-                    Some((vec![TbOpcode::ConstU64(lsb as u64)], width))
+                    let elements = anchor.checked_sub(range)?.checked_add(1)?;
+                    let offset = range.checked_mul(scale)?;
+                    (vec![TbOpcode::ConstU64(offset as u64)], elements)
                 }
                 veryl_analyzer::ir::VarSelectOp::PlusColon => {
+                    if range == 0 {
+                        return None;
+                    }
                     if let Some(anchor) = Self::try_const_usize(anchor) {
-                        Some((vec![TbOpcode::ConstU64(anchor as u64)], width))
+                        let offset = anchor.checked_mul(scale)?;
+                        (vec![TbOpcode::ConstU64(offset as u64)], range)
                     } else {
-                        self.emit(anchor, &mut ops);
-                        Some((ops, width))
+                        let mut part_ops = Vec::new();
+                        self.emit(anchor, &mut part_ops);
+                        if scale != 1 {
+                            part_ops.push(TbOpcode::ConstU64(scale as u64));
+                            part_ops.push(TbOpcode::BinOp(Op::Mul));
+                        }
+                        (part_ops, range)
                     }
                 }
                 veryl_analyzer::ir::VarSelectOp::MinusColon => {
+                    if range == 0 {
+                        return None;
+                    }
                     if let Some(anchor) = Self::try_const_usize(anchor) {
-                        let lsb = anchor.checked_add(1)?.checked_sub(width)?;
-                        Some((vec![TbOpcode::ConstU64(lsb as u64)], width))
+                        let lsb = anchor.checked_add(1)?.checked_sub(range)?;
+                        let offset = lsb.checked_mul(scale)?;
+                        (vec![TbOpcode::ConstU64(offset as u64)], range)
                     } else {
-                        self.emit(anchor, &mut ops);
-                        ops.push(TbOpcode::ConstU64(1));
-                        ops.push(TbOpcode::BinOp(Op::Add));
-                        ops.push(TbOpcode::ConstU64(width as u64));
-                        ops.push(TbOpcode::BinOp(Op::Sub));
-                        Some((ops, width))
+                        let mut part_ops = Vec::new();
+                        self.emit(anchor, &mut part_ops);
+                        part_ops.push(TbOpcode::ConstU64(1));
+                        part_ops.push(TbOpcode::BinOp(Op::Add));
+                        part_ops.push(TbOpcode::ConstU64(range as u64));
+                        part_ops.push(TbOpcode::BinOp(Op::Sub));
+                        if scale != 1 {
+                            part_ops.push(TbOpcode::ConstU64(scale as u64));
+                            part_ops.push(TbOpcode::BinOp(Op::Mul));
+                        }
+                        (part_ops, range)
                     }
                 }
                 veryl_analyzer::ir::VarSelectOp::Step => {
+                    if range == 0 {
+                        return None;
+                    }
                     if let Some(anchor) = Self::try_const_usize(anchor) {
-                        Some((vec![TbOpcode::ConstU64((anchor * width) as u64)], width))
+                        let offset = anchor.checked_mul(range)?.checked_mul(scale)?;
+                        (vec![TbOpcode::ConstU64(offset as u64)], range)
                     } else {
-                        self.emit(anchor, &mut ops);
-                        ops.push(TbOpcode::ConstU64(width as u64));
-                        ops.push(TbOpcode::BinOp(Op::Mul));
-                        Some((ops, width))
+                        let mut part_ops = Vec::new();
+                        self.emit(anchor, &mut part_ops);
+                        part_ops.push(TbOpcode::ConstU64(range as u64));
+                        part_ops.push(TbOpcode::BinOp(Op::Mul));
+                        if scale != 1 {
+                            part_ops.push(TbOpcode::ConstU64(scale as u64));
+                            part_ops.push(TbOpcode::BinOp(Op::Mul));
+                        }
+                        (part_ops, range)
                     }
                 }
-            }
-        } else if let Some(anchor) = Self::try_const_usize(anchor) {
-            Some((vec![TbOpcode::ConstU64(anchor as u64)], 1))
+            };
+            let selected_width = elements.checked_mul(scale)?;
+            Self::append_offset_term(&mut ops, |ops| ops.extend(part_ops));
+            Some((ops, selected_width))
         } else {
-            let mut ops = Vec::new();
-            self.emit(anchor, &mut ops);
-            Some((ops, 1))
+            if select.0.len() > packed_dims.len() {
+                return None;
+            }
+            for (index, expr) in select.0.iter().enumerate() {
+                append_index(&mut ops, expr, *strides.get(index)?)?;
+            }
+            let selected_width = if select.0.is_empty() {
+                stride
+            } else {
+                *strides.get(select.0.len() - 1)?
+            };
+            Some((ops, selected_width))
         }
     }
 
@@ -1230,7 +1327,7 @@ impl ExprCompiler<'_> {
         let (select_ops, select_width) = if destination.select.is_empty() {
             (vec![TbOpcode::ConstU64(0)], accessed_width)
         } else {
-            self.selection_offset(&destination.select)?
+            self.selection_offset(&destination.select, &info.packed_dims)?
         };
         Self::append_offset_term(&mut offset_ops, |ops| ops.extend(select_ops));
 

--- a/crates/celox-runtime/src/testbench.rs
+++ b/crates/celox-runtime/src/testbench.rs
@@ -3,8 +3,8 @@ use celox_testbench::{
     AssertMessage as GenericAssertMessage, ClockCount as GenericClockCount, CompiledExpr,
     ExecutableArgument, ExecutableAssertMessage, ExecutableClockCount, ExecutableLoopBound,
     ExecutableStatement, ExecutableTestbench, ExprBytecode, LoopBound as GenericLoopBound,
-    SemanticArgument, SemanticStatement, StateLocation, TestbenchProgram,
-    TestbenchStatement as GenericTestbenchStatement,
+    SemanticArgument, SemanticStatement, StateLocation, TestbenchProgram, TestbenchSelection,
+    TestbenchStatement as GenericTestbenchStatement, TestbenchTarget,
 };
 
 use crate::{SignalRef, backend::SimBackend};
@@ -81,6 +81,41 @@ fn bind_loop_bound<B: SimBackend>(
             width,
             signed,
         }),
+    }
+}
+
+fn bind_target<B: SimBackend>(
+    backend: &B,
+    target: TestbenchTarget<
+        celox_testbench::SemanticSignal<AbsoluteAddr>,
+        ExprBytecode<StateLocation<AbsoluteAddr>>,
+    >,
+) -> Option<TestbenchTarget<SignalRef, CompiledExpr>> {
+    Some(TestbenchTarget {
+        signal: backend.resolve_signal(&target.signal.address),
+        selection: match target.selection {
+            Some(selection) => Some(TestbenchSelection {
+                offset: bind_expr(backend, selection.offset)?,
+                width: selection.width,
+            }),
+            None => None,
+        },
+        width: target.width,
+    })
+}
+
+fn bind_optional_target<B: SimBackend>(
+    backend: &B,
+    target: Option<
+        TestbenchTarget<
+            celox_testbench::SemanticSignal<AbsoluteAddr>,
+            ExprBytecode<StateLocation<AbsoluteAddr>>,
+        >,
+    >,
+) -> Option<Option<TestbenchTarget<SignalRef, CompiledExpr>>> {
+    match target {
+        Some(target) => Some(Some(bind_target(backend, target)?)),
+        None => Some(None),
     }
 }
 
@@ -174,7 +209,7 @@ fn bind_statement<B: SimBackend>(
         }),
         GenericTestbenchStatement::Assign { dst, expr } => {
             Some(GenericTestbenchStatement::Assign {
-                dst: backend.resolve_signal(&dst.address),
+                dst: bind_target(backend, dst)?,
                 expr: bind_expr(backend, expr)?,
             })
         }
@@ -193,7 +228,7 @@ fn bind_statement<B: SimBackend>(
             handle,
             width,
             signed,
-            ret: ret.map(|signal| backend.resolve_signal(&signal.address)),
+            ret: bind_optional_target(backend, ret)?,
         }),
         GenericTestbenchStatement::RandomGetRange {
             handle,
@@ -208,12 +243,12 @@ fn bind_statement<B: SimBackend>(
             max: bind_expr(backend, max)?,
             width,
             signed,
-            ret: ret.map(|signal| backend.resolve_signal(&signal.address)),
+            ret: bind_optional_target(backend, ret)?,
         }),
         GenericTestbenchStatement::RandomGetSeed { handle, ret } => {
             Some(GenericTestbenchStatement::RandomGetSeed {
                 handle,
-                ret: ret.map(|signal| backend.resolve_signal(&signal.address)),
+                ret: bind_optional_target(backend, ret)?,
             })
         }
         GenericTestbenchStatement::Break => Some(GenericTestbenchStatement::Break),

--- a/crates/celox-testbench/src/lib.rs
+++ b/crates/celox-testbench/src/lib.rs
@@ -87,7 +87,7 @@ pub enum LoopBound<Expression> {
 /// unbound expressions. Runtime binding instantiates the same contract with
 /// backend event/signal handles and executable expressions.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum TestbenchStatement<Event, Signal, Expression, Argument> {
+pub enum TestbenchStatement<Event, Signal, Expression, Argument, Target = Signal> {
     ClockNext {
         clock_event: Event,
         count: ClockCount<Expression>,
@@ -126,7 +126,7 @@ pub enum TestbenchStatement<Event, Signal, Expression, Argument> {
         body: Vec<Self>,
     },
     Assign {
-        dst: Signal,
+        dst: Target,
         expr: Expression,
     },
     RandomSeed {
@@ -137,7 +137,7 @@ pub enum TestbenchStatement<Event, Signal, Expression, Argument> {
         handle: String,
         width: u32,
         signed: bool,
-        ret: Option<Signal>,
+        ret: Option<Target>,
     },
     RandomGetRange {
         handle: String,
@@ -145,11 +145,11 @@ pub enum TestbenchStatement<Event, Signal, Expression, Argument> {
         max: Expression,
         width: u32,
         signed: bool,
-        ret: Option<Signal>,
+        ret: Option<Target>,
     },
     RandomGetSeed {
         handle: String,
-        ret: Option<Signal>,
+        ret: Option<Target>,
     },
     Break,
     Finish,
@@ -162,6 +162,19 @@ pub struct SemanticSignal<A> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TestbenchSelection<Expression> {
+    pub offset: Expression,
+    pub width: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TestbenchTarget<Signal, Expression> {
+    pub signal: Signal,
+    pub selection: Option<TestbenchSelection<Expression>>,
+    pub width: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SemanticArgument<A> {
     pub expr: ExprBytecode<StateLocation<A>>,
     pub width: usize,
@@ -169,8 +182,13 @@ pub struct SemanticArgument<A> {
     pub is_string: bool,
 }
 
-pub type SemanticStatement<A> =
-    TestbenchStatement<A, SemanticSignal<A>, ExprBytecode<StateLocation<A>>, SemanticArgument<A>>;
+pub type SemanticStatement<A> = TestbenchStatement<
+    A,
+    SemanticSignal<A>,
+    ExprBytecode<StateLocation<A>>,
+    SemanticArgument<A>,
+    TestbenchTarget<SemanticSignal<A>, ExprBytecode<StateLocation<A>>>,
+>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TestbenchProgram<A> {
@@ -318,8 +336,13 @@ pub struct ExecutableArgument {
 pub type ExecutableAssertMessage = AssertMessage<ExecutableArgument>;
 pub type ExecutableClockCount = ClockCount<CompiledExpr>;
 pub type ExecutableLoopBound = LoopBound<CompiledExpr>;
-pub type ExecutableStatement<Event, Signal> =
-    TestbenchStatement<Event, Signal, CompiledExpr, ExecutableArgument>;
+pub type ExecutableStatement<Event, Signal> = TestbenchStatement<
+    Event,
+    Signal,
+    CompiledExpr,
+    ExecutableArgument,
+    TestbenchTarget<Signal, CompiledExpr>,
+>;
 
 pub struct ExecutableTestbench<Event, Signal> {
     statements: Vec<ExecutableStatement<Event, Signal>>,

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -18,7 +18,8 @@ pub use celox_testbench::SourceLocation;
 use celox_testbench::{
     DisplayFormatArg, ExecutableArgument, ExecutableAssertMessage, ExecutableClockCount,
     ExecutableLoopBound, ExecutableStatement, ExecutableTestbench, TestbenchOperator as Op,
-    TestbenchStatement as GenericTestbenchStatement, TestbenchValue as TbValue, format_display_arg,
+    TestbenchStatement as GenericTestbenchStatement, TestbenchTarget, TestbenchValue as TbValue,
+    format_display_arg,
 };
 use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::ToPrimitive as _;
@@ -168,6 +169,39 @@ fn sim_set_u64<B: SimBackend>(sim: &mut crate::Simulator<B>, sig: SignalRef, val
         33..=64 => sim.set(sig, value),
         _ => sim.set_wide(sig, BigUint::from(value)),
     }
+}
+
+fn sim_set_target<B: SimBackend>(
+    sim: &mut crate::Simulator<B>,
+    target: &TestbenchTarget<SignalRef, celox_testbench::CompiledExpr>,
+    value: TbValue,
+) {
+    let Some(selection) = &target.selection else {
+        match value {
+            TbValue::U64(value) => sim_set_u64(sim, target.signal, value),
+            TbValue::Wide(value) => sim.set_wide(target.signal, value),
+        }
+        return;
+    };
+
+    let (ptr, _) = sim.memory_as_mut_ptr();
+    let offset = selection.offset.eval_u64(ptr) as usize;
+    let width = selection
+        .width
+        .min(target.signal.width.saturating_sub(offset));
+    if width == 0 {
+        return;
+    }
+
+    let (root, root_mask) = sim.get_four_state(target.signal);
+    let selected_mask = width_mask(width) << offset;
+    let clear_mask = width_mask(target.signal.width) ^ &selected_mask;
+    let selected_value = (value.to_biguint() & width_mask(width)) << offset;
+    sim.set_four_state(
+        target.signal,
+        (root & &clear_mask) | selected_value,
+        root_mask & clear_mask,
+    );
 }
 
 fn execution_random_seed(seed: Option<u64>) -> u64 {
@@ -526,15 +560,15 @@ fn random_value_for_destination(
     }
 }
 
-fn sim_set_random<B: SimBackend>(
+fn sim_set_random_target<B: SimBackend>(
     sim: &mut crate::Simulator<B>,
-    sig: SignalRef,
+    target: &TestbenchTarget<SignalRef, celox_testbench::CompiledExpr>,
     value: u64,
     source_width: u32,
     signed: bool,
 ) {
-    let value = random_value_for_destination(value, source_width, signed, sig.width);
-    sim_set_biguint(sim, sig, value);
+    let value = random_value_for_destination(value, source_width, signed, target.width);
+    sim_set_target(sim, target, TbValue::Wide(value));
 }
 
 fn sim_set_bigint<B: SimBackend>(
@@ -1379,10 +1413,7 @@ fn exec_one_detailed<B: SimBackend>(
             }
             let (ptr, _) = sim.memory_as_mut_ptr();
             let val = expr.eval_value(ptr);
-            match val {
-                TbValue::U64(v) => sim_set_u64(sim, *dst, v),
-                TbValue::Wide(v) => sim.set_wide(*dst, v),
-            }
+            sim_set_target(sim, dst, val);
             ExecResult::Continue
         }
         GenericTestbenchStatement::RandomSeed { handle, value } => {
@@ -1401,7 +1432,12 @@ fn exec_one_detailed<B: SimBackend>(
         } => {
             let value = ctx.random.get(handle, *width);
             if let Some(ret) = ret {
-                sim_set_random(sim, *ret, value, *width, *signed);
+                if ret.selection.is_some()
+                    && let Err(e) = sim.eval_comb()
+                {
+                    return ExecResult::Fail(format!("eval_comb: {e}"));
+                }
+                sim_set_random_target(sim, ret, value, *width, *signed);
             }
             ExecResult::Continue
         }
@@ -1421,14 +1457,19 @@ fn exec_one_detailed<B: SimBackend>(
             let max = max.eval_u64(ptr);
             let value = ctx.random.get_range(handle, min, max, *width, *signed);
             if let Some(ret) = ret {
-                sim_set_random(sim, *ret, value, *width, *signed);
+                sim_set_random_target(sim, ret, value, *width, *signed);
             }
             ExecResult::Continue
         }
         GenericTestbenchStatement::RandomGetSeed { handle, ret } => {
             let seed = ctx.random.get_seed(handle);
             if let Some(ret) = ret {
-                sim_set_u64(sim, *ret, seed);
+                if ret.selection.is_some()
+                    && let Err(e) = sim.eval_comb()
+                {
+                    return ExecResult::Fail(format!("eval_comb: {e}"));
+                }
+                sim_set_target(sim, ret, TbValue::U64(seed));
             }
             ExecResult::Continue
         }

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -665,6 +665,57 @@ fn test_testbench_helper_hierarchical_read_returns_error_without_panicking() {
 }
 
 #[test]
+fn test_selected_random_return_hierarchical_index_returns_error_without_panicking() {
+    let code = r#"
+        module Driver (
+            idx: output logic<2>,
+        ) {
+            always_comb {
+                idx = 2;
+            }
+        }
+
+        #[test(t)]
+        module t {
+            inst dut: Driver (idx);
+            var idx: logic<2>;
+            var values: logic<8>[4];
+            var r: $tb::random::<u8>;
+
+            initial {
+                values[dut.idx] = r.get();
+                $finish();
+            }
+        }
+    "#;
+
+    let outcome = std::panic::catch_unwind(|| Simulator::builder(code, "t").build());
+    let result = outcome.expect("hierarchical random return destination must not panic");
+    match result.as_ref().map_err(|error| error.kind()) {
+        Err(SimulatorErrorKind::Analyzer(errors)) => assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                veryl_analyzer::AnalyzerError::InvisibleIndentifier { .. }
+            )),
+            "expected Veryl InvisibleIndentifier, got {errors:?}"
+        ),
+        Err(SimulatorErrorKind::SIRParser(ParserError::Unsupported {
+            issue,
+            phase: LoweringPhase::SimulatorParser,
+            feature,
+            ..
+        })) => {
+            assert_eq!(*issue, 467);
+            assert_eq!(*feature, "hierarchical variable reference");
+        }
+        Err(kind) => {
+            panic!("expected InvisibleIdentifier or Unsupported(SimulatorParser), got {kind:?}")
+        }
+        Ok(_) => panic!("expected hierarchical random return destination to be rejected"),
+    }
+}
+
+#[test]
 fn test_reset_compile_time_expression_duration_is_accepted() {
     let code = r#"
         #[test(t)]

--- a/crates/celox/tests/error_detection.rs
+++ b/crates/celox/tests/error_detection.rs
@@ -716,6 +716,71 @@ fn test_selected_random_return_hierarchical_index_returns_error_without_panickin
 }
 
 #[test]
+fn test_selected_testbench_destination_out_of_range_is_rejected() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            var word: logic<8>;
+
+            initial {
+                word[6 +: 4] = 4'hf;
+                $finish();
+            }
+        }
+    "#;
+
+    let err = Simulator::builder(code, "t")
+        .build()
+        .expect_err("out-of-range selected destination must be rejected");
+    match err.kind() {
+        SimulatorErrorKind::SIRParser(ParserError::IllegalContext { feature, .. }) => {
+            assert_eq!(*feature, "testbench selected destination");
+        }
+        other => panic!("expected selected destination geometry error, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_expression_testbench_function_selected_destination_is_rejected() {
+    let code = r#"
+        module Driver (source: output logic<8>) {
+            assign source = 8'h05;
+        }
+
+        #[test(t)]
+        module t {
+            var source: logic<8>;
+            inst dut: Driver (source);
+
+            function update(x: input logic<8>) -> logic<8> {
+                var tmp: logic<8>;
+                tmp = 8'ha0;
+                tmp[3:0] = x;
+                return tmp;
+            }
+
+            initial {
+                $assert(update(source) == 8'ha5);
+                $finish();
+            }
+        }
+    "#;
+
+    let err = Simulator::builder(code, "t")
+        .build()
+        .expect_err("selected destination in an expression helper must be rejected");
+    match err.kind() {
+        SimulatorErrorKind::SIRParser(ParserError::IllegalContext { feature, .. }) => {
+            assert_eq!(
+                *feature,
+                "selected destination in expression testbench function"
+            );
+        }
+        other => panic!("expected expression helper selected destination error, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_reset_compile_time_expression_duration_is_accepted() {
     let code = r#"
         #[test(t)]

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -1,5 +1,5 @@
 use celox::{
-    DeadStorePolicy, ParserError, ResetType, Simulator, SimulatorErrorKind, TestResult,
+    DeadStorePolicy, ResetType, Simulator, SimulatorErrorKind, TestResult,
     testbench::{compile_initial_testbench, run_compiled_testbench},
 };
 use veryl_analyzer::{AnalyzerError, analyzer_error::InvalidForRangeKind};
@@ -259,38 +259,61 @@ fn test_unset_testbench_seed_is_fresh_per_execution() {
 }
 
 #[test]
-fn test_selected_testbench_destinations_are_rejected() {
-    for code in [
-        r#"
+fn test_selected_testbench_destinations_update_only_selected_targets() {
+    let random_handle = veryl_parser::resource_table::insert_str("r");
+    veryl_simulator::random_table::seed_handle(random_handle, 42);
+    let random_value = veryl_simulator::random_table::get(random_handle, 8, false).payload_u64();
+
+    let cases = [
+        format!(
+            r#"
             #[test(t)]
-            module t {
+            module t {{
                 var values: logic<8>[4];
                 var index: logic<2>;
                 var r: $tb::random::<u8>;
-                initial {
+                initial {{
+                    values[0] = 8'h11;
+                    values[1] = 8'h22;
+                    values[2] = 8'h33;
+                    values[3] = 8'h44;
                     index = 1;
+                    r.seed(42);
                     values[index] = r.get();
+                    $assert(values[0] == 8'h11);
+                    $assert(values[1] == 8'd{random_value});
+                    $assert(values[2] == 8'h33);
+                    $assert(values[3] == 8'h44);
                     $finish();
-                }
-            }
-        "#,
+                }}
+            }}
+        "#
+        ),
         r#"
             #[test(t)]
             module t {
                 var word: logic<8>;
                 initial {
-                    word[3] = 1;
+                    word = 8'hAA;
+                    word[3] = 1'b0;
+                    $assert(word == 8'hA2);
+                    word[6:3] = 4'b0011;
+                    $assert(word == 8'h9A);
                     $finish();
                 }
             }
-        "#,
-    ] {
-        let error = Simulator::builder(code, "t").build().unwrap_err();
-        let SimulatorErrorKind::SIRParser(ParserError::Unsupported { issue, .. }) = error.kind()
-        else {
-            panic!("expected selected destination diagnostic, got {error:?}");
-        };
-        assert_eq!(*issue, 478);
+        "#
+        .to_string(),
+    ];
+    for code in cases {
+        assert_eq!(
+            Simulator::builder(&code, "t").run_test().unwrap(),
+            TestResult::Pass
+        );
+        assert_eq!(
+            Simulator::builder(&code, "t").run_test_cranelift().unwrap(),
+            TestResult::Pass
+        );
     }
 }
 

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -322,12 +322,17 @@ fn test_packed_prefix_and_low_bound_testbench_destinations() {
     let code = r#"
         #[test(t)]
         module t {
+            const W: u32 = 4;
             var word: logic<8>;
             var matrix: logic<4, 4>;
             initial {
                 word = 8'hA0;
-                word[3:0] = 4'hF;
+                word[W - 1:0] = 4'hF;
                 $assert(word == 8'hAF);
+
+                word = 8'hA0;
+                word[0 +: W] = 4'h5;
+                $assert(word == 8'hA5);
 
                 matrix = 16'h0000;
                 matrix[2][1] = 1'b1;

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -318,6 +318,82 @@ fn test_selected_testbench_destinations_update_only_selected_targets() {
 }
 
 #[test]
+fn test_packed_prefix_and_low_bound_testbench_destinations() {
+    let code = r#"
+        #[test(t)]
+        module t {
+            var word: logic<8>;
+            var matrix: logic<4, 4>;
+            initial {
+                word = 8'hA0;
+                word[3:0] = 4'hF;
+                $assert(word == 8'hAF);
+
+                matrix = 16'h0000;
+                matrix[2][1] = 1'b1;
+                $assert(matrix == 16'h0200);
+                $finish();
+            }
+        }
+    "#;
+
+    assert_eq!(
+        Simulator::builder(code, "t").run_test().unwrap(),
+        TestResult::Pass
+    );
+    assert_eq!(
+        Simulator::builder(code, "t").run_test_cranelift().unwrap(),
+        TestResult::Pass
+    );
+}
+
+#[test]
+fn test_selected_testbench_destinations_keep_dynamic_reads_and_old_value_live() {
+    let random_handle = veryl_parser::resource_table::insert_str("r");
+    veryl_simulator::random_table::seed_handle(random_handle, 42);
+    let random_value = veryl_simulator::random_table::get(random_handle, 8, false).payload_u64();
+    let code = format!(
+        r#"
+        module Driver (
+            index: output logic<2>,
+        ) {{
+            always_comb {{
+                index = 2;
+            }}
+        }}
+
+        #[test(t)]
+        module t {{
+            var values: logic<8>[4];
+            var index: logic<2>;
+            var word: logic<8>;
+            var r: $tb::random::<u8>;
+            inst dut: Driver(index);
+
+            initial {{
+                values = '{{default: 8'h00}};
+                word = 8'hA0;
+                r.seed(42);
+                values[index] = r.get();
+                word[3] = 1'b1;
+                $assert(values[2] == 8'd{random_value});
+                $assert(word == 8'hA8);
+                $finish();
+            }}
+        }}
+        "#,
+    );
+
+    assert_eq!(
+        Simulator::builder(&code, "t")
+            .dead_store_policy(DeadStorePolicy::PreserveListedSignals)
+            .run_test()
+            .unwrap(),
+        TestResult::Pass
+    );
+}
+
+#[test]
 fn test_counter_pass() {
     let code = format!(
         r#"


### PR DESCRIPTION
Fixes #478

## What changed

- Preserve unpacked-array indices and packed bit/range selections in native testbench targets.
- Bind selected target offset expressions through the runtime.
- Perform read-modify-write updates so assignments and random-method returns change only the selected bits/elements.
- Exercise dynamic array elements, bit selects, and packed ranges on Native and Cranelift backends.

## Why

Native testbench lowering previously discarded destination selections and wrote the root signal, silently corrupting unrelated elements or bits.

## Validation

- cargo fmt --all -- --check
- cargo check --workspace
- cargo check -p celox --no-default-features
- cargo test -p celox --test native_testbench
- cargo test -p celox-testbench -p celox-runtime -p celox-frontend-veryl
- pre-push hooks (submodule-check, cargo-fmt, biome, cargo-check, clean-tree)