### PR TITLE
fix(ci): skip CodSpeed for merge groups

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -20,6 +20,7 @@ permissions: {}
 jobs:
   codspeed:
     name: CodSpeed
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -55,9 +55,11 @@ pnpm bench
 bash scripts/run-verilator-bench.sh
 ```
 
-The CodSpeed workflow runs on pull requests, merge queues, and `master`. Pull
-requests are compared with the `master` baseline using deterministic CPU
-simulation, while the local command only checks that the benchmark suite runs.
+The CodSpeed workflow runs benchmarks on pull requests and `master`. Merge queue
+events preserve the workflow check without running CodSpeed because CodSpeed does
+not support the `merge_group` event. Pull requests are compared with the `master`
+baseline using deterministic CPU simulation, while the local command only checks
+that the benchmark suite runs.
 
 Local measurements are most useful for comparing two revisions on the same
 machine. CI history is better for long-term trends than for small one-off deltas.

--- a/docs/ja/benchmarks/index.md
+++ b/docs/ja/benchmarks/index.md
@@ -54,9 +54,11 @@ pnpm bench
 bash scripts/run-verilator-bench.sh
 ```
 
-CodSpeed ワークフローは pull request、merge queue、`master` で実行されます。pull
-request は決定的な CPU simulation を使って `master` の基準値と比較されます。
-ローカル実行ではベンチマーク suite が動作することだけを確認します。
+CodSpeed ワークフローは pull request と `master` でベンチマークを実行します。
+CodSpeed は `merge_group` event をサポートしていないため、merge queue では
+workflow check を維持しつつ CodSpeed を実行しません。pull request は決定的な CPU
+simulation を使って `master` の基準値と比較されます。ローカル実行では
+ベンチマーク suite が動作することだけを確認します。
 
 ローカル計測は、同じマシン上で 2 つのリビジョンを比較する場合に最も有効です。
 CI 履歴は、単発の小さな差より長期的な傾向の確認に向いています。


### PR DESCRIPTION
## Summary

- skip the CodSpeed job for `merge_group` events
- keep the merge-group workflow trigger so its check remains available to the merge queue
- document the merge-queue behavior in English and Japanese

## Root cause

CodSpeed does not support the `merge_group` event. The compile-time benchmark workflow invoked `CodSpeedHQ/action@v5` for merge groups, causing the action to fail with `Error: Event merge_group is not supported by CodSpeed`.

## Impact

Pull requests and pushes to `master` continue to run compile-time benchmarks. Merge-group runs no longer install, build, or invoke CodSpeed.

## Validation

- parsed `.github/workflows/codspeed.yml` and verified the CodSpeed job condition
- `git diff --check`
- `pnpm docs:build`
- pre-push hook: submodule check, `cargo fmt`, Biome, `cargo check`, clean-tree check