### PR TITLE
ci: track compile-time performance with CodSpeed

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,48 @@
+name: Compile-time Benchmarks
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_BENCH_DEBUG: "0"
+
+permissions: {}
+
+jobs:
+  codspeed:
+    name: CodSpeed
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-rust
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: codspeed-compilation
+
+      - name: Install cargo-codspeed
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-codspeed@5.0.1
+
+      - name: Build compile-time benchmarks
+        run: cargo codspeed build --locked -p celox --bench compilation
+
+      - name: Run compile-time benchmarks
+        uses: CodSpeedHQ/action@v5
+        with:
+          mode: simulation
+          run: cargo codspeed run -p celox

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +431,7 @@ dependencies = [
  "celox-state-layout",
  "celox-testbench",
  "clap",
+ "codspeed-criterion-compat",
  "criterion",
  "fxhash",
  "insta",
@@ -831,10 +841,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "codspeed"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7083f253260bcb4aaa3b4aa4c52973703dabc1a85c2f193997e2689aafa8a919"
+dependencies = [
+ "anyhow",
+ "cc",
+ "colored",
+ "getrandom 0.4.3",
+ "glob",
+ "libc",
+ "nix",
+ "serde",
+ "serde_json",
+ "statrs",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f24251445188c69d50f10179d795424bd71b533b7e3f84fc03f26893b01af0"
+dependencies = [
+ "clap",
+ "codspeed",
+ "codspeed-criterion-compat-walltime",
+ "colored",
+ "regex",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c38205d56e2cb4fe04b708de7f9653a3f1b89edbe3a20b28f21e9e525e9e061"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "codspeed",
+ "criterion-plot 0.5.0",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "console"
@@ -1120,7 +1197,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot",
+ "criterion-plot 0.8.2",
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
@@ -1132,6 +1209,16 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1781,6 +1868,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "globset"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2097,6 +2190,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,6 +2211,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2478,6 +2591,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85fbf1fa9f1babfe396d74bbbf52b3643770243e8f5b0b46715d4caf7f0dfc9a"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -3446,6 +3571,16 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
 
 [[package]]
 name = "strnum_bitwidth"

--- a/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_branchify_mux.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_branchify_mux.rs
@@ -543,13 +543,17 @@ fn run_branchify_mux(
     // and apply the non-overlapping whole-unit plan atomically.  Running
     // here preserves every existing CFG/block-number decision and appends
     // only complete regions which the leaf transforms could not consume.
-    if enable_whole_function_rewrites
-        && let Ok(placement) = PlacementAnalysis::analyze(eu)
-        && let Some(plan) = find_atomic_priority_placement(eu, &placement)
+    let mut placement = enable_whole_function_rewrites
+        .then(|| PlacementAnalysis::analyze(eu).ok())
+        .flatten();
+    let mut placement_stale = false;
+    if let Some(placement) = &placement
+        && let Some(plan) = find_atomic_priority_placement(eu, placement)
     {
         let regions =
             apply_atomic_priority_placement(eu, plan, &mut next_block_id, &mut reg_counter);
         applied += regions;
+        placement_stale = regions != 0;
     }
     verify_stage(eu, "atomic priority placement");
     report_stage("atomic priority placement");
@@ -559,9 +563,11 @@ fn run_branchify_mux(
     // This catches pure/state-versioned DAGs which feed only one existing
     // control arm even when no Mux remains at the use site.  The complete
     // connected move is selected and preflighted before any block changes.
-    if enable_whole_function_rewrites
-        && let Ok(placement) = PlacementAnalysis::analyze(eu)
-        && let Some(plan) = find_existing_cfg_placement(eu, &placement)
+    if placement_stale {
+        placement = PlacementAnalysis::analyze(eu).ok();
+    }
+    if let Some(placement) = &placement
+        && let Some(plan) = find_existing_cfg_placement(eu, placement)
     {
         applied += apply_existing_cfg_placement(eu, plan);
     }

--- a/crates/celox-sir-opt/src/optimizer/passes/memory/block_opt.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/memory/block_opt.rs
@@ -2,6 +2,7 @@ use super::shared::{def_reg, replace_reg_in_terminator};
 use crate::ir::*;
 use crate::{HashMap, HashSet};
 use num_bigint::BigUint;
+use std::collections::BTreeMap;
 
 const MAX_SCALAR_COALESCED_STORE_BITS: usize = 64;
 
@@ -600,7 +601,7 @@ fn coalesce_static_stores<A: Clone + std::fmt::Debug + PartialEq + Ord + std::ha
     true
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct AvailableStaticLoad {
     dst: RegisterId,
     load_offset: usize,
@@ -609,37 +610,77 @@ struct AvailableStaticLoad {
     valid_end: usize,
 }
 
-/// Remove a statically written range from the still-current portions of prior
-/// loads. A write can split one loaded range into two valid fragments: the
-/// register still contains the old value on both non-overlapping sides.
-fn subtract_static_write(
-    loads: &mut Vec<AvailableStaticLoad>,
-    write_start: usize,
-    write_end: usize,
-) {
-    if write_start >= write_end {
-        return;
+#[derive(Default)]
+struct AvailableStaticLoads {
+    by_valid_start: BTreeMap<usize, Vec<AvailableStaticLoad>>,
+    max_valid_width: usize,
+}
+
+impl AvailableStaticLoads {
+    fn insert(&mut self, load: AvailableStaticLoad) {
+        self.max_valid_width = self
+            .max_valid_width
+            .max(load.valid_end.saturating_sub(load.valid_start));
+        self.by_valid_start
+            .entry(load.valid_start)
+            .or_default()
+            .push(load);
     }
-    let mut retained = Vec::with_capacity(loads.len().saturating_add(1));
-    for load in loads.drain(..) {
-        if write_start >= load.valid_end || load.valid_start >= write_end {
-            retained.push(load);
-            continue;
+
+    fn containing(&self, start: usize, end: usize) -> impl Iterator<Item = &AvailableStaticLoad> {
+        let earliest_start = start.saturating_sub(self.max_valid_width);
+        self.by_valid_start
+            .range(earliest_start..=start)
+            .flat_map(|(_, loads)| loads)
+            .filter(move |load| load.valid_start <= start && end <= load.valid_end)
+    }
+
+    /// Remove a statically written range from the still-current portions of
+    /// prior loads. A write can split one loaded range into two valid
+    /// fragments: the register still contains the old value on both
+    /// non-overlapping sides.
+    fn subtract_write(&mut self, write_start: usize, write_end: usize) {
+        if write_start >= write_end {
+            return;
         }
-        if load.valid_start < write_start {
-            retained.push(AvailableStaticLoad {
-                valid_end: write_start,
-                ..load
-            });
-        }
-        if write_end < load.valid_end {
-            retained.push(AvailableStaticLoad {
-                valid_start: write_end,
-                ..load
-            });
+
+        let earliest_start = write_start.saturating_sub(self.max_valid_width.saturating_sub(1));
+        let affected_starts = self
+            .by_valid_start
+            .range(earliest_start..write_end)
+            .filter(|(_, loads)| {
+                loads
+                    .iter()
+                    .any(|load| write_start < load.valid_end && load.valid_start < write_end)
+            })
+            .map(|(&start, _)| start)
+            .collect::<Vec<_>>();
+
+        for start in affected_starts {
+            let loads = self
+                .by_valid_start
+                .remove(&start)
+                .expect("affected load bucket must exist");
+            for load in loads {
+                if write_start >= load.valid_end || load.valid_start >= write_end {
+                    self.insert(load);
+                    continue;
+                }
+                if load.valid_start < write_start {
+                    self.insert(AvailableStaticLoad {
+                        valid_end: write_start,
+                        ..load
+                    });
+                }
+                if write_end < load.valid_end {
+                    self.insert(AvailableStaticLoad {
+                        valid_start: write_end,
+                        ..load
+                    });
+                }
+            }
         }
     }
-    *loads = retained;
 }
 
 /// Replace a later static Load with a Slice of a prior wider static Load when
@@ -650,7 +691,7 @@ fn subsume_static_loads<A: Clone + Eq + std::hash::Hash>(
     instructions: &mut [SIRInstruction<A>],
     register_map: &HashMap<RegisterId, RegisterType>,
 ) -> bool {
-    let mut available: HashMap<A, Vec<AvailableStaticLoad>> = HashMap::default();
+    let mut available: HashMap<A, AvailableStaticLoads> = HashMap::default();
     let mut changed = false;
 
     for inst in instructions {
@@ -667,12 +708,9 @@ fn subsume_static_loads<A: Clone + Eq + std::hash::Hash>(
                 }
 
                 let exact_is_available = available.get(addr).is_some_and(|loads| {
-                    loads.iter().any(|load| {
-                        load.load_offset == offset
-                            && load.load_width == width
-                            && load.valid_start <= offset
-                            && end <= load.valid_end
-                    })
+                    loads
+                        .containing(offset, end)
+                        .any(|load| load.load_offset == offset && load.load_width == width)
                 });
                 if exact_is_available {
                     // Preserve the existing exact-load elimination path, which
@@ -682,11 +720,9 @@ fn subsume_static_loads<A: Clone + Eq + std::hash::Hash>(
 
                 let source = available.get(addr).and_then(|loads| {
                     loads
-                        .iter()
+                        .containing(offset, end)
                         .filter(|load| {
                             load.load_width > width
-                                && load.valid_start <= offset
-                                && end <= load.valid_end
                                 && match (register_map.get(&load.dst), register_map.get(&dst)) {
                                     (
                                         Some(RegisterType::Logic {
@@ -736,7 +772,7 @@ fn subsume_static_loads<A: Clone + Eq + std::hash::Hash>(
                 available
                     .entry(addr.clone())
                     .or_default()
-                    .push(AvailableStaticLoad {
+                    .insert(AvailableStaticLoad {
                         dst,
                         load_offset: offset,
                         load_width: width,
@@ -768,7 +804,7 @@ fn subsume_static_loads<A: Clone + Eq + std::hash::Hash>(
                     continue;
                 };
                 if let Some(loads) = available.get_mut(addr) {
-                    subtract_static_write(loads, *offset, write_end);
+                    loads.subtract_write(*offset, write_end);
                 }
             }
             SIRInstruction::Commit(_, dst, SIROffset::Static(offset), width, triggers) => {
@@ -781,7 +817,7 @@ fn subsume_static_loads<A: Clone + Eq + std::hash::Hash>(
                     continue;
                 };
                 if let Some(loads) = available.get_mut(dst) {
-                    subtract_static_write(loads, *offset, write_end);
+                    loads.subtract_write(*offset, write_end);
                 }
             }
             SIRInstruction::RuntimeEvent { .. }
@@ -932,7 +968,12 @@ fn coalesce_static_loads<A: Clone + std::fmt::Debug + PartialEq + Ord + std::has
     let mut replacements: HashMap<usize, Vec<SIRInstruction<A>>> = HashMap::default();
 
     for seg in segments {
-        if seg.loads.len() < 2 {
+        if seg.loads.len() < 2
+            || seg
+                .loads
+                .iter()
+                .all(|load| load.offset % 8 == 0 && matches!(load.width, 8 | 16 | 32 | 64))
+        {
             continue;
         }
 
@@ -1117,12 +1158,64 @@ fn coalesce_static_loads<A: Clone + std::fmt::Debug + PartialEq + Ord + std::has
     *instructions = out;
 }
 
+#[derive(Default)]
+struct KnownAddressValues {
+    static_values: BTreeMap<usize, (RegisterId, usize)>,
+    other_values: HashMap<SIROffset, (RegisterId, usize)>,
+    max_static_width: usize,
+}
+
+impl KnownAddressValues {
+    fn get(&self, offset: &SIROffset) -> Option<(RegisterId, usize)> {
+        match offset {
+            SIROffset::Static(start) => self.static_values.get(start).copied(),
+            _ => self.other_values.get(offset).copied(),
+        }
+    }
+
+    fn insert(&mut self, offset: SIROffset, value: (RegisterId, usize)) {
+        match offset {
+            SIROffset::Static(start) => {
+                self.max_static_width = self.max_static_width.max(value.1);
+                self.static_values.insert(start, value);
+            }
+            offset => {
+                self.other_values.insert(offset, value);
+            }
+        }
+    }
+
+    fn invalidate_store(&mut self, offset: &SIROffset, width: usize) {
+        let SIROffset::Static(store_start) = offset else {
+            self.static_values.clear();
+            self.other_values.clear();
+            self.max_static_width = 0;
+            return;
+        };
+
+        self.other_values.clear();
+        let store_end = *store_start + width;
+        let earliest_overlap = store_start.saturating_sub(self.max_static_width.saturating_sub(1));
+        let invalidated = self
+            .static_values
+            .range(earliest_overlap..store_end)
+            .filter_map(|(&load_start, &(_, load_width))| {
+                let load_end = load_start + load_width;
+                (*store_start < load_end && load_start < store_end).then_some(load_start)
+            })
+            .collect::<Vec<_>>();
+        for start in invalidated {
+            self.static_values.remove(&start);
+        }
+    }
+}
+
 fn eliminate_redundant_loads<A: Clone + std::fmt::Debug + PartialEq + Ord + std::hash::Hash>(
     instructions: &mut Vec<SIRInstruction<A>>,
     replacement_map: &mut HashMap<RegisterId, RegisterId>,
     register_map: &HashMap<RegisterId, RegisterType>,
 ) {
-    let mut known_values: HashMap<(A, SIROffset), (RegisterId, usize)> = HashMap::default();
+    let mut known_values: HashMap<A, KnownAddressValues> = HashMap::default();
     let mut new_instructions = Vec::with_capacity(instructions.len());
 
     for mut inst in instructions.drain(..) {
@@ -1203,93 +1296,49 @@ fn eliminate_redundant_loads<A: Clone + std::fmt::Debug + PartialEq + Ord + std:
 
         match &inst {
             SIRInstruction::Load(dst, addr, offset, width) => {
-                let key = (addr.clone(), offset.clone());
-                if let Some((existing_reg, existing_width)) = known_values.get(&key)
-                    && *existing_width == *width
+                if let Some((existing_reg, existing_width)) =
+                    known_values.get(addr).and_then(|values| values.get(offset))
+                    && existing_width == *width
                     && register_map
-                        .get(existing_reg)
+                        .get(&existing_reg)
                         .zip(register_map.get(dst))
                         .is_some_and(|(existing, destination)| existing == destination)
                 {
-                    replacement_map.insert(*dst, *existing_reg);
+                    replacement_map.insert(*dst, existing_reg);
                     continue;
                 }
 
-                known_values.insert(key, (*dst, *width));
+                known_values
+                    .entry(addr.clone())
+                    .or_default()
+                    .insert(offset.clone(), (*dst, *width));
                 new_instructions.push(inst);
             }
             SIRInstruction::Store(addr, offset, width, src, _, _) => {
-                let keys_to_remove: Vec<_> = known_values
-                    .keys()
-                    .filter(|(a, _)| *a == *addr)
-                    .cloned()
-                    .collect();
-
-                if let SIROffset::Static(store_off) = offset {
-                    let store_range = *store_off..(*store_off + *width);
-
-                    for key in keys_to_remove {
-                        let (_, key_offset) = &key;
-                        if let SIROffset::Static(load_off) = key_offset {
-                            let load_width = known_values[&key].1;
-                            let load_range = *load_off..(*load_off + load_width);
-
-                            if store_range.start < load_range.end
-                                && load_range.start < store_range.end
-                            {
-                                known_values.remove(&key);
-                            }
-                        } else {
-                            known_values.remove(&key);
-                        }
-                    }
-
-                    let key = (addr.clone(), offset.clone());
-                    known_values.insert(key, (*src, *width));
-                } else {
-                    for key in keys_to_remove {
-                        known_values.remove(&key);
-                    }
+                let values = known_values.entry(addr.clone()).or_default();
+                values.invalidate_store(offset, *width);
+                if matches!(offset, SIROffset::Static(_)) {
+                    values.insert(offset.clone(), (*src, *width));
                 }
 
                 new_instructions.push(inst);
             }
             SIRInstruction::Commit(src_addr, dst_addr, offset, width, triggers) => {
-                let keys_to_remove: Vec<_> = known_values
-                    .keys()
-                    .filter(|(a, _)| *a == *dst_addr)
-                    .cloned()
-                    .collect();
+                known_values
+                    .entry(dst_addr.clone())
+                    .or_default()
+                    .invalidate_store(offset, *width);
 
-                if let SIROffset::Static(commit_off) = offset {
-                    let commit_range = *commit_off..(*commit_off + *width);
-
-                    for key in keys_to_remove {
-                        let (_, key_offset) = &key;
-                        if let SIROffset::Static(load_off) = key_offset {
-                            let load_width = known_values[&key].1;
-                            let load_range = *load_off..(*load_off + load_width);
-                            if commit_range.start < load_range.end
-                                && load_range.start < commit_range.end
-                            {
-                                known_values.remove(&key);
-                            }
-                        } else {
-                            known_values.remove(&key);
-                        }
-                    }
-                } else {
-                    for key in keys_to_remove {
-                        known_values.remove(&key);
-                    }
-                }
-
-                let src_key = (src_addr.clone(), offset.clone());
-                if let Some((src_reg, src_width)) = known_values.get(&src_key).copied()
+                if let Some((src_reg, src_width)) = known_values
+                    .get(src_addr)
+                    .and_then(|values| values.get(offset))
                     && src_width == *width
                     && register_map.get(&src_reg) == Some(&RegisterType::Logic { width: *width })
                 {
-                    known_values.insert((dst_addr.clone(), offset.clone()), (src_reg, *width));
+                    known_values
+                        .entry(dst_addr.clone())
+                        .or_default()
+                        .insert(offset.clone(), (src_reg, *width));
                     new_instructions.push(SIRInstruction::Store(
                         dst_addr.clone(),
                         offset.clone(),
@@ -1315,6 +1364,7 @@ fn eliminate_redundant_loads<A: Clone + std::fmt::Debug + PartialEq + Ord + std:
 #[cfg(test)]
 mod tests {
     use super::{
+        AvailableStaticLoad, AvailableStaticLoads, KnownAddressValues,
         MAX_SCALAR_COALESCED_STORE_BITS, aggregate_static_offset,
         coalesce_static_loads as coalesce_static_loads_with_types,
         coalesce_static_stores as coalesce_static_stores_with_types, optimize_block,
@@ -1346,6 +1396,143 @@ mod tests {
             })
             .collect();
         subsume_static_loads_with_types(instructions, &register_map)
+    }
+
+    #[test]
+    fn known_values_invalidate_only_overlapping_static_ranges() {
+        let mut values = KnownAddressValues::default();
+        values.insert(SIROffset::Static(0), (RegisterId(0), 128));
+        values.insert(SIROffset::Static(160), (RegisterId(1), 32));
+        values.insert(SIROffset::Dynamic(RegisterId(9)), (RegisterId(2), 32));
+
+        values.invalidate_store(&SIROffset::Static(96), 32);
+
+        assert_eq!(values.get(&SIROffset::Static(0)), None);
+        assert_eq!(
+            values.get(&SIROffset::Static(160)),
+            Some((RegisterId(1), 32))
+        );
+        assert_eq!(values.get(&SIROffset::Dynamic(RegisterId(9))), None);
+    }
+
+    #[test]
+    fn dynamic_store_invalidates_every_known_range() {
+        let mut values = KnownAddressValues::default();
+        values.insert(SIROffset::Static(0), (RegisterId(0), 32));
+        values.insert(
+            SIROffset::PackedElements {
+                bit_offset: 32,
+                element_width: 8,
+            },
+            (RegisterId(1), 32),
+        );
+
+        values.invalidate_store(&SIROffset::Dynamic(RegisterId(9)), 32);
+
+        assert_eq!(values.get(&SIROffset::Static(0)), None);
+        assert_eq!(
+            values.get(&SIROffset::PackedElements {
+                bit_offset: 32,
+                element_width: 8,
+            }),
+            None
+        );
+        assert_eq!(values.max_static_width, 0);
+    }
+
+    #[test]
+    fn available_load_index_matches_naive_range_updates() {
+        let original = (0..12usize)
+            .map(|index| {
+                let start = index * 11 % 70;
+                let width = index * 13 % 31 + 1;
+                AvailableStaticLoad {
+                    dst: RegisterId(index),
+                    load_offset: start,
+                    load_width: width,
+                    valid_start: start,
+                    valid_end: start + width,
+                }
+            })
+            .collect::<Vec<_>>();
+        let sort = |loads: &mut Vec<AvailableStaticLoad>| {
+            loads.sort_by_key(|load| {
+                (
+                    load.dst,
+                    load.valid_start,
+                    load.valid_end,
+                    load.load_offset,
+                    load.load_width,
+                )
+            });
+        };
+
+        let mut untouched = AvailableStaticLoads::default();
+        for &load in &original {
+            untouched.insert(load);
+        }
+        for start in 0..96 {
+            for width in 0..24 {
+                let end = start + width;
+                let mut expected = original
+                    .iter()
+                    .filter(|load| load.valid_start <= start && end <= load.valid_end)
+                    .copied()
+                    .collect::<Vec<_>>();
+                let mut actual = untouched
+                    .containing(start, end)
+                    .copied()
+                    .collect::<Vec<_>>();
+                sort(&mut expected);
+                sort(&mut actual);
+                assert_eq!(actual, expected, "containing range {start}..{end}");
+            }
+        }
+
+        for write_start in 0..96 {
+            for write_width in 0..24 {
+                let write_end = write_start + write_width;
+                let mut expected = Vec::new();
+                for &load in &original {
+                    if write_start >= write_end
+                        || write_start >= load.valid_end
+                        || load.valid_start >= write_end
+                    {
+                        expected.push(load);
+                        continue;
+                    }
+                    if load.valid_start < write_start {
+                        expected.push(AvailableStaticLoad {
+                            valid_end: write_start,
+                            ..load
+                        });
+                    }
+                    if write_end < load.valid_end {
+                        expected.push(AvailableStaticLoad {
+                            valid_start: write_end,
+                            ..load
+                        });
+                    }
+                }
+
+                let mut indexed = AvailableStaticLoads::default();
+                for &load in &original {
+                    indexed.insert(load);
+                }
+                indexed.subtract_write(write_start, write_end);
+                let mut actual = indexed
+                    .by_valid_start
+                    .into_values()
+                    .flatten()
+                    .collect::<Vec<_>>();
+                sort(&mut expected);
+                sort(&mut actual);
+                assert_eq!(
+                    actual, expected,
+                    "subtracting write range {write_start}..{write_end}"
+                );
+            }
+        }
     }
 
     fn verify(
@@ -1547,6 +1734,30 @@ mod tests {
                 .all(|instruction| !matches!(instruction, SIRInstruction::Binary(..)))
         );
         verify(instructions, register_map);
+    }
+
+    #[test]
+    fn naturally_aligned_native_loads_skip_coalescing() {
+        let mut instructions = vec![
+            SIRInstruction::Load(RegisterId(0), 7u32, SIROffset::Static(0), 32),
+            SIRInstruction::Load(RegisterId(1), 7u32, SIROffset::Static(32), 32),
+        ];
+        let original = instructions.clone();
+        let mut register_map = [(RegisterId(0), logic(32)), (RegisterId(1), logic(32))]
+            .into_iter()
+            .collect();
+        let mut reg_counter = 1;
+
+        coalesce_static_loads_with_types(
+            &mut instructions,
+            &mut register_map,
+            &mut reg_counter,
+            false,
+            &HashMap::default(),
+        );
+
+        assert_eq!(instructions, original);
+        assert_eq!(reg_counter, 1);
     }
 
     #[test]

--- a/crates/celox-sir-opt/src/optimizer/passes/memory/block_opt.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/memory/block_opt.rs
@@ -334,8 +334,6 @@ fn coalesce_static_stores<A: Clone + std::fmt::Debug + PartialEq + Ord + std::ha
     element_widths: &HashMap<A, usize>,
 ) -> bool {
     let next_id = reg_counter;
-    let mut replaced_indices = std::collections::HashSet::new();
-    let mut insertions: HashMap<usize, Vec<SIRInstruction<A>>> = HashMap::default();
 
     type StoreGroupKey<A> = A;
     let mut groups: HashMap<StoreGroupKey<A>, Vec<usize>> = HashMap::default();
@@ -346,6 +344,31 @@ fn coalesce_static_stores<A: Clone + std::fmt::Debug + PartialEq + Ord + std::ha
             groups.entry(key).or_default().push(idx);
         }
     }
+    // A contiguous run made entirely of naturally aligned native-width
+    // stores is deliberately left unchanged below. Exclude those groups
+    // before building the load index and sorting detailed store metadata.
+    groups.retain(|_, indices| {
+        indices.len() >= 2
+            && indices.iter().any(|&index| {
+                matches!(
+                    &instructions[index],
+                    SIRInstruction::Store(
+                        _,
+                        SIROffset::Static(offset),
+                        width,
+                        _,
+                        _,
+                        _
+                    ) if *offset % 8 != 0 || !matches!(*width, 8 | 16 | 32 | 64)
+                )
+            })
+    });
+    if groups.is_empty() {
+        return false;
+    }
+
+    let mut replaced_indices = std::collections::HashSet::new();
+    let mut insertions: HashMap<usize, Vec<SIRInstruction<A>>> = HashMap::default();
 
     // Pre-index loads by address for efficient safety checks.
     // Each entry is (instruction_index, offset, width, is_dynamic).
@@ -1102,9 +1125,7 @@ fn eliminate_redundant_loads<A: Clone + std::fmt::Debug + PartialEq + Ord + std:
     let mut known_values: HashMap<(A, SIROffset), (RegisterId, usize)> = HashMap::default();
     let mut new_instructions = Vec::with_capacity(instructions.len());
 
-    for inst in instructions.drain(..) {
-        let mut inst = inst.clone();
-
+    for mut inst in instructions.drain(..) {
         match &mut inst {
             SIRInstruction::Binary(_, lhs, _, rhs) => {
                 if let Some(r) = replacement_map.get(lhs) {
@@ -1570,6 +1591,42 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(stores, vec![(0, 12, 24)]);
         verify(instructions, register_map);
+    }
+
+    #[test]
+    fn naturally_aligned_native_stores_skip_coalescing() {
+        let mut instructions = vec![
+            SIRInstruction::Store(
+                7u32,
+                SIROffset::Static(0),
+                32,
+                RegisterId(0),
+                vec![],
+                vec![],
+            ),
+            SIRInstruction::Store(
+                7u32,
+                SIROffset::Static(32),
+                32,
+                RegisterId(1),
+                vec![],
+                vec![],
+            ),
+        ];
+        let original = instructions.clone();
+        let mut register_map = [(RegisterId(0), logic(32)), (RegisterId(1), logic(32))]
+            .into_iter()
+            .collect();
+        let mut reg_counter = 1;
+
+        assert!(!coalesce_static_stores_with_types(
+            &mut instructions,
+            &mut register_map,
+            &mut reg_counter,
+            &HashMap::default(),
+        ));
+        assert_eq!(instructions, original);
+        assert_eq!(reg_counter, 1);
     }
 
     #[test]

--- a/crates/celox-sir-opt/src/optimizer/passes/memory/block_opt.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/memory/block_opt.rs
@@ -2,7 +2,7 @@ use super::shared::{def_reg, replace_reg_in_terminator};
 use crate::ir::*;
 use crate::{HashMap, HashSet};
 use num_bigint::BigUint;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 const MAX_SCALAR_COALESCED_STORE_BITS: usize = 64;
 
@@ -246,26 +246,32 @@ fn schedule_block_interleaved<A: Clone + PartialEq + Eq + std::hash::Hash>(
     // Scheduling loop with incremental ready set
     let mut out = Vec::with_capacity(n);
     let mut inflight_loads: HashSet<RegisterId> = HashSet::default();
-    let mut ready: Vec<usize> = (0..n).filter(|&i| indeg[i] == 0).collect();
+    let mut ready = (0..n).filter(|&i| indeg[i] == 0).collect::<BTreeSet<_>>();
+    let mut ready_stores = ready
+        .iter()
+        .copied()
+        .filter(|&i| matches!(window[i], SIRInstruction::Store(_, _, _, _, _, _)))
+        .collect::<BTreeSet<_>>();
+    let mut ready_loads = ready
+        .iter()
+        .copied()
+        .filter(|&i| matches!(window[i], SIRInstruction::Load(_, _, _, _)))
+        .collect::<BTreeSet<_>>();
 
     while !ready.is_empty() {
-        let pick = ready
-            .iter()
+        let pick = ready_stores
+            .first()
             .copied()
-            .find(|&i| matches!(window[i], SIRInstruction::Store(_, _, _, _, _, _)))
             .or_else(|| {
-                if inflight_loads.len() < max_inflight_loads {
-                    ready
-                        .iter()
-                        .copied()
-                        .find(|&i| matches!(window[i], SIRInstruction::Load(_, _, _, _)))
-                } else {
-                    None
-                }
+                (inflight_loads.len() < max_inflight_loads)
+                    .then(|| ready_loads.first().copied())
+                    .flatten()
             })
-            .unwrap_or(ready[0]);
+            .unwrap_or_else(|| *ready.first().expect("ready set must not be empty"));
 
-        ready.retain(|&x| x != pick);
+        ready.remove(&pick);
+        ready_stores.remove(&pick);
+        ready_loads.remove(&pick);
 
         let inst = window[pick].clone();
         if let SIRInstruction::Load(dst, _, _, _) = inst {
@@ -282,8 +288,16 @@ fn schedule_block_interleaved<A: Clone + PartialEq + Eq + std::hash::Hash>(
         for &s in &succs[pick] {
             indeg[s] -= 1;
             if indeg[s] == 0 {
-                let pos = ready.partition_point(|&x| x < s);
-                ready.insert(pos, s);
+                ready.insert(s);
+                match window[s] {
+                    SIRInstruction::Store(_, _, _, _, _, _) => {
+                        ready_stores.insert(s);
+                    }
+                    SIRInstruction::Load(_, _, _, _) => {
+                        ready_loads.insert(s);
+                    }
+                    _ => {}
+                }
             }
         }
     }
@@ -1368,7 +1382,7 @@ mod tests {
         MAX_SCALAR_COALESCED_STORE_BITS, aggregate_static_offset,
         coalesce_static_loads as coalesce_static_loads_with_types,
         coalesce_static_stores as coalesce_static_stores_with_types, optimize_block,
-        subsume_static_loads as subsume_static_loads_with_types,
+        schedule_instructions, subsume_static_loads as subsume_static_loads_with_types,
     };
     use crate::HashMap;
     use crate::ir::{
@@ -1396,6 +1410,44 @@ mod tests {
             })
             .collect();
         subsume_static_loads_with_types(instructions, &register_map)
+    }
+
+    #[test]
+    fn rescheduling_preserves_store_and_bounded_load_priority() {
+        let mut instructions = vec![
+            SIRInstruction::Imm(RegisterId(0), SIRValue::new(1u8)),
+            SIRInstruction::Load(RegisterId(1), 1u32, SIROffset::Static(0), 8),
+            SIRInstruction::Store(
+                2u32,
+                SIROffset::Static(0),
+                8,
+                RegisterId(0),
+                Vec::new(),
+                Vec::new(),
+            ),
+            SIRInstruction::Unary(RegisterId(2), crate::ir::UnaryOp::Ident, RegisterId(1)),
+            SIRInstruction::Load(RegisterId(3), 3u32, SIROffset::Static(0), 8),
+        ];
+
+        schedule_instructions(&mut instructions, 1);
+
+        assert!(matches!(
+            instructions[0],
+            SIRInstruction::Load(RegisterId(1), ..)
+        ));
+        assert!(matches!(
+            instructions[1],
+            SIRInstruction::Imm(RegisterId(0), ..)
+        ));
+        assert!(matches!(instructions[2], SIRInstruction::Store(2, ..)));
+        assert!(matches!(
+            instructions[3],
+            SIRInstruction::Unary(RegisterId(2), _, RegisterId(1))
+        ));
+        assert!(matches!(
+            instructions[4],
+            SIRInstruction::Load(RegisterId(3), ..)
+        ));
     }
 
     #[test]

--- a/crates/celox-sir-opt/src/optimizer/pipeline/cache.rs
+++ b/crates/celox-sir-opt/src/optimizer/pipeline/cache.rs
@@ -2,6 +2,48 @@
 
 use super::*;
 
+fn fingerprint(units: &[ExecutionUnit<RegionedAbsoluteAddr>]) -> u64 {
+    fn hash_item(value: impl Hash) -> u64 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    units.len().hash(&mut hasher);
+    for unit in units {
+        unit.entry_block_id.hash(&mut hasher);
+
+        unit.blocks.len().hash(&mut hasher);
+        let mut block_xor = 0u64;
+        let mut block_sum = 0u64;
+        for (&block_id, block) in &unit.blocks {
+            let item = hash_item((
+                block_id,
+                &block.params,
+                &block.instructions,
+                &block.terminator,
+            ));
+            block_xor ^= item;
+            block_sum = block_sum.wrapping_add(item);
+        }
+        block_xor.hash(&mut hasher);
+        block_sum.hash(&mut hasher);
+
+        unit.register_map.len().hash(&mut hasher);
+        let mut register_xor = 0u64;
+        let mut register_sum = 0u64;
+        for (&register, ty) in &unit.register_map {
+            let item = hash_item((register, ty));
+            register_xor ^= item;
+            register_sum = register_sum.wrapping_add(item);
+        }
+        register_xor.hash(&mut hasher);
+        register_sum.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
 pub(super) fn optimize_unit_groups_cached(
     groups: &mut crate::HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
     passes: &ExecutionUnitPassManager,
@@ -31,34 +73,6 @@ pub(super) fn optimize_unit_groups_cached(
                     .sum(),
             })
             .collect()
-    }
-
-    fn fingerprint(units: &[ExecutionUnit<RegionedAbsoluteAddr>]) -> u64 {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        units.len().hash(&mut hasher);
-        for unit in units {
-            unit.entry_block_id.hash(&mut hasher);
-
-            let mut block_ids = unit.blocks.keys().copied().collect::<Vec<_>>();
-            block_ids.sort_unstable();
-            block_ids.len().hash(&mut hasher);
-            for block_id in block_ids {
-                let block = &unit.blocks[&block_id];
-                block_id.hash(&mut hasher);
-                block.params.hash(&mut hasher);
-                block.instructions.hash(&mut hasher);
-                block.terminator.hash(&mut hasher);
-            }
-
-            let mut registers = unit.register_map.iter().collect::<Vec<_>>();
-            registers.sort_unstable_by_key(|(register, _)| **register);
-            registers.len().hash(&mut hasher);
-            for (register, ty) in registers {
-                register.hash(&mut hasher);
-                ty.hash(&mut hasher);
-            }
-        }
-        hasher.finish()
     }
 
     struct EquivalenceClass {
@@ -131,5 +145,58 @@ pub(super) fn optimize_unit_groups_cached(
             groups.len(),
             start.elapsed()
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fingerprint;
+    use crate::HashMap;
+    use crate::ir::{
+        BasicBlock, BlockId, ExecutionUnit, RegisterId, RegisterType, SIRInstruction,
+        SIRTerminator, SIRValue, UnaryOp,
+    };
+
+    fn unit(reverse: bool) -> ExecutionUnit<crate::ir::RegionedAbsoluteAddr> {
+        let entry = BasicBlock {
+            id: BlockId(0),
+            params: Vec::new(),
+            instructions: vec![SIRInstruction::Imm(RegisterId(0), SIRValue::new(1u8))],
+            terminator: SIRTerminator::Jump(BlockId(1), Vec::new()),
+        };
+        let exit = BasicBlock {
+            id: BlockId(1),
+            params: Vec::new(),
+            instructions: vec![SIRInstruction::Unary(
+                RegisterId(1),
+                UnaryOp::Ident,
+                RegisterId(0),
+            )],
+            terminator: SIRTerminator::Return,
+        };
+        let mut blocks = HashMap::default();
+        let mut register_map = HashMap::default();
+        let logic = RegisterType::Logic { width: 1 };
+        if reverse {
+            blocks.insert(BlockId(1), exit);
+            blocks.insert(BlockId(0), entry);
+            register_map.insert(RegisterId(1), logic.clone());
+            register_map.insert(RegisterId(0), logic);
+        } else {
+            blocks.insert(BlockId(0), entry);
+            blocks.insert(BlockId(1), exit);
+            register_map.insert(RegisterId(0), logic.clone());
+            register_map.insert(RegisterId(1), logic);
+        }
+        ExecutionUnit {
+            blocks,
+            entry_block_id: BlockId(0),
+            register_map,
+        }
+    }
+
+    #[test]
+    fn fingerprint_is_independent_of_hash_map_iteration_order() {
+        assert_eq!(fingerprint(&[unit(false)]), fingerprint(&[unit(true)]));
     }
 }

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -83,6 +83,7 @@ harness = false
 [[bench]]
 name = "compilation"
 harness = false
+bench = false
 
 [lints]
 workspace = true

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -65,6 +65,7 @@ celox-backend-arm64   = { path = "../celox-backend-arm64", optional = true }
 [dev-dependencies]
 insta      = "1.46"
 criterion  = "0.8"
+codspeed-criterion-compat = "5.0.1"
 proptest   = "1.10"
 test-case  = "3"
 tempfile.workspace = true
@@ -77,6 +78,10 @@ harness = false
 
 [[bench]]
 name = "overhead"
+harness = false
+
+[[bench]]
+name = "compilation"
 harness = false
 
 [lints]

--- a/crates/celox/benches/compilation.rs
+++ b/crates/celox/benches/compilation.rs
@@ -1,0 +1,51 @@
+// CodSpeed's Criterion harness reads its own environment during macro expansion.
+#![allow(clippy::disallowed_methods)]
+
+use celox::Simulator;
+use codspeed_criterion_compat::{Criterion, black_box, criterion_group, criterion_main};
+
+const COUNTER: &str = include_str!("../../../benches/veryl/top_n1000.veryl");
+const AXI_LITE_REG_FILE: &str = include_str!("../tests/fixtures/bitslice/axi_lite_reg_file.veryl");
+
+fn compile_default(source: &str, top: &str, parameter: Option<(&str, u64)>) {
+    let mut builder = Simulator::builder(black_box(source), top);
+    if let Some((name, value)) = parameter {
+        builder = builder.param(name, value);
+    }
+    black_box(builder.build().expect("benchmark design should compile"));
+}
+
+fn benchmark_compilation(c: &mut Criterion) {
+    // Initialize process-global analyzer state outside CodSpeed's measured spans.
+    // Otherwise the first benchmark alone would include one-time setup work.
+    compile_default(COUNTER, "Top", Some(("N", 1)));
+
+    let mut group = c.benchmark_group("compile/default");
+
+    group.bench_function("counter_n1", |b| {
+        b.iter(|| compile_default(COUNTER, "Top", Some(("N", 1))));
+    });
+
+    group.bench_function("axi_lite_reg_file", |b| {
+        b.iter(|| compile_default(AXI_LITE_REG_FILE, "AxiLiteRegFile", None));
+    });
+
+    group.bench_function("counter_n1000", |b| {
+        b.iter(|| compile_default(COUNTER, "Top", Some(("N", 1_000))));
+    });
+
+    group.finish();
+
+    c.bench_function("compile/cranelift/counter_n1000", |b| {
+        b.iter(|| {
+            let simulator = Simulator::builder(black_box(COUNTER), "Top")
+                .param("N", 1_000)
+                .build_cranelift()
+                .expect("benchmark design should compile with Cranelift");
+            black_box(simulator);
+        });
+    });
+}
+
+criterion_group!(benches, benchmark_compilation);
+criterion_main!(benches);

--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -15,6 +15,7 @@ The complete benchmark matrix and raw history are available on the
 
 | Group | What it exercises |
 |---|---|
+| Compile time (CodSpeed) | End-to-end frontend, optimization, layout, and native/Cranelift code generation |
 | Counter | Sequential state updates and clock-event overhead |
 | Standard library | A mix of combinational, sequential, and structured datapaths |
 | TypeScript testbench | N-API calls, typed signal access, and scheduler overhead |
@@ -39,6 +40,11 @@ described in [Heliodor Linux Benchmark](./heliodor.md).
 ## Run locally
 
 ```bash
+# Compile-time benchmarks with CodSpeed
+cargo install cargo-codspeed --locked --version 5.0.1
+cargo codspeed build --locked -p celox --bench compilation
+cargo codspeed run -p celox
+
 # Rust benchmarks
 cargo bench -p celox
 
@@ -48,6 +54,10 @@ pnpm bench
 # Verilator comparison (requires Verilator and a C++ toolchain)
 bash scripts/run-verilator-bench.sh
 ```
+
+The CodSpeed workflow runs on pull requests, merge queues, and `master`. Pull
+requests are compared with the `master` baseline using deterministic CPU
+simulation, while the local command only checks that the benchmark suite runs.
 
 Local measurements are most useful for comparing two revisions on the same
 machine. CI history is better for long-term trends than for small one-off deltas.

--- a/docs/ja/benchmarks/index.md
+++ b/docs/ja/benchmarks/index.md
@@ -15,6 +15,7 @@ RTL 設計の性能を予測するものではありません。
 
 | グループ | 測定対象 |
 |---|---|
+| コンパイル時間 (CodSpeed) | フロントエンド、最適化、レイアウト、native/Cranelift コード生成の全工程 |
 | Counter | 順序状態の更新とクロックイベントのオーバーヘッド |
 | 標準ライブラリ | 組み合わせ回路、順序回路、構造化データパス |
 | TypeScript テストベンチ | N-API 呼び出し、型付き信号アクセス、スケジューラ |
@@ -38,6 +39,11 @@ Heliodor では固定入力の追加ワークロードを使います。測定�
 ## ローカル実行
 
 ```bash
+# CodSpeed によるコンパイル時間ベンチマーク
+cargo install cargo-codspeed --locked --version 5.0.1
+cargo codspeed build --locked -p celox --bench compilation
+cargo codspeed run -p celox
+
 # Rust ベンチマーク
 cargo bench -p celox
 
@@ -47,6 +53,10 @@ pnpm bench
 # Verilator 比較（Verilator と C++ ツールチェーンが必要）
 bash scripts/run-verilator-bench.sh
 ```
+
+CodSpeed ワークフローは pull request、merge queue、`master` で実行されます。pull
+request は決定的な CPU simulation を使って `master` の基準値と比較されます。
+ローカル実行ではベンチマーク suite が動作することだけを確認します。
 
 ローカル計測は、同じマシン上で 2 つのリビジョンを比較する場合に最も有効です。
 CI 履歴は、単発の小さな差より長期的な傾向の確認に向いています。


### PR DESCRIPTION
## Summary

- add a dedicated compile-time benchmark suite for small, realistic, and generated-scale Veryl designs
- cover both the default native compiler and the Cranelift backend
- run CodSpeed CPU simulation on pull requests, merge groups, and pushes to `master` using job-scoped OIDC
- document the CodSpeed workflow and local commands in English and Japanese

## Why

Compile-time performance was only mixed into the broader runtime benchmark suite, so regressions were difficult to isolate and were not reported on pull requests. This adds stable, compiler-focused measurements and a `master` baseline for continuous comparison.

## Impact

Contributors will receive CodSpeed performance reports for compiler changes before merge. Existing simulation, TypeScript, Verilator, and Heliodor benchmark workflows remain unchanged.

## Validation

- `cargo codspeed build --locked -p celox --bench compilation`
- `cargo codspeed run -p celox` (all four benchmarks detected and executed)
- `cargo bench --locked -p celox --bench compilation -- --test`
- `cargo clippy --locked -p celox --bench compilation --no-deps`
- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo fmt --all -- --check`
- `pnpm docs:build`
- workflow YAML parse and `git diff --check`
- repository pre-push hook
