### PR TITLE
ci(bench): align Heliodor benchmarks across architectures

### DIFF
--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -185,7 +185,7 @@ jobs:
       HELIODOR_DIR: ${{ github.workspace }}/target/heliodor-arm64/source
       HELIODOR_RESULTS_DIR: ${{ github.workspace }}/target/heliodor-arm64/results
       HELIODOR_TOOLS_DIR: ${{ github.workspace }}/target/heliodor-arm64/tools
-      HELIODOR_RUNNERS: celox celox-cranelift
+      HELIODOR_RUNNERS: veryl-cc-sync celox celox-cranelift
       HELIODOR_TESTS: test_soc_linux_boot
       HELIODOR_TIMEOUT_SEC: "1200"
       HELIODOR_CELOX_CARGO_PROFILE: release
@@ -199,7 +199,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - uses: Swatinem/rust-cache@v2
 
-      - name: Boot Linux with the native and Cranelift ARM64 backends
+      - name: Boot Linux with Veryl-CC, native, and Cranelift on ARM64
         shell: bash
         run: set -o pipefail && bash scripts/run-heliodor-bench.sh run 2>&1 | tee heliodor-arm64-output.txt
 

--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -33,7 +33,7 @@ jobs:
   heliodor:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
         with:
@@ -91,6 +91,29 @@ jobs:
           fi
           echo "result_file=$result_file" >> "$GITHUB_OUTPUT"
 
+          runner_file="$(dirname "$result_file")/celox-target/release/celox-heliodor"
+          if [ ! -x "$runner_file" ]; then
+            echo "The Heliodor gate did not produce an executable Celox runner" >&2
+            exit 1
+          fi
+          echo "runner_file=$(realpath -e "$runner_file")" >> "$GITHUB_OUTPUT"
+
+      - name: Boot Linux with the Cranelift backend on the same host
+        if: steps.gate.outputs.status == '0'
+        shell: bash
+        env:
+          HELIODOR_DIR: ${{ github.workspace }}/target/heliodor/source
+          HELIODOR_RESULTS_DIR: ${{ github.workspace }}/target/heliodor/results/cranelift-x86_64
+          HELIODOR_TOOLS_DIR: ${{ github.workspace }}/target/heliodor/tools
+          HELIODOR_RUNNERS: celox-cranelift
+          HELIODOR_TESTS: test_soc_linux_boot
+          HELIODOR_TIMEOUT_SEC: "1200"
+          HELIODOR_CELOX_CARGO_PROFILE: release
+          HELIODOR_BUILD_CELOX_RUNNER: "0"
+          CELOX_RUNNER_BIN: ${{ steps.gate.outputs.runner_file }}
+          CELOX_OPT_LEVEL: O2
+        run: set -o pipefail && bash scripts/run-heliodor-bench.sh run 2>&1 | tee heliodor-cranelift-output.txt
+
       - name: Capture benchmark host final state
         if: always()
         shell: bash
@@ -137,54 +160,19 @@ jobs:
           path: |
             heliodor-host.txt
             heliodor-output.txt
+            heliodor-cranelift-output.txt
             heliodor-converted.json
             heliodor-jit.json
             target/heliodor/results/gate_*/results.tsv
             target/heliodor/results/gate_*/*.log
             target/heliodor/results/gate_*/*.before
             target/heliodor/results/gate_*/*.after
+            target/heliodor/results/cranelift-x86_64/results.tsv
+            target/heliodor/results/cranelift-x86_64/*.log
 
       - name: Enforce fixed gate result
         if: always() && steps.gate.outputs.status != '0'
         run: exit 1
-
-  cranelift-linux-boot:
-    name: Cranelift Linux boot
-    if: github.event_name != 'schedule'
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    env:
-      HELIODOR_DIR: ${{ github.workspace }}/target/heliodor-cranelift/source
-      HELIODOR_RESULTS_DIR: ${{ github.workspace }}/target/heliodor-cranelift/results
-      HELIODOR_TOOLS_DIR: ${{ github.workspace }}/target/heliodor-cranelift/tools
-      HELIODOR_RUNNERS: celox-cranelift
-      HELIODOR_TESTS: test_soc_linux_boot
-      HELIODOR_TIMEOUT_SEC: "1200"
-      HELIODOR_CELOX_CARGO_PROFILE: release
-      CELOX_OPT_LEVEL: O2
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: recursive
-
-      - uses: ./.github/actions/setup-rust
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Boot Linux with the Cranelift backend
-        shell: bash
-        run: set -o pipefail && bash scripts/run-heliodor-bench.sh run 2>&1 | tee heliodor-cranelift-output.txt
-
-      - name: Upload Cranelift Linux boot results
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: heliodor-cranelift-linux-boot
-          path: |
-            heliodor-cranelift-output.txt
-            target/heliodor-cranelift/results/results.tsv
-            target/heliodor-cranelift/results/*.log
 
   arm64-linux-boot:
     name: ARM64 Linux boot
@@ -228,7 +216,7 @@ jobs:
   publish-linux-boot:
     name: Publish Linux boot benchmarks
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    needs: [heliodor, cranelift-linux-boot, arm64-linux-boot]
+    needs: [heliodor, arm64-linux-boot]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -242,12 +230,7 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           name: heliodor-benchmark
-          path: artifacts/native-x86_64
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: heliodor-cranelift-linux-boot
-          path: artifacts/cranelift-x86_64
+          path: artifacts/x86_64
 
       - uses: actions/download-artifact@v8
         with:
@@ -257,8 +240,8 @@ jobs:
       - name: Convert backend and CPU architecture results
         shell: bash
         run: |
-          native_results="$(find artifacts/native-x86_64 -name results.tsv -type f -print -quit)"
-          cranelift_results="$(find artifacts/cranelift-x86_64 -name results.tsv -type f -print -quit)"
+          native_results="$(find artifacts/x86_64 -path '*/gate_*/results.tsv' -type f -print -quit)"
+          cranelift_results="$(find artifacts/x86_64 -path '*/cranelift-x86_64/results.tsv' -type f -print -quit)"
           arm64_results="$(find artifacts/native-aarch64 -name results.tsv -type f -print -quit)"
           if [[ -z "$native_results" || -z "$cranelift_results" || -z "$arm64_results" ]]; then
             echo "Could not find every Linux boot results.tsv artifact" >&2

