### PR TITLE
fix: restore Heliodor boot compatibility

### DIFF
--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -13,6 +13,8 @@ on:
       - "!crates/celox-napi/package.json"
       - "scripts/convert-heliodor-bench.mjs"
       - "scripts/run-heliodor-bench.sh"
+  schedule:
+    - cron: "37 2 * * *"
   workflow_dispatch:
 
 permissions:
@@ -21,14 +23,15 @@ permissions:
 env:
   CARGO_INCREMENTAL: "0"
 
-# This shares the gh-pages benchmark data with bench.yml. Serialize both
-# workflows so their independent benchmark-action pushes cannot race.
+# Pull requests neither write benchmark history nor need to wait behind unrelated
+# benchmark runs. Keep only the master/manual publisher serialized with bench.yml.
 concurrency:
-  group: bench
-  cancel-in-progress: false
+  group: ${{ github.event_name == 'pull_request' && format('heliodor-pr-{0}', github.event.pull_request.number) || github.event_name == 'schedule' && 'heliodor-head' || 'bench' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' }}
 
 jobs:
   heliodor:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -159,3 +162,56 @@ jobs:
       - name: Enforce fixed gate result
         if: always() && steps.gate.outputs.status != '0'
         run: exit 1
+
+  heliodor-head:
+    name: Heliodor HEAD compatibility
+    if: github.event_name == 'schedule'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      HELIODOR_DIR: target/heliodor-head/source
+      HELIODOR_RESULTS_DIR: target/heliodor-head/results
+      HELIODOR_TOOLS_DIR: target/heliodor-head/tools
+      HELIODOR_RUNNERS: celox
+      HELIODOR_TESTS: test_soc_linux_boot
+      HELIODOR_TIMEOUT_SEC: "420"
+      CELOX_OPT_LEVEL: O2
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/setup-rust
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Resolve Heliodor HEAD
+        shell: bash
+        run: |
+          set -euo pipefail
+          heliodor_revision="$(git ls-remote https://github.com/dalance/heliodor.git HEAD | cut -f1)"
+          if [[ ! "$heliodor_revision" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Could not resolve dalance/heliodor HEAD" >&2
+            exit 1
+          fi
+          echo "HELIODOR_REF=$heliodor_revision" >> "$GITHUB_ENV"
+          echo "$heliodor_revision" > heliodor-head-ref.txt
+          echo "Testing Heliodor HEAD at $heliodor_revision"
+          echo "### Heliodor HEAD compatibility" >> "$GITHUB_STEP_SUMMARY"
+          echo "Upstream revision: \`$heliodor_revision\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run Heliodor HEAD compatibility gate
+        shell: bash
+        run: set -o pipefail && bash scripts/run-heliodor-bench.sh run 2>&1 | tee heliodor-head-output.txt
+
+      - name: Upload Heliodor HEAD results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: heliodor-head-compatibility
+          path: |
+            heliodor-head-ref.txt
+            heliodor-head-output.txt
+            target/heliodor-head/results/results.tsv
+            target/heliodor-head/results/*.log

--- a/crates/celox-frontend-veryl/src/ff.rs
+++ b/crates/celox-frontend-veryl/src/ff.rs
@@ -298,6 +298,8 @@ pub struct FfParser<'a> {
     dynamic_defined_vars: HashSet<VarId>,
     dynamic_write_vars: HashSet<VarId>,
     sparse_write_vars: HashSet<VarId>,
+    direct_static_write_ranges: HashMap<VarId, Vec<celox_design::BitAccess>>,
+    direct_dynamic_write_vars: HashSet<VarId>,
     local_working_vars: HashSet<VarId>,
     local_let_values: HashMap<VarId, RegisterId>,
     loop_exit_blocks: Vec<BlockId>,
@@ -338,6 +340,8 @@ impl<'a> FfParser<'a> {
             dynamic_defined_vars: HashSet::default(),
             dynamic_write_vars: HashSet::default(),
             sparse_write_vars: HashSet::default(),
+            direct_static_write_ranges: HashMap::default(),
+            direct_dynamic_write_vars: HashSet::default(),
             local_working_vars,
             local_let_values: HashMap::default(),
             loop_exit_blocks: Vec::new(),
@@ -360,6 +364,16 @@ impl<'a> FfParser<'a> {
     ) -> Self {
         self.runtime_error_code_map = Some(runtime_error_code_map);
         self.runtime_event_site_base = runtime_event_site_base;
+        self
+    }
+
+    pub fn with_direct_write_ranges(
+        mut self,
+        static_ranges: HashMap<VarId, Vec<celox_design::BitAccess>>,
+        dynamic_vars: HashSet<VarId>,
+    ) -> Self {
+        self.direct_static_write_ranges = static_ranges;
+        self.direct_dynamic_write_vars = dynamic_vars;
         self
     }
 

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -2538,15 +2538,6 @@ impl<'a> FfParser<'a> {
         }
     }
 
-    pub(super) fn is_range_fully_defined(&self, var_id: VarId, access: BitAccess) -> bool {
-        if let Some(bits) = self.defined_ranges.get(&var_id) {
-            // Whether all bits in the specified range [lsb, msb] are set in BitSet
-            (access.lsb..=access.msb).all(|i| bits.contains(i))
-        } else {
-            false
-        }
-    }
-
     pub(super) fn op_load<A>(
         &mut self,
         var_id: VarId,
@@ -2634,9 +2625,11 @@ impl<'a> FfParser<'a> {
         // For source tracking, use the conservative range from eval_var_select
         // (covers all bits that might be read by a dynamic index).
         let access = eval_var_select(self.module, var_id, index, select)?;
-        let is_internal = self.local_working_vars.contains(&var_id)
-            || self.is_range_fully_defined(var_id, access)
-            || self.dynamic_defined_vars.contains(&var_id);
+        // Module state read in an always_ff block is always the pre-edge
+        // value, even when an earlier statement in the same block assigned
+        // that variable.  `defined_ranges` only describes pending writes; it
+        // must not hide the old-state read from the shared-clock scheduler.
+        let is_internal = self.local_working_vars.contains(&var_id);
         if !is_internal {
             sources.push(VarAtomBase::new(
                 convert(var_id, STABLE_REGION),
@@ -2669,6 +2662,7 @@ impl<'a> FfParser<'a> {
         };
         // Use get_access_width for actual element width (correct for dynamic array indices).
         let target_width = get_access_width(self.module, dst.id, &dst.index, &dst.select)?;
+        let access = eval_var_select(self.module, dst.id, &dst.index, &dst.select)?;
         let target_type = &self.module.variables[&dst.id].r#type;
         let src_reg = if target_type.is_2state()
             && matches!(ir_builder.register(&src_reg), RegisterType::Logic { .. })
@@ -2728,6 +2722,23 @@ impl<'a> FfParser<'a> {
         } else {
             domain.region()
         };
+        let direct_write = if is_static {
+            self.direct_static_write_ranges
+                .get(&dst.id)
+                .is_some_and(|ranges| {
+                    ranges
+                        .iter()
+                        .any(|range| range.lsb <= access.lsb && range.msb >= access.msb)
+                })
+        } else {
+            self.direct_dynamic_write_vars.contains(&dst.id)
+        };
+        let store_region =
+            if direct_write && matches!(store_region, WORKING_REGION | SPARSE_WORKING_REGION) {
+                STABLE_REGION
+            } else {
+                store_region
+            };
         ir_builder.emit(SIRInstruction::Store(
             convert(dst.id, store_region),
             offset,
@@ -2738,7 +2749,6 @@ impl<'a> FfParser<'a> {
         ));
 
         // Use conservative range from eval_var_select for tracking (covers all possible bits).
-        let access = eval_var_select(self.module, dst.id, &dst.index, &dst.select)?;
         if is_static {
             let bits = self.defined_ranges.entry(dst.id).or_default();
             for i in access.lsb..=access.msb {
@@ -4493,6 +4503,150 @@ mod tests {
     };
     use veryl_metadata::Metadata;
     use veryl_parser::Parser;
+
+    #[test]
+    fn module_state_read_after_write_is_tracked_as_an_old_state_source() {
+        symbol_table::clear();
+        attribute_table::clear();
+        let code = r#"
+module Top (
+    clk    : input clock,
+    present: input logic,
+    d      : input logic<8>,
+) {
+    var in_flight: logic;
+    var captured: logic<8>;
+    always_ff (clk) {
+        in_flight = present;
+        if in_flight {
+            captured = d;
+        }
+    }
+}
+"#;
+        let metadata = Metadata::create_default("prj").unwrap();
+        let parsed = Parser::parse(code, &"").unwrap();
+        let analyzer = Analyzer::new(&metadata);
+        let mut context = Context::default();
+        let mut ir = Ir::default();
+        assert!(analyzer.analyze_pass1("prj", &parsed.veryl).is_empty());
+        assert!(Analyzer::analyze_post_pass1().is_empty());
+        assert!(
+            analyzer
+                .analyze_pass2(&parsed.veryl, &mut context, Some(&mut ir))
+                .is_empty()
+        );
+        assert!(Analyzer::analyze_post_pass2(&ir).is_empty());
+
+        let module = ir
+            .components
+            .into_iter()
+            .find_map(|component| match component {
+                Component::Module(module) => Some(module),
+                _ => None,
+            })
+            .unwrap();
+        let declarations = module
+            .declarations
+            .iter()
+            .filter_map(|declaration| match declaration {
+                Declaration::Ff(declaration) => Some(declaration.as_ref()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        let in_flight = module
+            .variables
+            .iter()
+            .find_map(|(&id, variable)| (variable.path.to_string() == "in_flight").then_some(id))
+            .unwrap();
+
+        let mut parser = FfParser::new(&module, BuildConfig::default());
+        let mut builder = SIRBuilder::new();
+        let result = parser.parse_ff_group(&declarations, &mut builder).unwrap();
+
+        assert!(result.sources.iter().any(|source| {
+            source.id.var_id == in_flight
+                && source.id.region == celox_design::STABLE_REGION
+                && source.access == BitAccess::new(0, 0)
+        }));
+    }
+
+    #[test]
+    fn direct_ff_stores_are_selected_per_bit_range() {
+        symbol_table::clear();
+        attribute_table::clear();
+        let code = r#"
+module Top (
+    clk: input clock,
+    lo : input logic<8>,
+    hi : input logic<8>,
+) {
+    var state: logic<16>;
+    always_ff (clk) {
+        state[7:0] = lo;
+        state[15:8] = hi;
+    }
+}
+"#;
+        let metadata = Metadata::create_default("prj").unwrap();
+        let parsed = Parser::parse(code, &"").unwrap();
+        let analyzer = Analyzer::new(&metadata);
+        let mut context = Context::default();
+        let mut ir = Ir::default();
+        assert!(analyzer.analyze_pass1("prj", &parsed.veryl).is_empty());
+        assert!(Analyzer::analyze_post_pass1().is_empty());
+        assert!(
+            analyzer
+                .analyze_pass2(&parsed.veryl, &mut context, Some(&mut ir))
+                .is_empty()
+        );
+        assert!(Analyzer::analyze_post_pass2(&ir).is_empty());
+
+        let module = ir
+            .components
+            .into_iter()
+            .find_map(|component| match component {
+                Component::Module(module) => Some(module),
+                _ => None,
+            })
+            .unwrap();
+        let declarations = module
+            .declarations
+            .iter()
+            .filter_map(|declaration| match declaration {
+                Declaration::Ff(declaration) => Some(declaration.as_ref()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        let state = module
+            .variables
+            .iter()
+            .find_map(|(&id, variable)| (variable.path.to_string() == "state").then_some(id))
+            .unwrap();
+        let direct_ranges = [(state, vec![BitAccess::new(8, 15)])].into_iter().collect();
+
+        let mut parser = FfParser::new(&module, BuildConfig::default())
+            .with_direct_write_ranges(direct_ranges, HashSet::default());
+        let mut builder = SIRBuilder::new();
+        parser.parse_ff_group(&declarations, &mut builder).unwrap();
+        let execution_unit = builder.flush_eu().unwrap();
+        let stores = execution_unit
+            .blocks
+            .values()
+            .flat_map(|block| &block.instructions)
+            .filter_map(|instruction| match instruction {
+                SIRInstruction::Store(address, SIROffset::Static(offset), width, ..)
+                    if address.var_id == state =>
+                {
+                    Some((address.region, *offset, *width))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert!(stores.contains(&(WORKING_REGION, 0, 8)));
+        assert!(stores.contains(&(STABLE_REGION, 8, 8)));
+    }
 
     #[test]
     fn conditional_expression_effects_are_not_definitely_defined_after_merge() {

--- a/crates/celox-frontend-veryl/src/global_ff.rs
+++ b/crates/celox-frontend-veryl/src/global_ff.rs
@@ -48,32 +48,30 @@ impl<'a> SharedClockLowering<'a> {
         }
     }
 
-    fn direct_var(
+    fn direct_write(
+        direct_writes: &[VarAtomBase<RegionedAbsoluteAddr>],
+        write: &VarAtomBase<RegionedAbsoluteAddr>,
+    ) -> bool {
+        direct_writes.contains(write)
+    }
+
+    fn direct_dynamic_var(
         summary: &FfAccessSummary<RegionedAbsoluteAddr>,
-        action_direct: bool,
+        direct_writes: &[VarAtomBase<RegionedAbsoluteAddr>],
         address: AbsoluteAddr,
     ) -> bool {
-        action_direct
-            && summary.writes.iter().any(|write| {
-                write.id.absolute_addr() == address
-                    && !summary
-                        .reads
-                        .iter()
-                        .any(|read| read.id == write.id && read.access.overlaps(&write.access))
-            })
-            && !summary.writes.iter().any(|write| {
-                write.id.absolute_addr() == address
-                    && summary
-                        .reads
-                        .iter()
-                        .any(|read| read.id == write.id && read.access.overlaps(&write.access))
-            })
+        let mut writes = summary
+            .writes
+            .iter()
+            .filter(|write| write.id.absolute_addr() == address)
+            .peekable();
+        writes.peek().is_some() && writes.all(|write| Self::direct_write(direct_writes, write))
     }
 
     fn emit_region_copies(
         builder: &mut SIRBuilder<RegionedAbsoluteAddr>,
         summaries: &[FfAccessSummary<RegionedAbsoluteAddr>],
-        direct: &[bool],
+        direct_writes: &[Vec<VarAtomBase<RegionedAbsoluteAddr>>],
         src_region: u32,
         dst_region: u32,
     ) {
@@ -81,19 +79,20 @@ impl<'a> SharedClockLowering<'a> {
             .iter()
             .enumerate()
             .flat_map(|(index, summary)| {
-                let action_direct = direct.get(index).copied().unwrap_or(false);
+                let direct_writes = direct_writes.get(index).map_or(&[][..], Vec::as_slice);
                 summary.dynamic_writes.iter().filter(move |address| {
-                    !Self::direct_var(summary, action_direct, address.absolute_addr())
+                    !Self::direct_dynamic_var(summary, direct_writes, address.absolute_addr())
                 })
             })
             .map(RegionedAbsoluteAddr::absolute_addr)
             .collect::<HashSet<_>>();
         let mut ranges = BTreeMap::<AbsoluteAddr, Vec<BitAccess>>::new();
         for target in summaries.iter().enumerate().flat_map(|(index, summary)| {
-            let action_direct = direct.get(index).copied().unwrap_or(false);
-            summary.writes.iter().filter(move |target| {
-                !Self::direct_var(summary, action_direct, target.id.absolute_addr())
-            })
+            let direct_writes = direct_writes.get(index).map_or(&[][..], Vec::as_slice);
+            summary
+                .writes
+                .iter()
+                .filter(move |target| !Self::direct_write(direct_writes, target))
         }) {
             let addr = target.id.absolute_addr();
             if !dynamic.contains(&addr) {
@@ -127,25 +126,26 @@ impl<'a> SharedClockLowering<'a> {
     fn emit_sparse_commits(
         builder: &mut SIRBuilder<RegionedAbsoluteAddr>,
         summaries: &[FfAccessSummary<RegionedAbsoluteAddr>],
-        direct: &[bool],
+        direct_writes: &[Vec<VarAtomBase<RegionedAbsoluteAddr>>],
     ) {
         let dynamic = summaries
             .iter()
             .enumerate()
             .flat_map(|(index, summary)| {
-                let action_direct = direct.get(index).copied().unwrap_or(false);
+                let direct_writes = direct_writes.get(index).map_or(&[][..], Vec::as_slice);
                 summary.dynamic_writes.iter().filter(move |address| {
-                    !Self::direct_var(summary, action_direct, address.absolute_addr())
+                    !Self::direct_dynamic_var(summary, direct_writes, address.absolute_addr())
                 })
             })
             .map(RegionedAbsoluteAddr::absolute_addr)
             .collect::<HashSet<_>>();
         let mut widths = BTreeMap::<AbsoluteAddr, usize>::new();
         for target in summaries.iter().enumerate().flat_map(|(index, summary)| {
-            let action_direct = direct.get(index).copied().unwrap_or(false);
-            summary.writes.iter().filter(move |target| {
-                !Self::direct_var(summary, action_direct, target.id.absolute_addr())
-            })
+            let direct_writes = direct_writes.get(index).map_or(&[][..], Vec::as_slice);
+            summary
+                .writes
+                .iter()
+                .filter(move |target| !Self::direct_write(direct_writes, target))
         }) {
             let addr = target.id.absolute_addr();
             if dynamic.contains(&addr) {
@@ -177,14 +177,14 @@ impl scheduler::ClockFfLowering<RegionedAbsoluteAddr> for SharedClockLowering<'_
     fn begin(
         &mut self,
         builder: &mut SIRBuilder<RegionedAbsoluteAddr>,
-        direct: &[bool],
+        direct_writes: &[Vec<VarAtomBase<RegionedAbsoluteAddr>>],
     ) -> Result<(), ParserError> {
-        // Only actions whose old-state anti-dependencies form a cycle need a
-        // private snapshot. Direct actions run after every old-state reader.
+        // Only ranges whose old-state anti-dependencies could not be ordered
+        // need a private snapshot.
         Self::emit_region_copies(
             builder,
             &self.summaries,
-            direct,
+            direct_writes,
             STABLE_REGION,
             WORKING_REGION,
         );
@@ -194,7 +194,7 @@ impl scheduler::ClockFfLowering<RegionedAbsoluteAddr> for SharedClockLowering<'_
     fn lower(
         &mut self,
         index: usize,
-        direct: bool,
+        direct_writes: &[VarAtomBase<RegionedAbsoluteAddr>],
         builder: &mut SIRBuilder<RegionedAbsoluteAddr>,
     ) -> Result<(), ParserError> {
         let recipe = self.recipes.get(index).ok_or_else(|| {
@@ -210,40 +210,41 @@ impl scheduler::ClockFfLowering<RegionedAbsoluteAddr> for SharedClockLowering<'_
             .iter()
             .map(|address| address.var_id)
             .collect();
+        let direct_static_ranges = recipe
+            .summary
+            .writes
+            .iter()
+            .filter(|write| Self::direct_write(direct_writes, write))
+            .fold(
+                HashMap::<VarId, Vec<BitAccess>>::default(),
+                |mut ranges, write| {
+                    ranges
+                        .entry(write.id.var_id)
+                        .or_default()
+                        .push(write.access);
+                    ranges
+                },
+            );
+        let direct_dynamic_vars = recipe
+            .summary
+            .dynamic_writes
+            .iter()
+            .filter_map(|address| {
+                Self::direct_dynamic_var(&recipe.summary, direct_writes, address.absolute_addr())
+                    .then_some(address.var_id)
+            })
+            .collect::<HashSet<_>>();
         let mut parser = ff::FfParser::new(recipe.module, self.config)
             .with_relocated_runtime_ids(
                 recipe.runtime.error_codes.clone(),
                 recipe.runtime.event_site_base,
             )
-            .with_sparse_write_vars(sparse_write_vars);
-        let direct_vars = recipe
-            .summary
-            .writes
-            .iter()
-            .filter_map(|write| {
-                let address = write.id.absolute_addr();
-                let reads_old_value = recipe.summary.writes.iter().any(|candidate| {
-                    candidate.id.absolute_addr() == address
-                        && recipe.summary.reads.iter().any(|read| {
-                            read.id == candidate.id && read.access.overlaps(&candidate.access)
-                        })
-                });
-                (direct && !reads_old_value).then_some(write.id.var_id)
-            })
-            .collect::<HashSet<_>>();
-        let target_region = |var_id, region| {
-            if direct_vars.contains(&var_id)
-                && matches!(region, WORKING_REGION | SPARSE_WORKING_REGION)
-            {
-                STABLE_REGION
-            } else {
-                region
-            }
-        };
+            .with_sparse_write_vars(sparse_write_vars)
+            .with_direct_write_ranges(direct_static_ranges, direct_dynamic_vars);
         parser.parse_ff_group_into(
             &recipe.declarations,
             &|var_id, region| RegionedAbsoluteAddr {
-                region: target_region(var_id, region),
+                region,
                 instance_id: recipe.instance_id,
                 var_id,
             },
@@ -255,18 +256,18 @@ impl scheduler::ClockFfLowering<RegionedAbsoluteAddr> for SharedClockLowering<'_
     fn finish(
         &mut self,
         builder: &mut SIRBuilder<RegionedAbsoluteAddr>,
-        direct: &[bool],
+        direct_writes: &[Vec<VarAtomBase<RegionedAbsoluteAddr>>],
     ) -> Result<(), ParserError> {
-        // Cyclic actions retain the common snapshot and publish together.
-        // Direct actions have already published at their proven placement.
+        // Staged ranges publish together. Proven direct ranges have already
+        // published at their scheduled placement.
         Self::emit_region_copies(
             builder,
             &self.summaries,
-            direct,
+            direct_writes,
             WORKING_REGION,
             STABLE_REGION,
         );
-        Self::emit_sparse_commits(builder, &self.summaries, direct);
+        Self::emit_sparse_commits(builder, &self.summaries, direct_writes);
         Ok(())
     }
 }
@@ -335,8 +336,11 @@ pub fn build_ff_clock_recipes<'a>(
                 dynamic_writes: summary
                     .dynamic_writes
                     .iter()
-                    .copied()
-                    .map(relocate_addr)
+                    .map(|address| RegionedAbsoluteAddr {
+                        region: STABLE_REGION,
+                        instance_id,
+                        var_id: address.var_id,
+                    })
                     .collect(),
             };
             let recipe = FfClockRecipe {

--- a/crates/celox-sir-opt/src/optimizer/passes/dataflow/pass_circular_priority.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/dataflow/pass_circular_priority.rs
@@ -314,6 +314,7 @@ impl ExecutionUnitPass for CircularPriorityPass {
                 cfg.block_ids[natural_loop.header],
                 &loop_blocks,
                 &definitions,
+                &use_blocks,
             ) {
                 bit_map_plans.push(plan);
             }
@@ -413,6 +414,7 @@ pub(in crate::optimizer) fn recover_native_fixed_bit_map_loops(
         return 0;
     };
     let definitions = collect_definitions(eu);
+    let use_blocks = collect_use_blocks(eu);
     let mut planned_headers = HashSet::default();
     let mut plans = Vec::new();
     for natural_loop in &cfg.loops {
@@ -425,7 +427,9 @@ pub(in crate::optimizer) fn recover_native_fixed_bit_map_loops(
             .iter()
             .map(|&block| cfg.block_ids[block])
             .collect::<HashSet<_>>();
-        if let Some(plan) = recognize_bit_map_loop(eu, &cfg, header, &loop_blocks, &definitions) {
+        if let Some(plan) =
+            recognize_bit_map_loop(eu, &cfg, header, &loop_blocks, &definitions, &use_blocks)
+        {
             plans.push(plan);
         }
     }
@@ -1363,11 +1367,25 @@ fn recognize_bit_map_loop(
     eu: &ExecutionUnit<RegionedAbsoluteAddr>,
     cfg: &SirCfg,
     header: BlockId,
-    _loop_blocks: &HashSet<BlockId>,
+    loop_blocks: &HashSet<BlockId>,
     definitions: &HashMap<RegisterId, Definition>,
+    use_blocks: &HashMap<RegisterId, HashSet<BlockId>>,
 ) -> Option<BitMapLoopPlan> {
     let block = &eu.blocks[&header];
     if block.params.len() != 3 {
+        return None;
+    }
+    if block
+        .params
+        .iter()
+        .copied()
+        .chain(block.instructions.iter().filter_map(def_reg))
+        .any(|value| {
+            use_blocks
+                .get(&value)
+                .is_some_and(|users| users.iter().any(|user| !loop_blocks.contains(user)))
+        })
+    {
         return None;
     }
     if block.instructions.iter().any(|instruction| {
@@ -1442,6 +1460,14 @@ fn recognize_bit_map_loop(
         return None;
     }
     let exit_result_position = exit_arguments.iter().position(|&value| value == update)?;
+    if exit_arguments.iter().enumerate().any(|(position, value)| {
+        position != exit_result_position
+            && definitions
+                .get(value)
+                .is_some_and(|definition| definition.block() == header)
+    }) {
+        return None;
+    }
     let dependencies = collect_bit_dependencies(
         eu,
         cfg,
@@ -5193,5 +5219,33 @@ mod tests {
             assert_eq!(after, before, "input={input:#06x}");
             assert_eq!(after, vec![0xa55a_0000 | input]);
         }
+    }
+
+    #[test]
+    fn rejects_fixed_bit_insert_loop_with_escaping_definition() {
+        let mut unit = bit_map_loop_fixture();
+        let escaped = match unit.blocks[&BlockId(1)].instructions[0] {
+            SIRInstruction::Load(destination, ..) => destination,
+            ref instruction => panic!("expected loop load, got {instruction:?}"),
+        };
+        unit.blocks
+            .get_mut(&BlockId(2))
+            .unwrap()
+            .instructions
+            .push(SIRInstruction::Store(
+                address(4),
+                SIROffset::Static(0),
+                1,
+                escaped,
+                Vec::new(),
+                Vec::new(),
+            ));
+        unit.verify_result().unwrap();
+        let original = unit.to_string();
+
+        test_pass().run(&mut unit, &PassOptions::default());
+
+        unit.verify_result().unwrap();
+        assert_eq!(unit.to_string(), original);
     }
 }

--- a/crates/celox-sir-opt/src/optimizer/passes/memory/block_opt.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/memory/block_opt.rs
@@ -914,6 +914,13 @@ fn coalesce_static_loads<A: Clone + std::fmt::Debug + PartialEq + Ord + std::has
         }
 
         let element_width = element_widths.get(&seg.addr).copied();
+        let scalar_observed_end = element_width.is_none().then(|| {
+            seg.loads
+                .iter()
+                .filter_map(|load| load.offset.checked_add(load.width))
+                .max()
+                .unwrap_or(0)
+        });
         let mut by_word: HashMap<(usize, usize), Vec<LoadInfo>> = HashMap::default();
         for ld in seg.loads {
             if ld.width == 0 || ld.width > 64 {
@@ -954,6 +961,14 @@ fn coalesce_static_loads<A: Clone + std::fmt::Debug + PartialEq + Ord + std::has
         for ((mut word_base, mut word_width), mut loads) in by_word {
             if loads.len() < 2 {
                 continue;
+            }
+            // A scalar has no entry in `element_widths`.  The 64-bit bucket is
+            // only a grouping aid; it is not evidence that the backing object
+            // is 64 bits wide. Keep the combined load within the extent proven
+            // readable by any original load from this scalar. This preserves a
+            // native word load when a covering wide load already proves it safe.
+            if let Some(observed_end) = scalar_observed_end {
+                word_width = observed_end.saturating_sub(word_base).min(word_width);
             }
             if word_width == 0 {
                 word_base = loads.iter().map(|load| load.offset).min().unwrap();
@@ -1402,6 +1417,41 @@ mod tests {
         assert!(instructions.iter().all(|instruction| !matches!(
             instruction,
             SIRInstruction::Load(RegisterId(1) | RegisterId(2), _, _, _)
+        )));
+        verify(instructions, register_map);
+    }
+
+    #[test]
+    fn scalar_partial_load_coalescing_stays_within_the_accessed_span() {
+        let mut instructions = vec![
+            SIRInstruction::Load(RegisterId(0), 7u32, SIROffset::Static(0), 16),
+            SIRInstruction::Load(RegisterId(1), 7, SIROffset::Static(16), 2),
+            SIRInstruction::Load(RegisterId(2), 7, SIROffset::Static(18), 14),
+        ];
+        let mut register_map = [
+            (RegisterId(0), logic(16)),
+            (RegisterId(1), logic(2)),
+            (RegisterId(2), logic(14)),
+        ]
+        .into_iter()
+        .collect();
+        let mut reg_counter = 2;
+
+        coalesce_static_loads_with_types(
+            &mut instructions,
+            &mut register_map,
+            &mut reg_counter,
+            false,
+            &HashMap::default(),
+        );
+
+        assert!(instructions.iter().any(|instruction| matches!(
+            instruction,
+            SIRInstruction::Load(_, 7, SIROffset::Static(0), 32)
+        )));
+        assert!(instructions.iter().all(|instruction| !matches!(
+            instruction,
+            SIRInstruction::Load(_, 7, SIROffset::Static(0), 64)
         )));
         verify(instructions, register_map);
     }

--- a/crates/celox-slt/src/scheduler.rs
+++ b/crates/celox-slt/src/scheduler.rs
@@ -2345,18 +2345,21 @@ pub trait ClockFfLowering<Addr> {
     type Error;
 
     fn summaries(&self) -> &[FfAccessSummary<Addr>];
-    fn begin(&mut self, builder: &mut SIRBuilder<Addr>, direct: &[bool])
-    -> Result<(), Self::Error>;
+    fn begin(
+        &mut self,
+        builder: &mut SIRBuilder<Addr>,
+        direct_writes: &[Vec<VarAtomBase<Addr>>],
+    ) -> Result<(), Self::Error>;
     fn lower(
         &mut self,
         index: usize,
-        direct: bool,
+        direct_writes: &[VarAtomBase<Addr>],
         builder: &mut SIRBuilder<Addr>,
     ) -> Result<(), Self::Error>;
     fn finish(
         &mut self,
         builder: &mut SIRBuilder<Addr>,
-        direct: &[bool],
+        direct_writes: &[Vec<VarAtomBase<Addr>>],
     ) -> Result<(), Self::Error>;
 }
 
@@ -2930,6 +2933,113 @@ fn logic_path_materialization_tokens<Addr: Clone + Eq + Hash>(
     (raw_tokens, weights)
 }
 
+fn exact_native_storage_store(width: usize) -> bool {
+    width != 0 && width <= 64 && matches!(width.div_ceil(8), 1 | 2 | 4 | 8)
+}
+
+fn static_store_avoids_native_rmw<Addr: Copy + Eq + Hash>(
+    write: &VarAtomBase<Addr>,
+    var_widths: &HashMap<Addr, usize>,
+    unpacked_element_widths: &HashMap<Addr, usize>,
+) -> bool {
+    let Some(width) = write
+        .access
+        .msb
+        .checked_sub(write.access.lsb)
+        .and_then(|width| width.checked_add(1))
+    else {
+        return false;
+    };
+
+    if let Some(&element_width) = unpacked_element_widths.get(&write.id) {
+        // Unpacked layout selection happens after scheduling. Only a complete
+        // byte-aligned native-width element avoids RMW in both packed and
+        // independently strided layouts.
+        return element_width != 0
+            && width == element_width
+            && write.access.lsb.is_multiple_of(element_width)
+            && matches!(width, 8 | 16 | 32 | 64);
+    }
+
+    let whole_object = write.access.lsb == 0
+        && var_widths.get(&write.id).copied() == Some(width)
+        && exact_native_storage_store(width);
+    let aligned_native_range =
+        write.access.lsb.is_multiple_of(8) && matches!(width, 8 | 16 | 32 | 64);
+    whole_object || aligned_native_range
+}
+
+fn direct_ff_write_ranges<Addr: Copy + Eq + Hash>(
+    input: &[LogicPath<Addr>],
+    summaries: &[FfAccessSummary<Addr>],
+    plan: &FfCombSchedulePlan,
+    retained: &HashSet<(usize, usize)>,
+    ff_node_base: usize,
+    var_widths: &HashMap<Addr, usize>,
+    unpacked_element_widths: &HashMap<Addr, usize>,
+) -> Vec<Vec<VarAtomBase<Addr>>> {
+    summaries
+        .iter()
+        .enumerate()
+        .map(|(writer, summary)| {
+            summary
+                .writes
+                .iter()
+                .filter(|write| {
+                    // Direct publication is only a throughput optimization.
+                    // Dynamic destinations and static bitfields requiring a
+                    // physical read-modify-write stay staged.
+                    if summary.dynamic_writes.contains(&write.id)
+                        || !static_store_avoids_native_rmw(
+                            write,
+                            var_widths,
+                            unpacked_element_widths,
+                        )
+                    {
+                        return false;
+                    }
+
+                    // A read in the same always_ff action cannot be ordered
+                    // before only one of its own Stores. Keep just the
+                    // overlapping range staged so lowering reads pre-edge
+                    // state without penalizing disjoint writes.
+                    if summary
+                        .reads
+                        .iter()
+                        .any(|read| read.id == write.id && read.access.overlaps(&write.access))
+                    {
+                        return false;
+                    }
+
+                    let writer_node = ff_node_base + writer;
+                    let comb_readers_proven = plan.comb_before_direct_write[writer]
+                        .iter()
+                        .filter(|&&reader| {
+                            input[reader]
+                                .sources
+                                .iter()
+                                .chain(&input[reader].previous_sources)
+                                .any(|read| {
+                                    read.id == write.id && read.access.overlaps(&write.access)
+                                })
+                        })
+                        .all(|&reader| retained.contains(&(reader, writer_node)));
+                    let ff_readers_proven = plan.ff_before_direct_write[writer]
+                        .iter()
+                        .filter(|&&reader| {
+                            summaries[reader].reads.iter().any(|read| {
+                                read.id == write.id && read.access.overlaps(&write.access)
+                            })
+                        })
+                        .all(|&reader| retained.contains(&(ff_node_base + reader, writer_node)));
+                    comb_readers_proven && ff_readers_proven
+                })
+                .copied()
+                .collect()
+        })
+        .collect()
+}
+
 fn schedule_acyclic_path_region(
     paths: &[usize],
     dependencies: &[Vec<usize>],
@@ -3060,7 +3170,7 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
     ignored_loops: &HashSet<(Addr, Addr)>,
     true_loops: &HashMap<(Addr, Addr), usize>,
     four_state: bool,
-    _var_widths: &HashMap<Addr, usize>,
+    var_widths: &HashMap<Addr, usize>,
     unpacked_element_widths: &HashMap<Addr, usize>,
     first_runtime_error_code: i64,
     mut ff: Option<&mut dyn ClockFfLowering<Addr, Error = E>>,
@@ -3119,7 +3229,7 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
     let ff_count = ff
         .as_deref()
         .map_or(0, |lowering| lowering.summaries().len());
-    let mut direct_ff = vec![false; ff_count];
+    let mut direct_ff_writes_by_action = vec![Vec::new(); ff_count];
     if let Some(plan) = &ff_plan {
         adj.resize_with(n + ff_count, Vec::new);
         value_users.resize_with(n + ff_count, Vec::new);
@@ -3152,36 +3262,27 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
             .collect::<Vec<_>>();
         let retained =
             add_acyclic_ff_write_order_edges(&mut adj, write_order_edges.iter().flatten().copied());
-        for (writer, requirements) in write_order_edges.iter().enumerate() {
-            // An FF action with no old-state users is directly publishable.
-            // Otherwise every reader-before-writer anti-dependence must have
-            // survived cycle removal.  A partial set is not a proof.
-            direct_ff[writer] = requirements.iter().all(|edge| retained.contains(edge));
-        }
+        direct_ff_writes_by_action = direct_ff_write_ranges(
+            &input,
+            ff.as_deref()
+                .expect("an FF schedule plan requires an FF lowering callback")
+                .summaries(),
+            plan,
+            &retained,
+            n,
+            var_widths,
+            unpacked_element_widths,
+        );
         for edges in adj.iter_mut().chain(&mut value_users) {
             edges.sort_unstable();
             edges.dedup();
         }
     }
-    let direct_ff_writes =
-        ff.as_deref()
-            .map(|lowering| {
-                lowering
-                    .summaries()
-                    .iter()
-                    .enumerate()
-                    .filter(|(index, _)| direct_ff.get(*index).copied().unwrap_or(false))
-                    .flat_map(|(_, summary)| {
-                        summary.writes.iter().filter_map(|write| {
-                            let reads_old_value = summary.reads.iter().any(|read| {
-                                read.id == write.id && read.access.overlaps(&write.access)
-                            });
-                            (!reads_old_value).then_some(*write)
-                        })
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
+    let direct_ff_writes = direct_ff_writes_by_action
+        .iter()
+        .flatten()
+        .copied()
+        .collect();
 
     // 2. SCC extraction identifies the synchronization boundaries at which
     // the dataflow equations must be iterated rather than freely reordered.
@@ -3235,7 +3336,7 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
     let mut builder = SIRBuilder::new();
     if let Some(ff_lowering) = ff.as_deref_mut() {
         ff_lowering
-            .begin(&mut builder, &direct_ff)
+            .begin(&mut builder, &direct_ff_writes_by_action)
             .map_err(ClockSortError::Lowering)?;
     }
     let lowerer = crate::SLTToSIRLowerer::new(four_state)
@@ -3335,12 +3436,13 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
                     .ok_or(ClockSortError::Scheduler(
                         SchedulerError::InvalidDependencyGraph,
                     ))?
-                    .lower(index, direct_ff[index], &mut builder)
+                    .lower(index, &direct_ff_writes_by_action[index], &mut builder)
                     .map_err(ClockSortError::Lowering)?;
-                // FF state is staged in WORKING/SPARSE_WORKING and is invisible
-                // to the STABLE-only comb graph until the final publish. Values
-                // computed before the FF CFG dominate its merge block, so the
-                // ordinary comb lowering cache remains valid.
+                // Any directly published range is ordered after all of its
+                // old-state readers. Other FF state stays invisible in
+                // WORKING/SPARSE_WORKING until the final publish, so values
+                // computed before the FF CFG keep the ordinary lowering cache
+                // valid.
                 continue;
             }
         };
@@ -3700,7 +3802,7 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
 
     if let Some(ff_lowering) = ff {
         ff_lowering
-            .finish(&mut builder, &direct_ff)
+            .finish(&mut builder, &direct_ff_writes_by_action)
             .map_err(ClockSortError::Lowering)?;
     }
     builder.seal_block(SIRTerminator::Return);
@@ -3800,9 +3902,10 @@ mod tests {
         ExactFoldGroup, ExactIndexedLoadKey, FfAccessSummary, FoldGroupReadFacts,
         NormalizedIndexExpr, add_acyclic_ff_write_order_edges, best_weighted_fold_family,
         build_fold_group_schedule_index, build_logic_path_memory_ssa, collect_node_input_deps,
-        plan_ff_comb_schedule, prepare_atomic_fold_group_results, sort, stable_topological_sccs,
+        direct_ff_write_ranges, plan_ff_comb_schedule, prepare_atomic_fold_group_results, sort,
+        stable_topological_sccs,
     };
-    use crate::HashSet;
+    use crate::{HashMap, HashSet};
     use crate::{
         LogicPath, LogicPathTarget, SLTForFoldGroupState, SLTNode, SLTNodeArena, SLTToSIRLowerer,
     };
@@ -4145,6 +4248,93 @@ mod tests {
         let plan = plan_ff_comb_schedule(&[], &[summary]).unwrap();
 
         assert_eq!(plan.ff_before_direct_write, vec![Vec::<usize>::new()]);
+    }
+
+    #[test]
+    fn ff_direct_write_proof_is_kept_per_bit_range() {
+        let summaries = vec![
+            FfAccessSummary {
+                reads: vec![VarAtomBase::new(30, 0, 7)],
+                writes: vec![VarAtomBase::new(20, 0, 7), VarAtomBase::new(20, 8, 15)],
+                dynamic_writes: HashSet::default(),
+            },
+            FfAccessSummary {
+                reads: vec![VarAtomBase::new(20, 0, 7)],
+                writes: vec![VarAtomBase::new(30, 0, 7)],
+                dynamic_writes: HashSet::default(),
+            },
+        ];
+        let plan = plan_ff_comb_schedule(&[], &summaries).unwrap();
+        // The FF0 -> FF1 edge is retained, while the inverse edge which only
+        // protects FF0's low byte is dropped to break the cycle.
+        let retained = [(0, 1)].into_iter().collect();
+        let var_widths = [(20, 16), (30, 8)].into_iter().collect();
+
+        let direct = direct_ff_write_ranges(
+            &[],
+            &summaries,
+            &plan,
+            &retained,
+            0,
+            &var_widths,
+            &HashMap::default(),
+        );
+
+        assert_eq!(direct[0], vec![VarAtomBase::new(20, 8, 15)]);
+        assert_eq!(direct[1], vec![VarAtomBase::new(30, 0, 7)]);
+
+        let local_old_read = vec![FfAccessSummary {
+            reads: vec![VarAtomBase::new(20, 0, 7)],
+            writes: vec![VarAtomBase::new(20, 0, 7), VarAtomBase::new(20, 8, 15)],
+            dynamic_writes: HashSet::default(),
+        }];
+        let local_plan = plan_ff_comb_schedule(&[], &local_old_read).unwrap();
+        let local_direct = direct_ff_write_ranges(
+            &[],
+            &local_old_read,
+            &local_plan,
+            &HashSet::default(),
+            0,
+            &var_widths,
+            &HashMap::default(),
+        );
+
+        assert_eq!(local_direct[0], vec![VarAtomBase::new(20, 8, 15)]);
+    }
+
+    #[test]
+    fn ff_direct_write_rejects_ranges_requiring_rmw() {
+        let summary = FfAccessSummary {
+            reads: Vec::new(),
+            writes: vec![
+                VarAtomBase::new(20, 0, 3),
+                VarAtomBase::new(21, 0, 0),
+                VarAtomBase::new(22, 0, 7),
+                VarAtomBase::new(23, 6, 11),
+                VarAtomBase::new(24, 8, 15),
+            ],
+            dynamic_writes: [22].into_iter().collect(),
+        };
+        let plan = plan_ff_comb_schedule(&[], std::slice::from_ref(&summary)).unwrap();
+        let var_widths = [(20, 8), (21, 1), (22, 8), (23, 24), (24, 24)]
+            .into_iter()
+            .collect();
+        let unpacked_element_widths = [(23, 6), (24, 8)].into_iter().collect();
+
+        let direct = direct_ff_write_ranges(
+            &[],
+            &[summary],
+            &plan,
+            &HashSet::default(),
+            0,
+            &var_widths,
+            &unpacked_element_widths,
+        );
+
+        assert_eq!(
+            direct[0],
+            vec![VarAtomBase::new(21, 0, 0), VarAtomBase::new(24, 8, 15)]
+        );
     }
 
     #[test]

--- a/crates/celox-slt/src/scheduler.rs
+++ b/crates/celox-slt/src/scheduler.rs
@@ -2982,10 +2982,10 @@ fn direct_ff_write_ranges<Addr: Copy + Eq + Hash>(
         .iter()
         .enumerate()
         .map(|(writer, summary)| {
-            summary
+            let mut direct = summary
                 .writes
                 .iter()
-                .filter(|write| {
+                .map(|write| {
                     // Direct publication is only a throughput optimization.
                     // Dynamic destinations and static bitfields requiring a
                     // physical read-modify-write stay staged.
@@ -3034,6 +3034,36 @@ fn direct_ff_write_ranges<Addr: Copy + Eq + Hash>(
                         .all(|&reader| retained.contains(&(ff_node_base + reader, writer_node)));
                     comb_readers_proven && ff_readers_proven
                 })
+                .collect::<Vec<_>>();
+
+            // Direct Stores publish immediately, while staged Stores publish
+            // together in finish(). Mixing those destinations inside one
+            // overlapping write component can reverse procedural last-write-
+            // wins order. Propagate staging through the component while
+            // leaving disjoint ranges eligible for direct publication.
+            let mut staged = direct
+                .iter()
+                .enumerate()
+                .filter_map(|(index, &direct)| (!direct).then_some(index))
+                .collect::<Vec<_>>();
+            while let Some(staged_index) = staged.pop() {
+                let staged_write = summary.writes[staged_index];
+                for (candidate, candidate_write) in summary.writes.iter().enumerate() {
+                    if direct[candidate]
+                        && staged_write.id == candidate_write.id
+                        && staged_write.access.overlaps(&candidate_write.access)
+                    {
+                        direct[candidate] = false;
+                        staged.push(candidate);
+                    }
+                }
+            }
+
+            summary
+                .writes
+                .iter()
+                .zip(direct)
+                .filter_map(|(write, direct)| direct.then_some(write))
                 .copied()
                 .collect()
         })
@@ -4335,6 +4365,36 @@ mod tests {
             direct[0],
             vec![VarAtomBase::new(21, 0, 0), VarAtomBase::new(24, 8, 15)]
         );
+    }
+
+    #[test]
+    fn ff_direct_write_stages_complete_overlapping_components() {
+        let summary = FfAccessSummary {
+            reads: Vec::new(),
+            writes: vec![
+                VarAtomBase::new(20, 4, 19),
+                VarAtomBase::new(20, 16, 31),
+                VarAtomBase::new(20, 24, 31),
+                VarAtomBase::new(20, 40, 47),
+            ],
+            dynamic_writes: HashSet::default(),
+        };
+        let plan = plan_ff_comb_schedule(&[], std::slice::from_ref(&summary)).unwrap();
+        let var_widths = [(20, 64)].into_iter().collect();
+
+        let direct = direct_ff_write_ranges(
+            &[],
+            &[summary],
+            &plan,
+            &HashSet::default(),
+            0,
+            &var_widths,
+            &HashMap::default(),
+        );
+
+        // The unaligned first write is staged. Staging propagates through the
+        // two transitively overlapping native ranges, but not the disjoint byte.
+        assert_eq!(direct[0], vec![VarAtomBase::new(20, 40, 47)]);
     }
 
     #[test]

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -1262,6 +1262,7 @@ fn exec_one_detailed<B: SimBackend>(
             deassert_value,
         } => match eval_clock_count(sim, duration) {
             Ok(duration) => {
+                let duration = duration.max(1);
                 sim_set_u64(sim, *reset_signal, (*assert_value).into());
                 let mut remaining = duration;
                 while remaining != 0 {

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -106,6 +106,39 @@ fn test_native_testbench_ff_condition_reads_pre_edge_value_after_write() {
 }
 
 #[test]
+fn test_native_testbench_overlapping_ff_writes_preserve_last_write() {
+    let code = r#"
+        module Dut (
+            clk  : input  clock,
+            state: output logic<128>,
+        ) {
+            always_ff (clk) {
+                state = 128'h11111111111111111111111111111111;
+                state[15:8] = 8'hAA;
+            }
+        }
+
+        #[test(t)]
+        module t {
+            inst clk: $tb::clock_gen;
+            var state: logic<128>;
+            inst dut: Dut (clk, state);
+
+            initial {
+                clk.next(1);
+                $assert(state[23:0] == 24'h11AA11);
+                $finish();
+            }
+        }
+    "#;
+
+    assert_eq!(
+        Simulator::builder(code, "t").run_test().unwrap(),
+        TestResult::Pass,
+    );
+}
+
+#[test]
 fn test_native_testbench_uses_metadata_project_name() {
     let code = r#"
         #[test(t)]

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -59,6 +59,53 @@ fn bench_native_tb_std_counter() -> String {
 // ── Basic ──────────────────────────────────────────────────────────────
 
 #[test]
+fn test_native_testbench_ff_condition_reads_pre_edge_value_after_write() {
+    let code = r#"
+        module Dut (
+            clk     : input  clock,
+            present : input  logic,
+            d       : input  logic<8>,
+            captured: output logic<8>,
+        ) {
+            var in_flight: logic;
+            always_ff (clk) {
+                in_flight = present;
+                if in_flight {
+                    captured = d;
+                }
+            }
+        }
+
+        #[test(t)]
+        module t {
+            inst clk: $tb::clock_gen;
+            var present: logic;
+            var d: logic<8>;
+            var captured: logic<8>;
+            inst dut: Dut (clk, present, d, captured);
+
+            initial {
+                present = 1'b1;
+                d = 8'hA5;
+                clk.next(1);
+                $assert(captured == 8'h00);
+
+                present = 1'b0;
+                d = 8'h3C;
+                clk.next(1);
+                $assert(captured == 8'h3C);
+                $finish();
+            }
+        }
+    "#;
+
+    assert_eq!(
+        Simulator::builder(code, "t").run_test().unwrap(),
+        TestResult::Pass,
+    );
+}
+
+#[test]
 fn test_native_testbench_uses_metadata_project_name() {
     let code = r#"
         #[test(t)]
@@ -517,6 +564,60 @@ fn test_reset_dynamic_duration_from_variable() {
                 duration = 5;
                 rst.assert(duration);
                 $assert(ticks == 32'd5, "ticks=%d", ticks);
+                $finish();
+            }}
+        }}
+    "#
+    );
+    assert_eq!(
+        Simulator::builder(&code, "t").run_test().unwrap(),
+        TestResult::Pass,
+    );
+}
+
+#[test]
+fn test_reset_zero_duration_clamps_to_one_cycle() {
+    let code = format!(
+        r#"
+        {CLOCK_TICK_COUNTER}
+        #[test(t)]
+        module t {{
+            inst clk: $tb::clock_gen;
+            inst rst: $tb::reset_gen(clk);
+            var ticks: logic<32>;
+            var duration: logic<32>;
+            inst dut: ClockTickCounter (clk, rst, ticks);
+
+            initial {{
+                duration = 0;
+                rst.assert(duration);
+                $assert(ticks == 32'd1, "ticks=%d", ticks);
+                $finish();
+            }}
+        }}
+    "#
+    );
+    assert_eq!(
+        Simulator::builder(&code, "t").run_test().unwrap(),
+        TestResult::Pass,
+    );
+}
+
+#[test]
+fn test_reset_legacy_clock_argument_clamps_to_one_cycle() {
+    let code = format!(
+        r#"
+        {CLOCK_TICK_COUNTER}
+        #[test(t)]
+        module t {{
+            inst clk: $tb::clock_gen;
+            inst rst: $tb::reset_gen(clk);
+            var ticks: logic<32>;
+            inst dut: ClockTickCounter (clk, rst, ticks);
+
+            initial {{
+                rst.assert(clk);
+                $assert(ticks == 32'd1, "ticks=%d", ticks);
                 $finish();
             }}
         }}

--- a/crates/celox/tests/snapshots/false_loop__large_scc_dynamic_loop.snap
+++ b/crates/celox/tests/snapshots/false_loop__large_scc_dynamic_loop.snap
@@ -102,7 +102,7 @@ Execution Unit 0:
     r87: bit<64>
     r88: bit<64>
     r89: logic<20>
-    r90: logic<64>
+    r90: logic<4>
     r91: logic<64>
     r92: logic<64>
     r93: logic<64>
@@ -118,7 +118,7 @@ Execution Unit 0:
     r3 = r2 LtU r1
     Branch(r3 ? b2 : b4)
   b2:
-    r90 = Load(addr=v (region=0), offset=0, bits=64)
+    r90 = Load(addr=v (region=0), offset=0, bits=4)
     r9 = Load(addr=v (region=0), offset=4, bits=1)
     r13 = Load(addr=v (region=0), offset=5, bits=1)
     r17 = Load(addr=v (region=0), offset=6, bits=1)

--- a/crates/celox/tests/snapshots/false_loop__scc_bit_cross_dependency.snap
+++ b/crates/celox/tests/snapshots/false_loop__scc_bit_cross_dependency.snap
@@ -24,14 +24,14 @@ Execution Unit 0:
     r9: logic<1>
     r10: logic<1>
     r11: logic<2>
-    r12: logic<64>
+    r12: logic<2>
     r13: logic<64>
     r14: logic<64>
     r17: logic<2>
   b0:
     r0 = Load(addr=sel (region=0), offset=0, bits=1)
     r1 = Load(addr=v (region=0), offset=0, bits=1)
-    r12 = Load(addr=i (region=0), offset=0, bits=64)
+    r12 = Load(addr=i (region=0), offset=0, bits=2)
     r13 = SIRValue(0x1)
     r14 = r12 Shr r13
     r2 = r14 And r13

--- a/scripts/run-heliodor-bench.sh
+++ b/scripts/run-heliodor-bench.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CELOX_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 HELIODOR_REPO="${HELIODOR_REPO:-https://github.com/dalance/heliodor.git}"
-HELIODOR_REF="${HELIODOR_REF:-7ad830fc0f8506c934b61a853ce2eadfa5926b82}"
+HELIODOR_REF="${HELIODOR_REF:-94e9c5821c24a8941c3ddc3b76daddc7124a855a}"
 HELIODOR_DIR="${HELIODOR_DIR:-$CELOX_ROOT/target/heliodor/source}"
 HELIODOR_RESULTS_DIR="${HELIODOR_RESULTS_DIR:-$CELOX_ROOT/target/heliodor/results}"
 HELIODOR_TOOLS_DIR="${HELIODOR_TOOLS_DIR:-$CELOX_ROOT/target/heliodor/tools}"
@@ -26,10 +26,10 @@ HELIODOR_INSTALL_TOOLS="${HELIODOR_INSTALL_TOOLS:-1}"
 HELIODOR_VERYL_VERSION="${HELIODOR_VERYL_VERSION:-0.20.3}"
 VERYL_BIN="${VERYL_BIN:-}"
 
-readonly GATE_HELIODOR_REF=7ad830fc0f8506c934b61a853ce2eadfa5926b82
+readonly GATE_HELIODOR_REF=94e9c5821c24a8941c3ddc3b76daddc7124a855a
 readonly GATE_TEST=test_soc_linux_boot
 readonly GATE_TIMEOUT_SEC=420
-readonly GATE_EXPECTED_CYCLE=9ae070
+readonly GATE_EXPECTED_CYCLE=d83790
 readonly GATE_EXPECTED_X3=aa
 
 # Populated only while `gate` owns detached Heliodor worktrees. Keeping these

--- a/scripts/tests/run-heliodor-bench-gate.sh
+++ b/scripts/tests/run-heliodor-bench-gate.sh
@@ -35,13 +35,13 @@ write_valid_gate_logs() {
     local celox_reported="$((celox_compile + celox_execute + 1))"
     mkdir -p "$directory"
     printf '%s\n%s\n%s\n%s\n' \
-        "v4 SoC linux boot smoke: cy=009ae070 x3=00000000000000aa pass=1" \
+        "v4 SoC linux boot smoke: cy=00d83790 x3=00000000000000aa pass=1" \
         "VERYL_TEST_CONFIG test=$GATE_TEST backend=cc aot_c_async=false" \
         "VERYL_TEST_TIMING test=$GATE_TEST compile_ns=$veryl_compile execute_ns=$veryl_execute" \
         "VERYL_TEST_RESULT test=$GATE_TEST status=pass elapsed_ns=$veryl_reported" \
         >"$directory/veryl.log"
     printf '%s\n%s\n%s\n%s\n' \
-        "v4 SoC linux boot smoke: cy=9ae070 x3=aa pass=1" \
+        "v4 SoC linux boot smoke: cy=d83790 x3=aa pass=1" \
         "CELOX_TEST_CONFIG test=$GATE_TEST backend=native opt_level=O2 four_state=false compile_only=false" \
         "CELOX_TEST_TIMING test=$GATE_TEST compile_ns=$celox_compile execute_ns=$celox_execute jit_execute_ns=$celox_jit_execute" \
         "CELOX_TEST_RESULT test=$GATE_TEST status=pass elapsed_ns=$celox_reported" \
@@ -211,14 +211,14 @@ fi
 
 bad_veryl_cycle="$TMP/bad-veryl-cycle"
 write_gate_results "$bad_veryl_cycle" 200 100
-sed -i 's/cy=009ae070/cy=009ab960/' "$bad_veryl_cycle/veryl.log"
+sed -i 's/cy=00d83790/cy=00d83800/' "$bad_veryl_cycle/veryl.log"
 if validate_gate_results "$bad_veryl_cycle/results.tsv" "$bad_veryl_cycle" 2>/dev/null; then
     fail "gate accepted the wrong Veryl architectural completion cycle"
 fi
 
 bad_celox_cycle="$TMP/bad-celox-cycle"
 write_gate_results "$bad_celox_cycle" 200 100
-sed -i 's/cy=9ae070/cy=9ab960/' "$bad_celox_cycle/celox.log"
+sed -i 's/cy=d83790/cy=d83800/' "$bad_celox_cycle/celox.log"
 if validate_gate_results "$bad_celox_cycle/results.tsv" "$bad_celox_cycle" 2>/dev/null; then
     fail "gate accepted the wrong Celox architectural completion cycle"
 fi
@@ -492,7 +492,7 @@ run_one() {
             compile_elapsed=30
             execute_elapsed=40
             printf '%s\n%s\n%s\n%s\n' \
-                'v4 SoC linux boot smoke: cy=009ae070 x3=00000000000000aa pass=1' \
+                'v4 SoC linux boot smoke: cy=00d83790 x3=00000000000000aa pass=1' \
                 "VERYL_TEST_CONFIG test=$GATE_TEST backend=cc aot_c_async=false" \
                 "VERYL_TEST_TIMING test=$GATE_TEST compile_ns=$compile_elapsed execute_ns=$execute_elapsed" \
                 "VERYL_TEST_RESULT test=$GATE_TEST status=pass elapsed_ns=$reported" >"$log"
@@ -509,7 +509,7 @@ run_one() {
                 elapsed=NA
             fi
             printf '%s\n%s\n%s\n%s\n' \
-                'v4 SoC linux boot smoke: cy=9ae070 x3=aa pass=1' \
+                'v4 SoC linux boot smoke: cy=d83790 x3=aa pass=1' \
                 "CELOX_TEST_CONFIG test=$GATE_TEST backend=native opt_level=O2 four_state=false compile_only=false" \
                 "CELOX_TEST_TIMING test=$GATE_TEST compile_ns=$compile_elapsed execute_ns=$execute_elapsed jit_execute_ns=$jit_execute_elapsed" \
                 "CELOX_TEST_RESULT test=$GATE_TEST status=$MOCK_CELOX_STATUS elapsed_ns=$reported" >"$log"


### PR DESCRIPTION
## Summary

- update the pinned Heliodor revision and Linux boot gate expectation
- preserve reset compatibility by clamping zero-duration reset requests to one cycle
- restore pre-edge `always_ff` read semantics in the fused comb/FF schedule
- select direct FF publication per bit range and only when native lowering avoids read-modify-write
- reject unsafe circular-priority rewrites with escaping loop definitions
- keep scalar partial-load coalescing within the proven readable span
- isolate Heliodor gates per PR so unrelated benchmark runs cannot cancel them
- run a nightly native O2 compatibility gate against the resolved Heliodor upstream HEAD

## Root cause

The latest Heliodor revision exposed several independent Celox regressions. Reset lowering accepted a zero-cycle duration after an API change, fused FF source tracking hid module-state read-after-write dependencies, and two SIR optimizations could respectively let loop-local definitions escape or widen a scalar load beyond the accessed object.

The FF fix keeps only overlapping old-state ranges staged. Disjoint ranges may publish directly when every reader-before-writer dependency is retained and the resulting native store is proven not to require RMW. Dynamic and non-aligned destinations remain staged.

The Heliodor workflow also shared one global `bench` concurrency group. GitHub Actions permits only one pending run per group, so unrelated PR and benchmark activity canceled correctness gates before they started. PR runs now use a PR-specific group while master benchmark publishing remains serialized. A nightly canary resolves and records upstream Heliodor HEAD, then runs the semantic Linux boot test with Celox native O2; PR correctness remains pinned to a deterministic revision.

## Validation

- `cargo test -p celox-slt -p celox-frontend-veryl -p celox-sir-opt --locked`
  - scheduler: 142 passed
  - Veryl frontend: 80 passed
  - SIR optimizer: 392 passed plus doc tests
- `cargo test -p celox --test native_testbench --locked`
  - 85 passed, 1 ignored
- `cargo test -p celox --test false_loop --locked`
  - 16 passed, 1 ignored
- `cargo check --workspace --all-targets --locked`
- `bash scripts/tests/run-heliodor-bench-gate.sh`
- `bash scripts/tests/run-heliodor-bench-results.sh`
- workflow YAML parse and invariant checks
- formatting, diff checks, and pre-push hooks
- latest Heliodor native O2 full boot completed during diagnosis at `cy=0x00d83790`, `x3=0xaa`, `pass=1`; the final profitability tightening was validated with focused tests rather than another long boot run
