### PR TITLE
test(wasm): re-enable passing simulator coverage

### DIFF
--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -4489,7 +4489,6 @@ module Top (sel: input logic, a: input logic<8>, out: output logic<8>) {
 
 fn test_comb_function_loop_bounds_apply_output_effects_left_to_right(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
     @build Simulator::builder(r#"
 module Top (value: input logic<4>, out: output logic<8>) {
     function start_bound (x: input logic<4>, seen: output logic<8>) -> logic<4> {
@@ -4519,7 +4518,6 @@ module Top (value: input logic<4>, out: output logic<8>) {
 
 fn test_comb_function_loop_skips_conditions_after_break(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
     @build Simulator::builder(r#"
 module Top (
     stop: input logic,

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -1323,7 +1323,6 @@ fn test_ff_runtime_function_snapshots_nonlocal_read_before_later_write(sim) {
 
 fn test_ff_runtime_function_snapshots_input_before_callee_nonlocal_write(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1357,7 +1356,6 @@ fn test_ff_runtime_function_snapshots_input_before_callee_nonlocal_write(sim) {
 
 fn test_ff_runtime_function_snapshots_helper_input_before_callee_nonlocal_write(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1825,7 +1823,6 @@ fn test_ff_guarded_system_task_merges_definition_state(sim) {
 
 fn test_ff_nonlocal_source_ternary_preserves_unknown_merge(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2178,7 +2175,6 @@ fn test_ff_short_circuit_nested_output_updates_only_when_rhs_runs(sim) {
 
 fn test_ff_short_circuit_runtime_write_preserves_later_state_source(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2451,7 +2447,6 @@ fn test_ff_bits_and_size_do_not_evaluate_output_writing_operand(sim) {
 
 fn test_ff_bits_and_size_operands_do_not_alias_earlier_array_argument(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3684,7 +3679,6 @@ fn test_ff_unpacked_input_before_runtime_effect_stays_symbolically_bound(sim) {
 
 fn test_ff_effectful_array_item_output_is_not_a_read_alias(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6194,7 +6188,6 @@ fn test_ff_function_call_array_literal_snapshots_scalar_before_later_write(sim) 
 
 fn test_ff_function_call_array_literal_snapshots_scalar_before_callee_write(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
     @setup { let code = r#"
         module Top (
             clk: input clock,

--- a/crates/celox/tests/linear_sorter_pull_mre.rs
+++ b/crates/celox/tests/linear_sorter_pull_mre.rs
@@ -53,7 +53,6 @@ fn pull_until_empty<B: celox::SimBackend>(
 all_backends! {
 fn bit_array_index_64_ff_roundtrips(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
     @build Simulator::builder(r#"
 module BitArrayIndex64 (
     clk: input clock,
@@ -100,7 +99,6 @@ module BitArrayIndex64 (
 
 fn word_array_index_64_ff_roundtrips(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
     @build Simulator::builder(r#"
 module WordArrayIndex64 (
     clk: input clock,


### PR DESCRIPTION
## Summary

- remove 11 stale `@ignore_on(wasm)` annotations
- restore normal WASM coverage for function output effects, FF state snapshots, four-state ternaries, and 64-bit dynamic array indices
- keep the unrelated Veryl audit in PR #496

## Why

These WASM variants were still marked ignored even though they now pass. Running them explicitly with `--ignored` confirmed that each test succeeds, so leaving the annotations in place was hiding working backend coverage.

This PR only changes test selection. It does not modify simulator runtime behavior.

## Impact

Eleven WASM test variants now run in the normal test suite.

## Validation

- `cargo test -p celox --test comb_observer`
- `cargo test -p celox --test flip_flop`
- `cargo test -p celox --test linear_sorter_pull_mre`
- `cargo fmt --all -- --check`
- `git diff --check`
- pre-push submodule, Biome, Cargo formatting, and Cargo check hooks