--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -180,7 +180,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       HELIODOR_DIR: ${{ github.workspace }}/target/heliodor-arm64/source
       HELIODOR_RESULTS_DIR: ${{ github.workspace }}/target/heliodor-arm64/results

--- a/scripts/convert-heliodor-bench.mjs
+++ b/scripts/convert-heliodor-bench.mjs
@@ -146,7 +146,12 @@ if (craneliftResultsPath && arm64ResultsPath) {
     "celox-cranelift",
     arm64ResultsPath,
   );
-  for (const row of [cranelift, arm64, craneliftArm64]) {
+  const verylArm64 = requirePassedRunner(
+    arm64Rows,
+    "veryl-cc-sync",
+    arm64ResultsPath,
+  );
+  for (const row of [cranelift, arm64, craneliftArm64, verylArm64]) {
     if (row.test !== celox.test) {
       throw new Error(
         `runner tests differ: native-x86_64=${celox.test}, ${row.runner}=${row.test}`,
@@ -157,8 +162,10 @@ if (craneliftResultsPath && arm64ResultsPath) {
   for (const [platform, row] of [
     ["native-x86_64", celox],
     ["cranelift-x86_64", cranelift],
+    ["veryl-cc-x86_64", veryl],
     ["native-aarch64", arm64],
     ["cranelift-aarch64", craneliftArm64],
+    ["veryl-cc-aarch64", verylArm64],
   ]) {
     results.push(
       milliseconds(

--- a/scripts/tests/convert-heliodor-bench.sh
+++ b/scripts/tests/convert-heliodor-bench.sh
@@ -25,6 +25,7 @@ cat >"$TMP/arm64-results.tsv" <<'EOF'
 runner	test	status	elapsed_ns	log	semantic_status	exit_status	process_elapsed_ns	reported_elapsed_ns	compile_elapsed_ns	execute_elapsed_ns	jit_execute_elapsed_ns
 celox	test_soc_linux_boot	0	1150	arm64.log	pass	0	1150	1100	7000000	8000000	7500000
 celox-cranelift	test_soc_linux_boot	0	1350	cranelift-arm64.log	pass	0	1350	1300	9000000	10000000	NA
+veryl-cc-sync	test_soc_linux_boot	0	1550	veryl-arm64.log	pass	0	1550	1500	11000000	12000000	NA
 EOF
 
 node "$ROOT/scripts/convert-heliodor-bench.mjs" \
@@ -49,16 +50,20 @@ if (values.length !== 1 || values[0].name !== "heliodor-celox-jit/heliodor_linux
 node -e '
 const fs = require("fs");
 const values = Object.fromEntries(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).map((x) => [x.name, x.value]));
-if (Object.keys(values).length !== 13) process.exit(1);
+if (Object.keys(values).length !== 17) process.exit(1);
 const expected = {
   "heliodor-native-x86_64/heliodor_linux_boot_compilation": 1,
   "heliodor-native-x86_64/heliodor_linux_boot_execution": 2.5,
   "heliodor-cranelift-x86_64/heliodor_linux_boot_compilation": 5,
   "heliodor-cranelift-x86_64/heliodor_linux_boot_execution": 6,
+  "heliodor-veryl-cc-x86_64/heliodor_linux_boot_compilation": 3,
+  "heliodor-veryl-cc-x86_64/heliodor_linux_boot_execution": 4,
   "heliodor-native-aarch64/heliodor_linux_boot_compilation": 7,
   "heliodor-native-aarch64/heliodor_linux_boot_execution": 8,
   "heliodor-cranelift-aarch64/heliodor_linux_boot_compilation": 9,
   "heliodor-cranelift-aarch64/heliodor_linux_boot_execution": 10,
+  "heliodor-veryl-cc-aarch64/heliodor_linux_boot_compilation": 11,
+  "heliodor-veryl-cc-aarch64/heliodor_linux_boot_execution": 12,
 };
 for (const [name, value] of Object.entries(expected)) {
   if (values[name] !== value) process.exit(1);


### PR DESCRIPTION
## Summary

- run the x86 Cranelift Linux boot benchmark after the fixed Heliodor gate on the same GitHub-hosted runner
- reuse the gate-built release `celox-heliodor` binary and Heliodor checkout instead of repeating checkout, Rust setup, cache restore, and compilation in a separate job
- run the split-timing Veryl-CC benchmark alongside native Celox and Cranelift on the ARM64 runner
- publish native, Cranelift, and Veryl-CC compilation/execution results with explicit x86_64 and aarch64 metric names from the combined artifacts
- retain the existing x86 dashboard metric names for benchmark-history compatibility

## Validation

- `bash scripts/tests/run-heliodor-bench-gate.sh`
- `bash scripts/tests/run-heliodor-bench-results.sh`
- `bash scripts/tests/convert-heliodor-bench.sh`
- `shellcheck scripts/tests/convert-heliodor-bench.sh`
- `node --check scripts/convert-heliodor-bench.mjs`
- parsed the workflow as YAML and asserted the integrated x86 job, publisher dependencies, and ARM64 runner matrix
- pre-push hook: submodule check, `cargo fmt`, Biome, `cargo check`, clean-tree check