### PR TITLE
fix(ci): reconcile develop lockfile during sync

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -34,6 +34,8 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.release-token.outputs.token }}
 
+      - uses: ./.github/actions/setup-rust
+
       - name: Create develop on first use
         id: develop
         env:
@@ -79,13 +81,38 @@ jobs:
             exit 0
           fi
 
-          # Conflict resolution can add commits to the disposable sync branch.
-          # Reset it to master only if it has not moved since this inspection.
+          # Build the disposable branch from the exact merge that CI and develop
+          # will consume. Cargo.lock can merge cleanly as text while still
+          # referring to master's released Veryl crates, so re-resolve the HEAD
+          # dependency graph before publishing a conflict-free merge.
+          git config user.name "celox-release-bot"
+          git config user.email "celox-release-bot@users.noreply.github.com"
+          git switch --force-create "$SYNC_BRANCH" origin/develop
+
+          set +e
+          git merge --no-commit --no-ff "$master_sha"
+          merge_status="$?"
+          set -e
+
+          if [ "$merge_status" -eq 0 ]; then
+            cargo update -p veryl-analyzer
+            cargo metadata --locked --format-version 1 --no-deps >/dev/null
+            git add Cargo.lock
+            git commit -m "chore(develop): sync master"
+            sync_sha="$(git rev-parse HEAD)"
+          else
+            # Keep non-dependency conflicts visible and actionable on the PR.
+            git merge --abort
+            git switch --force-create "$SYNC_BRANCH" "$master_sha"
+            sync_sha="$master_sha"
+          fi
+
+          # Do not replace a branch that moved after this run inspected it.
           sync_ref="refs/heads/$SYNC_BRANCH"
           remote_sync_sha="$(git ls-remote origin "$sync_ref" | cut -f1)"
           git push origin \
             --force-with-lease="$sync_ref:$remote_sync_sha" \
-            "$master_sha:$sync_ref"
+            "$sync_sha:$sync_ref"
 
           sync_pr="$(
             gh pr list \


### PR DESCRIPTION
## Summary

- build the managed `integration/master-to-develop` branch from the actual `develop` + `master` merge
- re-resolve `Cargo.lock` against the Veryl HEAD dependency graph before publishing a clean merge
- retain the existing actionable-PR behavior when non-dependency merge conflicts occur

## Root cause

PR #519 merges stable Veryl declarations and its `Cargo.lock` from `master` into the Veryl HEAD overlay on `develop`. Git can merge `Cargo.lock` without a textual conflict, but the result still references the released dependency graph. Every `cargo --locked` job then fails because Cargo needs to restore the git-sourced Veryl graph; downstream JavaScript jobs also fail when their NAPI artifacts are not produced.

## Impact

Future master-to-develop synchronization PRs publish the exact merge that CI will consume, with a lockfile valid for `develop`. This fixes the shared failure behind Rust, ARM64, Heliodor, and dependent JavaScript checks on #519.

The separate CodSpeed `merge_group` failure is already addressed by #518 and is intentionally not duplicated here.

## Validation

- reproduced the #519 merge from `develop` `1d4fe6134` and `master` `4263a6419` in an isolated copy
- `cargo update -p veryl-analyzer`
- `cargo metadata --locked --format-version 1 --no-deps`
- parsed `.github/workflows/sync-develop.yml` with the repository's YAML parser
- `node --test scripts/check-veryl-lane.test.mjs scripts/use-veryl-head.test.mjs`
- `git diff --check`
- pre-push hook: submodule check, Biome, `cargo fmt`, full `cargo check`, clean-tree check