### PR TITLE
fix(playground): restore browser startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,16 @@ jobs:
       - name: Build NAPI WASM compatibility target
         run: pnpm --filter @celox-sim/celox-napi exec napi build --platform --target wasm32-wasip1-threads --manifest-path ../../Cargo.toml -p celox-napi
 
+      - name: Upload NAPI WASM artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: napi-wasm32-wasi
+          path: |
+            crates/celox-napi/celox.wasi-browser.js
+            crates/celox-napi/celox.wasm32-wasi.wasm
+            crates/celox-napi/wasi-worker-browser.mjs
+          if-no-files-found: error
+
   arm64-backend:
     name: ARM64 Backend Test
     needs: changes
@@ -362,3 +372,41 @@ jobs:
 
       - name: Run tests
         run: pnpm --filter="!@celox-sim/celox-napi" --filter="!@celox-sim/playground" -r test
+
+  playground-browser:
+    name: Playground Browser Test
+    needs: [changes, rust]
+    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.javascript == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Download NAPI WASM artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: napi-wasm32-wasi
+          path: crates/celox-napi
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm run build
+
+      - name: Build Playground
+        run: pnpm --filter @celox-sim/playground build
+
+      - name: Install Chromium
+        run: pnpm --filter @celox-sim/playground exec playwright install --with-deps chromium
+
+      - name: Run Playground browser tests
+        run: pnpm --filter @celox-sim/playground test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,9 +402,6 @@ jobs:
       - name: Build packages
         run: pnpm run build
 
