### PR TITLE
ci(veryl): add stable and HEAD development lanes

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -103,11 +103,10 @@ use the same mechanism so generated branch pushes start normal CI. Using the
 default `GITHUB_TOKEN` to create or update those branches would prevent their
 follow-up workflows from running.
 
-The App deliberately has no Issues permission, so Release Please does not add
-its normal status labels. The weekly workflow instead requires the exact
+The App has Issues write permission for Release Please's status labels. The
+weekly workflow still identifies the release pull request by the exact
 `release-please--branches--master--components--celox` branch from this repository
-and still honors a manually applied `release:hold` label before enabling
-auto-merge.
+and honors a manually applied `release:hold` label before enabling auto-merge.
 
 Configure merge commits to use the pull request title as the merge commit title.
 This preserves the Conventional Commit title consumed by Release Please. Protect

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -41,32 +41,61 @@ release metadata, but tags are not deployment triggers.
 
 ## Veryl dependency lanes
 
-`master` is the release lane. It always uses released Veryl crates and is the
-only source of Celox releases. Renovate groups those crates into one
-`fix(veryl):` pull request. A trusted `pull_request_target` workflow downloads
-the matching `veryl-metadata` crate, reapplies the `git-command`-only default,
-refreshes `Cargo.lock` in an isolated container, and pushes the result back to
-the Renovate branch. The normal lint job rejects a stale or incorrectly featured
-vendor copy, so the initial Renovate commit cannot race ahead of synchronization.
-After a three-day release-age guard, required CI checks passing causes that pull
-request to merge automatically. Its `fix` title then creates a Celox patch in
-the next automated release train. The complete HEAD-to-Veryl-release-to-Celox-
-release path therefore needs no routine manual step; a compatibility failure
-simply stops at the required checks.
+`master` is both the normal Celox development trunk and the stable release lane.
+It always uses released Veryl crates and is the only source of stable Celox
+releases. Every pull request targeting `master` is checked for accidental Veryl
+git dependencies.
 
-`integration/veryl-head` is a generated, non-release branch. **Veryl HEAD
-Integration** recreates it from the latest `master` every day and whenever the
-stable dependency definition changes, pins all Veryl crates to one exact commit
-from upstream `master`, and lets the normal CI workflow test that commit. A
-failure on this branch is an early compatibility signal; do not merge or release
-this branch. The next successful run replaces it, so work on failures in a
-separate pull request or git worktree.
+`develop` is a non-release compatibility overlay: the latest `master` plus the
+changes needed by the last Veryl HEAD revision that passed CI. **Sync Develop**
+opens `master` to `develop` pull requests and enables auto-merge. Ordinary Celox
+features and fixes belong on `master`, never only on `develop`, so the overlay is
+disposable and can be rebuilt after a Veryl release.
+
+**Veryl HEAD Integration** creates `integration/veryl-head` from `develop`, pins
+all Veryl crates to one exact upstream `master` commit, and opens a pull request
+back to `develop`. Passing rolls auto-merge. A failing roll remains open and is
+not replaced by the next scheduled run, making the compatibility regression an
+actionable pull request that a maintainer can take over. The integration branch
+is temporary and must never target `master`.
+
+Renovate groups released Veryl crates into one `fix(veryl):` pull request against
+`master`. The trusted vendoring workflow merges the tested `develop` overlay into
+that release candidate, retains Renovate's released dependency declarations,
+downloads the matching `veryl-metadata` crate, reapplies the `git-command`-only
+default, and refreshes `Cargo.lock` in an isolated container. Required CI then
+tests the complete promotion. A source conflict or a HEAD-only change that is
+not compatible with the release leaves the existing Renovate pull request and
+its failed check for investigation. Every `develop` update redispatches the
+trusted synchronization for an open Veryl release candidate, so a compatibility
+fix cannot be missed merely because Renovate opened its pull request first. Once
+merged, the normal master-to-develop sync and next HEAD roll rebuild the overlay
+on the new stable base.
+
+## Nightly channels
+
+The NAPI publication workflow publishes two daily prerelease channels from
+immutable commits:
+
+| npm dist-tag | Source | Veryl compatibility |
+| --- | --- | --- |
+| `nightly-stable` | `master` | Latest released Veryl crates |
+| `nightly-head` | `develop` | Last Veryl HEAD roll accepted by CI |
+
+Nightly versions use the next patch plus the channel, source commit timestamp,
+and abbreviated source revision, for example
+`0.1.36-nightly.head.20260805123456.g0123456789ab`. Publishing the same commit is
+idempotent. **Queue Nightly Packages** dispatches the existing trusted publisher
+workflow from each source branch so npm provenance names the actual source
+commit. Manual dispatch can publish either nightly channel when run from its
+corresponding branch, or retry a stable tag. The packages remain one lockstep
+distribution in every channel.
 
 ## Repository configuration
 
 Release automation uses the `celox-release-please` GitHub App, installed for this
 repository with repository contents and pull request write access. Store its
-Client ID as the `RELEASE_APP_CLIENT_ID` Actions variable and its complete PEM
+numeric App ID as the `RELEASE_APP_ID` Actions variable and its complete PEM
 private key as the `RELEASE_APP_PRIVATE_KEY` Actions secret. Each job mints a
 short-lived, repository-scoped installation token; never store an installation
 token itself because it expires. The Veryl HEAD and vendored-metadata workflows
@@ -82,8 +111,9 @@ auto-merge.
 
 Configure merge commits to use the pull request title as the merge commit title.
 This preserves the Conventional Commit title consumed by Release Please. Protect
-`master` and require both **Conventional Commit title** and the normal CI checks;
-do not allow those checks to be bypassed by the weekly release automation. Enable
-repository auto-merge so the weekly workflow can queue a checked release pull
-request. Allow the automation token to force-update the disposable
-`integration/veryl-head` branch; never grant that exception on `master`.
+`master` and `develop` and require both **Conventional Commit title** and the
+normal CI checks; do not allow those checks to be bypassed by automation. Enable
+repository auto-merge so dependency rolls, lane synchronization, and weekly
+releases can queue checked pull requests. Allow the automation token to create
+`develop` on first use and force-update the disposable `integration/veryl-head`
+branch; never grant a force-push exception on `master` or `develop`.

