### PR TITLE
fix(ci): stop repeated Veryl lockfile rolls

### DIFF
--- a/.github/workflows/veryl-head.yml
+++ b/.github/workflows/veryl-head.yml
@@ -73,9 +73,16 @@ jobs:
             exit 1
           fi
           node scripts/use-veryl-head.mjs "$veryl_revision"
-          # Updating one changed Veryl root resolves the complete shared git
-          # dependency graph without also refreshing unrelated unlocked crates.
-          cargo update -p veryl-analyzer
+          if git diff --quiet -- Cargo.toml; then
+            # A merged roll updates Cargo.lock and retriggers this workflow. Do
+            # not resolve the unchanged graph again: broad transitive version
+            # ranges can make cargo update alternate between valid lockfiles.
+            echo "develop already pins Veryl HEAD $veryl_revision."
+          else
+            # Updating one changed Veryl root resolves the complete shared git
+            # dependency graph without also refreshing unrelated unlocked crates.
+            cargo update -p veryl-analyzer
+          fi
           echo "VERYL_REVISION=$veryl_revision" >> "$GITHUB_ENV"
 
       - name: Create the rolling integration branch

--- a/scripts/use-veryl-head.test.mjs
+++ b/scripts/use-veryl-head.test.mjs
@@ -41,6 +41,12 @@ test("pins every Veryl workspace dependency to one HEAD revision", () => {
   );
 });
 
+test("is idempotent when the manifest already pins the requested revision", () => {
+  const pinned = useVerylHead(manifest, revision);
+
+  assert.equal(useVerylHead(pinned, revision), pinned);
+});
+
 test("rejects an ambiguous revision", () => {
   assert.throws(() => useVerylHead(manifest, "master"), /full lowercase git revision/);
 });


### PR DESCRIPTION
## Summary

- skip `cargo update -p veryl-analyzer` when `develop` already pins the resolved Veryl HEAD revision
- preserve the targeted Cargo update when the Veryl revision actually changes
- add an idempotency regression test for applying the same Veryl HEAD pin twice

## Root cause

The Veryl roll changes `Cargo.lock`, which retriggers the workflow after merge. With the same git revision, Cargo 1.97.1 alternates broad transitive dependency edges between already-locked `getrandom` and `windows-sys` versions, producing another valid but different lockfile on every run.

## Impact

A completed Veryl roll no longer creates another lockfile-only roll for the same upstream revision. New Veryl revisions continue to refresh the shared git dependency graph normally.

## Validation

- `node --test scripts/*.test.mjs`
- `git diff --check`
- pre-push hook: submodule check, `cargo fmt`, Biome, `cargo check`, clean-tree check