### PR TITLE
fix(ci): verify release merge queue entry

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -22,9 +22,12 @@ features are minor releases, and breaking changes are major releases.
 ## Automated release train
 
 Release Please maintains one release pull request against `master`. Every Monday
-at 03:00 UTC, the release workflow enables auto-merge for that pull request. The
-required checks and merge queue decide when it is safe to merge. If there are no
-releasable changes, the run is a no-op.
+at 03:00 UTC, the release workflow enables auto-merge for that pull request and
+waits for GitHub to accept it into the merge queue. The workflow also calls the
+queue API explicitly because enabling auto-merge alone does not prove that the
+queue entry was created. It succeeds only after observing a merge queue entry;
+required-check failures or a queue timeout therefore remain visible as a failed
+workflow. If there are no releasable changes, the run is a no-op.
 
 The commit that introduces this policy is the release-history baseline. Earlier
 commits after `v0.1.34` are intentionally not retroactively classified; release
@@ -105,8 +108,9 @@ follow-up workflows from running.
 
 The App has Issues write permission for Release Please's status labels. The
 weekly workflow still identifies the release pull request by the exact
-`release-please--branches--master--components--celox` branch from this repository
-and honors a manually applied `release:hold` label before enabling auto-merge.
+`release-please--branches--master--components--celox` branch from this repository.
+It rechecks the `release:hold` label while waiting and disables auto-merge or
+removes an existing queue entry before returning when the release is held.
 
 Configure merge commits to use the pull request title as the merge commit title.
 This preserves the Conventional Commit title consumed by Release Please. Protect

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -22,12 +22,12 @@ features are minor releases, and breaking changes are major releases.
 ## Automated release train
 
 Release Please maintains one release pull request against `master`. Every Monday
-at 03:00 UTC, the release workflow enables auto-merge for that pull request and
-waits for GitHub to accept it into the merge queue. The workflow also calls the
-queue API explicitly because enabling auto-merge alone does not prove that the
-queue entry was created. It succeeds only after observing a merge queue entry;
-required-check failures or a queue timeout therefore remain visible as a failed
-workflow. If there are no releasable changes, the run is a no-op.
+at 03:00 UTC, the release workflow first tries to add that pull request directly
+to the merge queue. If requirements are still pending, it enables auto-merge and
+retries until GitHub accepts the pull request. It succeeds only after observing a
+merge queue entry; required-check failures or a queue timeout therefore remain
+visible as a failed workflow. If there are no releasable changes, the run is a
+no-op.
 
 The commit that introduces this policy is the release-history baseline. Earlier
 commits after `v0.1.34` are intentionally not retroactively classified; release
@@ -101,10 +101,11 @@ repository with repository contents and pull request write access. Store its
 numeric App ID as the `RELEASE_APP_ID` Actions variable and its complete PEM
 private key as the `RELEASE_APP_PRIVATE_KEY` Actions secret. Each job mints a
 short-lived, repository-scoped installation token; never store an installation
-token itself because it expires. The Veryl HEAD and vendored-metadata workflows
-use the same mechanism so generated branch pushes start normal CI. Using the
-default `GITHUB_TOKEN` to create or update those branches would prevent their
-follow-up workflows from running.
+token itself because it expires. The weekly queue job uses this token so adding a
+pull request to the queue starts the required `merge_group` checks. The Veryl
+HEAD and vendored-metadata workflows use the same mechanism so generated branch
+pushes start normal CI. Using the default `GITHUB_TOKEN` for these events would
+prevent their follow-up workflows from running.
 
 The App has Issues write permission for Release Please's status labels. The
 weekly workflow still identifies the release pull request by the exact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,15 +89,24 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
-    env:
-      # Queueing an existing PR does not need to trigger another workflow, so
-      # the job-scoped token is sufficient and avoids minting a second app token.
-      GH_TOKEN: ${{ github.token }}
+      contents: read
     steps:
       - uses: actions/checkout@v7
 
+      # An enqueue event created with GITHUB_TOKEN would not start the required
+      # merge_group workflows. Use the release App so queue checks run normally.
+      - name: Create release app token
+        id: release-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
+
       - name: Queue the release pull request
         timeout-minutes: 65
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
         run: node scripts/queue-release-pr.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,29 +92,12 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      # Enqueuing an existing PR does not need to trigger another workflow, so