--- a/.github/actions/set-nightly-version/action.yml
+++ b/.github/actions/set-nightly-version/action.yml
@@ -1,0 +1,21 @@
+name: Set nightly package version
+description: Derive one deterministic prerelease version from the checked-out commit
+
+inputs:
+  enabled:
+    description: Whether to rewrite package versions for a nightly build
+    required: true
+  channel:
+    description: Nightly compatibility channel (stable or head)
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - if: inputs.enabled == 'true'
+      shell: bash
+      run: |
+        revision="$(git rev-parse HEAD)"
+        commit_epoch="$(git show -s --format=%ct HEAD)"
+        timestamp="$(node -e 'const date = new Date(Number(process.argv[1]) * 1000); process.stdout.write(date.toISOString().replace(/[-:T]/g, "").slice(0, 14));' "$commit_epoch")"
+        node scripts/set-nightly-version.mjs "${{ inputs.channel }}" "$timestamp" "$revision"

--- a/.github/workflows/ci-napi.yml
+++ b/.github/workflows/ci-napi.yml
@@ -69,7 +69,8 @@ jobs:
             exit 1
           fi
 
-      - uses: ./.github/actions/set-nightly-version
+      - if: env.NIGHTLY == 'true'
+        uses: ./.github/actions/set-nightly-version
         with:
           enabled: ${{ env.NIGHTLY }}
           channel: ${{ env.NIGHTLY_CHANNEL }}
@@ -149,7 +150,8 @@ jobs:
         with:
           node-version: 24
 
-      - uses: ./.github/actions/set-nightly-version
+      - if: env.NIGHTLY == 'true'
+        uses: ./.github/actions/set-nightly-version
         with:
           enabled: ${{ env.NIGHTLY }}
           channel: ${{ env.NIGHTLY_CHANNEL }}
@@ -225,7 +227,8 @@ jobs:
         with:
           node-version: 24
 
-      - uses: ./.github/actions/set-nightly-version
+      - if: env.NIGHTLY == 'true'
+        uses: ./.github/actions/set-nightly-version
         with:
           enabled: ${{ env.NIGHTLY }}
           channel: ${{ env.NIGHTLY_CHANNEL }}
@@ -265,7 +268,8 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - uses: ./.github/actions/set-nightly-version
+      - if: env.NIGHTLY == 'true'
+        uses: ./.github/actions/set-nightly-version
         with:
           enabled: ${{ env.NIGHTLY }}
           channel: ${{ env.NIGHTLY_CHANNEL }}
@@ -370,7 +374,8 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - uses: ./.github/actions/set-nightly-version
+      - if: env.NIGHTLY == 'true'
+        uses: ./.github/actions/set-nightly-version
         with:
           enabled: ${{ env.NIGHTLY }}
           channel: ${{ env.NIGHTLY_CHANNEL }}

--- a/.github/workflows/ci-napi.yml
+++ b/.github/workflows/ci-napi.yml
@@ -5,18 +5,31 @@ on:
     types: [napi-release]
   workflow_dispatch:
     inputs:
-      tag:
-        description: Existing v-prefixed release tag to publish or retry
+      channel:
+        description: Package channel to publish
         required: true
+        default: stable
+        type: choice
+        options:
+          - stable
+          - nightly-stable
+          - nightly-head
+      tag:
+        description: Existing v-prefixed release tag (required for stable)
+        required: false
         type: string
 
 concurrency:
-  group: napi-publish-${{ github.event.client_payload.tag || inputs.tag }}
+  group: napi-publish-${{ inputs.channel || github.event.client_payload.tag }}
   cancel-in-progress: false
 
 env:
   CARGO_INCREMENTAL: "0"
   RELEASE_TAG: ${{ github.event.client_payload.tag || inputs.tag }}
+  NIGHTLY: ${{ startsWith(inputs.channel, 'nightly-') }}
+  NIGHTLY_CHANNEL: ${{ inputs.channel == 'nightly-stable' && 'stable' || inputs.channel == 'nightly-head' && 'head' || '' }}
+  BUILD_REF: ${{ startsWith(inputs.channel, 'nightly-') && github.sha || (github.event.client_payload.tag || inputs.tag) }}
+  NPM_TAG: ${{ inputs.channel == 'nightly-stable' && 'nightly-stable' || inputs.channel == 'nightly-head' && 'nightly-head' || 'latest' }}
 
 permissions:
   contents: read
@@ -25,14 +38,54 @@ jobs:
   validate-release:
     name: Validate release version
     runs-on: ubuntu-latest
+    outputs:
+      build_sha: ${{ steps.revision.outputs.sha }}
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ env.BUILD_REF }}
+          fetch-depth: 0
 
-      - name: Check release tag
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Resolve immutable build revision
+        id: revision
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Check nightly source branch
+        if: env.NIGHTLY == 'true'
         shell: bash
         run: |
+          case "$NIGHTLY_CHANNEL" in
+            stable) expected_ref="refs/heads/master" ;;
+            head) expected_ref="refs/heads/develop" ;;
+            *) echo "Unknown nightly channel $NIGHTLY_CHANNEL." >&2; exit 1 ;;
+          esac
+          if [ "$GITHUB_REF" != "$expected_ref" ]; then
+            echo "$NPM_TAG must be dispatched from $expected_ref, got $GITHUB_REF." >&2
+            exit 1
+          fi
+
+      - uses: ./.github/actions/set-nightly-version
+        with:
+          enabled: ${{ env.NIGHTLY }}
+          channel: ${{ env.NIGHTLY_CHANNEL }}
+
+      - name: Check nightly Veryl compatibility lane
+        if: env.NIGHTLY == 'true'
+        run: node scripts/check-veryl-lane.mjs "$NIGHTLY_CHANNEL"
+
+      - name: Check release tag
+        if: env.NIGHTLY != 'true'
+        shell: bash
+        run: |
+          if [ -z "$RELEASE_TAG" ]; then
+            echo "A stable publication requires a v-prefixed release tag." >&2
+            exit 1
+          fi
           expected_tag="v$(tr -d '\r\n' < VERSION)"
           if [ "$RELEASE_TAG" != "$expected_tag" ]; then
             echo "Release tag $RELEASE_TAG does not match VERSION ($expected_tag)." >&2
@@ -40,6 +93,7 @@ jobs:
           fi
 
       - name: Check published GitHub release
+        if: env.NIGHTLY != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -56,6 +110,7 @@ jobs:
           fi
 
       - name: Check synchronized versions and stable dependencies
