### PR TITLE
ci: decouple develop sync from master queue

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -79,7 +79,13 @@ jobs:
             exit 0
           fi
 
-          git push origin "$master_sha:refs/heads/$SYNC_BRANCH"
+          # Conflict resolution can add commits to the disposable sync branch.
+          # Reset it to master only if it has not moved since this inspection.
+          sync_ref="refs/heads/$SYNC_BRANCH"
+          remote_sync_sha="$(git ls-remote origin "$sync_ref" | cut -f1)"
+          git push origin \
+            --force-with-lease="$sync_ref:$remote_sync_sha" \
+            "$master_sha:$sync_ref"
 
           sync_pr="$(
             gh pr list \

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -15,6 +15,8 @@ jobs:
   sync:
     name: Merge master into develop
     runs-on: ubuntu-latest
+    env:
+      SYNC_BRANCH: integration/master-to-develop
     steps:
       - name: Create release app token
         id: release-token
@@ -53,17 +55,37 @@ jobs:
         shell: bash
         run: |
           git fetch --no-tags origin refs/heads/develop:refs/remotes/origin/develop
+
+          # Do not use master itself as a pull request head. A queued develop
+          # synchronization would then hold the branch that master's own merge
+          # queue needs to advance. Remove any PR created by the old workflow
+          # before switching to the dedicated synchronization branch.
+          legacy_pr="$(
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --base develop \
+              --head master \
+              --json number,isCrossRepository \
+              --jq '[.[] | select(.isCrossRepository == false)][0].number // empty'
+          )"
+          if [ -n "$legacy_pr" ]; then
+            gh pr close "$legacy_pr" --repo "$GITHUB_REPOSITORY"
+          fi
+
           if git merge-base --is-ancestor "$GITHUB_SHA" origin/develop; then
             echo "develop already contains master $GITHUB_SHA."
             exit 0
           fi
+
+          git push origin "$GITHUB_SHA:refs/heads/$SYNC_BRANCH"
 
           sync_pr="$(
             gh pr list \
               --repo "$GITHUB_REPOSITORY" \
               --state open \
               --base develop \
-              --head master \
+              --head "$SYNC_BRANCH" \
               --json number,isCrossRepository \
               --jq '[.[] | select(.isCrossRepository == false)][0].number // empty'
           )"
@@ -73,9 +95,9 @@ jobs:
               gh pr create \
                 --repo "$GITHUB_REPOSITORY" \
                 --base develop \
-                --head master \
+                --head "$SYNC_BRANCH" \
                 --title "chore(develop): sync master" \
-                --body $'Bring stable-trunk changes into the Veryl HEAD compatibility lane.\n\nThis PR is managed automatically. A conflict is actionable and must be resolved without replacing the Veryl HEAD dependency on `develop`.'
+                --body $'Bring stable-trunk changes into the Veryl HEAD compatibility lane.\n\nThis PR is managed automatically through a dedicated synchronization branch so the develop merge queue never holds `master` itself as a pull request head. A conflict is actionable and must be resolved without replacing the Veryl HEAD dependency on `develop`.'
             )"
           fi
 

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -45,7 +45,7 @@ jobs:
             exit 0
           fi
 
-          git push origin "${GITHUB_SHA}:refs/heads/develop"
+          git push origin "HEAD:refs/heads/develop"
           echo "created=true" >> "$GITHUB_OUTPUT"
 
       - name: Open or update the master synchronization pull request
@@ -55,6 +55,7 @@ jobs:
         shell: bash
         run: |
           git fetch --no-tags origin refs/heads/develop:refs/remotes/origin/develop
+          master_sha="$(git rev-parse HEAD)"
 
           # Do not use master itself as a pull request head. A queued develop
           # synchronization would then hold the branch that master's own merge
@@ -73,12 +74,12 @@ jobs:
             gh pr close "$legacy_pr" --repo "$GITHUB_REPOSITORY"
           fi
 
-          if git merge-base --is-ancestor "$GITHUB_SHA" origin/develop; then
-            echo "develop already contains master $GITHUB_SHA."
+          if git merge-base --is-ancestor "$master_sha" origin/develop; then
+            echo "develop already contains master $master_sha."
             exit 0
           fi
 
-          git push origin "$GITHUB_SHA:refs/heads/$SYNC_BRANCH"
+          git push origin "$master_sha:refs/heads/$SYNC_BRANCH"
 
           sync_pr="$(
             gh pr list \


### PR DESCRIPTION
## Summary

- synchronize `master` into `develop` through `integration/master-to-develop`
- close any legacy synchronization PR that uses `master` itself as its head
- keep the dedicated synchronization PR enrolled in `develop`'s merge queue

## Why

The existing `master → develop` PR places `master` itself in the develop merge queue. While that synchronization runs its required checks, it couples the branch needed by master's own merge queue to a second queue.

Using a dedicated fast-forwarded synchronization branch keeps the two queues independent while preserving the protected PR-based develop update.

## Impact

The next master push migrates any open legacy synchronization PR automatically. Normal master pull requests can continue through their merge queue while the develop synchronization is still being validated.

## Validation

- `actionlint v1.7.12 .github/workflows/sync-develop.yml`
- `git diff --check`
- pre-push submodule check
- `cargo fmt --all -- --check`
- Biome check
- `cargo check --workspace --locked`
