### PR TITLE
feat(testbench): inject TypeScript components

### DIFF
--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1902,6 +1902,244 @@ fn convert_test_result(r: celox::TestResultDetailed) -> NapiTestResult {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+#[napi(object)]
+pub struct NapiInjectedValue {
+    pub name: Option<String>,
+    pub bits: Option<BigInt>,
+    pub mask_xz: Option<BigInt>,
+    pub width: Option<u32>,
+    pub string_value: Option<String>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[napi(object)]
+pub struct NapiInjectedCall {
+    pub instance: String,
+    pub phase: String,
+    pub method: Option<String>,
+    pub inputs: Vec<NapiInjectedValue>,
+    pub params: Vec<NapiInjectedValue>,
+    pub ports: Vec<NapiInjectedPort>,
+    pub args: Vec<NapiInjectedValue>,
+    pub cycle: BigInt,
+    pub time: BigInt,
+    pub seed: BigInt,
+    pub fired_clock: Option<String>,
+    pub four_state: bool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[napi(object)]
+pub struct NapiInjectedPort {
+    pub name: String,
+    pub direction: String,
+    pub role: Option<String>,
+    pub width: u32,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[napi(object)]
+pub struct NapiInjectedResult {
+    pub outputs: Option<Vec<NapiInjectedValue>>,
+    pub return_value: Option<NapiInjectedValue>,
+    pub failures: Option<Vec<String>>,
+    pub logs: Option<Vec<String>>,
+    pub finish: Option<bool>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[napi(object, object_to_js = false)]
+pub struct NapiInjectedComponent {
+    pub name: String,
+    pub manifest: String,
+    pub handler: FunctionRef<NapiInjectedCall, NapiInjectedResult>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct NapiInjectedHandler {
+    env: Env,
+    handler: FunctionRef<NapiInjectedCall, NapiInjectedResult>,
+}
+
+// Injected callbacks are only accepted by the synchronous runTest APIs and
+// are invoked on the JS thread which supplied this Env. The core trait is
+// Send + Sync because compiled component hooks may otherwise be movable.
+#[cfg(not(target_arch = "wasm32"))]
+unsafe impl Send for NapiInjectedHandler {}
+#[cfg(not(target_arch = "wasm32"))]
+unsafe impl Sync for NapiInjectedHandler {}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn napi_bigint(value: u64) -> BigInt {
+    BigInt {
+        sign_bit: false,
+        words: vec![value],
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn to_napi_injected_value(name: Option<String>, value: celox::InjectedValue) -> NapiInjectedValue {
+    match value {
+        celox::InjectedValue::Bits {
+            words,
+            mask_xz,
+            width,
+        } => NapiInjectedValue {
+            name,
+            bits: Some(BigInt {
+                sign_bit: false,
+                words,
+            }),
+            mask_xz: Some(BigInt {
+                sign_bit: false,
+                words: mask_xz,
+            }),
+            width: Some(width),
+            string_value: None,
+        },
+        celox::InjectedValue::String(value) => NapiInjectedValue {
+            name,
+            bits: None,
+            mask_xz: None,
+            width: None,
+            string_value: Some(value),
+        },
+        celox::InjectedValue::Unit => NapiInjectedValue {
+            name,
+            bits: None,
+            mask_xz: None,
+            width: None,
+            string_value: None,
+        },
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn from_napi_injected_value(
+    value: NapiInjectedValue,
+) -> std::result::Result<celox::InjectedValue, String> {
+    if let Some(bits) = value.bits {
+        if bits.sign_bit || value.mask_xz.as_ref().is_some_and(|mask| mask.sign_bit) {
+            return Err("component callback values cannot be negative".into());
+        }
+        let width = value
+            .width
+            .ok_or_else(|| "component callback bit value has no width".to_string())?;
+        return Ok(celox::InjectedValue::Bits {
+            words: bits.words,
+            mask_xz: value.mask_xz.map(|mask| mask.words).unwrap_or_default(),
+            width,
+        });
+    }
+    Ok(match value.string_value {
+        Some(value) => celox::InjectedValue::String(value),
+        None => celox::InjectedValue::Unit,
+    })
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl celox::InjectedComponentHandler for NapiInjectedHandler {
+    fn call(
+        &self,
+        call: celox::InjectedCall,
+    ) -> std::result::Result<celox::InjectedResult, String> {
+        let (phase, method, args) = match call.hook {
+            celox::InjectedHook::Create => ("create", None, Vec::new()),
+            celox::InjectedHook::Init => ("init", None, Vec::new()),
+            celox::InjectedHook::Reset => ("reset", None, Vec::new()),
+            celox::InjectedHook::Clock => ("clock", None, Vec::new()),
+            celox::InjectedHook::Finish => ("finish", None, Vec::new()),
+            celox::InjectedHook::Method { name, args } => ("method", Some(name), args),
+        };
+        let request = NapiInjectedCall {
+            instance: call.instance,
+            phase: phase.into(),
+            method,
+            inputs: call
+                .inputs
+                .into_iter()
+                .map(|value| to_napi_injected_value(Some(value.name), value.value))
+                .collect(),
+            params: call
+                .params
+                .into_iter()
+                .map(|value| to_napi_injected_value(Some(value.name), value.value))
+                .collect(),
+            ports: call
+                .ports
+                .into_iter()
+                .map(|port| NapiInjectedPort {
+                    name: port.name,
+                    direction: port.direction,
+                    role: port.role,
+                    width: port.width,
+                })
+                .collect(),
+            args: args
+                .into_iter()
+                .map(|value| to_napi_injected_value(None, value))
+                .collect(),
+            cycle: napi_bigint(call.cycle),
+            time: napi_bigint(call.time),
+            seed: napi_bigint(call.seed),
+            fired_clock: call.fired_clock,
+            four_state: call.four_state,
+        };
+        let result = self
+            .handler
+            .borrow_back(&self.env)
+            .and_then(|handler| handler.call(request))
+            .map_err(|error| error.to_string())?;
+        let outputs = result
+            .outputs
+            .unwrap_or_default()
+            .into_iter()
+            .map(|value| {
+                let name = value
+                    .name
+                    .clone()
+                    .ok_or_else(|| "component callback output has no name".to_string())?;
+                Ok(celox::InjectedNamedValue {
+                    name,
+                    value: from_napi_injected_value(value)?,
+                })
+            })
+            .collect::<std::result::Result<Vec<_>, String>>()?;
+        Ok(celox::InjectedResult {
+            outputs,
+            return_value: result
+                .return_value
+                .map(from_napi_injected_value)
+                .transpose()?,
+            failures: result.failures.unwrap_or_default(),
+            logs: result.logs.unwrap_or_default(),
+            finish: result.finish.unwrap_or(false),
+        })
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn injected_components(
+    env: Env,
+    definitions: Option<Vec<NapiInjectedComponent>>,
+) -> Result<celox::InjectedComponents> {
+    let mut components = celox::InjectedComponents::new();
+    for definition in definitions.unwrap_or_default() {
+        components
+            .insert(
+                definition.name,
+                &definition.manifest,
+                Arc::new(NapiInjectedHandler {
+                    env,
+                    handler: definition.handler,
+                }),
+            )
+            .map_err(Error::from_reason)?;
+    }
+    Ok(components)
+}
+
 /// Run a native testbench from Veryl source code.
 ///
 /// Compiles the given sources and runs the `#[test]` module specified by `top`,
@@ -1910,9 +2148,11 @@ fn convert_test_result(r: celox::TestResultDetailed) -> NapiTestResult {
 #[cfg(not(target_arch = "wasm32"))]
 #[napi]
 pub fn run_test(
+    env: Env,
     sources: Vec<NapiSourceFile>,
     top: String,
     options: Option<NapiOptions>,
+    components: Option<Vec<NapiInjectedComponent>>,
 ) -> Result<NapiTestResult> {
     let opts = parse_options(&options)?;
     let mut src_pairs: Vec<(String, std::path::PathBuf)> = sources
@@ -1925,7 +2165,8 @@ pub fn run_test(
         .iter()
         .map(|(s, p)| (s.as_str(), p.as_path()))
         .collect();
-    let builder = apply_options(celox::Simulator::from_sources(source_refs, &top), &opts);
+    let builder = apply_options(celox::Simulator::from_sources(source_refs, &top), &opts)
+        .with_injected_components(injected_components(env, components)?);
     let result = builder
         .run_test_detailed()
         .map_err(|e| Error::from_reason(format!("{e}")))?;
@@ -1939,9 +2180,11 @@ pub fn run_test(
 #[cfg(not(target_arch = "wasm32"))]
 #[napi]
 pub fn run_test_from_project(
+    env: Env,
     project_path: String,
     top: String,
     options: Option<NapiOptions>,
+    components: Option<Vec<NapiInjectedComponent>>,
 ) -> Result<NapiTestResult> {
     let opts = parse_options(&options)?;
     let (mut sources, metadata, _celox_cfg) = load_project_sources(&project_path)?;
@@ -1954,7 +2197,8 @@ pub fn run_test_from_project(
     let builder = apply_options(
         celox::Simulator::from_sources(source_refs, &top).with_metadata(metadata),
         &opts,
-    );
+    )
+    .with_injected_components(injected_components(env, components)?);
     let result = builder
         .run_test_detailed()
         .map_err(|e| Error::from_reason(format!("{e}")))?;
@@ -1965,11 +2209,43 @@ pub fn run_test_from_project(
 //  TypeScript type generation
 // ---------------------------------------------------------------------------
 
+#[napi(object)]
+pub struct NapiInjectedManifest {
+    pub name: String,
+    pub manifest: String,
+}
+
+fn inject_analyzer_components(definitions: Option<Vec<NapiInjectedManifest>>) -> Result<()> {
+    let definitions = definitions.unwrap_or_default();
+    let names: Vec<_> = definitions
+        .iter()
+        .map(|definition| definition.name.as_str())
+        .collect();
+    veryl_analyzer::tb_component::insert_external_components(&names);
+    for definition in definitions {
+        let manifest =
+            veryl_metadata::ComponentManifest::parse(&definition.manifest).ok_or_else(|| {
+                Error::from_reason(format!(
+                    "manifest of injected component `{}` cannot be parsed",
+                    definition.name
+                ))
+            })?;
+        veryl_analyzer::component_manifest_table::insert(
+            veryl_parser::resource_table::insert_str(&definition.name),
+            manifest,
+        );
+    }
+    Ok(())
+}
+
 /// Generate TypeScript type information as JSON for a Veryl project.
 ///
 /// Equivalent to running `celox-gen-ts --json` from the given project directory.
 #[napi]
-pub fn gen_ts(project_path: String) -> Result<String> {
+pub fn gen_ts(
+    project_path: String,
+    components: Option<Vec<NapiInjectedManifest>>,
+) -> Result<String> {
     use celox_ts_gen::{JsonModuleEntry, JsonOutput, generate_all};
 
     let toml_path = Metadata::search_from(&project_path)
@@ -2021,6 +2297,7 @@ pub fn gen_ts(project_path: String) -> Result<String> {
     attribute_table::clear();
 
     let analyzer = Analyzer::new(&metadata);
+    inject_analyzer_components(components)?;
     let mut parsers = Vec::new();
     let mut all_warnings = Vec::new();
 
@@ -2167,7 +2444,10 @@ pub fn gen_ts(project_path: String) -> Result<String> {
 /// Like `gen_ts()` but does not require a Veryl.toml or filesystem access.
 /// Works on both native and wasm32 targets.
 #[napi]
-pub fn gen_ts_from_source(sources: Vec<NapiSourceFile>) -> Result<String> {
+pub fn gen_ts_from_source(
+    sources: Vec<NapiSourceFile>,
+    components: Option<Vec<NapiInjectedManifest>>,
+) -> Result<String> {
     use celox_ts_gen::{JsonModuleEntry, JsonOutput, generate_all};
 
     if sources.is_empty() {
@@ -2182,6 +2462,7 @@ pub fn gen_ts_from_source(sources: Vec<NapiSourceFile>) -> Result<String> {
     attribute_table::clear();
 
     let analyzer = Analyzer::new(&metadata);
+    inject_analyzer_components(components)?;
     let mut parsers = Vec::new();
     let mut all_warnings = Vec::new();
 

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1876,12 +1876,14 @@ pub struct NapiAssertionResult {
 pub struct NapiTestResult {
     pub passed: bool,
     pub assertions: Vec<NapiAssertionResult>,
+    pub error: Option<String>,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 fn convert_test_result(r: celox::TestResultDetailed) -> NapiTestResult {
     NapiTestResult {
         passed: r.passed,
+        error: r.error,
         assertions: r
             .assertions
             .into_iter()

--- a/crates/celox/src/component.rs
+++ b/crates/celox/src/component.rs
@@ -526,13 +526,13 @@ impl ComponentRuntime {
                         } else {
                             veryl_component_sys::VRL_DIR_INPUT
                         };
-                        debug_assert_eq!(host.svc_port_index(port_name, direction), *port as i32);
+                        let resolved = host.svc_port_index(port_name, direction);
+                        debug_assert_eq!(resolved, *port as i32);
                     }
                     if let Some(port) = output {
-                        debug_assert_eq!(
-                            host.svc_port_index(port_name, veryl_component_sys::VRL_DIR_OUTPUT),
-                            *port as i32
-                        );
+                        let resolved =
+                            host.svc_port_index(port_name, veryl_component_sys::VRL_DIR_OUTPUT);
+                        debug_assert_eq!(resolved, *port as i32);
                     }
                 }
             }

--- a/crates/celox/src/component.rs
+++ b/crates/celox/src/component.rs
@@ -7,12 +7,18 @@ use celox_testbench::{
 use veryl_metadata::component_manifest::{ConnectionFacts, ConnectionTarget, ConnectionViolation};
 
 mod host;
+mod injected;
 mod loader;
 #[cfg(not(target_family = "wasm"))]
 mod wasm;
 
 use host::{ExternalInstance, HostContext, HostValue, PortDir, PortRole};
 use loader::lookup_component_backend;
+
+pub use injected::{
+    InjectedCall, InjectedComponentHandler, InjectedComponents, InjectedHook, InjectedNamedValue,
+    InjectedPort, InjectedResult, InjectedValue,
+};
 
 use crate::{EventHandle, SignalRef, SimBackend};
 
@@ -67,6 +73,13 @@ pub(crate) struct ComponentRuntime {
     components: Vec<LiveComponent>,
     last_trace_values: Vec<(num_bigint::BigUint, num_bigint::BigUint)>,
     active_reset_event: Option<usize>,
+    injected: InjectedComponents,
+}
+
+impl ComponentRuntime {
+    pub(crate) fn set_injected(&mut self, injected: InjectedComponents) {
+        self.injected = injected;
+    }
 }
 
 pub(crate) struct ComponentWrite {
@@ -351,17 +364,33 @@ impl ComponentRuntime {
                     descriptor.instance
                 ));
             }
+            let injected = self.injected.get(&descriptor.component).cloned();
             let library = libraries.get(descriptor.component.as_str()).copied();
             let type_name = library
                 .map(|library| library.type_name.as_str())
                 .unwrap_or(descriptor.component.as_str());
-            let component_backend =
-                lookup_component_backend(library.map(|library| library.path.as_path()), type_name)
-                    .map_err(|error| format!("component `{}`: {error}", descriptor.instance))?;
-            if let Some(manifest) = component_manifest(library, type_name)? {
-                validate_manifest(descriptor, type_name, &manifest)?;
+            let component_backend = if injected.is_none() {
+                Some(
+                    lookup_component_backend(
+                        library.map(|library| library.path.as_path()),
+                        type_name,
+                    )
+                    .map_err(|error| format!("component `{}`: {error}", descriptor.instance))?,
+                )
+            } else {
+                None
+            };
+            let manifest = match &injected {
+                Some(definition) => Some(definition.manifest.clone()),
+                None => component_manifest(library, type_name)?,
+            };
+            if let Some(manifest) = &manifest {
+                validate_manifest(descriptor, type_name, manifest)?;
             }
-            let kind = component_backend.kind();
+            let kind = injected
+                .as_ref()
+                .map(|definition| definition.kind)
+                .unwrap_or_else(|| component_backend.as_ref().unwrap().kind());
             if descriptor.is_var_form && kind == veryl_component_sys::VRL_KIND_CLOCKED {
                 return Err(format!(
                     "component `{}`: clocked component `{type_name}` must use inst form",
@@ -487,8 +516,31 @@ impl ComponentRuntime {
                 ));
             }
 
-            let instance = ExternalInstance::create(component_backend, &mut host)
-                .map_err(|error| format!("component `{}`: {error}", descriptor.instance))?;
+            if injected.is_some() {
+                for (port_name, _, input, output, is_clock, is_reset) in &offered_ports {
+                    if let Some(port) = input {
+                        let direction = if *is_clock {
+                            veryl_component_sys::VRL_DIR_CLOCK
+                        } else if *is_reset {
+                            veryl_component_sys::VRL_DIR_RESET
+                        } else {
+                            veryl_component_sys::VRL_DIR_INPUT
+                        };
+                        debug_assert_eq!(host.svc_port_index(port_name, direction), *port as i32);
+                    }
+                    if let Some(port) = output {
+                        debug_assert_eq!(
+                            host.svc_port_index(port_name, veryl_component_sys::VRL_DIR_OUTPUT),
+                            *port as i32
+                        );
+                    }
+                }
+            }
+            let instance = match injected {
+                Some(definition) => ExternalInstance::create_injected(definition, &mut host),
+                None => ExternalInstance::create(component_backend.unwrap(), &mut host),
+            }
+            .map_err(|error| format!("component `{}`: {error}", descriptor.instance))?;
             for (port_name, group, input, output, is_clock, is_reset) in &offered_ports {
                 if group.is_none()
                     && !input.is_some_and(|port| host.port_touched(port))

--- a/crates/celox/src/component/host.rs
+++ b/crates/celox/src/component/host.rs
@@ -260,11 +260,14 @@ impl HostContext {
     }
 
     fn injected_call(&self, instance: &str, hook: InjectedHook) -> InjectedCall {
-        let fired_clock = self
-            .ports
-            .get(self.fired_clock as usize)
-            .filter(|port| port.role == PortRole::Clock)
-            .map(|port| port.name.clone());
+        let fired_clock = if matches!(&hook, InjectedHook::Clock) {
+            self.ports
+                .get(self.fired_clock as usize)
+                .filter(|port| port.role == PortRole::Clock)
+                .map(|port| port.name.clone())
+        } else {
+            None
+        };
         InjectedCall {
             instance: instance.to_string(),
             hook,

--- a/crates/celox/src/component/host.rs
+++ b/crates/celox/src/component/host.rs
@@ -2,7 +2,11 @@
 //! `VrlCtx`, the `VrlHostApi` service table, and a safe wrapper around a
 //! component instance's vtable.
 
+use crate::component::injected::InjectedComponentDefinition;
 use crate::component::loader::ComponentError;
+use crate::component::{
+    InjectedCall, InjectedHook, InjectedNamedValue, InjectedResult, InjectedValue,
+};
 use std::ffi::c_void;
 use veryl_component_sys as sys;
 
@@ -241,6 +245,123 @@ impl HostContext {
 
     fn as_ctx(&mut self) -> *mut sys::VrlCtx {
         self as *mut HostContext as *mut sys::VrlCtx
+    }
+
+    fn injected_value(value: &HostValue) -> InjectedValue {
+        match value {
+            HostValue::Bits { words, width } => InjectedValue::Bits {
+                words: words.clone(),
+                mask_xz: vec![0; words.len()],
+                width: *width,
+            },
+            HostValue::Str(value) => InjectedValue::String(value.clone()),
+            HostValue::Unit => InjectedValue::Unit,
+        }
+    }
+
+    fn injected_call(&self, instance: &str, hook: InjectedHook) -> InjectedCall {
+        let fired_clock = self
+            .ports
+            .get(self.fired_clock as usize)
+            .filter(|port| port.role == PortRole::Clock)
+            .map(|port| port.name.clone());
+        InjectedCall {
+            instance: instance.to_string(),
+            hook,
+            inputs: self
+                .ports
+                .iter()
+                .filter(|port| port.dir == PortDir::Input)
+                .map(|port| InjectedNamedValue {
+                    name: port.name.clone(),
+                    value: InjectedValue::Bits {
+                        words: port.words.clone(),
+                        mask_xz: port.mask_xz.clone(),
+                        width: port.width,
+                    },
+                })
+                .collect(),
+            params: self
+                .params
+                .iter()
+                .map(|(name, value)| InjectedNamedValue {
+                    name: name.clone(),
+                    value: Self::injected_value(value),
+                })
+                .collect(),
+            ports: self
+                .ports
+                .iter()
+                .map(|port| crate::InjectedPort {
+                    name: port.name.clone(),
+                    direction: match port.dir {
+                        PortDir::Input => "input",
+                        PortDir::Output => "output",
+                    }
+                    .into(),
+                    role: match port.role {
+                        PortRole::Data => None,
+                        PortRole::Clock => Some("clock".into()),
+                        PortRole::Reset => Some("reset".into()),
+                    },
+                    width: port.width,
+                })
+                .collect(),
+            cycle: self.cycle,
+            time: self.time,
+            seed: self.seed,
+            fired_clock,
+            four_state: self.use_4state,
+        }
+    }
+
+    fn apply_injected_result(
+        &mut self,
+        result: InjectedResult,
+    ) -> Result<Option<HostValue>, String> {
+        for output in result.outputs {
+            let Some(index) = self.port_position(&output.name, PortDir::Output) else {
+                return Err(format!("callback wrote unknown output `{}`", output.name));
+            };
+            let expected_width = self.svc_port_width(index);
+            let InjectedValue::Bits {
+                mut words,
+                mut mask_xz,
+                width,
+            } = output.value
+            else {
+                return Err(format!(
+                    "callback output `{}` is not a bit value",
+                    output.name
+                ));
+            };
+            if width != expected_width {
+                return Err(format!(
+                    "callback output `{}` has width {width}, expected {expected_width}",
+                    output.name
+                ));
+            }
+            let word_count = words_for(width);
+            words.resize(word_count, 0);
+            mask_xz.resize(word_count, 0);
+            words.truncate(word_count);
+            mask_xz.truncate(word_count);
+            self.svc_write_output(index, &words, Some(&mask_xz));
+        }
+        for failure in result.failures {
+            self.svc_fail(&failure);
+        }
+        for log in result.logs {
+            self.svc_log(&log);
+        }
+        if result.finish {
+            self.svc_finish();
+        }
+        Ok(result.return_value.map(|value| match value {
+            InjectedValue::Bits { words, width, .. } => HostValue::Bits { words, width },
+            InjectedValue::String(value) => HostValue::Str(value),
+            InjectedValue::Unit => HostValue::Unit,
+        }))
     }
 }
 
@@ -683,6 +804,10 @@ enum InstanceInner {
     },
     #[cfg(not(target_family = "wasm"))]
     Wasm(Box<crate::component::wasm::WasmInstance>),
+    Injected {
+        instance: String,
+        definition: InjectedComponentDefinition,
+    },
 }
 
 // The ABI contract requires the component state to be `Send` (hooks may run
@@ -690,6 +815,51 @@ enum InstanceInner {
 unsafe impl Send for ExternalInstance {}
 
 impl ExternalInstance {
+    pub fn create_injected(
+        definition: InjectedComponentDefinition,
+        host: &mut HostContext,
+    ) -> Result<Self, ComponentError> {
+        let instance = host.label.clone();
+        let result = definition
+            .handler
+            .call(host.injected_call(&instance, InjectedHook::Create))
+            .map_err(|message| ComponentError::CreateFailed { messages: message })?;
+        host.apply_injected_result(result)
+            .map_err(|messages| ComponentError::CreateFailed { messages })?;
+        if !host.failures().is_empty() {
+            return Err(ComponentError::CreateFailed {
+                messages: host.take_failures().join("; "),
+            });
+        }
+        Ok(Self {
+            inner: InstanceInner::Injected {
+                instance,
+                definition,
+            },
+        })
+    }
+
+    fn call_injected(
+        instance: &str,
+        definition: &InjectedComponentDefinition,
+        host: &mut HostContext,
+        hook: InjectedHook,
+    ) -> Option<HostValue> {
+        match definition.handler.call(host.injected_call(instance, hook)) {
+            Ok(result) => match host.apply_injected_result(result) {
+                Ok(value) => value.or(Some(HostValue::Unit)),
+                Err(message) => {
+                    host.svc_fail(&message);
+                    None
+                }
+            },
+            Err(message) => {
+                host.svc_fail(&message);
+                None
+            }
+        }
+    }
+
     /// Port and parameter resolution happens inside the component's `new`;
     /// failures surface as `CreateFailed` with the messages the component
     /// reported.
@@ -741,6 +911,7 @@ impl ExternalInstance {
             InstanceInner::Native { vtable, .. } => vtable.kind,
             #[cfg(not(target_family = "wasm"))]
             InstanceInner::Wasm(instance) => instance.kind(),
+            InstanceInner::Injected { definition, .. } => definition.kind,
         }
     }
 
@@ -751,6 +922,12 @@ impl ExternalInstance {
             },
             #[cfg(not(target_family = "wasm"))]
             InstanceInner::Wasm(instance) => instance.on_init(host),
+            InstanceInner::Injected {
+                instance,
+                definition,
+            } => i32::from(
+                Self::call_injected(instance, definition, host, InjectedHook::Init).is_none(),
+            ),
         }
     }
 
@@ -761,6 +938,12 @@ impl ExternalInstance {
             },
             #[cfg(not(target_family = "wasm"))]
             InstanceInner::Wasm(instance) => instance.on_reset(host),
+            InstanceInner::Injected {
+                instance,
+                definition,
+            } => i32::from(
+                Self::call_injected(instance, definition, host, InjectedHook::Reset).is_none(),
+            ),
         }
     }
 
@@ -771,6 +954,12 @@ impl ExternalInstance {
             },
             #[cfg(not(target_family = "wasm"))]
             InstanceInner::Wasm(instance) => instance.on_clock(host),
+            InstanceInner::Injected {
+                instance,
+                definition,
+            } => i32::from(
+                Self::call_injected(instance, definition, host, InjectedHook::Clock).is_none(),
+            ),
         }
     }
 
@@ -781,6 +970,12 @@ impl ExternalInstance {
             },
             #[cfg(not(target_family = "wasm"))]
             InstanceInner::Wasm(instance) => instance.on_finish(host),
+            InstanceInner::Injected {
+                instance,
+                definition,
+            } => i32::from(
+                Self::call_injected(instance, definition, host, InjectedHook::Finish).is_none(),
+            ),
         }
     }
 
@@ -833,6 +1028,18 @@ impl ExternalInstance {
             }
             #[cfg(not(target_family = "wasm"))]
             InstanceInner::Wasm(instance) => instance.call_method(host, name, args),
+            InstanceInner::Injected {
+                instance,
+                definition,
+            } => Self::call_injected(
+                instance,
+                definition,
+                host,
+                InjectedHook::Method {
+                    name: name.to_string(),
+                    args: args.iter().map(HostContext::injected_value).collect(),
+                },
+            ),
         }
     }
 }
@@ -844,6 +1051,7 @@ impl Drop for ExternalInstance {
             // The wasm instance's own Drop calls the guest destructor.
             #[cfg(not(target_family = "wasm"))]
             InstanceInner::Wasm(_) => {}
+            InstanceInner::Injected { .. } => {}
         }
     }
 }
@@ -854,6 +1062,7 @@ impl std::fmt::Debug for ExternalInstance {
             InstanceInner::Native { .. } => "native",
             #[cfg(not(target_family = "wasm"))]
             InstanceInner::Wasm(_) => "wasm",
+            InstanceInner::Injected { .. } => "injected",
         };
         f.debug_struct("ExternalInstance")
             .field("transport", &transport)

--- a/crates/celox/src/component/injected.rs
+++ b/crates/celox/src/component/injected.rs
@@ -1,0 +1,143 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use veryl_metadata::ComponentManifest;
+
+/// A value crossing the boundary of an in-process component callback.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InjectedValue {
+    Bits {
+        words: Vec<u64>,
+        mask_xz: Vec<u64>,
+        width: u32,
+    },
+    String(String),
+    Unit,
+}
+
+/// The lifecycle operation requested from an injected component.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InjectedHook {
+    Create,
+    Init,
+    Reset,
+    Clock,
+    Finish,
+    Method {
+        name: String,
+        args: Vec<InjectedValue>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InjectedNamedValue {
+    pub name: String,
+    pub value: InjectedValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InjectedPort {
+    pub name: String,
+    pub direction: String,
+    pub role: Option<String>,
+    pub width: u32,
+}
+
+/// One synchronous call into an injected component implementation.
+#[derive(Clone, Debug)]
+pub struct InjectedCall {
+    pub instance: String,
+    pub hook: InjectedHook,
+    pub inputs: Vec<InjectedNamedValue>,
+    pub params: Vec<InjectedNamedValue>,
+    pub ports: Vec<InjectedPort>,
+    pub cycle: u64,
+    pub time: u64,
+    pub seed: u64,
+    pub fired_clock: Option<String>,
+    pub four_state: bool,
+}
+
+/// Effects returned by an injected callback. Outputs are staged using the
+/// same component/NBA path as compiled native and Wasm components.
+#[derive(Clone, Debug, Default)]
+pub struct InjectedResult {
+    pub outputs: Vec<InjectedNamedValue>,
+    pub return_value: Option<InjectedValue>,
+    pub failures: Vec<String>,
+    pub logs: Vec<String>,
+    pub finish: bool,
+}
+
+/// Synchronous component implementation supplied by an embedding runtime.
+pub trait InjectedComponentHandler: Send + Sync + 'static {
+    fn call(&self, call: InjectedCall) -> Result<InjectedResult, String>;
+}
+
+#[derive(Clone)]
+pub(crate) struct InjectedComponentDefinition {
+    pub manifest: ComponentManifest,
+    pub kind: u32,
+    pub handler: Arc<dyn InjectedComponentHandler>,
+}
+
+/// Component definitions injected by an embedding API for one simulator.
+#[derive(Clone, Default)]
+pub struct InjectedComponents {
+    pub(crate) definitions: HashMap<String, InjectedComponentDefinition>,
+}
+
+impl InjectedComponents {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(
+        &mut self,
+        name: impl Into<String>,
+        manifest_json: &str,
+        handler: Arc<dyn InjectedComponentHandler>,
+    ) -> Result<(), String> {
+        let name = name.into();
+        if name.is_empty() || name.contains("::") {
+            return Err("injected component names must be non-empty identifiers".into());
+        }
+        let manifest = ComponentManifest::parse(manifest_json)
+            .ok_or_else(|| format!("manifest of injected component `{name}` cannot be parsed"))?;
+        let kind = match manifest.kind.as_deref() {
+            Some("clocked") => veryl_component_sys::VRL_KIND_CLOCKED,
+            Some("method_only") => veryl_component_sys::VRL_KIND_METHOD_ONLY,
+            Some(kind) => return Err(format!("unsupported component kind `{kind}`")),
+            None => {
+                return Err(format!(
+                    "manifest of injected component `{name}` has no kind"
+                ));
+            }
+        };
+        if self.definitions.contains_key(&name) {
+            return Err(format!(
+                "injected component `{name}` is defined more than once"
+            ));
+        }
+        self.definitions.insert(
+            name,
+            InjectedComponentDefinition {
+                manifest,
+                kind,
+                handler,
+            },
+        );
+        Ok(())
+    }
+
+    pub(crate) fn get(&self, name: &str) -> Option<&InjectedComponentDefinition> {
+        self.definitions.get(name)
+    }
+
+    pub(crate) fn manifests(&self) -> Vec<(String, ComponentManifest)> {
+        self.definitions
+            .iter()
+            .map(|(name, definition)| (name.clone(), definition.manifest.clone()))
+            .collect()
+    }
+}

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -2,7 +2,11 @@ mod backend;
 #[cfg(feature = "host-runtime")]
 mod component;
 #[cfg(feature = "host-runtime")]
-pub use component::{register_static_component, register_static_component_manifest};
+pub use component::{
+    InjectedCall, InjectedComponentHandler, InjectedComponents, InjectedHook, InjectedNamedValue,
+    InjectedPort, InjectedResult, InjectedValue, register_static_component,
+    register_static_component_manifest,
+};
 mod debug;
 mod diagnostics;
 mod ir;

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -135,6 +135,7 @@ fn analyze(
     param_overrides: &[(String, u64)],
     optimize_options: &crate::optimizer::OptimizeOptions,
     diagnostics: &crate::RuntimeDiagnostics,
+    injected_manifests: &[(String, veryl_metadata::ComponentManifest)],
     preserve_element_storage_layout: bool,
 ) -> (
     Result<OptimizedSir, ParserError>,
@@ -173,6 +174,19 @@ fn analyze(
     let testbench_random_seed = metadata.test.seed;
     let (component_libraries, component_file_base) = component_runtime_config(&metadata);
     let analyzer = Analyzer::new(&metadata);
+    if !injected_manifests.is_empty() {
+        let names: Vec<_> = injected_manifests
+            .iter()
+            .map(|(name, _)| name.as_str())
+            .collect();
+        veryl_analyzer::tb_component::insert_external_components(&names);
+        for (name, manifest) in injected_manifests {
+            veryl_analyzer::component_manifest_table::insert(
+                resource_table::insert_str(name),
+                manifest.clone(),
+            );
+        }
+    }
     let project_name = metadata.project.name.clone();
 
     // Per-file: parse + pass1
@@ -300,6 +314,7 @@ pub fn compile_to_sir(
         param_overrides,
         optimize_options,
         &crate::RuntimeDiagnostics::default(),
+        &[],
         crate::backend::memory_layout::MemoryLayoutMode::Packed,
     )
 }
@@ -325,6 +340,7 @@ fn compile_to_sir_with_layout_mode(
     param_overrides: &[(String, u64)],
     optimize_options: &crate::optimizer::OptimizeOptions,
     diagnostics: &crate::RuntimeDiagnostics,
+    injected_manifests: &[(String, veryl_metadata::ComponentManifest)],
     layout_mode: crate::backend::memory_layout::MemoryLayoutMode,
 ) -> Result<(OptimizedSir, Vec<CompilationWarning>), SimulatorError> {
     let (sir, errors, frontend_diagnostics) = analyze(
@@ -341,6 +357,7 @@ fn compile_to_sir_with_layout_mode(
         param_overrides,
         optimize_options,
         diagnostics,
+        injected_manifests,
         layout_mode == crate::backend::memory_layout::MemoryLayoutMode::ElementStrided,
     );
     let (real_errors, analyzer_warnings): (Vec<_>, Vec<_>) =
@@ -464,6 +481,7 @@ mod host {
         reset_type: Option<ResetType>,
         param_overrides: Vec<(String, u64)>,
         live_signals: Vec<(Vec<(String, usize)>, Vec<String>)>,
+        injected_components: crate::InjectedComponents,
         _marker: std::marker::PhantomData<Target>,
     }
 
@@ -505,6 +523,12 @@ mod host {
         /// Override a top-level module parameter value.
         pub fn param(mut self, name: &str, value: u64) -> Self {
             self.param_overrides.push((name.to_string(), value));
+            self
+        }
+
+        /// Make in-process component implementations available as `$comp::<name>`.
+        pub fn with_injected_components(mut self, components: crate::InjectedComponents) -> Self {
+            self.injected_components = components;
             self
         }
 
@@ -780,6 +804,7 @@ mod host {
                 reset_type: None,
                 param_overrides: Vec::new(),
                 live_signals: Vec::new(),
+                injected_components: Default::default(),
                 _marker: std::marker::PhantomData,
             }
         }
@@ -797,6 +822,7 @@ mod host {
                 reset_type: None,
                 param_overrides: Vec::new(),
                 live_signals: Vec::new(),
+                injected_components: Default::default(),
                 _marker: std::marker::PhantomData,
             }
         }
@@ -813,11 +839,13 @@ mod host {
                 Vec<CompilationWarning>,
                 SimulatorOptions,
                 Option<std::path::PathBuf>,
+                crate::InjectedComponents,
             ),
             SimulatorError,
         > {
             let phase_timing = self.options.diagnostics.phase_timing;
             let compile_start = phase_timing.then(crate::timing::now);
+            let injected_manifests = self.injected_components.manifests();
             let (program, warnings) = compile_to_sir_with_layout_mode(
                 &self.sources,
                 self.top,
@@ -832,6 +860,7 @@ mod host {
                 &self.param_overrides,
                 &self.options.optimize_options,
                 &self.options.diagnostics,
+                &injected_manifests,
                 layout_mode,
             )?;
             if let Some(start) = compile_start {
@@ -857,7 +886,13 @@ mod host {
                 }
             }
 
-            Ok((laid_out, warnings, self.options, self.vcd_path))
+            Ok((
+                laid_out,
+                warnings,
+                self.options,
+                self.vcd_path,
+                self.injected_components,
+            ))
         }
 
         /// Compiles the Veryl source and constructs the simulator.
@@ -884,7 +919,7 @@ mod host {
             let phase_timing = self.options.diagnostics.phase_timing;
             let phase_start = phase_timing.then(crate::timing::now);
 
-            let (laid_out, warnings, options, vcd_path) = self
+            let (laid_out, warnings, options, vcd_path, injected_components) = self
                 .into_laid_out_program(crate::backend::memory_layout::MemoryLayoutMode::Packed)?;
 
             if let Some(s) = phase_start {
@@ -913,6 +948,7 @@ mod host {
 
             let mut sim =
                 Simulator::with_backend_and_program(backend, laid_out.into_runtime(), warnings);
+            sim.components.set_injected(injected_components);
             sim.diagnostics = options.diagnostics.clone();
             if let Some(path) = vcd_path {
                 let descs = sim.build_vcd_descs(options.four_state);
@@ -935,9 +971,10 @@ mod host {
         ) -> Result<Simulator<crate::backend::native::NativeBackend>, SimulatorError> {
             let phase_timing = self.options.diagnostics.phase_timing;
             let sir_start = phase_timing.then(crate::timing::now);
-            let (laid_out, warnings, options, vcd_path) = self.into_laid_out_program(
-                crate::backend::memory_layout::MemoryLayoutMode::ElementStrided,
-            )?;
+            let (laid_out, warnings, options, vcd_path, injected_components) = self
+                .into_laid_out_program(
+                    crate::backend::memory_layout::MemoryLayoutMode::ElementStrided,
+                )?;
             if let Some(start) = sir_start {
                 tracing::debug!(
                     "[phase-timing] into_laid_out_program total: {:?}",
@@ -951,6 +988,7 @@ mod host {
             }
             let mut sim =
                 Simulator::with_backend_and_program(backend, laid_out.into_runtime(), warnings);
+            sim.components.set_injected(injected_components);
             sim.diagnostics = options.diagnostics.clone();
             if let Some(path) = vcd_path {
                 let descs = sim.build_vcd_descs(options.four_state);
@@ -975,11 +1013,12 @@ mod host {
         pub fn build_wasm(
             self,
         ) -> Result<Simulator<crate::backend::wasm_runtime::WasmBackend>, SimulatorError> {
-            let (laid_out, warnings, options, vcd_path) = self
+            let (laid_out, warnings, options, vcd_path, injected_components) = self
                 .into_laid_out_program(crate::backend::memory_layout::MemoryLayoutMode::Packed)?;
             let backend = crate::backend::wasm_runtime::WasmBackend::new(&laid_out, &options)?;
             let mut sim =
                 Simulator::with_backend_and_program(backend, laid_out.into_runtime(), warnings);
+            sim.components.set_injected(injected_components);
             sim.diagnostics = options.diagnostics.clone();
             if let Some(path) = vcd_path {
                 let descs = sim.build_vcd_descs(options.four_state);
@@ -1055,6 +1094,7 @@ mod host {
                 &self.param_overrides,
                 &self.options.optimize_options,
                 &self.options.diagnostics,
+                &self.injected_components.manifests(),
                 layout_mode,
             );
 
@@ -1094,6 +1134,8 @@ mod host {
 
                 let mut sim =
                     Simulator::with_backend_and_program(backend, laid_out.into_runtime(), warnings);
+                sim.components
+                    .set_injected(self.injected_components.clone());
                 sim.diagnostics = self.options.diagnostics.clone();
                 sim.apply_initial_values();
                 sim.modify(|_| {}).map_err(SimulatorError::from)?;
@@ -1142,6 +1184,7 @@ mod host {
                 reset_type: None,
                 param_overrides: Vec::new(),
                 live_signals: Vec::new(),
+                injected_components: Default::default(),
                 _marker: std::marker::PhantomData,
             }
         }
@@ -1159,6 +1202,7 @@ mod host {
                 reset_type: None,
                 param_overrides: Vec::new(),
                 live_signals: Vec::new(),
+                injected_components: Default::default(),
                 _marker: std::marker::PhantomData,
             }
         }
@@ -1190,6 +1234,7 @@ mod host {
                 &self.param_overrides,
                 &self.options.optimize_options,
                 &self.options.diagnostics,
+                &self.injected_components.manifests(),
                 layout_mode,
             )?;
             let mut laid_out =
@@ -1211,6 +1256,7 @@ mod host {
 
             let mut sim =
                 Simulator::with_backend_and_program(backend, laid_out.into_runtime(), warnings);
+            sim.components.set_injected(self.injected_components);
             sim.diagnostics = self.options.diagnostics.clone();
             if let Some(path) = self.vcd_path {
                 let descs = sim.build_vcd_descs(self.options.four_state);

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -50,6 +50,7 @@ pub struct AssertionResult {
 pub struct TestResultDetailed {
     pub passed: bool,
     pub assertions: Vec<AssertionResult>,
+    pub error: Option<String>,
 }
 
 /// Opaque, precompiled native testbench program for a built simulator.
@@ -1070,21 +1071,21 @@ pub(crate) fn run_testbench_detailed<B: SimBackend>(
         &mut sim.backend,
     ) {
         Ok(writes) => writes,
-        Err(_) => {
+        Err(message) => {
             return TestResultDetailed {
                 passed: false,
                 assertions: Vec::new(),
+                error: Some(message),
             };
         }
     };
     if let Some(writer) = sim.vcd_writer.as_mut()
-        && writer
-            .add_external_signals(&sim.components.trace_descriptors())
-            .is_err()
+        && let Err(error) = writer.add_external_signals(&sim.components.trace_descriptors())
     {
         return TestResultDetailed {
             passed: false,
             assertions: Vec::new(),
+            error: Some(format!("component VCD registration failed: {error}")),
         };
     }
     apply_component_writes(sim, initial_writes);
@@ -1104,13 +1105,20 @@ pub(crate) fn run_testbench_detailed<B: SimBackend>(
     } else {
         exec_detailed(sim, testbench.statements(), &mut ctx)
     };
-    let finish_ok = sim.components.finish(ctx.current_time).is_ok();
-    let passed = finish_ok
-        && !matches!(result, ExecResult::Fail(_))
-        && ctx.assertions.iter().all(|a| a.passed);
+    let mut error = match result {
+        ExecResult::Fail(message) => Some(message),
+        ExecResult::Continue | ExecResult::Break | ExecResult::Finished => None,
+    };
+    if let Err(message) = sim.components.finish(ctx.current_time)
+        && error.is_none()
+    {
+        error = Some(message);
+    }
+    let passed = error.is_none() && ctx.assertions.iter().all(|a| a.passed);
     TestResultDetailed {
         passed,
         assertions: ctx.assertions,
+        error,
     }
 }
 

--- a/crates/celox/tests/injected_component.rs
+++ b/crates/celox/tests/injected_component.rs
@@ -9,6 +9,7 @@ use celox::{
 
 struct Model {
     phases: Arc<Mutex<Vec<String>>>,
+    fired_clocks: Arc<Mutex<Vec<Option<String>>>>,
 }
 
 impl InjectedComponentHandler for Model {
@@ -22,6 +23,10 @@ impl InjectedComponentHandler for Model {
             InjectedHook::Method { .. } => "method",
         };
         self.phases.lock().unwrap().push(phase.into());
+        self.fired_clocks
+            .lock()
+            .unwrap()
+            .push(call.fired_clock.clone());
         let output = match call.hook {
             InjectedHook::Init => Some(0),
             InjectedHook::Clock => {
@@ -75,6 +80,7 @@ fn injected_clocked_component_uses_component_scheduling() {
         }
     "#;
     let phases = Arc::new(Mutex::new(Vec::new()));
+    let fired_clocks = Arc::new(Mutex::new(Vec::new()));
     let mut components = InjectedComponents::new();
     components
         .insert(
@@ -89,6 +95,7 @@ fn injected_clocked_component_uses_component_scheduling() {
             }"#,
             Arc::new(Model {
                 phases: phases.clone(),
+                fired_clocks: fired_clocks.clone(),
             }),
         )
         .unwrap();
@@ -101,5 +108,9 @@ fn injected_clocked_component_uses_component_scheduling() {
     assert_eq!(
         *phases.lock().unwrap(),
         ["create", "init", "clock", "finish"]
+    );
+    assert_eq!(
+        *fired_clocks.lock().unwrap(),
+        [None, None, Some("clk".to_string()), None]
     );
 }

--- a/crates/celox/tests/injected_component.rs
+++ b/crates/celox/tests/injected_component.rs
@@ -1,0 +1,105 @@
+#![cfg(feature = "host-runtime")]
+
+use std::sync::{Arc, Mutex};
+
+use celox::{
+    InjectedCall, InjectedComponentHandler, InjectedComponents, InjectedHook, InjectedNamedValue,
+    InjectedResult, InjectedValue, Simulator, TestResult,
+};
+
+struct Model {
+    phases: Arc<Mutex<Vec<String>>>,
+}
+
+impl InjectedComponentHandler for Model {
+    fn call(&self, call: InjectedCall) -> Result<InjectedResult, String> {
+        let phase = match call.hook {
+            InjectedHook::Create => "create",
+            InjectedHook::Init => "init",
+            InjectedHook::Clock => "clock",
+            InjectedHook::Finish => "finish",
+            InjectedHook::Reset => "reset",
+            InjectedHook::Method { .. } => "method",
+        };
+        self.phases.lock().unwrap().push(phase.into());
+        let output = match call.hook {
+            InjectedHook::Init => Some(0),
+            InjectedHook::Clock => {
+                let input = call
+                    .inputs
+                    .iter()
+                    .find(|value| value.name == "d")
+                    .and_then(|value| match &value.value {
+                        InjectedValue::Bits { words, .. } => words.first().copied(),
+                        _ => None,
+                    })
+                    .unwrap();
+                Some(input + 3)
+            }
+            _ => None,
+        };
+        Ok(InjectedResult {
+            outputs: output
+                .map(|value| InjectedNamedValue {
+                    name: "q".into(),
+                    value: InjectedValue::Bits {
+                        words: vec![value],
+                        mask_xz: vec![0],
+                        width: 8,
+                    },
+                })
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        })
+    }
+}
+
+#[test]
+fn injected_clocked_component_uses_component_scheduling() {
+    let source = r#"
+        #[test(InjectedComponentTb)]
+        module InjectedComponentTb {
+            inst clk: $tb::clock_gen;
+            var d: logic<8>;
+            var q: logic<8>;
+            inst model: $comp::ts_model (clk, d, q);
+
+            initial {
+                $assert(q == 0, "on_init output");
+                d = 8'h20;
+                clk.next();
+                $assert(q == 8'h23, "injected component output");
+                $finish();
+            }
+        }
+    "#;
+    let phases = Arc::new(Mutex::new(Vec::new()));
+    let mut components = InjectedComponents::new();
+    components
+        .insert(
+            "ts_model",
+            r#"{
+                "kind":"clocked",
+                "ports":[
+                    {"name":"clk","dir":"input","role":"clock"},
+                    {"name":"d","dir":"input"},
+                    {"name":"q","dir":"output"}
+                ]
+            }"#,
+            Arc::new(Model {
+                phases: phases.clone(),
+            }),
+        )
+        .unwrap();
+
+    let result = Simulator::builder(source, "InjectedComponentTb")
+        .with_injected_components(components)
+        .run_test()
+        .unwrap();
+    assert_eq!(result, TestResult::Pass, "{result:?}");
+    assert_eq!(
+        *phases.lock().unwrap(),
+        ["create", "init", "clock", "finish"]
+    );
+}

--- a/docs/guide/vite-plugin.md
+++ b/docs/guide/vite-plugin.md
@@ -48,6 +48,50 @@ export default defineConfig({
 });
 ```
 
+### TypeScript Testbench Components
+
+Native Vitest testbenches can use synchronous components created with
+`defineTbComponent` without building a Rust or Wasm component library:
+
+```ts
+// test/tb-components.ts
+import { defineTbComponent } from "@celox-sim/celox";
+
+const store = defineTbComponent<{ value: bigint }>({
+  kind: "method_only",
+  create: () => ({ value: 0n }),
+  methods: {
+    set: {
+      args: [{ name: "value", type: "value" }],
+      call: ({ state }, [value]) => { state.value = value as bigint; },
+    },
+    get: {
+      returns: { width: 8 },
+      call: ({ state }) => ({ returnValue: state.value }),
+    },
+  },
+});
+
+export default { store };
+```
+
+Point the Vite plugin at the component module:
+
+```ts
+export default defineConfig({
+  plugins: [celox({
+    testbenchComponents: "./test/tb-components.ts",
+  })],
+});
+```
+
+The plugin loads the module through Vite, writes the extracted manifests to
+`.celox/testbench-components.manifest.json`, supplies them during type
+generation, and imports the original module in generated Vitest cases. Veryl
+can then declare `var model: $comp::store;`. This path is available to native
+Node/Vitest execution; browser Wasm simulation does not currently support
+synchronous JavaScript component callbacks.
+
 ### tsconfig.json
 
 To enable TypeScript support for `.veryl` imports, add the following to `tsconfig.json`:
@@ -108,3 +152,4 @@ The policy is embedded in the `ModuleDefinition` as `defaultOptions.deadStorePol
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `projectRoot` | `string` | *(auto-detected)* | Path to the directory containing `Veryl.toml` |
+| `testbenchComponents` | `string` | *(none)* | Component module injected into generated native Vitest testbenches |

--- a/docs/guide/vite-plugin.md
+++ b/docs/guide/vite-plugin.md
@@ -85,12 +85,27 @@ export default defineConfig({
 });
 ```
 
-The plugin loads the module through Vite, writes the extracted manifests to
-`.celox/testbench-components.manifest.json`, supplies them during type
-generation, and imports the original module in generated Vitest cases. Veryl
-can then declare `var model: $comp::store;`. This path is available to native
-Node/Vitest execution; browser Wasm simulation does not currently support
-synchronous JavaScript component callbacks.
+Register the generated manifest directory as a normal Veryl component source:
+
+```toml
+# Veryl.toml
+[[components]]
+path = ".celox/testbench-components"
+```
+
+The plugin loads the module through Vite and writes the extracted interfaces to
+`.celox/testbench-components/veryl.manifest.json`. Veryl's existing component
+discovery then makes the definitions visible to the compiler and language
+server, including method arguments and return types. No Rust or Wasm artifact
+is generated. The plugin also supplies the interfaces during TypeScript type
+generation and imports the original module in generated Vitest cases. Veryl can
+then declare `var model: $comp::store;`.
+
+Generate the manifest at least once before opening or reloading the Veryl
+project in an editor. If the language server does not notice a subsequent
+manifest update, reload its workspace. Runtime callbacks are available to
+native Node/Vitest execution; browser Wasm simulation does not currently
+support synchronous JavaScript component callbacks.
 
 ### tsconfig.json
 
@@ -118,8 +133,10 @@ my-project/
 ├── src/
 │   └── Counter.veryl          # Veryl source
 ├── .celox/
-│   └── src/
-│       └── Counter.d.veryl.ts # Generated type definition
+│   ├── src/
+│   │   └── Counter.d.veryl.ts # Generated type definition
+│   └── testbench-components/
+│       └── veryl.manifest.json    # Generated component interfaces
 └── vitest.config.ts
 ```
 

--- a/docs/guide/vite-plugin.md
+++ b/docs/guide/vite-plugin.md
@@ -197,4 +197,4 @@ The policy is embedded in the `ModuleDefinition` as `defaultOptions.deadStorePol
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `projectRoot` | `string` | *(auto-detected)* | Path to the directory containing `Veryl.toml` |
-| `testbenchComponents` | `string` | *(none)* | Component module injected into generated native Vitest testbenches |
+| `testbenchComponents` | `string` | *(none)* | Absolute path, or path relative to the Veryl project root, to a module that default-exports a TypeScript TB component registry. Used to generate manifests and inject callbacks into native Vitest tests. |

--- a/docs/guide/vite-plugin.md
+++ b/docs/guide/vite-plugin.md
@@ -1,16 +1,23 @@
 # Vite Plugin
 
-The `@celox-sim/vite-plugin` package provides seamless integration between Veryl source files and the TypeScript/Vitest toolchain.
+The `@celox-sim/vite-plugin` package connects Veryl source files to Vite-based
+tools. In Vitest, it also acts as a test-runner adapter: importing a Veryl test
+file turns its `#[test]` modules into ordinary Vitest cases. The plugin is not
+limited to that role; regular Veryl modules are exposed as typed module
+definitions for handwritten TypeScript tests and other Vite applications.
 
 ## What It Does
 
-The plugin handles three things automatically:
+The plugin handles four things automatically:
 
 1. **Module resolution** -- Allows `import { Counter } from "../src/Counter.veryl"` to work in test files.
-2. **Type generation** -- Produces `.d.veryl.ts` sidecar files so TypeScript understands the shape of each module (ports, events, types).
-3. **Hot reload** -- When a `.veryl` file changes, the plugin invalidates its cache and regenerates types.
+2. **Vitest integration** -- Converts each imported `#[test]` module into a Vitest `test()` case, runs it with Celox, and reports Veryl assertions as Vitest failures.
+3. **Type generation** -- Produces `.d.veryl.ts` sidecar files so TypeScript understands the shape of each module (ports, events, types).
+4. **Hot reload** -- When a `.veryl` file changes, the plugin invalidates its cache and regenerates types.
 
-Under the hood, the plugin calls the `celox-ts-gen` type generator via the NAPI addon. You never need to run the generator manually.
+Under the hood, the plugin calls the `celox-ts-gen` type generator and native
+simulator through the NAPI addon. You do not need to generate types or create
+Vitest wrappers manually.
 
 ## Installation
 
@@ -33,6 +40,27 @@ export default defineConfig({
 ```
 
 The plugin automatically finds the nearest `Veryl.toml` by walking up from the Vite project root.
+
+### Using Vitest as the Veryl Test Runner
+
+Create a normal Vitest entry file that imports a Veryl file containing one or
+more `#[test]` modules:
+
+```ts
+// test/counter.test.ts
+import "./CounterTest.veryl";
+```
+
+When Vitest evaluates the import, the plugin registers one Vitest case for each
+Veryl test module. Celox executes the testbench with its native simulator;
+failed Veryl assertions, including their source locations, appear in the
+Vitest report. This lets Vitest provide discovery, filtering, watch mode,
+reporters, and CI integration without rewriting the testbench in TypeScript.
+
+Importing an ordinary, non-test Veryl module instead returns a typed
+`ModuleDefinition`. It can be driven from a handwritten TypeScript test through
+`Simulator` or `Simulation`, and the same import mechanism can be used by other
+Vite-based tools.
 
 ### Custom Project Root
 

--- a/docs/ja/guide/vite-plugin.md
+++ b/docs/ja/guide/vite-plugin.md
@@ -85,11 +85,25 @@ export default defineConfig({
 });
 ```
 
-プラグインはVite経由でmoduleを読み込み、抽出したmanifestを
-`.celox/testbench-components.manifest.json` に生成します。そのmanifestを型生成へ渡し、
-生成するVitest caseから元のmoduleをimportします。Veryl側では
-`var model: $comp::store;` と宣言できます。この経路はnative Node/Vitest向けです。
-ブラウザWasmシミュレーションは同期JavaScript callbackに未対応です。
+生成されるmanifest directoryを、通常のVeryl component sourceとして登録します：
+
+```toml
+# Veryl.toml
+[[components]]
+path = ".celox/testbench-components"
+```
+
+プラグインはVite経由でmoduleを読み込み、抽出したinterfaceを
+`.celox/testbench-components/veryl.manifest.json` に生成します。Verylの既存の
+component discoveryにより、methodの引数や戻り値も含めてcompilerとLSPから
+認識されます。Rust/Wasm artifactは生成しません。そのmanifestはTypeScript型生成にも
+渡され、生成するVitest caseから元のmoduleをimportします。Veryl側では
+`var model: $comp::store;` と宣言できます。
+
+エディタでVeryl projectを開くかreloadする前に、少なくとも1回manifestを生成して
+ください。以後のmanifest更新をLSPが検知しない場合はworkspaceをreloadします。
+runtime callbackはnative Node/Vitest向けです。ブラウザWasmシミュレーションは
+同期JavaScript callbackに未対応です。
 
 ### tsconfig.json
 
@@ -117,8 +131,10 @@ my-project/
 ├── src/
 │   └── Counter.veryl          # Veryl ソース
 ├── .celox/
-│   └── src/
-│       └── Counter.d.veryl.ts # 生成された型定義
+│   ├── src/
+│   │   └── Counter.d.veryl.ts # 生成された型定義
+│   └── testbench-components/
+│       └── veryl.manifest.json    # 生成されたcomponent interface
 └── vitest.config.ts
 ```
 

--- a/docs/ja/guide/vite-plugin.md
+++ b/docs/ja/guide/vite-plugin.md
@@ -48,6 +48,49 @@ export default defineConfig({
 });
 ```
 
+### TypeScript テストベンチコンポーネント
+
+native Vitest テストベンチでは、`defineTbComponent` で作った同期コンポーネントを
+Rust/Wasm コンポーネントライブラリのビルドなしで利用できます：
+
+```ts
+// test/tb-components.ts
+import { defineTbComponent } from "@celox-sim/celox";
+
+const store = defineTbComponent<{ value: bigint }>({
+  kind: "method_only",
+  create: () => ({ value: 0n }),
+  methods: {
+    set: {
+      args: [{ name: "value", type: "value" }],
+      call: ({ state }, [value]) => { state.value = value as bigint; },
+    },
+    get: {
+      returns: { width: 8 },
+      call: ({ state }) => ({ returnValue: state.value }),
+    },
+  },
+});
+
+export default { store };
+```
+
+Vite 設定でコンポーネントmoduleを指定します：
+
+```ts
+export default defineConfig({
+  plugins: [celox({
+    testbenchComponents: "./test/tb-components.ts",
+  })],
+});
+```
+
+プラグインはVite経由でmoduleを読み込み、抽出したmanifestを
+`.celox/testbench-components.manifest.json` に生成します。そのmanifestを型生成へ渡し、
+生成するVitest caseから元のmoduleをimportします。Veryl側では
+`var model: $comp::store;` と宣言できます。この経路はnative Node/Vitest向けです。
+ブラウザWasmシミュレーションは同期JavaScript callbackに未対応です。
+
 ### tsconfig.json
 
 `.veryl` インポートの TypeScript サポートを有効にするには、`tsconfig.json` に以下を追加します：
@@ -108,3 +151,4 @@ import { Top } from "../src/Top.veryl?dse=preserveAllPorts";
 | オプション | 型 | デフォルト | 説明 |
 |---|---|---|---|
 | `projectRoot` | `string` | *（自動検出）* | `Veryl.toml` を含むディレクトリへのパス |
+| `testbenchComponents` | `string` | *（なし）* | 生成されるnative Vitestテストへ注入するコンポーネントmodule |

--- a/docs/ja/guide/vite-plugin.md
+++ b/docs/ja/guide/vite-plugin.md
@@ -192,4 +192,4 @@ import { Top } from "../src/Top.veryl?dse=preserveAllPorts";
 | オプション | 型 | デフォルト | 説明 |
 |---|---|---|---|
 | `projectRoot` | `string` | *（自動検出）* | `Veryl.toml` を含むディレクトリへのパス |
-| `testbenchComponents` | `string` | *（なし）* | 生成されるnative Vitestテストへ注入するコンポーネントmodule |
+| `testbenchComponents` | `string` | *（なし）* | TypeScript製TB component registryをdefault exportするmoduleへの絶対パス、またはVeryl project rootからの相対パス。manifest生成とnative Vitestテストへのcallback注入に使用します。 |

--- a/docs/ja/guide/vite-plugin.md
+++ b/docs/ja/guide/vite-plugin.md
@@ -1,16 +1,22 @@
 # Vite プラグイン
 
-`@celox-sim/vite-plugin` パッケージは、Veryl ソースファイルと TypeScript/Vitest ツールチェーンのシームレスな統合を提供します。
+`@celox-sim/vite-plugin` パッケージは、VerylソースをViteベースのツールへ接続します。
+Vitestではテストランナーアダプターとしても動作し、Verylのテストファイルをimportすると、
+その `#[test]` モジュールが通常のVitestテストケースになります。この用途だけに限定されている
+わけではなく、通常のVerylモジュールは、手書きのTypeScriptテストやその他のVite
+アプリケーションで使える型付きモジュール定義として公開されます。
 
 ## 機能
 
-プラグインは 3 つのことを自動的に処理します：
+プラグインは 4 つのことを自動的に処理します：
 
 1. **モジュール解決** -- テストファイルで `import { Counter } from "../src/Counter.veryl"` が動作するようにします。
-2. **型生成** -- TypeScript が各モジュールの形状（ポート、イベント、型）を理解できるように `.d.veryl.ts` サイドカーファイルを生成します。
-3. **ホットリロード** -- `.veryl` ファイルが変更されると、プラグインはキャッシュを無効化して型を再生成します。
+2. **Vitest統合** -- importした各 `#[test]` モジュールをVitestの `test()` ケースに変換し、Celoxで実行してVerylのassertionをVitestのfailureとして報告します。
+3. **型生成** -- TypeScript が各モジュールの形状（ポート、イベント、型）を理解できるように `.d.veryl.ts` サイドカーファイルを生成します。
+4. **ホットリロード** -- `.veryl` ファイルが変更されると、プラグインはキャッシュを無効化して型を再生成します。
 
-内部的には、プラグインは NAPI アドオンを介して `celox-ts-gen` 型ジェネレータを呼び出します。ジェネレータを手動で実行する必要はありません。
+内部的には、プラグインはNAPIアドオンを介して `celox-ts-gen` 型ジェネレーターと
+ネイティブシミュレーターを呼び出します。型生成やVitest wrapperの作成を手動で行う必要はありません。
 
 ## インストール
 
@@ -33,6 +39,25 @@ export default defineConfig({
 ```
 
 プラグインは Vite プロジェクトルートから上方に探索して、最も近い `Veryl.toml` を自動的に見つけます。
+
+### VitestをVerylのテストランナーとして使う
+
+1つ以上の `#[test]` モジュールを含むVerylファイルをimportする、通常のVitest
+エントリーファイルを作成します：
+
+```ts
+// test/counter.test.ts
+import "./CounterTest.veryl";
+```
+
+Vitestがこのimportを評価すると、プラグインはVerylのテストモジュールごとにVitest
+ケースを1つ登録します。Celoxのネイティブシミュレーターがtestbenchを実行し、失敗した
+Verylのassertionはソース位置付きでVitestのレポートに現れます。testbenchをTypeScriptに
+書き直すことなく、Vitestのテスト検出、フィルター、watch mode、reporter、CI統合を利用できます。
+
+通常の非テストVerylモジュールをimportした場合は、型付きの `ModuleDefinition` が返ります。
+手書きのTypeScriptテストから `Simulator` または `Simulation` で操作でき、同じimport機構を
+その他のViteベースのツールからも利用できます。
 
 ### カスタムプロジェクトルート
 

--- a/packages/celox/fixtures/.gitignore
+++ b/packages/celox/fixtures/.gitignore
@@ -1,0 +1,1 @@
+**/Veryl.lock

--- a/packages/celox/fixtures/testbench_project/Veryl.toml
+++ b/packages/celox/fixtures/testbench_project/Veryl.toml
@@ -1,0 +1,6 @@
+[project]
+name = "testbench_project"
+version = "0.1.0"
+
+[build]
+sources = ["src"]

--- a/packages/celox/fixtures/testbench_project/src/OptionNormalizationTb.veryl
+++ b/packages/celox/fixtures/testbench_project/src/OptionNormalizationTb.veryl
@@ -1,0 +1,7 @@
+#[test(OptionNormalizationTb)]
+module OptionNormalizationTb {
+    initial {
+        $assert(1 == 1, "project testbench passed");
+        $finish();
+    }
+}

--- a/packages/celox/src/e2e.test.ts
+++ b/packages/celox/src/e2e.test.ts
@@ -3003,4 +3003,35 @@ module InjectedMethodComponentTb {
 		expect(result.assertions.every((assertion) => assertion.passed)).toBe(true);
 		expect(finished).toBe(2);
 	});
+
+	test("preserves injected component failure messages", () => {
+		const source = `
+#[test(InjectedFailureTb)]
+module InjectedFailureTb {
+    var model: $comp::ts_failure;
+
+    initial {
+        model.fail();
+        $finish();
+    }
+}
+`;
+		const component = defineTbComponent({
+			kind: "method_only",
+			methods: {
+				fail: {
+					call: () => ({ failures: ["TypeScript component failed"] }),
+				},
+			},
+		});
+
+		const result = runTest(
+			[{ content: source, path: "injected_failure.veryl" }],
+			"InjectedFailureTb",
+			{ components: { ts_failure: component } },
+		);
+
+		expect(result.passed).toBe(false);
+		expect(result.error).toContain("TypeScript component failed");
+	});
 });

--- a/packages/celox/src/e2e.test.ts
+++ b/packages/celox/src/e2e.test.ts
@@ -22,6 +22,7 @@ import {
 } from "./napi-helpers.js";
 import { Simulation } from "./simulation.js";
 import { Simulator } from "./simulator.js";
+import { defineTbComponent, runTest } from "./testbench.js";
 import {
 	FourState,
 	type FourStateSignalValue,
@@ -2854,5 +2855,130 @@ describe("E2E: native testbench (runTest)", () => {
 		expect(a.file).toBeDefined();
 		expect(a.line).toBeGreaterThan(0);
 		expect(a.column).toBeGreaterThan(0);
+	});
+
+	test("injects a synchronous TypeScript clocked component", () => {
+		const source = `
+#[test(InjectedComponentTb)]
+module InjectedComponentTb {
+    inst clk: $tb::clock_gen;
+    var d: logic<8>;
+    var q: logic<8>;
+    inst model: $comp::ts_model #(STEP: 3) (clk, d, q);
+
+    initial {
+        $assert(q == 0, "on_init output");
+        d = 8'h20;
+        clk.next();
+        $assert(q == 8'h23, "TypeScript component output");
+        $finish();
+    }
+}
+`;
+		const phases: string[] = [];
+		const component = defineTbComponent<{ clocks: number }>({
+			kind: "clocked",
+			ports: {
+				clk: { direction: "input", role: "clock" },
+				d: { direction: "input" },
+				q: { direction: "output" },
+			},
+			params: { STEP: { type: "value" } },
+			create: () => {
+				phases.push("create");
+				return { clocks: 0 };
+			},
+			onInit: () => ({ outputs: { q: 0n } }),
+			onClock: ({ inputs, params, state, cycle }) => {
+				state.clocks++;
+				phases.push(`clock:${cycle}`);
+				return {
+					outputs: { q: inputs.d! + (params.STEP as bigint) },
+				};
+			},
+			onFinish: ({ state }) => {
+				phases.push(`finish:${state.clocks}`);
+			},
+		});
+		const result = runTest(
+			[{ content: source, path: "injected_component.veryl" }],
+			"InjectedComponentTb",
+			{ components: { ts_model: component } },
+		);
+
+		expect(result.assertions).toHaveLength(2);
+		expect(result.assertions.every((assertion) => assertion.passed)).toBe(true);
+		expect(phases).toEqual(["create", "clock:1", "finish:1"]);
+		expect(result.passed).toBe(true);
+	});
+
+	test("injects a stateful TypeScript method-only component", () => {
+		const source = `
+#[test(InjectedMethodComponentTb)]
+module InjectedMethodComponentTb {
+    var first: $comp::ts_store;
+    var second: $comp::ts_store;
+
+    initial {
+        first.set(40);
+        $assert(first.add(2) == 42, "method argument and return");
+        $assert(first.get() == 40, "first instance retained state");
+        $assert(second.get() == 0, "instances have independent state");
+        first.set_label("hello");
+        $assert(first.label_len() == 5, "string method argument");
+        $finish();
+    }
+}
+`;
+		let finished = 0;
+		const component = defineTbComponent<{ value: bigint; label: string }>({
+			kind: "method_only",
+			create: () => ({ value: 0n, label: "" }),
+			methods: {
+				set: {
+					args: [{ name: "value", type: "value" }],
+					call: ({ state }, [value]) => {
+						state.value = value as bigint;
+					},
+				},
+				add: {
+					args: [{ name: "value", type: "value" }],
+					returns: { width: 8 },
+					call: ({ state }, [value]) => ({
+						returnValue: state.value + (value as bigint),
+					}),
+				},
+				get: {
+					returns: { width: 8 },
+					call: ({ state }) => ({ returnValue: state.value }),
+				},
+				set_label: {
+					args: [{ name: "value", type: "string" }],
+					call: ({ state }, [value]) => {
+						state.label = value as string;
+					},
+				},
+				label_len: {
+					returns: { width: 8 },
+					call: ({ state }) => ({
+						returnValue: BigInt(state.label.length),
+					}),
+				},
+			},
+			onFinish: () => {
+				finished++;
+			},
+		});
+
+		const result = runTest(
+			[{ content: source, path: "injected_method_component.veryl" }],
+			"InjectedMethodComponentTb",
+			{ components: { ts_store: component } },
+		);
+
+		expect(result.passed).toBe(true);
+		expect(result.assertions).toHaveLength(4);
+		expect(result.assertions.every((assertion) => assertion.passed)).toBe(true);
+		expect(finished).toBe(2);
 	});
 });

--- a/packages/celox/src/e2e.test.ts
+++ b/packages/celox/src/e2e.test.ts
@@ -22,7 +22,7 @@ import {
 } from "./napi-helpers.js";
 import { Simulation } from "./simulation.js";
 import { Simulator } from "./simulator.js";
-import { defineTbComponent, runTest } from "./testbench.js";
+import { defineTbComponent, runTest, runTestFromProject } from "./testbench.js";
 import {
 	FourState,
 	type FourStateSignalValue,
@@ -38,6 +38,7 @@ const FIXTURES_DIR = path.resolve(
 const ADDER_PROJECT = path.join(FIXTURES_DIR, "adder");
 const COUNTER_PROJECT = path.join(FIXTURES_DIR, "counter_project");
 const CELOX_TOML_PROJECT = path.join(FIXTURES_DIR, "celox_toml");
+const TESTBENCH_PROJECT = path.join(FIXTURES_DIR, "testbench_project");
 
 // ---------------------------------------------------------------------------
 // Test Veryl sources
@@ -2855,6 +2856,27 @@ describe("E2E: native testbench (runTest)", () => {
 		expect(a.file).toBeDefined();
 		expect(a.line).toBeGreaterThan(0);
 		expect(a.column).toBeGreaterThan(0);
+	});
+
+	test("normalizes public runTest options before calling NAPI", () => {
+		const options = {
+			deadStorePolicy: "preserveTopPorts",
+			craneliftOptLevel: "speedAndSize",
+			regallocAlgorithm: "singlePass",
+		} as const;
+		const sourceResult = runTest(
+			[{ content: TB_PASS_SOURCE, path: "test.veryl" }],
+			"CounterTbPass",
+			options,
+		);
+		const projectResult = runTestFromProject(
+			TESTBENCH_PROJECT,
+			"OptionNormalizationTb",
+			options,
+		);
+
+		expect(sourceResult.passed).toBe(true);
+		expect(projectResult.passed).toBe(true);
 	});
 
 	test("injects a synchronous TypeScript clocked component", () => {

--- a/packages/celox/src/index.ts
+++ b/packages/celox/src/index.ts
@@ -37,6 +37,25 @@ export {
 export { Simulation } from "./simulation.js";
 // Simulator (event-based)
 export { Simulator } from "./simulator.js";
+export type {
+	InjectedTbComponent,
+	RunTestOptions,
+	TbComponentContext,
+	TbComponentDefinition,
+	TbComponentEffects,
+	TbFourStateValue,
+	TbMethodArgument,
+	TbMethodDefinition,
+	TbMethodResult,
+	TbOutputValue,
+	TbParameter,
+	TbPort,
+} from "./testbench.js";
+export {
+	defineTbComponent,
+	runTest,
+	runTestFromProject,
+} from "./testbench.js";
 // Core types
 /** @internal */
 export type {

--- a/packages/celox/src/napi-helpers.ts
+++ b/packages/celox/src/napi-helpers.ts
@@ -142,6 +142,7 @@ export interface NapiAssertionResult {
 export interface NapiTestResult {
 	passed: boolean;
 	assertions: NapiAssertionResult[];
+	error?: string;
 }
 
 export interface NapiInjectedValue {

--- a/packages/celox/src/napi-helpers.ts
+++ b/packages/celox/src/napi-helpers.ts
@@ -144,6 +144,55 @@ export interface NapiTestResult {
 	assertions: NapiAssertionResult[];
 }
 
+export interface NapiInjectedValue {
+	name?: string;
+	bits?: bigint;
+	maskXz?: bigint;
+	width?: number;
+	stringValue?: string;
+}
+
+export interface NapiInjectedPort {
+	name: string;
+	direction: string;
+	role?: string;
+	width: number;
+}
+
+export interface NapiInjectedCall {
+	instance: string;
+	phase: string;
+	method?: string;
+	inputs: NapiInjectedValue[];
+	params: NapiInjectedValue[];
+	ports: NapiInjectedPort[];
+	args: NapiInjectedValue[];
+	cycle: bigint;
+	time: bigint;
+	seed: bigint;
+	firedClock?: string;
+	fourState: boolean;
+}
+
+export interface NapiInjectedResult {
+	outputs?: NapiInjectedValue[];
+	returnValue?: NapiInjectedValue;
+	failures?: string[];
+	logs?: string[];
+	finish?: boolean;
+}
+
+export interface NapiInjectedComponent {
+	name: string;
+	manifest: string;
+	handler(call: NapiInjectedCall): NapiInjectedResult;
+}
+
+export interface NapiInjectedManifest {
+	name: string;
+	manifest: string;
+}
+
 export interface RawNapiAddon {
 	NativeSimulatorHandle: {
 		new (
@@ -169,17 +218,19 @@ export interface RawNapiAddon {
 			options?: NapiOptions,
 		): RawNapiSimulationHandle;
 	};
-	genTs(projectPath: string): string;
+	genTs(projectPath: string, components?: NapiInjectedManifest[]): string;
 	clearJitCache(): void;
 	runTest(
 		sources: NapiSourceFile[],
 		top: string,
 		options?: NapiOptions,
+		components?: NapiInjectedComponent[],
 	): NapiTestResult;
 	runTestFromProject(
 		projectPath: string,
 		top: string,
 		options?: NapiOptions,
+		components?: NapiInjectedComponent[],
 	): NapiTestResult;
 }
 

--- a/packages/celox/src/testbench.ts
+++ b/packages/celox/src/testbench.ts
@@ -1,0 +1,278 @@
+import {
+	loadNativeAddon,
+	type NapiInjectedCall,
+	type NapiInjectedComponent,
+	type NapiInjectedResult,
+	type NapiInjectedValue,
+	type NapiOptions,
+	type NapiTestResult,
+} from "./napi-helpers.js";
+import type { SourceFile } from "./types.js";
+
+export type TbPort = {
+	direction: "input" | "output";
+	role?: "clock" | "reset";
+};
+
+export type TbParameter = {
+	type: "value" | "string";
+	optional?: boolean;
+};
+
+export type TbFourStateValue = { value: bigint; maskXz: bigint };
+export type TbOutputValue = bigint | TbFourStateValue;
+
+export interface TbComponentContext<State> {
+	readonly instance: string;
+	readonly state: State;
+	readonly inputs: Readonly<Record<string, bigint>>;
+	readonly masks: Readonly<Record<string, bigint>>;
+	readonly params: Readonly<Record<string, bigint | string | undefined>>;
+	readonly cycle: bigint;
+	readonly time: bigint;
+	readonly seed: bigint;
+	readonly firedClock?: string;
+	readonly fourState: boolean;
+}
+
+export interface TbComponentEffects {
+	outputs?: Record<string, TbOutputValue>;
+	failures?: string[];
+	logs?: string[];
+	finish?: boolean;
+}
+
+export type TbMethodArgument = {
+	name: string;
+	type: "value" | "string";
+};
+
+export interface TbMethodResult extends TbComponentEffects {
+	returnValue?: bigint;
+}
+
+export interface TbMethodDefinition<State> {
+	args?: TbMethodArgument[];
+	/** Omit for a unit-returning method. */
+	returns?: { width: number };
+	call(
+		context: TbComponentContext<State>,
+		args: ReadonlyArray<bigint | string | undefined>,
+	): TbMethodResult | undefined;
+}
+
+export interface TbComponentDefinition<State> {
+	kind: "clocked" | "method_only";
+	ports?: Record<string, TbPort>;
+	params?: Record<string, TbParameter>;
+	methods?: Record<string, TbMethodDefinition<State>>;
+	create?(context: Omit<TbComponentContext<never>, "state">): State;
+	onInit?(context: TbComponentContext<State>): TbComponentEffects | undefined;
+	onClock?(context: TbComponentContext<State>): TbComponentEffects | undefined;
+	onReset?(context: TbComponentContext<State>): TbComponentEffects | undefined;
+	onFinish?(context: TbComponentContext<State>): TbComponentEffects | undefined;
+}
+
+const isPromise = (value: unknown): value is PromiseLike<unknown> =>
+	typeof value === "object" &&
+	value !== null &&
+	"then" in value &&
+	typeof (value as { then?: unknown }).then === "function";
+
+function records(values: NapiInjectedValue[]): {
+	values: Record<string, bigint | string | undefined>;
+	masks: Record<string, bigint>;
+} {
+	const result: Record<string, bigint | string | undefined> = {};
+	const masks: Record<string, bigint> = {};
+	for (const item of values) {
+		if (item.name === undefined) continue;
+		result[item.name] = item.bits ?? item.stringValue;
+		masks[item.name] = item.maskXz ?? 0n;
+	}
+	return { values: result, masks };
+}
+
+/**
+ * Define a synchronous TypeScript implementation of a Veryl clocked or
+ * method-only testbench component. No Rust/Wasm component library is built;
+ * the callback is injected into a single `runTest` invocation.
+ */
+export function defineTbComponent<State = undefined>(
+	definition: TbComponentDefinition<State>,
+): InjectedTbComponent {
+	const manifest = JSON.stringify({
+		kind: definition.kind,
+		ports: Object.entries(definition.ports ?? {}).map(([name, port]) => ({
+			name,
+			dir: port.direction,
+			...(port.role === undefined ? {} : { role: port.role }),
+		})),
+		params: Object.entries(definition.params ?? {}).map(([name, param]) => ({
+			name,
+			type: param.type,
+			optional: param.optional ?? false,
+		})),
+		methods: Object.entries(definition.methods ?? {}).map(([name, method]) => ({
+			name,
+			args: method.args ?? [],
+			...(method.returns === undefined
+				? {}
+				: { ret: "value", ret_width: method.returns.width }),
+		})),
+	});
+	const states = new Map<string, State>();
+
+	const handler = (call: NapiInjectedCall): NapiInjectedResult => {
+		const inputRecords = records(call.inputs);
+		const paramRecords = records(call.params);
+		const base = {
+			instance: call.instance,
+			inputs: inputRecords.values as Record<string, bigint>,
+			masks: inputRecords.masks,
+			params: paramRecords.values,
+			cycle: call.cycle,
+			time: call.time,
+			seed: call.seed,
+			firedClock: call.firedClock,
+			fourState: call.fourState,
+		};
+
+		if (call.phase === "create") {
+			const state = definition.create?.(
+				base as Omit<TbComponentContext<never>, "state">,
+			) as State;
+			if (isPromise(state)) {
+				throw new TypeError(
+					"testbench component create callback must be synchronous",
+				);
+			}
+			states.set(call.instance, state);
+			return {};
+		}
+
+		if (!states.has(call.instance)) {
+			throw new Error(`unknown testbench component instance: ${call.instance}`);
+		}
+		const context = { ...base, state: states.get(call.instance) as State };
+		const convertEffects = (
+			effects: TbComponentEffects,
+			returnValue?: NapiInjectedValue,
+		): NapiInjectedResult => {
+			const widths = new Map(call.ports.map((port) => [port.name, port.width]));
+			return {
+				outputs: Object.entries(effects.outputs ?? {}).map(([name, raw]) => {
+					const width = widths.get(name);
+					if (width === undefined)
+						throw new Error(`unknown component output: ${name}`);
+					const value =
+						typeof raw === "bigint" ? { value: raw, maskXz: 0n } : raw;
+					return {
+						name,
+						bits: value.value,
+						maskXz: value.maskXz,
+						width,
+					};
+				}),
+				returnValue,
+				failures: effects.failures,
+				logs: effects.logs,
+				finish: effects.finish,
+			};
+		};
+
+		if (call.phase === "method") {
+			const method =
+				call.method === undefined
+					? undefined
+					: definition.methods?.[call.method];
+			if (method === undefined) {
+				throw new Error(`unknown component method: ${String(call.method)}`);
+			}
+			const args = call.args.map((arg) => arg.bits ?? arg.stringValue);
+			const result = method.call(context, args) ?? {};
+			if (isPromise(result)) {
+				throw new TypeError("testbench component methods must be synchronous");
+			}
+			if (method.returns === undefined) {
+				if (result.returnValue !== undefined) {
+					throw new Error(`unit method ${call.method} returned a value`);
+				}
+				return convertEffects(result);
+			}
+			if (result.returnValue === undefined) {
+				throw new Error(`component method ${call.method} returned no value`);
+			}
+			return convertEffects(result, {
+				bits: result.returnValue,
+				maskXz: 0n,
+				width: method.returns.width,
+			});
+		}
+
+		const callback =
+			call.phase === "init"
+				? definition.onInit
+				: call.phase === "clock"
+					? definition.onClock
+					: call.phase === "reset"
+						? definition.onReset
+						: call.phase === "finish"
+							? definition.onFinish
+							: undefined;
+		const effects = callback?.(context) ?? {};
+		if (isPromise(effects)) {
+			throw new TypeError("testbench component callbacks must be synchronous");
+		}
+		if (call.phase === "finish") states.delete(call.instance);
+
+		return convertEffects(effects);
+	};
+
+	return { manifest, handler };
+}
+
+export interface InjectedTbComponent {
+	/** @internal */ readonly manifest: string;
+	/** @internal */ readonly handler: NapiInjectedComponent["handler"];
+}
+
+export interface RunTestOptions extends NapiOptions {
+	components?: Record<string, InjectedTbComponent>;
+}
+
+/** Compile Veryl sources and run a native testbench with optional TS components. */
+export function runTest(
+	sources: ReadonlyArray<SourceFile>,
+	top: string,
+	options: RunTestOptions = {},
+): NapiTestResult {
+	const { components, ...nativeOptions } = options;
+	const injected: NapiInjectedComponent[] = Object.entries(
+		components ?? {},
+	).map(([name, component]) => ({ name, ...component }));
+	return loadNativeAddon().runTest(
+		sources.map(({ content, path }) => ({ content, path })),
+		top,
+		nativeOptions,
+		injected,
+	);
+}
+
+/** Run a Veryl project testbench with optional TS components. */
+export function runTestFromProject(
+	projectPath: string,
+	top: string,
+	options: RunTestOptions = {},
+): NapiTestResult {
+	const { components, ...nativeOptions } = options;
+	const injected: NapiInjectedComponent[] = Object.entries(
+		components ?? {},
+	).map(([name, component]) => ({ name, ...component }));
+	return loadNativeAddon().runTestFromProject(
+		projectPath,
+		top,
+		nativeOptions,
+		injected,
+	);
+}

--- a/packages/celox/src/testbench.ts
+++ b/packages/celox/src/testbench.ts
@@ -1,13 +1,13 @@
 import {
+	buildNapiOpts,
 	loadNativeAddon,
 	type NapiInjectedCall,
 	type NapiInjectedComponent,
 	type NapiInjectedResult,
 	type NapiInjectedValue,
-	type NapiOptions,
 	type NapiTestResult,
 } from "./napi-helpers.js";
-import type { SourceFile } from "./types.js";
+import type { SimulatorOptions, SourceFile } from "./types.js";
 
 export type TbPort = {
 	direction: "input" | "output";
@@ -237,7 +237,7 @@ export interface InjectedTbComponent {
 	/** @internal */ readonly handler: NapiInjectedComponent["handler"];
 }
 
-export interface RunTestOptions extends NapiOptions {
+export interface RunTestOptions extends SimulatorOptions {
 	components?: Record<string, InjectedTbComponent>;
 }
 
@@ -254,7 +254,7 @@ export function runTest(
 	return loadNativeAddon().runTest(
 		sources.map(({ content, path }) => ({ content, path })),
 		top,
-		nativeOptions,
+		buildNapiOpts(nativeOptions),
 		injected,
 	);
 }
@@ -272,7 +272,7 @@ export function runTestFromProject(
 	return loadNativeAddon().runTestFromProject(
 		projectPath,
 		top,
-		nativeOptions,
+		buildNapiOpts(nativeOptions),
 		injected,
 	);
 }

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
+	"test:vite-components": "vitest run --config test/fixtures/injected-components/vitest.config.ts",
     "test:e2e": "pnpm run build && playwright test",
     "test:watch": "vitest",
     "test:wasm": "NAPI_RS_FORCE_WASI=1 vitest run --config vitest.wasm.config.ts"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:vite-components": "vitest run --config test/fixtures/injected-components/vitest.config.ts",
+    "test:vite-components": "vitest run --config test/fixtures/injected-components/vitest.config.ts && node test/fixtures/injected-components/dependency-e2e.mjs",
     "test:lsp-components": "pnpm run test:vite-components && node test/fixtures/injected-components/lsp-e2e.mjs",
     "test:e2e": "pnpm run build && playwright test",
     "test:watch": "vitest",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
-	"test:vite-components": "vitest run --config test/fixtures/injected-components/vitest.config.ts",
+    "test:vite-components": "vitest run --config test/fixtures/injected-components/vitest.config.ts",
+    "test:lsp-components": "pnpm run test:vite-components && node test/fixtures/injected-components/lsp-e2e.mjs",
     "test:e2e": "pnpm run build && playwright test",
     "test:watch": "vitest",
     "test:wasm": "NAPI_RS_FORCE_WASI=1 vitest run --config vitest.wasm.config.ts"

--- a/packages/playground/test/fixtures/injected-components/.gitignore
+++ b/packages/playground/test/fixtures/injected-components/.gitignore
@@ -1,0 +1,2 @@
+Veryl.lock
+.celox/

--- a/packages/playground/test/fixtures/injected-components/Veryl.toml
+++ b/packages/playground/test/fixtures/injected-components/Veryl.toml
@@ -1,0 +1,8 @@
+[project]
+name = "vite_injected_components"
+version = "0.1.0"
+
+[build]
+clock_type = "posedge"
+reset_type = "async_low"
+sources = ["src"]

--- a/packages/playground/test/fixtures/injected-components/Veryl.toml
+++ b/packages/playground/test/fixtures/injected-components/Veryl.toml
@@ -6,3 +6,6 @@ version = "0.1.0"
 clock_type = "posedge"
 reset_type = "async_low"
 sources = ["src"]
+
+[[components]]
+path = ".celox/testbench-components"

--- a/packages/playground/test/fixtures/injected-components/dependency-e2e.mjs
+++ b/packages/playground/test/fixtures/injected-components/dependency-e2e.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { resolve } from "node:path";
 import { resolveConfig } from "vite";
-import { loadTestbenchComponentModule } from "../../../../vite-plugin/dist/testbench-components.js";
+import {
+	loadTestbenchComponentModule,
+	normalizeTestbenchComponentPath,
+} from "../../../../vite-plugin/dist/testbench-components.js";
 
 const root = import.meta.dirname;
 const registry = resolve(root, "tb-components.ts");
@@ -27,6 +30,6 @@ const config = await resolveConfig(
 
 const loaded = await loadTestbenchComponentModule(registry, root, config);
 assert.ok(
-	loaded.dependencies.has(helper),
+	loaded.dependencies.has(normalizeTestbenchComponentPath(helper)),
 	"aliased registry dependency is missing from the HMR dependency graph",
 );

--- a/packages/playground/test/fixtures/injected-components/dependency-e2e.mjs
+++ b/packages/playground/test/fixtures/injected-components/dependency-e2e.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import { resolveConfig } from "vite";
+import { loadTestbenchComponentModule } from "../../../../vite-plugin/dist/testbench-components.js";
+
+const root = import.meta.dirname;
+const registry = resolve(root, "tb-components.ts");
+const helper = resolve(root, "tb-component-helper.ts");
+const virtualTbStep = {
+	name: "fixture-tb-step",
+	resolveId(source) {
+		if (source === "virtual:tb-step") return "\0virtual:tb-step";
+	},
+	load(id) {
+		if (id === "\0virtual:tb-step") return "export const step = 2n;";
+	},
+};
+const config = await resolveConfig(
+	{
+		root,
+		resolve: { alias: { "@fixture/tb-helper": helper } },
+		plugins: [virtualTbStep],
+	},
+	"serve",
+	"development",
+);
+
+const loaded = await loadTestbenchComponentModule(registry, root, config);
+assert.ok(
+	loaded.dependencies.has(helper),
+	"aliased registry dependency is missing from the HMR dependency graph",
+);

--- a/packages/playground/test/fixtures/injected-components/entry.test.ts
+++ b/packages/playground/test/fixtures/injected-components/entry.test.ts
@@ -3,10 +3,12 @@ import { expect, test } from "vitest";
 import "./src/InjectedTestbench.veryl";
 
 test("generates the injected component manifest sidecar", () => {
-	const path = `${import.meta.dirname}/.celox/testbench-components.manifest.json`;
+	const path = `${import.meta.dirname}/.celox/testbench-components/veryl.manifest.json`;
 	expect(existsSync(path)).toBe(true);
 	const sidecar = JSON.parse(readFileSync(path, "utf8")) as {
+		source: string;
 		types: Record<string, unknown>;
 	};
+	expect(sidecar.source).toBe("tb-components.ts");
 	expect(sidecar.types).toHaveProperty("vite_store");
 });

--- a/packages/playground/test/fixtures/injected-components/entry.test.ts
+++ b/packages/playground/test/fixtures/injected-components/entry.test.ts
@@ -1,0 +1,12 @@
+import { existsSync, readFileSync } from "node:fs";
+import { expect, test } from "vitest";
+import "./src/InjectedTestbench.veryl";
+
+test("generates the injected component manifest sidecar", () => {
+	const path = `${import.meta.dirname}/.celox/testbench-components.manifest.json`;
+	expect(existsSync(path)).toBe(true);
+	const sidecar = JSON.parse(readFileSync(path, "utf8")) as {
+		types: Record<string, unknown>;
+	};
+	expect(sidecar.types).toHaveProperty("vite_store");
+});

--- a/packages/playground/test/fixtures/injected-components/lsp-e2e.mjs
+++ b/packages/playground/test/fixtures/injected-components/lsp-e2e.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const root = import.meta.dirname;
+const sourcePath = join(root, "src", "InjectedTestbench.veryl");
+const manifestPath = join(
+	root,
+	".celox",
+	"testbench-components",
+	"veryl.manifest.json",
+);
+
+assert.ok(
+	existsSync(manifestPath),
+	"generated manifest is missing; run test:vite-components first",
+);
+
+const server = spawn(process.env.VERYL_LS ?? "veryl-ls", [], {
+	cwd: root,
+	stdio: ["pipe", "pipe", "pipe"],
+});
+let stderr = "";
+let receiveBuffer = Buffer.alloc(0);
+const messages = [];
+const waiters = [];
+
+server.stderr.setEncoding("utf8");
+server.stderr.on("data", (chunk) => {
+	stderr += chunk;
+});
+
+server.stdout.on("data", (chunk) => {
+	receiveBuffer = Buffer.concat([receiveBuffer, chunk]);
+	while (true) {
+		const headerEnd = receiveBuffer.indexOf("\r\n\r\n");
+		if (headerEnd < 0) return;
+		const header = receiveBuffer.subarray(0, headerEnd).toString("ascii");
+		const match = /(?:^|\r\n)Content-Length: (\d+)/i.exec(header);
+		assert.ok(match, `LSP response has no Content-Length header: ${header}`);
+		const length = Number(match[1]);
+		const bodyStart = headerEnd + 4;
+		if (receiveBuffer.length < bodyStart + length) return;
+		const body = receiveBuffer
+			.subarray(bodyStart, bodyStart + length)
+			.toString("utf8");
+		receiveBuffer = receiveBuffer.subarray(bodyStart + length);
+		dispatch(JSON.parse(body));
+	}
+});
+
+function dispatch(message) {
+	if (message.id !== undefined && message.method !== undefined) {
+		send({ jsonrpc: "2.0", id: message.id, result: null });
+		return;
+	}
+	const waiterIndex = waiters.findIndex(({ predicate }) => predicate(message));
+	if (waiterIndex >= 0) {
+		const [{ resolve, timer }] = waiters.splice(waiterIndex, 1);
+		clearTimeout(timer);
+		resolve(message);
+	} else {
+		messages.push(message);
+	}
+}
+
+function send(message) {
+	const body = JSON.stringify(message);
+	server.stdin.write(`Content-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`);
+}
+
+function waitFor(predicate, description) {
+	const queuedIndex = messages.findIndex(predicate);
+	if (queuedIndex >= 0) return Promise.resolve(messages.splice(queuedIndex, 1)[0]);
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			const index = waiters.findIndex((waiter) => waiter.resolve === resolve);
+			if (index >= 0) waiters.splice(index, 1);
+			reject(new Error(`timed out waiting for ${description}\n${stderr}`));
+		}, 15_000);
+		waiters.push({ predicate, resolve, timer });
+	});
+}
+
+const sourceUri = pathToFileURL(sourcePath).href;
+const rootUri = pathToFileURL(root).href;
+const completionSource = `#[test(InjectedTestbench)]
+module InjectedTestbench {
+    var store: $comp::vite_store;
+
+    initial {
+        store.
+        set(8'h2a);
+    }
+}
+`;
+
+try {
+	send({
+		jsonrpc: "2.0",
+		id: 1,
+		method: "initialize",
+		params: {
+			processId: process.pid,
+			rootUri,
+			capabilities: {},
+			workspaceFolders: [{ uri: rootUri, name: "injected-components" }],
+		},
+	});
+	const initialized = await waitFor(
+		(message) => message.id === 1,
+		"initialize response",
+	);
+	assert.equal(initialized.error, undefined, JSON.stringify(initialized.error));
+	send({ jsonrpc: "2.0", method: "initialized", params: {} });
+
+	send({
+		jsonrpc: "2.0",
+		method: "textDocument/didOpen",
+		params: {
+			textDocument: {
+				uri: sourceUri,
+				languageId: "veryl",
+				version: 1,
+				text: completionSource,
+			},
+		},
+	});
+
+	const diagnostics = await waitFor(
+		(message) =>
+			message.method === "textDocument/publishDiagnostics" &&
+			message.params?.uri === sourceUri,
+		"component diagnostics",
+	);
+	assert.deepEqual(diagnostics.params.diagnostics, []);
+
+	send({
+		jsonrpc: "2.0",
+		id: 2,
+		method: "textDocument/completion",
+		params: {
+			textDocument: { uri: sourceUri },
+			position: { line: 5, character: 14 },
+			context: { triggerKind: 2, triggerCharacter: "." },
+		},
+	});
+	const completion = await waitFor(
+		(message) => message.id === 2,
+		"component method completion",
+	);
+	assert.equal(completion.error, undefined, JSON.stringify(completion.error));
+	const items = Array.isArray(completion.result)
+		? completion.result
+		: completion.result?.items;
+	assert.ok(Array.isArray(items), "completion response has no items");
+	const labels = new Set(items.map(({ label }) => label));
+	assert.ok(labels.has("get"), "get method is missing from LSP completion");
+	assert.ok(labels.has("set"), "set method is missing from LSP completion");
+
+	send({ jsonrpc: "2.0", id: 3, method: "shutdown", params: null });
+	await waitFor((message) => message.id === 3, "shutdown response");
+	send({ jsonrpc: "2.0", method: "exit", params: null });
+	console.log("veryl-ls recognized generated testbench components");
+} finally {
+	server.kill();
+}

--- a/packages/playground/test/fixtures/injected-components/src/InjectedTestbench.veryl
+++ b/packages/playground/test/fixtures/injected-components/src/InjectedTestbench.veryl
@@ -3,8 +3,9 @@ module InjectedTestbench {
     var store: $comp::vite_store;
 
     initial {
+        $assert(store.get() == 8'd40, "Vite alias resolved in component module");
         store.set(8'h2a);
-        $assert(store.get() == 8'h2a, "Vite-injected TypeScript component");
+        $assert(store.get() == 8'd44, "Vite plugin resolved in component module");
         $finish();
     }
 }

--- a/packages/playground/test/fixtures/injected-components/src/InjectedTestbench.veryl
+++ b/packages/playground/test/fixtures/injected-components/src/InjectedTestbench.veryl
@@ -1,0 +1,10 @@
+#[test(InjectedTestbench)]
+module InjectedTestbench {
+    var store: $comp::vite_store;
+
+    initial {
+        store.set(8'h2a);
+        $assert(store.get() == 8'h2a, "Vite-injected TypeScript component");
+        $finish();
+    }
+}

--- a/packages/playground/test/fixtures/injected-components/tb-component-helper.ts
+++ b/packages/playground/test/fixtures/injected-components/tb-component-helper.ts
@@ -1,0 +1,1 @@
+export const initialValue = 40n;

--- a/packages/playground/test/fixtures/injected-components/tb-components.ts
+++ b/packages/playground/test/fixtures/injected-components/tb-components.ts
@@ -1,0 +1,20 @@
+import { defineTbComponent } from "@celox-sim/celox";
+
+const viteStore = defineTbComponent<{ value: bigint }>({
+	kind: "method_only",
+	create: () => ({ value: 0n }),
+	methods: {
+		set: {
+			args: [{ name: "value", type: "value" }],
+			call: ({ state }, [value]) => {
+				state.value = value as bigint;
+			},
+		},
+		get: {
+			returns: { width: 8 },
+			call: ({ state }) => ({ returnValue: state.value }),
+		},
+	},
+});
+
+export default { vite_store: viteStore };

--- a/packages/playground/test/fixtures/injected-components/tb-components.ts
+++ b/packages/playground/test/fixtures/injected-components/tb-components.ts
@@ -1,13 +1,15 @@
 import { defineTbComponent } from "@celox-sim/celox";
+import { initialValue } from "@fixture/tb-helper";
+import { step } from "virtual:tb-step";
 
 const viteStore = defineTbComponent<{ value: bigint }>({
 	kind: "method_only",
-	create: () => ({ value: 0n }),
+	create: () => ({ value: initialValue }),
 	methods: {
 		set: {
 			args: [{ name: "value", type: "value" }],
 			call: ({ state }, [value]) => {
-				state.value = value as bigint;
+				state.value = (value as bigint) + step;
 			},
 		},
 		get: {

--- a/packages/playground/test/fixtures/injected-components/vitest.config.ts
+++ b/packages/playground/test/fixtures/injected-components/vitest.config.ts
@@ -1,9 +1,30 @@
 import celox from "@celox-sim/vite-plugin";
+import { resolve } from "node:path";
+import type { Plugin } from "vite";
 import { defineConfig } from "vitest/config";
+
+const virtualTbStep: Plugin = {
+	name: "fixture-tb-step",
+	resolveId(source) {
+		if (source === "virtual:tb-step") return "\0virtual:tb-step";
+	},
+	load(id) {
+		if (id === "\0virtual:tb-step") return "export const step = 2n;";
+	},
+};
 
 export default defineConfig({
 	root: import.meta.dirname,
+	resolve: {
+		alias: {
+			"@fixture/tb-helper": resolve(
+				import.meta.dirname,
+				"tb-component-helper.ts",
+			),
+		},
+	},
 	plugins: [
+		virtualTbStep,
 		celox({
 			testbenchComponents: "./tb-components.ts",
 		}),

--- a/packages/playground/test/fixtures/injected-components/vitest.config.ts
+++ b/packages/playground/test/fixtures/injected-components/vitest.config.ts
@@ -1,0 +1,12 @@
+import celox from "@celox-sim/vite-plugin";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	root: import.meta.dirname,
+	plugins: [
+		celox({
+			testbenchComponents: "./tb-components.ts",
+		}),
+	],
+	test: { include: ["entry.test.ts"] },
+});

--- a/packages/playground/vitest.config.ts
+++ b/packages/playground/vitest.config.ts
@@ -2,8 +2,12 @@ import { configDefaults, defineConfig } from "vitest/config";
 import celox from "@celox-sim/vite-plugin";
 
 export default defineConfig({
-  plugins: [celox()],
-  test: {
-    exclude: [...configDefaults.exclude, "test/e2e/**/*.spec.ts"],
-  },
+	plugins: [celox()],
+	test: {
+		exclude: [
+			...configDefaults.exclude,
+			"test/e2e/**/*.spec.ts",
+			"test/fixtures/**",
+		],
+	},
 });

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -17,7 +17,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "pnpm --dir ../playground run test:vite-components"
+    "test": "pnpm --dir ../playground run test:vite-components",
+    "test:lsp": "pnpm --dir ../playground run test:lsp-components"
   },
   "keywords": [
     "celox",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -16,7 +16,8 @@
     "src"
   ],
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "pnpm --dir ../playground run test:vite-components"
   },
   "keywords": [
     "celox",

--- a/packages/vite-plugin/src/cache.ts
+++ b/packages/vite-plugin/src/cache.ts
@@ -1,13 +1,21 @@
 import { type Dirent, readdirSync, statSync } from "node:fs";
 import { extname, join } from "node:path";
 import { runGenTs } from "./generator.js";
-import type { GenTsJsonOutput } from "./types.js";
+import type { GenTsJsonOutput, TestbenchComponentManifests } from "./types.js";
 
 export class GenTsCache {
 	private _data: GenTsJsonOutput | undefined;
 	private _mtimeKey = "";
 
-	constructor(private readonly _projectRoot: string) {}
+	constructor(
+		private readonly _projectRoot: string,
+		private _testbenchComponents?: TestbenchComponentManifests,
+	) {}
+
+	setTestbenchComponents(components: TestbenchComponentManifests): void {
+		this._testbenchComponents = components;
+		this.invalidate();
+	}
 
 	/** Get cached data, refreshing if any .veryl file has changed. */
 	get(): GenTsJsonOutput {
@@ -15,7 +23,7 @@ export class GenTsCache {
 		if (this._data && this._mtimeKey === key) {
 			return this._data;
 		}
-		this._data = runGenTs(this._projectRoot);
+		this._data = runGenTs(this._projectRoot, this._testbenchComponents);
 		this._mtimeKey = key;
 		return this._data;
 	}

--- a/packages/vite-plugin/src/generator.ts
+++ b/packages/vite-plugin/src/generator.ts
@@ -1,11 +1,17 @@
 import { loadNativeAddon } from "@celox-sim/celox";
-import type { GenTsJsonOutput } from "./types.js";
+import type { GenTsJsonOutput, TestbenchComponentManifests } from "./types.js";
 
 /**
  * Run the TypeScript type generator via the NAPI addon and parse the output.
  */
-export function runGenTs(projectRoot: string): GenTsJsonOutput {
+export function runGenTs(
+	projectRoot: string,
+	testbenchComponents?: TestbenchComponentManifests,
+): GenTsJsonOutput {
 	const addon = loadNativeAddon();
-	const json = addon.genTs(projectRoot);
+	const manifests = Object.entries(testbenchComponents ?? {}).map(
+		([name, component]) => ({ name, manifest: component.manifest }),
+	);
+	const json = addon.genTs(projectRoot, manifests);
 	return JSON.parse(json) as GenTsJsonOutput;
 }

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
-import type { Plugin } from "vite";
+import type { Plugin, ResolvedConfig } from "vite";
 import { GenTsCache } from "./cache.js";
 import { cleanSidecars, generateSidecars } from "./sidecar.js";
 import {
@@ -35,12 +35,14 @@ export default function celoxPlugin(options?: CeloxPluginOptions): Plugin {
 	let cache: GenTsCache;
 	let sidecarPaths: string[] = [];
 	let testbenchComponents: string | undefined;
+	let viteConfig: ResolvedConfig;
 
 	return {
 		name: "vite-plugin-celox",
 		enforce: "pre",
 
-		async configResolved(config) {
+		configResolved(config) {
+			viteConfig = config;
 			// Determine project root
 			if (options?.projectRoot) {
 				projectRoot = resolve(options.projectRoot);
@@ -48,7 +50,6 @@ export default function celoxPlugin(options?: CeloxPluginOptions): Plugin {
 				projectRoot = findVerylProjectRoot(config.root);
 			}
 
-			let componentManifests: TestbenchComponentManifests | undefined;
 			if (options?.testbenchComponents) {
 				const componentsModule = options.testbenchComponents;
 				testbenchComponents = isAbsolute(componentsModule)
@@ -59,9 +60,16 @@ export default function celoxPlugin(options?: CeloxPluginOptions): Plugin {
 						`Could not find testbench components module: ${testbenchComponents}`,
 					);
 				}
+			}
+		},
+
+		async buildStart() {
+			let componentManifests: TestbenchComponentManifests | undefined;
+			if (testbenchComponents) {
 				componentManifests = await loadTestbenchComponentModule(
 					testbenchComponents,
 					projectRoot,
+					viteConfig,
 				);
 				writeTestbenchComponentSidecar(
 					projectRoot,
@@ -70,9 +78,6 @@ export default function celoxPlugin(options?: CeloxPluginOptions): Plugin {
 				);
 			}
 			cache = new GenTsCache(projectRoot, componentManifests);
-		},
-
-		buildStart() {
 			// Run generator and create type sidecars
 			const data = cache.get();
 			cleanSidecars(sidecarPaths);
@@ -177,6 +182,7 @@ export default function celoxPlugin(options?: CeloxPluginOptions): Plugin {
 				const manifests = await loadTestbenchComponentModule(
 					testbenchComponents,
 					projectRoot,
+					viteConfig,
 				);
 				writeTestbenchComponentSidecar(
 					projectRoot,

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -5,6 +5,7 @@ import { GenTsCache } from "./cache.js";
 import { cleanSidecars, generateSidecars } from "./sidecar.js";
 import {
 	loadTestbenchComponentModule,
+	normalizeTestbenchComponentPath,
 	writeTestbenchComponentSidecar,
 } from "./testbench-components.js";
 import type {
@@ -181,7 +182,9 @@ export default function celoxPlugin(options?: CeloxPluginOptions): Plugin {
 		async handleHotUpdate({ file, server }) {
 			const componentChanged =
 				testbenchComponents !== undefined &&
-				testbenchComponentDependencies.has(resolve(file));
+				testbenchComponentDependencies.has(
+					normalizeTestbenchComponentPath(file),
+				);
 			if (!file.endsWith(".veryl") && !componentChanged) return;
 
 			if (componentChanged && testbenchComponents) {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -35,6 +35,7 @@ export default function celoxPlugin(options?: CeloxPluginOptions): Plugin {
 	let cache: GenTsCache;
 	let sidecarPaths: string[] = [];
 	let testbenchComponents: string | undefined;
+	let testbenchComponentDependencies = new Set<string>();
 	let viteConfig: ResolvedConfig;
 
 	return {
@@ -66,11 +67,16 @@ export default function celoxPlugin(options?: CeloxPluginOptions): Plugin {
 		async buildStart() {
 			let componentManifests: TestbenchComponentManifests | undefined;
 			if (testbenchComponents) {
-				componentManifests = await loadTestbenchComponentModule(
+				const loaded = await loadTestbenchComponentModule(
 					testbenchComponents,
 					projectRoot,
 					viteConfig,
 				);
+				componentManifests = loaded.manifests;
+				testbenchComponentDependencies = loaded.dependencies;
+				for (const dependency of testbenchComponentDependencies) {
+					this.addWatchFile(dependency);
+				}
 				writeTestbenchComponentSidecar(
 					projectRoot,
 					testbenchComponents,
@@ -172,24 +178,26 @@ export default function celoxPlugin(options?: CeloxPluginOptions): Plugin {
 			return parts.join("\n\n") || "export {};";
 		},
 
-		async handleHotUpdate({ file }) {
+		async handleHotUpdate({ file, server }) {
 			const componentChanged =
 				testbenchComponents !== undefined &&
-				resolve(file) === resolve(testbenchComponents);
+				testbenchComponentDependencies.has(resolve(file));
 			if (!file.endsWith(".veryl") && !componentChanged) return;
 
 			if (componentChanged && testbenchComponents) {
-				const manifests = await loadTestbenchComponentModule(
+				const loaded = await loadTestbenchComponentModule(
 					testbenchComponents,
 					projectRoot,
 					viteConfig,
 				);
+				testbenchComponentDependencies = loaded.dependencies;
+				server.watcher.add([...testbenchComponentDependencies]);
 				writeTestbenchComponentSidecar(
 					projectRoot,
 					testbenchComponents,
-					manifests,
+					loaded.manifests,
 				);
-				cache.setTestbenchComponents(manifests);
+				cache.setTestbenchComponents(loaded.manifests);
 			}
 
 			// Invalidate cache so next load re-runs the generator
@@ -317,7 +325,9 @@ function generateTestCode(
 		);
 		lines.push(`    }`);
 		lines.push(`  }`);
-		lines.push(`  expect(__result.passed).toBe(true);`);
+		lines.push(
+			`  expect(__result.passed, __result.error ?? "testbench failed").toBe(true);`,
+		);
 		lines.push(`});`);
 		lines.push(``);
 	}

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -3,7 +3,15 @@ import { dirname, isAbsolute, resolve } from "node:path";
 import type { Plugin } from "vite";
 import { GenTsCache } from "./cache.js";
 import { cleanSidecars, generateSidecars } from "./sidecar.js";
-import type { CeloxPluginOptions, GenTsModule } from "./types.js";
+import {
+	loadTestbenchComponentModule,
+	writeTestbenchComponentSidecar,
+} from "./testbench-components.js";
+import type {
+	CeloxPluginOptions,
+	GenTsModule,
+	TestbenchComponentManifests,
+} from "./types.js";
 
 export type { CeloxPluginOptions } from "./types.js";
 
@@ -26,12 +34,13 @@ export default function celoxPlugin(options?: CeloxPluginOptions): Plugin {
 	let projectRoot: string;
 	let cache: GenTsCache;
 	let sidecarPaths: string[] = [];
+	let testbenchComponents: string | undefined;
 
 	return {
 		name: "vite-plugin-celox",
 		enforce: "pre",
 
-		configResolved(config) {
+		async configResolved(config) {
 			// Determine project root
 			if (options?.projectRoot) {
 				projectRoot = resolve(options.projectRoot);
@@ -39,7 +48,28 @@ export default function celoxPlugin(options?: CeloxPluginOptions): Plugin {
 				projectRoot = findVerylProjectRoot(config.root);
 			}
 
-			cache = new GenTsCache(projectRoot);
+			let componentManifests: TestbenchComponentManifests | undefined;
+			if (options?.testbenchComponents) {
+				const componentsModule = options.testbenchComponents;
+				testbenchComponents = isAbsolute(componentsModule)
+					? componentsModule
+					: resolve(projectRoot, componentsModule);
+				if (!existsSync(testbenchComponents)) {
+					throw new Error(
+						`Could not find testbench components module: ${testbenchComponents}`,
+					);
+				}
+				componentManifests = await loadTestbenchComponentModule(
+					testbenchComponents,
+					projectRoot,
+				);
+				writeTestbenchComponentSidecar(
+					projectRoot,
+					testbenchComponents,
+					componentManifests,
+				);
+			}
+			cache = new GenTsCache(projectRoot, componentManifests);
 		},
 
 		buildStart() {
@@ -129,14 +159,32 @@ export default function celoxPlugin(options?: CeloxPluginOptions): Plugin {
 				testModules.length > 0 &&
 				(process.env.VITEST === "true" || process.env.NODE_ENV === "test")
 			) {
-				parts.push(generateTestCode(testModules, data.projectPath));
+				parts.push(
+					generateTestCode(testModules, data.projectPath, testbenchComponents),
+				);
 			}
 
 			return parts.join("\n\n") || "export {};";
 		},
 
-		handleHotUpdate({ file }) {
-			if (!file.endsWith(".veryl")) return;
+		async handleHotUpdate({ file }) {
+			const componentChanged =
+				testbenchComponents !== undefined &&
+				resolve(file) === resolve(testbenchComponents);
+			if (!file.endsWith(".veryl") && !componentChanged) return;
+
+			if (componentChanged && testbenchComponents) {
+				const manifests = await loadTestbenchComponentModule(
+					testbenchComponents,
+					projectRoot,
+				);
+				writeTestbenchComponentSidecar(
+					projectRoot,
+					testbenchComponents,
+					manifests,
+				);
+				cache.setTestbenchComponents(manifests);
+			}
 
 			// Invalidate cache so next load re-runs the generator
 			cache.invalidate();
@@ -228,19 +276,30 @@ function generateEsmExport(
 function generateTestCode(
 	testModuleNames: string[],
 	projectPath: string,
+	testbenchComponents?: string,
 ): string {
-	const lines: string[] = [
-		`import { test, expect } from "vitest";`,
-		`import { loadNativeAddon } from "@celox-sim/celox";`,
-		``,
-		`const __addon = loadNativeAddon();`,
-		``,
-	];
+	const lines: string[] = [`import { test, expect } from "vitest";`];
+	if (testbenchComponents) {
+		lines.push(
+			`import { runTestFromProject } from "@celox-sim/celox";`,
+			`import __components from ${JSON.stringify(testbenchComponents.replace(/\\/g, "/"))};`,
+			``,
+		);
+	} else {
+		lines.push(
+			`import { loadNativeAddon } from "@celox-sim/celox";`,
+			``,
+			`const __addon = loadNativeAddon();`,
+			``,
+		);
+	}
 
 	for (const name of testModuleNames) {
 		lines.push(`test(${JSON.stringify(name)}, () => {`);
 		lines.push(
-			`  const __result = __addon.runTestFromProject(${JSON.stringify(projectPath)}, ${JSON.stringify(name)});`,
+			testbenchComponents
+				? `  const __result = runTestFromProject(${JSON.stringify(projectPath)}, ${JSON.stringify(name)}, { components: __components });`
+				: `  const __result = __addon.runTestFromProject(${JSON.stringify(projectPath)}, ${JSON.stringify(name)});`,
 		);
 		lines.push(`  for (const __a of __result.assertions) {`);
 		lines.push(`    if (!__a.passed) {`);

--- a/packages/vite-plugin/src/testbench-components.ts
+++ b/packages/vite-plugin/src/testbench-components.ts
@@ -3,6 +3,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import {
 	createServer,
 	type ModuleNode,
+	normalizePath,
 	type Plugin,
 	type ResolvedConfig,
 } from "vite";
@@ -19,18 +20,26 @@ export interface LoadedTestbenchComponents {
 	dependencies: Set<string>;
 }
 
+/** Normalize dependency keys the same way on Vite's watcher and module graph. */
+export function normalizeTestbenchComponentPath(file: string): string {
+	const normalized = normalizePath(resolve(file));
+	return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
 function collectModuleFiles(
 	entry: string,
 	roots: Iterable<ModuleNode>,
 ): Set<string> {
-	const files = new Set([resolve(entry)]);
+	const files = new Set([normalizeTestbenchComponentPath(entry)]);
 	const pending = [...roots];
 	const seen = new Set<ModuleNode>();
 	while (pending.length > 0) {
 		const module = pending.pop()!;
 		if (seen.has(module)) continue;
 		seen.add(module);
-		if (module.file) files.add(resolve(module.file));
+		if (module.file) {
+			files.add(normalizeTestbenchComponentPath(module.file));
+		}
 		pending.push(...module.importedModules);
 	}
 	return files;
@@ -102,7 +111,8 @@ export async function loadTestbenchComponentModule(
 			JSON.parse(component.manifest);
 			manifests[name] = { manifest: component.manifest };
 		}
-		const roots = server.moduleGraph.getModulesByFile(modulePath) ?? [];
+		const roots =
+			server.moduleGraph.getModulesByFile(normalizePath(modulePath)) ?? [];
 		return {
 			manifests,
 			dependencies: collectModuleFiles(modulePath, roots),

--- a/packages/vite-plugin/src/testbench-components.ts
+++ b/packages/vite-plugin/src/testbench-components.ts
@@ -1,6 +1,11 @@
 import { mkdirSync, writeFileSync } from "node:fs";
-import { dirname, join, relative } from "node:path";
-import { createServer, type Plugin, type ResolvedConfig } from "vite";
+import { dirname, join, relative, resolve } from "node:path";
+import {
+	createServer,
+	type ModuleNode,
+	type Plugin,
+	type ResolvedConfig,
+} from "vite";
 import type { TestbenchComponentManifests } from "./types.js";
 
 export const TESTBENCH_COMPONENT_SIDECAR = join(
@@ -8,6 +13,28 @@ export const TESTBENCH_COMPONENT_SIDECAR = join(
 	"testbench-components",
 	"veryl.manifest.json",
 );
+
+export interface LoadedTestbenchComponents {
+	manifests: TestbenchComponentManifests;
+	dependencies: Set<string>;
+}
+
+function collectModuleFiles(
+	entry: string,
+	roots: Iterable<ModuleNode>,
+): Set<string> {
+	const files = new Set([resolve(entry)]);
+	const pending = [...roots];
+	const seen = new Set<ModuleNode>();
+	while (pending.length > 0) {
+		const module = pending.pop()!;
+		if (seen.has(module)) continue;
+		seen.add(module);
+		if (module.file) files.add(resolve(module.file));
+		pending.push(...module.importedModules);
+	}
+	return files;
+}
 
 function componentLoaderPlugins(config: ResolvedConfig): Plugin[] {
 	return config.plugins
@@ -29,7 +56,7 @@ export async function loadTestbenchComponentModule(
 	modulePath: string,
 	projectRoot: string,
 	config: ResolvedConfig,
-): Promise<TestbenchComponentManifests> {
+): Promise<LoadedTestbenchComponents> {
 	const server = await createServer({
 		root: projectRoot,
 		configFile: false,
@@ -75,7 +102,11 @@ export async function loadTestbenchComponentModule(
 			JSON.parse(component.manifest);
 			manifests[name] = { manifest: component.manifest };
 		}
-		return manifests;
+		const roots = server.moduleGraph.getModulesByFile(modulePath) ?? [];
+		return {
+			manifests,
+			dependencies: collectModuleFiles(modulePath, roots),
+		};
 	} finally {
 		await server.close();
 	}

--- a/packages/vite-plugin/src/testbench-components.ts
+++ b/packages/vite-plugin/src/testbench-components.ts
@@ -5,7 +5,8 @@ import type { TestbenchComponentManifests } from "./types.js";
 
 export const TESTBENCH_COMPONENT_SIDECAR = join(
 	".celox",
-	"testbench-components.manifest.json",
+	"testbench-components",
+	"veryl.manifest.json",
 );
 
 /** Load a TypeScript component module through Vite's own transform pipeline. */
@@ -53,7 +54,10 @@ export async function loadTestbenchComponentModule(
 	}
 }
 
-/** Write an aggregated, deterministic manifest sidecar under `.celox/`. */
+/**
+ * Write an aggregated, deterministic manifest where Veryl's existing
+ * `[[components]]` discovery can consume it as a committed manifest.
+ */
 export function writeTestbenchComponentSidecar(
 	projectRoot: string,
 	modulePath: string,

--- a/packages/vite-plugin/src/testbench-components.ts
+++ b/packages/vite-plugin/src/testbench-components.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
-import { createServer } from "vite";
+import { createServer, type Plugin, type ResolvedConfig } from "vite";
 import type { TestbenchComponentManifests } from "./types.js";
 
 export const TESTBENCH_COMPONENT_SIDECAR = join(
@@ -9,14 +9,41 @@ export const TESTBENCH_COMPONENT_SIDECAR = join(
 	"veryl.manifest.json",
 );
 
+function componentLoaderPlugins(config: ResolvedConfig): Plugin[] {
+	return config.plugins
+		.filter(
+			(plugin) =>
+				plugin.name !== "vite-plugin-celox" && !plugin.name.startsWith("vite:"),
+		)
+		.map((plugin) => ({
+			name: `celox-component-loader:${plugin.name}`,
+			enforce: plugin.enforce,
+			resolveId: plugin.resolveId,
+			load: plugin.load,
+			transform: plugin.transform,
+		}));
+}
+
 /** Load a TypeScript component module through Vite's own transform pipeline. */
 export async function loadTestbenchComponentModule(
 	modulePath: string,
 	projectRoot: string,
+	config: ResolvedConfig,
 ): Promise<TestbenchComponentManifests> {
 	const server = await createServer({
 		root: projectRoot,
 		configFile: false,
+		mode: config.mode,
+		define: config.define,
+		resolve: {
+			alias: config.resolve.alias,
+			conditions: config.resolve.conditions,
+			dedupe: config.resolve.dedupe,
+			extensions: config.resolve.extensions,
+			mainFields: config.resolve.mainFields,
+			preserveSymlinks: config.resolve.preserveSymlinks,
+		},
+		plugins: componentLoaderPlugins(config),
 		logLevel: "silent",
 		appType: "custom",
 		server: { middlewareMode: true },

--- a/packages/vite-plugin/src/testbench-components.ts
+++ b/packages/vite-plugin/src/testbench-components.ts
@@ -1,0 +1,76 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { createServer } from "vite";
+import type { TestbenchComponentManifests } from "./types.js";
+
+export const TESTBENCH_COMPONENT_SIDECAR = join(
+	".celox",
+	"testbench-components.manifest.json",
+);
+
+/** Load a TypeScript component module through Vite's own transform pipeline. */
+export async function loadTestbenchComponentModule(
+	modulePath: string,
+	projectRoot: string,
+): Promise<TestbenchComponentManifests> {
+	const server = await createServer({
+		root: projectRoot,
+		configFile: false,
+		logLevel: "silent",
+		appType: "custom",
+		server: { middlewareMode: true },
+	});
+	try {
+		const loaded = (await server.ssrLoadModule(modulePath)) as {
+			default?: unknown;
+		};
+		if (
+			typeof loaded.default !== "object" ||
+			loaded.default === null ||
+			Array.isArray(loaded.default)
+		) {
+			throw new TypeError(
+				`Testbench component module must default-export an object: ${modulePath}`,
+			);
+		}
+		const components = loaded.default as Record<
+			string,
+			{ readonly manifest?: unknown }
+		>;
+		const manifests: TestbenchComponentManifests = {};
+		for (const [name, component] of Object.entries(components)) {
+			if (typeof component?.manifest !== "string") {
+				throw new TypeError(
+					`Testbench component ${name} has no generated manifest`,
+				);
+			}
+			JSON.parse(component.manifest);
+			manifests[name] = { manifest: component.manifest };
+		}
+		return manifests;
+	} finally {
+		await server.close();
+	}
+}
+
+/** Write an aggregated, deterministic manifest sidecar under `.celox/`. */
+export function writeTestbenchComponentSidecar(
+	projectRoot: string,
+	modulePath: string,
+	components: TestbenchComponentManifests,
+): string {
+	const path = join(projectRoot, TESTBENCH_COMPONENT_SIDECAR);
+	const types = Object.fromEntries(
+		Object.entries(components)
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(([name, component]) => [name, JSON.parse(component.manifest)]),
+	);
+	const source = relative(projectRoot, modulePath).replace(/\\/g, "/");
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(
+		path,
+		`${JSON.stringify({ source, types }, null, 2)}\n`,
+		"utf8",
+	);
+	return path;
+}

--- a/packages/vite-plugin/src/types.ts
+++ b/packages/vite-plugin/src/types.ts
@@ -34,8 +34,10 @@ export interface CeloxPluginOptions {
 	/** Explicit path to the Veryl project root (directory containing Veryl.toml). */
 	projectRoot?: string;
 	/**
-	 * TypeScript component module used by generated native Vitest cases.
-	 * Its default export must map `$comp` names to `defineTbComponent` results.
+	 * Path to a TypeScript TB component registry module, absolute or relative
+	 * to the Veryl project root. Its default export must map `$comp` names to
+	 * `defineTbComponent` results. The plugin uses it for manifest generation
+	 * and callback injection into generated native Vitest cases.
 	 */
 	testbenchComponents?: string;
 }

--- a/packages/vite-plugin/src/types.ts
+++ b/packages/vite-plugin/src/types.ts
@@ -25,8 +25,17 @@ export interface GenTsPortInfo {
 	readonly is4state: boolean;
 }
 
-/** Plugin options. */
+export type TestbenchComponentManifests = Record<
+	string,
+	{ readonly manifest: string }
+>;
+
 export interface CeloxPluginOptions {
 	/** Explicit path to the Veryl project root (directory containing Veryl.toml). */
 	projectRoot?: string;
+	/**
+	 * TypeScript component module used by generated native Vitest cases.
+	 * Its default export must map `$comp` names to `defineTbComponent` results.
+	 */
+	testbenchComponents?: string;
 }


### PR DESCRIPTION
## Summary

- add a synchronous injected-component ABI to the Celox runtime and N-API boundary
- add `defineTbComponent` for clocked and method-only TypeScript testbench components
- integrate component loading, test generation, and manifest generation with the Vite plugin
- emit `.celox/testbench-components/veryl.manifest.json` so Veryl's existing `[[components]]` discovery exposes injected components to the compiler and LSP
- document the workflow in English and Japanese

## Why

Small testbench models and reference models should be usable directly from TypeScript without compiling a Rust, native, or Wasm component library. Reusing Veryl's committed component-manifest format also gives editors diagnostics and method completion without a Celox-specific LSP change.

## User impact

Projects can point the Vite plugin at a TypeScript component module:

```ts
celox({
  testbenchComponents: "./test/tb-components.ts",
})
```

and register the generated interfaces in `Veryl.toml`:

```toml
[[components]]
path = ".celox/testbench-components"
```

Synchronous JavaScript callbacks currently target native Node/Vitest execution. Browser Wasm simulation does not execute these callbacks.

## Validation

- `cargo check --workspace --all-targets`
- `cargo clippy -p celox -p celox-napi --lib --tests -- -D warnings`
- Celox component-method tests: 50 passed
- injected-component Rust test: 1 passed
- Celox TypeScript tests: 156 passed
- playground tests: 18 passed, 5 skipped
- Vite injected-component fixture: 2 passed
- TypeScript builds and Biome checks
- `veryl-ls 0.20.3` JSON-RPC E2E: no diagnostics and `get`/`set` method completion from the generated manifest