+        if: env.NIGHTLY != 'true'
         run: node scripts/check-release-version.mjs
 
   build:
@@ -87,12 +142,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ needs.validate-release.outputs.build_sha }}
           submodules: recursive
 
       - uses: actions/setup-node@v7
         with:
           node-version: 24
+
+      - uses: ./.github/actions/set-nightly-version
+        with:
+          enabled: ${{ env.NIGHTLY }}
+          channel: ${{ env.NIGHTLY_CHANNEL }}
 
       - uses: pnpm/action-setup@v6
 
@@ -142,7 +202,7 @@ jobs:
           if-no-files-found: error
 
   test:
-    needs: build
+    needs: [validate-release, build]
     strategy:
       fail-fast: false
       matrix:
@@ -158,12 +218,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ needs.validate-release.outputs.build_sha }}
           submodules: recursive
 
       - uses: actions/setup-node@v7
         with:
           node-version: 24
+
+      - uses: ./.github/actions/set-nightly-version
+        with:
+          enabled: ${{ env.NIGHTLY }}
+          channel: ${{ env.NIGHTLY_CHANNEL }}
 
       - uses: pnpm/action-setup@v6
 
@@ -183,7 +248,7 @@ jobs:
         run: pnpm --filter="!@celox-sim/celox-napi" --filter="!@celox-sim/playground" -r test
 
   publish:
-    needs: test
+    needs: [validate-release, test]
     runs-on: ubuntu-latest
     name: Publish
     permissions:
@@ -192,13 +257,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ needs.validate-release.outputs.build_sha }}
           submodules: recursive
 
       - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
+
+      - uses: ./.github/actions/set-nightly-version
+        with:
+          enabled: ${{ env.NIGHTLY }}
+          channel: ${{ env.NIGHTLY_CHANNEL }}
 
       - uses: pnpm/action-setup@v6
 
@@ -265,7 +335,7 @@ jobs:
               if npm view "$package_name@$package_version" version >/dev/null 2>&1; then
                 echo "$package_name@$package_version is already published; skipping."
               else
-                npm publish "$dir" --provenance --access public
+                npm publish "$dir" --provenance --access public --tag "$NPM_TAG"
               fi
             fi
           done
@@ -279,11 +349,11 @@ jobs:
           if npm view "$package_name@$package_version" version >/dev/null 2>&1; then
             echo "$package_name@$package_version is already published; skipping."
           else
-            npm publish --provenance --access public
+            npm publish --provenance --access public --tag "$NPM_TAG"
           fi
 
   publish-js:
-    needs: publish
+    needs: [validate-release, publish]
     runs-on: ubuntu-latest
     name: Publish JS Packages
     permissions:
@@ -292,13 +362,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ needs.validate-release.outputs.build_sha }}
           submodules: recursive
 
       - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
+
+      - uses: ./.github/actions/set-nightly-version
+        with:
+          enabled: ${{ env.NIGHTLY }}
+          channel: ${{ env.NIGHTLY_CHANNEL }}
 
       - uses: pnpm/action-setup@v6
 
@@ -317,7 +392,7 @@ jobs:
           if npm view "$package_name@$package_version" version >/dev/null 2>&1; then
             echo "$package_name@$package_version is already published; skipping."
           else
-            pnpm publish --provenance --access public --no-git-checks
+            pnpm publish --provenance --access public --no-git-checks --tag "$NPM_TAG"
           fi
 
       - name: Publish @celox-sim/vite-plugin
@@ -329,5 +404,5 @@ jobs:
           if npm view "$package_name@$package_version" version >/dev/null 2>&1; then
             echo "$package_name@$package_version is already published; skipping."
           else
-            pnpm publish --provenance --access public --no-git-checks
+            pnpm publish --provenance --access public --no-git-checks --tag "$NPM_TAG"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
     needs: changes
     if: always() && (needs.changes.result != 'success' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.javascript == 'true' || needs.changes.outputs.scripts == 'true')
     runs-on: ubuntu-latest
+    env:
+      VERYL_LANE: ${{ ((github.event_name == 'push' && github.ref_name == 'develop') || (github.event_name == 'pull_request' && github.base_ref == 'develop') || (github.event_name == 'merge_group' && github.event.merge_group.base_ref == 'refs/heads/develop')) && 'head' || 'stable' }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -86,9 +88,14 @@ jobs:
         if: needs.changes.result != 'success' || needs.changes.outputs.rust == 'true'
         run: cargo fmt --all -- --check
 
-      - name: Verify vendored Veryl metadata
+      - name: Verify Veryl dependency lane
         if: needs.changes.result != 'success' || needs.changes.outputs.rust == 'true'
-        run: node scripts/veryl-vendor.mjs check
+        shell: bash
+        run: |
+          node scripts/check-veryl-lane.mjs "$VERYL_LANE"
+          if [ "$VERYL_LANE" = stable ]; then
+            node scripts/veryl-vendor.mjs check
+          fi
 
       - name: cargo clippy
         if: needs.changes.result != 'success' || needs.changes.outputs.rust == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master, integration/veryl-head]
+    branches: [master, develop]
   pull_request:
   merge_group:
 
@@ -21,7 +21,7 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     env:
-      RELEASE_PLEASE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'celox-release-please[bot]' && github.head_ref == 'release-please--branches--master--components--celox' }}
+      STABLE_LANE: ${{ (github.event_name == 'push' && github.ref_name == 'master') || (github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name == 'merge_group' && github.event.merge_group.base_ref == 'refs/heads/master') }}
     outputs:
       docs: ${{ steps.classify.outputs.docs }}
       javascript: ${{ steps.classify.outputs.javascript }}
@@ -41,8 +41,8 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
         run: node scripts/ci-changes.mjs "$BASE_SHA" "$HEAD_SHA"
 
-      - name: Validate release version
-        if: env.RELEASE_PLEASE_PR == 'true'
+      - name: Reject development dependencies from the stable lane
+        if: env.STABLE_LANE == 'true'
         run: node scripts/check-release-version.mjs
 
   docs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,33 @@
