### PR TITLE
fix(ci): allow stable develop transition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     if: always() && (needs.changes.result != 'success' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.javascript == 'true' || needs.changes.outputs.scripts == 'true')
     runs-on: ubuntu-latest
     env:
-      VERYL_LANE: ${{ ((github.event_name == 'push' && github.ref_name == 'develop') || (github.event_name == 'pull_request' && github.base_ref == 'develop') || (github.event_name == 'merge_group' && github.event.merge_group.base_ref == 'refs/heads/develop')) && 'head' || 'stable' }}
+      VERYL_LANE: ${{ ((github.event_name == 'push' && github.ref_name == 'develop') || (github.event_name == 'pull_request' && github.base_ref == 'develop') || (github.event_name == 'merge_group' && github.event.merge_group.base_ref == 'refs/heads/develop')) && 'detect' || 'stable' }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -92,8 +92,14 @@ jobs:
         if: needs.changes.result != 'success' || needs.changes.outputs.rust == 'true'
         shell: bash
         run: |
-          node scripts/check-veryl-lane.mjs "$VERYL_LANE"
-          if [ "$VERYL_LANE" = stable ]; then
+          if [ "$VERYL_LANE" = detect ]; then
+            detected_lane="$(node scripts/check-veryl-lane.mjs detect)"
+            echo "Detected Veryl $detected_lane lane on develop."
+          else
+            node scripts/check-veryl-lane.mjs "$VERYL_LANE"
+            detected_lane="$VERYL_LANE"
+          fi
+          if [ "$detected_lane" = stable ]; then
             node scripts/veryl-vendor.mjs check
           fi
 

--- a/scripts/check-veryl-lane.mjs
+++ b/scripts/check-veryl-lane.mjs
@@ -3,50 +3,153 @@ import fs from "node:fs";
 import { verylDependencyNames } from "./use-veryl-head.mjs";
 
 const verylRepository = "https://github.com/veryl-lang/veryl.git";
+const exactVersion =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:[-+][0-9A-Za-z.-]+)?$/;
+
+function workspaceDependencies(manifest) {
+  const header = "[workspace.dependencies]";
+  const start = manifest.indexOf(`${header}\n`);
+  if (start === -1) {
+    throw new Error(`Could not find ${header}`);
+  }
+
+  const bodyStart = start + header.length + 1;
+  const next = manifest.indexOf("\n[", bodyStart);
+  return manifest.slice(bodyStart, next === -1 ? manifest.length : next + 1);
+}
+
+function dependencyDeclaration(dependencies, name) {
+  const escaped = name.replaceAll("-", "\\-");
+  const matches = [
+    ...dependencies.matchAll(new RegExp(`^${escaped}\\s*=\\s*(.+)$`, "gm")),
+  ];
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one workspace dependency ${name}, found ${matches.length}`,
+    );
+  }
+  return matches[0][1].replace(/\s+#.*$/, "").trim();
+}
+
+function fieldValues(declaration, field) {
+  const occurrences = [
+    ...declaration.matchAll(new RegExp(`\\b${field}\\s*=`, "g")),
+  ];
+  const values = [
+    ...declaration.matchAll(new RegExp(`\\b${field}\\s*=\\s*"([^"]*)"`, "g")),
+  ];
+  if (occurrences.length !== values.length) {
+    throw new Error(`Veryl dependency field ${field} must be a string`);
+  }
+  return values.map((match) => match[1]);
+}
+
+function stableVersion(name, declaration) {
+  if (/\b(?:git|rev|path|branch|tag|registry|package)\s*=/.test(declaration)) {
+    throw new Error(
+      `Released Veryl dependency ${name} uses a non-release source`,
+    );
+  }
+
+  const direct = declaration.match(/^"([^"]+)"$/);
+  const versions = fieldValues(declaration, "version");
+  const version = direct?.[1] ?? (versions.length === 1 ? versions[0] : undefined);
+  if (
+    version === undefined ||
+    !exactVersion.test(version) ||
+    (direct === null && !/^\{.*\}$/.test(declaration))
+  ) {
+    throw new Error(`Released Veryl dependency ${name} must use one exact version`);
+  }
+  return version;
+}
+
+function headRevision(name, declaration) {
+  if (!/^\{.*\}$/.test(declaration)) {
+    throw new Error(
+      `Veryl HEAD dependency ${name} must use an inline git dependency`,
+    );
+  }
+  if (/\b(?:version|path|branch|tag|registry|package)\s*=/.test(declaration)) {
+    throw new Error(
+      `Veryl HEAD dependency ${name} mixes incompatible source fields`,
+    );
+  }
+
+  const repositories = fieldValues(declaration, "git");
+  if (repositories.length !== 1 || repositories[0] !== verylRepository) {
+    throw new Error(
+      `Veryl HEAD dependency ${name} does not use the upstream repository`,
+    );
+  }
+
+  const revisions = fieldValues(declaration, "rev");
+  if (revisions.length !== 1 || !/^[0-9a-f]{40}$/.test(revisions[0])) {
+    throw new Error(`Veryl HEAD dependency ${name} is not pinned to one full revision`);
+  }
+  return revisions[0];
+}
+
+export function detectVerylLane(manifest) {
+  const dependencies = workspaceDependencies(manifest);
+  const lanes = new Set();
+  const versions = new Set();
+  const revisions = new Set();
+
+  for (const name of verylDependencyNames) {
+    const declaration = dependencyDeclaration(dependencies, name);
+    if (/\b(?:git|rev|branch|tag)\s*=/.test(declaration)) {
+      lanes.add("head");
+      revisions.add(headRevision(name, declaration));
+    } else {
+      lanes.add("stable");
+      versions.add(stableVersion(name, declaration));
+    }
+  }
+
+  if (lanes.size !== 1) {
+    throw new Error("Veryl workspace dependencies mix released and HEAD declarations");
+  }
+
+  const [lane] = lanes;
+  if (lane === "stable") {
+    if (versions.size !== 1) {
+      throw new Error(
+        `Released Veryl dependencies use ${versions.size} different versions`,
+      );
+    }
+    return { lane, version: [...versions][0] };
+  }
+
+  if (revisions.size !== 1) {
+    throw new Error(`Veryl HEAD dependencies use ${revisions.size} different revisions`);
+  }
+  return { lane, revision: [...revisions][0] };
+}
 
 export function checkVerylLane(manifest, lane) {
   if (lane !== "stable" && lane !== "head") {
     throw new Error(`Expected Veryl lane stable or head, got ${lane}`);
   }
 
-  const revisions = new Set();
-  for (const name of verylDependencyNames) {
-    const match = manifest.match(new RegExp(`^${name}\\s*=\\s*(.+)$`, "m"));
-    if (match === null) {
-      throw new Error(`Could not find workspace dependency ${name}`);
-    }
-
-    const declaration = match[1];
-    if (lane === "stable") {
-      if (/\bgit\s*=/.test(declaration)) {
-        throw new Error(`Stable Veryl lane cannot use a git dependency: ${name}`);
-      }
-      continue;
-    }
-
-    if (!declaration.includes(`git = "${verylRepository}"`)) {
-      throw new Error(`Veryl HEAD dependency ${name} does not use the upstream repository`);
-    }
-    const revision = declaration.match(/\brev\s*=\s*"([0-9a-f]{40})"/);
-    if (revision === null) {
-      throw new Error(`Veryl HEAD dependency ${name} is not pinned to a full revision`);
-    }
-    revisions.add(revision[1]);
+  const detected = detectVerylLane(manifest);
+  if (detected.lane !== lane) {
+    throw new Error(`Expected Veryl ${lane} lane, detected ${detected.lane}`);
   }
-
-  if (lane === "head" && revisions.size !== 1) {
-    throw new Error(`Veryl HEAD dependencies use ${revisions.size} different revisions`);
-  }
-
-  return lane === "head" ? [...revisions][0] : undefined;
+  return detected.lane === "head" ? detected.revision : undefined;
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   const lane = process.argv[2] ?? "";
-  const revision = checkVerylLane(fs.readFileSync("Cargo.toml", "utf8"), lane);
-  console.log(
-    lane === "head"
-      ? `Validated Veryl HEAD lane at ${revision}`
-      : "Validated released Veryl lane",
-  );
+  const manifest = fs.readFileSync("Cargo.toml", "utf8");
+  if (lane === "detect") {
+    console.log(detectVerylLane(manifest).lane);
+  } else {
+    const revision = checkVerylLane(manifest, lane);
+    console.log(
+      lane === "head"
+        ? `Validated Veryl HEAD lane at ${revision}`
+        : "Validated released Veryl lane",
+    );
+  }
 }

--- a/scripts/check-veryl-lane.test.mjs
+++ b/scripts/check-veryl-lane.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { checkVerylLane } from "./check-veryl-lane.mjs";
+import {
+  checkVerylLane,
+  detectVerylLane,
+} from "./check-veryl-lane.mjs";
 import { useVerylHead } from "./use-veryl-head.mjs";
 
 const revision = "0123456789abcdef0123456789abcdef01234567";
@@ -15,22 +18,92 @@ veryl-simulator = "0.20.3"
 veryl-std = "0.20.3"
 `;
 
-test("accepts released crates only in the stable lane", () => {
+test("detects a complete released lane", () => {
+  assert.deepEqual(detectVerylLane(stableManifest), {
+    lane: "stable",
+    version: "0.20.3",
+  });
   assert.equal(checkVerylLane(stableManifest, "stable"), undefined);
-  assert.throws(() => checkVerylLane(useVerylHead(stableManifest, revision), "stable"), /git/);
+  assert.throws(() => checkVerylLane(stableManifest, "head"), /detected stable/);
 });
 
-test("requires one exact upstream revision in the HEAD lane", () => {
+test("detects a complete HEAD lane at one exact upstream revision", () => {
   const headManifest = useVerylHead(stableManifest, revision);
+  assert.deepEqual(detectVerylLane(headManifest), { lane: "head", revision });
   assert.equal(checkVerylLane(headManifest, "head"), revision);
-  assert.throws(() => checkVerylLane(stableManifest, "head"), /upstream repository/);
+  assert.throws(() => checkVerylLane(headManifest, "stable"), /detected head/);
+});
+
+test("allows a stable develop sync before an atomic HEAD roll", () => {
+  assert.equal(detectVerylLane(stableManifest).lane, "stable");
+  assert.equal(
+    detectVerylLane(useVerylHead(stableManifest, revision)).lane,
+    "head",
+  );
+});
+
+test("rejects mixed released and HEAD declarations", () => {
+  const headManifest = useVerylHead(stableManifest, revision);
+  const mixedManifest = headManifest.replace(
+    /^veryl-std = .*$/m,
+    'veryl-std = "0.20.3"',
+  );
+  assert.throws(() => detectVerylLane(mixedManifest), /mix released and HEAD/);
+});
+
+test("rejects mismatched released versions and HEAD revisions", () => {
   assert.throws(
     () =>
-      checkVerylLane(
+      detectVerylLane(
+        stableManifest.replace(
+          'veryl-std = "0.20.3"',
+          'veryl-std = "0.20.4"',
+        ),
+      ),
+    /different versions/,
+  );
+
+  const headManifest = useVerylHead(stableManifest, revision);
+  assert.throws(
+    () =>
+      detectVerylLane(
         headManifest.replace(revision, "fedcba9876543210fedcba9876543210fedcba98"),
-        "head",
       ),
     /different revisions/,
+  );
+});
+
+test("rejects missing and malformed dependency declarations", () => {
+  assert.throws(
+    () => detectVerylLane(stableManifest.replace(/^veryl-std = .*\n/m, "")),
+    /exactly one workspace dependency veryl-std/,
+  );
+  assert.throws(
+    () =>
+      detectVerylLane(
+        stableManifest.replace(
+          'veryl-std = "0.20.3"',
+          'veryl-std = { path = "vendor/veryl-std" }',
+        ),
+      ),
+    /non-release source/,
+  );
+  assert.throws(
+    () =>
+      detectVerylLane(
+        useVerylHead(stableManifest, revision).replace(
+          "https://github.com/veryl-lang/veryl.git",
+          "https://github.com/example/veryl.git",
+        ),
+      ),
+    /upstream repository/,
+  );
+  assert.throws(
+    () =>
+      detectVerylLane(
+        useVerylHead(stableManifest, revision).replace(revision, "master"),
+      ),
+    /full revision/,
   );
 });
 


### PR DESCRIPTION
## Summary

- detect whether all Veryl workspace dependencies form a complete stable or HEAD lane
- allow develop CI to validate either complete state during the stable-to-HEAD transition
- reject mixed sources, malformed declarations, mismatched release versions, and mismatched HEAD revisions
- run vendor consistency checks whenever develop is detected as stable

## Root cause

CI previously treated every develop build as HEAD-only. A newly created develop branch, or a master synchronization after a Veryl release promotion, intentionally contains stable dependencies until the next atomic HEAD roll. Required checks rejected that valid intermediate state before the roll could occur.

## Impact

Master remains stable-only. Develop can pass required checks in either complete state, while mixed states are rejected. Nightly HEAD publication remains HEAD-only because the publishing workflow still explicitly requires the `head` lane.

Closes #504

## Validation

- `node --test scripts/*.test.mjs`
- stable detection against the current master manifest
- HEAD detection against the current develop manifest
- `node scripts/veryl-vendor.mjs check`
- `actionlint v1.7.12 .github/workflows/ci.yml`
- `pnpm run lint`
- pre-push submodule check
- `cargo fmt --all -- --check`
- pre-push Biome check
- `cargo check --workspace --locked`
- `git diff --check`
