### PR TITLE
perf: reduce Heliodor O2 compile time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,9 @@ dependencies = [
 [[package]]
 name = "celox-analysis"
 version = "0.0.0"
+dependencies = [
+ "fxhash",
+]
 
 [[package]]
 name = "celox-backend-arm64"
@@ -472,6 +475,7 @@ dependencies = [
  "celox-backend-x86",
  "celox-state-layout",
  "dynasmrt",
+ "fxhash",
  "libc",
 ]
 
@@ -591,6 +595,7 @@ dependencies = [
 name = "celox-macros"
 version = "0.0.0"
 dependencies = [
+ "fxhash",
  "insta",
  "num-bigint",
  "prettyplease",
@@ -608,6 +613,7 @@ version = "0.0.0"
 dependencies = [
  "celox",
  "celox-ts-gen",
+ "fxhash",
  "globset",
  "miette",
  "napi",
@@ -632,6 +638,7 @@ dependencies = [
  "celox-state-layout",
  "celox-testbench",
  "chrono",
+ "fxhash",
  "num-bigint",
  "tempfile",
 ]
@@ -701,6 +708,7 @@ dependencies = [
 name = "celox-ts-gen"
 version = "0.0.0"
 dependencies = [
+ "fxhash",
  "insta",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ warnings = "deny"
 all = { level = "deny", priority = -1 }
 disallowed_macros = "deny"
 disallowed_methods = "deny"
+disallowed_types = "deny"
 type_complexity = "allow"
 too_many_arguments = "allow"
 collapsible_if = "allow"

--- a/clippy.toml
+++ b/clippy.toml
@@ -8,3 +8,8 @@ disallowed-methods = [
     { path = "std::env::vars", reason = "read CELOX diagnostics through DiagnosticsOptions::from_env at the application boundary" },
     { path = "std::env::vars_os", reason = "read CELOX diagnostics through DiagnosticsOptions::from_env at the application boundary" },
 ]
+
+disallowed-types = [
+    { path = "std::collections::HashMap", reason = "compiler data is trusted; use fxhash::FxHashMap (or the crate HashMap alias) to avoid RandomState overhead" },
+    { path = "std::collections::HashSet", reason = "compiler data is trusted; use fxhash::FxHashSet (or the crate HashSet alias) to avoid RandomState overhead" },
+]

--- a/crates/celox-analysis/Cargo.toml
+++ b/crates/celox-analysis/Cargo.toml
@@ -8,5 +8,8 @@ license.workspace     = true
 description           = "IR-independent compiler analyses used by Celox"
 edition.workspace     = true
 
+[dependencies]
+fxhash.workspace = true
+
 [lints]
 workspace = true

--- a/crates/celox-analysis/src/cfg_order.rs
+++ b/crates/celox-analysis/src/cfg_order.rs
@@ -1,5 +1,6 @@
-use std::collections::HashMap;
 use std::hash::Hash;
+
+use fxhash::FxHashMap;
 
 /// Return blocks in dominator-tree preorder.
 ///
@@ -27,7 +28,7 @@ where
         .iter()
         .enumerate()
         .map(|(index, &id)| (id, index))
-        .collect::<HashMap<_, _>>();
+        .collect::<FxHashMap<_, _>>();
 
     let successors = ids
         .iter()

--- a/crates/celox-backend-arm64/Cargo.toml
+++ b/crates/celox-backend-arm64/Cargo.toml
@@ -12,6 +12,7 @@ celox-backend-common = { path = "../celox-backend-common" }
 celox-backend-x86 = { path = "../celox-backend-x86" }
 celox-state-layout = { path = "../celox-state-layout" }
 dynasmrt = "5.1.0"
+fxhash = { workspace = true }
 
 [target.'cfg(all(target_arch = "aarch64", target_os = "linux"))'.dev-dependencies]
 libc = { workspace = true }

--- a/crates/celox-backend-arm64/src/allocation.rs
+++ b/crates/celox-backend-arm64/src/allocation.rs
@@ -1,9 +1,8 @@
 //! AArch64-owned register assignments and out-of-SSA copy plans.
 
-use std::collections::HashMap;
 use std::hash::Hash;
 
-use crate::Arm64Reg;
+use crate::{Arm64Reg, HashMap};
 
 /// Physical register assignment produced for one target MIR function.
 #[derive(Debug, Clone)]
@@ -14,7 +13,7 @@ pub(crate) struct Assignment<V> {
 impl<V> Default for Assignment<V> {
     fn default() -> Self {
         Self {
-            registers: HashMap::new(),
+            registers: HashMap::default(),
         }
     }
 }
@@ -72,7 +71,7 @@ pub(crate) struct EdgeCopyPlan<B> {
 impl<B> Default for EdgeCopyPlan<B> {
     fn default() -> Self {
         Self {
-            edges: HashMap::new(),
+            edges: HashMap::default(),
         }
     }
 }

--- a/crates/celox-backend-arm64/src/lib.rs
+++ b/crates/celox-backend-arm64/src/lib.rs
@@ -9,8 +9,9 @@ use celox_backend_common::regalloc::{
     Allocation, BlockAllocationFacts, FunctionAllocationFacts, InstructionAllocationFacts,
     LinearScanError, LiveRange, MachineRegister, allocate_linear_scan,
 };
-use std::collections::HashMap;
 use std::fmt;
+
+type HashMap<K, V> = fxhash::FxHashMap<K, V>;
 
 mod allocation;
 pub mod jit_mem;
@@ -286,7 +287,7 @@ fn live_ranges(
     facts: &FunctionAllocationFacts<VReg, Arm64Reg>,
 ) -> Result<Vec<LiveRange<VReg>>, CompileError> {
     let instructions = &facts.blocks[0].instructions;
-    let mut ranges = HashMap::<VReg, LiveRange<VReg>>::new();
+    let mut ranges = HashMap::<VReg, LiveRange<VReg>>::default();
     for (index, instruction) in instructions.iter().enumerate() {
         let index = u32::try_from(index)
             .map_err(|_| CompileError::InvalidMir("too many instructions".into()))?;

--- a/crates/celox-backend-arm64/src/regalloc.rs
+++ b/crates/celox-backend-arm64/src/regalloc.rs
@@ -6,7 +6,7 @@
 //! analyses and algorithms are shared.
 
 use std::cmp::Reverse;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 use celox_backend_common::regalloc::{
@@ -14,9 +14,9 @@ use celox_backend_common::regalloc::{
     PhiAllocationFacts, PhiSource, analyze_live_intervals, color_stack_slots,
 };
 
-use crate::Arm64Reg;
 use crate::allocation::{Assignment, CopyDestination, CopyOperation, CopySource, EdgeCopyPlan};
 use crate::mir::{AllocatedFunction, BlockId, MFunction, MInst, VReg};
+use crate::{Arm64Reg, HashMap};
 
 pub(crate) type AllocationFacts = FunctionAllocationFacts<VReg, Arm64Reg>;
 

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -1,6 +1,5 @@
 //! AArch64 emission for the transitional scalar MIR pipeline.
 
-use std::collections::HashMap;
 use std::fmt;
 
 use celox_backend_x86::native::mir::MFunction as LegacyFunction;
@@ -15,12 +14,12 @@ use celox_state_layout::{
 use dynasmrt::aarch64::Aarch64Relocation;
 use dynasmrt::{DynamicLabel, DynasmApi, DynasmError, DynasmLabelApi, VecAssembler, dynasm};
 
-use crate::Arm64Reg;
 use crate::allocation::{Assignment, CopyDestination, CopyOperation, CopySource, EdgeCopyPlan};
 use crate::mir::{
     BaseReg, BlockId, BranchPredicate, CmpKind, MFunction, MInst, OpSize, PackedLaneCompareRhs,
     SPARSE_COMMIT_DESCRIPTOR_WORDS, VReg,
 };
+use crate::{Arm64Reg, HashMap};
 
 const STATE_REG: u8 = 0;
 const SCRATCH0: u8 = 16;

--- a/crates/celox-backend-common/src/regalloc.rs
+++ b/crates/celox-backend-common/src/regalloc.rs
@@ -1,7 +1,7 @@
 //! Register-allocation data types and target-independent allocation helpers.
 
+use std::collections::BTreeSet;
 use std::collections::VecDeque;
-use std::collections::{BTreeSet, HashMap};
 use std::fmt;
 use std::hash::Hash;
 
@@ -297,10 +297,104 @@ where
 ///
 /// Distances are measured in target instructions. Loop-exit paths receive a
 /// deliberately large penalty so an allocator prefers uses within the loop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NextUseDistances<V> {
+    entries: Vec<(V, u32)>,
+}
+
+impl<V> Default for NextUseDistances<V> {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+}
+
+impl<V: Ord> NextUseDistances<V> {
+    fn from_min_entries(mut entries: Vec<(V, u32)>) -> Self {
+        entries.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+        let mut merged: Vec<(V, u32)> = Vec::with_capacity(entries.len());
+        for (value, distance) in entries {
+            if let Some((previous_value, previous_distance)) = merged.last_mut()
+                && *previous_value == value
+            {
+                *previous_distance = (*previous_distance).min(distance);
+            } else {
+                merged.push((value, distance));
+            }
+        }
+        Self { entries: merged }
+    }
+
+    pub fn get(&self, value: &V) -> Option<&u32> {
+        self.entries
+            .binary_search_by(|(candidate, _)| candidate.cmp(value))
+            .ok()
+            .map(|index| &self.entries[index].1)
+    }
+
+    pub fn contains_key(&self, value: &V) -> bool {
+        self.get(value).is_some()
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn iter(&self) -> NextUseDistanceIter<'_, V> {
+        NextUseDistanceIter(self.entries.iter())
+    }
+
+    pub fn keys(&self) -> NextUseDistanceKeys<'_, V> {
+        NextUseDistanceKeys(self.entries.iter())
+    }
+}
+
+impl<V: Ord> std::ops::Index<&V> for NextUseDistances<V> {
+    type Output = u32;
+
+    fn index(&self, value: &V) -> &Self::Output {
+        self.get(value).expect("next-use distance key must exist")
+    }
+}
+
+pub struct NextUseDistanceIter<'a, V>(std::slice::Iter<'a, (V, u32)>);
+
+impl<'a, V> Iterator for NextUseDistanceIter<'a, V> {
+    type Item = (&'a V, &'a u32);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(value, distance)| (value, distance))
+    }
+}
+
+pub struct NextUseDistanceKeys<'a, V>(std::slice::Iter<'a, (V, u32)>);
+
+impl<'a, V> Iterator for NextUseDistanceKeys<'a, V> {
+    type Item = &'a V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(value, _)| value)
+    }
+}
+
+impl<'a, V: Ord> IntoIterator for &'a NextUseDistances<V> {
+    type Item = (&'a V, &'a u32);
+    type IntoIter = NextUseDistanceIter<'a, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct NextUseAnalysis<V> {
-    pub entry_distances: Vec<FxHashMap<V, u32>>,
-    pub exit_distances: Vec<FxHashMap<V, u32>>,
+    pub entry_distances: Vec<NextUseDistances<V>>,
+    pub exit_distances: Vec<NextUseDistances<V>>,
     pub predecessors: Vec<Vec<usize>>,
     pub backedge_successors: Vec<Vec<usize>>,
 }
@@ -344,8 +438,8 @@ where
     let phi_edge_uses = compute_phi_edge_uses(facts, &successors);
     let transfers = compute_block_transfers(facts);
 
-    let mut entry_distances = vec![FxHashMap::default(); block_count];
-    let mut exit_distances = vec![FxHashMap::default(); block_count];
+    let mut entry_distances = vec![NextUseDistances::default(); block_count];
+    let mut exit_distances = vec![NextUseDistances::default(); block_count];
     let mut worklist = (0..block_count).rev().collect::<VecDeque<_>>();
     let mut in_worklist = vec![true; block_count];
     while let Some(block) = worklist.pop_front() {
@@ -395,7 +489,7 @@ where
             let mut defs = FxHashSet::default();
             defs.reserve(block.phis.len() + block.instructions.len());
             defs.extend(block.phis.iter().map(|phi| phi.destination));
-            let mut local_uses = FxHashMap::default();
+            let mut local_uses = Vec::new();
             for (instruction_index, instruction) in block.instructions.iter().enumerate() {
                 for &definition in &instruction.defs {
                     defs.insert(definition);
@@ -403,12 +497,12 @@ where
                 let position = instruction_index as u32;
                 for &used in &instruction.uses {
                     if !defs.contains(&used) {
-                        local_uses.entry(used).or_insert(position);
+                        local_uses.push((used, position));
                     }
                 }
             }
-            let mut local_uses = local_uses.into_iter().collect::<Vec<_>>();
-            local_uses.sort_by_key(|(value, _)| *value);
+            local_uses.sort_unstable_by_key(|(value, position)| (*value, *position));
+            local_uses.dedup_by_key(|(value, _)| *value);
             BlockTransfer {
                 block_len: block.instructions.len() as u32,
                 defs,
@@ -454,19 +548,18 @@ fn compute_block_distances<V>(
     backedge_edges: &[Vec<bool>],
     phi_edge_uses: &[Vec<Vec<V>>],
     transfers: &[BlockTransfer<V>],
-    entry_distances: &[FxHashMap<V, u32>],
-) -> (FxHashMap<V, u32>, FxHashMap<V, u32>)
+    entry_distances: &[NextUseDistances<V>],
+) -> (NextUseDistances<V>, NextUseDistances<V>)
 where
-    V: Copy + Eq + Hash,
+    V: Copy + Hash + Ord,
 {
     let transfer = &transfers[block];
-    let mut new_exit = FxHashMap::default();
     let exit_capacity = successors[block]
         .iter()
         .map(|&successor| entry_distances[successor].len())
         .sum::<usize>()
         + phi_edge_uses[block].iter().map(Vec::len).sum::<usize>();
-    new_exit.reserve(exit_capacity);
+    let mut new_exit_entries = Vec::with_capacity(exit_capacity);
     for (edge, &successor) in successors[block].iter().enumerate() {
         let edge_length = if backedge_edges[block][edge] {
             LOOP_EXIT_LENGTH
@@ -475,25 +568,22 @@ where
         };
         for (&value, &distance) in &entry_distances[successor] {
             let distance = distance.saturating_add(edge_length);
-            let entry = new_exit.entry(value).or_insert(u32::MAX);
-            *entry = (*entry).min(distance);
+            new_exit_entries.push((value, distance));
         }
         for &value in &phi_edge_uses[block][edge] {
-            let entry = new_exit.entry(value).or_insert(u32::MAX);
-            *entry = (*entry).min(edge_length);
+            new_exit_entries.push((value, edge_length));
         }
     }
+    let new_exit = NextUseDistances::from_min_entries(new_exit_entries);
 
-    let mut new_entry = FxHashMap::default();
-    new_entry.reserve(new_exit.len() + transfer.local_uses.len());
+    let mut new_entry_entries = Vec::with_capacity(new_exit.len() + transfer.local_uses.len());
     for (&value, &distance) in &new_exit {
         if !transfer.defs.contains(&value) {
-            new_entry.insert(value, transfer.block_len.saturating_add(distance));
+            new_entry_entries.push((value, transfer.block_len.saturating_add(distance)));
         }
     }
-    for &(value, position) in &transfer.local_uses {
-        new_entry.insert(value, position);
-    }
+    new_entry_entries.extend(transfer.local_uses.iter().copied());
+    let new_entry = NextUseDistances::from_min_entries(new_entry_entries);
     (new_entry, new_exit)
 }
 
@@ -545,7 +635,7 @@ pub struct LiveRange<V> {
 /// Register assignment returned by [`allocate_linear_scan`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Allocation<V: Eq + Hash, R> {
-    assignments: HashMap<V, R>,
+    assignments: FxHashMap<V, R>,
 }
 
 impl<V: Eq + Hash, R: Copy> Allocation<V, R> {
@@ -617,7 +707,7 @@ where
     }
 
     let mut active = Vec::<(u32, V, R)>::new();
-    let mut assignments = HashMap::with_capacity(ordered.len());
+    let mut assignments = FxHashMap::with_capacity_and_hasher(ordered.len(), Default::default());
     for range in ordered {
         active.retain(|(end, _, _)| *end >= range.start);
         let register = allocatable

--- a/crates/celox-backend-cranelift/src/translator/core.rs
+++ b/crates/celox-backend-cranelift/src/translator/core.rs
@@ -28,8 +28,7 @@ fn preload_trigger_old_values<'a>(
         return HashMap::default();
     }
 
-    let mut trigger_addrs: std::collections::HashSet<(AbsoluteAddr, u32)> =
-        std::collections::HashSet::new();
+    let mut trigger_addrs = crate::HashSet::<(AbsoluteAddr, u32)>::default();
     for block in blocks {
         for inst in &block.instructions {
             match inst {

--- a/crates/celox-backend-wasm/src/lib.rs
+++ b/crates/celox-backend-wasm/src/lib.rs
@@ -13,6 +13,7 @@ use wasm_encoder::{
 };
 
 pub type HashMap<K, V> = fxhash::FxHashMap<K, V>;
+pub type HashSet<K> = fxhash::FxHashSet<K>;
 
 use celox_design::{
     BinaryOp, SPARSE_WORKING_REGION, STABLE_REGION, StateAddr, TriggerIdWithKind, UnaryOp,
@@ -5684,8 +5685,7 @@ fn emit_wide_get_chunk(instrs: &mut Vec<Instruction<'static>>, reg: &RegLocal, c
 fn collect_trigger_addrs(
     units: &[ExecutionUnit<RegionedAbsoluteAddr>],
 ) -> Vec<(AbsoluteAddr, u32)> {
-    let mut addrs: std::collections::HashSet<(AbsoluteAddr, u32)> =
-        std::collections::HashSet::new();
+    let mut addrs = HashSet::<(AbsoluteAddr, u32)>::default();
     for unit in units {
         for block in unit.blocks.values() {
             for inst in &block.instructions {

--- a/crates/celox-backend-x86/src/backend/native/emit.rs
+++ b/crates/celox-backend-x86/src/backend/native/emit.rs
@@ -8,7 +8,6 @@
 //! Function signature: `fn(unified_mem: *mut u8) -> i64`
 
 use std::cell::Cell;
-use std::collections::{HashMap, HashSet};
 use std::fmt;
 
 use iced_x86::BlockEncoderOptions;
@@ -25,7 +24,10 @@ use crate::native::ssa_destroy::{
     EdgeCopyPlan, ParallelCopyDestination, ParallelCopyOperation, ParallelCopySource,
     SsaDestructionPlan,
 };
-use crate::{STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET, STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET};
+use crate::{
+    HashMap, HashSet, STATE_HEADER_NATIVE_LOOP_EVENT_SEQ_OFFSET,
+    STATE_HEADER_NATIVE_LOOP_REMAINING_OFFSET,
+};
 use celox_state_layout::STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET;
 
 pub use crate::native::ssa_destroy::SsaDestructionError;
@@ -378,7 +380,7 @@ fn select_spill_register_cache(
     assignment: &AssignmentMap,
     tick_loop: bool,
 ) -> SpillRegisterCache {
-    let mut access_counts = HashMap::<i32, usize>::new();
+    let mut access_counts = HashMap::<i32, usize>::default();
     let mut incompatible_ranges = Vec::<(i32, u32)>::new();
     let mut indexed_stack_access = false;
 
@@ -456,7 +458,7 @@ fn select_spill_register_cache(
         return SpillRegisterCache::default();
     }
 
-    let mut edge_slots = HashSet::<i32>::new();
+    let mut edge_slots = HashSet::<i32>::default();
     for edge in plan.edges() {
         for row in &edge.rows {
             if let ParallelCopyDestination::Stack(offset) = row.destination {
@@ -1510,7 +1512,7 @@ impl BlockLabels {
         block_order: &[usize],
     ) -> Self {
         let mut labels = Vec::new();
-        let mut canonical = HashMap::new();
+        let mut canonical = HashMap::default();
 
         for (position, &block_index) in block_order.iter().enumerate().rev() {
             let block = &func.blocks[block_index];
@@ -2140,7 +2142,7 @@ fn emit_planned(
         .iter()
         .map(|_| asm.create_label())
         .collect::<Vec<_>>();
-    let mut jump_table_labels = HashMap::<(BlockId, usize), CodeLabel>::new();
+    let mut jump_table_labels = HashMap::<(BlockId, usize), CodeLabel>::default();
     for block in &func.blocks {
         for (instruction, inst) in block.insts.iter().enumerate() {
             if matches!(inst, MInst::JumpTable { .. }) {
@@ -2642,7 +2644,7 @@ fn emit_planned(
 }
 
 fn count_vreg_uses(func: &MFunction, plan: &SsaDestructionPlan) -> HashMap<VReg, usize> {
-    let mut counts = HashMap::new();
+    let mut counts = HashMap::default();
     for edge in plan.edges() {
         for row in &edge.rows {
             *counts.entry(row.source_value).or_default() += 1;
@@ -5186,12 +5188,23 @@ pub fn emit_prepared_eu(
         timing || mir_stats || diagnostics.regalloc_timing || diagnostics.regalloc_stats;
     let total_start = timing.then(crate::timing::now);
 
-    sir_eu
-        .verify_result()
-        .map_err(|error| ChainedEmitError::Sir {
-            phase: "at x86 backend boundary",
-            error,
-        })?;
+    if cfg!(debug_assertions) || diagnostics.verify_sir {
+        sir_eu
+            .verify_result()
+            .map_err(|error| ChainedEmitError::Sir {
+                phase: "at x86 backend boundary",
+                error,
+            })?;
+    }
+    let verify_mir = |mfunc: &MFunction, phase| {
+        if cfg!(debug_assertions) || diagnostics.verify_mir {
+            mfunc
+                .verify_result()
+                .map_err(|error| ChainedEmitError::Mir { phase, error })
+        } else {
+            Ok(())
+        }
+    };
     if let Some(trace) = trace.as_deref_mut() {
         trace.optimized_sir = sir_eu.to_string();
     }
@@ -5216,12 +5229,7 @@ pub fn emit_prepared_eu(
     if timing {
         tracing::debug!("[native-timing] emit_chained verify after_isel label={label}");
     }
-    mfunc
-        .verify_result()
-        .map_err(|error| ChainedEmitError::Mir {
-            phase: "after native instruction selection",
-            error,
-        })?;
+    verify_mir(&mfunc, "after native instruction selection")?;
     let legalize_start = timing.then(crate::timing::now);
     super::mir_legalize::legalize(&mut mfunc);
     if let Some(start) = legalize_start {
@@ -5237,12 +5245,7 @@ pub fn emit_prepared_eu(
     if timing {
         tracing::debug!("[native-timing] emit_chained verify after_legalize label={label}");
     }
-    mfunc
-        .verify_result()
-        .map_err(|error| ChainedEmitError::Mir {
-            phase: "after MIR legalization",
-            error,
-        })?;
+    verify_mir(&mfunc, "after MIR legalization")?;
     let opt_start = timing.then(crate::timing::now);
     super::mir_opt::optimize_with_diagnostics(&mut mfunc, diagnostics);
     if let Some(start) = opt_start {
@@ -5254,23 +5257,13 @@ pub fn emit_prepared_eu(
             start.elapsed()
         );
     }
-    mfunc
-        .verify_result()
-        .map_err(|error| ChainedEmitError::Mir {
-            phase: "after MIR optimization before x86 SLP",
-            error,
-        })?;
+    verify_mir(&mfunc, "after MIR optimization before x86 SLP")?;
     let slp_stats = if options.slp {
         super::x86_slp::select(&mut mfunc)
     } else {
         super::x86_slp::SlpStats::default()
     };
-    mfunc
-        .verify_result()
-        .map_err(|error| ChainedEmitError::Mir {
-            phase: "after x86 SLP before VReg compaction",
-            error,
-        })?;
+    verify_mir(&mfunc, "after x86 SLP before VReg compaction")?;
     if timing {
         tracing::debug!(
             "[native-timing] emit_chained x86_slp vector_zeroes={} vector_packs={} vector_loads={} vector_binary_ops={} vector_stores={} scalar_instructions_removed={}",
@@ -5303,18 +5296,13 @@ pub fn emit_prepared_eu(
     if timing {
         tracing::debug!("[native-timing] emit_chained verify after_mir_opt label={label}");
     }
-    mfunc
-        .verify_result()
-        .map_err(|error| ChainedEmitError::Mir {
-            phase: "after MIR optimization",
-            error,
-        })?;
+    verify_mir(&mfunc, "after MIR optimization")?;
     if let Some(trace) = trace.as_deref_mut() {
         trace.mir_before_regalloc = mfunc.to_string();
     }
     let regalloc_start = timing.then(crate::timing::now);
     let mut regalloc_trace = trace.as_ref().map(|_| regalloc::RegallocTrace::default());
-    let ra = regalloc::run_regalloc_with_label_and_trace_and_diagnostics(
+    let ra = regalloc::run_regalloc_for_codegen(
         &mut mfunc,
         label,
         regalloc_trace.as_mut(),
@@ -5340,7 +5328,9 @@ pub fn emit_prepared_eu(
     super::mir_opt::post_regalloc_peephole(&mut mfunc);
     super::mir_opt::post_regalloc_cleanup(&mut mfunc);
     super::mir_opt::post_regalloc_direct_load_cse(&mut mfunc, &ra.assignment);
-    regalloc::verify_assignment(&mfunc, &ra.assignment)?;
+    if cfg!(debug_assertions) || diagnostics.verify_regalloc {
+        regalloc::verify_assignment(&mfunc, &ra.assignment)?;
+    }
     if let Some(start) = post_regalloc_start {
         tracing::debug!(
             "[native-timing] emit_chained post_regalloc_cleanup mir_blocks={} mir_insts={} vregs={} elapsed={:?}",
@@ -5350,12 +5340,7 @@ pub fn emit_prepared_eu(
             start.elapsed()
         );
     }
-    mfunc
-        .verify_result()
-        .map_err(|error| ChainedEmitError::Mir {
-            phase: "after post-allocation MIR peepholes",
-            error,
-        })?;
+    verify_mir(&mfunc, "after post-allocation MIR peepholes")?;
     if let Some(trace) = trace.as_deref_mut() {
         trace.mir_after_regalloc = mfunc.to_string();
         trace.register_assignment.clear();
@@ -5377,7 +5362,9 @@ pub fn emit_prepared_eu(
     // present on a phi edge. Build the edge-copy plan from this final MIR, not
     // from the pre-cleanup allocation input.
     let ssa_destruction = SsaDestructionPlan::build(&mfunc, &ra.assignment)?;
-    ssa_destruction.verify(&mfunc, &ra.assignment, ra.spill_frame_size)?;
+    if cfg!(debug_assertions) || diagnostics.verify_regalloc {
+        ssa_destruction.verify(&mfunc, &ra.assignment, ra.spill_frame_size)?;
+    }
     if copy_stats {
         let stats = ssa_destruction.stats();
         tracing::debug!(

--- a/crates/celox-backend-x86/src/backend/native/isel.rs
+++ b/crates/celox-backend-x86/src/backend/native/isel.rs
@@ -1284,8 +1284,7 @@ pub fn lower_execution_unit_with_diagnostics(
     }
 
     let mut next_extra_block_id = block_ids.iter().map(|bid| bid.0).max().unwrap_or(0) + 1;
-    let mut sir_exit_mir_blocks: std::collections::HashMap<crate::BlockId, BlockId> =
-        std::collections::HashMap::new();
+    let mut sir_exit_mir_blocks: HashMap<crate::BlockId, BlockId> = HashMap::default();
 
     let mut mask_map = RegMap::new(max_sir_regs);
     // Pre-allocate mask VRegs for 4-state
@@ -1352,10 +1351,8 @@ pub fn lower_execution_unit_with_diagnostics(
     }
 
     // Collect mask phi sources per-block (captures mask state at each terminator)
-    let mut mask_phi_sources: std::collections::HashMap<
-        BlockId,
-        Vec<(BlockId, usize, usize, VReg)>,
-    > = std::collections::HashMap::new();
+    let mut mask_phi_sources: HashMap<BlockId, Vec<(BlockId, usize, usize, VReg)>> =
+        HashMap::default();
 
     for &sir_block_id in &block_ids {
         let sir_block = &eu.blocks[&sir_block_id];
@@ -1764,9 +1761,10 @@ pub fn lower_execution_unit_with_diagnostics(
     // Build phi nodes from SIR block params and predecessor terminators.
     // For each SIR block with params, find all predecessors that pass args.
     {
-        use std::collections::HashMap;
+        use crate::HashMap;
         // Collect phi sources: target_block → [(pred_block, param_idx, chunk_idx, arg_vreg)]
-        let mut phi_sources: HashMap<BlockId, Vec<(BlockId, usize, usize, VReg)>> = HashMap::new();
+        let mut phi_sources: HashMap<BlockId, Vec<(BlockId, usize, usize, VReg)>> =
+            HashMap::default();
         for &sir_block_id in &block_ids {
             let sir_block = &eu.blocks[&sir_block_id];
             let pred_mir_id = sir_exit_mir_blocks

--- a/crates/celox-backend-x86/src/backend/native/mir.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir.rs
@@ -5,7 +5,9 @@
 //! only in [`SpillDesc`] side-tables so the register allocator can make
 //! cost-aware spill decisions without knowing about bit layouts.
 
-use std::{collections::HashMap, fmt};
+use std::fmt;
+
+use crate::HashMap;
 
 use crate::RegionedAbsoluteAddr;
 

--- a/crates/celox-backend-x86/src/backend/native/mir_legalize.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_legalize.rs
@@ -1,6 +1,5 @@
-use std::collections::{HashMap, HashSet};
-
 use super::mir::*;
+use crate::{HashMap, HashSet};
 
 pub fn legalize(func: &mut MFunction) {
     eliminate_trivial_phis(func);
@@ -108,7 +107,7 @@ fn alloc_shift_temp(
 }
 
 fn eliminate_trivial_phis(func: &mut MFunction) {
-    let mut aliases: HashMap<VReg, VReg> = HashMap::new();
+    let mut aliases: HashMap<VReg, VReg> = HashMap::default();
 
     for block in &func.blocks {
         for phi in &block.phis {
@@ -141,10 +140,11 @@ fn eliminate_trivial_phis(func: &mut MFunction) {
         return;
     }
 
-    let mut resolved: HashMap<VReg, VReg> = HashMap::with_capacity(aliases.len());
+    let mut resolved: HashMap<VReg, VReg> =
+        HashMap::with_capacity_and_hasher(aliases.len(), Default::default());
     for (&dst, &src) in &aliases {
         let mut target = src;
-        let mut seen = HashSet::from([dst]);
+        let mut seen = [dst].into_iter().collect::<HashSet<_>>();
         let mut cyclic = false;
         while let Some(&next) = aliases.get(&target) {
             if !seen.insert(target) || !seen.insert(next) {

--- a/crates/celox-backend-x86/src/backend/native/mir_opt.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt.rs
@@ -3,11 +3,12 @@
 //! - Copy propagation: `v2 = mov v1` → replace all uses of v2 with v1
 //! - Dead code elimination: remove instructions whose defs are unused
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use super::memory_effect;
 use super::mir::*;
 use super::regalloc::assignment::{AssignmentMap, PhysReg, clobbers};
+use crate::{HashMap, HashSet};
 
 mod pipeline;
 pub use pipeline::{optimize, optimize_with_diagnostics};
@@ -142,7 +143,7 @@ pub(crate) fn compact_vregs(func: &mut MFunction) -> VRegCompaction {
 /// justify with instruction reordering. Wider immediates are truncated to the
 /// access width, exactly as the original final store truncates the register.
 pub(crate) fn fold_direct_immediate_stores(func: &mut MFunction) -> usize {
-    let mut use_counts = HashMap::<VReg, usize>::new();
+    let mut use_counts = HashMap::<VReg, usize>::default();
     for block in &func.blocks {
         for phi in &block.phis {
             for (_, source) in &phi.sources {
@@ -259,7 +260,7 @@ pub(crate) fn fold_direct_immediate_stores(func: &mut MFunction) -> usize {
 /// indexed load. x86 effective-address scaling and the original shift both
 /// use modulo-64-bit arithmetic, so the rewrite preserves wrapping exactly.
 fn fold_scaled_indexed_loads(func: &mut MFunction) {
-    let mut use_counts = HashMap::<VReg, usize>::new();
+    let mut use_counts = HashMap::<VReg, usize>::default();
     for block in &func.blocks {
         for phi in &block.phis {
             for (_, source) in &phi.sources {
@@ -274,7 +275,7 @@ fn fold_scaled_indexed_loads(func: &mut MFunction) {
     }
 
     for block in &mut func.blocks {
-        let mut shifts = HashMap::<VReg, (VReg, u8)>::new();
+        let mut shifts = HashMap::<VReg, (VReg, u8)>::default();
         for inst in &mut block.insts {
             if let MInst::ShlImm { dst, src, imm } = inst {
                 if (1..=3).contains(imm) {
@@ -304,7 +305,7 @@ fn fold_scaled_indexed_loads(func: &mut MFunction) {
 /// adjacent. These conditions make the replacement independent of alias and
 /// scheduling speculation while removing one allocation value per chunk.
 fn fold_contiguous_memory_copies(func: &mut MFunction) {
-    let mut use_counts = HashMap::<VReg, usize>::new();
+    let mut use_counts = HashMap::<VReg, usize>::default();
     for block in &func.blocks {
         for phi in &block.phis {
             for (_, source) in &phi.sources {
@@ -421,7 +422,7 @@ fn refresh_constant_spill_descs(func: &mut MFunction) {
 /// `offset & 7`, so retaining that guard is unnecessary. Bounds here are
 /// intentionally limited to operations that cannot underestimate a value.
 fn fold_proven_comparisons(func: &mut MFunction) {
-    let mut defs = HashMap::new();
+    let mut defs = HashMap::default();
     for block in &func.blocks {
         for inst in &block.insts {
             if let Some(dst) = inst.def() {
@@ -429,7 +430,7 @@ fn fold_proven_comparisons(func: &mut MFunction) {
             }
         }
     }
-    let mut upper_bounds = HashMap::new();
+    let mut upper_bounds = HashMap::default();
     for block in &mut func.blocks {
         for inst in &mut block.insts {
             let replacement = match inst {
@@ -445,7 +446,7 @@ fn fold_proven_comparisons(func: &mut MFunction) {
                         *lhs,
                         &defs,
                         &mut upper_bounds,
-                        &mut HashSet::new(),
+                        &mut HashSet::default(),
                     )
                     .is_some_and(|bound| bound < *value)) =>
                 {
@@ -466,7 +467,7 @@ fn fold_proven_comparisons(func: &mut MFunction) {
                         *lhs,
                         &defs,
                         &mut upper_bounds,
-                        &mut HashSet::new(),
+                        &mut HashSet::default(),
                     )
                     .is_some_and(|bound| bound < *imm as u64) =>
                 {
@@ -489,8 +490,8 @@ fn fold_proven_comparisons(func: &mut MFunction) {
 /// comparison. These forms become visible especially after immediate lowering;
 /// eliminating them here avoids materializing an intermediate condition.
 fn fold_boolean_normalizations(func: &mut MFunction) {
-    let mut defs = HashMap::new();
-    let mut use_counts = HashMap::<VReg, usize>::new();
+    let mut defs = HashMap::default();
+    let mut use_counts = HashMap::<VReg, usize>::default();
     for block in &func.blocks {
         for phi in &block.phis {
             for &(_, source) in &phi.sources {
@@ -506,7 +507,7 @@ fn fold_boolean_normalizations(func: &mut MFunction) {
             }
         }
     }
-    let mut upper_bounds = HashMap::new();
+    let mut upper_bounds = HashMap::default();
     for block in &mut func.blocks {
         for inst in &mut block.insts {
             let replacement = match inst {
@@ -515,8 +516,13 @@ fn fold_boolean_normalizations(func: &mut MFunction) {
                     lhs,
                     imm: 0,
                     kind: CmpKind::Ne,
-                } if unsigned_upper_bound(*lhs, &defs, &mut upper_bounds, &mut HashSet::new())
-                    .is_some_and(|bound| bound <= 1) =>
+                } if unsigned_upper_bound(
+                    *lhs,
+                    &defs,
+                    &mut upper_bounds,
+                    &mut HashSet::default(),
+                )
+                .is_some_and(|bound| bound <= 1) =>
                 {
                     Some(MInst::Mov {
                         dst: *dst,
@@ -528,13 +534,17 @@ fn fold_boolean_normalizations(func: &mut MFunction) {
                     lhs,
                     rhs,
                     kind: CmpKind::Ne,
-                } if unsigned_upper_bound(*rhs, &defs, &mut upper_bounds, &mut HashSet::new())
-                    == Some(0)
+                } if unsigned_upper_bound(
+                    *rhs,
+                    &defs,
+                    &mut upper_bounds,
+                    &mut HashSet::default(),
+                ) == Some(0)
                     && unsigned_upper_bound(
                         *lhs,
                         &defs,
                         &mut upper_bounds,
-                        &mut HashSet::new(),
+                        &mut HashSet::default(),
                     )
                     .is_some_and(|bound| bound <= 1) =>
                 {
@@ -687,7 +697,7 @@ fn unsigned_upper_bound(
 pub fn post_regalloc_peephole(func: &mut MFunction) {
     const IMM_FOLD_SCAN_LIMIT: usize = 8;
 
-    let mut use_counts: HashMap<VReg, usize> = HashMap::new();
+    let mut use_counts: HashMap<VReg, usize> = HashMap::default();
     for block in &func.blocks {
         for phi in &block.phis {
             for (_, src) in &phi.sources {
@@ -703,7 +713,7 @@ pub fn post_regalloc_peephole(func: &mut MFunction) {
 
     for block in &mut func.blocks {
         let mut remove = vec![false; block.insts.len()];
-        let mut replacements: HashMap<usize, MInst> = HashMap::new();
+        let mut replacements: HashMap<usize, MInst> = HashMap::default();
 
         // A state-home rematerialization immediately before a forwarded
         // width-normalizing copy is one machine load, not a load followed by
@@ -857,7 +867,7 @@ pub(crate) fn post_regalloc_direct_load_cse(
 
     let mut reused = 0usize;
     for block in &mut func.blocks {
-        let mut available = HashMap::<PhysReg, AvailableDirectLoad>::new();
+        let mut available = HashMap::<PhysReg, AvailableDirectLoad>::default();
         let mut replacements = Vec::<(usize, VReg, VReg)>::new();
         for (position, instruction) in block.insts.iter().enumerate() {
             let writes = memory_effect::writes(instruction);
@@ -1154,7 +1164,7 @@ fn and_imm_ok(value: u64) -> bool {
 }
 
 fn fuse_compare_selects(func: &mut MFunction) {
-    let mut use_counts: HashMap<VReg, usize> = HashMap::new();
+    let mut use_counts: HashMap<VReg, usize> = HashMap::default();
     for block in &func.blocks {
         for phi in &block.phis {
             for (_, src) in &phi.sources {
@@ -1169,7 +1179,7 @@ fn fuse_compare_selects(func: &mut MFunction) {
     }
 
     for block in &mut func.blocks {
-        let mut def_pos: HashMap<VReg, usize> = HashMap::new();
+        let mut def_pos: HashMap<VReg, usize> = HashMap::default();
         for (idx, inst) in block.insts.iter().enumerate() {
             if let Some(def) = inst.def() {
                 def_pos.insert(def, idx);
@@ -1177,7 +1187,7 @@ fn fuse_compare_selects(func: &mut MFunction) {
         }
 
         let mut remove = vec![false; block.insts.len()];
-        let mut replacements: HashMap<usize, MInst> = HashMap::new();
+        let mut replacements: HashMap<usize, MInst> = HashMap::default();
 
         for (idx, inst) in block.insts.iter().enumerate() {
             let MInst::Select {
@@ -1348,7 +1358,7 @@ impl IndexedLoadTreeSummary {
 /// maximal roots are traversed, so failed nested candidates cannot cause
 /// quadratic rediscovery.
 fn sink_selected_indexed_loads(func: &mut MFunction) {
-    let mut use_counts = HashMap::<VReg, usize>::new();
+    let mut use_counts = HashMap::<VReg, usize>::default();
     for block in &func.blocks {
         for phi in &block.phis {
             for (_, source) in &phi.sources {
@@ -1364,7 +1374,7 @@ fn sink_selected_indexed_loads(func: &mut MFunction) {
 
     let mut plans = Vec::<Vec<IndexedLoadSelectionPlan>>::with_capacity(func.blocks.len());
     for block in &func.blocks {
-        let mut definitions = HashMap::<VReg, usize>::new();
+        let mut definitions = HashMap::<VReg, usize>::default();
         for (index, inst) in block.insts.iter().enumerate() {
             if let Some(dst) = inst.def() {
                 definitions.insert(dst, index);
@@ -1379,7 +1389,7 @@ fn sink_selected_indexed_loads(func: &mut MFunction) {
                     + usize::from(memory_effect::writes(inst).has_effect()),
             );
         }
-        let mut selectable = HashMap::<VReg, IndexedLoadTreeSummary>::new();
+        let mut selectable = HashMap::<VReg, IndexedLoadTreeSummary>::default();
         for (instruction, inst) in block.insts.iter().enumerate() {
             if let MInst::LoadIndexed {
                 dst,
@@ -1434,7 +1444,7 @@ fn sink_selected_indexed_loads(func: &mut MFunction) {
             );
         }
 
-        let mut claimed = HashSet::<usize>::new();
+        let mut claimed = HashSet::<usize>::default();
         let mut block_plans = Vec::new();
         for root in (0..block.insts.len()).rev() {
             if claimed.contains(&root)
@@ -1452,7 +1462,7 @@ fn sink_selected_indexed_loads(func: &mut MFunction) {
             pending.push(false_val);
             let mut select_indices = vec![root];
             let mut load_indices = Vec::new();
-            let mut seen_values = HashSet::new();
+            let mut seen_values = HashSet::default();
             let mut failed = false;
 
             while let Some(value) = pending.pop() {
@@ -1546,8 +1556,8 @@ fn sink_selected_indexed_loads(func: &mut MFunction) {
             select_indices.sort_unstable();
             load_indices.sort_unstable();
             let mut replacement = Vec::new();
-            let mut remapped = HashMap::<VReg, VReg>::new();
-            let mut offset_constants = HashMap::<i32, VReg>::new();
+            let mut remapped = HashMap::<VReg, VReg>::default();
+            let mut offset_constants = HashMap::<i32, VReg>::default();
             for &load_index in &load_indices {
                 let MInst::LoadIndexed { dst, offset, .. } = block.insts[load_index] else {
                     unreachable!()
@@ -1647,8 +1657,8 @@ fn sink_selected_indexed_loads(func: &mut MFunction) {
         if block_plans.is_empty() {
             continue;
         }
-        let mut removals = HashSet::new();
-        let mut replacements = HashMap::new();
+        let mut removals = HashSet::default();
+        let mut replacements = HashMap::default();
         for plan in block_plans {
             removals.extend(plan.remove);
             replacements.insert(plan.root, plan.replacement);
@@ -1673,7 +1683,7 @@ fn sink_selected_indexed_loads(func: &mut MFunction) {
 /// Constant folding: evaluate operations with constant operands at compile time.
 fn constant_fold(func: &mut MFunction) {
     // Build def map: VReg → LoadImm value
-    let mut consts: HashMap<VReg, u64> = HashMap::new();
+    let mut consts: HashMap<VReg, u64> = HashMap::default();
     for block in &func.blocks {
         for inst in &block.insts {
             if let MInst::LoadImm { dst, value } = inst {
@@ -1899,7 +1909,7 @@ fn mask_width(mask: u64) -> Option<usize> {
 /// fact across a block boundary does not extend a live range or add an
 /// ordering constraint.
 fn redundant_mask_eliminate(func: &mut MFunction) {
-    let mut constants: HashMap<VReg, u64> = HashMap::new();
+    let mut constants: HashMap<VReg, u64> = HashMap::default();
     for block in &func.blocks {
         for inst in &block.insts {
             if let MInst::LoadImm { dst, value } = inst {
@@ -1910,7 +1920,7 @@ fn redundant_mask_eliminate(func: &mut MFunction) {
     let possible_ones = global_possible_one_bits(func, &constants);
 
     for block in &mut func.blocks {
-        let mut definitions: HashMap<VReg, MaskDefinition> = HashMap::new();
+        let mut definitions: HashMap<VReg, MaskDefinition> = HashMap::default();
 
         for inst in &mut block.insts {
             let should_replace =
@@ -2641,7 +2651,7 @@ fn gvn_affected_memory_variables(
             }
         });
     }
-    let mut affected = HashSet::<GvnMemoryVariable>::new();
+    let mut affected = HashSet::<GvnMemoryVariable>::default();
     for range in effect.ranges() {
         let end = range.end()?;
         affected.extend(
@@ -2709,12 +2719,13 @@ fn compute_gvn_load_versions(
         }
     }
     if tracked.sim_state.is_empty() && tracked.stack_frame.is_empty() {
-        return Some(HashMap::new());
+        return Some(HashMap::default());
     }
 
     let frontiers = gvn_dominance_frontiers(predecessors, idom)?;
-    let mut definition_blocks = HashMap::<GvnMemoryVariable, BTreeSet<usize>>::new();
-    let mut write_versions = HashMap::<(usize, usize, GvnMemoryVariable), GvnMemoryVersion>::new();
+    let mut definition_blocks = HashMap::<GvnMemoryVariable, BTreeSet<usize>>::default();
+    let mut write_versions =
+        HashMap::<(usize, usize, GvnMemoryVariable), GvnMemoryVersion>::default();
     let mut write_ordinal = 0usize;
     for (block, mir_block) in func.blocks.iter().enumerate() {
         for (instruction, inst) in mir_block.insts.iter().enumerate() {
@@ -2771,8 +2782,8 @@ fn compute_gvn_load_versions(
         Enter(usize),
         Exit(Vec<(GvnMemoryVariable, Option<GvnMemoryVersion>)>),
     }
-    let mut current = HashMap::<GvnMemoryVariable, GvnMemoryVersion>::new();
-    let mut versions = HashMap::<(usize, usize), GvnLoadVersion>::new();
+    let mut current = HashMap::<GvnMemoryVariable, GvnMemoryVersion>::default();
+    let mut versions = HashMap::<(usize, usize), GvnLoadVersion>::default();
     let mut actions = vec![Action::Enter(0)];
     while let Some(action) = actions.pop() {
         let block = match action {
@@ -2849,7 +2860,7 @@ fn global_gvn(func: &mut MFunction) {
         .blocks
         .iter()
         .map(|block| {
-            let mut uses = HashMap::new();
+            let mut uses = HashMap::default();
             for (instruction, inst) in block.insts.iter().enumerate() {
                 for value in inst.uses() {
                     uses.insert(value, instruction);
@@ -2877,7 +2888,7 @@ fn global_gvn(func: &mut MFunction) {
     let mut leader_blocks = vec![None; vreg_count];
     debug_assert_eq!(value_numbers.len(), vreg_count);
 
-    let mut value_table: HashMap<GvnKey, ValueNumber> = HashMap::new();
+    let mut value_table: HashMap<GvnKey, ValueNumber> = HashMap::default();
     let mut table_changes: Vec<(GvnKey, Option<ValueNumber>)> = Vec::new();
     let mut leader_changes: Vec<(ValueNumber, VReg, Option<usize>)> = Vec::new();
     let mut replacements: Vec<(usize, usize, MInst)> = Vec::new(); // (block_idx, inst_idx, new_inst)
@@ -3053,8 +3064,8 @@ fn compute_gvn_liveness(
     succs: &[Vec<usize>],
 ) -> (Vec<HashSet<VReg>>, Vec<HashSet<VReg>>) {
     let block_count = func.blocks.len();
-    let mut uses = vec![HashSet::new(); block_count];
-    let mut defs = vec![HashSet::new(); block_count];
+    let mut uses = vec![HashSet::default(); block_count];
+    let mut defs = vec![HashSet::default(); block_count];
 
     for (block_index, block) in func.blocks.iter().enumerate() {
         defs[block_index].extend(block.phis.iter().map(|phi| phi.dst));
@@ -3070,13 +3081,13 @@ fn compute_gvn_liveness(
         }
     }
 
-    let mut live_in = vec![HashSet::new(); block_count];
+    let mut live_in = vec![HashSet::default(); block_count];
     let mut changed = true;
     while changed {
         changed = false;
         for block_index in (0..block_count).rev() {
             let block_id = func.blocks[block_index].id;
-            let mut live_out = HashSet::new();
+            let mut live_out = HashSet::default();
             for &successor in &succs[block_index] {
                 live_out.extend(live_in[successor].iter().copied());
                 for phi in &func.blocks[successor].phis {
@@ -3102,7 +3113,7 @@ fn compute_gvn_liveness(
         }
     }
 
-    let mut live_out = vec![HashSet::new(); block_count];
+    let mut live_out = vec![HashSet::default(); block_count];
     for (block_index, block) in func.blocks.iter().enumerate() {
         for &successor in &succs[block_index] {
             live_out[block_index].extend(live_in[successor].iter().copied());
@@ -3318,7 +3329,7 @@ fn sink_bitwise_and_masks(func: &mut MFunction) {
 
             let mut stack = vec![(root_value, true)];
             let mut nodes = Vec::new();
-            let mut visited = HashSet::new();
+            let mut visited = HashSet::default();
             let mut combined_mask = u64::MAX;
             let mut immediate_masks = 0usize;
             let mut has_binary_and = false;
@@ -3376,7 +3387,7 @@ fn sink_bitwise_and_masks(func: &mut MFunction) {
         }
     }
 
-    let mut removals = vec![HashSet::<usize>::new(); func.blocks.len()];
+    let mut removals = vec![HashSet::<usize>::default(); func.blocks.len()];
     let mut replacements = vec![BTreeMap::<usize, Vec<MInst>>::new(); func.blocks.len()];
     for plan in plans {
         let root_instruction = func.blocks[plan.block].insts[plan.root].clone();
@@ -3388,7 +3399,7 @@ fn sink_bitwise_and_masks(func: &mut MFunction) {
         let root_raw_destination =
             (!root_is_mask && plan.combined_mask != u64::MAX).then(|| transient_vreg(func));
         let original = &func.blocks[plan.block].insts;
-        let mut aliases = HashMap::new();
+        let mut aliases = HashMap::default();
 
         for &instruction_index in &plan.nodes {
             match &original[instruction_index] {
@@ -3499,9 +3510,9 @@ fn algebraic_simplify(func: &mut MFunction) {
     sink_bitwise_and_masks(func);
 
     // Build def map for constant lookups
-    let mut consts: HashMap<VReg, u64> = HashMap::new();
-    let mut and_immediates: HashMap<VReg, (VReg, u64)> = HashMap::new();
-    let mut and_immediates32: HashMap<VReg, (VReg, u32)> = HashMap::new();
+    let mut consts: HashMap<VReg, u64> = HashMap::default();
+    let mut and_immediates: HashMap<VReg, (VReg, u64)> = HashMap::default();
+    let mut and_immediates32: HashMap<VReg, (VReg, u32)> = HashMap::default();
     for block in &func.blocks {
         for inst in &block.insts {
             match inst {
@@ -3911,7 +3922,7 @@ impl ContiguousLoadPack {
 /// version without moving a read across an effect.
 fn fold_contiguous_load_packs(func: &mut MFunction) {
     for block in &mut func.blocks {
-        let mut summaries = HashMap::<VReg, ContiguousLoadPack>::new();
+        let mut summaries = HashMap::<VReg, ContiguousLoadPack>::default();
         let mut last_write = None::<usize>;
 
         for instruction_index in 0..block.insts.len() {
@@ -3990,7 +4001,7 @@ enum BranchPredicateClass {
 }
 
 fn fold_branch_predicates(func: &mut MFunction, class: BranchPredicateClass) -> usize {
-    let mut use_counts = HashMap::<VReg, usize>::new();
+    let mut use_counts = HashMap::<VReg, usize>::default();
     for block in &func.blocks {
         for phi in &block.phis {
             for &(_, source) in &phi.sources {
@@ -4116,7 +4127,7 @@ fn simplify_cfg(func: &mut MFunction) {
 
     // Build jump-through map: if a block contains only `jmp target`,
     // redirect all references to this block directly to `target`.
-    let mut redirect: HashMap<BlockId, BlockId> = HashMap::new();
+    let mut redirect: HashMap<BlockId, BlockId> = HashMap::default();
     for block in &func.blocks {
         if Some(block.id) != entry
             && !phi_predecessors.contains(&block.id)
@@ -4131,10 +4142,10 @@ fn simplify_cfg(func: &mut MFunction) {
 
     if !redirect.is_empty() {
         // Transitively resolve redirects
-        let mut resolved: HashMap<BlockId, BlockId> = HashMap::new();
+        let mut resolved: HashMap<BlockId, BlockId> = HashMap::default();
         for &src in redirect.keys() {
             let mut target = src;
-            let mut seen = std::collections::HashSet::new();
+            let mut seen = HashSet::default();
             while let Some(&next) = redirect.get(&target) {
                 if !seen.insert(next) {
                     break;
@@ -4235,7 +4246,7 @@ fn byte_range(offset: i32, byte_len: usize) -> Option<(i64, i64)> {
 /// This runs late (after CSE/constant fold) to maximize opportunities.
 fn lower_to_imm_forms(func: &mut MFunction) {
     // Collect constants
-    let mut consts: HashMap<VReg, u64> = HashMap::new();
+    let mut consts: HashMap<VReg, u64> = HashMap::default();
     for block in &func.blocks {
         for inst in &block.insts {
             if let MInst::LoadImm { dst, value } = inst {
@@ -4266,8 +4277,8 @@ fn lower_to_imm_forms(func: &mut MFunction) {
 /// algebraic pass. The 32-bit operation is a zero-extending machine
 /// operation, so mixed-width composition must retain an And32 result.
 fn fold_late_serial_and_immediates(func: &mut MFunction) {
-    let mut and64 = HashMap::<VReg, (VReg, u64)>::new();
-    let mut and32 = HashMap::<VReg, (VReg, u32)>::new();
+    let mut and64 = HashMap::<VReg, (VReg, u64)>::default();
+    let mut and32 = HashMap::<VReg, (VReg, u32)>::default();
     for block in &func.blocks {
         for instruction in &block.insts {
             match instruction {
@@ -4350,7 +4361,7 @@ fn fold_late_serial_and_immediates(func: &mut MFunction) {
 /// This is produced by dynamic bit-select XOR assignment such as
 /// `x[s] ^= 1`. For 2-state values it is equivalent to `x ^ (1 << s)`.
 fn fold_bit_toggle_insert(func: &mut MFunction) {
-    let mut defs: HashMap<VReg, MInst> = HashMap::new();
+    let mut defs: HashMap<VReg, MInst> = HashMap::default();
     for block in &func.blocks {
         for inst in &block.insts {
             if let Some(d) = inst.def() {
@@ -4590,7 +4601,7 @@ fn shifted_source(result: VReg, expected_shift: u8, defs: &HashMap<VReg, MInst>)
 /// where source bits are the contiguous low bits `0..N` and destination bits
 /// are strictly increasing. This is exactly `pdep(src, mask)`.
 fn fold_deposit_chain_to_pdep(func: &mut MFunction) {
-    let mut defs: HashMap<VReg, MInst> = HashMap::new();
+    let mut defs: HashMap<VReg, MInst> = HashMap::default();
     for block in &func.blocks {
         for inst in &block.insts {
             if let Some(d) = inst.def() {
@@ -4856,7 +4867,7 @@ fn load_imm_value(reg: VReg, defs: &HashMap<VReg, MInst>) -> Option<u64> {
 /// where destination chunks are contiguous low bits and source chunks are
 /// strictly increasing. This is `pext(src, mask)`.
 fn fold_extract_chain_to_pext(func: &mut MFunction) {
-    let mut defs: HashMap<VReg, MInst> = HashMap::new();
+    let mut defs: HashMap<VReg, MInst> = HashMap::default();
     for block in &func.blocks {
         for inst in &block.insts {
             if let Some(d) = inst.def() {
@@ -4974,7 +4985,7 @@ fn fold_extract_chain_to_pext(func: &mut MFunction) {
 /// `mask = (1 << a) | (1 << b) | ...`
 fn fold_xor_chain_to_pext(func: &mut MFunction) {
     // Build def map: VReg → instruction (cloned to avoid borrowing func)
-    let mut defs: HashMap<VReg, MInst> = HashMap::new();
+    let mut defs: HashMap<VReg, MInst> = HashMap::default();
     for block in &func.blocks {
         for inst in &block.insts {
             if let Some(d) = inst.def() {
@@ -5075,7 +5086,7 @@ fn fold_xor_chain_to_pext(func: &mut MFunction) {
 ///   if mask == all_ones: `popcnt src`
 ///   else: `masked = and src, mask; popcnt masked`
 fn fold_add_chain_to_popcnt(func: &mut MFunction) {
-    let mut defs: HashMap<VReg, MInst> = HashMap::new();
+    let mut defs: HashMap<VReg, MInst> = HashMap::default();
     for block in &func.blocks {
         for inst in &block.insts {
             if let Some(d) = inst.def() {
@@ -5281,9 +5292,9 @@ fn collect_add_chain_bits(
 /// Constant deduplication: merge LoadImm instructions with the same value
 /// into a single VReg. Reduces register pressure and instruction count.
 fn constant_dedup(func: &mut MFunction) {
-    let mut aliases: HashMap<VReg, VReg> = HashMap::new();
+    let mut aliases: HashMap<VReg, VReg> = HashMap::default();
     // Map from constant value → canonical VReg
-    let mut const_map: HashMap<u64, VReg> = HashMap::new();
+    let mut const_map: HashMap<u64, VReg> = HashMap::default();
 
     for block in &func.blocks {
         const_map.clear(); // per-block to avoid cross-block live range extension
@@ -5486,7 +5497,7 @@ fn fold_relocated_bit_copy_groups(func: &mut MFunction) {
     // A bypassed projection must be private to the reconstructed root across
     // the whole function.  In particular, phi sources are edge uses and must
     // not disappear merely because this pass scans one block at a time.
-    let mut use_counts = HashMap::<VReg, usize>::new();
+    let mut use_counts = HashMap::<VReg, usize>::default();
     for block in &func.blocks {
         for phi in &block.phis {
             for &(_, source) in &phi.sources {
@@ -5509,7 +5520,7 @@ fn fold_relocated_bit_copy_groups(func: &mut MFunction) {
                 .enumerate()
                 .filter_map(|(index, instruction)| instruction.def().map(|dst| (dst, index)))
                 .collect::<HashMap<_, _>>();
-            let mut nested_or_inputs = HashSet::<VReg>::new();
+            let mut nested_or_inputs = HashSet::<VReg>::default();
             for instruction in &block.insts {
                 match instruction {
                     MInst::Or { lhs, rhs, .. } | MInst::Or32 { lhs, rhs, .. } => {
@@ -5547,7 +5558,7 @@ fn fold_relocated_bit_copy_groups(func: &mut MFunction) {
                 }
 
                 let mut groups = Vec::<RelocatedBitGroup>::new();
-                let mut grouped = HashMap::<(VReg, i16), usize>::new();
+                let mut grouped = HashMap::<(VReg, i16), usize>::default();
                 let mut shared_terms = Vec::<(usize, (VReg, i16), u64)>::new();
                 for term in terms {
                     // A nonzero copied mask normally proves that the affine
@@ -6075,10 +6086,10 @@ enum LinearCopyOp {
 
 fn eliminate_redundant_or_terms(func: &mut MFunction) {
     for block in &mut func.blocks {
-        let mut mov_aliases: HashMap<VReg, VReg> = HashMap::new();
-        let mut rewrite_aliases: HashMap<VReg, VReg> = HashMap::new();
-        let mut select_terms: HashMap<VReg, SelectTerm> = HashMap::new();
-        let mut or_terms: HashMap<VReg, HashSet<SelectTerm>> = HashMap::new();
+        let mut mov_aliases: HashMap<VReg, VReg> = HashMap::default();
+        let mut rewrite_aliases: HashMap<VReg, VReg> = HashMap::default();
+        let mut select_terms: HashMap<VReg, SelectTerm> = HashMap::default();
+        let mut or_terms: HashMap<VReg, HashSet<SelectTerm>> = HashMap::default();
 
         for inst in &mut block.insts {
             if !rewrite_aliases.is_empty() {
@@ -6309,12 +6320,12 @@ fn discover_partial_round_trips(
     possible_ones: &[u64],
     constants: &HashMap<VReg, u64>,
 ) -> (Vec<PartialRoundTripPlan>, Vec<Option<PartialStoreEvent>>) {
-    let mut last_events = HashMap::<LocalMemoryByte, LocalMemoryEvent>::new();
-    let mut last_writes = HashMap::<LocalMemoryByte, usize>::new();
+    let mut last_events = HashMap::<LocalMemoryByte, LocalMemoryEvent>::default();
+    let mut last_writes = HashMap::<LocalMemoryByte, usize>::default();
     let mut stores = vec![None; block.insts.len()];
     let mut plans = Vec::new();
     let mut region_start = 0usize;
-    let mut definitions = HashMap::<VReg, &MInst>::new();
+    let mut definitions = HashMap::<VReg, &MInst>::default();
 
     for (instruction, inst) in block.insts.iter().enumerate() {
         match *inst {
@@ -6466,8 +6477,8 @@ fn retain_dead_partial_store_plans(
         .map(|(plan, candidate)| (candidate.load_instruction, plan))
         .collect::<HashMap<_, _>>();
     let mut accepted = vec![false; plans.len()];
-    let mut removed_stores = HashSet::<usize>::new();
-    let mut next_events = HashMap::<LocalMemoryByte, LocalMemoryEvent>::new();
+    let mut removed_stores = HashSet::<usize>::default();
+    let mut next_events = HashMap::<LocalMemoryByte, LocalMemoryEvent>::default();
 
     for (instruction, inst) in block.insts.iter().enumerate().rev() {
         if let Some(plan) = plans_by_load.remove(&instruction) {
@@ -6699,9 +6710,9 @@ fn promote_partial_store_round_trips(func: &mut MFunction) {
             continue;
         }
 
-        let mut insertions = HashMap::<usize, Vec<MInst>>::new();
-        let mut replacements = HashMap::<usize, Vec<MInst>>::new();
-        let mut removals = HashSet::<usize>::new();
+        let mut insertions = HashMap::<usize, Vec<MInst>>::default();
+        let mut replacements = HashMap::<usize, Vec<MInst>>::default();
+        let mut removals = HashSet::<usize>::default();
         for plan in plans {
             let old = alloc_transient_vreg(vregs, spill_descs);
             insertions
@@ -6760,7 +6771,7 @@ fn promote_partial_store_round_trips(func: &mut MFunction) {
 fn forward_local_store_loads(func: &mut MFunction) {
     let (vregs, spill_descs, blocks) = (&mut func.vregs, &mut func.spill_descs, &mut func.blocks);
     for block in blocks {
-        let mut available: HashMap<MemorySlot, VReg> = HashMap::new();
+        let mut available: HashMap<MemorySlot, VReg> = HashMap::default();
         let mut rewritten = Vec::with_capacity(block.insts.len());
 
         for inst in block.insts.drain(..) {
@@ -7138,14 +7149,14 @@ fn invalidate_overlapping_byte_range<T>(
 /// remains a real truncating definition.
 fn copy_propagate(func: &mut MFunction) {
     // Build alias map: dst → src (transitively resolved)
-    let mut aliases: HashMap<VReg, VReg> = HashMap::new();
+    let mut aliases: HashMap<VReg, VReg> = HashMap::default();
     let definitions = func
         .blocks
         .iter()
         .flat_map(|block| &block.insts)
         .filter_map(|inst| inst.def().map(|dst| (dst, inst.clone())))
         .collect::<HashMap<_, _>>();
-    let mut upper_bounds = HashMap::new();
+    let mut upper_bounds = HashMap::default();
 
     for block in &func.blocks {
         for inst in &block.insts {
@@ -7156,7 +7167,7 @@ fn copy_propagate(func: &mut MFunction) {
                         *src,
                         &definitions,
                         &mut upper_bounds,
-                        &mut HashSet::new(),
+                        &mut HashSet::default(),
                     )
                     .is_some_and(|bound| bound <= u32::MAX as u64) =>
                 {
@@ -7226,7 +7237,7 @@ fn dead_code_eliminate_preserving_phis(func: &mut MFunction) {
 fn dead_code_eliminate_impl(func: &mut MFunction, remove_unused_phis: bool) {
     // Iterate until no more dead code is removed (cascading DCE).
     loop {
-        let mut used: std::collections::HashSet<VReg> = std::collections::HashSet::new();
+        let mut used: HashSet<VReg> = HashSet::default();
         for block in &func.blocks {
             for inst in &block.insts {
                 for u in inst.uses() {

--- a/crates/celox-backend-x86/src/backend/native/regalloc.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc.rs
@@ -232,13 +232,11 @@ pub(crate) fn run_regalloc_with_label_and_trace(
     label: &str,
     trace: Option<&mut RegallocTrace>,
 ) -> Result<RegallocResult, RegallocError> {
-    run_regalloc_with_label_and_trace_and_diagnostics(
-        func,
-        label,
-        trace,
-        &crate::NativeDiagnostics::default(),
-        true,
-    )
+    let diagnostics = crate::NativeDiagnostics {
+        verify_regalloc: true,
+        ..crate::NativeDiagnostics::default()
+    };
+    run_regalloc_with_label_and_trace_and_diagnostics(func, label, trace, &diagnostics, true)
 }
 
 pub(crate) fn run_regalloc_with_label_and_trace_and_diagnostics(

--- a/crates/celox-backend-x86/src/backend/native/regalloc.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc.rs
@@ -257,6 +257,22 @@ pub(crate) fn run_regalloc_with_label_and_trace_and_diagnostics(
     Ok(allocation)
 }
 
+/// Allocate the code-generation-owned MIR directly.
+///
+/// The public allocator keeps its transactional error contract by operating
+/// on a clone. Native emission owns and discards this MIR on error, so cloning
+/// a multi-million-instruction function only to provide the same rollback is
+/// redundant.
+pub(crate) fn run_regalloc_for_codegen(
+    func: &mut MFunction,
+    label: &str,
+    trace: Option<&mut RegallocTrace>,
+    diagnostics: &crate::NativeDiagnostics,
+    native_tick_loop: bool,
+) -> Result<RegallocResult, RegallocError> {
+    run_regalloc_in_place(func, label, trace, diagnostics, native_tick_loop)
+}
+
 fn run_regalloc_in_place(
     func: &mut MFunction,
     label: &str,
@@ -265,21 +281,26 @@ fn run_regalloc_in_place(
     native_tick_loop: bool,
 ) -> Result<RegallocResult, RegallocError> {
     let timing = diagnostics.regalloc_timing || diagnostics.phase_timing;
+    let verify = cfg!(debug_assertions) || diagnostics.verify_regalloc;
     // Allocation must never depend on callers having run the optional MIR
     // optimization pipeline. Select flag-consuming register branches at the
     // allocation boundary so their unmaterialized boolean result cannot
     // acquire a live range.
     super::mir_opt::fold_register_branch_predicates(func);
-    func.verify_result()
-        .map_err(|error| RegallocError::mir("input MIR verification", error))?;
+    if verify {
+        func.verify_result()
+            .map_err(|error| RegallocError::mir("input MIR verification", error))?;
+    }
     let cfg_start = timing.then(crate::timing::now);
     let normalized_cfg =
         cfg::normalize(func).map_err(|error| cfg_error("CFG normalization", error))?;
-    normalized_cfg
-        .verify(func)
-        .map_err(|error| cfg_error("CFG normalization verification", error))?;
-    func.verify_result()
-        .map_err(|error| RegallocError::mir("CFG normalization verification", error))?;
+    if verify {
+        normalized_cfg
+            .verify(func)
+            .map_err(|error| cfg_error("CFG normalization verification", error))?;
+        func.verify_result()
+            .map_err(|error| RegallocError::mir("CFG normalization verification", error))?;
+    }
     if let Some(start) = cfg_start {
         tracing::debug!(
             "[regalloc-timing] label={label} cfg_normalize blocks={} elapsed={:?}",
@@ -305,8 +326,10 @@ fn run_regalloc_in_place(
     super::mir_opt::eliminate_redundant_local_stores(func);
     let folded_direct_immediate_stores = super::mir_opt::fold_direct_immediate_stores(func);
     let folded_memory_branches = super::mir_opt::fold_memory_branch_predicates(func);
-    func.verify_result()
-        .map_err(|error| RegallocError::mir("late memory-fold verification", error))?;
+    if verify {
+        func.verify_result()
+            .map_err(|error| RegallocError::mir("late memory-fold verification", error))?;
+    }
     if let Some(trace) = trace.as_deref_mut() {
         trace.mir_after_late_memory_folds = func.to_string();
     }
@@ -316,11 +339,14 @@ fn run_regalloc_in_place(
             start.elapsed()
         );
     }
-    let allocation_constraints = constraints::ConstraintModel::build(func, &normalized_cfg)
-        .map_err(|error| constraint_error("placement constraint construction", error))?;
-    allocation_constraints
-        .verify(func)
-        .map_err(|error| constraint_error("placement constraint verification", error))?;
+    let allocation_constraints =
+        constraints::ConstraintModel::build_for_codegen(func, &normalized_cfg, verify)
+            .map_err(|error| constraint_error("placement constraint construction", error))?;
+    if verify {
+        allocation_constraints
+            .verify(func)
+            .map_err(|error| constraint_error("placement constraint verification", error))?;
+    }
     // W/S planning owns independent homes, explicit phi-edge transfers, and
     // the one authoritative dependency-ready instruction order. Introducing
     // snapshot copies before that walk would lengthen the ranges it is meant
@@ -344,9 +370,11 @@ fn run_regalloc_in_place(
         );
     }
     let next_use_verify_start = timing.then(crate::timing::now);
-    next_use
-        .verify(func, &normalized_cfg)
-        .map_err(|error| next_use_error("next-use verification", error))?;
+    if verify {
+        next_use
+            .verify(func, &normalized_cfg)
+            .map_err(|error| next_use_error("next-use verification", error))?;
+    }
     if let Some(start) = next_use_verify_start {
         tracing::debug!(
             "[regalloc-timing] label={label} next_use_verify elapsed={:?}",
@@ -362,6 +390,7 @@ fn run_regalloc_in_place(
         &allocation_constraints,
         trace,
         timing,
+        verify,
     )?;
     let mut assignment = allocation.assignment;
     let mut spill_frame_size = allocation.spill_frame_size;
@@ -408,7 +437,9 @@ fn run_regalloc_in_place(
     }
 
     let verify_start = timing.then(crate::timing::now);
-    verify_assignment(func, &assignment)?;
+    if verify {
+        verify_assignment(func, &assignment)?;
+    }
     if let Some(start) = verify_start {
         tracing::debug!(
             "[regalloc-timing] label={label} verify elapsed={:?}",
@@ -445,7 +476,7 @@ fn run_regalloc_in_place(
 /// order is not a valid way to distinguish forward edges from backedges.
 fn reorder_blocks_rpo(func: &mut MFunction) -> Result<(), cfg::CfgError> {
     use super::mir::BlockId;
-    use std::collections::{HashMap, HashSet};
+    use crate::{HashMap, HashSet};
 
     let Some(entry) = func.blocks.first().map(|block| block.id) else {
         return Ok(());
@@ -455,7 +486,7 @@ fn reorder_blocks_rpo(func: &mut MFunction) -> Result<(), cfg::CfgError> {
         .iter()
         .map(|block| (block.id, block.successors()))
         .collect::<HashMap<_, _>>();
-    let mut visited = HashSet::new();
+    let mut visited = HashSet::default();
     let mut postorder = Vec::with_capacity(func.blocks.len());
     let mut stack: Vec<(BlockId, usize)> = vec![(entry, 0)];
     visited.insert(entry);
@@ -554,10 +585,7 @@ fn log_regalloc_stats(
     spill_frame_size: u32,
 ) {
     let after = collect_regalloc_block_stats(func);
-    let before_by_block = before
-        .iter()
-        .copied()
-        .collect::<std::collections::HashMap<_, _>>();
+    let before_by_block = before.iter().copied().collect::<crate::HashMap<_, _>>();
     let mut rows = Vec::new();
     let mut total = RegallocBlockStats::default();
     let mut total_delta = RegallocBlockStats::default();

--- a/crates/celox-backend-x86/src/backend/native/regalloc/assignment.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/assignment.rs
@@ -3,7 +3,6 @@
 //! Defines `PhysReg`, `RegConstraint`, `AssignmentMap`, and helpers for
 //! querying instruction constraints and clobbers.
 
-use std::collections::{HashMap, HashSet};
 use std::fmt;
 
 use celox_backend_common::regalloc::{
@@ -12,6 +11,7 @@ use celox_backend_common::regalloc::{
 
 use crate::native::features::VariableShiftEncoding;
 use crate::native::mir::*;
+use crate::{HashMap, HashSet};
 
 // ────────────────────────────────────────────────────────────────
 // Physical registers

--- a/crates/celox-backend-x86/src/backend/native/regalloc/cfg.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/cfg.rs
@@ -1,11 +1,12 @@
 //! Normalized CFG information shared by every allocation phase.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 
 use celox_analysis::cfg::ForwardControlFlowGraph;
 pub(super) use celox_analysis::cfg::NaturalLoop;
 use celox_analysis::ssa::SsaCfg;
 
+use crate::HashMap;
 use crate::native::mir::{BlockId, MBlock, MFunction, MInst};
 
 #[derive(Debug)]

--- a/crates/celox-backend-x86/src/backend/native/regalloc/color.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/color.rs
@@ -4,9 +4,9 @@
 //! only the colors live at the current program point: no program-point live
 //! table and no explicit interference graph are constructed.
 
-use std::collections::HashMap;
 use std::fmt;
 
+use crate::HashMap;
 use crate::native::mir::{BlockId, MFunction, MInst, PhiNode, VReg};
 
 use super::analysis::AnalysisResult;
@@ -132,8 +132,8 @@ pub(super) fn color_ssa(
     let forbidden = forbidden_colors(func, analysis)?;
     let preferences = phi_preferences(func, cfg);
     let mut colors = vec![None; func.vregs.count() as usize];
-    let mut perm_matching = HashMap::<VReg, PhysReg>::new();
-    let mut boundary_for_block = HashMap::<BlockId, &PermBoundary>::new();
+    let mut perm_matching = HashMap::<VReg, PhysReg>::default();
+    let mut boundary_for_block = HashMap::<BlockId, &PermBoundary>::default();
     for boundary in &perms.boundaries {
         if boundary_for_block
             .insert(boundary.block, boundary)
@@ -166,7 +166,7 @@ pub(super) fn color_ssa(
     let mut work = vec![0usize];
     while let Some(block_index) = work.pop() {
         let block = &func.blocks[block_index];
-        let mut last_use = HashMap::<VReg, usize>::new();
+        let mut last_use = HashMap::<VReg, usize>::default();
         for (instruction, inst) in block.insts.iter().enumerate() {
             for value in inst.uses() {
                 last_use.insert(value, instruction);
@@ -546,7 +546,7 @@ fn forbid(
 }
 
 fn phi_preferences(func: &MFunction, cfg: &NormalizedCfg) -> HashMap<VReg, Vec<VReg>> {
-    let mut preferences = HashMap::<VReg, Vec<VReg>>::new();
+    let mut preferences = HashMap::<VReg, Vec<VReg>>::default();
     for block in &func.blocks {
         for phi in &block.phis {
             for &(_, source) in &phi.sources {
@@ -890,7 +890,7 @@ fn best_phi_bundle_score(
 fn is_live_after_entry(
     value: VReg,
     last_use: &HashMap<VReg, usize>,
-    live_out: &crate::HashMap<VReg, u32>,
+    live_out: &celox_backend_common::regalloc::NextUseDistances<VReg>,
 ) -> bool {
     last_use.contains_key(&value) || live_out.contains_key(&value)
 }
@@ -1171,7 +1171,7 @@ mod tests {
         let destination = VReg(1);
         let required = vec![None; 2];
         let forbidden = vec![ColorMask::empty(); 2];
-        let preferences = HashMap::new();
+        let preferences = HashMap::default();
         let colors = vec![Some(PhysReg::R14), None];
 
         let color = choose_color(
@@ -1208,10 +1208,12 @@ mod tests {
         };
         let required = vec![None; 5];
         let forbidden = vec![ColorMask::empty(); 5];
-        let preferences = HashMap::from([
+        let preferences = [
             (first_destination, vec![first_rax, first_rdx]),
             (second_destination, vec![second_rax]),
-        ]);
+        ]
+        .into_iter()
+        .collect();
         let colors = vec![
             Some(PhysReg::RAX),
             Some(PhysReg::RDX),

--- a/crates/celox-backend-x86/src/backend/native/regalloc/constraints.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/constraints.rs
@@ -46,7 +46,24 @@ impl ConstraintError {
 }
 
 impl ConstraintModel {
+    #[cfg(test)]
     pub(super) fn build(func: &MFunction, cfg: &NormalizedCfg) -> Result<Self, ConstraintError> {
+        Self::build_with_verification(func, cfg, true)
+    }
+
+    pub(super) fn build_for_codegen(
+        func: &MFunction,
+        cfg: &NormalizedCfg,
+        verify: bool,
+    ) -> Result<Self, ConstraintError> {
+        Self::build_with_verification(func, cfg, verify)
+    }
+
+    fn build_with_verification(
+        func: &MFunction,
+        cfg: &NormalizedCfg,
+        verify: bool,
+    ) -> Result<Self, ConstraintError> {
         if func.blocks.len() != cfg.predecessors.len() {
             return Err(ConstraintError::new(
                 "CONSTRAINT.CFG_SHAPE",
@@ -92,24 +109,26 @@ impl ConstraintModel {
         for (facts_block, successors) in facts.blocks.iter_mut().zip(&cfg.successors) {
             facts_block.successors.clone_from(successors);
         }
-        facts.verify().map_err(|error| {
-            ConstraintError::new(
-                "CONSTRAINT.ALLOCATION_FACTS",
-                None,
-                None,
-                Vec::new(),
-                error.to_string(),
-            )
-        })?;
-        celox_backend_common::regalloc::analyze_live_intervals(&facts).map_err(|error| {
-            ConstraintError::new(
-                "CONSTRAINT.LIVE_INTERVALS",
-                error.block.map(|block| func.blocks[block].id),
-                error.instruction,
-                error.values,
-                error.message,
-            )
-        })?;
+        if verify {
+            facts.verify().map_err(|error| {
+                ConstraintError::new(
+                    "CONSTRAINT.ALLOCATION_FACTS",
+                    None,
+                    None,
+                    Vec::new(),
+                    error.to_string(),
+                )
+            })?;
+            celox_backend_common::regalloc::analyze_live_intervals(&facts).map_err(|error| {
+                ConstraintError::new(
+                    "CONSTRAINT.LIVE_INTERVALS",
+                    error.block.map(|block| func.blocks[block].id),
+                    error.instruction,
+                    error.values,
+                    error.message,
+                )
+            })?;
+        }
         let instructions = facts
             .blocks
             .iter()
@@ -167,7 +186,7 @@ impl ConstraintModel {
             for (instruction_index, constraints) in
                 self.instructions[block_index].iter().enumerate()
             {
-                let mut required = std::collections::HashMap::new();
+                let mut required = crate::HashMap::default();
                 for &(value, register) in &constraints.fixed_uses {
                     if let Some(previous) = required.insert(value, register) {
                         if previous != register {

--- a/crates/celox-backend-x86/src/backend/native/regalloc/home_verify.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/home_verify.rs
@@ -9,9 +9,10 @@
 //! operations; materialization emits all stores before any reload, and this
 //! verifier uses the same ordering.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt;
 
+use crate::HashMap;
 use crate::native::mir::{BlockId, MFunction, SpillKind, VReg};
 
 use super::cfg::NormalizedCfg;
@@ -171,7 +172,7 @@ fn verify_with_work(
         }
     }
 
-    let mut edge_ops = HashMap::<(usize, usize), Vec<PlannedEdgeOp>>::new();
+    let mut edge_ops = HashMap::<(usize, usize), Vec<PlannedEdgeOp>>::default();
     for (&(predecessor, successor), operations) in &plan.edge_ops {
         let Some(successors) = cfg.successors.get(predecessor) else {
             return Err(structural_error(
@@ -271,7 +272,7 @@ fn verify_with_work(
     // unless the source's S_exit says that the shared congruence home is
     // already valid.  Keep these stores edge-specific: a store on one arm may
     // not establish a home on another arm.
-    let mut implicit_edge_stores = HashMap::<(usize, usize), BTreeSet<SpillHome>>::new();
+    let mut implicit_edge_stores = HashMap::<(usize, usize), BTreeSet<SpillHome>>::default();
     for spilled_phi in &spilled_phis {
         for &(predecessor_id, source) in &spilled_phi.sources {
             let Some(&predecessor) = cfg.block_index.get(&predecessor_id) else {
@@ -318,7 +319,7 @@ fn verify_with_work(
         }
     }
 
-    let mut definition_blocks = HashMap::<SpillHome, BTreeSet<usize>>::new();
+    let mut definition_blocks = HashMap::<SpillHome, BTreeSet<usize>>::default();
     for (block, operations_by_point) in point_ops.iter().enumerate() {
         for operations in operations_by_point.values() {
             let mut stores = BTreeSet::new();
@@ -520,7 +521,7 @@ fn rename_and_collect_queries(
         Exit(Vec<(SpillHome, Option<SparseDefinition>)>),
     }
 
-    let mut current = HashMap::<SpillHome, SparseDefinition>::new();
+    let mut current = HashMap::<SpillHome, SparseDefinition>::default();
     let mut pending = Vec::<PendingQuery>::new();
     let mut actions = vec![Action::Enter(0)];
     while let Some(action) = actions.pop() {

--- a/crates/celox-backend-x86/src/backend/native/regalloc/interval_union.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/interval_union.rs
@@ -4,10 +4,11 @@
 //! one linear instruction interval. Each dynamically-created slot stores only
 //! the occupied CFG rows required for first-fit coloring.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Arc;
 
+use crate::HashMap;
 use crate::native::mir::BlockId;
 
 use super::cfg::NormalizedCfg;
@@ -254,22 +255,38 @@ impl DynamicSlotUnion {
         }
     }
 
-    fn interferes_indexed(&self, segments: ValidatedSegments<'_>) -> bool {
-        for (segment, block) in segments.iter() {
-            let mut current = self.heads[block];
-            while current != Self::NONE {
-                let node = self.nodes[current as usize];
-                if node.end <= segment.start {
-                    current = node.next;
-                    continue;
-                }
-                if node.start >= segment.end {
-                    break;
-                }
-                return true;
+    fn interferes_segment(&self, segment: LiveSegment, block: usize) -> bool {
+        let mut current = self.heads[block];
+        while current != Self::NONE {
+            let node = self.nodes[current as usize];
+            if node.end <= segment.start {
+                current = node.next;
+                continue;
             }
+            if node.start >= segment.end {
+                break;
+            }
+            return true;
         }
         false
+    }
+
+    fn interferes_indexed(&self, segments: ValidatedSegments<'_>) -> bool {
+        segments
+            .iter()
+            .any(|(segment, block)| self.interferes_segment(segment, block))
+    }
+
+    fn interferes_indexed_with_hint(&self, segments: ValidatedSegments<'_>, hint: usize) -> bool {
+        if self.interferes_segment(segments.segments[hint], segments.block_indices[hint]) {
+            return true;
+        }
+        segments
+            .iter()
+            .enumerate()
+            .any(|(index, (segment, block))| {
+                index != hint && self.interferes_segment(segment, block)
+            })
     }
 
     fn insert_indexed(
@@ -448,12 +465,14 @@ pub(super) struct DynamicIntervalMatrix {
     index: Arc<IntervalIndex>,
     unions: Vec<DynamicSlotUnion>,
     assignments: BTreeMap<AllocationBundleId, usize>,
+    block_slot_counts: Vec<u32>,
 }
 
 impl PartialEq for DynamicIntervalMatrix {
     fn eq(&self, other: &Self) -> bool {
         self.index == other.index
             && self.assignments == other.assignments
+            && self.block_slot_counts == other.block_slot_counts
             && self.unions.len() == other.unions.len()
             && self
                 .unions
@@ -471,6 +490,7 @@ impl DynamicIntervalMatrix {
             index: Arc::new(IntervalIndex::new(cfg)?),
             unions: Vec::new(),
             assignments: BTreeMap::new(),
+            block_slot_counts: vec![0; cfg.successors.len()],
         })
     }
 
@@ -498,10 +518,19 @@ impl DynamicIntervalMatrix {
         segments: ValidatedSegments<'_>,
     ) -> Result<usize, IntervalUnionError> {
         self.validate_token(segments)?;
+        let Some(hint) = segments
+            .block_indices
+            .iter()
+            .enumerate()
+            .max_by_key(|&(_, &block)| self.block_slot_counts[block])
+            .map(|(index, _)| index)
+        else {
+            return Ok(self.unions.len());
+        };
         Ok(self
             .unions
             .iter()
-            .position(|union| !union.interferes_indexed(segments))
+            .position(|union| !union.interferes_indexed_with_hint(segments, hint))
             .unwrap_or(self.unions.len()))
     }
 
@@ -528,6 +557,18 @@ impl DynamicIntervalMatrix {
                 format!("dynamic slot {slot} skips the current color domain"),
             ));
         }
+        let mut newly_occupied_blocks = Vec::new();
+        let mut previous_block = None;
+        for (_, block) in segments.iter() {
+            if previous_block == Some(block) {
+                continue;
+            }
+            previous_block = Some(block);
+            if slot == self.unions.len() || self.unions[slot].heads[block] == DynamicSlotUnion::NONE
+            {
+                newly_occupied_blocks.push(block);
+            }
+        }
         if slot == self.unions.len() {
             let mut union = DynamicSlotUnion::new(self.index.block_ids.len());
             union.insert_indexed(bundle, segments)?;
@@ -535,16 +576,28 @@ impl DynamicIntervalMatrix {
         } else {
             self.unions[slot].insert_indexed(bundle, segments)?;
         }
+        for block in newly_occupied_blocks {
+            self.block_slot_counts[block] = self.block_slot_counts[block]
+                .checked_add(1)
+                .ok_or_else(|| {
+                    IntervalUnionError::new(
+                        "INTERVAL_UNION.BLOCK_SLOT_COUNT",
+                        self.index.block_ids.get(block).copied(),
+                        [bundle],
+                        "dynamic stack-slot occupancy count exceeds u32",
+                    )
+                })?;
+        }
         self.assignments.insert(bundle, slot);
         Ok(())
     }
 
-    pub(super) fn slot(&self, bundle: AllocationBundleId) -> Option<usize> {
-        self.assignments.get(&bundle).copied()
-    }
-
     pub(super) fn slot_count(&self) -> usize {
         self.unions.len()
+    }
+
+    pub(super) fn slot(&self, bundle: AllocationBundleId) -> Option<usize> {
+        self.assignments.get(&bundle).copied()
     }
 
     pub(super) fn verify(&self) -> Result<(), IntervalUnionError> {

--- a/crates/celox-backend-x86/src/backend/native/regalloc/legalize.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/legalize.rs
@@ -1,7 +1,8 @@
 //! Machine constraints expressed as SSA Perm boundaries.
 
-use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeSet, VecDeque};
 
+use crate::HashMap;
 use crate::native::mir::{BlockId, MBlock, MFunction, MInst, PhiNode, SpillDesc, VReg};
 
 use super::analysis::AnalysisResult;
@@ -149,7 +150,7 @@ impl PermBoundary {
                 return None;
             }
         }
-        let mut result = HashMap::with_capacity(self.rows.len());
+        let mut result = HashMap::with_capacity_and_hasher(self.rows.len(), Default::default());
         for (row, facts) in self.rows.iter().enumerate() {
             let color = assigned[row]?;
             result.insert(facts.destination, ALLOCATABLE_REGS[color]);
@@ -243,7 +244,7 @@ impl PermModel {
             };
             let live_after =
                 live_after_first_instruction(block, &analysis.exit_distances[block_index]);
-            let mut fixed = HashMap::<VReg, PhysReg>::new();
+            let mut fixed = HashMap::<VReg, PhysReg>::default();
             for (value, constraint) in instruction.uses().into_iter().zip(use_constraints(
                 instruction,
                 func.target_features.variable_shift_encoding(),
@@ -483,7 +484,7 @@ impl PermModel {
 
 fn live_after_first_instruction(
     block: &MBlock,
-    exit: &crate::HashMap<VReg, u32>,
+    exit: &celox_backend_common::regalloc::NextUseDistances<VReg>,
 ) -> BTreeSet<VReg> {
     let mut live = exit.keys().copied().collect::<BTreeSet<_>>();
     for instruction in block.insts.iter().skip(1).rev() {
@@ -549,7 +550,8 @@ fn constraint_boundary_liveness(
                 constraint_boundaries(block, func.target_features.variable_shift_encoding())
                     .into_iter()
                     .collect::<BTreeSet<_>>();
-            let mut points = HashMap::with_capacity(boundaries.len());
+            let mut points =
+                HashMap::with_capacity_and_hasher(boundaries.len(), Default::default());
             let mut live = analysis.exit_distances[block_index]
                 .keys()
                 .copied()
@@ -609,7 +611,7 @@ fn split_constraint_blocks(
         ));
     };
     let mut rewritten = Vec::<(MBlock, bool)>::new();
-    let mut final_block = HashMap::<BlockId, BlockId>::new();
+    let mut final_block = HashMap::<BlockId, BlockId>::default();
     let mut boundary_blocks = Vec::new();
 
     for (block_index, block) in original.into_iter().enumerate() {
@@ -754,8 +756,8 @@ fn insert_permutation_merge_phis(
         })
         .collect::<Vec<_>>();
 
-    let mut definition_blocks = HashMap::<VReg, BTreeSet<usize>>::new();
-    let mut existing_phi_blocks = HashMap::<VReg, BTreeSet<usize>>::new();
+    let mut definition_blocks = HashMap::<VReg, BTreeSet<usize>>::default();
+    let mut existing_phi_blocks = HashMap::<VReg, BTreeSet<usize>>::default();
     for (block, mir_block) in func.blocks.iter().enumerate() {
         for phi in &mir_block.phis {
             let logical = logical_for_vreg[phi.dst.0 as usize];
@@ -821,7 +823,7 @@ fn rename_permutation_representatives(
         Enter(usize),
         Exit(Vec<VReg>),
     }
-    let mut stacks = HashMap::<VReg, Vec<VReg>>::new();
+    let mut stacks = HashMap::<VReg, Vec<VReg>>::default();
     let mut work = vec![Event::Enter(0)];
     while let Some(event) = work.pop() {
         match event {

--- a/crates/celox-backend-x86/src/backend/native/regalloc/live_interval.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/live_interval.rs
@@ -7,12 +7,13 @@
 //! interfere merely because their blocks are adjacent in layout.
 
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeSet, VecDeque};
 use std::fmt;
 use std::ops::Deref;
 use std::sync::Arc;
 
 use crate::native::mir::{BlockId, MFunction, Uses, VReg};
+use crate::{HashMap, HashSet};
 
 use super::cfg::NormalizedCfg;
 
@@ -391,9 +392,18 @@ impl LivenessProgram for MFunction {
     }
 }
 
+#[cfg(test)]
 pub(super) fn analyze_program<P: LivenessProgram + ?Sized>(
     program: &P,
     cfg: &NormalizedCfg,
+) -> Result<LiveIntervals, LiveIntervalError> {
+    analyze_program_with_verification(program, cfg, true)
+}
+
+pub(super) fn analyze_program_with_verification<P: LivenessProgram + ?Sized>(
+    program: &P,
+    cfg: &NormalizedCfg,
+    verify: bool,
 ) -> Result<LiveIntervals, LiveIntervalError> {
     check_model_shape(program, cfg)?;
     let block_slots = assign_slots(program)?;
@@ -404,7 +414,9 @@ pub(super) fn analyze_program<P: LivenessProgram + ?Sized>(
         block_slots,
         intervals,
     };
-    result.verify_program(program, cfg)?;
+    if verify {
+        result.verify_program(program, cfg)?;
+    }
     Ok(result)
 }
 
@@ -605,7 +617,7 @@ fn collect_facts<P: LivenessProgram + ?Sized>(
         .map(|_| BlockFacts::default())
         .collect::<Vec<_>>();
     let mut phi_definitions = (0..program.block_count())
-        .map(|_| HashSet::new())
+        .map(|_| HashSet::default())
         .collect::<Vec<_>>();
 
     for block_index in 0..program.block_count() {
@@ -674,7 +686,7 @@ fn collect_facts<P: LivenessProgram + ?Sized>(
         }
     }
 
-    let mut edge_uses = HashMap::<(usize, usize), HashSet<VReg>>::new();
+    let mut edge_uses = HashMap::<(usize, usize), HashSet<VReg>>::default();
     for successor in 0..program.block_count() {
         let successor_id = program.block_id(successor);
         for phi_index in 0..program.phi_count(successor) {
@@ -748,13 +760,14 @@ fn solve_liveness(
     cfg: &NormalizedCfg,
     facts: &ModelFacts,
 ) -> (Vec<HashSet<VReg>>, Vec<HashSet<VReg>>) {
-    let mut live_in = (0..block_count).map(|_| HashSet::new()).collect::<Vec<_>>();
-    let mut live_out = live_in.clone();
+    let mut live_in = (0..block_count)
+        .map(|_| HashSet::default())
+        .collect::<Vec<_>>();
     let mut queue = (0..block_count).rev().collect::<VecDeque<_>>();
     let mut queued = vec![true; block_count];
     while let Some(block) = queue.pop_front() {
         queued[block] = false;
-        let mut next_out = HashSet::new();
+        let mut next_out = HashSet::default();
         for &successor in &cfg.successors[block] {
             next_out.extend(live_in[successor].iter().copied());
             if let Some(edge) = facts.edge_uses.get(&(block, successor)) {
@@ -768,9 +781,11 @@ fn solve_liveness(
                 .copied()
                 .filter(|value| !facts.blocks[block].definitions.contains(value)),
         );
-        if next_in != live_in[block] || next_out != live_out[block] {
+        // Only live-in is visible to predecessors. Keep the fixed point over
+        // that one relation and reconstruct live-out once after convergence;
+        // retaining and comparing both tables duplicates every live relation.
+        if next_in != live_in[block] {
             live_in[block] = next_in;
-            live_out[block] = next_out;
             for &predecessor in &cfg.predecessors[block] {
                 if !queued[predecessor] {
                     queued[predecessor] = true;
@@ -779,6 +794,18 @@ fn solve_liveness(
             }
         }
     }
+    let live_out = (0..block_count)
+        .map(|block| {
+            let mut values = HashSet::default();
+            for &successor in &cfg.successors[block] {
+                values.extend(live_in[successor].iter().copied());
+                if let Some(edge) = facts.edge_uses.get(&(block, successor)) {
+                    values.extend(edge.iter().copied());
+                }
+            }
+            values
+        })
+        .collect();
     (live_in, live_out)
 }
 
@@ -793,7 +820,7 @@ fn build_intervals<P: LivenessProgram + ?Sized>(
     let mut segments = vec![Vec::<LiveSegment>::new(); facts.definitions.len()];
     for block_index in 0..program.block_count() {
         let block_id = program.block_id(block_index);
-        let mut values = HashSet::new();
+        let mut values = HashSet::default();
         values.extend(live_in[block_index].iter().copied());
         values.extend(live_out[block_index].iter().copied());
         values.extend(facts.blocks[block_index].definitions.iter().copied());
@@ -934,7 +961,7 @@ impl LiveIntervals {
         let facts = collect_facts(program, cfg, &expected_slots)?;
         let dominators = DominatorIntervals::build(program, cfg)?;
         let mut cached_in = (0..program.block_count())
-            .map(|_| HashSet::new())
+            .map(|_| HashSet::default())
             .collect::<Vec<_>>();
         let mut cached_out = cached_in.clone();
 
@@ -1046,7 +1073,7 @@ impl LiveIntervals {
         }
 
         for block in 0..program.block_count() {
-            let mut expected_out = HashSet::new();
+            let mut expected_out = HashSet::default();
             for &successor in &cfg.successors[block] {
                 expected_out.extend(cached_in[successor].iter().copied());
                 if let Some(edge) = facts.edge_uses.get(&(block, successor)) {

--- a/crates/celox-backend-x86/src/backend/native/regalloc/materialized_state_home.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/materialized_state_home.rs
@@ -1,9 +1,10 @@
 //! Sparse physical MemorySSA verification for allocation-owned state homes.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use crate::native::memory_effect::{self, UnknownMemory};
 use crate::native::mir::{BaseReg, BlockId, MFunction, MInst, PackedStateHome, StateHomeId, VReg};
+use crate::{HashMap, HashSet};
 
 use super::cfg::NormalizedCfg;
 
@@ -422,7 +423,7 @@ fn verify_program(
 ) -> Result<(), MaterializedStateHomeError> {
     validate_cfg(program, cfg)?;
 
-    let mut homes = HashMap::<StateHomeId, PackedStateHome>::new();
+    let mut homes = HashMap::<StateHomeId, PackedStateHome>::default();
     let mut required = BTreeSet::<StateHomeId>::new();
     for block in &program.blocks {
         for instruction in &block.instructions {
@@ -445,7 +446,7 @@ fn verify_program(
     }
 
     let mut tracked = BTreeSet::<i64>::new();
-    let mut entry_owner = HashMap::<i64, StateHomeId>::new();
+    let mut entry_owner = HashMap::<i64, StateHomeId>::default();
     for &home_id in &required {
         let home = homes[&home_id];
         let bytes = home
@@ -553,10 +554,10 @@ fn verify_program(
         }
     }
 
-    let mut definitions = HashSet::<(ByteId, usize)>::new();
-    let mut upward_uses = HashSet::<(ByteId, usize)>::new();
+    let mut definitions = HashSet::<(ByteId, usize)>::default();
+    let mut upward_uses = HashSet::<(ByteId, usize)>::default();
     for block in 0..program.blocks.len() {
-        let mut defined = HashSet::<ByteId>::new();
+        let mut defined = HashSet::<ByteId>::default();
         let mut event = 0usize;
         let mut query = 0usize;
         for position in 0..program.blocks[block].instructions.len() {
@@ -595,7 +596,7 @@ fn verify_program(
         }
     }
 
-    let mut phi_pairs = HashSet::<(ByteId, usize)>::new();
+    let mut phi_pairs = HashSet::<(ByteId, usize)>::default();
     let mut queued = definitions.clone();
     for byte in 0..byte_count {
         queued.insert((ByteId(byte), 0));

--- a/crates/celox-backend-x86/src/backend/native/regalloc/next_use.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/next_use.rs
@@ -1,9 +1,10 @@
 //! Braun--Hack section 4.1: CFG-global next-use distances.
 
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeSet, VecDeque};
 
 use crate::native::mir::{BlockId, MFunction, VReg};
+use crate::{HashMap, HashSet};
 
 use super::cfg::NormalizedCfg;
 
@@ -178,7 +179,7 @@ pub(super) fn analyze(
         .blocks
         .iter()
         .map(|block| {
-            let mut positions = HashMap::<VReg, Vec<usize>>::new();
+            let mut positions = HashMap::<VReg, Vec<usize>>::default();
             for (instruction, inst) in block.insts.iter().enumerate() {
                 for value in inst.uses() {
                     let value_positions = positions.entry(value).or_default();
@@ -193,14 +194,15 @@ pub(super) fn analyze(
     let phi_uses = phi_edge_uses(func, cfg)?;
     let region_topology = RegionTopology::build(cfg)?;
     let edge_loop_exits = &region_topology.edge_exits;
-    let mut entry: Vec<HashMap<VReg, NextUseDistance>> = vec![HashMap::new(); func.blocks.len()];
-    let mut exit: Vec<HashMap<VReg, NextUseDistance>> = vec![HashMap::new(); func.blocks.len()];
-    let mut anticipated_after_phis = vec![HashSet::<VReg>::new(); func.blocks.len()];
+    let mut entry: Vec<HashMap<VReg, NextUseDistance>> =
+        vec![HashMap::default(); func.blocks.len()];
+    let mut exit: Vec<HashMap<VReg, NextUseDistance>> = vec![HashMap::default(); func.blocks.len()];
+    let mut anticipated_after_phis = vec![HashSet::<VReg>::default(); func.blocks.len()];
     let mut queue = (0..func.blocks.len()).rev().collect::<VecDeque<_>>();
     let mut queued = vec![true; func.blocks.len()];
     while let Some(block) = queue.pop_front() {
         queued[block] = false;
-        let mut next_exit = HashMap::<VReg, NextUseDistance>::new();
+        let mut next_exit = HashMap::<VReg, NextUseDistance>::default();
         for (edge, &successor) in cfg.successors[block].iter().enumerate() {
             let edge_exits = edge_loop_exits[block][edge];
             for (&value, &distance) in &entry[successor] {
@@ -230,7 +232,7 @@ pub(super) fn analyze(
             }
         }
         let transfer = &transfers[block];
-        let mut next_entry = HashMap::new();
+        let mut next_entry = HashMap::default();
         for (&value, &distance) in &next_exit {
             if !transfer.definitions.contains(&value) {
                 let Some(distance) = distance.checked_prepend_instructions(transfer.length) else {
@@ -583,7 +585,7 @@ fn verify_use_positions_match_mir(
 ) -> Result<(), NextUseError> {
     for (block, mir_block) in func.blocks.iter().enumerate() {
         let actual = &analysis.use_positions[block];
-        let mut expected_count = HashMap::<VReg, usize>::new();
+        let mut expected_count = HashMap::<VReg, usize>::default();
         for (instruction, inst) in mir_block.insts.iter().enumerate() {
             let uses = inst.uses();
             for (operand, &value) in uses.iter().enumerate() {
@@ -654,7 +656,7 @@ fn verify_anticipated_equations(
             values.extend(phi_uses[block][0].iter().copied());
             values
         } else {
-            HashSet::new()
+            HashSet::default()
         };
         for (edge, &successor) in cfg.successors[block].iter().enumerate().skip(1) {
             expected_exit.retain(|value| {
@@ -664,8 +666,8 @@ fn verify_anticipated_equations(
             });
         }
 
-        let mut instruction_definitions = HashSet::<VReg>::new();
-        let mut after_phi_uses = HashSet::<VReg>::new();
+        let mut instruction_definitions = HashSet::<VReg>::default();
+        let mut after_phi_uses = HashSet::<VReg>::default();
         for inst in &mir_block.insts {
             for value in inst.uses() {
                 if !instruction_definitions.contains(&value) {
@@ -732,7 +734,7 @@ fn verify_dataflow_equations(
             ));
         }
 
-        let mut expected_exit = HashMap::<VReg, NextUseDistance>::new();
+        let mut expected_exit = HashMap::<VReg, NextUseDistance>::default();
         for (edge, &successor) in cfg.successors[block].iter().enumerate() {
             let loop_exits = edge_loop_exits[edge];
             for (&value, &successor_distance) in &analysis.entry[successor] {
@@ -772,7 +774,7 @@ fn verify_dataflow_equations(
             .iter()
             .map(|phi| phi.dst)
             .collect::<HashSet<_>>();
-        let mut local_uses = HashMap::<VReg, usize>::new();
+        let mut local_uses = HashMap::<VReg, usize>::default();
         for (instruction, inst) in mir_block.insts.iter().enumerate() {
             for value in inst.uses() {
                 if !definitions.contains(&value) {
@@ -784,7 +786,7 @@ fn verify_dataflow_equations(
             }
         }
 
-        let mut expected_entry = HashMap::<VReg, NextUseDistance>::new();
+        let mut expected_entry = HashMap::<VReg, NextUseDistance>::default();
         for (&value, &exit_distance) in &expected_exit {
             if definitions.contains(&value) {
                 continue;
@@ -829,7 +831,7 @@ fn verifier_phi_edge_uses(
         .collect::<Vec<_>>();
     for (successor, block) in func.blocks.iter().enumerate() {
         for phi in &block.phis {
-            let mut covered = HashSet::<usize>::new();
+            let mut covered = HashSet::<usize>::default();
             for &(predecessor_id, source) in &phi.sources {
                 let Some(&predecessor) = cfg.block_index.get(&predecessor_id) else {
                     return Err(NextUseError::new(
@@ -1167,7 +1169,7 @@ fn block_region_summaries(
                     "instruction-summary work exceeds addressable size",
                 )
             })?;
-        let mut used = HashSet::new();
+        let mut used = HashSet::default();
         for phi in &mir_block.phis {
             used.insert(phi.dst);
             used.extend(phi.sources.iter().map(|(_, source)| *source));
@@ -1702,9 +1704,9 @@ fn block_transfers(func: &MFunction) -> Vec<BlockTransfer> {
         .map(|block| {
             let phi_definitions = block.phis.iter().map(|phi| phi.dst).collect::<HashSet<_>>();
             let mut definitions = phi_definitions.clone();
-            let mut instruction_definitions = HashSet::<VReg>::new();
-            let mut local_uses = HashMap::<VReg, usize>::new();
-            let mut after_phi_uses = HashSet::<VReg>::new();
+            let mut instruction_definitions = HashSet::<VReg>::default();
+            let mut local_uses = HashMap::<VReg, usize>::default();
+            let mut after_phi_uses = HashSet::<VReg>::default();
             for (position, inst) in block.insts.iter().enumerate() {
                 for used in inst.uses() {
                     if !definitions.contains(&used) {
@@ -1749,7 +1751,7 @@ fn anticipated_on_all_successors(
             .len()
             .saturating_add(phi_edge_uses[*edge].len())
     }) else {
-        return HashSet::new();
+        return HashSet::default();
     };
     let seed_successor = successors[seed_edge];
     let mut result = anticipated_after_phis[seed_successor]
@@ -2010,14 +2012,14 @@ mod tests {
         successor.push(MInst::Return);
         func.blocks = vec![predecessor, successor];
         let cfg = NormalizedCfg {
-            block_index: HashMap::from([(BlockId(0), 0), (BlockId(1), 1)]),
+            block_index: [(BlockId(0), 0), (BlockId(1), 1)].into_iter().collect(),
             predecessors: vec![vec![], vec![0]],
             successors: vec![vec![1], vec![]],
             idom: vec![None, Some(0)],
             dominator_children: vec![vec![1], vec![]],
             dominance_frontier: vec![BTreeSet::new(); 2],
             loops: Vec::new(),
-            loop_for_header: HashMap::new(),
+            loop_for_header: HashMap::default(),
         };
 
         let error = analyze(&func, &cfg).unwrap_err();
@@ -2193,14 +2195,14 @@ mod tests {
         // neither is a natural-loop header.  Exiting the SCC must nevertheless
         // increment the lexicographic loop component.
         let cfg = NormalizedCfg {
-            block_index: HashMap::new(),
+            block_index: HashMap::default(),
             predecessors: vec![vec![], vec![0, 2], vec![0, 1], vec![1, 2]],
             successors: vec![vec![1, 2], vec![2, 3], vec![1, 3], vec![]],
             idom: vec![None, Some(0), Some(0), Some(0)],
             dominator_children: vec![vec![1, 2, 3], vec![], vec![], vec![]],
             dominance_frontier: vec![BTreeSet::new(); 4],
             loops: Vec::new(),
-            loop_for_header: HashMap::new(),
+            loop_for_header: HashMap::default(),
         };
         let topology = RegionTopology::build(&cfg).unwrap();
         assert_eq!(topology.edge_exits[1], vec![0, 1]);

--- a/crates/celox-backend-x86/src/backend/native/regalloc/reconstruct.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/reconstruct.rs
@@ -1,7 +1,8 @@
 //! Materialize a SpillPlan and reconstruct strict SSA with dominance frontiers.
 
-use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeSet, VecDeque};
 
+use crate::HashMap;
 use crate::native::memory_effect::{self, UnknownMemory};
 use crate::native::mir::{
     BaseReg, BlockId, MBlock, MFunction, MInst, OpSize, PhiNode, SpillDesc, SpillKind, VReg,
@@ -162,10 +163,21 @@ pub(super) fn reconstruct(
     plan: &SpillPlan,
     _next_use: &NextUseAnalysis,
     reload_recipes: &ReloadRecipeAnalysis,
+    timing: bool,
+    verify: bool,
 ) -> Result<ReconstructionResult, ReconstructError> {
     let recipe_homes = &plan.recipe_homes;
-    let stack_coloring =
-        super::stack_color::color_spill_plan(func, cfg, plan).map_err(stack_color_error)?;
+    let phase = timing.then(crate::timing::now);
+    let stack_coloring = super::stack_color::color_spill_plan(func, cfg, plan, timing, verify)
+        .map_err(stack_color_error)?;
+    if let Some(start) = phase {
+        tracing::debug!(
+            "[regalloc-timing] reconstruct stack_color homes={} slots={} elapsed={:?}",
+            stack_coloring.offsets.len(),
+            stack_coloring.slot_count,
+            start.elapsed()
+        );
+    }
     let stack_offsets = stack_coloring.offsets;
     let frame_size = stack_coloring.frame_size;
     verify_reload_homes(func, plan, &stack_offsets, recipe_homes)?;
@@ -173,9 +185,10 @@ pub(super) fn reconstruct(
     let mut logical_for_vreg = (0..original_vregs)
         .map(|index| plan.logical.of(VReg(index as u32)))
         .collect::<Vec<_>>();
-    let mut insertions = HashMap::<(usize, usize), Vec<MaterializedOp>>::new();
-    let mut reload_blocks = HashMap::<LogicalValue, BTreeSet<usize>>::new();
+    let mut insertions = HashMap::<(usize, usize), Vec<MaterializedOp>>::default();
+    let mut reload_blocks = HashMap::<LogicalValue, BTreeSet<usize>>::default();
     let mut edge_reload_bundles = Vec::<EdgeReloadBundle>::new();
+    let phase = timing.then(crate::timing::now);
     for spill in super::ssa_state_home::planned_spills(func, cfg, plan).map_err(|error| {
         ReconstructError::new(
             error.rule,
@@ -390,10 +403,20 @@ pub(super) fn reconstruct(
             edge_reload_bundles.push(bundle);
         }
     }
+    if let Some(start) = phase {
+        tracing::debug!(
+            "[regalloc-timing] reconstruct materialize_plan insertions={} reload_values={} edge_bundles={} elapsed={:?}",
+            insertions.len(),
+            reload_blocks.len(),
+            edge_reload_bundles.len(),
+            start.elapsed()
+        );
+    }
 
+    let phase = timing.then(crate::timing::now);
     let affected = reload_blocks.keys().copied().collect::<BTreeSet<_>>();
-    let mut definition_blocks = HashMap::<LogicalValue, BTreeSet<usize>>::new();
-    let mut existing_phi_blocks = HashMap::<LogicalValue, BTreeSet<usize>>::new();
+    let mut definition_blocks = HashMap::<LogicalValue, BTreeSet<usize>>::default();
+    let mut existing_phi_blocks = HashMap::<LogicalValue, BTreeSet<usize>>::default();
     for (block, mir_block) in func.blocks.iter().enumerate() {
         for phi in &mir_block.phis {
             let logical = reconstruct_logical(&logical_for_vreg, phi.dst, mir_block.id)?;
@@ -418,7 +441,7 @@ pub(super) fn reconstruct(
         definition_blocks.entry(logical).or_default().extend(blocks);
     }
 
-    let mut reconstruction_phis = HashMap::<(usize, LogicalValue), VReg>::new();
+    let mut reconstruction_phis = HashMap::<(usize, LogicalValue), VReg>::default();
     for logical in affected {
         let mut has_phi = existing_phi_blocks.remove(&logical).unwrap_or_default();
         let mut queue = definition_blocks
@@ -445,7 +468,15 @@ pub(super) fn reconstruct(
             }
         }
     }
+    if let Some(start) = phase {
+        tracing::debug!(
+            "[regalloc-timing] reconstruct place_phis phis={} elapsed={:?}",
+            reconstruction_phis.len(),
+            start.elapsed()
+        );
+    }
 
+    let phase = timing.then(crate::timing::now);
     let mut children = vec![Vec::new(); func.blocks.len()];
     for (block, &idom) in cfg.idom.iter().enumerate().skip(1) {
         let Some(idom) = idom else {
@@ -459,7 +490,7 @@ pub(super) fn reconstruct(
         };
         children[idom].push(block);
     }
-    let mut stacks = HashMap::<LogicalValue, Vec<VReg>>::new();
+    let mut stacks = HashMap::<LogicalValue, Vec<VReg>>::default();
     let mut recipe_reloads = Vec::<ExpectedMaterializedReload>::new();
     let mut pending_state_stores = Vec::<PendingStateStore>::new();
     let mut state_reloads = Vec::<MaterializedStateReload>::new();
@@ -479,6 +510,15 @@ pub(super) fn reconstruct(
         &mut pending_state_stores,
         &mut state_reloads,
     )?;
+    if let Some(start) = phase {
+        tracing::debug!(
+            "[regalloc-timing] reconstruct rename recipe_reloads={} state_reloads={} elapsed={:?}",
+            recipe_reloads.len(),
+            state_reloads.len(),
+            start.elapsed()
+        );
+    }
+    let phase = timing.then(crate::timing::now);
     let state_stores = resolve_state_store_ordinals(func, &pending_state_stores)?;
     let shared_reload_blocks = share_identical_edge_reload_bundles(
         func,
@@ -488,6 +528,14 @@ pub(super) fn reconstruct(
     )?;
     let removed = eliminate_dead_definitions(func, &mut recipe_reloads);
     state_reloads.retain(|reload| !removed.contains(&reload.reload));
+    if let Some(start) = phase {
+        tracing::debug!(
+            "[regalloc-timing] reconstruct finalize shared_blocks={} removed_defs={} elapsed={:?}",
+            shared_reload_blocks.len(),
+            removed.len(),
+            start.elapsed()
+        );
+    }
 
     Ok(ReconstructionResult {
         frame_size,
@@ -644,7 +692,7 @@ fn eliminate_dead_definitions(
     func: &mut MFunction,
     recipe_reloads: &mut Vec<ExpectedMaterializedReload>,
 ) -> BTreeSet<VReg> {
-    let mut definition_inputs = HashMap::<VReg, Vec<VReg>>::new();
+    let mut definition_inputs = HashMap::<VReg, Vec<VReg>>::default();
     let mut work = Vec::<VReg>::new();
     for block in &func.blocks {
         for phi in &block.phis {
@@ -698,7 +746,7 @@ fn resolve_state_store_ordinals(
     func: &MFunction,
     pending: &[PendingStateStore],
 ) -> Result<Vec<MaterializedStateStore>, ReconstructError> {
-    let mut by_location = HashMap::with_capacity(pending.len());
+    let mut by_location = HashMap::with_capacity_and_hasher(pending.len(), Default::default());
     for store in pending {
         if by_location
             .insert((store.block, store.instruction), store.home)
@@ -1299,7 +1347,7 @@ fn share_identical_edge_reload_bundles(
     recipe_reloads: &mut Vec<ExpectedMaterializedReload>,
     state_reloads: &mut Vec<MaterializedStateReload>,
 ) -> Result<Vec<MemoryPhiFactoring>, ReconstructError> {
-    let mut grouped = HashMap::<EdgeReloadGroupKey, Vec<usize>>::new();
+    let mut grouped = HashMap::<EdgeReloadGroupKey, Vec<usize>>::default();
     for (bundle, edge) in bundles.iter().enumerate() {
         grouped
             .entry(EdgeReloadGroupKey {
@@ -2477,7 +2525,9 @@ mod tests {
             dst: fresh,
             sources: Vec::new(),
         });
-        let reconstruction_phis = HashMap::from([((successor, LogicalValue(original.0)), fresh)]);
+        let reconstruction_phis = [((successor, LogicalValue(original.0)), fresh)]
+            .into_iter()
+            .collect();
         let mut children = vec![Vec::new(); func.blocks.len()];
         children[0].push(successor);
         let recipe_homes = BTreeSet::new();
@@ -2492,10 +2542,10 @@ mod tests {
             &plan,
             &children,
             &reconstruction_phis,
-            &HashMap::new(),
+            &HashMap::default(),
             &logical_for_vreg,
-            &mut HashMap::new(),
-            &mut HashMap::new(),
+            &mut HashMap::default(),
+            &mut HashMap::default(),
             &recipe_homes,
             &mut recipe_reloads,
             &mut pending_state_stores,
@@ -2754,7 +2804,7 @@ mod tests {
         plan.verify(&func, &cfg, registers).unwrap();
         plan.verify_recipe_homes(&func, &cfg, &recipes).unwrap();
         super::super::home_verify::verify(&func, &cfg, &plan).unwrap();
-        let result = reconstruct(&mut func, &cfg, &plan, &next_use, &recipes).unwrap();
+        let result = reconstruct(&mut func, &cfg, &plan, &next_use, &recipes, false, true).unwrap();
         let rebuilt_cfg = (!result.shared_reload_blocks.is_empty())
             .then(|| super::super::cfg::normalize(&mut func).unwrap());
         let cfg = rebuilt_cfg.as_ref().unwrap_or(&cfg);
@@ -2841,7 +2891,7 @@ mod tests {
         plan.verify(&func, &cfg, 2).unwrap();
         plan.verify_recipe_homes(&func, &cfg, &recipes).unwrap();
         super::super::home_verify::verify(&func, &cfg, &plan).unwrap();
-        let result = reconstruct(&mut func, &cfg, &plan, &next_use, &recipes).unwrap();
+        let result = reconstruct(&mut func, &cfg, &plan, &next_use, &recipes, false, true).unwrap();
         super::super::reload::verify_expected_materialized_reloads(
             &func,
             &cfg,
@@ -3117,7 +3167,7 @@ mod tests {
         plan.verify(&func, &cfg, 2).unwrap();
         plan.verify_recipe_homes(&func, &cfg, &recipes).unwrap();
         super::super::home_verify::verify(&func, &cfg, &plan).unwrap();
-        let result = reconstruct(&mut func, &cfg, &plan, &next_use, &recipes).unwrap();
+        let result = reconstruct(&mut func, &cfg, &plan, &next_use, &recipes, false, true).unwrap();
         super::super::reload::verify_expected_materialized_reloads(
             &func,
             &cfg,

--- a/crates/celox-backend-x86/src/backend/native/regalloc/reload.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/reload.rs
@@ -6,7 +6,7 @@
 //! the shared access-based MemorySSA graph. A recipe is usable only where the
 //! same clobber graph reaches that exact physical load.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt;
 
 use celox_analysis::memory::{MemoryEffect, MemoryLocation, effects_may_alias};
@@ -15,6 +15,7 @@ use celox_analysis::memory_ssa::{
     MemoryClobber, MemoryPointMap,
 };
 
+use crate::HashMap;
 use crate::native::memory_effect::{self, MemoryObject, analysis_effects};
 use crate::native::mir::{BaseReg, BlockId, CmpKind, MFunction, MInst, OpSize, VReg};
 
@@ -1177,6 +1178,7 @@ struct ReloadMemorySsa {
     writes: BTreeMap<MemoryDefinition, Vec<MemoryEffect<MemoryObject>>>,
     block_ids: Vec<BlockId>,
     walker: ClobberWalker,
+    clobber_cache: HashMap<(StateLoad, MemoryAccessId), MemoryAccessId>,
 }
 
 impl ReloadMemorySsa {
@@ -1228,6 +1230,7 @@ impl ReloadMemorySsa {
         let graph = &self.graph;
         let writes = &self.writes;
         let block_ids = &self.block_ids;
+        let clobber_cache = &mut self.clobber_cache;
         let oracle = |definition: &MemoryDefinition, query: &MemoryEffect<MemoryObject>| {
             writes.get(definition).is_some_and(|effects| {
                 effects
@@ -1237,22 +1240,30 @@ impl ReloadMemorySsa {
             })
         };
         let mut clobber_query = self.walker.query(graph, &query, &oracle);
-        let mut clobber_access = |start| match clobber_query.clobber(start) {
-            Some(MemoryClobber::Access(access)) => Ok(access),
-            Some(MemoryClobber::Indeterminate) => Err(ReloadRecipeError::new(
-                "RELOAD_RECIPE.CLOBBER_CYCLE",
-                None,
-                None,
-                None,
-                "query-specific clobber graph is an unresolved closed cycle",
-            )),
-            None => Err(ReloadRecipeError::new(
-                "RELOAD_RECIPE.CLOBBER_ACCESS",
-                None,
-                None,
-                None,
-                "clobber query starts outside the MemorySSA graph",
-            )),
+        let mut clobber_access = |start| {
+            if let Some(&access) = clobber_cache.get(&(load, start)) {
+                return Ok(access);
+            }
+            match clobber_query.clobber(start) {
+                Some(MemoryClobber::Access(access)) => {
+                    clobber_cache.insert((load, start), access);
+                    Ok(access)
+                }
+                Some(MemoryClobber::Indeterminate) => Err(ReloadRecipeError::new(
+                    "RELOAD_RECIPE.CLOBBER_CYCLE",
+                    None,
+                    None,
+                    None,
+                    "query-specific clobber graph is an unresolved closed cycle",
+                )),
+                None => Err(ReloadRecipeError::new(
+                    "RELOAD_RECIPE.CLOBBER_ACCESS",
+                    None,
+                    None,
+                    None,
+                    "clobber query starts outside the MemorySSA graph",
+                )),
+            }
         };
         let root_access = clobber_access(start)?;
         let root = Self::stable_access(graph, block_ids, root_access)?;
@@ -1469,9 +1480,9 @@ fn analyze_unverified_with_queries(
         requested_points,
         collect_all_uses,
     )?;
-    let mut store_homes = HashMap::<(usize, usize), Vec<StoreHomeSpec>>::new();
-    let mut preserving_writes = HashMap::<(usize, usize), ValidatedStateFragment>::new();
-    let mut fragment_homes = HashMap::<(usize, usize), ValidatedStateFragment>::new();
+    let mut store_homes = HashMap::<(usize, usize), Vec<StoreHomeSpec>>::default();
+    let mut preserving_writes = HashMap::<(usize, usize), ValidatedStateFragment>::default();
+    let mut fragment_homes = HashMap::<(usize, usize), ValidatedStateFragment>::default();
     for (block, mir_block) in func.blocks.iter().enumerate() {
         for (instruction, inst) in mir_block.insts.iter().enumerate() {
             if let Some(insert) = validated_state_fragment(func, inst) {
@@ -2169,6 +2180,7 @@ fn build_reload_memory_ssa(
         writes,
         block_ids: func.blocks.iter().map(|block| block.id).collect(),
         walker: ClobberWalker::new(),
+        clobber_cache: HashMap::default(),
     })
 }
 

--- a/crates/celox-backend-x86/src/backend/native/regalloc/schedule.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/schedule.rs
@@ -1,12 +1,13 @@
 //! Exact dependency DAGs for allocation-owned machine scheduling.
 
 use std::cmp::Reverse;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 #[cfg(test)]
 use std::fmt;
 
 use celox_analysis::dependence::MemoryDependencyTracker;
 
+use crate::HashMap;
 use crate::native::memory_effect::{self, MemoryObject, analysis_effects};
 #[cfg(test)]
 use crate::native::mir::BlockId;
@@ -303,7 +304,7 @@ impl InstructionDag {
             .collect::<Vec<_>>();
         let mut dependencies = vec![Vec::<usize>::new(); region.len()];
         let mut dependents = vec![Vec::<usize>::new(); region.len()];
-        let mut use_candidates = HashMap::<VReg, Vec<usize>>::new();
+        let mut use_candidates = HashMap::<VReg, Vec<usize>>::default();
         for (user, uses) in unique_uses.iter().enumerate() {
             for &used in uses {
                 use_candidates.entry(used).or_default().push(user);
@@ -422,7 +423,7 @@ impl ForwardReadyRegion {
             .filter_map(|(instruction, &dependencies)| (dependencies == 0).then_some(instruction))
             .collect();
         let remaining_uses = dag.unique_uses.iter().flatten().copied().fold(
-            HashMap::<VReg, usize>::new(),
+            HashMap::<VReg, usize>::default(),
             |mut counts, value| {
                 *counts.entry(value).or_default() += 1;
                 counts

--- a/crates/celox-backend-x86/src/backend/native/regalloc/spill_plan.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/spill_plan.rs
@@ -1,8 +1,9 @@
 //! Braun--Hack sections 4.2 and 4.3: W/S states and coupling plan.
 
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
+use crate::HashMap;
 use crate::native::mir::{BlockId, MFunction, MInst, PackedStateHome, VReg};
 
 use super::assignment::clobbers;
@@ -271,7 +272,7 @@ impl EdgeTranslations {
         cfg: &NormalizedCfg,
         logical: &LogicalValues,
     ) -> Result<Self, SpillPlanError> {
-        let mut by_edge = HashMap::<(usize, usize), EdgeTranslation>::new();
+        let mut by_edge = HashMap::<(usize, usize), EdgeTranslation>::default();
         for (successor, block) in func.blocks.iter().enumerate() {
             for phi in &block.phis {
                 let destination = logical.checked_of(phi.dst, Some(block.id), None)?;
@@ -721,7 +722,7 @@ fn exit_reload_costs(
     edge_translations: &EdgeTranslations,
     block: usize,
 ) -> Result<HashMap<LogicalValue, u32>, SpillPlanError> {
-    let mut costs = HashMap::<LogicalValue, u32>::new();
+    let mut costs = HashMap::<LogicalValue, u32>::default();
     for &successor in &cfg.successors[block] {
         let mut demanded = BTreeSet::<LogicalValue>::new();
         for &value in next_use.entry[successor].keys() {
@@ -1382,7 +1383,7 @@ impl<'a> BlockTransitionPlanner<'a> {
         &mut self,
         point: TransitionPoint,
         inst: &MInst,
-        remaining: &mut RemainingBlockUses,
+        remaining: &mut RemainingBlockUses<'_>,
     ) -> Result<ScheduledStepDelta, SpillPlanError> {
         let resident_before = self.resident.clone();
         let deferred_before = self.deferred_recipe_reloads.clone();
@@ -1426,7 +1427,7 @@ impl<'a> BlockTransitionPlanner<'a> {
         &self,
         source: usize,
         inst: &MInst,
-        remaining: &RemainingBlockUses,
+        remaining: &RemainingBlockUses<'_>,
     ) -> Result<AllocationCandidateScore, SpillPlanError> {
         let block_id = self.func.blocks[self.block].id;
         let uses = inst
@@ -1750,7 +1751,7 @@ fn init_usual(
             .flat_map(|value| edge_translations.to_successors(predecessor, block, value))
             .collect();
     }
-    let mut frequency = HashMap::<LogicalValue, usize>::new();
+    let mut frequency = HashMap::<LogicalValue, usize>::default();
     for predecessor in &processed {
         for &value in &plan.w_exit[*predecessor] {
             for value in edge_translations.to_successors(*predecessor, block, value) {
@@ -1918,23 +1919,30 @@ impl FutureUses for LinearFutureUses<'_> {
     }
 }
 
-struct RemainingBlockUses {
+#[derive(Default)]
+struct RemainingUses {
+    points: Vec<(usize, usize)>,
+    next: usize,
+    count: usize,
+}
+
+struct RemainingBlockUses<'a> {
     block: BlockId,
     preferred_rank: Vec<usize>,
-    remaining: HashMap<LogicalValue, BTreeSet<(usize, usize)>>,
-    exit: HashMap<LogicalValue, NextUseDistance>,
-    exit_reload_costs: HashMap<LogicalValue, u32>,
+    remaining: HashMap<LogicalValue, RemainingUses>,
+    exit: &'a HashMap<VReg, NextUseDistance>,
+    exit_reload_costs: &'a HashMap<LogicalValue, u32>,
     emitted: Vec<bool>,
     emitted_count: usize,
 }
 
-impl RemainingBlockUses {
+impl<'a> RemainingBlockUses<'a> {
     fn build(
         func: &MFunction,
-        next_use: &NextUseAnalysis,
+        next_use: &'a NextUseAnalysis,
         logical: &LogicalValues,
         block: usize,
-        exit_reload_costs: &HashMap<LogicalValue, u32>,
+        exit_reload_costs: &'a HashMap<LogicalValue, u32>,
         preferred_order: Option<&[usize]>,
     ) -> Result<Self, SpillPlanError> {
         let instructions = func.blocks[block].insts.len();
@@ -1973,7 +1981,7 @@ impl RemainingBlockUses {
         } else {
             (0..instructions).collect::<Vec<_>>()
         };
-        let mut remaining = HashMap::<LogicalValue, BTreeSet<(usize, usize)>>::new();
+        let mut remaining = HashMap::<LogicalValue, RemainingUses>::default();
         for (source, inst) in func.blocks[block].insts.iter().enumerate() {
             let mut uses = inst.uses().to_vec();
             uses.sort_unstable();
@@ -1983,23 +1991,23 @@ impl RemainingBlockUses {
                 remaining
                     .entry(value)
                     .or_default()
-                    .insert((preferred_rank[source], source));
+                    .points
+                    .push((preferred_rank[source], source));
             }
         }
-        let exit = next_use.exit[block]
-            .iter()
-            .map(|(&value, &distance)| {
-                logical
-                    .checked_of(value, Some(func.blocks[block].id), Some(instructions))
-                    .map(|value| (value, distance))
-            })
-            .collect::<Result<HashMap<_, _>, _>>()?;
+        for uses in remaining.values_mut() {
+            uses.points.sort_unstable();
+            uses.count = uses.points.len();
+        }
+        for &value in next_use.exit[block].keys() {
+            logical.checked_of(value, Some(func.blocks[block].id), Some(instructions))?;
+        }
         Ok(Self {
             block: func.blocks[block].id,
             preferred_rank,
             remaining,
-            exit,
-            exit_reload_costs: exit_reload_costs.clone(),
+            exit: &next_use.exit[block],
+            exit_reload_costs,
             emitted: vec![false; instructions],
             emitted_count: 0,
         })
@@ -2027,7 +2035,7 @@ impl RemainingBlockUses {
         let mut changed = Vec::with_capacity(uses.len());
         for value in uses {
             let value = logical.checked_of(value, Some(self.block), Some(source))?;
-            let points = self.remaining.get_mut(&value).ok_or_else(|| {
+            let uses = self.remaining.get_mut(&value).ok_or_else(|| {
                 SpillPlanError::new(
                     "SPILL_PLAN.SCHEDULE_ORDER",
                     Some(self.block),
@@ -2036,7 +2044,8 @@ impl RemainingBlockUses {
                     "committed use has no remaining-use entry",
                 )
             })?;
-            if !points.remove(&(self.preferred_rank[source], source)) {
+            let point = (self.preferred_rank[source], source);
+            if uses.points.binary_search(&point).is_err() || uses.count == 0 {
                 return Err(SpillPlanError::new(
                     "SPILL_PLAN.SCHEDULE_ORDER",
                     Some(self.block),
@@ -2045,28 +2054,41 @@ impl RemainingBlockUses {
                     "committed use was absent from its remaining-use set",
                 ));
             }
+            uses.count -= 1;
+            while uses
+                .points
+                .get(uses.next)
+                .is_some_and(|&(_, instruction)| self.emitted[instruction])
+            {
+                uses.next += 1;
+            }
             changed.push(value);
         }
         Ok(changed)
     }
 
     fn remaining_uses(&self, value: LogicalValue) -> usize {
-        self.remaining.get(&value).map_or(0, BTreeSet::len)
+        self.remaining.get(&value).map_or(0, |uses| uses.count)
     }
 
     fn is_live_out(&self, value: LogicalValue) -> bool {
-        self.exit.contains_key(&value)
+        self.exit.contains_key(&VReg(value.0))
     }
 
     fn distance(&self, value: LogicalValue) -> NextUseDistance {
-        if let Some(&(rank, _)) = self.remaining.get(&value).and_then(BTreeSet::first) {
+        if let Some((rank, _)) = self
+            .remaining
+            .get(&value)
+            .and_then(|uses| uses.points.get(uses.next))
+            .copied()
+        {
             return NextUseDistance::Finite {
                 loop_exits: 0,
                 instructions: rank.saturating_sub(self.emitted_count),
             };
         }
         let remaining_instructions = self.emitted.len().saturating_sub(self.emitted_count);
-        match self.exit.get(&value).copied() {
+        match self.exit.get(&VReg(value.0)).copied() {
             Some(NextUseDistance::Finite {
                 loop_exits,
                 instructions,
@@ -2079,7 +2101,8 @@ impl RemainingBlockUses {
     }
 
     fn next_point(&self, value: LogicalValue) -> Option<PointUse> {
-        let &(_, instruction) = self.remaining.get(&value)?.first()?;
+        let uses = self.remaining.get(&value)?;
+        let &(_, instruction) = uses.points.get(uses.next)?;
         Some(PointUse {
             block: self.block,
             instruction,
@@ -2092,9 +2115,9 @@ impl RemainingBlockUses {
     }
 }
 
-struct DynamicFutureUses<'a>(&'a RemainingBlockUses);
+struct DynamicFutureUses<'view, 'data>(&'view RemainingBlockUses<'data>);
 
-impl FutureUses for DynamicFutureUses<'_> {
+impl FutureUses for DynamicFutureUses<'_, '_> {
     fn distance(&self, value: LogicalValue) -> NextUseDistance {
         self.0.distance(value)
     }
@@ -3050,7 +3073,7 @@ mod tests {
             &BTreeSet::new(),
             BTreeSet::new(),
             &constraints.instructions[0],
-            &HashMap::new(),
+            &HashMap::default(),
         )
         .unwrap();
 
@@ -3138,7 +3161,7 @@ mod tests {
             &BTreeSet::new(),
             BTreeSet::new(),
             &constraints.instructions[0],
-            &HashMap::new(),
+            &HashMap::default(),
         )
         .unwrap();
 
@@ -3214,7 +3237,7 @@ mod tests {
             &BTreeSet::new(),
             BTreeSet::new(),
             &constraints.instructions[0],
-            &HashMap::new(),
+            &HashMap::default(),
         )
         .unwrap();
 

--- a/crates/celox-backend-x86/src/backend/native/regalloc/spilling.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/spilling.rs
@@ -10,8 +10,7 @@
 //!   are reloaded from their original location, not from the stack.
 //! - **Spill slot allocation**: each spilled value gets a unique stack slot.
 
-use std::collections::HashMap;
-
+use crate::HashMap;
 use crate::native::mir::*;
 
 // ────────────────────────────────────────────────────────────────
@@ -29,7 +28,7 @@ pub(super) struct SpillSlotAllocator {
 impl SpillSlotAllocator {
     pub(super) fn new() -> Self {
         Self {
-            slots: HashMap::new(),
+            slots: HashMap::default(),
             next_offset: 0,
         }
     }

--- a/crates/celox-backend-x86/src/backend/native/regalloc/ssa.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/ssa.rs
@@ -25,6 +25,7 @@ pub(super) fn allocate(
     constraints: &super::constraints::ConstraintModel,
     trace: Option<&mut super::RegallocTrace>,
     timing: bool,
+    verify: bool,
 ) -> Result<Allocation, super::RegallocError> {
     let register_count = func.target_features.allocatable_register_count();
     let phase = timing.then(crate::timing::now);
@@ -49,16 +50,18 @@ pub(super) fn allocate(
     if let Some(trace) = trace {
         trace.mir_after_scheduling = func.to_string();
     }
-    plan.verify(func, cfg, register_count).map_err(|error| {
-        super::RegallocError::new(
-            "spill-plan verification",
-            error.rule,
-            error.block,
-            error.instruction,
-            error.values,
-            error.message,
-        )
-    })?;
+    if verify {
+        plan.verify(func, cfg, register_count).map_err(|error| {
+            super::RegallocError::new(
+                "spill-plan verification",
+                error.rule,
+                error.block,
+                error.instruction,
+                error.values,
+                error.message,
+            )
+        })?;
+    }
     if let Some(start) = phase {
         tracing::debug!(
             "[regalloc-timing] ssa spill_plan elapsed={:?}",
@@ -77,16 +80,18 @@ pub(super) fn allocate(
             error.message,
         )
     })?;
-    super::ssa_state_home::verify(func, cfg, &plan).map_err(|error| {
-        super::RegallocError::new(
-            "packed state-home verification",
-            error.rule,
-            error.block,
-            error.instruction,
-            error.values,
-            error.message,
-        )
-    })?;
+    if verify {
+        super::ssa_state_home::verify(func, cfg, &plan).map_err(|error| {
+            super::RegallocError::new(
+                "packed state-home verification",
+                error.rule,
+                error.block,
+                error.instruction,
+                error.values,
+                error.message,
+            )
+        })?;
+    }
     if let Some(start) = phase {
         tracing::debug!(
             "[regalloc-timing] ssa packed_state_homes homes={} reloads={} elapsed={:?}",
@@ -117,20 +122,10 @@ pub(super) fn allocate(
                 error.message,
             )
         })?;
-    plan.verify(func, cfg, register_count).map_err(|error| {
-        super::RegallocError::new(
-            "final spill-plan verification",
-            error.rule,
-            error.block,
-            error.instruction,
-            error.values,
-            error.message,
-        )
-    })?;
-    plan.verify_recipe_homes(func, cfg, &reload_recipes)
-        .map_err(|error| {
+    if verify {
+        plan.verify(func, cfg, register_count).map_err(|error| {
             super::RegallocError::new(
-                "recipe-home verification",
+                "final spill-plan verification",
                 error.rule,
                 error.block,
                 error.instruction,
@@ -138,34 +133,46 @@ pub(super) fn allocate(
                 error.message,
             )
         })?;
-    super::ssa_state_home::verify(func, cfg, &plan).map_err(|error| {
-        super::RegallocError::new(
-            "final packed state-home verification",
-            error.rule,
-            error.block,
-            error.instruction,
-            error.values,
-            error.message,
-        )
-    })?;
-    if let Err(error) = super::home_verify::verify(func, cfg, &plan) {
-        let (block, instruction) = match error.location {
-            Some(super::home_verify::HomeLocation::Point(point)) => {
-                (Some(point.block), Some(point.instruction))
-            }
-            Some(super::home_verify::HomeLocation::Edge { predecessor, .. }) => {
-                (Some(predecessor), None)
-            }
-            None => (None, None),
-        };
-        return Err(super::RegallocError::new(
-            "spill-home verification",
-            error.rule,
-            block,
-            instruction,
-            error.value.map(|value| VReg(value.0)).into_iter().collect(),
-            error.message,
-        ));
+        plan.verify_recipe_homes(func, cfg, &reload_recipes)
+            .map_err(|error| {
+                super::RegallocError::new(
+                    "recipe-home verification",
+                    error.rule,
+                    error.block,
+                    error.instruction,
+                    error.values,
+                    error.message,
+                )
+            })?;
+        super::ssa_state_home::verify(func, cfg, &plan).map_err(|error| {
+            super::RegallocError::new(
+                "final packed state-home verification",
+                error.rule,
+                error.block,
+                error.instruction,
+                error.values,
+                error.message,
+            )
+        })?;
+        if let Err(error) = super::home_verify::verify(func, cfg, &plan) {
+            let (block, instruction) = match error.location {
+                Some(super::home_verify::HomeLocation::Point(point)) => {
+                    (Some(point.block), Some(point.instruction))
+                }
+                Some(super::home_verify::HomeLocation::Edge { predecessor, .. }) => {
+                    (Some(predecessor), None)
+                }
+                None => (None, None),
+            };
+            return Err(super::RegallocError::new(
+                "spill-home verification",
+                error.rule,
+                block,
+                instruction,
+                error.value.map(|value| VReg(value.0)).into_iter().collect(),
+                error.message,
+            ));
+        }
     }
     if let Some(start) = phase {
         tracing::debug!(
@@ -176,19 +183,25 @@ pub(super) fn allocate(
     }
 
     let phase = timing.then(crate::timing::now);
-    let reconstruction =
-        super::reconstruct::reconstruct(func, cfg, &plan, next_use, &reload_recipes).map_err(
-            |error| {
-                super::RegallocError::new(
-                    "SSA reconstruction",
-                    error.rule,
-                    error.block,
-                    error.instruction,
-                    error.values,
-                    error.message,
-                )
-            },
-        )?;
+    let reconstruction = super::reconstruct::reconstruct(
+        func,
+        cfg,
+        &plan,
+        next_use,
+        &reload_recipes,
+        timing,
+        verify,
+    )
+    .map_err(|error| {
+        super::RegallocError::new(
+            "SSA reconstruction",
+            error.rule,
+            error.block,
+            error.instruction,
+            error.values,
+            error.message,
+        )
+    })?;
     if let Some(start) = phase {
         tracing::debug!(
             "[regalloc-timing] ssa reconstruct vregs={} insts={} frame={} shared_reload_blocks={} elapsed={:?}",
@@ -202,9 +215,11 @@ pub(super) fn allocate(
             start.elapsed()
         );
     }
-    func.verify_result().map_err(|error| {
-        super::RegallocError::mir("SSA reconstruction structural verification", error)
-    })?;
+    if verify {
+        func.verify_result().map_err(|error| {
+            super::RegallocError::mir("SSA reconstruction structural verification", error)
+        })?;
+    }
 
     // Shared edge-reload tails add real CFG blocks after the original
     // allocation graph was frozen. Rebuild the normalized graph once, then
@@ -213,67 +228,75 @@ pub(super) fn allocate(
     let reconstructed_cfg = if !reconstruction.shared_reload_blocks.is_empty() {
         let rebuilt = super::cfg::normalize(func)
             .map_err(|error| super::cfg_error("shared reload CFG normalization", error))?;
-        rebuilt.verify(func).map_err(|error| {
-            super::cfg_error("shared reload CFG normalization verification", error)
-        })?;
-        func.verify_result().map_err(|error| {
-            super::RegallocError::mir("shared reload CFG structural verification", error)
-        })?;
+        if verify {
+            rebuilt.verify(func).map_err(|error| {
+                super::cfg_error("shared reload CFG normalization verification", error)
+            })?;
+            func.verify_result().map_err(|error| {
+                super::RegallocError::mir("shared reload CFG structural verification", error)
+            })?;
+        }
         Some(rebuilt)
     } else {
         None
     };
     let cfg = reconstructed_cfg.as_ref().unwrap_or(cfg);
 
-    super::materialized_state_home::verify_materialized_state_homes(
-        func,
-        cfg,
-        &reconstruction.state_stores,
-        &reconstruction.state_reloads,
-    )
-    .map_err(|error| {
-        super::RegallocError::new(
-            "materialized packed state-home verification",
-            error.rule,
-            error.block,
-            error.instruction,
-            error.values,
-            error.message,
+    if verify {
+        super::materialized_state_home::verify_materialized_state_homes(
+            func,
+            cfg,
+            &reconstruction.state_stores,
+            &reconstruction.state_reloads,
         )
-    })?;
+        .map_err(|error| {
+            super::RegallocError::new(
+                "materialized packed state-home verification",
+                error.rule,
+                error.block,
+                error.instruction,
+                error.values,
+                error.message,
+            )
+        })?;
+    }
 
     let inserted_state_writes = reconstruction
         .state_stores
         .iter()
         .map(|store| (store.block, store.write_ordinal))
         .collect::<Vec<_>>();
-    super::reload::verify_expected_materialized_reloads_after_state_spills(
-        func,
-        cfg,
-        &reconstruction.recipe_reloads,
-        &inserted_state_writes,
-        &reconstruction.shared_reload_blocks,
-    )
-    .map_err(|error| {
-        super::reload_recipe_error("spill-planner reload-recipe verification", error)
-    })?;
+    if verify {
+        super::reload::verify_expected_materialized_reloads_after_state_spills(
+            func,
+            cfg,
+            &reconstruction.recipe_reloads,
+            &inserted_state_writes,
+            &reconstruction.shared_reload_blocks,
+        )
+        .map_err(|error| {
+            super::reload_recipe_error("spill-planner reload-recipe verification", error)
+        })?;
+    }
 
     // Prove the spill result itself fits the machine before Perm boundaries
     // introduce fresh representatives.  This keeps pressure correctness
     // independent from constraint legalization and follows the frozen phase
     // order: reconstruct -> pressure proof -> Perm -> color.
     let phase = timing.then(crate::timing::now);
-    let reconstructed_analysis = super::analysis::analyze(func);
-    if let Err(error) = super::pressure::verify(func, &reconstructed_analysis, register_count) {
-        let message = error.to_string();
-        return Err(super::RegallocError::new(
-            "reconstructed pressure verification",
-            "PRESSURE.EXCEEDS_CAPACITY",
-            Some(error.block),
-            Some(error.instruction),
-            error.values,
-            message,
-        ));
+    if verify {
+        let reconstructed_analysis = super::analysis::analyze(func);
+        if let Err(error) = super::pressure::verify(func, &reconstructed_analysis, register_count) {
+            let message = error.to_string();
+            return Err(super::RegallocError::new(
+                "reconstructed pressure verification",
+                "PRESSURE.EXCEEDS_CAPACITY",
+                Some(error.block),
+                Some(error.instruction),
+                error.values,
+                message,
+            ));
+        }
     }
     if let Some(start) = phase {
         tracing::debug!(
@@ -296,8 +319,10 @@ pub(super) fn allocate(
                 )
             },
         )?;
-    func.verify_result()
-        .map_err(|error| super::RegallocError::mir("Perm structural verification", error))?;
+    if verify {
+        func.verify_result()
+            .map_err(|error| super::RegallocError::mir("Perm structural verification", error))?;
+    }
     if let Some(start) = phase {
         tracing::debug!(
             "[regalloc-timing] ssa constraint_perms boundaries={} vregs={} elapsed={:?}",
@@ -321,16 +346,18 @@ pub(super) fn allocate(
                 message,
             )
         })?;
-    for (&destination, &register) in &coloring.perm_matching {
-        if coloring.assignment.get(destination) != Some(register) {
-            return Err(super::RegallocError::new(
-                "SSA coloring verification",
-                "COLOR.PERM_MATCHING_APPLIED",
-                None,
-                None,
-                vec![destination],
-                format!("Perm matching color {register:?} was not applied"),
-            ));
+    if verify {
+        for (&destination, &register) in &coloring.perm_matching {
+            if coloring.assignment.get(destination) != Some(register) {
+                return Err(super::RegallocError::new(
+                    "SSA coloring verification",
+                    "COLOR.PERM_MATCHING_APPLIED",
+                    None,
+                    None,
+                    vec![destination],
+                    format!("Perm matching color {register:?} was not applied"),
+                ));
+            }
         }
     }
     if let Some(start) = phase {

--- a/crates/celox-backend-x86/src/backend/native/regalloc/ssa_state_home.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/ssa_state_home.rs
@@ -6,8 +6,9 @@
 //! home is established and consumed; this module only proves that replacing
 //! one stack home by one physical SimState word is valid at every reload.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
+use crate::HashMap;
 use crate::native::mir::{BaseReg, BlockId, MFunction, MInst, PackedStateHome, SpillKind, VReg};
 
 use super::cfg::NormalizedCfg;
@@ -533,7 +534,7 @@ fn build_probe(
     homes: &BTreeMap<SpillHome, PackedStateHome>,
     reloads: &BTreeMap<SpillHome, BTreeSet<ReloadKey>>,
 ) -> Result<Probe, StateHomeError> {
-    let mut insertions = HashMap::<(usize, usize), Vec<SpillInsertion>>::new();
+    let mut insertions = HashMap::<(usize, usize), Vec<SpillInsertion>>::default();
     for spill in planned_spills(func, cfg, plan)? {
         if spill.edge_transfer {
             // The probe has no synthetic VReg for the atomic source-home
@@ -845,8 +846,16 @@ mod tests {
 
         let requested = super::super::ssa::planner_reload_queries(&func, &cfg, &plan).unwrap();
         let ordinary_recipes = reload::analyze_with_queries(&func, &cfg, &requested).unwrap();
-        let result =
-            reconstruct::reconstruct(&mut func, &cfg, &plan, &next_use, &ordinary_recipes).unwrap();
+        let result = reconstruct::reconstruct(
+            &mut func,
+            &cfg,
+            &plan,
+            &next_use,
+            &ordinary_recipes,
+            false,
+            true,
+        )
+        .unwrap();
         assert_eq!(result.frame_size, 0);
         assert!(func.blocks[0].insts.iter().any(|inst| {
             matches!(

--- a/crates/celox-backend-x86/src/backend/native/regalloc/stack_color.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/stack_color.rs
@@ -6,15 +6,17 @@
 //! decision over the same CFG-sparse interval model as machine VRegs, not a
 //! lifetime approximation based on instruction layout or last reloads.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt;
 
 use crate::native::mir::{BlockId, MFunction, SpillKind, Uses, VReg};
+use crate::{HashMap, HashSet};
 
 use super::cfg::NormalizedCfg;
 use super::interval_union::{AllocationBundleId, DynamicIntervalMatrix, IntervalUnionError};
 use super::live_interval::{
-    LiveIntervalError, LiveIntervals, LiveSegment, LivenessProgram, analyze_program,
+    LiveIntervalError, LiveIntervals, LiveSegment, LivenessProgram,
+    analyze_program_with_verification,
 };
 use super::spill_plan::{LogicalValue, PlannedEdgeOp, PlannedOp, SpillHome, SpillPlan};
 
@@ -520,10 +522,10 @@ fn build_planned_stack_program_from_events(
 
     // Sparse pruned MemorySSA.  `definitions` and `live_in` contain only
     // relations which actually occur; no home-by-block matrix is built.
-    let mut definitions = HashSet::<(SpillHome, usize)>::new();
-    let mut upward_uses = HashSet::<(SpillHome, usize)>::new();
+    let mut definitions = HashSet::<(SpillHome, usize)>::default();
+    let mut upward_uses = HashSet::<(SpillHome, usize)>::default();
     for (block, block_events) in events.iter().enumerate() {
-        let mut locally_defined = HashSet::<SpillHome>::new();
+        let mut locally_defined = HashSet::<SpillHome>::default();
         for event in block_events {
             match event.kind {
                 PlannedStackEventKind::Store => {
@@ -549,7 +551,7 @@ fn build_planned_stack_program_from_events(
         }
     }
 
-    let mut phi_relations = HashSet::<(SpillHome, usize)>::new();
+    let mut phi_relations = HashSet::<(SpillHome, usize)>::default();
     let mut queued = definitions.clone();
     let mut phi_work = definitions.iter().copied().collect::<Vec<_>>();
     while let Some((home, block)) = phi_work.pop() {
@@ -601,7 +603,7 @@ fn build_planned_stack_program_from_events(
         Enter(usize),
         Exit(Vec<(SpillHome, Option<VReg>)>),
     }
-    let mut current = HashMap::<SpillHome, VReg>::new();
+    let mut current = HashMap::<SpillHome, VReg>::default();
     let mut actions = vec![RenameAction::Enter(0)];
     while let Some(action) = actions.pop() {
         let block = match action {
@@ -812,28 +814,46 @@ pub(super) fn color_spill_plan(
     func: &MFunction,
     cfg: &NormalizedCfg,
     plan: &SpillPlan,
+    timing: bool,
+    verify: bool,
 ) -> Result<PlannedStackColoring, StackColorError> {
+    let phase = timing.then(crate::timing::now);
     let (program, homes) = build_planned_stack_program(func, cfg, plan)?;
-    color_planned_stack_program(program, homes, cfg)
+    if let Some(start) = phase {
+        tracing::debug!(
+            "[regalloc-timing] stack_color build_program versions={} homes={} elapsed={:?}",
+            program.version_homes.len(),
+            homes.len(),
+            start.elapsed()
+        );
+    }
+    color_planned_stack_program(program, homes, cfg, timing, verify)
 }
 
 fn color_planned_stack_program(
     program: PlannedStackLivenessProgram,
     homes: BTreeSet<SpillHome>,
     cfg: &NormalizedCfg,
+    timing: bool,
+    verify: bool,
 ) -> Result<PlannedStackColoring, StackColorError> {
     if homes.is_empty() {
         return Ok(PlannedStackColoring {
-            offsets: HashMap::new(),
+            offsets: HashMap::default(),
             frame_size: 0,
             slot_count: 0,
         });
     }
-    let intervals = analyze_program(&program, cfg)
+    let phase = timing.then(crate::timing::now);
+    let intervals = analyze_program_with_verification(&program, cfg, verify)
         .map_err(|error| planned_live_error(error, &program.version_homes))?;
-    intervals
-        .verify_program(&program, cfg)
-        .map_err(|error| planned_live_error(error, &program.version_homes))?;
+    if let Some(start) = phase {
+        tracing::debug!(
+            "[regalloc-timing] stack_color analyze_intervals elapsed={:?}",
+            start.elapsed()
+        );
+    }
+    let phase = timing.then(crate::timing::now);
     let ranges = merge_home_segments(&intervals, &program.version_homes, &homes)?;
     let bundle_homes = homes.iter().copied().collect::<Vec<_>>();
     let mut bundle_ranges = Vec::with_capacity(bundle_homes.len());
@@ -863,10 +883,22 @@ fn color_planned_stack_program(
             .then_with(|| right.2.cmp(&left.2))
             .then_with(|| bundle_homes[left.0].cmp(&bundle_homes[right.0]))
     });
+    let order = order
+        .into_iter()
+        .map(|(bundle, _, _)| bundle)
+        .collect::<Vec<_>>();
+    if let Some(start) = phase {
+        tracing::debug!(
+            "[regalloc-timing] stack_color merge_ranges homes={} elapsed={:?}",
+            bundle_homes.len(),
+            start.elapsed()
+        );
+    }
 
+    let phase = timing.then(crate::timing::now);
     let mut matrix = DynamicIntervalMatrix::new(cfg)
         .map_err(|error| planned_union_error(error, &bundle_homes))?;
-    for (bundle, _, _) in order {
+    for &bundle in &order {
         let range = matrix
             .make_range(bundle_ranges[bundle].clone())
             .map_err(|error| planned_union_error(error, &bundle_homes))?;
@@ -877,53 +909,72 @@ fn color_planned_stack_program(
             .assign_validated(AllocationBundleId(bundle as u32), slot, range.validated())
             .map_err(|error| planned_union_error(error, &bundle_homes))?;
     }
-    matrix
-        .verify()
-        .map_err(|error| planned_union_error(error, &bundle_homes))?;
-
-    // Rebuild from the final immutable assignment, independently of the
-    // mutation order used by first-fit coloring.
-    let mut rebuilt = DynamicIntervalMatrix::new(cfg)
-        .map_err(|error| planned_union_error(error, &bundle_homes))?;
-    let mut rebuild_order = (0..bundle_homes.len())
-        .map(|bundle| {
-            matrix
-                .slot(AllocationBundleId(bundle as u32))
-                .map(|slot| (slot, bundle))
-                .ok_or_else(|| {
-                    StackColorError::new(
-                        "STACK_COLOR.PLANNED_ASSIGNMENT_COVERAGE",
-                        None,
-                        None,
-                        [bundle_homes[bundle]],
-                        "production stack home has no colored frame slot",
-                    )
-                })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    rebuild_order.sort_unstable();
-    for (slot, bundle) in rebuild_order {
-        let range = rebuilt
-            .make_range(bundle_ranges[bundle].clone())
+    if let Some(start) = phase {
+        tracing::debug!(
+            "[regalloc-timing] stack_color assign slots={} elapsed={:?}",
+            matrix.slot_count(),
+            start.elapsed()
+        );
+    }
+    let phase = timing.then(crate::timing::now);
+    if verify {
+        matrix
+            .verify()
             .map_err(|error| planned_union_error(error, &bundle_homes))?;
+
+        // Rebuild from the final immutable assignment, independently of the
+        // mutation order used by first-fit coloring. This is a diagnostic
+        // proof of the already-computed assignment, not part of coloring.
+        let mut rebuilt = DynamicIntervalMatrix::new(cfg)
+            .map_err(|error| planned_union_error(error, &bundle_homes))?;
+        let mut rebuild_order = (0..bundle_homes.len())
+            .map(|bundle| {
+                matrix
+                    .slot(AllocationBundleId(bundle as u32))
+                    .map(|slot| (slot, bundle))
+                    .ok_or_else(|| {
+                        StackColorError::new(
+                            "STACK_COLOR.PLANNED_ASSIGNMENT_COVERAGE",
+                            None,
+                            None,
+                            [bundle_homes[bundle]],
+                            "production stack home has no colored frame slot",
+                        )
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        rebuild_order.sort_unstable();
+        for (slot, bundle) in rebuild_order {
+            let range = rebuilt
+                .make_range(bundle_ranges[bundle].clone())
+                .map_err(|error| planned_union_error(error, &bundle_homes))?;
+            rebuilt
+                .assign_validated(AllocationBundleId(bundle as u32), slot, range.validated())
+                .map_err(|error| planned_union_error(error, &bundle_homes))?;
+        }
         rebuilt
-            .assign_validated(AllocationBundleId(bundle as u32), slot, range.validated())
+            .verify()
             .map_err(|error| planned_union_error(error, &bundle_homes))?;
+        if rebuilt != matrix {
+            return Err(StackColorError::new(
+                "STACK_COLOR.PLANNED_MATRIX_IDENTITY",
+                None,
+                None,
+                [],
+                "rebuilt production stack-slot matrix differs from completed coloring",
+            ));
+        }
     }
-    rebuilt
-        .verify()
-        .map_err(|error| planned_union_error(error, &bundle_homes))?;
-    if rebuilt != matrix {
-        return Err(StackColorError::new(
-            "STACK_COLOR.PLANNED_MATRIX_IDENTITY",
-            None,
-            None,
-            [],
-            "rebuilt production stack-slot matrix differs from completed coloring",
-        ));
+    if let Some(start) = phase {
+        tracing::debug!(
+            "[regalloc-timing] stack_color verify enabled={} elapsed={:?}",
+            verify,
+            start.elapsed()
+        );
     }
 
-    let mut offsets = HashMap::with_capacity(bundle_homes.len());
+    let phase = timing.then(crate::timing::now);
+    let mut offsets = HashMap::with_capacity_and_hasher(bundle_homes.len(), Default::default());
     for (bundle, &home) in bundle_homes.iter().enumerate() {
         let slot = matrix
             .slot(AllocationBundleId(bundle as u32))
@@ -963,6 +1014,12 @@ fn color_planned_stack_program(
                 "colored production stack frame exceeds u32",
             )
         })?;
+    if let Some(start) = phase {
+        tracing::debug!(
+            "[regalloc-timing] stack_color offsets elapsed={:?}",
+            start.elapsed()
+        );
+    }
     Ok(PlannedStackColoring {
         offsets,
         frame_size,
@@ -1015,7 +1072,7 @@ mod tests {
             }
         }
         let (program, homes) = build_planned_stack_program_from_events(func, cfg, events, homes)?;
-        color_planned_stack_program(program, homes, cfg)
+        color_planned_stack_program(program, homes, cfg, false, true)
     }
 
     fn diamond_function() -> MFunction {

--- a/crates/celox-backend-x86/src/backend/native/ssa_destroy.rs
+++ b/crates/celox-backend-x86/src/backend/native/ssa_destroy.rs
@@ -1466,9 +1466,9 @@ mod tests {
 
     #[test]
     fn consecutive_empty_fallthrough_blocks_alias_the_next_instruction() {
+        use crate::HashMap;
         use crate::native::jit_mem::JitCode;
         use iced_x86::{Decoder, DecoderOptions, Mnemonic};
-        use std::collections::HashMap;
 
         let mut vregs = VRegAllocator::new();
         let condition = vregs.alloc();
@@ -1551,9 +1551,9 @@ mod tests {
 
     #[test]
     fn trailing_continuation_label_aliases_an_empty_fallthrough_chain() {
+        use crate::HashMap;
         use crate::native::jit_mem::JitCode;
         use iced_x86::{Decoder, DecoderOptions, Mnemonic};
-        use std::collections::HashMap;
 
         let mut vregs = VRegAllocator::new();
         let source = vregs.alloc();

--- a/crates/celox-backend-x86/src/backend/native/x86_slp.rs
+++ b/crates/celox-backend-x86/src/backend/native/x86_slp.rs
@@ -4,13 +4,14 @@
 //! whose complete scalar use graph is covered by a cheaper executable x86
 //! recipe, so unsupported packs remain ordinary scalar MIR.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::BTreeMap;
 
 use super::memory_effect::{self, UnknownMemory};
 use super::mir::{
     BaseReg, MFunction, MInst, OpSize, VReg, X86SimdBinaryOp, X86SimdInst, X86VecReg,
 };
 use super::regalloc::assignment::{X86PhysVec, X86VectorLocation};
+use crate::{HashMap, HashSet};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct SlpStats {
@@ -75,8 +76,8 @@ struct ScalarLoad {
 /// replaced, yielding `1 + N` vector instructions instead of `2 + 2N`.
 pub(crate) fn select(func: &mut MFunction) -> SlpStats {
     let mut stats = SlpStats::default();
-    let mut function_uses = HashMap::<VReg, Vec<(usize, usize)>>::new();
-    let mut phi_uses = HashSet::<VReg>::new();
+    let mut function_uses = HashMap::<VReg, Vec<(usize, usize)>>::default();
+    let mut phi_uses = HashSet::<VReg>::default();
     for (block_index, block) in func.blocks.iter().enumerate() {
         for phi in &block.phis {
             phi_uses.extend(phi.sources.iter().map(|(_, source)| *source));
@@ -93,7 +94,7 @@ pub(crate) fn select(func: &mut MFunction) -> SlpStats {
 
     let mut plans = Vec::new();
     for (block_index, block) in func.blocks.iter().enumerate() {
-        let mut loads = HashMap::<VReg, ScalarLoad>::new();
+        let mut loads = HashMap::<VReg, ScalarLoad>::default();
         for (instruction, inst) in block.insts.iter().enumerate() {
             if let MInst::Load {
                 dst,
@@ -213,7 +214,7 @@ pub(crate) fn select(func: &mut MFunction) -> SlpStats {
 
     for (block_index, plans) in by_block {
         let block = &mut func.blocks[block_index];
-        let mut replacements = HashMap::<usize, Option<MInst>>::new();
+        let mut replacements = HashMap::<usize, Option<MInst>>::default();
         for (vector, plan) in plans {
             if replacements.contains_key(&plan.first_load)
                 || replacements.contains_key(&plan.second_load)
@@ -340,8 +341,8 @@ fn exact_scalar_load_pair(
 /// small complete-cone subset: it never lengthens a scalar live range and it
 /// never leaves a GPR/XMM crossing behind for a later pass to repair.
 fn select_binary_store_pairs(func: &mut MFunction, stats: &mut SlpStats) {
-    let mut function_uses = HashMap::<VReg, Vec<(usize, usize)>>::new();
-    let mut phi_uses = HashSet::<VReg>::new();
+    let mut function_uses = HashMap::<VReg, Vec<(usize, usize)>>::default();
+    let mut phi_uses = HashSet::<VReg>::default();
     for (block_index, block) in func.blocks.iter().enumerate() {
         for phi in &block.phis {
             phi_uses.extend(phi.sources.iter().map(|(_, source)| *source));
@@ -510,7 +511,7 @@ fn select_binary_store_pairs(func: &mut MFunction, stats: &mut SlpStats) {
     }
     for (block_index, plans) in by_block {
         let block = &mut func.blocks[block_index];
-        let mut replacements = HashMap::<usize, Option<MInst>>::new();
+        let mut replacements = HashMap::<usize, Option<MInst>>::default();
         for (lhs_vector, rhs_vector, result_vector, plan) in plans {
             let touched = [
                 plan.lhs.low_instruction,
@@ -788,7 +789,7 @@ fn allocate_from_registers(
     };
 
     for block in &func.blocks {
-        let mut intervals = HashMap::<X86VecReg, (usize, usize)>::new();
+        let mut intervals = HashMap::<X86VecReg, (usize, usize)>::default();
         for (instruction, inst) in block.insts.iter().enumerate() {
             if let Some(definition) = inst.x86_vec_def() {
                 intervals.insert(definition, (instruction, instruction));

--- a/crates/celox-bench/src/bin/celox-heliodor.rs
+++ b/crates/celox-bench/src/bin/celox-heliodor.rs
@@ -198,7 +198,8 @@ fn run() -> Result<(), CeloxHeliodorError> {
         .opt_level(opts.opt_level)
         .optimize_options(optimize_options)
         .x86_slp(opts.x86_slp)
-        .four_state(opts.four_state);
+        .four_state(opts.four_state)
+        .diagnostics_from_env();
     for block in &opts.native_profile_blocks {
         builder = builder.trace_native_profile_block(&block.function, block.block, block.samples);
     }
@@ -404,7 +405,7 @@ fn run() -> Result<(), CeloxHeliodorError> {
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             ))]
             Backend::Native => {
-                let _sim = builder.build_native()?;
+                let _compiled = builder.compile_native()?;
             }
             #[cfg(not(any(
                 target_arch = "x86_64",

--- a/crates/celox-bench/src/bin/veryl-heliodor.rs
+++ b/crates/celox-bench/src/bin/veryl-heliodor.rs
@@ -26,6 +26,9 @@ struct Options {
     test: String,
     #[arg(long = "source-file")]
     source_files: Vec<PathBuf>,
+    /// Build the complete AOT-C simulator without running the testbench.
+    #[arg(long)]
+    compile_only: bool,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -73,8 +76,8 @@ fn run() -> Result<(), VerylHeliodorError> {
         .collect::<Result<Vec<_>, _>>()?;
 
     println!(
-        "VERYL_TEST_CONFIG test={} backend=cc aot_c_async=false",
-        options.test
+        "VERYL_TEST_CONFIG test={} backend=cc aot_c_async=false compile_only={}",
+        options.test, options.compile_only
     );
 
     let total_start = Instant::now();
@@ -133,6 +136,21 @@ fn run() -> Result<(), VerylHeliodorError> {
         })?;
     let testbench = convert_initial_to_testbench(initial_stmts, &event_map, &clock_periods, 3);
     let compile_elapsed = compile_start.elapsed();
+
+    if options.compile_only {
+        let elapsed = total_start.elapsed();
+        println!(
+            "VERYL_TEST_TIMING test={} compile_ns={} execute_ns=0",
+            options.test,
+            compile_elapsed.as_nanos()
+        );
+        println!(
+            "VERYL_TEST_RESULT test={} status=compile-only elapsed_ns={}",
+            options.test,
+            elapsed.as_nanos()
+        );
+        return Ok(());
+    }
 
     let execute_cpu_start = process_cpu_time();
     let execute_start = Instant::now();

--- a/crates/celox-frontend-veryl/src/hierarchy.rs
+++ b/crates/celox-frontend-veryl/src/hierarchy.rs
@@ -1,4 +1,5 @@
 use celox_design::ModuleId;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use veryl_analyzer::ir::{Component, Declaration, Module, VarKind};
 use veryl_parser::resource_table::{self, StrId};
 
@@ -137,17 +138,58 @@ pub fn parse_ir_with_loop_provenance<'a>(
         inst_sequences.insert(module_id, inst_ids);
     }
 
-    // veryl-parser's resource table is process-global, so module parsing must
-    // remain serial even though modules are otherwise independent.
-    for (module_id, ir_module) in &module_ir {
-        let inst_ids = inst_sequences
-            .get(module_id)
-            .map(Vec::as_slice)
-            .unwrap_or_default();
-        let sim_module =
-            ModuleParser::parse_with_loop_provenance(ir_module, loop_provenance, config, inst_ids)?;
-        modules.insert(*module_id, sim_module);
-    }
+    // Analyzer/parser resources are thread-local. Copy the read-only parser
+    // tables into each worker before lowering otherwise independent modules.
+    // Hierarchy discovery above remains serial, so ModuleId and instance-ID
+    // assignment are identical to the single-threaded construction.
+    let resource_snapshot = resource_table::export_tables();
+    let tasks = module_ir
+        .iter()
+        .map(|(&module_id, &ir_module)| {
+            let inst_ids = inst_sequences
+                .get(&module_id)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            (module_id, ir_module, inst_ids)
+        })
+        .collect::<Vec<_>>();
+    let worker_count = tasks
+        .len()
+        .min(std::thread::available_parallelism().map_or(1, usize::from));
+    let next_task = AtomicUsize::new(0);
+    let parsed_modules = std::thread::scope(|scope| {
+        let handles = (0..worker_count)
+            .map(|_| {
+                scope.spawn(|| {
+                    resource_table::import_tables(&resource_snapshot);
+                    let mut parsed = Vec::new();
+                    loop {
+                        let task = next_task.fetch_add(1, Ordering::Relaxed);
+                        let Some(&(module_id, ir_module, inst_ids)) = tasks.get(task) else {
+                            break;
+                        };
+                        let module = ModuleParser::parse_with_loop_provenance(
+                            ir_module,
+                            loop_provenance,
+                            config,
+                            inst_ids,
+                        )?;
+                        parsed.push((module_id, module));
+                    }
+                    Ok::<_, ParserError>(parsed)
+                })
+            })
+            .collect::<Vec<_>>();
+        let mut parsed_modules = Vec::with_capacity(tasks.len());
+        for handle in handles {
+            let parsed = handle
+                .join()
+                .unwrap_or_else(|panic| std::panic::resume_unwind(panic))?;
+            parsed_modules.extend(parsed);
+        }
+        Ok::<_, ParserError>(parsed_modules)
+    })?;
+    modules.extend(parsed_modules);
 
     Ok(SymbolicRtl {
         modules,

--- a/crates/celox-frontend-veryl/src/testbench.rs
+++ b/crates/celox-frontend-veryl/src/testbench.rs
@@ -2266,8 +2266,8 @@ struct SemanticTestbenchBuilder<'a> {
     lookup: &'a VerylFrontendLookup,
     testbench_source: &'a VerylTestbenchSource,
     runtime_event_site_count: usize,
-    event_map: std::collections::HashMap<StrId, StateAddr>,
-    signal_map: std::collections::HashMap<StrId, SemanticSignal<StateAddr>>,
+    event_map: HashMap<StrId, StateAddr>,
+    signal_map: HashMap<StrId, SemanticSignal<StateAddr>>,
     default_reset_duration: u64,
 }
 

--- a/crates/celox-macros/Cargo.toml
+++ b/crates/celox-macros/Cargo.toml
@@ -12,6 +12,7 @@ edition.workspace     = true
 proc-macro = true
 
 [dependencies]
+fxhash            = { workspace = true }
 proc-macro2       = "1.0"
 quote             = "1.0"
 syn               = { version = "3.0", features = ["full", "extra-traits"] }

--- a/crates/celox-macros/src/generator.rs
+++ b/crates/celox-macros/src/generator.rs
@@ -14,14 +14,14 @@ pub fn generate_project(ir: &Ir) -> proc_macro2::TokenStream {
         let module_name = format_ident!("{}", module_name_str);
 
         // Group ports by interface
-        let mut interface_map: std::collections::HashMap<
+        let mut interface_map: fxhash::FxHashMap<
             String,
             Vec<(
                 &VarPath,
                 veryl_analyzer::ir::VarId,
                 &veryl_analyzer::ir::Type,
             )>,
-        > = std::collections::HashMap::new();
+        > = fxhash::FxHashMap::default();
         let mut top_level_ports = Vec::new();
 
         for (var_path, var_id) in &module.ports {

--- a/crates/celox-macros/src/lib.rs
+++ b/crates/celox-macros/src/lib.rs
@@ -63,7 +63,7 @@ pub fn veryl_test(input: TokenStream) -> TokenStream {
     };
 
     // Veryl CLI dependency logic
-    let mut table = std::collections::HashMap::new();
+    let mut table = fxhash::FxHashMap::default();
     for path in &paths {
         table.insert(path.src.clone(), path);
     }
@@ -79,7 +79,7 @@ pub fn veryl_test(input: TokenStream) -> TokenStream {
         .flatten()
         .collect();
 
-    let mut used_paths = std::collections::HashMap::new();
+    let mut used_paths = fxhash::FxHashMap::default();
     for symbol in &candidate_symbols {
         if let veryl_parser::veryl_token::TokenSource::File { path, .. } = symbol.token.source {
             let path = PathBuf::from(format!("{path}"));

--- a/crates/celox-napi/Cargo.toml
+++ b/crates/celox-napi/Cargo.toml
@@ -24,6 +24,7 @@ serde             = { workspace = true }
 serde_json        = { workspace = true }
 toml              = { workspace = true }
 globset           = "0.4"
+fxhash            = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 celox = { path = "../celox" }

--- a/crates/celox-napi/src/layout.rs
+++ b/crates/celox-napi/src/layout.rs
@@ -4,9 +4,9 @@ use celox::{DefaultBackend, InstanceHierarchy, NamedSignal, get_byte_size};
 #[cfg(not(target_arch = "wasm32"))]
 type NamedEvent = celox::NamedEvent<DefaultBackend>;
 #[cfg(not(target_arch = "wasm32"))]
-use serde::Serialize;
+use fxhash::FxHashMap as HashMap;
 #[cfg(not(target_arch = "wasm32"))]
-use std::collections::HashMap;
+use serde::Serialize;
 
 /// Layout information for a single signal, serialized to JS.
 #[cfg(not(target_arch = "wasm32"))]
@@ -87,7 +87,7 @@ pub fn build_signal_layout(
     signals: &[NamedSignal],
     four_state_mode: bool,
 ) -> HashMap<String, SignalLayout> {
-    let mut map = HashMap::new();
+    let mut map = HashMap::default();
     for ns in signals {
         map.insert(
             ns.name.clone(),
@@ -100,12 +100,12 @@ pub fn build_signal_layout(
 /// Build a hierarchy node from an InstanceHierarchy.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn build_hierarchy_node(h: &InstanceHierarchy, four_state: bool) -> HierarchyNode {
-    let mut signals = HashMap::new();
+    let mut signals = HashMap::default();
     for ns in &h.signals {
         signals.insert(ns.name.clone(), build_signal_layout_entry(ns, four_state));
     }
 
-    let mut children = HashMap::new();
+    let mut children = HashMap::default();
     for (name, instances) in &h.children {
         let nodes: Vec<HierarchyNode> = instances
             .iter()
@@ -124,7 +124,7 @@ pub fn build_hierarchy_node(h: &InstanceHierarchy, four_state: bool) -> Hierarch
 /// Build a map of event name -> event ID from named events.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn build_event_map(events: &[NamedEvent]) -> HashMap<String, u32> {
-    let mut map = HashMap::new();
+    let mut map = HashMap::default();
     for ne in events {
         map.insert(ne.name.clone(), ne.id as u32);
     }

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1,6 +1,6 @@
 mod layout;
 
-use std::collections::HashMap;
+use fxhash::FxHashMap as HashMap;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::{Arc, Mutex};
 
@@ -726,7 +726,7 @@ impl From<&celox::OptimizeOptions> for SirOptimizationCacheKey {
 
 #[cfg(not(target_arch = "wasm32"))]
 static JIT_CACHE: std::sync::LazyLock<Mutex<HashMap<CacheKey, Arc<CachedBuild>>>> =
-    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+    std::sync::LazyLock::new(|| Mutex::new(HashMap::default()));
 
 #[cfg(not(target_arch = "wasm32"))]
 /// Build a collision-free cache key from source content, top module, and options.
@@ -2077,7 +2077,7 @@ pub fn gen_ts(project_path: String) -> Result<String> {
     let source_file_refs: Vec<&str> = all_source_files.iter().map(|s| s.as_str()).collect();
 
     let mut all_modules = Vec::new();
-    let mut file_modules: HashMap<String, Vec<String>> = HashMap::new();
+    let mut file_modules: HashMap<String, Vec<String>> = HashMap::default();
     let mut post_pass_ir = Ir::default();
 
     for (i, (_path, parser)) in parsers.iter().enumerate() {
@@ -2224,7 +2224,7 @@ pub fn gen_ts_from_source(sources: Vec<NapiSourceFile>) -> Result<String> {
     let source_file_refs: Vec<&str> = all_source_files.iter().map(|s| s.as_str()).collect();
 
     let mut all_modules = Vec::new();
-    let mut file_modules: HashMap<String, Vec<String>> = HashMap::new();
+    let mut file_modules: HashMap<String, Vec<String>> = HashMap::default();
     let mut post_pass_ir = Ir::default();
 
     for (i, (_prj, _path, parser)) in parsers.iter().enumerate() {

--- a/crates/celox-runtime/Cargo.toml
+++ b/crates/celox-runtime/Cargo.toml
@@ -13,6 +13,7 @@ celox-state-layout = { path = "../celox-state-layout" }
 celox-testbench = { path = "../celox-testbench" }
 bit-set = { workspace = true }
 chrono = "0.4"
+fxhash.workspace = true
 num-bigint = { workspace = true }
 
 [dev-dependencies]

--- a/crates/celox-runtime/src/simulation.rs
+++ b/crates/celox-runtime/src/simulation.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
 use bit_set::BitSet;
 use celox_design::DomainKind;
+use fxhash::FxHashMap;
 
 use crate::{
     SignalRef, SimulatorErrorCode,
@@ -92,7 +91,7 @@ pub struct SimulationState<B: SimBackend> {
     topo_signals: Vec<(SignalRef, usize, usize)>,
     domain_kinds: Vec<Option<DomainKind>>,
     event_info: Vec<EventInfo<B>>,
-    signal_to_id: HashMap<SignalRef, usize>,
+    signal_to_id: FxHashMap<SignalRef, usize>,
 }
 
 impl<B: SimBackend> SimulationState<B> {
@@ -141,7 +140,7 @@ impl<B: SimBackend> SimulationState<B> {
         event_info: Vec<EventInfo<B>>,
     ) -> Self {
         let mut last_clock_values = BitSet::with_capacity(backend.num_events());
-        let mut signal_to_id = HashMap::new();
+        let mut signal_to_id = FxHashMap::default();
         for (signal, id, _) in topo_signals.iter().copied() {
             if id == usize::MAX {
                 continue;

--- a/crates/celox-runtime/src/testbench.rs
+++ b/crates/celox-runtime/src/testbench.rs
@@ -20,10 +20,10 @@ fn bind_expr<B: SimBackend>(
     Some(CompiledExpr::new(bytecode))
 }
 
-fn bind_component<B: SimBackend, S: std::hash::BuildHasher>(
+fn bind_component<B: SimBackend>(
     backend: &B,
     component: SemanticComponentBinding<AbsoluteAddr>,
-    rtl_writes: &std::collections::HashSet<VarAtomBase<AbsoluteAddr>, S>,
+    rtl_writes: &fxhash::FxHashSet<VarAtomBase<AbsoluteAddr>>,
 ) -> Option<celox_testbench::ExecutableComponentBinding<B::Event, SignalRef>> {
     Some(celox_testbench::ComponentBinding {
         instance: component.instance,
@@ -338,10 +338,10 @@ fn bind_statement<B: SimBackend>(
     }
 }
 
-pub fn bind_testbench_program<B: SimBackend, S: std::hash::BuildHasher>(
+pub fn bind_testbench_program<B: SimBackend>(
     backend: &B,
     program: TestbenchProgram<AbsoluteAddr>,
-    rtl_writes: &std::collections::HashSet<VarAtomBase<AbsoluteAddr>, S>,
+    rtl_writes: &fxhash::FxHashSet<VarAtomBase<AbsoluteAddr>>,
 ) -> Option<ExecutableTestbench<B::Event, SignalRef>> {
     let random_seed = program.configured_random_seed();
     let components = program.components().to_vec();

--- a/crates/celox-runtime/src/vcd.rs
+++ b/crates/celox-runtime/src/vcd.rs
@@ -145,7 +145,7 @@ impl VcdWriter {
 
         let mut scope_order = Vec::<String>::new();
         let mut scope_groups = Vec::<Vec<usize>>::new();
-        let mut scope_idx = std::collections::HashMap::<String, usize>::new();
+        let mut scope_idx = fxhash::FxHashMap::<String, usize>::default();
         for (signal_index, signal) in self.signals.iter().enumerate() {
             if let Some(index) = scope_idx.get(&signal.scope).copied() {
                 scope_groups[index].push(signal_index);

--- a/crates/celox-sir-opt/src/optimizer/native.rs
+++ b/crates/celox-sir-opt/src/optimizer/native.rs
@@ -15,23 +15,27 @@ pub fn optimize_merged_chain(
     recover_merged_effect_regions: bool,
     diagnostics: &crate::SirDiagnostics,
 ) -> Result<(), crate::OptimizationError> {
+    let verify = |eu: &ExecutionUnit<RegionedAbsoluteAddr>, stage| {
+        if cfg!(debug_assertions) || diagnostics.verify_boundaries {
+            eu.verify_result()
+                .map_err(|error| crate::OptimizationError::verification(stage, error))
+        } else {
+            Ok(())
+        }
+    };
     let mut changed = false;
     if crate::ir::inline_single_predecessor_jumps(eu).map_err(|error| {
         crate::OptimizationError::verification("during native jump inlining", error)
     })? {
         changed = true;
     }
-    eu.verify_result().map_err(|error| {
-        crate::OptimizationError::verification("after native jump inlining", error)
-    })?;
+    verify(eu, "after native jump inlining")?;
     OptimizeBlocksPass {
         skip_final_schedule: false,
         element_widths: Arc::clone(&element_widths),
     }
     .run(eu, &PassOptions::default());
-    eu.verify_result().map_err(|error| {
-        crate::OptimizationError::verification("after native block optimization", error)
-    })?;
+    verify(eu, "after native block optimization")?;
     // The native function is assembled after the ordinary per-EU pipeline.
     // Merging exposes constants and control-flow facts across the old EU
     // boundaries, and OptimizeBlocks can expose more of them while rewriting
@@ -45,12 +49,7 @@ pub fn optimize_merged_chain(
             ..PassOptions::default()
         },
     );
-    eu.verify_result().map_err(|error| {
-        crate::OptimizationError::verification(
-            "after native merged-chain CFG simplification",
-            error,
-        )
-    })?;
+    verify(eu, "after native merged-chain CFG simplification")?;
     if recover_merged_effect_regions && !four_state {
         pass_guarded_region_sinking::recover_merged_effect_regions(eu, four_state);
         pass_guarded_region_sinking::eliminate_dead_control_regions(eu);
@@ -62,12 +61,7 @@ pub fn optimize_merged_chain(
             },
         );
         pass_vectorize_concat::remove_dead_definitions(eu);
-        eu.verify_result().map_err(|error| {
-            crate::OptimizationError::verification(
-                "after native merged effect-region recovery",
-                error,
-            )
-        })?;
+        verify(eu, "after native merged effect-region recovery")?;
         changed = true;
     }
     if !four_state {
@@ -83,24 +77,14 @@ pub fn optimize_merged_chain(
             // Concat back into scalar shifts in ISel.
             VectorizeConcatPass::default().run(eu, &PassOptions::default());
             GvnPass.run(eu, &PassOptions::default());
-            eu.verify_result().map_err(|error| {
-                crate::OptimizationError::verification(
-                    "after native packed conditional-store recovery",
-                    error,
-                )
-            })?;
+            verify(eu, "after native packed conditional-store recovery")?;
         }
     }
     if !four_state && pass_vectorize_concat::expose_packed_bit_store_sinks(eu) {
         changed = true;
         VectorizeConcatPass::default().run(eu, &PassOptions::default());
         GvnPass.run(eu, &PassOptions::default());
-        eu.verify_result().map_err(|error| {
-            crate::OptimizationError::verification(
-                "after native packed bit-store vectorization",
-                error,
-            )
-        })?;
+        verify(eu, "after native packed bit-store vectorization")?;
     }
     let recovered_bit_maps = if four_state {
         0
@@ -117,9 +101,7 @@ pub fn optimize_merged_chain(
         .run(eu, &PassOptions::default());
         VectorizeConcatPass::default().run(eu, &PassOptions::default());
         GvnPass.run(eu, &PassOptions::default());
-        eu.verify_result().map_err(|error| {
-            crate::OptimizationError::verification("after native fixed bit-map recovery", error)
-        })?;
+        verify(eu, "after native fixed bit-map recovery")?;
     }
     if !four_state
         && diagnostics.effect_case_dispatch
@@ -153,16 +135,12 @@ pub fn optimize_merged_chain(
             dead_control_ns as f64 / 1_000_000.0,
             cfg_cleanup_ns as f64 / 1_000_000.0,
         );
-        eu.verify_result().map_err(|error| {
-            crate::OptimizationError::verification("after native effect-case dispatch", error)
-        })?;
+        verify(eu, "after native effect-case dispatch")?;
     }
     if !four_state && pass_pack_concat_phi::pack_concat_phis(eu) != 0 {
         changed = true;
         GvnPass.run(eu, &PassOptions::default());
-        eu.verify_result().map_err(|error| {
-            crate::OptimizationError::verification("after native packed phi forwarding", error)
-        })?;
+        verify(eu, "after native packed phi forwarding")?;
     }
     if !four_state {
         // Fusion and the native-only packed/control rewrites above can create
@@ -172,15 +150,11 @@ pub fn optimize_merged_chain(
         // head and kept live across the edge.
         pass_guarded_region_sinking::sink_pure_values_with_predicate_repair(eu);
         changed = true;
-        eu.verify_result().map_err(|error| {
-            crate::OptimizationError::verification("after native final pure-value placement", error)
-        })?;
+        verify(eu, "after native final pure-value placement")?;
     }
     if changed {
         pass_vectorize_concat::remove_dead_definitions(eu);
-        eu.verify_result().map_err(|error| {
-            crate::OptimizationError::verification("after native merged-chain DCE", error)
-        })?;
+        verify(eu, "after native merged-chain DCE")?;
     }
     Ok(())
 }

--- a/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_branchify_mux.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_branchify_mux.rs
@@ -347,6 +347,9 @@ fn run_branchify_mux(
     let mut next_block_id = eu.blocks.keys().map(|id| id.0).max().unwrap_or(0) + 1;
     let mut reg_counter = eu.register_map.keys().map(|reg| reg.0).max().unwrap_or(0);
     let mut applied = 0usize;
+    let mut cross_priority_applied = 0usize;
+    let mut cross_group_applied = 0usize;
+    let mut cross_mux_applied = 0usize;
     let mut use_counts = count_uses(eu);
 
     // Recover a source-level conditional state update before treating its
@@ -389,7 +392,6 @@ fn run_branchify_mux(
     }
     report_stage("coupled updates");
     use_counts = count_uses(eu);
-    let mut def_blocks = instruction_def_blocks(eu);
 
     // A priority spine is one short-circuit expression, not a collection
     // of independent selects.  Handle the whole spine before the
@@ -460,8 +462,8 @@ fn run_branchify_mux(
             panic!("cross-block priority rewrite produced invalid SIR");
         }
         applied += 1;
+        cross_priority_applied += 1;
         use_counts = count_uses(eu);
-        def_blocks = instruction_def_blocks(eu);
     }
     verify_stage(eu, "cross-block priority chains");
     report_stage("cross-block priority chains");
@@ -478,8 +480,8 @@ fn run_branchify_mux(
     {
         apply_cross_block_group_branchify(eu, plan, &mut next_block_id, &mut reg_counter);
         applied += 1;
+        cross_group_applied += 1;
         use_counts = count_uses(eu);
-        def_blocks = instruction_def_blocks(eu);
     }
     verify_stage(eu, "cross-block groups");
     report_stage("cross-block groups");
@@ -488,11 +490,12 @@ fn run_branchify_mux(
     {
         apply_cross_block_branchify(eu, plan, &mut next_block_id, &mut reg_counter);
         applied += 1;
+        cross_mux_applied += 1;
         use_counts = count_uses(eu);
-        def_blocks = instruction_def_blocks(eu);
     }
     verify_stage(eu, "cross-block muxes");
     report_stage("cross-block muxes");
+    let mut def_blocks = instruction_def_blocks(eu);
     let mut block_ids = eu.blocks.keys().copied().collect::<Vec<_>>();
     block_ids.sort_by_key(|id| id.0);
     let mut worklist = VecDeque::from(block_ids);
@@ -610,7 +613,7 @@ fn run_branchify_mux(
             .map(|block| block.instructions.len())
             .sum::<usize>();
         tracing::debug!(
-            "[branchify-stats] done applied={applied} blocks={} insts={} elapsed={:?}",
+            "[branchify-stats] done applied={applied} cross_priority={cross_priority_applied} cross_group={cross_group_applied} cross_mux={cross_mux_applied} blocks={} insts={} elapsed={:?}",
             eu.blocks.len(),
             insts,
             stats_start.unwrap().elapsed()
@@ -2217,15 +2220,7 @@ fn apply_cross_block_priority_chain(
         .blocks
         .remove(&plan.block_id)
         .expect("priority chain target block must exist");
-    for block in eu.blocks.values_mut() {
-        block.instructions = block
-            .instructions
-            .iter()
-            .enumerate()
-            .filter(|(index, _)| !removed_locations.contains(&(block.id, *index)))
-            .map(|(_, instruction)| instruction.clone())
-            .collect();
-    }
+    remove_instructions_at_locations(eu, &removed_locations, plan.block_id);
 
     let outer_index = plan.muxes.len() - 1;
     let outer = &plan.muxes[outer_index];
@@ -2373,14 +2368,8 @@ fn find_cross_block_branchify_plan(
             // remains in the Mux block.  Such a prefix is not independently
             // movable: the local node still executes before the new branch.
             let condition_defs = closed_cross_block_condition_slice(condition_defs, block_id);
-            let head = block
-                .instructions
-                .iter()
-                .enumerate()
-                .take(mux_idx)
-                .map(|(_, instruction)| instruction.clone())
-                .collect::<Vec<_>>();
-            if moved_defs_insertion_index(&head, &condition_defs).is_none() {
+            if moved_defs_insertion_index(&block.instructions[..mux_idx], &condition_defs).is_none()
+            {
                 continue;
             }
             let mut true_seen = HashSet::default();
@@ -2422,17 +2411,16 @@ fn find_cross_block_branchify_plan(
                 .iter()
                 .map(|def| (def.block, def.index))
                 .collect::<HashSet<_>>();
+            let false_locations = false_defs
+                .iter()
+                .map(|def| (def.block, def.index))
+                .collect::<HashSet<_>>();
             if condition_locations
                 .intersection(&true_locations)
                 .next()
                 .is_some()
                 || condition_locations
-                    .intersection(
-                        &false_defs
-                            .iter()
-                            .map(|def| (def.block, def.index))
-                            .collect::<HashSet<_>>(),
-                    )
+                    .intersection(&false_locations)
                     .next()
                     .is_some()
             {
@@ -4123,15 +4111,7 @@ fn apply_cross_block_group_branchify(
         .blocks
         .remove(&plan.block_id)
         .expect("cross-group branchify target block must exist");
-    for block in eu.blocks.values_mut() {
-        block.instructions = block
-            .instructions
-            .iter()
-            .enumerate()
-            .filter(|(index, _)| !removed_locations.contains(&(block.id, *index)))
-            .map(|(_, instruction)| instruction.clone())
-            .collect();
-    }
+    remove_instructions_at_locations(eu, &removed_locations, plan.block_id);
 
     let mut head_insts = original
         .instructions
@@ -4247,15 +4227,7 @@ fn apply_cross_block_branchify(
         .blocks
         .remove(&plan.block_id)
         .expect("cross-block branchify target block must exist");
-    for block in eu.blocks.values_mut() {
-        block.instructions = block
-            .instructions
-            .iter()
-            .enumerate()
-            .filter(|(index, _)| !removed_locations.contains(&(block.id, *index)))
-            .map(|(_, instruction)| instruction.clone())
-            .collect();
-    }
+    remove_instructions_at_locations(eu, &removed_locations, plan.block_id);
 
     let mut head_insts = original
         .instructions
@@ -4330,6 +4302,32 @@ fn apply_cross_block_branchify(
     eu.blocks.insert(true_id, true_block);
     eu.blocks.insert(false_id, false_block);
     eu.blocks.insert(merge_id, merge_block);
+}
+
+fn remove_instructions_at_locations(
+    eu: &mut ExecutionUnit<RegionedAbsoluteAddr>,
+    removed: &HashSet<(BlockId, usize)>,
+    removed_block: BlockId,
+) {
+    let mut affected = removed
+        .iter()
+        .map(|&(block, _)| block)
+        .filter(|&block| block != removed_block)
+        .collect::<Vec<_>>();
+    affected.sort_unstable_by_key(|block| block.0);
+    affected.dedup();
+    for block_id in affected {
+        let block = eu
+            .blocks
+            .get_mut(&block_id)
+            .expect("moved cross-block definition must remain in the execution unit");
+        let mut index = 0usize;
+        block.instructions.retain(|_| {
+            let keep = !removed.contains(&(block_id, index));
+            index += 1;
+            keep
+        });
+    }
 }
 
 fn eliminate_controlled_join_muxes(

--- a/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_sparse_case_dispatch.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_sparse_case_dispatch.rs
@@ -129,19 +129,48 @@ impl ExecutionUnitPass for SparseCaseDispatchPass {
         let diagnostics = &options.optimize_options.diagnostics;
         let stats = diagnostics.branchify_stats;
         let mut applied = 0usize;
+        let Some(mut next_block) = eu
+            .blocks
+            .keys()
+            .map(|id| id.0)
+            .max()
+            .unwrap_or(0)
+            .checked_add(1)
+        else {
+            return;
+        };
+        let Some(mut next_register) = eu
+            .register_map
+            .keys()
+            .map(|id| id.0)
+            .max()
+            .unwrap_or(0)
+            .checked_add(1)
+        else {
+            return;
+        };
+        let mut candidate_blocks: Option<HashSet<BlockId>> = None;
         loop {
-            let plans = find_sparse_case_plans(eu, &self.stable_alias_class);
+            let plans =
+                find_sparse_case_plans(eu, &self.stable_alias_class, candidate_blocks.as_ref());
             if plans.is_empty() {
                 break;
             }
+            let mut next_candidates = HashSet::default();
             for plan in plans {
-                apply_sparse_case_plan(eu, plan);
+                next_candidates.extend(apply_sparse_case_plan(
+                    eu,
+                    plan,
+                    &mut next_block,
+                    &mut next_register,
+                ));
                 changed = true;
                 applied += 1;
                 if stats && applied.is_multiple_of(100) {
                     tracing::debug!("[branchify-stats] sparse_case applied={applied}");
                 }
             }
+            candidate_blocks = Some(next_candidates);
         }
         if stats || diagnostics.pass_timing {
             tracing::debug!("[branchify-stats] sparse_case done applied={applied}");
@@ -159,10 +188,16 @@ impl ExecutionUnitPass for SparseCaseDispatchPass {
 fn find_sparse_case_plans(
     eu: &ExecutionUnit<RegionedAbsoluteAddr>,
     stable_alias_class: &HashMap<AbsoluteAddr, AbsoluteAddr>,
+    candidate_blocks: Option<&HashSet<BlockId>>,
 ) -> Vec<SparseCasePlan> {
     let use_counts = count_uses(eu);
     let def_sites = definition_sites(eu);
-    let mut block_ids = eu.blocks.keys().copied().collect::<Vec<_>>();
+    let mut block_ids = eu
+        .blocks
+        .keys()
+        .copied()
+        .filter(|block| candidate_blocks.is_none_or(|candidates| candidates.contains(block)))
+        .collect::<Vec<_>>();
     block_ids.sort_unstable();
     let mut planned_blocks = HashSet::default();
     let mut plans = Vec::new();
@@ -1567,8 +1602,16 @@ fn runtime_instruction_cost(
     }
 }
 
-fn apply_sparse_case_plan(eu: &mut ExecutionUnit<RegionedAbsoluteAddr>, plan: SparseCasePlan) {
-    let original = eu.blocks[&plan.block_id].clone();
+fn apply_sparse_case_plan(
+    eu: &mut ExecutionUnit<RegionedAbsoluteAddr>,
+    plan: SparseCasePlan,
+    next_block: &mut usize,
+    next_register: &mut usize,
+) -> Vec<BlockId> {
+    let original = eu
+        .blocks
+        .remove(&plan.block_id)
+        .expect("sparse case plan must reference an existing block");
     let chain_indices = plan
         .stages
         .iter()
@@ -1583,14 +1626,12 @@ fn apply_sparse_case_plan(eu: &mut ExecutionUnit<RegionedAbsoluteAddr>, plan: Sp
     removed.extend(plan.dead_defs.iter().copied());
     removed.extend(sink_indices);
 
-    let mut next_block = eu.blocks.keys().map(|id| id.0).max().unwrap_or(0) + 1;
-    let mut next_register = eu.register_map.keys().map(|id| id.0).max().unwrap_or(0) + 1;
-    let merge_id = fresh_block(&mut next_block);
+    let merge_id = fresh_block(next_block);
 
     let mut generated = HashMap::<BlockId, BasicBlock<RegionedAbsoluteAddr>>::default();
     let mut arm_blocks = HashMap::<usize, BlockId>::default();
     for &arm_index in &plan.reachable_arms {
-        let id = fresh_block(&mut next_block);
+        let id = fresh_block(next_block);
         let instructions = plan.arms[arm_index]
             .sink_defs
             .iter()
@@ -1644,8 +1685,8 @@ fn apply_sparse_case_plan(eu: &mut ExecutionUnit<RegionedAbsoluteAddr>, plan: Sp
             &arm_blocks,
             plan.selector,
             &selector_type,
-            &mut next_block,
-            &mut next_register,
+            next_block,
+            next_register,
             &mut eu.register_map,
             &mut generated,
         );
@@ -1681,9 +1722,13 @@ fn apply_sparse_case_plan(eu: &mut ExecutionUnit<RegionedAbsoluteAddr>, plan: Sp
         terminator: original.terminator,
     };
 
+    let mut touched = generated.keys().copied().collect::<Vec<_>>();
+    touched.push(plan.block_id);
+    touched.push(merge_id);
     eu.blocks.insert(plan.block_id, head);
     eu.blocks.insert(merge_id, merge);
     eu.blocks.extend(generated);
+    touched
 }
 
 fn prune_dead_pure_instructions(eu: &mut ExecutionUnit<RegionedAbsoluteAddr>) {

--- a/crates/celox-sir-opt/src/optimizer/passes/dataflow/pass_bit_extract_peephole.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/dataflow/pass_bit_extract_peephole.rs
@@ -163,8 +163,8 @@ fn optimize_bit_extracts(
 
     // For each replacement, decrement use counts for the operands we're removing
     // and only mark instructions as dead if their result has no remaining uses.
-    let mut dead_set = std::collections::HashSet::new();
-    let mut replaced_set = std::collections::HashSet::new();
+    let mut dead_set = crate::HashSet::default();
+    let mut replaced_set = crate::HashSet::default();
 
     for repl in &replacements {
         replaced_set.insert(repl.and_idx);

--- a/crates/celox-sir-opt/src/optimizer/passes/memory/block_opt.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/memory/block_opt.rs
@@ -382,7 +382,7 @@ fn coalesce_static_stores<A: Clone + std::fmt::Debug + PartialEq + Ord + std::ha
         return false;
     }
 
-    let mut replaced_indices = std::collections::HashSet::new();
+    let mut replaced_indices = HashSet::default();
     let mut insertions: HashMap<usize, Vec<SIRInstruction<A>>> = HashMap::default();
 
     // Pre-index loads by address for efficient safety checks.
@@ -460,7 +460,7 @@ fn coalesce_static_stores<A: Clone + std::fmt::Debug + PartialEq + Ord + std::ha
                     })
                     .or_insert(i);
             }
-            let keep: std::collections::HashSet<usize> = best.into_values().collect();
+            let keep: crate::HashSet<usize> = best.into_values().collect();
             let mut i = 0;
             details.retain(|_| {
                 let k = keep.contains(&i);

--- a/crates/celox-sir-opt/src/optimizer/passes/memory/pass_eliminate_working_round_trip.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/memory/pass_eliminate_working_round_trip.rs
@@ -17,7 +17,7 @@ pub fn eliminate_working_round_trip(
     eu: &mut ExecutionUnit<RegionedAbsoluteAddr>,
     _eu_boundary_blocks: &[BlockId],
 ) {
-    use std::collections::HashMap;
+    use crate::HashMap;
 
     // Phase 1: Scan — collect info about each WORKING variable
     struct VarInfo {
@@ -33,10 +33,10 @@ pub fn eliminate_working_round_trip(
         invalid_apply: bool,
     }
 
-    let mut vars: HashMap<AbsoluteAddr, VarInfo> = HashMap::new();
-    let mut sparse_vars: HashMap<AbsoluteAddr, SparseVarInfo> = HashMap::new();
-    let mut working_loads = std::collections::HashSet::new();
-    let mut working_stores = std::collections::HashSet::new();
+    let mut vars: HashMap<AbsoluteAddr, VarInfo> = HashMap::default();
+    let mut sparse_vars: HashMap<AbsoluteAddr, SparseVarInfo> = HashMap::default();
+    let mut working_loads = crate::HashSet::default();
+    let mut working_stores = crate::HashSet::default();
 
     for (&bid, block) in &eu.blocks {
         for (ii, inst) in block.instructions.iter().enumerate() {
@@ -113,7 +113,7 @@ pub fn eliminate_working_round_trip(
     }
 
     // Phase 2: Determine eligible variables
-    let eligible: std::collections::HashSet<AbsoluteAddr> = vars
+    let eligible: crate::HashSet<AbsoluteAddr> = vars
         .iter()
         .filter(|(abs, info)| {
             // A seeded slot may retain its old value on paths without a
@@ -140,7 +140,7 @@ pub fn eliminate_working_round_trip(
         .collect();
 
     let unsafe_after_store = super::commit_ops::direct_stable_store_hazards(eu);
-    let eligible: std::collections::HashSet<AbsoluteAddr> = eligible
+    let eligible: crate::HashSet<AbsoluteAddr> = eligible
         .into_iter()
         .filter(|addr| !unsafe_after_store.contains_addr(*addr))
         .collect();
@@ -148,7 +148,7 @@ pub fn eliminate_working_round_trip(
     // Sparse state has no per-EU seed: every producer writes the same pending
     // value in merged event order.  Therefore producer count is not a safety
     // condition; only an observation/competing write before the tail Commit is.
-    let sparse_eligible: std::collections::HashSet<AbsoluteAddr> = sparse_vars
+    let sparse_eligible: crate::HashSet<AbsoluteAddr> = sparse_vars
         .iter()
         .filter(|(addr, info)| {
             info.has_store

--- a/crates/celox-sir-opt/src/optimizer/passes/memory/pass_split_coalesced_stores.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/memory/pass_split_coalesced_stores.rs
@@ -6,9 +6,9 @@
 
 use super::pass_manager::ExecutionUnitPass;
 use super::sir_analysis::{UseSite, collect_uses};
+use crate::HashMap;
 use crate::PassOptions;
 use crate::ir::*;
-use std::collections::HashMap;
 
 pub(in crate::optimizer) struct SplitCoalescedStoresPass {
     pub max_store_width: usize,
@@ -36,7 +36,7 @@ fn split_coalesced_stores(eu: &mut ExecutionUnit<RegionedAbsoluteAddr>, max_stor
         };
 
         // Phase 1: Build def position map — O(n)
-        let mut def_pos: HashMap<RegisterId, usize> = HashMap::new();
+        let mut def_pos: HashMap<RegisterId, usize> = HashMap::default();
         for (i, inst) in block.instructions.iter().enumerate() {
             if let Some(d) = inst_def(inst) {
                 def_pos.insert(d, i);
@@ -181,7 +181,7 @@ fn split_coalesced_stores(eu: &mut ExecutionUnit<RegionedAbsoluteAddr>, max_stor
         let block = eu.blocks.get_mut(&bid).unwrap();
 
         // Collect indices to skip (original Store + Concat)
-        let mut skip: std::collections::HashSet<usize> = std::collections::HashSet::new();
+        let mut skip: crate::HashSet<usize> = crate::HashSet::default();
         for plan in &plans {
             skip.insert(plan.store_idx);
             if plan.remove_concat {
@@ -191,7 +191,7 @@ fn split_coalesced_stores(eu: &mut ExecutionUnit<RegionedAbsoluteAddr>, max_stor
 
         // Collect insertions by position: after index i, insert these instructions
         let mut insert_map: HashMap<usize, Vec<SIRInstruction<RegionedAbsoluteAddr>>> =
-            HashMap::new();
+            HashMap::default();
         for plan in plans {
             for (after_idx, insts) in plan.insertions {
                 insert_map.entry(after_idx).or_default().extend(insts);

--- a/crates/celox-sir-opt/src/optimizer/pipeline.rs
+++ b/crates/celox-sir-opt/src/optimizer/pipeline.rs
@@ -12,9 +12,11 @@ mod runner;
 use pass_manager::ExecutionUnitPassManager;
 
 pub(crate) fn run(program: &mut OptimizationContext<'_>, options: &PassOptions) {
-    // TailCallSplit is a backend selector, not a SIR transform. Avoid walking,
-    // hashing, and cloning the whole program when no actual SIR pass is active.
+    // TailCallSplit is a backend selector, not a SIR transform. Skip the
+    // optional hashing/cloning pipeline when no actual SIR pass is active,
+    // but retain correctness-required canonicalization.
     if !options.optimize_options.any_enabled() {
+        runner::canonicalize_required(program);
         return;
     }
     runner::optimize_with_options(
@@ -24,4 +26,77 @@ pub(crate) fn run(program: &mut OptimizationContext<'_>, options: &PassOptions) 
         &options.optimize_options,
         options.preserve_element_storage_layout,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{OptLevel, OptimizeOptions};
+    use celox_design::StateObjectId;
+
+    fn unit(
+        instructions: Vec<SIRInstruction<RegionedAbsoluteAddr>>,
+    ) -> ExecutionUnit<RegionedAbsoluteAddr> {
+        let mut blocks = crate::HashMap::default();
+        blocks.insert(
+            BlockId(0),
+            BasicBlock {
+                id: BlockId(0),
+                params: Vec::new(),
+                instructions,
+                terminator: SIRTerminator::Return,
+            },
+        );
+        ExecutionUnit {
+            blocks,
+            entry_block_id: BlockId(0),
+            register_map: crate::HashMap::default(),
+        }
+    }
+
+    #[test]
+    fn o0_keeps_sparse_commit_after_all_event_evaluators() {
+        let event = AbsoluteAddr {
+            instance_id: InstanceId(0),
+            var_id: StateObjectId(0),
+        };
+        let sparse = RegionedAbsoluteAddr::from_absolute_addr(SPARSE_WORKING_REGION, event);
+        let stable = RegionedAbsoluteAddr::from_absolute_addr(STABLE_REGION, event);
+        let commit = SIRInstruction::Commit(sparse, stable, SIROffset::Static(0), 8, Vec::new());
+        let mut sir = SirProgram {
+            eval_comb: Vec::new(),
+            eval_apply_ffs: [(event, vec![unit(vec![commit.clone()]), unit(Vec::new())])]
+                .into_iter()
+                .collect(),
+            eval_comb_apply_ffs: crate::HashMap::default(),
+            eval_only_ffs: crate::HashMap::default(),
+            apply_ffs: crate::HashMap::default(),
+        };
+        let design = celox_design::ElaboratedDesign::default();
+        let runtime_schema = celox_design::RuntimeSchema::default();
+        let mut layout_requirements = celox_state_layout::LayoutRequirements::default();
+        let mut context = OptimizationContext {
+            sir: &mut sir,
+            design: &design,
+            runtime_schema: &runtime_schema,
+            layout_requirements: &mut layout_requirements,
+        };
+
+        run(
+            &mut context,
+            &PassOptions {
+                optimize_options: OptimizeOptions::new(OptLevel::O0),
+                ..PassOptions::default()
+            },
+        );
+
+        let units = &context.sir.eval_apply_ffs[&event];
+        assert_eq!(units.len(), 3);
+        assert!(units[..2].iter().all(|unit| {
+            unit.blocks
+                .values()
+                .all(|block| !block.instructions.contains(&commit))
+        }));
+        assert_eq!(units[2].blocks[&BlockId(0)].instructions, vec![commit]);
+    }
 }

--- a/crates/celox-sir-opt/src/optimizer/pipeline.rs
+++ b/crates/celox-sir-opt/src/optimizer/pipeline.rs
@@ -12,6 +12,11 @@ mod runner;
 use pass_manager::ExecutionUnitPassManager;
 
 pub(crate) fn run(program: &mut OptimizationContext<'_>, options: &PassOptions) {
+    // TailCallSplit is a backend selector, not a SIR transform. Avoid walking,
+    // hashing, and cloning the whole program when no actual SIR pass is active.
+    if !options.optimize_options.any_enabled() {
+        return;
+    }
     runner::optimize_with_options(
         program,
         options.max_inflight_loads,

--- a/crates/celox-sir-opt/src/optimizer/pipeline/cache.rs
+++ b/crates/celox-sir-opt/src/optimizer/pipeline/cache.rs
@@ -125,9 +125,7 @@ pub(super) fn optimize_unit_groups_cached(
             let units = groups
                 .get_mut(&class.representative)
                 .expect("equivalence-class representative must exist");
-            for eu in units {
-                passes.run(eu, options);
-            }
+            passes.run_parallel(units, options);
         }
         if class.aliases.is_empty() {
             continue;

--- a/crates/celox-sir-opt/src/optimizer/pipeline/pass_manager.rs
+++ b/crates/celox-sir-opt/src/optimizer/pipeline/pass_manager.rs
@@ -3,7 +3,7 @@ use crate::PassOptions;
 use crate::ir::{AbsoluteAddr, ExecutionUnit, RegionedAbsoluteAddr, SIRInstruction, SIROffset};
 use std::sync::Arc;
 
-pub(in crate::optimizer) trait ExecutionUnitPass {
+pub(in crate::optimizer) trait ExecutionUnitPass: Send + Sync {
     fn name(&self) -> &'static str;
     fn run(&self, eu: &mut ExecutionUnit<RegionedAbsoluteAddr>, options: &PassOptions);
 }
@@ -79,6 +79,78 @@ impl ExecutionUnitPassManager {
                 panic!("after SIR pass pipeline: {error}");
             }
         }
+    }
+
+    /// Run the same ordered pipeline over independent execution units.
+    ///
+    /// Units are owned by workers while being optimized and restored to their
+    /// original order afterward.  This keeps event semantics deterministic;
+    /// only unrelated per-unit work overlaps.
+    pub(in crate::optimizer) fn run_parallel(
+        &self,
+        units: &mut Vec<ExecutionUnit<RegionedAbsoluteAddr>>,
+        options: &PassOptions,
+    ) {
+        const MAX_PARALLEL_UNITS: usize = 4;
+
+        let worker_count = units.len().min(
+            std::thread::available_parallelism()
+                .map_or(1, usize::from)
+                .min(MAX_PARALLEL_UNITS),
+        );
+        if worker_count <= 1 {
+            for unit in units {
+                self.run(unit, options);
+            }
+            return;
+        }
+
+        let mut pending = std::mem::take(units)
+            .into_iter()
+            .enumerate()
+            .map(|(index, unit)| {
+                let work = unit.blocks.len()
+                    + unit
+                        .blocks
+                        .values()
+                        .map(|block| block.instructions.len())
+                        .sum::<usize>();
+                (work, index, unit)
+            })
+            .collect::<Vec<_>>();
+        // Workers pop the largest units first to keep the long tail bounded.
+        pending.sort_unstable_by_key(|(work, index, _)| (*work, *index));
+        let pending = std::sync::Mutex::new(pending);
+        let completed = std::sync::Mutex::new(Vec::with_capacity(units.capacity()));
+
+        std::thread::scope(|scope| {
+            for _ in 0..worker_count {
+                let pending = &pending;
+                let completed = &completed;
+                scope.spawn(move || {
+                    loop {
+                        let task = pending
+                            .lock()
+                            .expect("SIR optimization work queue must not be poisoned")
+                            .pop();
+                        let Some((_, index, mut unit)) = task else {
+                            break;
+                        };
+                        self.run(&mut unit, options);
+                        completed
+                            .lock()
+                            .expect("SIR optimization result queue must not be poisoned")
+                            .push((index, unit));
+                    }
+                });
+            }
+        });
+
+        let mut completed = completed
+            .into_inner()
+            .expect("SIR optimization result queue must not be poisoned");
+        completed.sort_unstable_by_key(|(index, _)| *index);
+        units.extend(completed.into_iter().map(|(_, unit)| unit));
     }
 }
 

--- a/crates/celox-sir-opt/src/optimizer/pipeline/runner.rs
+++ b/crates/celox-sir-opt/src/optimizer/pipeline/runner.rs
@@ -79,6 +79,14 @@ fn move_sparse_commits_to_event_tail(
     }
 }
 
+pub(super) fn canonicalize_required(program: &mut OptimizationContext<'_>) {
+    // Sparse next-state data must stay invisible until every evaluator for the
+    // event has sampled STABLE. Keep the commit in a final EU even at O0,
+    // where all optional SIR transforms are disabled.
+    move_sparse_commits_to_event_tail(&mut program.sir.eval_apply_ffs);
+    move_sparse_commits_to_event_tail(&mut program.sir.eval_comb_apply_ffs);
+}
+
 pub(super) fn optimize_with_options(
     program: &mut OptimizationContext,
     max_inflight_loads: usize,
@@ -130,11 +138,7 @@ pub(super) fn optimize_with_options(
     // Helper closure to check pass enablement.
     let on = |pass: SirPass| opt.is_enabled(pass);
 
-    // Sparse next-state data must stay invisible until every evaluator for the
-    // event has sampled STABLE.  Keep the commit in the same unified generated
-    // function, but place it in a final EU after all evaluator EUs.
-    move_sparse_commits_to_event_tail(&mut program.sir.eval_apply_ffs);
-    move_sparse_commits_to_event_tail(&mut program.sir.eval_comb_apply_ffs);
+    canonicalize_required(program);
 
     // 1. Unified Case (Fast Path): Full optimizations are safe.
     let phase_start = timing.then(crate::timing::now);

--- a/crates/celox-sir-opt/src/optimizer/pipeline/runner.rs
+++ b/crates/celox-sir-opt/src/optimizer/pipeline/runner.rs
@@ -165,46 +165,60 @@ pub(super) fn optimize_with_options(
     );
     let ff_passes = pipeline_builder.fused_ff(program);
     let comb_ff_passes = pipeline_builder.fused_comb_ff(program);
+    let comb_ff_late_passes = pipeline_builder.fused_comb_ff_late(program);
+    let ff_post_passes = pipeline_builder.fused_ff_post();
+    let comb_passes = pipeline_builder.combinational(program);
 
     let ff_eu_count: usize = program.sir.eval_apply_ffs.values().map(Vec::len).sum();
     let comb_ff_eu_count: usize = program.sir.eval_comb_apply_ffs.values().map(Vec::len).sum();
     let eu_count = ff_eu_count + comb_ff_eu_count;
-    optimize_unit_groups_cached(&mut program.sir.eval_apply_ffs, &ff_passes, &options);
-    optimize_unit_groups_cached(
-        &mut program.sir.eval_comb_apply_ffs,
-        &comb_ff_passes,
-        &options,
-    );
+    let comb_phase_start = timing.then(crate::timing::now);
+    let comb_eu_count = program.sir.eval_comb.len();
+    let sir = &mut *program.sir;
+    std::thread::scope(|scope| {
+        let comb_worker = scope.spawn(|| {
+            for (i, eu) in sir.eval_comb.iter_mut().enumerate() {
+                if timing {
+                    let inst_count: usize = eu.blocks.values().map(|b| b.instructions.len()).sum();
+                    let block_count = eu.blocks.len();
+                    tracing::debug!(
+                        "[phase] eval_comb eu[{i}]: blocks={block_count} insts={inst_count}"
+                    );
+                }
+                comb_passes.run(eu, &options);
+            }
+        });
 
-    // The late comb pipeline must start from the CFG produced by the complete
-    // initial pipeline. Keep it in the same exact-equivalence cache: clock
-    // and reset triggers commonly share the complete fused body.
-    let comb_ff_late_passes = pipeline_builder.fused_comb_ff_late(program);
-    optimize_unit_groups_cached(
-        &mut program.sir.eval_comb_apply_ffs,
-        &comb_ff_late_passes,
-        &options,
-    );
+        optimize_unit_groups_cached(&mut sir.eval_apply_ffs, &ff_passes, &options);
+        optimize_unit_groups_cached(&mut sir.eval_comb_apply_ffs, &comb_ff_passes, &options);
 
-    optimize_unified_commit_groups(
-        &mut program.sir.eval_apply_ffs,
-        on(SirPass::CommitSinking),
-        on(SirPass::InlineCommitForwarding),
-    );
-    optimize_unified_commit_groups(
-        &mut program.sir.eval_comb_apply_ffs,
-        on(SirPass::CommitSinking),
-        on(SirPass::InlineCommitForwarding),
-    );
-    let ff_post_passes = pipeline_builder.fused_ff_post();
-    optimize_unit_groups_cached(&mut program.sir.eval_apply_ffs, &ff_post_passes, &options);
-    optimize_unit_groups_cached(
-        &mut program.sir.eval_comb_apply_ffs,
-        &ff_post_passes,
-        &options,
-    );
+        // The late comb pipeline must start from the CFG produced by the complete
+        // initial pipeline. Keep it in the same exact-equivalence cache: clock
+        // and reset triggers commonly share the complete fused body.
+        optimize_unit_groups_cached(&mut sir.eval_comb_apply_ffs, &comb_ff_late_passes, &options);
+
+        optimize_unified_commit_groups(
+            &mut sir.eval_apply_ffs,
+            on(SirPass::CommitSinking),
+            on(SirPass::InlineCommitForwarding),
+        );
+        optimize_unified_commit_groups(
+            &mut sir.eval_comb_apply_ffs,
+            on(SirPass::CommitSinking),
+            on(SirPass::InlineCommitForwarding),
+        );
+        optimize_unit_groups_cached(&mut sir.eval_apply_ffs, &ff_post_passes, &options);
+        optimize_unit_groups_cached(&mut sir.eval_comb_apply_ffs, &ff_post_passes, &options);
+
+        comb_worker
+            .join()
+            .expect("combinational SIR optimization worker must not panic");
+    });
     if let Some(s) = phase_start {
         tracing::debug!("[phase] eval_apply_ffs ({eu_count} EUs): {:?}", s.elapsed());
+    }
+    if let Some(s) = comb_phase_start {
+        tracing::debug!("[phase] eval_comb ({comb_eu_count} EUs): {:?}", s.elapsed());
     }
 
     // 2. Logic-Only Cache (Split Path Phase 1):
@@ -230,23 +244,6 @@ pub(super) fn optimize_with_options(
     }
     if let Some(s) = phase_start {
         tracing::debug!("[phase] apply_ffs ({eu_count} EUs): {:?}", s.elapsed());
-    }
-
-    // 4. Combinational Blocks:
-    let phase_start = timing.then(crate::timing::now);
-    let comb_passes = pipeline_builder.combinational(program);
-
-    let eu_count = program.sir.eval_comb.len();
-    for (i, eu) in program.sir.eval_comb.iter_mut().enumerate() {
-        if timing {
-            let inst_count: usize = eu.blocks.values().map(|b| b.instructions.len()).sum();
-            let block_count = eu.blocks.len();
-            tracing::debug!("[phase] eval_comb eu[{i}]: blocks={block_count} insts={inst_count}");
-        }
-        comb_passes.run(eu, &options);
-    }
-    if let Some(s) = phase_start {
-        tracing::debug!("[phase] eval_comb ({eu_count} EUs): {:?}", s.elapsed());
     }
 
     super::late::optimize_late_comb(program, opt, &options, &unpacked_element_widths);

--- a/crates/celox-sir-opt/src/policy.rs
+++ b/crates/celox-sir-opt/src/policy.rs
@@ -273,7 +273,7 @@ impl Default for PassOptions {
 #[cfg(test)]
 mod tests {
     use super::{OptLevel, OptimizeOptions, SirPass};
-    use std::collections::HashSet;
+    use crate::HashSet;
 
     #[test]
     fn every_pass_name_round_trips_and_is_unique() {

--- a/crates/celox-ts-gen/Cargo.toml
+++ b/crates/celox-ts-gen/Cargo.toml
@@ -9,6 +9,7 @@ description.workspace = true
 edition.workspace     = true
 
 [dependencies]
+fxhash          = { workspace = true }
 serde           = { workspace = true }
 serde_json      = { workspace = true }
 veryl-analyzer  = { workspace = true }

--- a/crates/celox-ts-gen/src/generator.rs
+++ b/crates/celox-ts-gen/src/generator.rs
@@ -1,5 +1,5 @@
+use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use serde::Serialize;
-use std::collections::{HashMap, HashSet};
 use veryl_analyzer::ir::{Component, Declaration, Ir, Module, TypeKind, VarId, VarKind};
 use veryl_analyzer::symbol::Affiliation;
 use veryl_parser::resource_table;
@@ -307,10 +307,10 @@ fn extract_instances(module: &Module) -> Vec<InstanceInfo> {
 /// under a synthetic parent entry with an `interface` map so that the
 /// TypeScript DUT can expose them as `dut.bus.data`.
 fn ports_to_json(ports: &[PortInfo]) -> HashMap<String, JsonPortInfo> {
-    let mut result: HashMap<String, JsonPortInfo> = HashMap::new();
+    let mut result: HashMap<String, JsonPortInfo> = HashMap::default();
     // Accumulate interface members for each parent name separately so we can
     // insert the parent entry once at the end.
-    let mut iface_maps: HashMap<String, HashMap<String, JsonPortInfo>> = HashMap::new();
+    let mut iface_maps: HashMap<String, HashMap<String, JsonPortInfo>> = HashMap::default();
 
     for p in ports {
         let json = JsonPortInfo {
@@ -1439,7 +1439,7 @@ module Top (
         // No port key collisions from scoped vars
         let port_names: Vec<&String> = top.ports.keys().collect();
         let unique_count = {
-            let mut s = std::collections::HashSet::new();
+            let mut s = HashSet::default();
             port_names.iter().filter(|n| s.insert(n.as_str())).count()
         };
         assert_eq!(port_names.len(), unique_count, "no duplicate port keys");

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -148,14 +148,17 @@ fn prepare_merged_sir(
     first_ff_unit: Option<usize>,
     diagnostics: &crate::optimizer::SirDiagnostics,
 ) -> Result<crate::ir::ExecutionUnit<crate::ir::RegionedAbsoluteAddr>, SimulatorError> {
-    for (unit_index, unit) in units.iter().enumerate() {
-        if let Err(error) = unit.verify_result() {
-            return Err(codegen_err(CodegenError::SirVerification {
-                phase: format!(
-                    "invalid SIR before x86 source-unit merge: {label} source unit {unit_index}"
-                ),
-                source: error,
-            }));
+    let verify_enabled = cfg!(debug_assertions) || diagnostics.verify_boundaries;
+    if verify_enabled {
+        for (unit_index, unit) in units.iter().enumerate() {
+            if let Err(error) = unit.verify_result() {
+                return Err(codegen_err(CodegenError::SirVerification {
+                    phase: format!(
+                        "invalid SIR before x86 source-unit merge: {label} source unit {unit_index}"
+                    ),
+                    source: error,
+                }));
+            }
         }
     }
 
@@ -163,12 +166,16 @@ fn prepare_merged_sir(
     let boundaries = merge_provenance.unit_entries[1..].to_vec();
     let verify = |eu: &crate::ir::ExecutionUnit<crate::ir::RegionedAbsoluteAddr>,
                   phase: &'static str| {
-        eu.verify_result().map_err(|source| {
-            codegen_err(CodegenError::SirVerification {
-                phase: phase.to_string(),
-                source,
+        if verify_enabled {
+            eu.verify_result().map_err(|source| {
+                codegen_err(CodegenError::SirVerification {
+                    phase: phase.to_string(),
+                    source,
+                })
             })
-        })
+        } else {
+            Ok(())
+        }
     };
 
     verify(&sir_eu, "before x86 merged-SIR optimization")?;

--- a/crates/celox/src/component.rs
+++ b/crates/celox/src/component.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use crate::{HashMap, HashSet};
 
 use celox_testbench::{
     CompiledExpr, ComponentLibrary, ComponentParameterValue, ExecutableComponentBinding,
@@ -188,7 +188,7 @@ fn validate_manifest(
     manifest: &veryl_metadata::ComponentManifest,
 ) -> Result<(), String> {
     let has_ports = !(manifest.ports.is_empty() && manifest.groups.is_empty());
-    let mut bound = std::collections::HashSet::new();
+    let mut bound = HashSet::default();
     for connection in &descriptor.connections {
         if !has_ports {
             break;
@@ -329,7 +329,7 @@ impl ComponentRuntime {
         self.active_reset_event = None;
         let mut initialized = Vec::with_capacity(descriptors.len());
         let mut initial_writes = Vec::new();
-        let mut driven_outputs = HashMap::<SignalRef, Vec<ComponentOutputDriver>>::new();
+        let mut driven_outputs = HashMap::<SignalRef, Vec<ComponentOutputDriver>>::default();
         let libraries: HashMap<_, _> = libraries
             .iter()
             .map(|library| (library.export.as_str(), library))

--- a/crates/celox/src/component/loader.rs
+++ b/crates/celox/src/component/loader.rs
@@ -5,7 +5,7 @@
 //! registry that bypasses dlopen — used by tests and available for builtin
 //! components.
 
-use std::collections::HashMap;
+use crate::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex};
 use thiserror::Error;
@@ -160,7 +160,7 @@ pub(crate) fn library_export_names(path: &Path) -> Vec<String> {
 /// The `&'static` in the value is sound because registered vtables either
 /// live in a leaked (never-unloaded) library or in guest `static` tables.
 static STATIC_REGISTRY: LazyLock<Mutex<HashMap<String, &'static sys::VrlComponentVTable>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+    LazyLock::new(|| Mutex::new(HashMap::default()));
 
 pub fn register_static_component(name: &str, vtable: &'static sys::VrlComponentVTable) {
     STATIC_REGISTRY
@@ -171,7 +171,7 @@ pub fn register_static_component(name: &str, vtable: &'static sys::VrlComponentV
 
 /// Per-type manifest JSON registered alongside static components.
 static STATIC_MANIFESTS: LazyLock<Mutex<HashMap<String, String>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+    LazyLock::new(|| Mutex::new(HashMap::default()));
 
 pub fn register_static_manifest(name: &str, json: &str) {
     STATIC_MANIFESTS
@@ -277,7 +277,7 @@ pub fn lookup_component(
 #[cfg(not(target_family = "wasm"))]
 fn get_library(path: &Path) -> Result<&'static libloading::Library, ComponentError> {
     static LIBRARIES: LazyLock<Mutex<HashMap<PathBuf, &'static libloading::Library>>> =
-        LazyLock::new(|| Mutex::new(HashMap::new()));
+        LazyLock::new(|| Mutex::new(HashMap::default()));
 
     let mut libraries = LIBRARIES.lock().unwrap();
     match libraries.get(path) {

--- a/crates/celox/src/component/wasm.rs
+++ b/crates/celox/src/component/wasm.rs
@@ -8,9 +8,9 @@
 //! duration of each guest call; outside a call (probe instances, guest
 //! destructors) the imports see NULL and degrade to no-ops.
 
+use crate::HashMap;
 use crate::component::host::{HostContext, HostValue, METHOD_RET_WORDS};
 use crate::component::loader::{ComponentBackend, ComponentError};
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, Mutex};
 use veryl_component_sys as sys;
@@ -102,7 +102,7 @@ pub struct WasmLibrary {
 
 pub fn get_wasm_library(path: &Path) -> Result<Arc<WasmLibrary>, ComponentError> {
     static LIBRARIES: LazyLock<Mutex<HashMap<PathBuf, Arc<WasmLibrary>>>> =
-        LazyLock::new(|| Mutex::new(HashMap::new()));
+        LazyLock::new(|| Mutex::new(HashMap::default()));
 
     let mut libraries = LIBRARIES.lock().unwrap();
     if let Some(library) = libraries.get(path) {

--- a/crates/celox/src/diagnostics.rs
+++ b/crates/celox/src/diagnostics.rs
@@ -11,7 +11,7 @@ pub struct RuntimeDiagnostics {
 #[cfg(feature = "host-runtime")]
 mod host {
     use super::RuntimeDiagnostics;
-    use std::collections::HashMap;
+    use crate::HashMap;
     use std::ffi::{OsStr, OsString};
 
     /// Complete explicit diagnostics configuration for a simulator build.

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -451,12 +451,12 @@ impl OptimizedSir {
     /// Collect the set of `AbsoluteAddr` values that are accessed in the working
     /// region (region != STABLE). These are the only variables that need working
     /// region space.
-    pub fn collect_working_region_addrs(&self) -> std::collections::HashSet<AbsoluteAddr> {
-        let mut addrs = std::collections::HashSet::new();
+    pub fn collect_working_region_addrs(&self) -> crate::HashSet<AbsoluteAddr> {
+        let mut addrs = crate::HashSet::default();
 
         let scan_units =
             |units: &HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
-             addrs: &mut std::collections::HashSet<AbsoluteAddr>| {
+             addrs: &mut crate::HashSet<AbsoluteAddr>| {
                 for eu_list in units.values() {
                     for eu in eu_list {
                         for block in eu.blocks.values() {
@@ -491,8 +491,8 @@ impl OptimizedSir {
         addrs
     }
 
-    pub fn collect_sparse_working_region_addrs(&self) -> std::collections::HashSet<AbsoluteAddr> {
-        let mut addrs = std::collections::HashSet::new();
+    pub fn collect_sparse_working_region_addrs(&self) -> crate::HashSet<AbsoluteAddr> {
+        let mut addrs = crate::HashSet::default();
         for units in self
             .sir
             .eval_apply_ffs

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -52,6 +52,11 @@ mod host_api {
     pub use crate::debug::CompilationTraceResult;
     pub use crate::diagnostics::DiagnosticsOptions;
     pub use crate::simulation::Simulation;
+    #[cfg(any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    ))]
+    pub use crate::simulator::NativeCompilation;
     pub use crate::simulator::{
         DeadStorePolicy, InstanceHierarchy, NamedEvent, NamedSignal, RuntimeEvent,
         RuntimeEventDrain, RuntimeFormatContext, Simulator, SimulatorBuilder, SimulatorOptions,

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -414,10 +414,14 @@ pub fn parse(
         t.pre_optimized_sir = Some(program.clone());
     }
 
-    timed_phase!(
-        "verify_sir_before_optimize",
-        verify_program_sir(&program.sir, &program.runtime, "before optimization")
-    )?;
+    let verify_boundaries =
+        cfg!(debug_assertions) || optimize_options.diagnostics.verify_boundaries;
+    if verify_boundaries {
+        timed_phase!(
+            "verify_sir_before_optimize",
+            verify_program_sir(&program.sir, &program.runtime, "before optimization")
+        )?;
+    }
 
     // Always run the SIR pipeline so required canonicalization and explicit
     // per-pass overrides are applied consistently. Concrete backend planning
@@ -433,10 +437,12 @@ pub fn parse(
             crate::optimizer::optimize(&mut program, four_state, optimize_options)
         }
     });
-    timed_phase!(
-        "verify_sir_after_optimize",
-        verify_program_sir(&program.sir, &program.runtime, "after optimization")
-    )?;
+    if verify_boundaries {
+        timed_phase!(
+            "verify_sir_after_optimize",
+            verify_program_sir(&program.sir, &program.runtime, "after optimization")
+        )?;
+    }
 
     let program = program.into_optimized();
 

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -1,6 +1,14 @@
 mod builder;
 mod error;
 
+#[cfg(all(
+    feature = "host-runtime",
+    any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    )
+))]
+pub use builder::NativeCompilation;
 pub use builder::compile_to_sir;
 #[cfg(feature = "host-runtime")]
 pub use builder::{DeadStorePolicy, SimulatorBuilder, SimulatorOptions};

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -419,6 +419,69 @@ mod host {
         pub dead_store_policy: DeadStorePolicy,
     }
 
+    /// A fully code-generated native simulator that has not run any simulator
+    /// initialization yet.
+    ///
+    /// Keeping compilation separate from initialization lets compiler-only
+    /// clients stop after native code generation without applying initial
+    /// values or executing the first combinational settle.
+    #[cfg(any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    ))]
+    #[must_use]
+    pub struct NativeCompilation {
+        backend: crate::backend::native::NativeBackend,
+        program: LaidOutProgram,
+        warnings: Vec<CompilationWarning>,
+        options: SimulatorOptions,
+        vcd_path: Option<std::path::PathBuf>,
+    }
+
+    #[cfg(any(
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    ))]
+    impl NativeCompilation {
+        /// Warnings emitted while compiling this artifact.
+        pub fn warnings(&self) -> &[CompilationWarning] {
+            &self.warnings
+        }
+
+        /// Allocate and initialize the runtime state for this compiled artifact.
+        pub fn initialize(
+            self,
+        ) -> Result<Simulator<crate::backend::native::NativeBackend>, SimulatorError> {
+            let Self {
+                backend,
+                program,
+                warnings,
+                options,
+                vcd_path,
+            } = self;
+            let mut sim =
+                Simulator::with_backend_and_program(backend, program.into_runtime(), warnings);
+            sim.diagnostics = options.diagnostics.clone();
+            if let Some(path) = vcd_path {
+                let descs = sim.build_vcd_descs(options.four_state);
+                let vcd_writer = crate::VcdWriter::new(path, &descs)
+                    .map_err(|_| SimulatorError::from(crate::RuntimeErrorCode::InternalError))?;
+                sim.vcd_writer = Some(vcd_writer);
+            }
+            let apply_initial_start = options.diagnostics.phase_timing.then(crate::timing::now);
+            sim.apply_initial_values();
+            if let Some(start) = apply_initial_start {
+                tracing::debug!("[phase-timing] apply_initial_values: {:?}", start.elapsed());
+            }
+            let settle_start = options.diagnostics.phase_timing.then(crate::timing::now);
+            sim.modify(|_| {}).map_err(SimulatorError::from)?;
+            if let Some(start) = settle_start {
+                tracing::debug!("[phase-timing] initial_settle: {:?}", start.elapsed());
+            }
+            Ok(sim)
+        }
+    }
+
     impl Default for SimulatorOptions {
         fn default() -> Self {
             let opt = crate::optimizer::OptimizeOptions::default();
@@ -930,9 +993,7 @@ mod host {
             target_arch = "x86_64",
             all(target_arch = "aarch64", feature = "experimental-arm64-backend")
         ))]
-        pub fn build_native(
-            self,
-        ) -> Result<Simulator<crate::backend::native::NativeBackend>, SimulatorError> {
+        pub fn compile_native(self) -> Result<NativeCompilation, SimulatorError> {
             let phase_timing = self.options.diagnostics.phase_timing;
             let sir_start = phase_timing.then(crate::timing::now);
             let (laid_out, warnings, options, vcd_path) = self.into_laid_out_program(
@@ -949,26 +1010,24 @@ mod host {
             if let Some(start) = backend_start {
                 tracing::debug!("[phase-timing] native_backend: {:?}", start.elapsed());
             }
-            let mut sim =
-                Simulator::with_backend_and_program(backend, laid_out.into_runtime(), warnings);
-            sim.diagnostics = options.diagnostics.clone();
-            if let Some(path) = vcd_path {
-                let descs = sim.build_vcd_descs(options.four_state);
-                let vcd_writer = crate::VcdWriter::new(path, &descs)
-                    .map_err(|_| SimulatorError::from(crate::RuntimeErrorCode::InternalError))?;
-                sim.vcd_writer = Some(vcd_writer);
-            }
-            let apply_initial_start = phase_timing.then(crate::timing::now);
-            sim.apply_initial_values();
-            if let Some(start) = apply_initial_start {
-                tracing::debug!("[phase-timing] apply_initial_values: {:?}", start.elapsed());
-            }
-            let settle_start = phase_timing.then(crate::timing::now);
-            sim.modify(|_| {}).map_err(SimulatorError::from)?;
-            if let Some(start) = settle_start {
-                tracing::debug!("[phase-timing] initial_settle: {:?}", start.elapsed());
-            }
-            Ok(sim)
+            Ok(NativeCompilation {
+                backend,
+                program: laid_out,
+                warnings,
+                options,
+                vcd_path,
+            })
+        }
+
+        /// Compiles using the custom native backend and initializes the simulator.
+        #[cfg(any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        ))]
+        pub fn build_native(
+            self,
+        ) -> Result<Simulator<crate::backend::native::NativeBackend>, SimulatorError> {
+            self.compile_native()?.initialize()
         }
 
         /// Compiles using the Wasmtime WASM backend.

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use veryl_analyzer::ir::{Comptime, Expression, VarPath};
@@ -10,8 +9,8 @@ use veryl_parser::resource_table;
 
 use crate::parser::BuildConfig;
 use crate::{
-    CompilationWarning, FrontendDiagnostic, ParserError, SimulatorError, SimulatorErrorKind,
-    ir::OptimizedSir, parser,
+    CompilationWarning, FrontendDiagnostic, HashMap, ParserError, SimulatorError,
+    SimulatorErrorKind, ir::OptimizedSir, parser,
 };
 
 fn component_library_path(

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -5,6 +5,7 @@
 //! memory buffer.  Signals ≤64 bits use native `u64` arithmetic with zero
 //! heap allocation; wider signals fall back to `BigUint`.
 
+use crate::HashMap;
 use crate::RuntimeErrorCode;
 use crate::backend::memory_layout::{
     RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET,
@@ -25,7 +26,6 @@ use num_bigint::{BigInt, BigUint, Sign};
 use num_traits::ToPrimitive as _;
 use rand::{RngExt as _, SeedableRng as _};
 use rand_pcg::Pcg64;
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 // ── Public types ───────────────────────────────────────────────────────
@@ -219,7 +219,7 @@ impl RandomTable {
     fn new(base_seed: u64) -> Self {
         Self {
             base_seed,
-            rngs: HashMap::new(),
+            rngs: HashMap::default(),
         }
     }
 

--- a/crates/celox/tests/component_method.rs
+++ b/crates/celox/tests/component_method.rs
@@ -1822,7 +1822,7 @@ fn synchronous_reset_without_runtime_reset_event_still_binds() {
     let bound = celox_runtime::bind_testbench_program(
         simulator.backend_ref(),
         isolated,
-        &std::collections::HashSet::new(),
+        &fxhash::FxHashSet::default(),
     )
     .unwrap();
     assert!(matches!(

--- a/crates/celox/tests/native_exec.rs
+++ b/crates/celox/tests/native_exec.rs
@@ -6,6 +6,21 @@
 
 use celox::{MemoryLayout, MemoryLayoutMode, OptimizedSir, Simulator, SimulatorBuilder};
 
+#[test]
+fn native_compilation_can_be_initialized_later() {
+    let code = r#"
+        module Top (o: output logic<8>) {
+            assign o = 8'h5a;
+        }
+    "#;
+
+    let compilation = Simulator::builder(code, "Top").compile_native().unwrap();
+    assert!(compilation.warnings().is_empty());
+
+    let mut sim = compilation.initialize().unwrap();
+    assert_eq!(sim.get(sim.signal("o")), 0x5au64.into());
+}
+
 fn run_single_block_mir(insts: Vec<celox::native_backend::mir::MInst>, vreg_count: usize) -> u64 {
     use celox::native_backend::emit;
     use celox::native_backend::jit_mem;

--- a/crates/celox/tests/std_lfsr.rs
+++ b/crates/celox/tests/std_lfsr.rs
@@ -1,5 +1,5 @@
 use celox::Simulator;
-use std::collections::HashSet;
+use fxhash::FxHashSet as HashSet;
 
 #[path = "test_utils/mod.rs"]
 #[macro_use]

--- a/scripts/run-heliodor-bench.sh
+++ b/scripts/run-heliodor-bench.sh
@@ -20,8 +20,8 @@ CELOX_RUNNER_BIN="${CELOX_RUNNER_BIN:-$CELOX_ROOT/target/$HELIODOR_CELOX_CARGO_P
 VERYL_TIMED_RUNNER_BIN="${VERYL_TIMED_RUNNER_BIN:-$CELOX_ROOT/target/$HELIODOR_CELOX_CARGO_PROFILE/veryl-heliodor}"
 HELIODOR_BUILD_CELOX_RUNNER="${HELIODOR_BUILD_CELOX_RUNNER:-1}"
 HELIODOR_CELOX_TARGET_DIR="${HELIODOR_CELOX_TARGET_DIR:-}"
-HELIODOR_CELOX_COMPILE_ONLY="${HELIODOR_CELOX_COMPILE_ONLY:-0}"
-HELIODOR_CELOX_COMPILE_TIMEOUT_SEC="${HELIODOR_CELOX_COMPILE_TIMEOUT_SEC:-}"
+HELIODOR_COMPILE_ONLY="${HELIODOR_COMPILE_ONLY:-${HELIODOR_CELOX_COMPILE_ONLY:-0}}"
+HELIODOR_COMPILE_TIMEOUT_SEC="${HELIODOR_COMPILE_TIMEOUT_SEC:-${HELIODOR_CELOX_COMPILE_TIMEOUT_SEC:-}}"
 HELIODOR_CELOX_TIMEOUT_MULTIPLIER="${HELIODOR_CELOX_TIMEOUT_MULTIPLIER:-2}"
 HELIODOR_INSTALL_TOOLS="${HELIODOR_INSTALL_TOOLS:-1}"
 HELIODOR_VERYL_VERSION="${HELIODOR_VERYL_VERSION:-0.20.3}"
@@ -88,10 +88,10 @@ Environment:
                        build CELOX_RUNNER_BIN before Celox runs (default: 1)
   HELIODOR_CELOX_TARGET_DIR
                        optional explicit Cargo target directory for the Celox build
-  HELIODOR_CELOX_COMPILE_ONLY
-                       for Celox runners, build the simulator and exit without running the testbench
-  HELIODOR_CELOX_COMPILE_TIMEOUT_SEC
-                       optional safety timeout for Celox compile-only mode
+  HELIODOR_COMPILE_ONLY
+                       for Celox and veryl-cc-sync, build the simulator and exit without running the testbench
+  HELIODOR_COMPILE_TIMEOUT_SEC
+                       optional safety timeout for compile-only mode
   HELIODOR_INSTALL_TOOLS
                        install missing tools into HELIODOR_TOOLS_DIR (default: 1)
   HELIODOR_VERYL_VERSION
@@ -390,10 +390,11 @@ classify_timed_veryl_result() {
     local log="$1"
     local expected_test="$2"
     local exit_status="$3"
+    local compile_only="${4:-0}"
     local line result_count=0 result_valid=0 timing_count=0 timing_valid=0
     local marker_test="" marker_status="" marker_elapsed=""
     local timing_test="" compile_elapsed="" execute_elapsed=""
-    local result_pattern='^VERYL_TEST_RESULT test=([^[:space:]]+) status=(pass|fail) elapsed_ns=([0-9]+)$'
+    local result_pattern='^VERYL_TEST_RESULT test=([^[:space:]]+) status=(pass|fail|compile-only) elapsed_ns=([0-9]+)$'
     local timing_pattern='^VERYL_TEST_TIMING test=([^[:space:]]+) compile_ns=([0-9]+) execute_ns=([0-9]+)( execute_cpu_ns=[0-9]+)?$'
 
     VERYL_TIMED_SEMANTIC_STATUS="unreported"
@@ -437,12 +438,16 @@ classify_timed_veryl_result() {
     VERYL_TIMED_REPORTED_ELAPSED_NS="$marker_elapsed"
     VERYL_TIMED_COMPILE_ELAPSED_NS="$compile_elapsed"
     VERYL_TIMED_EXECUTE_ELAPSED_NS="$execute_elapsed"
-    case "$marker_status:$exit_status" in
-        pass:0)
+    case "$marker_status:$exit_status:$compile_only" in
+        pass:0:0)
             VERYL_TIMED_SEMANTIC_STATUS="pass"
             return 0
             ;;
-        fail:[1-9]*)
+        compile-only:0:1)
+            VERYL_TIMED_SEMANTIC_STATUS="compile-only"
+            return 0
+            ;;
+        fail:[1-9]*:0)
             VERYL_TIMED_SEMANTIC_STATUS="fail"
             return 0
             ;;
@@ -484,7 +489,7 @@ validate_gate_celox_config() {
 validate_gate_timed_veryl_config() {
     local log="$1"
     local expected_test="$2"
-    local expected="VERYL_TEST_CONFIG test=$expected_test backend=cc aot_c_async=false"
+    local expected="VERYL_TEST_CONFIG test=$expected_test backend=cc aot_c_async=false compile_only=false"
     local line config_count=0 valid_count=0
 
     if [[ ! -f "$log" ]]; then
@@ -1136,8 +1141,8 @@ fallback_timeout_sec() {
 timeout_sec_for() {
     local runner="$1"
     local test="$2"
-    if [[ "$runner" == celox* && "$HELIODOR_CELOX_COMPILE_ONLY" == 1 ]]; then
-        printf '%s\n' "$HELIODOR_CELOX_COMPILE_TIMEOUT_SEC"
+    if [[ ("$runner" == celox* || "$runner" == veryl-cc-sync) && "$HELIODOR_COMPILE_ONLY" == 1 ]]; then
+        printf '%s\n' "$HELIODOR_COMPILE_TIMEOUT_SEC"
         return
     fi
     if [[ -n "${HELIODOR_TIMEOUT_SEC:-}" ]]; then
@@ -1202,15 +1207,18 @@ run_one() {
         timed_veryl_args+=(--source-file "$source_file")
     done
     for pass_override in $CELOX_SIR_PASS_OVERRIDES; do
-        celox_args+=(--sir-pass "$pass_override")
+        # Keep a leading '-' attached to the option so clap does not parse a
+        # disabled pass as a new command-line flag.
+        celox_args+=(--sir-pass="$pass_override")
     done
-    if [[ "$HELIODOR_CELOX_COMPILE_ONLY" == 1 ]]; then
+    if [[ "$HELIODOR_COMPILE_ONLY" == 1 ]]; then
         celox_args+=(--compile-only)
+        timed_veryl_args+=(--compile-only)
     fi
     stamp="$(date -u +%Y%m%dT%H%M%SZ)"
     log="$HELIODOR_RESULTS_DIR/${stamp}_${runner}_${test}.log"
     timeout_sec="$(timeout_sec_for "$runner" "$test")"
-    if [[ "$runner" == celox* && "$HELIODOR_CELOX_COMPILE_ONLY" == 1 ]]; then
+    if [[ ("$runner" == celox* || "$runner" == veryl-cc-sync) && "$HELIODOR_COMPILE_ONLY" == 1 ]]; then
         if [[ -n "$timeout_sec" && "$timeout_sec" != 0 ]]; then
             echo "== $runner :: $test (compile-only, safety timeout ${timeout_sec}s) =="
         else
@@ -1302,7 +1310,7 @@ run_one() {
     case "$runner" in
         celox*)
             if classify_celox_result \
-                "$log" "$test" "$process_status" "$HELIODOR_CELOX_COMPILE_ONLY"; then
+                "$log" "$test" "$process_status" "$HELIODOR_COMPILE_ONLY"; then
                 semantic_status="$CELOX_SEMANTIC_STATUS"
                 reported_elapsed="$CELOX_REPORTED_ELAPSED_NS"
                 compile_elapsed="$CELOX_COMPILE_ELAPSED_NS"
@@ -1319,7 +1327,7 @@ run_one() {
             fi
             ;;
         veryl-cc-sync)
-            if classify_timed_veryl_result "$log" "$test" "$process_status"; then
+            if classify_timed_veryl_result "$log" "$test" "$process_status" "$HELIODOR_COMPILE_ONLY"; then
                 semantic_status="$VERYL_TIMED_SEMANTIC_STATUS"
                 reported_elapsed="$VERYL_TIMED_REPORTED_ELAPSED_NS"
                 compile_elapsed="$VERYL_TIMED_COMPILE_ELAPSED_NS"
@@ -1683,8 +1691,8 @@ run_gate() {
     HELIODOR_RUNNERS="veryl-cc-sync celox"
     HELIODOR_TIMEOUT_SEC="$GATE_TIMEOUT_SEC"
     HELIODOR_CELOX_TIMEOUT_MULTIPLIER=1
-    HELIODOR_CELOX_COMPILE_ONLY=0
-    HELIODOR_CELOX_COMPILE_TIMEOUT_SEC=""
+    HELIODOR_COMPILE_ONLY=0
+    HELIODOR_COMPILE_TIMEOUT_SEC=""
     HELIODOR_BUILD_CELOX_RUNNER=1
     HELIODOR_INSTALL_TOOLS=0
     VERYL_BIN=""

--- a/scripts/tests/run-heliodor-bench-gate.sh
+++ b/scripts/tests/run-heliodor-bench-gate.sh
@@ -36,7 +36,7 @@ write_valid_gate_logs() {
     mkdir -p "$directory"
     printf '%s\n%s\n%s\n%s\n' \
         "v4 SoC linux boot smoke: cy=00d83790 x3=00000000000000aa pass=1" \
-        "VERYL_TEST_CONFIG test=$GATE_TEST backend=cc aot_c_async=false" \
+        "VERYL_TEST_CONFIG test=$GATE_TEST backend=cc aot_c_async=false compile_only=false" \
         "VERYL_TEST_TIMING test=$GATE_TEST compile_ns=$veryl_compile execute_ns=$veryl_execute" \
         "VERYL_TEST_RESULT test=$GATE_TEST status=pass elapsed_ns=$veryl_reported" \
         >"$directory/veryl.log"
@@ -287,7 +287,7 @@ assert_eq "$(sed -n '2p' "$TMP/cargo-env")" unset "CARGO_BUILD_TARGET neutraliza
 (
     HELIODOR_RESULTS_DIR="$TMP/source-enumeration-results"
     CELOX_RUNNER_BIN=/bin/true
-    HELIODOR_CELOX_COMPILE_ONLY=0
+    HELIODOR_COMPILE_ONLY=0
     mkdir -p "$HELIODOR_RESULTS_DIR"
     ensure_results_schema "$HELIODOR_RESULTS_DIR/results.tsv"
     test_source_files() {
@@ -487,7 +487,7 @@ run_one() {
         "benchmark-owned tools directory"
     assert_eq "$GATE_TIMEOUT_SEC" 420 "fixed gate timeout constant"
     assert_eq "$HELIODOR_TIMEOUT_SEC" "$GATE_TIMEOUT_SEC" "fixed timeout"
-    assert_eq "$HELIODOR_CELOX_COMPILE_ONLY" 0 "full Celox execution"
+    assert_eq "$HELIODOR_COMPILE_ONLY" 0 "full compiler execution"
     assert_eq "$CELOX_OPT_LEVEL" O2 "fixed Celox optimization"
     assert_eq "$CELOX_SIR_PASS_OVERRIDES" "" "no pass overrides"
     [[ "$HELIODOR_DIR" == "$HELIODOR_RESULTS_DIR/worktrees/$runner" ]] \
@@ -500,7 +500,7 @@ run_one() {
             execute_elapsed=40
             printf '%s\n%s\n%s\n%s\n' \
                 'v4 SoC linux boot smoke: cy=00d83790 x3=00000000000000aa pass=1' \
-                "VERYL_TEST_CONFIG test=$GATE_TEST backend=cc aot_c_async=false" \
+                "VERYL_TEST_CONFIG test=$GATE_TEST backend=cc aot_c_async=false compile_only=false" \
                 "VERYL_TEST_TIMING test=$GATE_TEST compile_ns=$compile_elapsed execute_ns=$execute_elapsed" \
                 "VERYL_TEST_RESULT test=$GATE_TEST status=pass elapsed_ns=$reported" >"$log"
             ;;
@@ -553,7 +553,7 @@ run_gate_fixture() {
     HELIODOR_TESTS=hostile-test
     HELIODOR_RUNNERS=celox-cranelift
     HELIODOR_TIMEOUT_SEC=1
-    HELIODOR_CELOX_COMPILE_ONLY=1
+    HELIODOR_COMPILE_ONLY=1
     HELIODOR_VERYL_VERSION=99.0.0
     VERYL_BIN="$TMP/hostile-path-veryl"
     CELOX_OPT_LEVEL=O0

--- a/scripts/tests/run-heliodor-bench-results.sh
+++ b/scripts/tests/run-heliodor-bench-results.sh
@@ -63,6 +63,19 @@ assert_eq "$VERYL_TIMED_REPORTED_ELAPSED_NS" 15 "timed Veryl reported elapsed"
 assert_eq "$VERYL_TIMED_COMPILE_ELAPSED_NS" 6 "timed Veryl compile elapsed"
 assert_eq "$VERYL_TIMED_EXECUTE_ELAPSED_NS" 7 "timed Veryl execute elapsed"
 
+timed_veryl_compile_log="$TMP/timed-veryl-compile.log"
+write_log "$timed_veryl_compile_log" \
+    'VERYL_TEST_TIMING test=boot_compile compile_ns=9 execute_ns=0' \
+    'VERYL_TEST_RESULT test=boot_compile status=compile-only elapsed_ns=10'
+classify_timed_veryl_result "$timed_veryl_compile_log" boot_compile 0 1 \
+    || fail "timed Veryl compile-only result was rejected: $VERYL_TIMED_RESULT_DIAGNOSTIC"
+assert_eq "$VERYL_TIMED_SEMANTIC_STATUS" compile-only \
+    "timed Veryl compile-only semantic status"
+assert_eq "$VERYL_TIMED_COMPILE_ELAPSED_NS" 9 \
+    "timed Veryl compile-only compile elapsed"
+assert_eq "$VERYL_TIMED_EXECUTE_ELAPSED_NS" 0 \
+    "timed Veryl compile-only execute elapsed"
+
 wrong_timed_veryl_log="$TMP/wrong-timed-veryl.log"
 write_log "$wrong_timed_veryl_log" \
     'VERYL_TEST_TIMING test=other compile_ns=6 execute_ns=7' \
@@ -254,7 +267,7 @@ CELOX_RUNNER_BIN=/bin/true
 VERYL_TIMED_RUNNER_BIN=/bin/true
 RESOLVED_VERYL_BIN=/bin/true
 CELOX_SIR_PASS_OVERRIDES=""
-HELIODOR_CELOX_COMPILE_TIMEOUT_SEC=""
+HELIODOR_COMPILE_TIMEOUT_SEC=""
 FIXTURE_RESULT_LINE=""
 FIXTURE_EXIT_STATUS=0
 FIXTURE_AOT_CACHE_DIR=""
@@ -287,8 +300,9 @@ run_in_heliodor() {
 }
 
 ensure_results_schema "$integration_results/results.tsv"
-HELIODOR_CELOX_COMPILE_ONLY=0
+HELIODOR_COMPILE_ONLY=0
 CELOX_OPT_LEVEL=O2
+CELOX_SIR_PASS_OVERRIDES="-branchify_mux +gvn"
 FIXTURE_RESULT_LINE=$'CELOX_TEST_TIMING test=integration_pass compile_ns=20 execute_ns=30 jit_execute_ns=25\nCELOX_TEST_RESULT test=integration_pass status=pass elapsed_ns=71'
 run_one celox integration_pass >/dev/null \
     || fail "run_one rejected a fixture full pass"
@@ -297,6 +311,11 @@ assert_eq "${FIXTURE_RUN_ARGS[$((fixture_arg_count - 2))]}" --opt-level \
     "Celox optimization flag"
 assert_eq "${FIXTURE_RUN_ARGS[$((fixture_arg_count - 1))]}" o2 \
     "normalized Celox optimization level"
+[[ " ${FIXTURE_RUN_ARGS[*]} " == *" --sir-pass=-branchify_mux "* ]] \
+    || fail "Celox disabled pass override was not kept as one argument"
+[[ " ${FIXTURE_RUN_ARGS[*]} " == *" --sir-pass=+gvn "* ]] \
+    || fail "Celox enabled pass override was not kept as one argument"
+CELOX_SIR_PASS_OVERRIDES=""
 assert_eq "$(awk -F '\t' 'NR == 2 { print $6 }' "$integration_results/results.tsv")" pass \
     "run_one pass semantic status"
 [[ "$(awk -F '\t' 'NR == 2 { print $4 }' "$integration_results/results.tsv")" =~ ^[0-9]+$ ]] \
@@ -308,7 +327,7 @@ assert_eq "$(awk -F '\t' 'NR == 2 { print $11 }' "$integration_results/results.t
 assert_eq "$(awk -F '\t' 'NR == 2 { print $12 }' "$integration_results/results.tsv")" 25 \
     "run_one pass JIT execute elapsed"
 
-HELIODOR_CELOX_COMPILE_ONLY=1
+HELIODOR_COMPILE_ONLY=1
 FIXTURE_RESULT_LINE=$'CELOX_TEST_TIMING test=integration_compile compile_ns=70 execute_ns=0 jit_execute_ns=0\nCELOX_TEST_RESULT test=integration_compile status=compile-only elapsed_ns=72'
 run_one celox integration_compile >/dev/null \
     || fail "run_one rejected a fixture compile-only completion"
@@ -317,7 +336,7 @@ assert_eq "$(awk -F '\t' 'NR == 3 { print $6 }' "$integration_results/results.ts
 assert_eq "$(awk -F '\t' 'NR == 3 { print $4 }' "$integration_results/results.tsv")" NA \
     "run_one compile-only speed elapsed"
 
-HELIODOR_CELOX_COMPILE_ONLY=0
+HELIODOR_COMPILE_ONLY=0
 FIXTURE_EXIT_STATUS=1
 FIXTURE_RESULT_LINE=$'CELOX_TEST_TIMING test=integration_fail compile_ns=20 execute_ns=30 jit_execute_ns=25\nCELOX_TEST_RESULT test=integration_fail status=fail elapsed_ns=73'
 if run_one celox integration_fail >/dev/null 2>&1; then
@@ -357,6 +376,18 @@ assert_eq "$(awk -F '\t' 'NR == 6 { print $10 }' "$integration_results/results.t
 assert_eq "$(awk -F '\t' 'NR == 6 { print $11 }' "$integration_results/results.tsv")" 50 \
     "run_one timed Veryl execute elapsed"
 
+HELIODOR_COMPILE_ONLY=1
+FIXTURE_RESULT_LINE=$'VERYL_TEST_TIMING test=integration_veryl_compile compile_ns=60 execute_ns=0\nVERYL_TEST_RESULT test=integration_veryl_compile status=compile-only elapsed_ns=61'
+run_one veryl-cc-sync integration_veryl_compile >/dev/null \
+    || fail "run_one rejected a fixture timed Veryl compile-only result"
+[[ " ${FIXTURE_RUN_ARGS[*]} " == *" --compile-only "* ]] \
+    || fail "run_one did not request timed Veryl compile-only mode"
+assert_eq "$(awk -F '\t' 'NR == 7 { print $6 }' "$integration_results/results.tsv")" \
+    compile-only "run_one timed Veryl compile-only semantic status"
+assert_eq "$(awk -F '\t' 'NR == 7 { print $4 }' "$integration_results/results.tsv")" NA \
+    "run_one timed Veryl compile-only speed elapsed"
+HELIODOR_COMPILE_ONLY=0
+
 FIXTURE_AOT_CACHE_DIR=""
 FIXTURE_RESULT_LINE=$'[INFO ]    Succeeded test (integration_veryl_cli)\n[INFO ]    Completed tests : 1 passed, 0 failed'
 run_one veryl-cc integration_veryl_cli >/dev/null \
@@ -365,9 +396,9 @@ run_one veryl-cc integration_veryl_cli >/dev/null \
     || fail "run_one did not pass an absolute isolated cache to the Veryl CLI"
 [[ ! -e "$FIXTURE_AOT_CACHE_DIR" ]] \
     || fail "run_one did not remove the Veryl CLI AOT cache"
-assert_eq "$(awk -F '\t' 'NR == 7 { print $10 }' "$integration_results/results.tsv")" NA \
+assert_eq "$(awk -F '\t' 'NR == 8 { print $10 }' "$integration_results/results.tsv")" NA \
     "run_one Veryl CLI compile elapsed"
-assert_eq "$(awk -F '\t' 'NR == 7 { print $11 }' "$integration_results/results.tsv")" NA \
+assert_eq "$(awk -F '\t' 'NR == 8 { print $11 }' "$integration_results/results.tsv")" NA \
     "run_one Veryl CLI execute elapsed"
 
 echo "run-heliodor-bench result fixture tests: PASS"


### PR DESCRIPTION
## Summary

- add a real native compile-only API and make the Heliodor benchmark measure compilation rather than simulator initialization
- parallelize independent Veryl frontend and SIR optimization work while preserving the O2 optimization pipeline
- reduce redundant allocation, cloning, liveness, spill-planning, and stack-slot coloring work in the native backend
- disallow direct `std::collections::{HashMap, HashSet}` usage with Clippy and migrate the workspace to the FxHash aliases

## Current result

On the same local Heliodor checkout and machine:

- Celox native O2 baseline: 63.299 s
- Celox native O2 after this checkpoint: 45.727–49.551 s (best: 27.8% faster)
- `veryl-cc` reference: 32.778 s

This is intentionally a draft checkpoint: the best Celox result is still about 1.39x the Veryl reference, so the original parity target is not complete. No O2 pass was disabled and code-generation optimization settings were not weakened.

The latest `perf` profile points primarily at frontend SLT / symbolic-store handling (`merge_symbolic_stores`, `RangeStore`, recursive expression evaluation, and allocator traffic), which is the next optimization target.

## Validation

- `cargo fmt --all`
- `cargo check --workspace --all-targets --offline`
- `cargo clippy --workspace --all-targets --exclude celox-backend-arm64 --offline -- -D warnings`
- `cargo test -p celox-backend-x86 -p celox-sir-opt -p celox-frontend-veryl -p celox --offline`
- `bash scripts/tests/run-heliodor-bench-results.sh`
- `bash scripts/tests/run-heliodor-bench-gate.sh`
- native O2 Heliodor Linux boot semantic check (`pass=1`)

Full ARM64 Clippy remains excluded because that crate has pre-existing warnings unrelated to this change.