+name: Queue Nightly Packages
+
+on:
+  schedule:
+    - cron: "43 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  queue:
+    name: Queue ${{ matrix.channel }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - channel: nightly-stable
+            ref: master
+          - channel: nightly-head
+            ref: develop
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Dispatch the package build from its source branch
+        shell: bash
+        run: |
+          gh workflow run ci-napi.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "${{ matrix.ref }}" \
+            -f "channel=${{ matrix.channel }}"

--- a/.github/workflows/refresh-veryl-release.yml
+++ b/.github/workflows/refresh-veryl-release.yml
@@ -1,0 +1,50 @@
+name: Refresh Veryl Release Candidate
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+concurrency:
+  group: refresh-veryl-release-candidate
+  cancel-in-progress: true
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  refresh:
+    name: Refresh open release promotions
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Redispatch open Renovate Veryl updates
+        shell: bash
+        run: |
+          mapfile -t candidates < <(
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --base master \
+              --limit 1000 \
+              --json number,author,headRefName,title \
+              --jq '.[] | select(.author.login == "renovate" or .author.login == "renovate[bot]") | select(.headRefName | startswith("renovate/")) | select(.title | startswith("fix(veryl):")) | .number'
+          )
+
+          for pr_number in "${candidates[@]}"; do
+            if ! gh pr view "$pr_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json files \
+              --jq '.files[].path' \
+              | grep -qx Cargo.toml; then
+              continue
+            fi
+
+            gh workflow run sync-veryl-vendor.yml \
+              --repo "$GITHUB_REPOSITORY" \
+              --ref master \
+              -f "pr_number=$pr_number"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
+          permission-issues: write
           permission-pull-requests: write
           permission-workflows: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,9 @@ jobs:
         id: release-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
-          permission-issues: write
           permission-pull-requests: write
           permission-workflows: write
 

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -1,0 +1,84 @@
+name: Sync Develop
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: sync-master-to-develop
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  sync:
+    name: Merge master into develop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create release app token
+        id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - uses: actions/checkout@v7
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ steps.release-token.outputs.token }}
+
+      - name: Create develop on first use
+        id: develop
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+        shell: bash
+        run: |
+          if git ls-remote --exit-code origin refs/heads/develop >/dev/null 2>&1; then
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git push origin "${GITHUB_SHA}:refs/heads/develop"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update the master synchronization pull request
+        if: steps.develop.outputs.created != 'true'
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+        shell: bash
+        run: |
+          git fetch --no-tags origin refs/heads/develop:refs/remotes/origin/develop
+          if git merge-base --is-ancestor "$GITHUB_SHA" origin/develop; then
+            echo "develop already contains master $GITHUB_SHA."
+            exit 0
+          fi
+
+          sync_pr="$(
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --base develop \
+              --head master \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+
+          if [ -z "$sync_pr" ]; then
+            sync_pr="$(
+              gh pr create \
+                --repo "$GITHUB_REPOSITORY" \
+                --base develop \
+                --head master \
+                --title "chore(develop): sync master" \
+                --body $'Bring stable-trunk changes into the Veryl HEAD compatibility lane.\n\nThis PR is managed automatically. A conflict is actionable and must be resolved without replacing the Veryl HEAD dependency on `develop`.'
+            )"
+          fi
+
+          gh pr merge "$sync_pr" \
+            --repo "$GITHUB_REPOSITORY" \
+            --auto \
+            --merge

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -24,6 +24,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
 
       - uses: actions/checkout@v7
         with:
@@ -63,8 +64,8 @@ jobs:
               --state open \
               --base develop \
               --head master \
-              --json number \
-              --jq '.[0].number // empty'
+              --json number,isCrossRepository \
+              --jq '[.[] | select(.isCrossRepository == false)][0].number // empty'
           )"
 
           if [ -z "$sync_pr" ]; then

--- a/.github/workflows/sync-veryl-vendor.yml
+++ b/.github/workflows/sync-veryl-vendor.yml
@@ -5,27 +5,73 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - Cargo.toml
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Open same-repository Renovate PR to refresh
+        required: true
+        type: number
 
 permissions:
   contents: write
+
+concurrency:
+  group: sync-veryl-vendor-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: false
 
 jobs:
   sync:
     name: Refresh veryl-metadata
     if: >-
-      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event.pull_request.user.login == 'renovate' ||
       github.event.pull_request.user.login == 'renovate[bot]') &&
-      startsWith(github.event.pull_request.head.ref, 'renovate/')
+      startsWith(github.event.pull_request.head.ref, 'renovate/') &&
+      startsWith(github.event.pull_request.title, 'fix(veryl):'))
     runs-on: ubuntu-latest
     steps:
       - name: Create release app token
         id: release-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
