### PR TITLE
fix(wasm): preserve array layout metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,12 @@ jobs:
       - name: Build NAPI WASM compatibility target
         run: pnpm --filter @celox-sim/celox-napi exec napi build --platform --target wasm32-wasip1-threads --manifest-path ../../Cargo.toml -p celox-napi
 
+      - name: Build TypeScript runtime for WASM tests
+        run: pnpm --filter @celox-sim/celox build
+
+      - name: Run WASM tests
+        run: pnpm --filter @celox-sim/playground test:wasm
+
       - name: Upload NAPI WASM artifact
         uses: actions/upload-artifact@v7
         with:

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1682,19 +1682,26 @@ impl NativeSimulatorHandle {
                 continue;
             };
             let name = program.get_path(addr);
-            let width = layout.widths.get(addr).copied().unwrap_or(0);
+            let total_width = layout.widths.get(addr).copied().unwrap_or(0);
+            let (width, array_dims) = if info.array_dims.is_empty() {
+                (total_width, None)
+            } else {
+                let element_count = info.array_dims.iter().product::<usize>();
+                (total_width / element_count, Some(&info.array_dims))
+            };
             let byte_size = celox::get_byte_size(width);
-            layout_map.insert(
-                name,
-                serde_json::json!({
-                    "offset": offset,
-                    "width": width,
-                    "byte_size": byte_size,
-                    "is_4state": four_state && info.is_4state,
-                    "direction": layout::direction_str(info.var_kind),
-                    "type_kind": layout::type_kind_str(info.type_kind),
-                }),
-            );
+            let mut entry = serde_json::json!({
+                "offset": offset,
+                "width": width,
+                "byte_size": byte_size,
+                "is_4state": four_state && info.is_4state,
+                "direction": layout::direction_str(info.var_kind),
+                "type_kind": layout::type_kind_str(info.type_kind),
+            });
+            if let Some(array_dims) = array_dims {
+                entry["array_dims"] = serde_json::json!(array_dims);
+            }
+            layout_map.insert(name, entry);
         }
 
         serde_json::to_string(&layout_map).unwrap_or_else(|_| "{}".to_string())

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -12,7 +12,7 @@
     "test:lsp-components": "pnpm run test:vite-components && node test/fixtures/injected-components/lsp-e2e.mjs",
     "test:e2e": "pnpm run build && playwright test",
     "test:watch": "vitest",
-    "test:wasm": "NAPI_RS_FORCE_WASI=1 vitest run --config vitest.wasm.config.ts"
+    "test:wasm": "vitest run --config vitest.wasm.config.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.55.1",

--- a/packages/playground/test/4state-wasm.test.ts
+++ b/packages/playground/test/4state-wasm.test.ts
@@ -16,7 +16,10 @@ module FourStateDemo (
 }
 `;
 
-const isWasm = !!process.env.NAPI_RS_FORCE_WASI;
+const isWasm =
+	!!process.env.NAPI_RS_WASI_FLAVOR ||
+	process.env.NAPI_RS_FORCE_WASI === "true" ||
+	process.env.NAPI_RS_FORCE_WASI === "error";
 
 describe.skipIf(!isWasm)("FourState (WASM bridge)", () => {
 	test("writes and reads all-X", () => {

--- a/packages/playground/test/adder-wasm.test.ts
+++ b/packages/playground/test/adder-wasm.test.ts
@@ -22,8 +22,11 @@ module Adder (
 }
 `;
 
