### PR TITLE
fix(ci): restore Heliodor on pull requests

### DIFF
--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -74,7 +74,8 @@ jobs:
         run: bash scripts/tests/convert-heliodor-bench.sh
 
   heliodor:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    # Keep the x86_64 gate on every workflow trigger. Only the ARM64 PR lane is
+    # change-gated by arm64-changes below.
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## Summary

- run the x86_64 Heliodor job for every event that triggers the workflow, including pull requests
- keep the ARM64 pull-request lane gated by the existing changed-file classifier
- document the intended split directly in the workflow

## Root cause

The x86_64 `heliodor` job was restricted to scheduled and manually dispatched runs while narrowing ARM64 pull-request coverage. As a result, Heliodor was skipped entirely for pull requests whose changes did not select the ARM64 lane.

## Impact

Pull requests matching the Heliodor workflow path filters once again run the x86_64 correctness and benchmark gate. ARM64 runner usage remains selectively gated.

## Validation

- `node --test scripts/ci-changes.test.mjs`
- parsed `.github/workflows/heliodor-bench.yml` and asserted that x86_64 is ungated while ARM64 still depends on `arm64-changes`
- `git diff --check`
- pre-push hook: submodule check, Cargo formatting, Biome, `cargo check`, and clean-tree check