+          permission-pull-requests: read
+
+      - name: Resolve and validate the Renovate pull request
+        id: pull-request
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        shell: bash
+        run: |
+          metadata="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          author="$(jq -r '.user.login' <<<"$metadata")"
+          base_ref="$(jq -r '.base.ref' <<<"$metadata")"
+          head_ref="$(jq -r '.head.ref' <<<"$metadata")"
+          title="$(jq -r '.title' <<<"$metadata")"
+          changed_files="$(
+            gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" \
+              --jq '.[].filename'
+          )"
+          if [ "$(jq -r '.state' <<<"$metadata")" != open ] \
+            || [ "$(jq -r '.head.repo.full_name' <<<"$metadata")" != "$GITHUB_REPOSITORY" ] \
+            || { [ "$author" != renovate ] && [ "$author" != 'renovate[bot]' ]; } \
+            || [ "$base_ref" != master ] \
+            || [[ "$head_ref" != renovate/* ]] \
+            || [[ "$title" != "fix(veryl):"* ]] \
+            || ! grep -qx Cargo.toml <<<"$changed_files"; then
+            echo "PR $PR_NUMBER is not an open same-repository Renovate Cargo update for master." >&2
+            exit 1
+          fi
+
+          {
+            echo "base_sha=$(jq -r '.base.sha' <<<"$metadata")"
+            echo "head_sha=$(jq -r '.head.sha' <<<"$metadata")"
+            echo "head_ref=$head_ref"
+          } >> "$GITHUB_OUTPUT"
 
       # Only scripts from the trusted base revision run on the host. The PR
       # checkout is treated as data, and Cargo processes it in a disposable
@@ -33,20 +79,70 @@ jobs:
       - name: Check out trusted automation
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ steps.pull-request.outputs.base_sha }}
           path: automation
           persist-credentials: false
 
       - name: Check out Renovate branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ steps.pull-request.outputs.head_sha }}
           path: target
+          fetch-depth: 0
           token: ${{ steps.release-token.outputs.token }}
+
+      - name: Add the tested Veryl HEAD compatibility overlay
+        working-directory: target
+        shell: bash
+        run: |
+          git config user.name "celox-release-bot"
+          git config user.email "celox-release-bot@users.noreply.github.com"
+          git fetch --no-tags origin refs/heads/develop:refs/remotes/origin/develop
+
+          if git merge-base --is-ancestor origin/develop HEAD; then
+            echo "The release candidate already contains develop."
+            exit 0
+          fi
+
+          set +e
+          git merge --no-commit --no-ff origin/develop
+          merge_status="$?"
+          set -e
+
+          if [ "$merge_status" -eq 0 ]; then
+            exit 0
+          fi
+
+          mapfile -t conflicts < <(git diff --name-only --diff-filter=U)
+          unexpected=()
+          for path in "${conflicts[@]}"; do
+            case "$path" in
+              Cargo.toml|Cargo.lock|vendor/veryl-metadata/*)
+                # The Renovate side contains the released dependency. The
+                # vendored tree and lockfile are regenerated below.
+                git checkout --ours -- "$path"
+                git add -- "$path"
+                ;;
+              *)
+                unexpected+=("$path")
+                ;;
+            esac
+          done
+
+          if [ "${#unexpected[@]}" -ne 0 ]; then
+            printf 'develop conflicts with the Veryl release candidate in:\n' >&2
+            printf '  %s\n' "${unexpected[@]}" >&2
+            exit 1
+          fi
+
+          if git diff --name-only --diff-filter=U | grep -q .; then
+            echo "Dependency conflict resolution left unresolved paths." >&2
+            exit 1
+          fi
 
       - name: Refresh vendored metadata and lockfile
         env:
-          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          HEAD_BRANCH: ${{ steps.pull-request.outputs.head_ref }}
         run: |
           version="$(node automation/scripts/veryl-vendor.mjs version target/Cargo.toml)"
           archive="$RUNNER_TEMP/veryl-metadata.crate"
@@ -78,13 +174,15 @@ jobs:
           node automation/scripts/veryl-vendor.mjs check target
 
           cd target
-          if git diff --quiet -- Cargo.lock vendor/veryl-metadata; then
-            echo "Vendored veryl-metadata is already synchronized."
+          git add Cargo.toml Cargo.lock vendor/veryl-metadata
+          if ! git rev-parse -q --verify MERGE_HEAD >/dev/null \
+            && git diff --quiet \
+            && git diff --cached --quiet; then
+            echo "Veryl release candidate is already synchronized."
             exit 0
           fi
 
           git config user.name "celox-release-bot"
           git config user.email "celox-release-bot@users.noreply.github.com"
-          git add Cargo.lock vendor/veryl-metadata
-          git commit -m "fix(veryl): sync vendored metadata $version"
+          git commit -m "fix(veryl): promote tested HEAD compatibility to $version"
           git push origin "HEAD:$HEAD_BRANCH"

--- a/.github/workflows/sync-veryl-vendor.yml
+++ b/.github/workflows/sync-veryl-vendor.yml
@@ -39,6 +39,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: read
+          permission-workflows: write
 
       - name: Resolve and validate the Renovate pull request
         id: pull-request
@@ -117,7 +118,28 @@ jobs:
           unexpected=()
           for path in "${conflicts[@]}"; do
             case "$path" in
-              Cargo.toml|Cargo.lock|vendor/veryl-metadata/*)
+              Cargo.toml)
+                # Keep develop's complete manifest, then restore only the
+                # released Veryl declarations from the Renovate side. Verify
+                # first that Renovate did not change anything else in it.
+                manifest_merge="$(mktemp -d "$RUNNER_TEMP/veryl-manifest-merge.XXXXXX")"
+                git show :1:Cargo.toml > "$manifest_merge/base.toml"
+                git show :2:Cargo.toml > "$manifest_merge/release.toml"
+                node ../automation/scripts/veryl-vendor.mjs promote \
+                  "$manifest_merge/release.toml" \
+                  "$manifest_merge/base.toml"
+                if ! cmp -s "$manifest_merge/base.toml" "$manifest_merge/release.toml"; then
+                  echo "Renovate changed Cargo.toml outside the Veryl dependency declarations." >&2
+                  exit 1
+                fi
+
+                git checkout --theirs -- Cargo.toml
+                node ../automation/scripts/veryl-vendor.mjs promote \
+                  "$manifest_merge/release.toml" \
+                  Cargo.toml
+                git add -- Cargo.toml
+                ;;
+              Cargo.lock|vendor/veryl-metadata/*)
                 # The Renovate side contains the released dependency. The
                 # vendored tree and lockfile are regenerated below.
                 git checkout --ours -- "$path"

--- a/.github/workflows/veryl-head.yml
+++ b/.github/workflows/veryl-head.yml
@@ -2,11 +2,10 @@ name: Veryl HEAD Integration
 
 on:
   push:
-    branches: [master]
+    branches: [develop]
     paths:
       - "Cargo.toml"
       - "Cargo.lock"
-      - "vendor/veryl-metadata/**"
       - "scripts/use-veryl-head.mjs"
       - ".github/workflows/veryl-head.yml"
   schedule:
@@ -18,30 +17,54 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   update:
-    name: Update integration/veryl-head
+    name: Propose the next Veryl HEAD
     runs-on: ubuntu-latest
     steps:
       - name: Create release app token
         id: release-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@v7
         with:
-          ref: master
+          ref: develop
           fetch-depth: 0
           token: ${{ steps.release-token.outputs.token }}
 
       - uses: ./.github/actions/setup-rust
 
+      - name: Keep an actionable failed roll intact
+        id: existing
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+        shell: bash
+        run: |
+          roll_pr="$(
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --base develop \
+              --head integration/veryl-head \
+              --json number,url \
+              --jq '.[0].url // empty'
+          )"
+          if [ -n "$roll_pr" ]; then
+            echo "Keeping the existing Veryl roll for investigation: $roll_pr"
+            echo "open=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "open=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Pin Veryl dependencies to upstream HEAD
+        if: steps.existing.outputs.open != 'true'
         shell: bash
         run: |
           veryl_revision="$(git ls-remote https://github.com/veryl-lang/veryl.git refs/heads/master | cut -f1)"
@@ -55,12 +78,41 @@ jobs:
           cargo update -p veryl-analyzer
           echo "VERYL_REVISION=$veryl_revision" >> "$GITHUB_ENV"
 
-      - name: Update generated integration branch
+      - name: Create the rolling integration branch
+        if: steps.existing.outputs.open != 'true'
+        id: roll
         shell: bash
         run: |
+          if git diff --quiet -- Cargo.toml Cargo.lock; then
+            echo "develop already uses Veryl HEAD $VERYL_REVISION."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           git config user.name "celox-release-bot"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -C integration/veryl-head
           git add Cargo.toml Cargo.lock
-          git commit -m "ci(veryl): test Veryl HEAD ${VERYL_REVISION:0:12}"
-          git push --force-with-lease origin HEAD:integration/veryl-head
+          git commit -m "fix(veryl): roll HEAD to ${VERYL_REVISION:0:12}"
+          git push --force origin HEAD:integration/veryl-head
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open the Veryl roll pull request
+        if: steps.roll.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+        shell: bash
+        run: |
+          roll_pr="$(
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base develop \
+              --head integration/veryl-head \
+              --title "fix(veryl): roll HEAD to ${VERYL_REVISION:0:12}" \
+              --body $'Roll all Veryl crates to one exact upstream `master` revision.\n\nCI success merges this automatically into the non-release `develop` lane. CI failure deliberately leaves this PR open so it can be taken over and fixed. Do not retarget this PR to `master`.'
+          )"
+
+          gh pr merge "$roll_pr" \
+            --repo "$GITHUB_REPOSITORY" \
+            --auto \
+            --merge

--- a/.github/workflows/veryl-head.yml
+++ b/.github/workflows/veryl-head.yml
@@ -53,8 +53,8 @@ jobs:
               --state open \
               --base develop \
               --head integration/veryl-head \
-              --json number,url \
-              --jq '.[0].url // empty'
+              --json isCrossRepository,url \
+              --jq '[.[] | select(.isCrossRepository == false)][0].url // empty'
           )"
           if [ -n "$roll_pr" ]; then
             echo "Keeping the existing Veryl roll for investigation: $roll_pr"

--- a/scripts/check-release-version.mjs
+++ b/scripts/check-release-version.mjs
@@ -31,8 +31,8 @@ for (const [path, candidate] of versions) {
 const cargoManifest = fs.readFileSync("Cargo.toml", "utf8");
 for (const line of cargoManifest.split("\n")) {
   if (/^veryl-[a-z-]+\s*=/.test(line) && /\bgit\s*=/.test(line)) {
-    throw new Error(`Stable releases cannot use a Veryl git dependency: ${line}`);
+    throw new Error(`The stable lane cannot use a Veryl git dependency: ${line}`);
   }
 }
 
-console.log(`Validated Celox release ${version}`);
+console.log(`Validated stable Celox version ${version}`);

--- a/scripts/check-veryl-lane.mjs
+++ b/scripts/check-veryl-lane.mjs
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+
+import { verylDependencyNames } from "./use-veryl-head.mjs";
+
+const verylRepository = "https://github.com/veryl-lang/veryl.git";
+
+export function checkVerylLane(manifest, lane) {
+  if (lane !== "stable" && lane !== "head") {
+    throw new Error(`Expected Veryl lane stable or head, got ${lane}`);
+  }
+
+  const revisions = new Set();
+  for (const name of verylDependencyNames) {
+    const match = manifest.match(new RegExp(`^${name}\\s*=\\s*(.+)$`, "m"));
+    if (match === null) {
+      throw new Error(`Could not find workspace dependency ${name}`);
+    }
+
+    const declaration = match[1];
+    if (lane === "stable") {
+      if (/\bgit\s*=/.test(declaration)) {
+        throw new Error(`Stable Veryl lane cannot use a git dependency: ${name}`);
+      }
+      continue;
+    }
+
+    if (!declaration.includes(`git = "${verylRepository}"`)) {
+      throw new Error(`Veryl HEAD dependency ${name} does not use the upstream repository`);
+    }
+    const revision = declaration.match(/\brev\s*=\s*"([0-9a-f]{40})"/);
+    if (revision === null) {
+      throw new Error(`Veryl HEAD dependency ${name} is not pinned to a full revision`);
+    }
+    revisions.add(revision[1]);
+  }
+
+  if (lane === "head" && revisions.size !== 1) {
+    throw new Error(`Veryl HEAD dependencies use ${revisions.size} different revisions`);
+  }
+
+  return lane === "head" ? [...revisions][0] : undefined;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const lane = process.argv[2] ?? "";
+  const revision = checkVerylLane(fs.readFileSync("Cargo.toml", "utf8"), lane);
+  console.log(
+    lane === "head"
+      ? `Validated Veryl HEAD lane at ${revision}`
+      : "Validated released Veryl lane",
+  );
+}

--- a/scripts/check-veryl-lane.test.mjs
+++ b/scripts/check-veryl-lane.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { checkVerylLane } from "./check-veryl-lane.mjs";
+import { useVerylHead } from "./use-veryl-head.mjs";
+
+const revision = "0123456789abcdef0123456789abcdef01234567";
+const stableManifest = `[workspace.dependencies]
+veryl-analyzer = "0.20.3"
+veryl-emitter = "0.20.3"
+veryl-metadata = "0.20.3"
+veryl-parser = { version = "0.20.3", default-features = false }
+veryl-path = "0.20.3"
+veryl-simulator = "0.20.3"
+veryl-std = "0.20.3"
+`;
+
+test("accepts released crates only in the stable lane", () => {
+  assert.equal(checkVerylLane(stableManifest, "stable"), undefined);
+  assert.throws(() => checkVerylLane(useVerylHead(stableManifest, revision), "stable"), /git/);
+});
+
+test("requires one exact upstream revision in the HEAD lane", () => {
+  const headManifest = useVerylHead(stableManifest, revision);
+  assert.equal(checkVerylLane(headManifest, "head"), revision);
+  assert.throws(() => checkVerylLane(stableManifest, "head"), /upstream repository/);
+  assert.throws(
+    () =>
+      checkVerylLane(
+        headManifest.replace(revision, "fedcba9876543210fedcba9876543210fedcba98"),
+        "head",
+      ),
+    /different revisions/,
+  );
+});
+
+test("rejects an unknown compatibility lane", () => {
+  assert.throws(() => checkVerylLane(stableManifest, "edge"), /stable or head/);
+});

--- a/scripts/set-nightly-version.mjs
+++ b/scripts/set-nightly-version.mjs
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+
+const stableSemver = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const timestampPattern = /^\d{14}$/;
+const revisionPattern = /^[0-9a-f]{40}$/;
+const nightlyChannels = new Set(["stable", "head"]);
+
+export function nightlyVersion(stable, channel, timestamp, revision) {
+  const match = stable.match(stableSemver);
+  if (match === null) {
+    throw new Error(`Expected a stable SemVer base, got ${stable}`);
+  }
+  if (!timestampPattern.test(timestamp)) {
+    throw new Error(`Expected a UTC timestamp in YYYYMMDDHHMMSS form, got ${timestamp}`);
+  }
+  if (!revisionPattern.test(revision)) {
+    throw new Error(`Expected a full lowercase git revision, got ${revision}`);
+  }
+  if (!nightlyChannels.has(channel)) {
+    throw new Error(`Expected nightly channel stable or head, got ${channel}`);
+  }
+
+  const [, major, minor, patch] = match;
+  return `${major}.${minor}.${Number(patch) + 1}-nightly.${channel}.${timestamp}.g${revision.slice(0, 12)}`;
+}
+
+function writeJson(path, update) {
+  const value = JSON.parse(fs.readFileSync(path, "utf8"));
+  update(value);
+  fs.writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function setNightlyVersion(root, channel, timestamp, revision) {
+  const versionPath = `${root}/VERSION`;
+  const stable = fs.readFileSync(versionPath, "utf8").trim();
+  const version = nightlyVersion(stable, channel, timestamp, revision);
+  fs.writeFileSync(versionPath, `${version}\n`);
+
+  writeJson(`${root}/.release-please-manifest.json`, (manifest) => {
+    manifest["."] = version;
+  });
+
+  for (const path of [
+    "packages/celox/package.json",
+    "packages/vite-plugin/package.json",
+    "crates/celox-napi/package.json",
+  ]) {
+    writeJson(`${root}/${path}`, (manifest) => {
+      manifest.version = version;
+    });
+  }
+
+  return version;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const channel = process.argv[2] ?? "";
+  const timestamp = process.argv[3] ?? "";
+  const revision = process.argv[4] ?? "";
+  console.log(setNightlyVersion(process.cwd(), channel, timestamp, revision));
+}

--- a/scripts/set-nightly-version.test.mjs
+++ b/scripts/set-nightly-version.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { nightlyVersion, setNightlyVersion } from "./set-nightly-version.mjs";
+
+const revision = "0123456789abcdef0123456789abcdef01234567";
+
+test("builds a deterministic next-patch nightly version", () => {
+  assert.equal(
+    nightlyVersion("0.1.35", "head", "20260805123456", revision),
+    "0.1.36-nightly.head.20260805123456.g0123456789ab",
+  );
+});
+
+test("keeps stable and HEAD nightlies in distinct SemVer lines", () => {
+  assert.equal(
+    nightlyVersion("0.1.35", "stable", "20260805123456", revision),
+    "0.1.36-nightly.stable.20260805123456.g0123456789ab",
+  );
+});
+
+test("rejects unstable bases and ambiguous build inputs", () => {
+  assert.throws(
+    () => nightlyVersion("0.1.36-rc.1", "head", "20260805123456", revision),
+    /stable SemVer base/,
+  );
+  assert.throws(
+    () => nightlyVersion("0.1.35", "head", "2026-08-05", revision),
+    /UTC timestamp/,
+  );
+  assert.throws(
+    () => nightlyVersion("0.1.35", "head", "20260805123456", "main"),
+    /full lowercase git revision/,
+  );
+  assert.throws(
+    () => nightlyVersion("0.1.35", "edge", "20260805123456", revision),
+    /nightly channel stable or head/,
+  );
+});
+
+test("updates every published package version in lockstep", (context) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "celox-nightly-version-"));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  fs.mkdirSync(path.join(root, "packages/celox"), { recursive: true });
+  fs.mkdirSync(path.join(root, "packages/vite-plugin"), { recursive: true });
+  fs.mkdirSync(path.join(root, "crates/celox-napi"), { recursive: true });
+  fs.writeFileSync(path.join(root, "VERSION"), "0.1.35\n");
+  fs.writeFileSync(path.join(root, ".release-please-manifest.json"), '{".":"0.1.35"}\n');
+  for (const packagePath of [
+    "packages/celox/package.json",
+    "packages/vite-plugin/package.json",
+    "crates/celox-napi/package.json",
+  ]) {
+    fs.writeFileSync(path.join(root, packagePath), '{"name":"example","version":"0.1.35"}\n');
+  }
+
+  const version = setNightlyVersion(root, "head", "20260805123456", revision);
+  assert.equal(version, "0.1.36-nightly.head.20260805123456.g0123456789ab");
+  assert.equal(fs.readFileSync(path.join(root, "VERSION"), "utf8"), `${version}\n`);
+  assert.equal(
+    JSON.parse(fs.readFileSync(path.join(root, ".release-please-manifest.json"), "utf8"))["."],
+    version,
+  );
+  for (const packagePath of [
+    "packages/celox/package.json",
+    "packages/vite-plugin/package.json",
+    "crates/celox-napi/package.json",
+  ]) {
+    assert.equal(
+      JSON.parse(fs.readFileSync(path.join(root, packagePath), "utf8")).version,
+      version,
+    );
+  }
+});

--- a/scripts/setup-npm-trusted-publish.sh
+++ b/scripts/setup-npm-trusted-publish.sh
@@ -5,7 +5,8 @@
 # Prerequisites:
 #   - npm login (you must be logged in to npm with publish rights to @celox-sim)
 #
-# After running this script:
+# After running this script, stable and both nightly channels use the same
+# trusted workflow identity:
 #   1. Go to https://www.npmjs.com/package/<name>/access for each package
 #   2. Add a trusted publisher:
 #        Provider:   GitHub Actions

--- a/scripts/use-veryl-head.mjs
+++ b/scripts/use-veryl-head.mjs
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 
 const verylRepository = "https://github.com/veryl-lang/veryl.git";
-const dependencyNames = [
+export const verylDependencyNames = [
   "veryl-analyzer",
   "veryl-emitter",
   "veryl-metadata",
@@ -21,7 +21,7 @@ export function useVerylHead(manifest, revision) {
   const patches = patchStart === -1 ? "" : manifest.slice(patchStart);
   let updated = dependencies;
 
-  for (const name of dependencyNames) {
+  for (const name of verylDependencyNames) {
     const pattern = new RegExp(`^${name}\\s*=.*$`, "m");
     const matches = updated.match(pattern);
     if (matches === null) {

--- a/scripts/veryl-vendor.mjs
+++ b/scripts/veryl-vendor.mjs
@@ -52,6 +52,30 @@ export function requestedVerylVersion(rootManifest) {
   return version;
 }
 
+export function promoteReleasedVerylDependencies(developManifest, releaseManifest) {
+  requestedVerylVersion(releaseManifest);
+  const releasedDependencies = section(releaseManifest, "workspace.dependencies");
+  let promotedDependencies = section(developManifest, "workspace.dependencies");
+
+  for (const crate of VERYL_CRATES) {
+    const escaped = crate.replaceAll("-", "\\-");
+    const pattern = new RegExp(`^${escaped}\\s*=.*$`, "m");
+    const released = releasedDependencies.match(pattern);
+    if (!released) {
+      throw new Error(`missing released ${crate} dependency declaration`);
+    }
+    if (!pattern.test(promotedDependencies)) {
+      throw new Error(`missing develop ${crate} dependency declaration`);
+    }
+    promotedDependencies = promotedDependencies.replace(pattern, released[0]);
+  }
+
+  return developManifest.replace(
+    section(developManifest, "workspace.dependencies"),
+    promotedDependencies,
+  );
+}
+
 export function vendorPackageVersion(vendorManifest) {
   const packageSection = section(vendorManifest, "package");
   const match = packageSection.match(/^version\s*=\s*"([^"]+)"/m);
@@ -112,7 +136,7 @@ export function verifyLockfile(rootManifest, lockfile) {
 }
 
 function run(argv) {
-  const [command = "check", argument] = argv;
+  const [command = "check", argument, destination] = argv;
   if (command === "version") {
     const manifest = fs.readFileSync(argument ?? "Cargo.toml", "utf8");
     process.stdout.write(`${requestedVerylVersion(manifest)}\n`);
@@ -123,6 +147,20 @@ function run(argv) {
     const manifestPath = argument ?? "vendor/veryl-metadata/Cargo.toml";
     const manifest = fs.readFileSync(manifestPath, "utf8");
     fs.writeFileSync(manifestPath, disableGitoxideDefault(manifest));
+    return;
+  }
+
+  if (command === "promote") {
+    if (!argument) {
+      throw new Error("promote requires a released Cargo.toml path");
+    }
+    const manifestPath = destination ?? "Cargo.toml";
+    const developManifest = fs.readFileSync(manifestPath, "utf8");
+    const releaseManifest = fs.readFileSync(argument, "utf8");
+    fs.writeFileSync(
+      manifestPath,
+      promoteReleasedVerylDependencies(developManifest, releaseManifest),
+    );
     return;
   }
 

--- a/scripts/veryl-vendor.test.mjs
+++ b/scripts/veryl-vendor.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   defaultFeatures,
   disableGitoxideDefault,
+  promoteReleasedVerylDependencies,
   requestedVerylVersion,
   verifyLockfile,
   verifyVendor,
@@ -58,6 +59,25 @@ test("rejects Veryl crates that are not in lockstep", () => {
     () => requestedVerylVersion(rootManifest().replace('veryl-std = "0.20.2"', 'veryl-std = "0.20.3"')),
     /not in lockstep/,
   );
+});
+
+test("promotes only released Veryl declarations onto the develop manifest", () => {
+  const developManifest = rootManifest("0.20.2")
+    .replace('[workspace.dependencies]\n', '[workspace.dependencies]\nlocal-overlay = "develop"\n')
+    .replace(
+      'veryl-parser = { version = "0.20.2", default-features = false }',
+      'veryl-parser = { git = "https://github.com/veryl-lang/veryl.git", rev = "0123456789abcdef0123456789abcdef01234567", default-features = false }',
+    );
+  const releaseManifest = rootManifest("0.20.3").replace(
+    '[patch.crates-io]',
+    'release-only = "unchanged-by-promotion"\n\n[patch.crates-io]',
+  );
+
+  const promoted = promoteReleasedVerylDependencies(developManifest, releaseManifest);
+
+  assert.equal(requestedVerylVersion(promoted), "0.20.3");
+  assert.match(promoted, /^local-overlay = "develop"$/m);
+  assert.doesNotMatch(promoted, /release-only/);
 });
 
 test("removes gitoxide from the vendored default features", () => {


### PR DESCRIPTION
## Summary

- keep `master` as the normal Celox trunk on released Veryl crates
- maintain `develop` as a tested Veryl HEAD compatibility overlay
- roll upstream Veryl revisions through actionable, auto-merged integration PRs
- promote the tested overlay into Renovate's released-Veryl update PRs
- publish separate `nightly-stable` and `nightly-head` npm channels with deterministic versions and correct source provenance

## Why

Veryl compatibility regressions currently arrive as a batch when a release is published. This introduces an early integration lane without delaying ordinary Celox changes on `master` or allowing unreleased Veryl dependencies into stable releases. Failed rolls remain visible as pull requests instead of becoming ignored red branches.

## Validation

- `actionlint` 1.7.12 over all workflows
- `node --test scripts/*.test.mjs`
- `node scripts/check-veryl-lane.mjs stable`
- `node scripts/check-release-version.mjs`
- `pnpm run lint`
- `pnpm run build`
- `pnpm docs:build`
- pre-push hook: submodule check, Cargo format, Biome, and `cargo check --workspace --locked`
- packed nightly JS packages and verified lockstep prerelease versions plus rewritten workspace dependency versions

## Repository setup after merge

- set Actions variable `RELEASE_APP_ID` to the GitHub App's numeric App ID; keep `RELEASE_APP_PRIVATE_KEY` as the PEM secret
- enable repository auto-merge
- protect `develop` with the same required PR title and CI checks used for `master`
- allow the release App to create `develop` initially and force-update only `integration/veryl-head`
- keep npm trusted publishing configured for `.github/workflows/ci-napi.yml`; it serves stable and both nightly dist-tags