-// Only run when NAPI_RS_FORCE_WASI is set (i.e., testing the WASM path).
-const isWasm = !!process.env.NAPI_RS_FORCE_WASI;
+// Only run when the NAPI loader is explicitly using the WASM binding.
+const isWasm =
+  !!process.env.NAPI_RS_WASI_FLAVOR ||
+  process.env.NAPI_RS_FORCE_WASI === "true" ||
+  process.env.NAPI_RS_FORCE_WASI === "error";
 
 describe.skipIf(!isWasm)("Adder (WASM bridge)", () => {
   test("adds two numbers via WASM", () => {

--- a/packages/playground/test/array-wasm.test.ts
+++ b/packages/playground/test/array-wasm.test.ts
@@ -1,0 +1,43 @@
+import { Simulator } from "@celox-sim/celox";
+import { describe, expect, test } from "vitest";
+
+const ARRAY_SOURCE = `
+module ArrayPassThrough (
+    data: input  logic<3> [4],
+    copy: output logic<3> [4],
+) {
+    for i in 0..4 :g {
+        assign copy[i] = data[i];
+    }
+}
+`;
+
+describe("Array ports (WASM bridge)", () => {
+	test("reads and writes unpacked array elements", () => {
+		interface Ports {
+			data: {
+				at(i: number): bigint;
+				set(i: number, value: bigint): void;
+				readonly length: number;
+			};
+			readonly copy: {
+				at(i: number): bigint;
+				readonly length: number;
+			};
+		}
+
+		const sim = Simulator.fromSource<Ports>(ARRAY_SOURCE, "ArrayPassThrough");
+
+		expect(sim.dut.data.length).toBe(4);
+		expect(sim.dut.copy.length).toBe(4);
+		for (let i = 0; i < 4; i++) {
+			sim.dut.data.set(i, BigInt(i + 1));
+		}
+		for (let i = 0; i < 4; i++) {
+			expect(sim.dut.data.at(i)).toBe(BigInt(i + 1));
+			expect(sim.dut.copy.at(i)).toBe(BigInt(i + 1));
+		}
+
+		sim.dispose();
+	});
+});

--- a/packages/playground/test/wasm.setup.ts
+++ b/packages/playground/test/wasm.setup.ts
@@ -1,3 +1,4 @@
 // Set this after Vitest starts so only the Celox addon, not the test runner's
 // own native dependencies, is forced onto the WASI binding.
 process.env.NAPI_RS_WASI_FLAVOR = "wasm32-wasi";
+process.env.NAPI_RS_FORCE_WASI = "true";

--- a/packages/playground/test/wasm.setup.ts
+++ b/packages/playground/test/wasm.setup.ts
@@ -1,0 +1,3 @@
+// Set this after Vitest starts so only the Celox addon, not the test runner's
+// own native dependencies, is forced onto the WASI binding.
+process.env.NAPI_RS_WASI_FLAVOR = "wasm32-wasi";

--- a/packages/playground/vitest.wasm.config.ts
+++ b/packages/playground/vitest.wasm.config.ts
@@ -10,5 +10,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["test/*-wasm.test.ts"],
+    setupFiles: ["test/wasm.setup.ts"],
   },
 });


### PR DESCRIPTION
## Summary

- preserve unpacked-array dimensions and element widths in WASM layout metadata
- add strict WASI coverage for JavaScript/TypeScript array reads and writes
- run the WASM suite in CI without allowing silent native-addon fallback

## Root cause

The wasm32 layout serializer emitted each unpacked array as one flattened scalar and omitted `array_dims`. As a result, `Simulator.fromSource()` and `Simulator.fromProject()` built scalar DUT properties instead of array accessors with `.at()` and `.set()`.

The existing WASM test command also used `NAPI_RS_FORCE_WASI=1`, which the generated loader does not recognize as a forced-WASI value, so those tests could silently use the native addon.

## Impact

Browser/WASM simulations now expose unpacked arrays consistently with native simulations, including arrays whose element widths are not byte-aligned.

## Validation

- current WASI NAPI build
- WASM Vitest: 6 passed
- native focused array E2E: 5 passed
- DUT/native array Vitest: 33 passed
- `cargo test -p celox-napi --lib`: 21 passed
- `cargo clippy -p celox-napi --all-targets -- -D warnings`
- TypeScript build, Cargo fmt, Biome, and the full pre-push Cargo check
