### PR TITLE
perf(native): match Heliodor compile time to Veryl

### DIFF
--- a/crates/celox-backend-x86/src/backend/native/mir_opt.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt.rs
@@ -2904,7 +2904,7 @@ fn global_gvn(func: &mut MFunction) {
         value_numbers: &mut [ValueNumber],
         value_leaders: &mut [VReg],
         leader_blocks: &mut [Option<usize>],
-        live_out: &[HashSet<VReg>],
+        live_out: &[Vec<VReg>],
         last_uses: &[HashMap<VReg, usize>],
         load_versions: &HashMap<(usize, usize), GvnLoadVersion>,
         value_table: &mut HashMap<GvnKey, ValueNumber>,
@@ -2971,7 +2971,7 @@ fn global_gvn(func: &mut MFunction) {
         value_numbers: &mut [ValueNumber],
         value_leaders: &mut [VReg],
         leader_blocks: &mut [Option<usize>],
-        live_out: &HashSet<VReg>,
+        live_out: &[VReg],
         last_uses: &HashMap<VReg, usize>,
         load_versions: &HashMap<(usize, usize), GvnLoadVersion>,
         value_table: &mut HashMap<GvnKey, ValueNumber>,
@@ -2996,7 +2996,7 @@ fn global_gvn(func: &mut MFunction) {
                     let leader = value_leaders[number as usize];
                     value_numbers[dst.0 as usize] = number;
                     let leader_block = leader_blocks[number as usize];
-                    let reuse_does_not_extend_live_range = live_out.contains(&leader)
+                    let reuse_does_not_extend_live_range = live_out.binary_search(&leader).is_ok()
                         || last_uses
                             .get(&leader)
                             .is_some_and(|last_use| *last_use >= inst_idx);
@@ -3062,7 +3062,7 @@ fn compute_gvn_liveness(
     func: &MFunction,
     block_id_to_idx: &HashMap<BlockId, usize>,
     succs: &[Vec<usize>],
-) -> (Vec<HashSet<VReg>>, Vec<HashSet<VReg>>) {
+) -> (Vec<Vec<VReg>>, Vec<Vec<VReg>>) {
     let block_count = func.blocks.len();
     let mut uses = vec![HashSet::default(); block_count];
     let mut defs = vec![HashSet::default(); block_count];
@@ -3081,31 +3081,75 @@ fn compute_gvn_liveness(
         }
     }
 
-    let mut live_in = vec![HashSet::default(); block_count];
+    let uses = uses
+        .into_iter()
+        .map(|set| {
+            let mut values = set.into_iter().collect::<Vec<_>>();
+            values.sort_unstable();
+            values
+        })
+        .collect::<Vec<_>>();
+
+    fn sorted_union(left: &[VReg], right: &[VReg]) -> Vec<VReg> {
+        let mut merged = Vec::with_capacity(left.len().saturating_add(right.len()));
+        let (mut left_index, mut right_index) = (0usize, 0usize);
+        while left_index < left.len() && right_index < right.len() {
+            match left[left_index].cmp(&right[right_index]) {
+                std::cmp::Ordering::Less => {
+                    merged.push(left[left_index]);
+                    left_index += 1;
+                }
+                std::cmp::Ordering::Equal => {
+                    merged.push(left[left_index]);
+                    left_index += 1;
+                    right_index += 1;
+                }
+                std::cmp::Ordering::Greater => {
+                    merged.push(right[right_index]);
+                    right_index += 1;
+                }
+            }
+        }
+        merged.extend_from_slice(&left[left_index..]);
+        merged.extend_from_slice(&right[right_index..]);
+        merged
+    }
+
+    fn merged_successor_live(
+        func: &MFunction,
+        succs: &[Vec<usize>],
+        live_in: &[Vec<VReg>],
+        block_index: usize,
+    ) -> Vec<VReg> {
+        let block_id = func.blocks[block_index].id;
+        let mut live_out = Vec::new();
+        for &successor in &succs[block_index] {
+            let mut edge_uses = func.blocks[successor]
+                .phis
+                .iter()
+                .filter_map(|phi| {
+                    phi.sources
+                        .iter()
+                        .find(|(predecessor, _)| *predecessor == block_id)
+                        .map(|(_, source)| *source)
+                })
+                .collect::<Vec<_>>();
+            edge_uses.sort_unstable();
+            edge_uses.dedup();
+            let successor_live = sorted_union(&live_in[successor], &edge_uses);
+            live_out = sorted_union(&live_out, &successor_live);
+        }
+        live_out
+    }
+
+    let mut live_in = vec![Vec::new(); block_count];
     let mut changed = true;
     while changed {
         changed = false;
         for block_index in (0..block_count).rev() {
-            let block_id = func.blocks[block_index].id;
-            let mut live_out = HashSet::default();
-            for &successor in &succs[block_index] {
-                live_out.extend(live_in[successor].iter().copied());
-                for phi in &func.blocks[successor].phis {
-                    if let Some((_, source)) = phi
-                        .sources
-                        .iter()
-                        .find(|(predecessor, _)| *predecessor == block_id)
-                    {
-                        live_out.insert(*source);
-                    }
-                }
-            }
-            let mut next = uses[block_index].clone();
-            next.extend(
-                live_out
-                    .into_iter()
-                    .filter(|value| !defs[block_index].contains(value)),
-            );
+            let mut live_out = merged_successor_live(func, succs, &live_in, block_index);
+            live_out.retain(|value| !defs[block_index].contains(value));
+            let next = sorted_union(&uses[block_index], &live_out);
             if next != live_in[block_index] {
                 live_in[block_index] = next;
                 changed = true;
@@ -3113,20 +3157,9 @@ fn compute_gvn_liveness(
         }
     }
 
-    let mut live_out = vec![HashSet::default(); block_count];
-    for (block_index, block) in func.blocks.iter().enumerate() {
-        for &successor in &succs[block_index] {
-            live_out[block_index].extend(live_in[successor].iter().copied());
-            for phi in &func.blocks[successor].phis {
-                if let Some((_, source)) = phi
-                    .sources
-                    .iter()
-                    .find(|(predecessor, _)| *predecessor == block.id)
-                {
-                    live_out[block_index].insert(*source);
-                }
-            }
-        }
+    let mut live_out = vec![Vec::new(); block_count];
+    for (block_index, values) in live_out.iter_mut().enumerate() {
+        *values = merged_successor_live(func, succs, &live_in, block_index);
     }
 
     debug_assert!(

--- a/crates/celox-backend-x86/src/backend/native/regalloc/live_interval.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/live_interval.rs
@@ -767,7 +767,18 @@ fn solve_liveness(
     let mut queued = vec![true; block_count];
     while let Some(block) = queue.pop_front() {
         queued[block] = false;
+        let next_out_capacity = cfg.successors[block]
+            .iter()
+            .map(|&successor| {
+                live_in[successor].len()
+                    + facts
+                        .edge_uses
+                        .get(&(block, successor))
+                        .map_or(0, HashSet::len)
+            })
+            .sum();
         let mut next_out = HashSet::default();
+        next_out.reserve(next_out_capacity);
         for &successor in &cfg.successors[block] {
             next_out.extend(live_in[successor].iter().copied());
             if let Some(edge) = facts.edge_uses.get(&(block, successor)) {
@@ -775,6 +786,7 @@ fn solve_liveness(
             }
         }
         let mut next_in = facts.blocks[block].upward_uses.clone();
+        next_in.reserve(next_out.len());
         next_in.extend(
             next_out
                 .iter()
@@ -796,7 +808,18 @@ fn solve_liveness(
     }
     let live_out = (0..block_count)
         .map(|block| {
+            let capacity = cfg.successors[block]
+                .iter()
+                .map(|&successor| {
+                    live_in[successor].len()
+                        + facts
+                            .edge_uses
+                            .get(&(block, successor))
+                            .map_or(0, HashSet::len)
+                })
+                .sum();
             let mut values = HashSet::default();
+            values.reserve(capacity);
             for &successor in &cfg.successors[block] {
                 values.extend(live_in[successor].iter().copied());
                 if let Some(edge) = facts.edge_uses.get(&(block, successor)) {
@@ -821,6 +844,13 @@ fn build_intervals<P: LivenessProgram + ?Sized>(
     for block_index in 0..program.block_count() {
         let block_id = program.block_id(block_index);
         let mut values = HashSet::default();
+        values.reserve(
+            live_in[block_index]
+                .len()
+                .saturating_add(live_out[block_index].len())
+                .saturating_add(facts.blocks[block_index].definitions.len())
+                .saturating_add(facts.blocks[block_index].last_use.len()),
+        );
         values.extend(live_in[block_index].iter().copied());
         values.extend(live_out[block_index].iter().copied());
         values.extend(facts.blocks[block_index].definitions.iter().copied());

--- a/crates/celox-backend-x86/src/backend/native/regalloc/reload.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/reload.rs
@@ -1164,9 +1164,9 @@ type MemoryProgramPoint = (usize, usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 struct MemoryDefinition {
-    point: MemoryProgramPoint,
     block: BlockId,
     ordinal: usize,
+    write_index: usize,
 }
 
 /// Reload-specific adapter around the shared access graph. MIR effects and
@@ -1175,7 +1175,7 @@ struct MemoryDefinition {
 struct ReloadMemorySsa {
     graph: MemoryAccessGraph<MemoryDefinition>,
     points: MemoryPointMap<MemoryProgramPoint>,
-    writes: BTreeMap<MemoryDefinition, Vec<MemoryEffect<MemoryObject>>>,
+    writes: Vec<Vec<MemoryEffect<MemoryObject>>>,
     block_ids: Vec<BlockId>,
     walker: ClobberWalker,
     clobber_cache: HashMap<(StateLoad, MemoryAccessId), MemoryAccessId>,
@@ -1232,7 +1232,7 @@ impl ReloadMemorySsa {
         let block_ids = &self.block_ids;
         let clobber_cache = &mut self.clobber_cache;
         let oracle = |definition: &MemoryDefinition, query: &MemoryEffect<MemoryObject>| {
-            writes.get(definition).is_some_and(|effects| {
+            writes.get(definition.write_index).is_some_and(|effects| {
                 effects
                     .iter()
                     .copied()
@@ -2105,7 +2105,7 @@ fn build_reload_memory_ssa(
         Vec::<MemoryAccessEvent<MemoryDefinition, MemoryProgramPoint>>::new();
         func.blocks.len()
     ];
-    let mut writes = BTreeMap::<MemoryDefinition, Vec<MemoryEffect<MemoryObject>>>::new();
+    let mut writes = Vec::<Vec<MemoryEffect<MemoryObject>>>::new();
     let sim_state = MemoryEffect::UnknownObject(MemoryObject::SimState);
 
     for (block, mir_block) in func.blocks.iter().enumerate() {
@@ -2141,19 +2141,11 @@ fn build_reload_memory_ssa(
                     )
                 })?;
                 let definition = MemoryDefinition {
-                    point: (block, instruction),
                     block: mir_block.id,
                     ordinal,
+                    write_index: writes.len(),
                 };
-                if writes.insert(definition, effects).is_some() {
-                    return Err(ReloadRecipeError::new(
-                        "RELOAD_RECIPE.WRITE_IDENTITY",
-                        Some(mir_block.id),
-                        Some(instruction),
-                        None,
-                        "one MIR write produced multiple MemoryDef identities",
-                    ));
-                }
+                writes.push(effects);
                 Some(definition)
             };
             events[block].push(MemoryAccessEvent {

--- a/crates/celox-backend-x86/src/backend/native/regalloc/spill_plan.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/spill_plan.rs
@@ -14,6 +14,97 @@ use super::reload::{EdgeUse, PlanningRecipes, PointUse, ReloadRecipeAnalysis, Re
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(super) struct LogicalValue(pub u32);
 
+/// Sparse logical-value set with the same ascending iteration order as a
+/// `BTreeSet`, stored contiguously for the allocator's small W/S frontiers.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct LogicalSet(Vec<LogicalValue>);
+
+impl LogicalSet {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    #[cfg(test)]
+    pub(super) fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    pub(super) fn contains(&self, value: &LogicalValue) -> bool {
+        self.0.binary_search(value).is_ok()
+    }
+
+    pub(super) fn insert(&mut self, value: LogicalValue) -> bool {
+        let Err(index) = self.0.binary_search(&value) else {
+            return false;
+        };
+        self.0.insert(index, value);
+        true
+    }
+
+    fn remove(&mut self, value: &LogicalValue) -> bool {
+        let Ok(index) = self.0.binary_search(value) else {
+            return false;
+        };
+        self.0.remove(index);
+        true
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn iter(&self) -> std::slice::Iter<'_, LogicalValue> {
+        self.0.iter()
+    }
+
+    fn retain(&mut self, mut keep: impl FnMut(&LogicalValue) -> bool) {
+        self.0.retain(|value| keep(value));
+    }
+
+    fn difference<'a>(&'a self, other: &'a Self) -> impl Iterator<Item = &'a LogicalValue> + 'a {
+        self.0.iter().filter(|value| !other.contains(value))
+    }
+}
+
+impl FromIterator<LogicalValue> for LogicalSet {
+    fn from_iter<T: IntoIterator<Item = LogicalValue>>(iter: T) -> Self {
+        let mut values = iter.into_iter().collect::<Vec<_>>();
+        values.sort_unstable();
+        values.dedup();
+        Self(values)
+    }
+}
+
+impl Extend<LogicalValue> for LogicalSet {
+    fn extend<T: IntoIterator<Item = LogicalValue>>(&mut self, iter: T) {
+        for value in iter {
+            self.insert(value);
+        }
+    }
+}
+
+impl IntoIterator for LogicalSet {
+    type Item = LogicalValue;
+    type IntoIter = std::vec::IntoIter<LogicalValue>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a LogicalSet {
+    type Item = &'a LogicalValue;
+    type IntoIter = std::slice::Iter<'a, LogicalValue>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(super) struct SpillHome(pub u32);
 
@@ -112,18 +203,18 @@ pub(super) struct SpillPlan {
     /// Keys retain the pre-reconstruction insertion point; reconstruction
     /// independently proves the emitted load against final MIR.
     pub state_reload_recipes: BTreeMap<(BlockId, usize, LogicalValue), ResolvedRecipe>,
-    pub w_entry: Vec<BTreeSet<LogicalValue>>,
-    pub w_exit: Vec<BTreeSet<LogicalValue>>,
-    pub s_entry: Vec<BTreeSet<LogicalValue>>,
-    pub s_exit: Vec<BTreeSet<LogicalValue>>,
+    pub w_entry: Vec<LogicalSet>,
+    pub w_exit: Vec<LogicalSet>,
+    pub s_entry: Vec<LogicalSet>,
+    pub s_exit: Vec<LogicalSet>,
 }
 
 #[derive(Debug)]
 struct BlockTransition {
     point_ops: Vec<(ProgramPoint, PlannedOp)>,
     recipe_reloads: BTreeSet<(BlockId, usize, LogicalValue)>,
-    w_exit: BTreeSet<LogicalValue>,
-    s_exit: BTreeSet<LogicalValue>,
+    w_exit: LogicalSet,
+    s_exit: LogicalSet,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -433,10 +524,10 @@ fn plan_internal(
         recipe_homes: BTreeSet::new(),
         state_homes: BTreeMap::new(),
         state_reload_recipes: BTreeMap::new(),
-        w_entry: vec![BTreeSet::new(); func.blocks.len()],
-        w_exit: vec![BTreeSet::new(); func.blocks.len()],
-        s_entry: vec![BTreeSet::new(); func.blocks.len()],
-        s_exit: vec![BTreeSet::new(); func.blocks.len()],
+        w_entry: vec![LogicalSet::new(); func.blocks.len()],
+        w_exit: vec![LogicalSet::new(); func.blocks.len()],
+        s_entry: vec![LogicalSet::new(); func.blocks.len()],
+        s_exit: vec![LogicalSet::new(); func.blocks.len()],
     };
     for block in 0..func.blocks.len() {
         let entry = if let Some(region) = next_use.region_at_entry(block) {
@@ -462,7 +553,7 @@ fn plan_internal(
                     .logical
                     .checked_of(value, Some(func.blocks[block].id), Some(0))
             })
-            .collect::<Result<BTreeSet<_>, _>>()?;
+            .collect::<Result<LogicalSet, _>>()?;
         let exit_reload_costs = constraints
             .map(|_| {
                 exit_reload_costs(
@@ -563,7 +654,7 @@ fn plan_internal(
             PlannedOp::SpillPhi { value, .. } => Some(*value),
             _ => None,
         })
-        .collect::<BTreeSet<_>>();
+        .collect::<LogicalSet>();
     for successor in 0..func.blocks.len() {
         for &predecessor in &cfg.predecessors[successor] {
             let mut resident_spills = Vec::new();
@@ -724,7 +815,7 @@ fn exit_reload_costs(
 ) -> Result<HashMap<LogicalValue, u32>, SpillPlanError> {
     let mut costs = HashMap::<LogicalValue, u32>::default();
     for &successor in &cfg.successors[block] {
-        let mut demanded = BTreeSet::<LogicalValue>::new();
+        let mut demanded = LogicalSet::new();
         for &value in next_use.entry[successor].keys() {
             let destination =
                 logical.checked_of(value, Some(func.blocks[successor].id), Some(0))?;
@@ -765,13 +856,13 @@ fn spilled_at_entry(
     plan: &SpillPlan,
     edge_translations: &EdgeTranslations,
     block: usize,
-    live_entry: &BTreeSet<LogicalValue>,
-    resident: &BTreeSet<LogicalValue>,
-) -> BTreeSet<LogicalValue> {
+    live_entry: &LogicalSet,
+    resident: &LogicalSet,
+) -> LogicalSet {
     let mut spilled = live_entry
         .difference(resident)
         .copied()
-        .collect::<BTreeSet<_>>();
+        .collect::<LogicalSet>();
     if !cfg.predecessors[block].is_empty() {
         spilled.extend(resident.iter().copied().filter(|value| {
             cfg.predecessors[block].iter().all(|predecessor| {
@@ -797,10 +888,10 @@ fn entry_residents_evicted_before_first_use(
     func: &MFunction,
     next_use: &NextUseAnalysis,
     block: usize,
-    resident: &BTreeSet<LogicalValue>,
+    resident: &LogicalSet,
     transition: &BlockTransition,
     order: Option<&[usize]>,
-) -> BTreeSet<LogicalValue> {
+) -> LogicalSet {
     let first_use = |value: LogicalValue| {
         order.map_or_else(
             || next_use.next_local_use(block, 0, VReg(value.0)),
@@ -848,8 +939,8 @@ fn plan_block_transition(
     homes: &SpillHomes,
     block: usize,
     registers: usize,
-    w_entry: &BTreeSet<LogicalValue>,
-    spilled: BTreeSet<LogicalValue>,
+    w_entry: &LogicalSet,
+    spilled: LogicalSet,
 ) -> Result<BlockTransition, SpillPlanError> {
     let mut planner = BlockTransitionPlanner::new(
         func,
@@ -1053,8 +1144,8 @@ fn plan_scheduled_block_transition(
     homes: &SpillHomes,
     block: usize,
     registers: usize,
-    w_entry: &BTreeSet<LogicalValue>,
-    spilled: BTreeSet<LogicalValue>,
+    w_entry: &LogicalSet,
+    spilled: LogicalSet,
     constraints: &[super::constraints::InstructionConstraints],
     exit_reload_costs: &HashMap<LogicalValue, u32>,
 ) -> Result<(BlockTransition, Vec<usize>), SpillPlanError> {
@@ -1254,8 +1345,8 @@ fn plan_explicit_block_order(
     homes: &SpillHomes,
     block: usize,
     registers: usize,
-    w_entry: &BTreeSet<LogicalValue>,
-    spilled: BTreeSet<LogicalValue>,
+    w_entry: &LogicalSet,
+    spilled: LogicalSet,
     exit_reload_costs: &HashMap<LogicalValue, u32>,
     order: &[usize],
 ) -> Result<BlockTransition, SpillPlanError> {
@@ -1303,8 +1394,8 @@ struct BlockTransitionPlanner<'a> {
     block: usize,
     registers: usize,
     transition: BlockTransition,
-    resident: BTreeSet<LogicalValue>,
-    spilled: BTreeSet<LogicalValue>,
+    resident: LogicalSet,
+    spilled: LogicalSet,
     deferred_recipe_reloads: BTreeMap<LogicalValue, PointUse>,
     last_definition: Option<LogicalValue>,
 }
@@ -1319,14 +1410,14 @@ impl<'a> BlockTransitionPlanner<'a> {
         homes: &'a SpillHomes,
         block: usize,
         registers: usize,
-        w_entry: &BTreeSet<LogicalValue>,
-        mut spilled: BTreeSet<LogicalValue>,
+        w_entry: &LogicalSet,
+        mut spilled: LogicalSet,
     ) -> Result<Self, SpillPlanError> {
         let mut transition = BlockTransition {
             point_ops: Vec::new(),
             recipe_reloads: BTreeSet::new(),
-            w_exit: BTreeSet::new(),
-            s_exit: BTreeSet::new(),
+            w_exit: LogicalSet::new(),
+            s_exit: LogicalSet::new(),
         };
         let resident = w_entry.clone();
         for phi in &func.blocks[block].phis {
@@ -1385,8 +1476,12 @@ impl<'a> BlockTransitionPlanner<'a> {
         inst: &MInst,
         remaining: &mut RemainingBlockUses<'_>,
     ) -> Result<ScheduledStepDelta, SpillPlanError> {
-        let resident_before = self.resident.clone();
-        let deferred_before = self.deferred_recipe_reloads.clone();
+        let resident_before = self.resident.iter().copied().collect::<Vec<_>>();
+        let deferred_before = self
+            .deferred_recipe_reloads
+            .iter()
+            .map(|(&value, &point)| (value, point))
+            .collect::<Vec<_>>();
         let last_definition_before = self.last_definition;
         let uses = {
             let before = DynamicFutureUses(remaining);
@@ -1397,24 +1492,61 @@ impl<'a> BlockTransitionPlanner<'a> {
             let after = DynamicFutureUses(remaining);
             self.finish_step(point, inst, &uses, &after)?;
         }
-        let resident = resident_before
-            .symmetric_difference(&self.resident)
+        let mut resident = resident_before
+            .iter()
             .copied()
-            .collect();
-        let deferred = deferred_before
-            .keys()
-            .chain(self.deferred_recipe_reloads.keys())
-            .copied()
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .filter(|value| deferred_before.get(value) != self.deferred_recipe_reloads.get(value))
-            .collect();
-        let continuation = [last_definition_before, self.last_definition]
+            .filter(|value| !self.resident.contains(value))
+            .chain(
+                self.resident
+                    .iter()
+                    .copied()
+                    .filter(|value| resident_before.binary_search(value).is_err()),
+            )
+            .collect::<Vec<_>>();
+        resident.sort_unstable();
+
+        let mut deferred = Vec::new();
+        let (mut before_index, mut after) =
+            (0usize, self.deferred_recipe_reloads.iter().peekable());
+        while before_index < deferred_before.len() || after.peek().is_some() {
+            match (deferred_before.get(before_index), after.peek().copied()) {
+                (Some(&(before_value, before_point)), Some((&after_value, &after_point))) => {
+                    match before_value.cmp(&after_value) {
+                        Ordering::Less => {
+                            deferred.push(before_value);
+                            before_index += 1;
+                        }
+                        Ordering::Equal => {
+                            if before_point != after_point {
+                                deferred.push(before_value);
+                            }
+                            before_index += 1;
+                            after.next();
+                        }
+                        Ordering::Greater => {
+                            deferred.push(after_value);
+                            after.next();
+                        }
+                    }
+                }
+                (Some(&(before_value, _)), None) => {
+                    deferred.push(before_value);
+                    before_index += 1;
+                }
+                (None, Some((&after_value, _))) => {
+                    deferred.push(after_value);
+                    after.next();
+                }
+                (None, None) => break,
+            }
+        }
+
+        let mut continuation = [last_definition_before, self.last_definition]
             .into_iter()
             .flatten()
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect();
+            .collect::<Vec<_>>();
+        continuation.sort_unstable();
+        continuation.dedup();
         Ok(ScheduledStepDelta {
             resident,
             deferred,
@@ -1430,12 +1562,14 @@ impl<'a> BlockTransitionPlanner<'a> {
         remaining: &RemainingBlockUses<'_>,
     ) -> Result<AllocationCandidateScore, SpillPlanError> {
         let block_id = self.func.blocks[self.block].id;
-        let uses = inst
+        let mut uses = inst
             .uses()
             .iter()
             .copied()
             .map(|value| self.logical.checked_of(value, Some(block_id), Some(source)))
-            .collect::<Result<BTreeSet<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()?;
+        uses.sort_unstable();
+        uses.dedup();
         let mut blocked_by_deferred_reload = false;
         let mut missing = 0usize;
         let mut resident_operands = 0usize;
@@ -1511,16 +1645,18 @@ impl<'a> BlockTransitionPlanner<'a> {
         point: TransitionPoint,
         inst: &MInst,
         future_uses: &impl FutureUses,
-    ) -> Result<BTreeSet<LogicalValue>, SpillPlanError> {
+    ) -> Result<Vec<LogicalValue>, SpillPlanError> {
         let block_id = self.func.blocks[self.block].id;
-        let uses = inst
+        let mut uses = inst
             .uses()
             .into_iter()
             .map(|value| {
                 self.logical
                     .checked_of(value, Some(block_id), Some(point.output))
             })
-            .collect::<Result<BTreeSet<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()?;
+        uses.sort_unstable();
+        uses.dedup();
         for &value in &uses {
             if self.resident.insert(value) {
                 if let Some(expected) = self.deferred_recipe_reloads.remove(&value) {
@@ -1578,7 +1714,7 @@ impl<'a> BlockTransitionPlanner<'a> {
         &mut self,
         point: TransitionPoint,
         inst: &MInst,
-        uses: &BTreeSet<LogicalValue>,
+        uses: &[LogicalValue],
         future_uses: &impl FutureUses,
     ) -> Result<(), SpillPlanError> {
         let block_id = self.func.blocks[self.block].id;
@@ -1677,8 +1813,8 @@ fn limit_live_through_clobber(
     block: usize,
     point_instruction: usize,
     capacity: usize,
-    resident: &mut BTreeSet<LogicalValue>,
-    spilled: &mut BTreeSet<LogicalValue>,
+    resident: &mut LogicalSet,
+    spilled: &mut LogicalSet,
     deferred_recipe_reloads: &mut BTreeMap<LogicalValue, PointUse>,
     future_uses: &impl FutureUses,
 ) -> Result<(), SpillPlanError> {
@@ -1734,14 +1870,14 @@ fn init_usual(
     edge_translations: &EdgeTranslations,
     block: usize,
     registers: usize,
-) -> BTreeSet<LogicalValue> {
+) -> LogicalSet {
     let processed = cfg.predecessors[block]
         .iter()
         .copied()
         .filter(|predecessor| *predecessor < block)
         .collect::<Vec<_>>();
     if processed.is_empty() {
-        return BTreeSet::new();
+        return LogicalSet::new();
     }
     if processed.len() == 1 && cfg.predecessors[block].len() == 1 {
         let predecessor = processed[0];
@@ -1845,7 +1981,7 @@ fn init_loop_region(
     block: usize,
     region: usize,
     registers: usize,
-) -> Result<BTreeSet<LogicalValue>, SpillPlanError> {
+) -> Result<LogicalSet, SpillPlanError> {
     let mut alive = next_use.entry[block]
         .keys()
         .copied()
@@ -1853,7 +1989,7 @@ fn init_loop_region(
             plan.logical
                 .checked_of(value, Some(func.blocks[block].id), Some(0))
         })
-        .collect::<Result<BTreeSet<_>, _>>()?;
+        .collect::<Result<LogicalSet, _>>()?;
     for phi in &func.blocks[block].phis {
         alive.insert(
             plan.logical
@@ -2140,9 +2276,9 @@ fn limit(
     block: usize,
     point_instruction: usize,
     maximum: usize,
-    pinned: &BTreeSet<LogicalValue>,
-    resident: &mut BTreeSet<LogicalValue>,
-    spilled: &mut BTreeSet<LogicalValue>,
+    pinned: &[LogicalValue],
+    resident: &mut LogicalSet,
+    spilled: &mut LogicalSet,
     deferred_recipe_reloads: &mut BTreeMap<LogicalValue, PointUse>,
     future_uses: &impl FutureUses,
 ) -> Result<(), SpillPlanError> {
@@ -2199,7 +2335,7 @@ fn evict_value(
     block: usize,
     point_instruction: usize,
     value: LogicalValue,
-    spilled: &mut BTreeSet<LogicalValue>,
+    spilled: &mut LogicalSet,
     deferred_recipe_reloads: &mut BTreeMap<LogicalValue, PointUse>,
     future_uses: &impl FutureUses,
 ) -> Result<(), SpillPlanError> {
@@ -2265,7 +2401,7 @@ fn next_use_point_recipe(
 fn compare_eviction_candidates(
     func: &MFunction,
     planning_recipes: &PlanningRecipes,
-    spilled: &BTreeSet<LogicalValue>,
+    spilled: &LogicalSet,
     future_uses: &impl FutureUses,
     left: (LogicalValue, NextUseDistance),
     right: (LogicalValue, NextUseDistance),
@@ -2304,7 +2440,7 @@ fn compare_eviction_candidates(
 fn eviction_cost(
     func: &MFunction,
     planning_recipes: &PlanningRecipes,
-    spilled: &BTreeSet<LogicalValue>,
+    spilled: &LogicalSet,
     value: LogicalValue,
     future_uses: &impl FutureUses,
 ) -> u32 {
@@ -3070,8 +3206,8 @@ mod tests {
             &homes,
             0,
             4,
-            &BTreeSet::new(),
-            BTreeSet::new(),
+            &LogicalSet::new(),
+            LogicalSet::new(),
             &constraints.instructions[0],
             &HashMap::default(),
         )
@@ -3158,8 +3294,8 @@ mod tests {
             &homes,
             0,
             4,
-            &BTreeSet::new(),
-            BTreeSet::new(),
+            &LogicalSet::new(),
+            LogicalSet::new(),
             &constraints.instructions[0],
             &HashMap::default(),
         )
@@ -3234,8 +3370,8 @@ mod tests {
             &homes,
             0,
             4,
-            &BTreeSet::new(),
-            BTreeSet::new(),
+            &LogicalSet::new(),
+            LogicalSet::new(),
             &constraints.instructions[0],
             &HashMap::default(),
         )
@@ -3470,10 +3606,10 @@ mod tests {
             recipe_homes: BTreeSet::new(),
             state_homes: BTreeMap::new(),
             state_reload_recipes: BTreeMap::new(),
-            w_entry: vec![BTreeSet::new(); func.blocks.len()],
-            w_exit: vec![BTreeSet::new(); func.blocks.len()],
-            s_entry: vec![BTreeSet::new(); func.blocks.len()],
-            s_exit: vec![BTreeSet::new(); func.blocks.len()],
+            w_entry: vec![LogicalSet::new(); func.blocks.len()],
+            w_exit: vec![LogicalSet::new(); func.blocks.len()],
+            s_entry: vec![LogicalSet::new(); func.blocks.len()],
+            s_exit: vec![LogicalSet::new(); func.blocks.len()],
         };
         let predecessor = cfg.block_index[&BlockId(0)];
         let successor = cfg.block_index[&BlockId(1)];
@@ -3494,7 +3630,7 @@ mod tests {
             1,
         );
 
-        assert_eq!(inherited, BTreeSet::from([logical_value]));
+        assert_eq!(inherited, LogicalSet::from_iter([logical_value]));
     }
 
     #[test]
@@ -3568,10 +3704,10 @@ mod tests {
             recipe_homes: BTreeSet::new(),
             state_homes: BTreeMap::new(),
             state_reload_recipes: BTreeMap::new(),
-            w_entry: vec![BTreeSet::new(); func.blocks.len()],
-            w_exit: vec![BTreeSet::new(); func.blocks.len()],
-            s_entry: vec![BTreeSet::new(); func.blocks.len()],
-            s_exit: vec![BTreeSet::new(); func.blocks.len()],
+            w_entry: vec![LogicalSet::new(); func.blocks.len()],
+            w_exit: vec![LogicalSet::new(); func.blocks.len()],
+            s_entry: vec![LogicalSet::new(); func.blocks.len()],
+            s_exit: vec![LogicalSet::new(); func.blocks.len()],
         };
         let join = cfg.block_index[&BlockId(3)];
         let predecessors = &cfg.predecessors[join];
@@ -3594,7 +3730,10 @@ mod tests {
             1,
         );
 
-        assert_eq!(retained, BTreeSet::from([LogicalValue(guaranteed.0)]));
+        assert_eq!(
+            retained,
+            LogicalSet::from_iter([LogicalValue(guaranteed.0)])
+        );
     }
 
     #[test]
@@ -3660,10 +3799,10 @@ mod tests {
             recipe_homes: BTreeSet::new(),
             state_homes: BTreeMap::new(),
             state_reload_recipes: BTreeMap::new(),
-            w_entry: vec![BTreeSet::new(); func.blocks.len()],
-            w_exit: vec![BTreeSet::new(); func.blocks.len()],
-            s_entry: vec![BTreeSet::new(); func.blocks.len()],
-            s_exit: vec![BTreeSet::new(); func.blocks.len()],
+            w_entry: vec![LogicalSet::new(); func.blocks.len()],
+            w_exit: vec![LogicalSet::new(); func.blocks.len()],
+            s_entry: vec![LogicalSet::new(); func.blocks.len()],
+            s_exit: vec![LogicalSet::new(); func.blocks.len()],
         };
         let join = cfg.block_index[&BlockId(3)];
         let predecessors = &cfg.predecessors[join];
@@ -3682,7 +3821,10 @@ mod tests {
             1,
         );
 
-        assert_eq!(retained, BTreeSet::from([LogicalValue(repeated_use.0)]));
+        assert_eq!(
+            retained,
+            LogicalSet::from_iter([LogicalValue(repeated_use.0)])
+        );
         next_use.verify(&func, &cfg).unwrap();
     }
 
@@ -3834,7 +3976,7 @@ mod tests {
         let cfg = super::super::cfg::normalize(&mut func).unwrap();
         let next_use = super::super::next_use::analyze(&func, &cfg).unwrap();
         let planning_recipes = PlanningRecipes::stack_only(func.vregs.count());
-        let spilled = BTreeSet::new();
+        let spilled = LogicalSet::new();
         let future = LinearFutureUses {
             func: &func,
             next_use: &next_use,
@@ -4149,8 +4291,8 @@ mod tests {
             &homes,
             0,
             1,
-            &BTreeSet::new(),
-            BTreeSet::new(),
+            &LogicalSet::new(),
+            LogicalSet::new(),
         )
         .unwrap();
         for (source, inst) in func.blocks[0].insts.iter().enumerate() {
@@ -4656,7 +4798,10 @@ mod tests {
             LoopRegionKind::IrreducibleScc
         );
         for entry in [left, right] {
-            assert_eq!(plan.w_entry[entry], BTreeSet::from([LogicalValue(hot.0)]));
+            assert_eq!(
+                plan.w_entry[entry],
+                LogicalSet::from_iter([LogicalValue(hot.0)])
+            );
             assert!(!plan.w_entry[entry].contains(&LogicalValue(live_through.0)));
         }
     }

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -1006,9 +1006,16 @@ fn merge_symbolic_stores(
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<SymbolicStore<VarId>, ParserError> {
     let mut merged_store = SymbolicStore::default();
+    merged_store.reserve(then_store.len());
     for id in then_store.keys() {
         let t_range_store = &then_store[id];
         let e_range_store = &else_store[id];
+
+        if t_range_store == e_range_store {
+            let inserted = merged_store.clone_entry_from(id, then_store);
+            debug_assert!(inserted);
+            continue;
+        }
 
         let mut merged_range_store = RangeStore {
             ranges: std::collections::BTreeMap::new(),
@@ -1033,13 +1040,10 @@ fn merge_symbolic_stores(
             let else_parts = e_range_store
                 .get_parts(access)
                 .map_err(|error| range_store_error("conditional merge", error, None))?;
-            let (t_expr, t_sources) =
-                combine_parts_with_default(*id, lsb, then_parts.clone(), arena)?;
-            let (e_expr, e_sources) =
-                combine_parts_with_default(*id, lsb, else_parts.clone(), arena)?;
-
             let t_modified = then_parts.iter().any(|(v, _)| v.is_some());
             let e_modified = else_parts.iter().any(|(v, _)| v.is_some());
+            let (t_expr, t_sources) = combine_parts_with_default(*id, lsb, then_parts, arena)?;
+            let (e_expr, e_sources) = combine_parts_with_default(*id, lsb, else_parts, arena)?;
 
             let result_val = if !t_modified && !e_modified {
                 None

--- a/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_control_flow_simplify.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_control_flow_simplify.rs
@@ -21,6 +21,7 @@ use crate::{HashMap, HashSet};
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
 use std::collections::VecDeque;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 pub(in crate::optimizer) struct ControlFlowSimplifyPass;
@@ -549,10 +550,37 @@ fn resolve_condition_alias(
     (register, inverted)
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug)]
 struct ExactCaseConstant {
+    fingerprint: u64,
     width: usize,
-    payload: Vec<u64>,
+    payload: Arc<[u64]>,
+}
+
+impl ExactCaseConstant {
+    fn new(width: usize, payload: Vec<u64>) -> Self {
+        Self {
+            fingerprint: fxhash::hash64(&(width, &payload)),
+            width,
+            payload: payload.into(),
+        }
+    }
+}
+
+impl PartialEq for ExactCaseConstant {
+    fn eq(&self, other: &Self) -> bool {
+        self.fingerprint == other.fingerprint
+            && self.width == other.width
+            && (Arc::ptr_eq(&self.payload, &other.payload) || self.payload == other.payload)
+    }
+}
+
+impl Eq for ExactCaseConstant {}
+
+impl Hash for ExactCaseConstant {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.fingerprint);
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -1260,10 +1288,10 @@ fn exact_case_constant(
         let &(block, index) = definitions.get(&register)?;
         match &eu.blocks[&block].instructions[index] {
             SIRInstruction::Imm(_, value) if value.mask.is_zero() => {
-                return Some(ExactCaseConstant {
-                    width: eu.register_map.get(&register)?.width(),
-                    payload: value.payload.to_u64_digits(),
-                });
+                return Some(ExactCaseConstant::new(
+                    eu.register_map.get(&register)?.width(),
+                    value.payload.to_u64_digits(),
+                ));
             }
             SIRInstruction::Unary(_, UnaryOp::Ident | UnaryOp::ToTwoState, source) => {
                 register = *source;

--- a/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_sparse_case_dispatch.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_sparse_case_dispatch.rs
@@ -151,6 +151,12 @@ impl ExecutionUnitPass for SparseCaseDispatchPass {
         };
         let mut candidate_blocks: Option<HashSet<BlockId>> = None;
         loop {
+            // Applying a batch normally leaves no newly split block to
+            // inspect. Avoid rebuilding whole-EU use and definition indices
+            // merely to discover that the restricted candidate set is empty.
+            if candidate_blocks.as_ref().is_some_and(HashSet::is_empty) {
+                break;
+            }
             let plans =
                 find_sparse_case_plans(eu, &self.stable_alias_class, candidate_blocks.as_ref());
             if plans.is_empty() {

--- a/crates/celox-slt/src/lib.rs
+++ b/crates/celox-slt/src/lib.rs
@@ -16,6 +16,7 @@ mod node_rules;
 mod path;
 pub mod range_store;
 pub mod scheduler;
+mod symbolic_store;
 mod symbolic_verify;
 
 #[doc(hidden)]
@@ -29,6 +30,7 @@ pub use node_facts::{SLTNodeFacts, SLTNodeFactsError};
 pub use path::{LogicPath, LogicPathId, LogicPathTarget};
 pub use range_store::{RangeStore, RangeStoreError};
 pub use scheduler::FfAccessSummary;
+pub use symbolic_store::SymbolicStore;
 pub use symbolic_verify::verify_symbolic_roots;
 
 /// Return the construction-time width cached when a node was interned.
@@ -42,8 +44,6 @@ pub fn get_width<A: std::hash::Hash + Eq + Clone>(node: NodeId, arena: &SLTNodeA
 ///
 /// `N` is the symbolic expression identity. It remains generic until the SLT
 /// arena itself moves into this crate.
-pub type SymbolicStore<A, N> = HashMap<A, RangeStore<Option<(N, HashSet<VarAtomBase<A>>)>>>;
-
 /// Bit boundaries discovered while constructing symbolic state.
 pub type BoundaryMap<A> = HashMap<A, BTreeSet<usize>>;
 

--- a/crates/celox-slt/src/range_store.rs
+++ b/crates/celox-slt/src/range_store.rs
@@ -145,7 +145,13 @@ impl<T: Clone + PartialEq + Eq> RangeStore<T> {
     pub fn get_parts(&self, access: BitAccess) -> Result<Vec<(T, BitAccess)>, RangeStoreError> {
         self.validate_access(access)?;
         let mut parts = Vec::new();
-        for (&range_lsb, (expr, range_width, origin)) in self.ranges.range(..=access.msb) {
+        let first_lsb = self
+            .ranges
+            .range(..=access.lsb)
+            .next_back()
+            .map(|(&lsb, _)| lsb)
+            .ok_or_else(|| RangeStoreError::new("range store does not cover access LSB"))?;
+        for (&range_lsb, (expr, range_width, origin)) in self.ranges.range(first_lsb..=access.msb) {
             if *range_width == 0 {
                 return Err(RangeStoreError::new(format!(
                     "range at bit {range_lsb} has zero width"
@@ -202,6 +208,22 @@ mod tests {
                 (0, BitAccess::new(1, 1)),
                 (1, BitAccess::new(0, 3)),
                 (0, BitAccess::new(6, 6)),
+            ]
+        );
+    }
+
+    #[test]
+    fn reads_from_the_range_containing_the_access_lsb() {
+        let mut store = RangeStore::new(0u8, 64);
+        for bit in 0..64 {
+            store.update(BitAccess::new(bit, bit), bit as u8).unwrap();
+        }
+        assert_eq!(
+            store.get_parts(BitAccess::new(60, 62)).unwrap(),
+            vec![
+                (60, BitAccess::new(0, 0)),
+                (61, BitAccess::new(0, 0)),
+                (62, BitAccess::new(0, 0)),
             ]
         );
     }

--- a/crates/celox-slt/src/symbolic_store.rs
+++ b/crates/celox-slt/src/symbolic_store.rs
@@ -1,0 +1,275 @@
+use std::hash::Hash;
+use std::ops::Index;
+use std::sync::Arc;
+
+use celox_design::VarAtomBase;
+use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
+
+use crate::RangeStore;
+
+type SymbolicRange<A, N> = RangeStore<Option<(N, HashSet<VarAtomBase<A>>)>>;
+
+/// Symbolic state whose range maps are shared until one branch mutates them.
+///
+/// Branch evaluation frequently clones the complete store while changing only
+/// a handful of variables. Keeping the outer map independent preserves normal
+/// map value semantics; sharing each range map avoids deep-cloning untouched
+/// B-trees at every branch.
+#[derive(Clone, Debug)]
+pub struct SymbolicStore<A, N> {
+    entries: HashMap<A, Arc<SymbolicRange<A, N>>>,
+}
+
+impl<A, N> Default for SymbolicStore<A, N> {
+    fn default() -> Self {
+        Self {
+            entries: HashMap::default(),
+        }
+    }
+}
+
+impl<A: Eq + Hash, N> SymbolicStore<A, N> {
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn reserve(&mut self, additional: usize) {
+        self.entries.reserve(additional);
+    }
+
+    pub fn contains_key(&self, key: &A) -> bool {
+        self.entries.contains_key(key)
+    }
+
+    pub fn get(&self, key: &A) -> Option<&SymbolicRange<A, N>> {
+        self.entries.get(key).map(AsRef::as_ref)
+    }
+
+    pub fn insert(
+        &mut self,
+        key: A,
+        value: SymbolicRange<A, N>,
+    ) -> Option<Arc<SymbolicRange<A, N>>> {
+        self.entries.insert(key, Arc::new(value))
+    }
+
+    pub fn remove(&mut self, key: &A) -> Option<Arc<SymbolicRange<A, N>>> {
+        self.entries.remove(key)
+    }
+
+    pub fn iter(&self) -> Iter<'_, A, N> {
+        Iter {
+            inner: self.entries.iter(),
+        }
+    }
+
+    pub fn values(&self) -> Values<'_, A, N> {
+        Values {
+            inner: self.entries.values(),
+        }
+    }
+
+    pub fn keys(&self) -> impl ExactSizeIterator<Item = &A> {
+        self.entries.keys()
+    }
+
+    pub fn extend<I>(&mut self, values: I)
+    where
+        I: IntoIterator<Item = (A, SymbolicRange<A, N>)>,
+    {
+        self.entries.extend(
+            values
+                .into_iter()
+                .map(|(key, value)| (key, Arc::new(value))),
+        );
+    }
+}
+
+impl<A: Clone + Eq + Hash, N: Clone> SymbolicStore<A, N> {
+    pub fn clone_entry_from(&mut self, key: &A, source: &Self) -> bool {
+        let Some(value) = source.entries.get(key) else {
+            return false;
+        };
+        self.entries.insert(key.clone(), Arc::clone(value));
+        true
+    }
+
+    pub fn entry(&mut self, key: A) -> Entry<'_, A, N> {
+        Entry {
+            inner: self.entries.entry(key),
+        }
+    }
+
+    pub fn get_mut(&mut self, key: &A) -> Option<&mut SymbolicRange<A, N>> {
+        self.entries.get_mut(key).map(Arc::make_mut)
+    }
+
+    pub fn values_mut(&mut self) -> ValuesMut<'_, A, N> {
+        ValuesMut {
+            inner: self.entries.values_mut(),
+        }
+    }
+}
+
+pub struct Entry<'a, A, N> {
+    inner: std::collections::hash_map::Entry<'a, A, Arc<SymbolicRange<A, N>>>,
+}
+
+impl<'a, A: Clone, N: Clone> Entry<'a, A, N> {
+    pub fn or_insert_with(
+        self,
+        default: impl FnOnce() -> SymbolicRange<A, N>,
+    ) -> &'a mut SymbolicRange<A, N> {
+        let value = match self.inner {
+            std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+            std::collections::hash_map::Entry::Vacant(entry) => entry.insert(Arc::new(default())),
+        };
+        Arc::make_mut(value)
+    }
+}
+
+impl<A: Eq + Hash, N> Index<&A> for SymbolicStore<A, N> {
+    type Output = SymbolicRange<A, N>;
+
+    fn index(&self, key: &A) -> &Self::Output {
+        self.entries.index(key)
+    }
+}
+
+pub struct Iter<'a, A, N> {
+    inner: std::collections::hash_map::Iter<'a, A, Arc<SymbolicRange<A, N>>>,
+}
+
+impl<'a, A, N> Iterator for Iter<'a, A, N> {
+    type Item = (&'a A, &'a SymbolicRange<A, N>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(key, value)| (key, value.as_ref()))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<A, N> ExactSizeIterator for Iter<'_, A, N> {}
+
+pub struct Values<'a, A, N> {
+    inner: std::collections::hash_map::Values<'a, A, Arc<SymbolicRange<A, N>>>,
+}
+
+impl<'a, A, N> Iterator for Values<'a, A, N> {
+    type Item = &'a SymbolicRange<A, N>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(AsRef::as_ref)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<A, N> ExactSizeIterator for Values<'_, A, N> {}
+
+pub struct ValuesMut<'a, A: Clone, N: Clone> {
+    inner: std::collections::hash_map::ValuesMut<'a, A, Arc<SymbolicRange<A, N>>>,
+}
+
+impl<'a, A: Clone, N: Clone> Iterator for ValuesMut<'a, A, N> {
+    type Item = &'a mut SymbolicRange<A, N>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(Arc::make_mut)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<A: Clone, N: Clone> ExactSizeIterator for ValuesMut<'_, A, N> {}
+
+pub struct IntoIter<A, N> {
+    inner: std::collections::hash_map::IntoIter<A, Arc<SymbolicRange<A, N>>>,
+}
+
+impl<A: Clone, N: Clone> Iterator for IntoIter<A, N> {
+    type Item = (A, SymbolicRange<A, N>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|(key, value)| {
+            let value = Arc::try_unwrap(value).unwrap_or_else(|shared| shared.as_ref().clone());
+            (key, value)
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl<A: Clone, N: Clone> ExactSizeIterator for IntoIter<A, N> {}
+
+impl<'a, A: Eq + Hash, N> IntoIterator for &'a SymbolicStore<A, N> {
+    type Item = (&'a A, &'a SymbolicRange<A, N>);
+    type IntoIter = Iter<'a, A, N>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<A: Clone + Eq + Hash, N: Clone> IntoIterator for SymbolicStore<A, N> {
+    type Item = (A, SymbolicRange<A, N>);
+    type IntoIter = IntoIter<A, N>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter {
+            inner: self.entries.into_iter(),
+        }
+    }
+}
+
+impl<A: Clone + Eq + Hash, N: Clone> FromIterator<(A, SymbolicRange<A, N>)>
+    for SymbolicStore<A, N>
+{
+    fn from_iter<T: IntoIterator<Item = (A, SymbolicRange<A, N>)>>(iter: T) -> Self {
+        let mut store = Self::default();
+        store.extend(iter);
+        store
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use celox_design::BitAccess;
+
+    use super::*;
+
+    #[test]
+    fn cloned_store_copies_a_range_only_when_it_is_mutated() {
+        let mut original = SymbolicStore::<u32, u32>::default();
+        original.insert(7, RangeStore::new(None, 8));
+
+        let mut branch = original.clone();
+        branch
+            .get_mut(&7)
+            .unwrap()
+            .update(BitAccess::new(0, 3), Some((11, HashSet::default())))
+            .unwrap();
+
+        assert_eq!(
+            original[&7].get_parts(BitAccess::new(0, 7)).unwrap()[0].0,
+            None
+        );
+        assert_eq!(
+            branch[&7].get_parts(BitAccess::new(0, 7)).unwrap()[0].0,
+            Some((11, HashSet::default()))
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- share symbolic range stores across branches and start range reads at the containing interval
- replace native O2 hot-path tree/hash allocations in GVN liveness, reload MemorySSA, and spill planning with ordered vectors or indexed storage
- avoid repeated whole-EU sparse-case indexing and reduce exact-case key cloning while preserving exact equality

## Benchmark

Heliodor `test_soc_linux_boot`, compile-only, native O2 versus cold Veryl AOT-C caches, measured ABBA from the Heliodor source directory:

| compiler | mean |
| --- | ---: |
| Veryl AOT-C | 33.907 s |
| Celox native O2 | 34.755 s |

Celox is 1.025x the Veryl compile time (2.5% slower), down from about 1.93x before the combined optimization work.

## Optimization-quality guard

- pre-optimized SIR, post-optimized SIR, native-optimized SIR, MIR, reactive event graph, and native state layout are byte-identical to the baseline
- full Heliodor native O2 Linux boot smoke passed (`pass=1`)

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p celox-backend-x86 -p celox-slt -p celox-frontend-veryl -p celox-sir-opt --all-targets --offline -- -D warnings`
- `cargo test --workspace --all-targets --offline`