+      # Queueing an existing PR does not need to trigger another workflow, so
       # the job-scoped token is sufficient and avoids minting a second app token.
       GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Enable auto-merge for the release pull request
-        shell: bash
-        run: |
-          release_pr="$(
-            gh pr list \
-              --repo "$GITHUB_REPOSITORY" \
-              --state open \
-              --base master \
-              --limit 1000 \
-              --json number,headRefName,isCrossRepository,labels \
-              --jq '[.[] | select(.isCrossRepository == false) | select(.headRefName == "release-please--branches--master--components--celox") | select((.labels | map(.name) | index("release:hold")) | not)][0].number // empty'
-          )"
+      - uses: actions/checkout@v7
 
-          if [ -z "$release_pr" ]; then
-            echo "No unheld release pull request is ready to queue."
-            exit 0
-          fi
-
-          gh pr merge "$release_pr" \
-            --repo "$GITHUB_REPOSITORY" \
-            --auto \
-            --merge
+      - name: Queue the release pull request
+        timeout-minutes: 65
+        run: node scripts/queue-release-pr.mjs

--- a/scripts/queue-release-pr.mjs
+++ b/scripts/queue-release-pr.mjs
@@ -141,10 +141,6 @@ export async function queueReleasePullRequest({
     log(`Release pull request #${pullRequest.number} is already queued.`);
     return { outcome: "queued", number: pullRequest.number };
   }
-  if (pullRequest.autoMergeRequest === null) {
-    await github.enableAutoMerge(pullRequest.id);
-    log(`Enabled auto-merge for release pull request #${pullRequest.number}.`);
-  }
 
   const deadline = now() + timeoutMs;
   let lastError = null;
@@ -186,6 +182,20 @@ export async function queueReleasePullRequest({
       lastError = new Error("enqueuePullRequest returned no merge queue entry");
     } catch (error) {
       lastError = error;
+    }
+
+    // A green pull request can be enqueued directly, while GitHub rejects
+    // enablePullRequestAutoMerge once its requirements have already passed.
+    // Only use auto-merge as the fallback that waits for pending requirements.
+    if (pullRequest.autoMergeRequest === null) {
+      try {
+        await github.enableAutoMerge(pullRequest.id);
+        log(`Enabled auto-merge for release pull request #${pullRequest.number}.`);
+      } catch (error) {
+        lastError = new Error(
+          `${lastError?.message ?? "enqueuePullRequest failed"}; enabling auto-merge also failed: ${error.message}`,
+        );
+      }
     }
 
     if (now() >= deadline) {

--- a/scripts/queue-release-pr.mjs
+++ b/scripts/queue-release-pr.mjs
@@ -64,8 +64,8 @@ mutation($prId: ID!) {
 }`;
 
 const DEQUEUE_PULL_REQUEST_MUTATION = `
-mutation($entryId: ID!) {
-  dequeuePullRequest(input: {id: $entryId}) {
+mutation($prId: ID!) {
+  dequeuePullRequest(input: {id: $prId}) {
     clientMutationId
   }
 }`;
@@ -90,12 +90,7 @@ export function selectReleasePullRequest(pullRequests) {
 
 async function stopHeldRelease(github, pullRequest, log) {
   if (pullRequest.isInMergeQueue) {
-    if (pullRequest.mergeQueueEntry?.id === undefined) {
-      throw new Error(
-        `Release pull request #${pullRequest.number} is queued without a queue entry ID`,
-      );
-    }
-    await github.dequeuePullRequest(pullRequest.mergeQueueEntry.id);
+    await github.dequeuePullRequest(pullRequest.id);
     log(`Removed release pull request #${pullRequest.number} from the merge queue.`);
     pullRequest = await github.getPullRequest(pullRequest.id);
   }
@@ -290,16 +285,8 @@ export class GitHubCli {
     return data.enqueuePullRequest.mergeQueueEntry;
   }
 
-  async dequeuePullRequest(entryId) {
-    const output = await this.run([
-      "api",
-      "graphql",
-      "-f",
-      `query=${DEQUEUE_PULL_REQUEST_MUTATION}`,
-      "-f",
-      `entryId=${entryId}`,
-    ]);
-    JSON.parse(output);
+  async dequeuePullRequest(pullRequestId) {
+    await this.graphql(DEQUEUE_PULL_REQUEST_MUTATION, pullRequestId);
   }
 }
 

--- a/scripts/queue-release-pr.mjs
+++ b/scripts/queue-release-pr.mjs
@@ -1,0 +1,324 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { pathToFileURL } from "node:url";
+
+const execFileAsync = promisify(execFile);
+
+export const RELEASE_HEAD =
+  "release-please--branches--master--components--celox";
+export const RELEASE_HOLD_LABEL = "release:hold";
+
+const PULL_REQUEST_STATE_QUERY = `
+query($prId: ID!) {
+  node(id: $prId) {
+    ... on PullRequest {
+      id
+      number
+      state
+      merged
+      isInMergeQueue
+      mergeQueueEntry {
+        id
+        position
+      }
+      autoMergeRequest {
+        enabledAt
+      }
+      labels(first: 100) {
+        nodes {
+          name
+        }
+      }
+    }
+  }
+}`;
+
+const ENABLE_AUTO_MERGE_MUTATION = `
+mutation($prId: ID!) {
+  enablePullRequestAutoMerge(
+    input: {pullRequestId: $prId, mergeMethod: MERGE}
+  ) {
+    pullRequest {
+      id
+    }
+  }
+}`;
+
+const DISABLE_AUTO_MERGE_MUTATION = `
+mutation($prId: ID!) {
+  disablePullRequestAutoMerge(input: {pullRequestId: $prId}) {
+    pullRequest {
+      id
+    }
+  }
+}`;
+
+const ENQUEUE_PULL_REQUEST_MUTATION = `
+mutation($prId: ID!) {
+  enqueuePullRequest(input: {pullRequestId: $prId}) {
+    mergeQueueEntry {
+      id
+      position
+    }
+  }
+}`;
+
+const DEQUEUE_PULL_REQUEST_MUTATION = `
+mutation($entryId: ID!) {
+  dequeuePullRequest(input: {id: $entryId}) {
+    clientMutationId
+  }
+}`;
+
+function hasLabel(pullRequest, label) {
+  return pullRequest.labels.some((item) => item.name === label);
+}
+
+export function selectReleasePullRequest(pullRequests) {
+  const matches = pullRequests.filter(
+    (pullRequest) =>
+      pullRequest.headRefName === RELEASE_HEAD &&
+      pullRequest.isCrossRepository === false,
+  );
+
+  if (matches.length > 1) {
+    throw new Error(`Found ${matches.length} matching release pull requests`);
+  }
+
+  return matches[0] ?? null;
+}
+
+async function stopHeldRelease(github, pullRequest, log) {
+  if (pullRequest.isInMergeQueue) {
+    if (pullRequest.mergeQueueEntry?.id === undefined) {
+      throw new Error(
+        `Release pull request #${pullRequest.number} is queued without a queue entry ID`,
+      );
+    }
+    await github.dequeuePullRequest(pullRequest.mergeQueueEntry.id);
+    log(`Removed release pull request #${pullRequest.number} from the merge queue.`);
+    pullRequest = await github.getPullRequest(pullRequest.id);
+  }
+
+  if (pullRequest.autoMergeRequest !== null) {
+    await github.disableAutoMerge(pullRequest.id);
+    log(`Disabled auto-merge for held release pull request #${pullRequest.number}.`);
+  }
+
+  log(`Release pull request #${pullRequest.number} is held by ${RELEASE_HOLD_LABEL}.`);
+  return { outcome: "held", number: pullRequest.number };
+}
+
+export async function queueReleasePullRequest({
+  github,
+  timeoutMs = 60 * 60 * 1000,
+  pollIntervalMs = 15 * 1000,
+  now = Date.now,
+  sleep = (duration) =>
+    new Promise((resolve) => setTimeout(resolve, duration)),
+  log = console.log,
+}) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error("timeoutMs must be a positive finite number");
+  }
+  if (!Number.isFinite(pollIntervalMs) || pollIntervalMs <= 0) {
+    throw new Error("pollIntervalMs must be a positive finite number");
+  }
+
+  const candidate = selectReleasePullRequest(
+    await github.listOpenPullRequests(),
+  );
+  if (candidate === null) {
+    log("No release pull request is open.");
+    return { outcome: "missing" };
+  }
+
+  let pullRequest = await github.getPullRequest(candidate.id);
+  if (hasLabel(pullRequest, RELEASE_HOLD_LABEL)) {
+    return stopHeldRelease(github, pullRequest, log);
+  }
+  if (pullRequest.isInMergeQueue) {
+    log(`Release pull request #${pullRequest.number} is already queued.`);
+    return { outcome: "queued", number: pullRequest.number };
+  }
+  if (pullRequest.autoMergeRequest === null) {
+    await github.enableAutoMerge(pullRequest.id);
+    log(`Enabled auto-merge for release pull request #${pullRequest.number}.`);
+  }
+
+  const deadline = now() + timeoutMs;
+  let lastError = null;
+  let attempt = 0;
+
+  while (true) {
+    attempt += 1;
+    pullRequest = await github.getPullRequest(candidate.id);
+
+    if (pullRequest.merged || pullRequest.state === "MERGED") {
+      log(`Release pull request #${pullRequest.number} merged while waiting.`);
+      return { outcome: "merged", number: pullRequest.number };
+    }
+    if (pullRequest.state !== "OPEN") {
+      throw new Error(
+        `Release pull request #${pullRequest.number} became ${pullRequest.state}`,
+      );
+    }
+    if (hasLabel(pullRequest, RELEASE_HOLD_LABEL)) {
+      return stopHeldRelease(github, pullRequest, log);
+    }
+    if (pullRequest.isInMergeQueue) {
+      log(`Release pull request #${pullRequest.number} entered the merge queue.`);
+      return { outcome: "queued", number: pullRequest.number };
+    }
+
+    try {
+      const entry = await github.enqueuePullRequest(candidate.id);
+      if (entry?.id) {
+        log(
+          `Queued release pull request #${pullRequest.number} at position ${entry.position}.`,
+        );
+        return {
+          outcome: "queued",
+          number: pullRequest.number,
+          position: entry.position,
+        };
+      }
+      lastError = new Error("enqueuePullRequest returned no merge queue entry");
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (now() >= deadline) {
+      throw new Error(
+        `Timed out queueing release pull request #${pullRequest.number} after ${attempt} attempts: ${lastError?.message ?? "unknown error"}`,
+      );
+    }
+
+    log(
+      `Release pull request #${pullRequest.number} is not queueable yet; retrying (${lastError?.message ?? "unknown error"}).`,
+    );
+    await sleep(pollIntervalMs);
+  }
+}
+
+export class GitHubCli {
+  constructor(repository) {
+    if (!/^[^/]+\/[^/]+$/.test(repository)) {
+      throw new Error(`Invalid GITHUB_REPOSITORY: ${repository}`);
+    }
+    this.repository = repository;
+  }
+
+  async run(args) {
+    try {
+      const { stdout } = await execFileAsync("gh", args, {
+        encoding: "utf8",
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      return stdout;
+    } catch (error) {
+      const detail = error.stderr?.trim() || error.stdout?.trim() || error.message;
+      throw new Error(detail);
+    }
+  }
+
+  async graphql(query, pullRequestId) {
+    const output = await this.run([
+      "api",
+      "graphql",
+      "-f",
+      `query=${query}`,
+      "-f",
+      `prId=${pullRequestId}`,
+    ]);
+    return JSON.parse(output).data;
+  }
+
+  async listOpenPullRequests() {
+    const output = await this.run([
+      "pr",
+      "list",
+      "--repo",
+      this.repository,
+      "--state",
+      "open",
+      "--base",
+      "master",
+      "--limit",
+      "1000",
+      "--json",
+      "id,number,headRefName,isCrossRepository",
+    ]);
+    return JSON.parse(output);
+  }
+
+  async getPullRequest(pullRequestId) {
+    const data = await this.graphql(PULL_REQUEST_STATE_QUERY, pullRequestId);
+    const pullRequest = data.node;
+    if (pullRequest === null) {
+      throw new Error(`Pull request ${pullRequestId} was not found`);
+    }
+    return {
+      ...pullRequest,
+      labels: pullRequest.labels.nodes,
+    };
+  }
+
+  async enableAutoMerge(pullRequestId) {
+    await this.graphql(ENABLE_AUTO_MERGE_MUTATION, pullRequestId);
+  }
+
+  async disableAutoMerge(pullRequestId) {
+    await this.graphql(DISABLE_AUTO_MERGE_MUTATION, pullRequestId);
+  }
+
+  async enqueuePullRequest(pullRequestId) {
+    const data = await this.graphql(
+      ENQUEUE_PULL_REQUEST_MUTATION,
+      pullRequestId,
+    );
+    return data.enqueuePullRequest.mergeQueueEntry;
+  }
+
+  async dequeuePullRequest(entryId) {
+    const output = await this.run([
+      "api",
+      "graphql",
+      "-f",
+      `query=${DEQUEUE_PULL_REQUEST_MUTATION}`,
+      "-f",
+      `entryId=${entryId}`,
+    ]);
+    JSON.parse(output);
+  }
+}
+
+function positiveSeconds(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined) {
+    return fallback;
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a positive number`);
+  }
+  return value * 1000;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    const repository = process.env.GITHUB_REPOSITORY;
+    const github = new GitHubCli(repository ?? "");
+    await queueReleasePullRequest({
+      github,
+      timeoutMs: positiveSeconds("RELEASE_QUEUE_TIMEOUT_SECONDS", 60 * 60),
+      pollIntervalMs: positiveSeconds("RELEASE_QUEUE_POLL_SECONDS", 15),
+    });
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/queue-release-pr.test.mjs
+++ b/scripts/queue-release-pr.test.mjs
@@ -23,7 +23,7 @@ function pullRequest(overrides = {}) {
   };
 }
 
-function fakeGitHub({ candidates = [pullRequest()], states, enqueue }) {
+function fakeGitHub({ candidates = [pullRequest()], states, enqueue, enable }) {
   const calls = [];
   const queuedStates = [...(states ?? [pullRequest()])];
   let lastState = queuedStates.at(-1);
@@ -41,6 +41,7 @@ function fakeGitHub({ candidates = [pullRequest()], states, enqueue }) {
     },
     async enableAutoMerge(id) {
       calls.push(["enable", id]);
+      return enable?.();
     },
     async disableAutoMerge(id) {
       calls.push(["disable", id]);
@@ -81,17 +82,79 @@ test("does nothing when no release pull request is open", async () => {
   assert.deepEqual(github.calls, ["list"]);
 });
 
-test("enables auto-merge and requires an explicit queue entry", async () => {
+test("enqueues a green release before trying to enable auto-merge", async () => {
   const github = fakeGitHub({});
   const result = await queueReleasePullRequest({ github });
   assert.deepEqual(result, { outcome: "queued", number: 388, position: 1 });
   assert.deepEqual(github.calls, [
     "list",
     ["get", "PR_1"],
-    ["enable", "PR_1"],
     ["get", "PR_1"],
     ["enqueue", "PR_1"],
   ]);
+});
+
+test("enables auto-merge after pending requirements reject direct enqueue", async () => {
+  const github = fakeGitHub({
+    states: [
+      pullRequest(),
+      pullRequest(),
+      pullRequest({
+        autoMergeRequest: { enabledAt: "now" },
+        isInMergeQueue: true,
+      }),
+    ],
+    enqueue() {
+      throw new Error("Required checks have not passed");
+    },
+  });
+  let clock = 0;
+  const result = await queueReleasePullRequest({
+    github,
+    timeoutMs: 100,
+    pollIntervalMs: 10,
+    now: () => clock,
+    sleep: async (duration) => {
+      clock += duration;
+    },
+    log() {},
+  });
+  assert.deepEqual(result, { outcome: "queued", number: 388 });
+  assert.deepEqual(github.calls.slice(0, 5), [
+    "list",
+    ["get", "PR_1"],
+    ["get", "PR_1"],
+    ["enqueue", "PR_1"],
+    ["enable", "PR_1"],
+  ]);
+});
+
+test("keeps polling when auto-merge is rejected for a green release", async () => {
+  const github = fakeGitHub({
+    states: [
+      pullRequest(),
+      pullRequest(),
+      pullRequest({ isInMergeQueue: true }),
+    ],
+    enqueue() {
+      throw new Error("Queue entry is not visible yet");
+    },
+    enable() {
+      throw new Error("Pull request is already queueable");
+    },
+  });
+  let clock = 0;
+  const result = await queueReleasePullRequest({
+    github,
+    timeoutMs: 100,
+    pollIntervalMs: 10,
+    now: () => clock,
+    sleep: async (duration) => {
+      clock += duration;
+    },
+    log() {},
+  });
+  assert.deepEqual(result, { outcome: "queued", number: 388 });
 });
 
 test("observes a queue entry created asynchronously", async () => {

--- a/scripts/queue-release-pr.test.mjs
+++ b/scripts/queue-release-pr.test.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  queueReleasePullRequest,
+  RELEASE_HEAD,
+  selectReleasePullRequest,
+} from "./queue-release-pr.mjs";
+
+function pullRequest(overrides = {}) {
+  return {
+    id: "PR_1",
+    number: 388,
+    state: "OPEN",
+    merged: false,
+    headRefName: RELEASE_HEAD,
+    isCrossRepository: false,
+    isInMergeQueue: false,
+    mergeQueueEntry: null,
+    autoMergeRequest: null,
+    labels: [],
+    ...overrides,
+  };
+}
+
+function fakeGitHub({ candidates = [pullRequest()], states, enqueue }) {
+  const calls = [];
+  const queuedStates = [...(states ?? [pullRequest()])];
+  let lastState = queuedStates.at(-1);
+
+  return {
+    calls,
+    async listOpenPullRequests() {
+      calls.push("list");
+      return candidates;
+    },
+    async getPullRequest(id) {
+      calls.push(["get", id]);
+      lastState = queuedStates.shift() ?? lastState;
+      return lastState;
+    },
+    async enableAutoMerge(id) {
+      calls.push(["enable", id]);
+    },
+    async disableAutoMerge(id) {
+      calls.push(["disable", id]);
+    },
+    async enqueuePullRequest(id) {
+      calls.push(["enqueue", id]);
+      return enqueue ? enqueue() : { id: "MQE_1", position: 1 };
+    },
+    async dequeuePullRequest(id) {
+      calls.push(["dequeue", id]);
+    },
+  };
+}
+
+test("selects only the trusted same-repository release branch", () => {
+  const expected = pullRequest();
+  assert.equal(
+    selectReleasePullRequest([
+      pullRequest({ id: "fork", isCrossRepository: true }),
+      pullRequest({ id: "other", headRefName: "release-lookalike" }),
+      expected,
+    ]),
+    expected,
+  );
+});
+
+test("rejects ambiguous release pull requests", () => {
+  assert.throws(
+    () => selectReleasePullRequest([pullRequest(), pullRequest({ id: "PR_2" })]),
+    /Found 2 matching release pull requests/,
+  );
+});
+
+test("does nothing when no release pull request is open", async () => {
+  const github = fakeGitHub({ candidates: [] });
+  const result = await queueReleasePullRequest({ github });
+  assert.deepEqual(result, { outcome: "missing" });
+  assert.deepEqual(github.calls, ["list"]);
+});
+
+test("enables auto-merge and requires an explicit queue entry", async () => {
+  const github = fakeGitHub({});
+  const result = await queueReleasePullRequest({ github });
+  assert.deepEqual(result, { outcome: "queued", number: 388, position: 1 });
+  assert.deepEqual(github.calls, [
+    "list",
+    ["get", "PR_1"],
+    ["enable", "PR_1"],
+    ["get", "PR_1"],
+    ["enqueue", "PR_1"],
+  ]);
+});
+
+test("observes a queue entry created asynchronously", async () => {
+  const github = fakeGitHub({
+    states: [
+      pullRequest({ autoMergeRequest: { enabledAt: "now" } }),
+      pullRequest({ autoMergeRequest: { enabledAt: "now" } }),
+      pullRequest({
+        autoMergeRequest: { enabledAt: "now" },
+        isInMergeQueue: true,
+      }),
+    ],
+    enqueue() {
+      throw new Error("Required checks have not passed");
+    },
+  });
+  let clock = 0;
+  const result = await queueReleasePullRequest({
+    github,
+    timeoutMs: 100,
+    pollIntervalMs: 10,
+    now: () => clock,
+    sleep: async (duration) => {
+      clock += duration;
+    },
+    log() {},
+  });
+  assert.deepEqual(result, { outcome: "queued", number: 388 });
+});
+
+test("honors a hold added while waiting", async () => {
+  const github = fakeGitHub({
+    states: [
+      pullRequest({ autoMergeRequest: { enabledAt: "now" } }),
+      pullRequest({ autoMergeRequest: { enabledAt: "now" } }),
+      pullRequest({
+        autoMergeRequest: { enabledAt: "now" },
+        labels: [{ name: "release:hold" }],
+      }),
+    ],
+    enqueue() {
+      throw new Error("Required checks have not passed");
+    },
+  });
+  let clock = 0;
+  const result = await queueReleasePullRequest({
+    github,
+    timeoutMs: 100,
+    pollIntervalMs: 10,
+    now: () => clock,
+    sleep: async (duration) => {
+      clock += duration;
+    },
+    log() {},
+  });
+  assert.deepEqual(result, { outcome: "held", number: 388 });
+  assert.ok(
+    github.calls.some(
+      (call) => Array.isArray(call) && call[0] === "disable",
+    ),
+  );
+});
+
+test("removes an already queued held release", async () => {
+  const held = pullRequest({
+    isInMergeQueue: true,
+    mergeQueueEntry: { id: "MQE_1", position: 1 },
+    autoMergeRequest: { enabledAt: "now" },
+    labels: [{ name: "release:hold" }],
+  });
+  const github = fakeGitHub({ states: [held, held] });
+  const result = await queueReleasePullRequest({ github, log() {} });
+  assert.deepEqual(result, { outcome: "held", number: 388 });
+  assert.ok(
+    github.calls.some(
+      (call) => call[0] === "dequeue" && call[1] === "MQE_1",
+    ),
+  );
+  assert.ok(github.calls.some((call) => call[0] === "disable"));
+});
+
+test("fails instead of reporting success when queueing times out", async () => {
+  const github = fakeGitHub({
+    enqueue() {
+      throw new Error("Required checks have not passed");
+    },
+  });
+  let clock = 0;
+  await assert.rejects(
+    queueReleasePullRequest({
+      github,
+      timeoutMs: 20,
+      pollIntervalMs: 10,
+      now: () => clock,
+      sleep: async (duration) => {
+        clock += duration;
+      },
+      log() {},
+    }),
+    /Timed out queueing release pull request #388.*Required checks have not passed/,
+  );
+});

--- a/scripts/queue-release-pr.test.mjs
+++ b/scripts/queue-release-pr.test.mjs
@@ -230,6 +230,11 @@ test("removes an already queued held release", async () => {
   assert.deepEqual(result, { outcome: "held", number: 388 });
   assert.ok(
     github.calls.some(
+      (call) => call[0] === "dequeue" && call[1] === "PR_1",
+    ),
+  );
+  assert.ok(
+    !github.calls.some(
       (call) => call[0] === "dequeue" && call[1] === "MQE_1",
     ),
   );


### PR DESCRIPTION
## Summary

- replace the weekly release job's unchecked `gh pr merge --auto` call with an explicit, retrying merge-queue client
- require an observed `mergeQueueEntry` before the workflow reports success
- honor `release:hold` while waiting by disabling auto-merge and removing an existing queue entry
- document and unit-test the release queue state machine

## Root cause

`gh pr merge --auto` returned success after creating an auto-merge request, but that did not guarantee the release pull request had entered the required merge queue. PR #388 remained open with successful required checks and no queue entry, while repeated weekly runs still exited successfully.

The new helper keeps auto-merge as a fallback, calls `enqueuePullRequest` directly until GitHub accepts the PR, verifies the returned queue entry, and fails after the repository's one-hour queue window instead of silently reporting success.

## Validation

- `node --test scripts/*.test.mjs`
- `node --check scripts/queue-release-pr.mjs`
- `node --check scripts/queue-release-pr.test.mjs`
- parsed `.github/workflows/release.yml` with PyYAML
- `git diff --check`
- read-only live query against PR #388 confirmed the helper parses its PR node and merge queue entry
- repository pre-push checks: submodule consistency, `cargo fmt`, Biome