### PR TITLE
ci: publish Linux boot benchmark matrix

### DIFF
--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -162,6 +162,7 @@ jobs:
       HELIODOR_RUNNERS: celox-cranelift
       HELIODOR_TESTS: test_soc_linux_boot
       HELIODOR_TIMEOUT_SEC: "1200"
+      HELIODOR_CELOX_CARGO_PROFILE: release
       CELOX_OPT_LEVEL: O2
     steps:
       - uses: actions/checkout@v7
@@ -199,6 +200,7 @@ jobs:
       HELIODOR_RUNNERS: celox celox-cranelift
       HELIODOR_TESTS: test_soc_linux_boot
       HELIODOR_TIMEOUT_SEC: "1200"
+      HELIODOR_CELOX_CARGO_PROFILE: release
       HELIODOR_CELOX_CARGO_FEATURES: experimental-arm64-backend
       CELOX_OPT_LEVEL: O2
     steps:

--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -114,21 +114,6 @@ jobs:
           node scripts/convert-heliodor-bench.mjs "${{ steps.gate.outputs.result_file }}" heliodor-converted.json
           node scripts/convert-heliodor-bench.mjs "${{ steps.gate.outputs.result_file }}" heliodor-jit.json --jit-only
 
-      - name: Store Heliodor benchmark history
-        if: github.event_name != 'pull_request'
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Heliodor Benchmarks
-          tool: customSmallerIsBetter
-          output-file-path: heliodor-converted.json
-          gh-pages-branch: gh-pages
-          benchmark-data-dir-path: dev/bench
-          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-          alert-threshold: "110%"
-          fail-on-alert: false
-          comment-on-alert: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Compare generated-JIT benchmark
         if: github.event_name == 'pull_request'
         uses: benchmark-action/github-action-benchmark@v1
@@ -206,12 +191,12 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 45
+    timeout-minutes: 60
     env:
       HELIODOR_DIR: ${{ github.workspace }}/target/heliodor-arm64/source
       HELIODOR_RESULTS_DIR: ${{ github.workspace }}/target/heliodor-arm64/results
       HELIODOR_TOOLS_DIR: ${{ github.workspace }}/target/heliodor-arm64/tools
-      HELIODOR_RUNNERS: celox
+      HELIODOR_RUNNERS: celox celox-cranelift
       HELIODOR_TESTS: test_soc_linux_boot
       HELIODOR_TIMEOUT_SEC: "1200"
       HELIODOR_CELOX_CARGO_FEATURES: experimental-arm64-backend
@@ -224,7 +209,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - uses: Swatinem/rust-cache@v2
 
-      - name: Boot Linux with the ARM64 backend
+      - name: Boot Linux with the native and Cranelift ARM64 backends
         shell: bash
         run: set -o pipefail && bash scripts/run-heliodor-bench.sh run 2>&1 | tee heliodor-arm64-output.txt
 
