### PR TITLE
ci: skip unrelated ARM64 Heliodor PR runs

### DIFF
--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -202,7 +202,7 @@ jobs:
     name: ARM64 Linux boot
     needs: arm64-changes
     if: >-
-      always() &&
+      !cancelled() &&
       github.event_name != 'schedule' &&
       (github.event_name != 'pull_request' ||
       needs.arm64-changes.result != 'success' ||

--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -12,6 +12,8 @@ on:
       - "crates/**"
       - "!crates/celox-napi/package.json"
       - "scripts/convert-heliodor-bench.mjs"
+      - "scripts/ci-changes.mjs"
+      - "scripts/ci-changes.test.mjs"
       - "scripts/run-heliodor-bench.sh"
   schedule:
     - cron: "37 2 * * *"
@@ -30,6 +32,28 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' }}
 
 jobs:
+  # PRs use this gate to avoid spending a dedicated ARM runner on unrelated
+  # Rust changes. Detection failures fail open in arm64-linux-boot below.
+  arm64-changes:
+    name: Detect ARM64 changes
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      heliodor_arm64: ${{ steps.classify.outputs.heliodor_arm64 }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed files
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/ci-changes.mjs "$BASE_SHA" "$HEAD_SHA"
+
   heliodor:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
@@ -176,7 +200,13 @@ jobs:
 
   arm64-linux-boot:
     name: ARM64 Linux boot
-    if: github.event_name != 'schedule'
+    needs: arm64-changes
+    if: >-
+      always() &&
+      github.event_name != 'schedule' &&
+      (github.event_name != 'pull_request' ||
+      needs.arm64-changes.result != 'success' ||
+      needs.arm64-changes.outputs.heliodor_arm64 == 'true')
     permissions:
       contents: read
     runs-on: ubuntu-24.04-arm

--- a/scripts/ci-changes.mjs
+++ b/scripts/ci-changes.mjs
@@ -37,6 +37,32 @@ function startsWithAny(path, prefixes) {
   return prefixes.some((prefix) => path.startsWith(prefix));
 }
 
+export function affectsHeliodorArm64(files) {
+  // Keep PR scheduling deliberately narrow. Generic Rust and manifest changes
+  // still exercise x86-64/Cranelift in PRs, while master and manual runs always
+  // retain the ARM64 Linux boot coverage.
+  return files
+    .map((path) => path.replace(/^\.\//, ""))
+    .some(
+      (path) =>
+        path === ".github/workflows/heliodor-bench.yml" ||
+        startsWithAny(path, [
+          ".github/actions/setup-rust/",
+          "crates/celox-backend-arm64/",
+          "crates/celox-backend-common/",
+          "crates/celox/src/backend/native/",
+          "scripts/ci-changes.",
+        ]) ||
+        [
+          "crates/celox/src/backend.rs",
+          "crates/celox-bench/src/bin/celox-heliodor.rs",
+          "scripts/run-heliodor-bench.sh",
+          "scripts/setup-arm64-backend-dev.sh",
+          "scripts/tests/run-heliodor-bench-gate.sh",
+        ].includes(path),
+    );
+}
+
 export function classifyFiles(files, { releasePlease = false } = {}) {
   const affected = {
     docs: false,
@@ -168,11 +194,14 @@ if (
   import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
   const files = changedFiles(process.argv[2] ?? "", process.argv[3] ?? "");
-  writeOutputs(
+  const affected =
     files === null
-      ? ALL_AFFECTED
-      : classifyFiles(files, {
-          releasePlease: process.env.RELEASE_PLEASE_PR === "true",
-        }),
-  );
+      ? { ...ALL_AFFECTED, heliodor_arm64: true }
+      : {
+          ...classifyFiles(files, {
+            releasePlease: process.env.RELEASE_PLEASE_PR === "true",
+          }),
+          heliodor_arm64: affectsHeliodorArm64(files),
+        };
+  writeOutputs(affected);
 }

--- a/scripts/ci-changes.mjs
+++ b/scripts/ci-changes.mjs
@@ -56,6 +56,7 @@ export function affectsHeliodorArm64(files) {
         [
           "crates/celox/src/backend.rs",
           "crates/celox-bench/src/bin/celox-heliodor.rs",
+          "crates/celox-bench/src/bin/veryl-heliodor.rs",
           "scripts/run-heliodor-bench.sh",
           "scripts/setup-arm64-backend-dev.sh",
           "scripts/tests/run-heliodor-bench-gate.sh",

--- a/scripts/ci-changes.test.mjs
+++ b/scripts/ci-changes.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { classifyFiles } from "./ci-changes.mjs";
+import {
+  affectsHeliodorArm64,
+  classifyFiles,
+} from "./ci-changes.mjs";
 
 const none = {
   docs: false,
@@ -103,4 +106,34 @@ test("repository script changes only run script tests", () => {
 
 test("unknown paths fail open", () => {
   assert.deepEqual(classifyFiles(["new-source-area/input.xyz"]), all);
+});
+
+test("ARM64 Heliodor changes include backend and harness integration", () => {
+  for (const path of [
+    "crates/celox-backend-arm64/src/lib.rs",
+    "crates/celox-backend-common/src/lib.rs",
+    "crates/celox/src/backend/native/backend.rs",
+    "crates/celox/src/backend.rs",
+    "crates/celox-bench/src/bin/celox-heliodor.rs",
+    "scripts/run-heliodor-bench.sh",
+    ".github/actions/setup-rust/action.yml",
+    ".github/workflows/heliodor-bench.yml",
+    "scripts/ci-changes.mjs",
+  ]) {
+    assert.equal(affectsHeliodorArm64([path]), true, path);
+  }
+});
+
+test("generic Rust changes do not schedule ARM64 Heliodor on pull requests", () => {
+  assert.equal(
+    affectsHeliodorArm64([
+      "Cargo.lock",
+      "Cargo.toml",
+      "crates/celox/Cargo.toml",
+      "crates/celox/src/simulator.rs",
+      "crates/celox-backend-x86/src/lib.rs",
+      ".github/workflows/codspeed.yml",
+    ]),
+    false,
+  );
 });

--- a/scripts/ci-changes.test.mjs
+++ b/scripts/ci-changes.test.mjs
@@ -115,6 +115,7 @@ test("ARM64 Heliodor changes include backend and harness integration", () => {
     "crates/celox/src/backend/native/backend.rs",
     "crates/celox/src/backend.rs",
     "crates/celox-bench/src/bin/celox-heliodor.rs",
+    "crates/celox-bench/src/bin/veryl-heliodor.rs",
     "scripts/run-heliodor-bench.sh",
     ".github/actions/setup-rust/action.yml",
     ".github/workflows/heliodor-bench.yml",


### PR DESCRIPTION
## Summary

- detect whether a pull request changes ARM64-specific backend or Heliodor integration files
- skip the dedicated ARM64 Linux boot job for unrelated pull requests
- keep ARM64 Linux boot coverage for `master` pushes, manual runs, and change-detection failures

## Why

The organization uses the GitHub Free plan, which limits standard GitHub-hosted runner concurrency. The ARM64 Linux boot job can occupy a dedicated ARM runner for up to 60 minutes and previously ran for every Rust-related pull request, including generic manifest and lockfile changes.

## Impact

Generic Rust, Cargo manifest, lockfile, x86 backend, and CodSpeed workflow changes no longer schedule the ARM64 Linux boot job on pull requests. Changes to the ARM64 backend, shared backend, native backend adapter, Heliodor runner or harness, Rust setup action, classifier, or Heliodor workflow still schedule it. Detection failures fail open.

## Validation

- `node --test scripts/ci-changes.test.mjs`
- JavaScript syntax checks with `node --check`
- workflow YAML parse
- `git diff --check`
- repository pre-push hook, including submodule check, Biome, Cargo formatting, and `cargo check --workspace --locked`
- actual CodSpeed PR diff classified as `heliodor_arm64=false`
- actual ARM64 Linux boot PR diff classified as `heliodor_arm64=true`
