### PR TITLE
fix(cranelift): boot Linux correctly

### DIFF
--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -163,6 +163,43 @@ jobs:
         if: always() && steps.gate.outputs.status != '0'
         run: exit 1
 
+  cranelift-linux-boot:
+    name: Cranelift Linux boot
+    if: github.event_name != 'schedule'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      HELIODOR_DIR: ${{ github.workspace }}/target/heliodor-cranelift/source
+      HELIODOR_RESULTS_DIR: ${{ github.workspace }}/target/heliodor-cranelift/results
+      HELIODOR_TOOLS_DIR: ${{ github.workspace }}/target/heliodor-cranelift/tools
+      HELIODOR_RUNNERS: celox-cranelift
+      HELIODOR_TESTS: test_soc_linux_boot
+      HELIODOR_TIMEOUT_SEC: "1200"
+      CELOX_OPT_LEVEL: O2
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - uses: ./.github/actions/setup-rust
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Boot Linux with the Cranelift backend
+        shell: bash
+        run: set -o pipefail && bash scripts/run-heliodor-bench.sh run 2>&1 | tee heliodor-cranelift-output.txt
+
+      - name: Upload Cranelift Linux boot results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: heliodor-cranelift-linux-boot
+          path: |
+            heliodor-cranelift-output.txt
+            target/heliodor-cranelift/results/results.tsv
+            target/heliodor-cranelift/results/*.log
+
   heliodor-head:
     name: Heliodor HEAD compatibility
     if: github.event_name == 'schedule'

--- a/crates/celox-backend-cranelift/src/translator/arith.rs
+++ b/crates/celox-backend-cranelift/src/translator/arith.rs
@@ -181,17 +181,30 @@ impl SIRTranslator {
             };
 
             for i in 0..arg_num_chunks {
-                let chunk_val_v = get_chunk_as_i64(state.builder, &arg_chunks_v, i);
-                let chunk_val_m = if self.options.four_state {
+                let arg_chunk_bits = arg_width.saturating_sub(i * 64).min(64);
+                let raw_chunk_v = get_chunk_as_i64(state.builder, &arg_chunks_v, i);
+                let raw_chunk_m = if self.options.four_state {
                     get_chunk_as_i64(state.builder, &arg_chunks_m, i)
                 } else {
                     state.builder.ins().iconst(types::I64, 0)
+                };
+                // Cranelift represents sub-byte HDL values with an i8.  Mask the
+                // physical padding before concatenation so it cannot become part
+                // of an adjacent field.
+                let (chunk_val_v, chunk_val_m) = if arg_chunk_bits < 64 {
+                    let mask_value = (1u64 << arg_chunk_bits) - 1;
+                    let mask = state.builder.ins().iconst(types::I64, mask_value as i64);
+                    (
+                        state.builder.ins().band(raw_chunk_v, mask),
+                        state.builder.ins().band(raw_chunk_m, mask),
+                    )
+                } else {
+                    (raw_chunk_v, raw_chunk_m)
                 };
 
                 let abs_bit_offset = current_bit_offset + i * 64;
                 let dst_chunk_idx = abs_bit_offset / 64;
                 let bit_shift = abs_bit_offset % 64;
-                let arg_chunk_bits = arg_width.saturating_sub(i * 64).min(64);
 
                 // 1. Write to dst_chunks[dst_chunk_idx]
                 if dst_chunk_idx < num_chunks {
@@ -628,8 +641,8 @@ impl SIRTranslator {
                     }
                 };
 
-                let final_res_v = cast_type(state.builder, res_v, dst_ty);
-                let final_res_m = cast_type(state.builder, res_m, dst_ty);
+                let final_res_v = promote_to_physical(state, res_v, d_width, false, dst_ty);
+                let final_res_m = promote_to_physical(state, res_m, d_width, false, dst_ty);
                 // Normalize: operations produce X (v=1,m=1), never Z (v=0,m=1)
                 let normalized_v = state.builder.ins().bor(final_res_v, final_res_m);
                 state.regs.insert(
@@ -640,7 +653,7 @@ impl SIRTranslator {
                     },
                 );
             } else {
-                let final_res = cast_type(state.builder, res_v, dst_ty);
+                let final_res = promote_to_physical(state, res_v, d_width, false, dst_ty);
                 state
                     .regs
                     .insert(*dst, TransValue::TwoState(vec![final_res]));
@@ -1315,16 +1328,8 @@ impl SIRTranslator {
                     }
                 };
 
-                let final_res_v = if common_ty.bits() > dst_ty.bits() {
-                    state.builder.ins().ireduce(dst_ty, res_v)
-                } else {
-                    res_v
-                };
-                let final_res_m = if common_ty.bits() > dst_ty.bits() {
-                    state.builder.ins().ireduce(dst_ty, res_m)
-                } else {
-                    res_m
-                };
+                let final_res_v = promote_to_physical(state, res_v, d_width, false, dst_ty);
+                let final_res_m = promote_to_physical(state, res_m, d_width, false, dst_ty);
                 // Identity/casts preserve X versus Z. Other unary operations
                 // produce X for an unknown input bit.
                 let normalized_v = match op {
@@ -1348,11 +1353,7 @@ impl SIRTranslator {
                     },
                 );
             } else {
-                let final_res = if common_ty.bits() > dst_ty.bits() {
-                    state.builder.ins().ireduce(dst_ty, res_v)
-                } else {
-                    res_v
-                };
+                let final_res = promote_to_physical(state, res_v, d_width, false, dst_ty);
                 state
                     .regs
                     .insert(*dst, TransValue::TwoState(vec![final_res]));

--- a/crates/celox-backend-cranelift/src/translator/memory.rs
+++ b/crates/celox-backend-cranelift/src/translator/memory.rs
@@ -1240,6 +1240,20 @@ impl SIRTranslator {
         src_val: Value,   // source
         max_bit_shift: usize,
     ) {
+        // A scalar whose packed bit range crosses an i64 boundary needs two
+        // memory words even though its logical value still fits in one CLIF
+        // value. Reuse the chunked RMW path so the high fragment is preserved.
+        if op_width.saturating_add(max_bit_shift) > 64 {
+            self.translate_store_multi_word_from_chunks(
+                state,
+                addr,
+                bit_shift,
+                op_width,
+                &[src_val],
+            );
+            return;
+        }
+
         // 1. Determine minimum necessary access type
         let access_ty = scalar_access_type(op_width, max_bit_shift);
         let m_raw = if op_width >= 64 {
@@ -1305,6 +1319,17 @@ impl SIRTranslator {
         d_phys_width: usize,
         max_bit_shift: usize,
     ) -> Value {
+        // Packed scalar fields can straddle two i64 words. The ordinary
+        // scalar path cannot represent `op_width + bit_shift > 64`, so use
+        // the slide-combine implementation and return its single value chunk.
+        if op_width.saturating_add(max_bit_shift) > 64 {
+            return self
+                .translate_load_multi_word(state, addr, bit_shift, op_width, d_phys_width)
+                .into_iter()
+                .next()
+                .expect("a scalar load produces one chunk");
+        }
+
         // 1. Determine minimum necessary access type
         let access_ty = scalar_access_type(op_width, max_bit_shift);
 

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -18,6 +18,7 @@ pub type SimFunc = unsafe extern "C" fn(*mut u8) -> u64;
 #[derive(Clone, Copy)]
 pub struct EventRef {
     pub func: SimFunc,
+    pub comb_apply_func: SimFunc,
     pub addr: AbsoluteAddr,
     pub id: usize,
 }
@@ -26,6 +27,7 @@ impl std::fmt::Debug for EventRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EventRef")
             .field("func", &(self.func as usize))
+            .field("comb_apply_func", &(self.comb_apply_func as usize))
             .field("addr", &self.addr)
             .field("id", &self.id)
             .finish()
@@ -440,6 +442,7 @@ impl JitBackend {
                     *clock,
                     EventRef {
                         func,
+                        comb_apply_func: func,
                         addr: *clock,
                         id,
                     },
@@ -470,6 +473,28 @@ impl JitBackend {
         // Release borrows captured by compile_ffs so engine is available again.
         // (Using `let _` instead of `drop()` to avoid clippy::drop_non_drop.)
         let _ = compile_ffs;
+
+        // Deferred testbench ticks require the scheduler's combined comb/FF
+        // program. Calling independently compiled comb and FF functions can
+        // observe a different pre-edge snapshot around reset and NBA regions.
+        for (clock, ff_units) in &sir.sir.eval_apply_ffs {
+            let mut combined_units;
+            let units = if let Some(fused) = sir.sir.eval_comb_apply_ffs.get(clock) {
+                fused.as_slice()
+            } else {
+                combined_units = sir.sir.eval_comb.clone();
+                combined_units.extend(ff_units.iter().cloned());
+                combined_units.as_slice()
+            };
+            let ptr = engine
+                .compile_units(units, None, None, None)
+                .map_err(SimulatorError::from)?;
+            let comb_apply_func: SimFunc = unsafe { std::mem::transmute(ptr) };
+            event_map
+                .get_mut(clock)
+                .expect("compiled clock event is present")
+                .comb_apply_func = comb_apply_func;
+        }
 
         // Insert clock_domains aliases so every event signal resolves
         for (alias, canonical) in &sir.design.events.aliases {
@@ -983,6 +1008,10 @@ impl super::SimBackend for JitBackend {
 
     fn eval_apply_ff_at(&mut self, event: EventRef) -> Result<(), SimulatorErrorCode> {
         self.eval_apply_ff_at(event)
+    }
+
+    fn eval_comb_apply_ff_at(&mut self, event: EventRef) -> Result<(), SimulatorErrorCode> {
+        self.run_sim_func(event.comb_apply_func)
     }
 
     fn eval_only_ff_at(&mut self, event: EventRef) -> Result<(), SimulatorErrorCode> {

--- a/crates/celox/tests/native_boundary_hardening.rs
+++ b/crates/celox/tests/native_boundary_hardening.rs
@@ -375,6 +375,25 @@ fn static_commit_offset_width_boundary_table_preserves_neighbors() {
 }
 
 #[test]
+fn cranelift_static_64_bit_commit_crosses_word_boundary() {
+    let offset = 1;
+    let width = 64;
+    let total_width = case_total_width(offset, width);
+    let code = ff_commit_source(offset, width, total_width);
+    let base = patterned_value(0x0123_4567_89ab_cdef, total_width);
+    let val = BigUint::from(0xffff_ffff_ffff_fad8u64);
+    let expected = expected_replace(total_width, offset, width, &base, &val);
+
+    let mut cranelift = SimulatorBuilder::new(&code, "Top")
+        .optimize(true)
+        .build_cranelift()
+        .unwrap();
+    tick_ff_case(&mut cranelift, width, &base, &val);
+
+    assert_eq!(cranelift.get(cranelift.signal("o")), expected);
+}
+
+#[test]
 fn post_optimized_sir_keeps_boundary_store_and_commit_corpus() {
     let wide_unaligned = ff_commit_source(1, 99, case_total_width(1, 99));
     assert_optimized_sir_has_static_store(&wide_unaligned, "Top", 1, 99);

--- a/crates/celox/tests/nba_dynamic_array.rs
+++ b/crates/celox/tests/nba_dynamic_array.rs
@@ -6,6 +6,53 @@ mod test_utils;
 
 all_backends! {
 
+    fn test_subbyte_arithmetic_padding_does_not_corrupt_concat(sim) {
+        @omit_veryl;
+        @setup { let code = r#"
+module Top (
+    bound: input  logic<4>,
+    o    : output logic<72>,
+) {
+    var occupied: logic    [8];
+    var rs1_rdy : logic    [8];
+    var rs2_rdy : logic    [8];
+    var rob_idx : logic<5> [8];
+    var cand    : logic<9> [8];
+
+    always_comb {
+        for i in 0..8 {
+            occupied[i] = 1'b0;
+            rs1_rdy[i]  = 1'b0;
+            rs2_rdy[i]  = 1'b0;
+            rob_idx[i]  = 5'd0;
+        }
+        occupied[1] = 1'b1;
+        rs1_rdy[0]  = 1'b1;
+        rs2_rdy[0]  = 1'b1;
+        rs2_rdy[1]  = 1'b1;
+
+        for i in 0..bound {
+            let age    : logic<5> = rob_idx[i] - 5'd2;
+            let ready: logic = occupied[i] && rs1_rdy[i] && rs2_rdy[i];
+            cand[i] = {ready, age, i as 3};
+        }
+        o = {cand[7], cand[6], cand[5], cand[4], cand[3], cand[2], cand[1], cand[0]};
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+
+        let bound = sim.signal("bound");
+        let o = sim.signal("o");
+        sim.modify(|io| io.set(bound, 8u8)).unwrap();
+        let mut expected = BigUint::from(0u8);
+        for i in 0usize..8 {
+            let candidate = (30 << 3) | i;
+            expected |= BigUint::from(candidate) << (i * 9);
+        }
+        assert_eq!(sim.get(o), expected);
+    }
+
     fn test_child_dynamic_ff_read_reaches_parent_after_same_edge_enable(sim) {
         @setup { let code = r#"
 module Cache (


### PR DESCRIPTION
## Summary

- fix Cranelift lowering so sub-byte arithmetic padding cannot leak into concatenations
- preserve packed scalar loads and stores that cross a 64-bit memory-word boundary
- execute deferred testbench clock edges with the scheduler's fused combinational/FF program
- add focused regressions for the arithmetic and boundary-store failures
- add a Cranelift Linux boot job to the Heliodor CI workflow

## Root cause

The Cranelift backend retained physical i8 padding above narrow HDL arithmetic results, truncated packed 64-bit fields when an unaligned access crossed an i64 boundary, and evaluated deferred clock edges using independently compiled combinational and FF programs. Together these differences caused the Heliodor SoC to diverge before Linux could boot.

## Impact

The Cranelift backend now boots the fixed Heliodor Linux workload and CI continuously exercises that path with a 20-minute workload timeout.

## Validation

- Cranelift Heliodor Linux boot:
  - `v4 SoC linux boot smoke: cy=d83790 x3=aa pass=1`
  - compile: 47.1 s
  - execute: 595.5 s
- `cargo test -p celox --tests`
- `cargo test -p celox-backend-cranelift`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- focused Clippy checks with `-D warnings`
- Heliodor result/gate script tests and Node script tests