-      - name: Build Playground
-        run: pnpm --filter @celox-sim/playground build
-
       - name: Install Chromium
         run: pnpm --filter @celox-sim/playground exec playwright install --with-deps chromium
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ crates/celox-napi/index.d.ts
 crates/celox-napi/*.wasm
 crates/celox-napi/celox.wasi.cjs
 crates/celox-napi/celox.wasi-browser.js
+crates/celox-napi/celox.wasi.d.cts
 crates/celox-napi/wasi-worker.mjs
 crates/celox-napi/wasi-worker-browser.mjs
 

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:e2e": "playwright test",
+    "test:e2e": "pnpm run build && playwright test",
     "test:watch": "vitest",
     "test:wasm": "NAPI_RS_FORCE_WASI=1 vitest run --config vitest.wasm.config.ts"
   },

--- a/packages/playground/playwright.config.ts
+++ b/packages/playground/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
 		headless: true,
 	},
 	webServer: {
-		command: "pnpm exec vite --host 127.0.0.1 --port 4173",
+		command: "pnpm exec vite preview --host 127.0.0.1 --port 4173",
 		port: 4173,
 		reuseExistingServer: !process.env.CI,
 		timeout: 120_000,

--- a/packages/playground/src/celox-wasm-loader.js
+++ b/packages/playground/src/celox-wasm-loader.js
@@ -1,7 +1,7 @@
 import {
   createOnMessage as __wasmCreateOnMessageForFsProxy,
   getDefaultContext as __emnapiGetDefaultContext,
-  instantiateNapiModuleSync as __emnapiInstantiateNapiModuleSync,
+  instantiateNapiModule as __emnapiInstantiateNapiModule,
   WASI as __WASI,
 } from '@napi-rs/wasm-runtime'
 import { memfs } from '@napi-rs/wasm-runtime/fs'
@@ -29,13 +29,11 @@ const __sharedMemory = new WebAssembly.Memory({
   shared: typeof SharedArrayBuffer !== 'undefined',
 })
 
-const __wasmFile = await fetch(__wasmUrl).then((res) => res.arrayBuffer())
-
 const {
   instance: __napiInstance,
   module: __wasiModule,
   napiModule: __napiModule,
-} = __emnapiInstantiateNapiModuleSync(__wasmFile, {
+} = await __emnapiInstantiateNapiModule(__wasmUrl, {
   context: __emnapiContext,
   asyncWorkPoolSize: typeof SharedArrayBuffer !== 'undefined' ? 4 : 0,
   wasi: __wasi,

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -708,17 +708,17 @@ const editorOpts: monaco.editor.IStandaloneEditorConstructionOptions = {
 };
 
 // Configure TS compiler options for testbench files
-monaco.languages.typescript.typescriptDefaults.setEagerModelSync(true);
-const monacoTestbenchCompilerOptions = buildMonacoTestbenchCompilerOptions(
-	monaco.languages.typescript,
-);
-monaco.languages.typescript.typescriptDefaults.setCompilerOptions(
+const monacoTypeScript = monaco.typescript;
+monacoTypeScript.typescriptDefaults.setEagerModelSync(true);
+const monacoTestbenchCompilerOptions =
+	buildMonacoTestbenchCompilerOptions(monacoTypeScript);
+monacoTypeScript.typescriptDefaults.setCompilerOptions(
 	monacoTestbenchCompilerOptions,
 );
-monaco.languages.typescript.javascriptDefaults.setCompilerOptions(
+monacoTypeScript.javascriptDefaults.setCompilerOptions(
 	monacoTestbenchCompilerOptions,
 );
-monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+monacoTypeScript.typescriptDefaults.setDiagnosticsOptions({
 	diagnosticsOptions: {
 		noSemanticValidation: false,
 		noSyntaxValidation: false,
@@ -1012,7 +1012,7 @@ function promptNewFile() {
 
 // ── vitest type declarations for Monaco ─────────────────
 
-monaco.languages.typescript.typescriptDefaults.addExtraLib(
+monacoTypeScript.typescriptDefaults.addExtraLib(
 	`
 declare module "vitest" {
   export function describe(name: string, fn: () => void): void;
@@ -1073,19 +1073,19 @@ const celoxDtsFiles: Record<string, string> = {
 	"wasm-bridge": celoxWasmBridgeDts,
 	"napi-bridge": celoxNapiBridgeDts,
 };
-monaco.languages.typescript.typescriptDefaults.addExtraLib(
+monacoTypeScript.typescriptDefaults.addExtraLib(
 	fixDtsImports(celoxIndexDts),
 	"file:///node_modules/@celox-sim/celox/index.d.ts",
 );
 for (const [name, content] of Object.entries(celoxDtsFiles)) {
 	const fixed = fixDtsImports(content);
 	// Register as both the sub-module path and the node_modules-style path
-	monaco.languages.typescript.typescriptDefaults.addExtraLib(
+	monacoTypeScript.typescriptDefaults.addExtraLib(
 		fixed,
 		`file:///node_modules/@celox-sim/celox/dist/${name}.d.ts`,
 	);
 	// Also register as a bare module specifier for "from '@celox-sim/celox/xxx'" resolution
-	monaco.languages.typescript.typescriptDefaults.addExtraLib(
+	monacoTypeScript.typescriptDefaults.addExtraLib(
 		fixed,
 		`file:///node_modules/@celox-sim/celox/${name}.d.ts`,
 	);
@@ -1143,7 +1143,7 @@ declare module "../src/${moduleName}.veryl" {
 ${virtualModuleDts}
 }
 `;
-	currentExtraLib = monaco.languages.typescript.typescriptDefaults.addExtraLib(
+	currentExtraLib = monacoTypeScript.typescriptDefaults.addExtraLib(
 		dts,
 		"file:///celox-sim.d.ts",
 	);
@@ -1152,11 +1152,11 @@ ${virtualModuleDts}
 	const verylModuleDts = virtualModuleDts;
 	// Register under multiple paths to ensure resolution works
 	// test/foo.test.ts imports "../src/Adder.veryl" → resolves to file:///src/Adder.veryl
-	monaco.languages.typescript.typescriptDefaults.addExtraLib(
+	monacoTypeScript.typescriptDefaults.addExtraLib(
 		verylModuleDts,
 		`file:///src/${moduleName}.veryl`,
 	);
-	monaco.languages.typescript.typescriptDefaults.addExtraLib(
+	monacoTypeScript.typescriptDefaults.addExtraLib(
 		verylModuleDts,
 		`file:///src/${moduleName}.d.veryl.ts`,
 	);
@@ -1940,7 +1940,7 @@ async function run() {
 		const tests: TestEntry[] = [];
 
 		statusEl.textContent = "Running…";
-		const tsWorker = await monaco.languages.typescript.getTypeScriptWorker();
+		const tsWorker = await monacoTypeScript.getTypeScriptWorker();
 		const testModels = getTestModels();
 		if (testModels.length === 0) throw new Error("No test files found");
 
@@ -2143,8 +2143,7 @@ function installPlaygroundTestApi() {
 		async getTypeScriptDiagnostics(path: string) {
 			const file = getFile(path);
 			if (!file) throw new Error(`File not found: ${path}`);
-			const workerFactory =
-				await monaco.languages.typescript.getTypeScriptWorker();
+			const workerFactory = await monacoTypeScript.getTypeScriptWorker();
 			const worker = await workerFactory(file.model.uri);
 			const uri = file.model.uri.toString();
 			const [semantic, syntactic, suggestion] = await Promise.all([

--- a/packages/playground/src/monaco-testbench-options.ts
+++ b/packages/playground/src/monaco-testbench-options.ts
@@ -1,7 +1,7 @@
 import type * as monaco from "monaco-editor";
 
 type TypeScriptDefaultsApi = Pick<
-	typeof monaco.languages.typescript,
+	typeof monaco.typescript,
 	"ScriptTarget" | "ModuleKind" | "ModuleResolutionKind"
 >;
 
@@ -25,7 +25,7 @@ export const MONACO_TESTBENCH_LIBS = [
 
 export function buildMonacoTestbenchCompilerOptions(
 	ts: TypeScriptDefaultsApi,
-): monaco.languages.typescript.CompilerOptions {
+): monaco.typescript.CompilerOptions {
 	return {
 		target: pickEnumValue(ts.ScriptTarget, ["ES2022", "ES2021", "ES2020"]),
 		module: pickEnumValue(ts.ModuleKind, ["ES2022", "ES2020", "ESNext"]),

--- a/packages/playground/test/e2e/monaco-diagnostics.spec.ts
+++ b/packages/playground/test/e2e/monaco-diagnostics.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 type PlaygroundTestMarker = {
 	code?: string | number;
@@ -27,12 +27,40 @@ describe("bigint literals", () => {
 });
 `;
 
-test("playground does not report TS2737 for bigint literals", async ({ page }) => {
+async function openPlayground(page: Page) {
+	const browserErrors: string[] = [];
+	const pageError = new Promise<never>((_, reject) => {
+		page.on("pageerror", (error) => {
+			browserErrors.push(error.message);
+			reject(new Error(`Playground browser error: ${error.message}`));
+		});
+	});
+
 	await page.goto("/");
 
-	await page.waitForFunction(
-		() => typeof window.__CELOX_PLAYGROUND_TEST_API__ !== "undefined",
+	await Promise.race([
+		page.waitForFunction(() => {
+			const api = window.__CELOX_PLAYGROUND_TEST_API__;
+			return api && api.getStatusText() !== "Loading WASM…";
+		}),
+		pageError,
+	]);
+	const status = await page.evaluate(() =>
+		window.__CELOX_PLAYGROUND_TEST_API__?.getStatusText(),
 	);
+	expect(status).toBe("Ready");
+
+	return browserErrors;
+}
+
+test("playground reaches Ready without browser errors", async ({ page }) => {
+	const browserErrors = await openPlayground(page);
+	await expect(page.locator("#editor .monaco-editor")).toBeVisible();
+	expect(browserErrors).toEqual([]);
+});
+
+test("playground does not report TS2737 for bigint literals", async ({ page }) => {
+	const browserErrors = await openPlayground(page);
 
 	await page.evaluate((source) => {
 		const api = window.__CELOX_PLAYGROUND_TEST_API__;
@@ -62,4 +90,5 @@ test("playground does not report TS2737 for bigint literals", async ({ page }) =
 			{ timeout: 60_000 },
 		)
 		.toBe(true);
+	expect(browserErrors).toEqual([]);
 });

--- a/packages/playground/test/e2e/monaco-diagnostics.spec.ts
+++ b/packages/playground/test/e2e/monaco-diagnostics.spec.ts
@@ -39,7 +39,12 @@ async function openPlayground(page: Page) {
 		});
 	});
 
-	await page.goto("/");
+	const response = await page.goto("/");
+	expect(response?.headers()["cross-origin-opener-policy"]).toBe("same-origin");
+	expect(response?.headers()["cross-origin-embedder-policy"]).toBe(
+		"credentialless",
+	);
+	expect(await page.evaluate(() => window.crossOriginIsolated)).toBe(true);
 
 	await Promise.race([
 		page.waitForFunction(() => {

--- a/packages/playground/test/e2e/monaco-diagnostics.spec.ts
+++ b/packages/playground/test/e2e/monaco-diagnostics.spec.ts
@@ -29,6 +29,9 @@ describe("bigint literals", () => {
 
 async function openPlayground(page: Page) {
 	const browserErrors: string[] = [];
+	page.on("console", (message) => {
+		if (message.type() === "error") browserErrors.push(message.text());
+	});
 	const pageError = new Promise<never>((_, reject) => {
 		page.on("pageerror", (error) => {
 			browserErrors.push(error.message);
@@ -48,19 +51,17 @@ async function openPlayground(page: Page) {
 	const status = await page.evaluate(() =>
 		window.__CELOX_PLAYGROUND_TEST_API__?.getStatusText(),
 	);
-	expect(status).toBe("Ready");
+	expect(
+		status,
+		`Browser errors: ${browserErrors.join("\n") || "none"}`,
+	).toBe("Ready");
 
 	return browserErrors;
 }
 
-test("playground reaches Ready without browser errors", async ({ page }) => {
+test("playground starts and accepts bigint literals", async ({ page }) => {
 	const browserErrors = await openPlayground(page);
 	await expect(page.locator("#editor .monaco-editor")).toBeVisible();
-	expect(browserErrors).toEqual([]);
-});
-
-test("playground does not report TS2737 for bigint literals", async ({ page }) => {
-	const browserErrors = await openPlayground(page);
 
 	await page.evaluate((source) => {
 		const api = window.__CELOX_PLAYGROUND_TEST_API__;

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -1,4 +1,9 @@
-import { defineConfig, type Plugin } from "vite";
+import {
+  defineConfig,
+  type Plugin,
+  type PreviewServer,
+  type ViteDevServer,
+} from "vite";
 import monacoEditorPlugin from "vite-plugin-monaco-editor";
 
 const monacoPlugin = (monacoEditorPlugin as any).default || monacoEditorPlugin;
@@ -6,15 +11,18 @@ const monacoPlugin = (monacoEditorPlugin as any).default || monacoEditorPlugin;
 // Vite's server.headers only applies to the main HTML.
 // We need COOP/COEP on ALL responses for SharedArrayBuffer to work.
 function crossOriginIsolation(): Plugin {
+  const configureHeaders = (server: PreviewServer | ViteDevServer) => {
+    server.middlewares.use((_, res, next) => {
+      res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+      res.setHeader("Cross-Origin-Embedder-Policy", "credentialless");
+      next();
+    });
+  };
+
   return {
     name: "cross-origin-isolation",
-    configureServer(server) {
-      server.middlewares.use((_, res, next) => {
-        res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
-        res.setHeader("Cross-Origin-Embedder-Policy", "credentialless");
-        next();
-      });
-    },
+    configureServer: configureHeaders,
+    configurePreviewServer: configureHeaders,
   };
 }
 


### PR DESCRIPTION
## Summary

- migrate the Playground to Monaco 0.56's top-level TypeScript API
- instantiate the WASI module asynchronously so Chromium can compile the large module
- run the production Playground build in Chromium and fail immediately on browser startup errors
- add a dedicated Playground browser-test job to CI using the WASM artifact from the Rust job

## Root cause

Monaco 0.56 moved the TypeScript language API from `monaco.languages.typescript` to `monaco.typescript`, so the Playground threw before creating the editor. The existing Playwright test was not run in CI and only timed out after startup failed. Chromium also rejects synchronous compilation of the current WASM module because it exceeds the main-thread size limit.

## Validation

- `pnpm run lint`
- `pnpm run build`
- `pnpm --filter @celox-sim/playground test` (18 passed, 5 skipped)
- `pnpm --filter @celox-sim/playground test:e2e` (2 passed)
- `node --test scripts/*.test.mjs` (6 passed)
- `cargo check --workspace --locked`

Closes #494