@@ -237,6 +222,64 @@ jobs:
             heliodor-arm64-output.txt
             target/heliodor-arm64/results/results.tsv
             target/heliodor-arm64/results/*.log
+
+  publish-linux-boot:
+    name: Publish Linux boot benchmarks
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: [heliodor, cranelift-linux-boot, arm64-linux-boot]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: heliodor-benchmark
+          path: artifacts/native-x86_64
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: heliodor-cranelift-linux-boot
+          path: artifacts/cranelift-x86_64
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: heliodor-arm64-linux-boot
+          path: artifacts/native-aarch64
+
+      - name: Convert backend and CPU architecture results
+        shell: bash
+        run: |
+          native_results="$(find artifacts/native-x86_64 -name results.tsv -type f -print -quit)"
+          cranelift_results="$(find artifacts/cranelift-x86_64 -name results.tsv -type f -print -quit)"
+          arm64_results="$(find artifacts/native-aarch64 -name results.tsv -type f -print -quit)"
+          if [[ -z "$native_results" || -z "$cranelift_results" || -z "$arm64_results" ]]; then
+            echo "Could not find every Linux boot results.tsv artifact" >&2
+            exit 1
+          fi
+          node scripts/convert-heliodor-bench.mjs \
+            "$native_results" heliodor-published.json \
+            --cranelift-results "$cranelift_results" \
+            --arm64-results "$arm64_results"
+
+      - name: Store Heliodor benchmark history
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Heliodor Benchmarks
+          tool: customSmallerIsBetter
+          output-file-path: heliodor-published.json
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: true
+          alert-threshold: "110%"
+          fail-on-alert: false
+          comment-on-alert: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   heliodor-head:
     name: Heliodor HEAD compatibility

--- a/docs/.vitepress/components/BenchmarkDashboard.vue
+++ b/docs/.vitepress/components/BenchmarkDashboard.vue
@@ -62,6 +62,10 @@ interface Series {
     | "heliodor-celox-compile"
     | "heliodor-veryl"
     | "heliodor-veryl-compile"
+    | "heliodor-native-x86_64"
+    | "heliodor-cranelift-x86_64"
+    | "heliodor-native-aarch64"
+    | "heliodor-cranelift-aarch64"
     | "unknown";
   points: SeriesPoint[];
 }
@@ -219,6 +223,10 @@ const RUNTIME_COLORS: Record<string, string> = {
   "heliodor-celox-compile": "#06b6d4",
   "heliodor-veryl": "#f97316",
   "heliodor-veryl-compile": "#eab308",
+  "heliodor-native-x86_64": "#2563eb",
+  "heliodor-cranelift-x86_64": "#a855f7",
+  "heliodor-native-aarch64": "#16a34a",
+  "heliodor-cranelift-aarch64": "#f97316",
 };
 
 const RUNTIME_LABELS: Record<string, string> = {
@@ -233,6 +241,10 @@ const RUNTIME_LABELS: Record<string, string> = {
   "heliodor-celox-compile": "Celox compile",
   "heliodor-veryl": "Veryl-CC execution",
   "heliodor-veryl-compile": "Veryl-CC compile",
+  "heliodor-native-x86_64": "Native x86-64",
+  "heliodor-cranelift-x86_64": "Cranelift x86-64",
+  "heliodor-native-aarch64": "Native AArch64",
+  "heliodor-cranelift-aarch64": "Cranelift AArch64",
 };
 
 // --- State ---
@@ -246,7 +258,7 @@ const activeTab = ref("counter");
 
 function stripPrefix(name: string): string {
   return name.replace(
-    /^(rust-dse|rust|ts|verilator|heliodor-celox-jit|heliodor-celox-total|heliodor-celox-compile|heliodor-veryl|heliodor-veryl-compile)\//,
+    /^(rust-dse|rust|ts|verilator|heliodor-celox-jit|heliodor-celox-total|heliodor-celox-compile|heliodor-veryl|heliodor-veryl-compile|heliodor-native-x86_64|heliodor-cranelift-x86_64|heliodor-native-aarch64|heliodor-cranelift-aarch64)\//,
     "",
   );
 }
@@ -278,6 +290,10 @@ function runtime(name: string): Series["runtime"] {
   if (name.startsWith("heliodor-celox-compile/")) return "heliodor-celox-compile";
   if (name.startsWith("heliodor-veryl-compile/")) return "heliodor-veryl-compile";
   if (name.startsWith("heliodor-veryl/")) return "heliodor-veryl";
+  if (name.startsWith("heliodor-native-x86_64/")) return "heliodor-native-x86_64";
+  if (name.startsWith("heliodor-cranelift-x86_64/")) return "heliodor-cranelift-x86_64";
+  if (name.startsWith("heliodor-native-aarch64/")) return "heliodor-native-aarch64";
+  if (name.startsWith("heliodor-cranelift-aarch64/")) return "heliodor-cranelift-aarch64";
   if (name.startsWith("rust-dse/")) return "rust-dse";
   if (name.startsWith("rust/") && stripPrefix(name).startsWith("native_tb_")) return "native-tb";
   if (name.startsWith("rust/")) return "rust";

--- a/scripts/convert-heliodor-bench.mjs
+++ b/scripts/convert-heliodor-bench.mjs
@@ -3,18 +3,39 @@
 
 import { readFileSync, writeFileSync } from "node:fs";
 
-const [inputPath, outputPath, mode] = process.argv.slice(2);
+const [inputPath, outputPath, ...options] = process.argv.slice(2);
 if (!inputPath || !outputPath) {
   console.error(
-    "Usage: node convert-heliodor-bench.mjs <results.tsv> <output.json> [--jit-only]",
+    "Usage: node convert-heliodor-bench.mjs <results.tsv> <output.json> [--jit-only | --cranelift-results <results.tsv> --arm64-results <results.tsv>]",
   );
   process.exit(1);
 }
-if (mode && mode !== "--jit-only") {
-  throw new Error(`unknown conversion mode: ${mode}`);
+
+let jitOnly = false;
+let craneliftResultsPath;
+let arm64ResultsPath;
+for (let index = 0; index < options.length; index += 1) {
+  switch (options[index]) {
+    case "--jit-only":
+      jitOnly = true;
+      break;
+    case "--cranelift-results":
+      craneliftResultsPath = options[++index];
+      break;
+    case "--arm64-results":
+      arm64ResultsPath = options[++index];
+      break;
+    default:
+      throw new Error(`unknown conversion option: ${options[index]}`);
+  }
+}
+if (jitOnly && (craneliftResultsPath || arm64ResultsPath)) {
+  throw new Error("--jit-only cannot be combined with platform results");
+}
+if (Boolean(craneliftResultsPath) !== Boolean(arm64ResultsPath)) {
+  throw new Error("Cranelift and ARM64 results must be provided together");
 }
 
-const lines = readFileSync(inputPath, "utf8").trim().split("\n");
 const expectedHeader = [
   "runner",
   "test",
@@ -29,23 +50,36 @@ const expectedHeader = [
   "execute_elapsed_ns",
   "jit_execute_elapsed_ns",
 ];
-const header = lines.shift()?.split("\t") ?? [];
-if (header.join("\t") !== expectedHeader.join("\t")) {
-  throw new Error(`unsupported Heliodor result schema: ${header.join("\t")}`);
+
+function readResults(path) {
+  const lines = readFileSync(path, "utf8").trim().split("\n");
+  const header = lines.shift()?.split("\t") ?? [];
+  if (header.join("\t") !== expectedHeader.join("\t")) {
+    throw new Error(
+      `unsupported Heliodor result schema in ${path}: ${header.join("\t")}`,
+    );
+  }
+  return lines.filter(Boolean).map((line) => {
+    const fields = line.split("\t");
+    if (fields.length !== expectedHeader.length) {
+      throw new Error(
+        `expected 12 fields in ${path}, found ${fields.length}: ${line}`,
+      );
+    }
+    return Object.fromEntries(
+      expectedHeader.map((name, index) => [name, fields[index]]),
+    );
+  });
 }
 
-const rows = lines.filter(Boolean).map((line) => {
-  const fields = line.split("\t");
-  if (fields.length !== expectedHeader.length) {
-    throw new Error(`expected 12 fields, found ${fields.length}: ${line}`);
-  }
-  return Object.fromEntries(expectedHeader.map((name, index) => [name, fields[index]]));
-});
+const rows = readResults(inputPath);
 
-function requirePassedRunner(name) {
-  const matches = rows.filter((row) => row.runner === name);
+function requirePassedRunner(resultRows, name, sourcePath) {
+  const matches = resultRows.filter((row) => row.runner === name);
   if (matches.length !== 1) {
-    throw new Error(`expected exactly one ${name} row, found ${matches.length}`);
+    throw new Error(
+      `expected exactly one ${name} row in ${sourcePath}, found ${matches.length}`,
+    );
   }
   const row = matches[0];
   if (row.semantic_status !== "pass" || row.exit_status !== "0") {
@@ -70,8 +104,8 @@ function milliseconds(name, nanoseconds) {
   };
 }
 
-const celox = requirePassedRunner("celox");
-const veryl = requirePassedRunner("veryl-cc-sync");
+const celox = requirePassedRunner(rows, "celox", inputPath);
+const veryl = requirePassedRunner(rows, "veryl-cc-sync", inputPath);
 if (celox.test !== veryl.test) {
   throw new Error(`runner tests differ: Celox=${celox.test}, Veryl=${veryl.test}`);
 }
@@ -99,7 +133,47 @@ const results = [
   ),
 ];
 
-const selectedResults = mode === "--jit-only" ? results.slice(0, 1) : results;
+if (craneliftResultsPath && arm64ResultsPath) {
+  const cranelift = requirePassedRunner(
+    readResults(craneliftResultsPath),
+    "celox-cranelift",
+    craneliftResultsPath,
+  );
+  const arm64Rows = readResults(arm64ResultsPath);
+  const arm64 = requirePassedRunner(arm64Rows, "celox", arm64ResultsPath);
+  const craneliftArm64 = requirePassedRunner(
+    arm64Rows,
+    "celox-cranelift",
+    arm64ResultsPath,
+  );
+  for (const row of [cranelift, arm64, craneliftArm64]) {
+    if (row.test !== celox.test) {
+      throw new Error(
+        `runner tests differ: native-x86_64=${celox.test}, ${row.runner}=${row.test}`,
+      );
+    }
+  }
+
+  for (const [platform, row] of [
+    ["native-x86_64", celox],
+    ["cranelift-x86_64", cranelift],
+    ["native-aarch64", arm64],
+    ["cranelift-aarch64", craneliftArm64],
+  ]) {
+    results.push(
+      milliseconds(
+        `heliodor-${platform}/heliodor_linux_boot_compilation`,
+        ns(row, "compile_elapsed_ns"),
+      ),
+      milliseconds(
+        `heliodor-${platform}/heliodor_linux_boot_execution`,
+        ns(row, "execute_elapsed_ns"),
+      ),
+    );
+  }
+}
+
+const selectedResults = jitOnly ? results.slice(0, 1) : results;
 
 writeFileSync(outputPath, JSON.stringify(selectedResults, null, 2));
 console.log(`Converted ${selectedResults.length} Heliodor metrics → ${outputPath}`);

--- a/scripts/tests/convert-heliodor-bench.sh
+++ b/scripts/tests/convert-heliodor-bench.sh
@@ -16,6 +16,22 @@ node "$ROOT/scripts/convert-heliodor-bench.mjs" \
 node "$ROOT/scripts/convert-heliodor-bench.mjs" \
     "$TMP/results.tsv" "$TMP/jit.json" --jit-only >/dev/null
 
+cat >"$TMP/cranelift-results.tsv" <<'EOF'
+runner	test	status	elapsed_ns	log	semantic_status	exit_status	process_elapsed_ns	reported_elapsed_ns	compile_elapsed_ns	execute_elapsed_ns	jit_execute_elapsed_ns
+celox-cranelift	test_soc_linux_boot	0	950	cranelift.log	pass	0	950	900	5000000	6000000	NA
+EOF
+
+cat >"$TMP/arm64-results.tsv" <<'EOF'
+runner	test	status	elapsed_ns	log	semantic_status	exit_status	process_elapsed_ns	reported_elapsed_ns	compile_elapsed_ns	execute_elapsed_ns	jit_execute_elapsed_ns
+celox	test_soc_linux_boot	0	1150	arm64.log	pass	0	1150	1100	7000000	8000000	7500000
+celox-cranelift	test_soc_linux_boot	0	1350	cranelift-arm64.log	pass	0	1350	1300	9000000	10000000	NA
+EOF
+
+node "$ROOT/scripts/convert-heliodor-bench.mjs" \
+    "$TMP/results.tsv" "$TMP/platform-results.json" \
+    --cranelift-results "$TMP/cranelift-results.tsv" \
+    --arm64-results "$TMP/arm64-results.tsv" >/dev/null
+
 node -e '
 const fs = require("fs");
 const values = Object.fromEntries(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).map((x) => [x.name, x.value]));
@@ -29,5 +45,24 @@ const fs = require("fs");
 const values = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
 if (values.length !== 1 || values[0].name !== "heliodor-celox-jit/heliodor_linux_boot_execution") process.exit(1);
 ' "$TMP/jit.json"
+
+node -e '
+const fs = require("fs");
+const values = Object.fromEntries(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).map((x) => [x.name, x.value]));
+if (Object.keys(values).length !== 13) process.exit(1);
+const expected = {
+  "heliodor-native-x86_64/heliodor_linux_boot_compilation": 1,
+  "heliodor-native-x86_64/heliodor_linux_boot_execution": 2.5,
+  "heliodor-cranelift-x86_64/heliodor_linux_boot_compilation": 5,
+  "heliodor-cranelift-x86_64/heliodor_linux_boot_execution": 6,
+  "heliodor-native-aarch64/heliodor_linux_boot_compilation": 7,
+  "heliodor-native-aarch64/heliodor_linux_boot_execution": 8,
+  "heliodor-cranelift-aarch64/heliodor_linux_boot_compilation": 9,
+  "heliodor-cranelift-aarch64/heliodor_linux_boot_execution": 10,
+};
+for (const [name, value] of Object.entries(expected)) {
+  if (values[name] !== value) process.exit(1);
+}
+' "$TMP/platform-results.json"
 
 echo "convert-heliodor-bench fixture test: PASS"


### PR DESCRIPTION
## Summary

- run Heliodor Linux boot with native and Cranelift backends on both x86-64 and AArch64 runners
- aggregate all backend/architecture results before publishing one coherent history entry
- preserve the existing Heliodor benchmark series while adding explicit compilation and execution metrics for each matrix entry

## Why

The x86 native benchmark was published historically, while the newer Cranelift x86 and native AArch64 jobs only uploaded artifacts. This made the benchmark dashboard incomplete and left backend/CPU architecture comparisons outside the recorded history.

The publisher now waits for all Linux boot jobs, validates their `results.tsv` rows, and writes the combined result to the existing `Heliodor Benchmarks` dataset on `gh-pages`. The AArch64 job also runs Cranelift so the backend/architecture matrix is complete.

## Validation

- `bash scripts/tests/convert-heliodor-bench.sh`
- `shellcheck scripts/tests/convert-heliodor-bench.sh`
- parsed `.github/workflows/heliodor-bench.yml` with the project-installed YAML parser
- `git diff --check`
- pre-push hook: submodule check, `cargo fmt`, Biome, and `cargo check --workspace --locked`
