### PR TITLE
perf(slt): make symbolic construction sparse

### DIFF
--- a/crates/celox-frontend-veryl/src/bitaccess.rs
+++ b/crates/celox-frontend-veryl/src/bitaccess.rs
@@ -248,7 +248,6 @@ pub enum PartSelectGeometry {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelectGeometry {
-    pub dimensions: Vec<usize>,
     pub strides: Vec<usize>,
     pub total_width: usize,
     /// Number of aggregate indices before the optional part-select anchor.
@@ -269,18 +268,20 @@ pub fn select_geometry(
     index: &VarIndex,
     select: &VarSelect,
 ) -> Result<SelectGeometry, ParserError> {
-    let (dimensions, strides, total_width) = get_dimensions_and_strides(module, var_id)?;
+    let mut strides = collect_dims(module, var_id)?;
+    let dimensions_len = strides.len();
+    let total_width = dimensions_to_strides(&mut strides)?;
     let total_indices = index.0.len().checked_add(select.0.len()).ok_or_else(|| {
         ParserError::illegal_context("variable select", "index count overflows usize", None)
     })?;
 
     let Some((op, range_expr)) = &select.1 else {
-        if total_indices > dimensions.len() {
+        if total_indices > dimensions_len {
             return Err(ParserError::illegal_context(
                 "variable select",
                 format!(
                     "{total_indices} indices exceed the variable's {} dimensions",
-                    dimensions.len()
+                    dimensions_len
                 ),
                 None,
             ));
@@ -297,7 +298,6 @@ pub fn select_geometry(
             })?
         };
         return Ok(SelectGeometry {
-            dimensions,
             strides,
             total_width,
             dimension_count: total_indices,
@@ -320,16 +320,19 @@ pub fn select_geometry(
             Some(&range_expr.token_range()),
         )
     })?;
-    let dimension_width = *dimensions.get(dimension_count).ok_or_else(|| {
-        ParserError::illegal_context(
+    let dimension_width = if dimension_count >= dimensions_len {
+        return Err(ParserError::illegal_context(
             "variable part select",
             format!(
-                "part-select dimension {dimension_count} is outside the {}-dimension variable",
-                dimensions.len()
+                "part-select dimension {dimension_count} is outside the {dimensions_len}-dimension variable"
             ),
             Some(&range_expr.token_range()),
-        )
-    })?;
+        ));
+    } else if dimension_count == 0 {
+        total_width / strides[0]
+    } else {
+        strides[dimension_count - 1] / strides[dimension_count]
+    };
     let stride = *strides.get(dimension_count).ok_or_else(|| {
         ParserError::illegal_context(
             "variable part select",
@@ -442,7 +445,6 @@ pub fn select_geometry(
     })?;
 
     Ok(SelectGeometry {
-        dimensions,
         strides,
         total_width,
         dimension_count,
@@ -674,16 +676,11 @@ pub fn is_static_access(index: &VarIndex, select: &VarSelect) -> bool {
     true
 }
 
-pub fn get_dimensions_and_strides(
-    module: &Module,
-    var_id: VarId,
-) -> Result<(Vec<usize>, Vec<usize>, usize), ParserError> {
-    let dims = collect_dims(module, var_id)?;
-
-    let mut strides = vec![1; dims.len()];
+fn dimensions_to_strides(strides: &mut [usize]) -> Result<usize, ParserError> {
     let mut current_stride = 1usize;
-    for i in (0..dims.len()).rev() {
-        if dims[i] == 0 {
+    for i in (0..strides.len()).rev() {
+        let dimension = strides[i];
+        if dimension == 0 {
             return Err(ParserError::illegal_context(
                 "variable dimensions",
                 format!("dimension {i} has zero width"),
@@ -691,18 +688,27 @@ pub fn get_dimensions_and_strides(
             ));
         }
         strides[i] = current_stride;
-        current_stride = current_stride.checked_mul(dims[i]).ok_or_else(|| {
+        current_stride = current_stride.checked_mul(dimension).ok_or_else(|| {
             ParserError::illegal_context(
                 "variable dimensions",
                 format!(
-                    "dimension {} times accumulated stride {current_stride} overflows usize",
-                    dims[i]
+                    "dimension {dimension} times accumulated stride {current_stride} overflows usize"
                 ),
                 None,
             )
         })?;
     }
-    Ok((dims, strides, current_stride))
+    Ok(current_stride)
+}
+
+pub fn get_dimensions_and_strides(
+    module: &Module,
+    var_id: VarId,
+) -> Result<(Vec<usize>, Vec<usize>, usize), ParserError> {
+    let dims = collect_dims(module, var_id)?;
+    let mut strides = dims.clone();
+    let total_width = dimensions_to_strides(&mut strides)?;
+    Ok((dims, strides, total_width))
 }
 
 pub fn get_access_width(

--- a/crates/celox-frontend-veryl/src/bitaccess.rs
+++ b/crates/celox-frontend-veryl/src/bitaccess.rs
@@ -8,7 +8,7 @@ use veryl_analyzer::ir::{
 use veryl_analyzer::value::Value;
 use veryl_parser::token_range::TokenRange;
 
-use crate::{ParserError, resolve_dims};
+use crate::{ParserError, types::extend_resolved_dims};
 
 /// Extract a compile-time constant value for Celox 4-state encoding.
 ///
@@ -213,24 +213,27 @@ fn checked_bit_access(
 fn collect_dims(module: &Module, var_id: VarId) -> Result<Vec<usize>, ParserError> {
     let variable = &module.variables[&var_id];
     let var_type = &variable.r#type;
+    let width = var_type.width();
 
-    let mut dims = resolve_dims(module, variable, var_type.array.as_slice(), "array")?;
+    let mut dims = Vec::with_capacity(var_type.array.as_slice().len() + width.as_slice().len() + 1);
+    extend_resolved_dims(
+        module,
+        variable,
+        var_type.array.as_slice(),
+        "array",
+        &mut dims,
+    )?;
     // For enum-typed variables, the width Shape is empty but the actual
     // bit width is encoded in the TypeKind. Use kind.width() as the
     // base scalar width when the explicit width shape is absent.
-    if var_type.width().is_empty() {
+    if width.is_empty() {
         if let Some(kind_width) = var_type.kind.width()
             && kind_width > 1
         {
             dims.push(kind_width);
         }
     } else {
-        dims.extend(resolve_dims(
-            module,
-            variable,
-            var_type.width().as_slice(),
-            "width",
-        )?);
+        extend_resolved_dims(module, variable, width.as_slice(), "width", &mut dims)?;
     }
     Ok(dims)
 }
@@ -486,19 +489,16 @@ pub fn eval_var_select(
         Ok(access)
     };
 
-    let mut all_indices = index.0.clone();
-    all_indices.extend(select.0.iter().cloned());
-
     let mut base_offset = 0usize;
     let mut processed_count = 0;
 
-    let limit = if select.1.is_some() {
-        all_indices.len().saturating_sub(1)
-    } else {
-        all_indices.len()
-    };
-
-    for (i, index_val) in all_indices[..limit].iter().enumerate() {
+    for (i, index_val) in index
+        .0
+        .iter()
+        .chain(&select.0)
+        .take(geometry.dimension_count)
+        .enumerate()
+    {
         if let Some(idx) = eval_constexpr_usize(index_val, "variable select index")? {
             if let Some(&stride) = strides.get(i) {
                 let term = idx.checked_mul(stride).ok_or_else(|| {
@@ -524,7 +524,7 @@ pub fn eval_var_select(
     }
 
     if let Some((op, range_expr)) = &select.1 {
-        let Some(anchor_expr) = all_indices.last() else {
+        let Some(anchor_expr) = select.0.last() else {
             return Err(ParserError::illegal_context(
                 "variable select",
                 "part select is missing its anchor expression",

--- a/crates/celox-frontend-veryl/src/bitaccess.rs
+++ b/crates/celox-frontend-veryl/src/bitaccess.rs
@@ -460,6 +460,14 @@ pub fn eval_var_select(
     select: &VarSelect,
 ) -> Result<BitAccess, ParserError> {
     let geometry = select_geometry(module, var_id, index, select)?;
+    eval_var_select_with_geometry(index, select, &geometry)
+}
+
+pub(crate) fn eval_var_select_with_geometry(
+    index: &VarIndex,
+    select: &VarSelect,
+    geometry: &SelectGeometry,
+) -> Result<BitAccess, ParserError> {
     let strides = &geometry.strides;
     let total_width = geometry.total_width;
 

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -183,13 +183,19 @@ impl<'a> FfParser<'a> {
         index: &VarIndex,
         select: &VarSelect,
     ) -> Option<BitAccess> {
-        let mut dims: Vec<usize> = typ.array.iter().copied().collect::<Option<Vec<_>>>()?;
-        if typ.width().is_empty() {
+        let width = typ.width();
+        let mut dims = Vec::with_capacity(typ.array.as_slice().len() + width.as_slice().len() + 1);
+        for dimension in typ.array.as_slice() {
+            dims.push((*dimension)?);
+        }
+        if width.is_empty() {
             if let Some(kind_width) = typ.kind.width() {
                 dims.push(kind_width);
             }
         } else {
-            dims.extend(typ.width().iter().copied().collect::<Option<Vec<_>>>()?);
+            for dimension in width.iter() {
+                dims.push((*dimension)?);
+            }
         }
 
         let mut strides = vec![1; dims.len()];
@@ -214,18 +220,18 @@ impl<'a> FfParser<'a> {
             BitAccess::new(base, base + width - 1)
         };
 
-        let mut all_indices = index.0.clone();
-        all_indices.extend(select.0.iter().cloned());
-
         let mut base_offset = 0usize;
         let mut processed_count = 0usize;
-        let limit = if select.1.is_some() {
-            all_indices.len().saturating_sub(1)
-        } else {
-            all_indices.len()
-        };
+        let index_count =
+            (index.0.len() + select.0.len()).saturating_sub(usize::from(select.1.is_some()));
 
-        for (i, index_val) in all_indices[..limit].iter().enumerate() {
+        for (i, index_val) in index
+            .0
+            .iter()
+            .chain(&select.0)
+            .take(index_count)
+            .enumerate()
+        {
             let idx = to_u(index_val)?;
             let stride = *strides.get(i)?;
             base_offset += idx * stride;
@@ -233,7 +239,7 @@ impl<'a> FfParser<'a> {
         }
 
         if let Some((op, range_expr)) = &select.1 {
-            let anchor_expr = all_indices.last()?;
+            let anchor_expr = select.0.last()?;
             let anchor = to_u(anchor_expr)?;
             let val = to_u(range_expr)?;
             let weight = *strides.get(processed_count).unwrap_or(&1);

--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -2351,9 +2351,9 @@ impl<'a> FfParser<'a> {
         // Backends may give array elements a physical stride different from
         // their logical packed width, so combining both here loses essential
         // source-type information.
-        let (_, strides, total_width) =
-            crate::bitaccess::get_dimensions_and_strides(self.module, var_id)?;
         let geometry = crate::bitaccess::select_geometry(self.module, var_id, index, select)?;
+        let strides = &geometry.strides;
+        let total_width = geometry.total_width;
         let array_dimension_count = self.module.variables[&var_id].r#type.array.iter().count();
         let element_width = if array_dimension_count == 0 {
             total_width

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -266,10 +266,14 @@ pub fn parse_comb_with_loop_recovery(
         )?;
     }
 
-    // 3. Path Extraction: Convert the final symbolic store into a list of LogicPaths.
-    // Each LogicPath represents a modified bit-range and the logic required to compute it.
+    // 3. Path Extraction: Convert written definitions into LogicPaths. The
+    // statement scan already found every possible write, so avoid revisiting
+    // unrelated module variables in the final symbolic store.
     let mut paths = Vec::new();
-    for (id, range_store) in &final_store {
+    for id in written_accesses.keys() {
+        let Some(range_store) = final_store.get(id) else {
+            continue;
+        };
         if module.variables[id].affiliation == veryl_analyzer::symbol::Affiliation::AlwaysComb {
             continue;
         }

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -1013,10 +1013,10 @@ fn merge_symbolic_versions(
         // Function-local state can be introduced while evaluating only the
         // else branch. It is scoped to that branch and must not escape through
         // this merge; the previous implementation likewise iterated then keys.
-        let Some(t_range_store) = then_store.get(&id) else {
+        let Some(t_range_store) = then_store.get(id) else {
             continue;
         };
-        let e_range_store = &else_store[&id];
+        let e_range_store = &else_store[id];
 
         if t_range_store == e_range_store {
             continue;
@@ -1029,7 +1029,7 @@ fn merge_symbolic_versions(
         let mut all_lsbs: BTreeSet<usize> = t_range_store.ranges.keys().cloned().collect();
         all_lsbs.extend(e_range_store.ranges.keys().cloned());
 
-        let var = &module.variables[&id];
+        let var = &module.variables[id];
         let var_width = resolve_total_width(module, var)?;
         let mut lsbs_vec: Vec<usize> = all_lsbs.into_iter().collect();
         lsbs_vec.push(var_width);
@@ -1047,8 +1047,8 @@ fn merge_symbolic_versions(
                 .map_err(|error| range_store_error("conditional merge", error, None))?;
             let t_modified = then_parts.iter().any(|(v, _)| v.is_some());
             let e_modified = else_parts.iter().any(|(v, _)| v.is_some());
-            let (t_expr, t_sources) = combine_parts_with_default(id, lsb, then_parts, arena)?;
-            let (e_expr, e_sources) = combine_parts_with_default(id, lsb, else_parts, arena)?;
+            let (t_expr, t_sources) = combine_parts_with_default(*id, lsb, then_parts, arena)?;
+            let (e_expr, e_sources) = combine_parts_with_default(*id, lsb, else_parts, arena)?;
 
             let result_val = if !t_modified && !e_modified {
                 None
@@ -1076,7 +1076,7 @@ fn merge_symbolic_versions(
                 .insert(lsb, (result_val, next_lsb - lsb, lsb));
         }
 
-        merged_store.insert(id, merged_range_store);
+        merged_store.insert(*id, merged_range_store);
     }
 
     Ok(merged_store)
@@ -1408,7 +1408,10 @@ fn extract_store_updates(
 ) -> Result<Vec<(VarAtomBase<VarId>, NodeId, HashSet<VarAtomBase<VarId>>)>, SLTNodeFactsError> {
     let mut updates = Vec::new();
 
-    for (id, range_store_after) in store_after {
+    for id in store_before.differing_keys(store_after) {
+        let Some(range_store_after) = store_after.get(id) else {
+            continue;
+        };
         let Some(range_store_before) = store_before.get(id) else {
             continue;
         };

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -1089,7 +1089,7 @@ fn apply_loop_continue_guard(
     next_boundaries: BoundaryMap<VarId>,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<LoopControlState, ParserError> {
-    let base_store = state.store.clone();
+    let base_store = state.store.fork();
     let boundaries = merge_boundaries(state.boundaries, next_boundaries);
 
     if matches!(constant_bool(arena, state.continue_expr), Some(true)) {
@@ -1249,7 +1249,7 @@ fn eval_loop_case(
                 .try_fold(state, |s, step| eval_loop_statement(module, s, step, arena));
         };
 
-        let mut cond_store = state.store.clone();
+        let mut cond_store = state.store.fork();
         let ((cond_expr, cond_sources), cond_bounds) = eval_case_arm_condition_effectful(
             module,
             &mut cond_store,
@@ -1278,7 +1278,7 @@ fn eval_loop_case(
 
         let then_state = arm.body.iter().try_fold(
             LoopControlState {
-                store: state.store.clone(),
+                store: state.store.fork(),
                 boundaries: boundaries.clone(),
                 continue_expr: state.continue_expr,
                 continue_sources: state.continue_sources.clone(),
@@ -1323,7 +1323,7 @@ fn eval_loop_case(
         })
     }
 
-    let mut target_store = state.store.clone();
+    let mut target_store = state.store.fork();
     let (target, target_boundaries) =
         eval_case_target_effectful(module, &mut target_store, &case_stmt.case_target, arena)?;
     state = apply_loop_continue_guard(module, state, target_store, target_boundaries, arena)?;
@@ -1336,7 +1336,7 @@ fn eval_loop_if(
     stmt: &IfStatement,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<LoopControlState, ParserError> {
-    let mut cond_store = state.store.clone();
+    let mut cond_store = state.store.fork();
     let ((cond_expr, cond_sources), cond_bounds) =
         eval_expression_effectful(module, &mut cond_store, &stmt.cond, arena, None)?;
     state = apply_loop_continue_guard(module, state, cond_store, cond_bounds, arena)?;
@@ -1360,7 +1360,7 @@ fn eval_loop_if(
 
     let then_state = stmt.true_side.iter().try_fold(
         LoopControlState {
-            store: state.store.clone(),
+            store: state.store.fork(),
             boundaries: boundaries.clone(),
             continue_expr: state.continue_expr,
             continue_sources: state.continue_sources.clone(),
@@ -1975,7 +1975,7 @@ fn eval_for_with_effects(
             }
         };
 
-    let mut symbolic_store = store.clone();
+    let mut symbolic_store = store.fork();
     let mut written_accesses = HashMap::default();
     collect_written_accesses(module, &for_stmt.body, &mut written_accesses)?;
     for (id, accesses) in written_accesses {
@@ -2014,7 +2014,7 @@ fn eval_for_with_effects(
         symbolic_store.insert(id, loop_store);
     }
     symbolic_store.insert(for_stmt.var_id, RangeStore::new(None, loop_width));
-    let iter_store_before = symbolic_store.clone();
+    let iter_store_before = symbolic_store.fork();
 
     let loop_state = for_stmt.body.iter().try_fold(
         LoopControlState {
@@ -2676,7 +2676,7 @@ fn eval_statement_form_function_call(
         }
     }
 
-    let mut local_store = store.clone();
+    let mut local_store = store.fork();
     for (arg_id, arg_node, arg_sources, arg_width) in evaluated_inputs {
         local_store.insert(
             arg_id,

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -74,6 +74,21 @@ pub(super) fn range_store_error(
     ParserError::illegal_context(context, error.to_string(), token)
 }
 
+pub(super) fn symbolic_parts_or_default(
+    store: &SymbolicStore<VarId>,
+    id: VarId,
+    access: BitAccess,
+    context: &'static str,
+    token: Option<&TokenRange>,
+) -> Result<Vec<(Option<(NodeId, HashSet<VarAtomBase<VarId>>)>, BitAccess)>, ParserError> {
+    match store.get(&id) {
+        Some(range_store) => range_store
+            .get_parts(access)
+            .map_err(|error| range_store_error(context, error, token)),
+        None => Ok(vec![(None, access)]),
+    }
+}
+
 /// Veryl validates function arity before producing usable IR. A formal argument
 /// absent from both connection maps is therefore invalid IR, not an unsupported
 /// lowering shape.
@@ -224,16 +239,19 @@ pub fn parse_comb_with_loop_recovery(
     ),
     ParserError,
 > {
-    // 1. Initialization: Create a RangeStore for each variable in the module.
-    // Variables start in an 'unassigned' state (None), representing their initial input values.
+    let mut written_accesses = HashMap::default();
+    collect_written_accesses(module, &decl.statements, &mut written_accesses)?;
+
+    // 1. Initialization: only definitions this process can write need mutable
+    // symbolic ranges. Reads of every other variable lower directly to Input,
+    // keeping setup proportional to the block instead of the whole module.
     let mut current_store = SymbolicStore::default();
-    for (id, var) in &module.variables {
+    for id in written_accesses.keys() {
+        let var = &module.variables[id];
         let width = resolve_total_width(module, var)?;
         current_store.insert(*id, RangeStore::new(None, width));
     }
 
-    let mut written_accesses = HashMap::default();
-    collect_written_accesses(module, &decl.statements, &mut written_accesses)?;
     let written_atoms: Vec<_> = written_accesses
         .iter()
         .flat_map(|(&id, accesses)| {
@@ -1014,13 +1032,14 @@ fn merge_symbolic_versions(
     // shared entries cannot need a phi.
     let mut merged_store = then_store.fork();
     for id in then_store.differing_keys(else_store) {
-        // Function-local state can be introduced while evaluating only the
-        // else branch. It is scoped to that branch and must not escape through
-        // this merge; the previous implementation likewise iterated then keys.
+        // Function-local state can be introduced while evaluating only one
+        // branch. It is scoped to that branch and must not escape the merge.
         let Some(t_range_store) = then_store.get(id) else {
             continue;
         };
-        let e_range_store = &else_store[id];
+        let Some(e_range_store) = else_store.get(id) else {
+            continue;
+        };
 
         if t_range_store == e_range_store {
             continue;
@@ -2075,16 +2094,13 @@ fn eval_for_with_effects(
         let initial_updates = updates
             .iter()
             .map(|(target, _, _)| {
-                let range_store = store.get(&target.id).ok_or_else(|| {
-                    ParserError::illegal_context(
-                        "for-loop initial state",
-                        "state variable is absent from the symbolic store",
-                        Some(&for_stmt.token),
-                    )
-                })?;
-                let parts = range_store.get_parts(target.access).map_err(|error| {
-                    range_store_error("for-loop initial state", error, Some(&for_stmt.token))
-                })?;
+                let parts = symbolic_parts_or_default(
+                    &store,
+                    target.id,
+                    target.access,
+                    "for-loop initial state",
+                    Some(&for_stmt.token),
+                )?;
                 let (expr, sources) =
                     combine_parts_with_default(target.id, target.access.lsb, parts, arena)?;
                 initial_sources.extend(sources);
@@ -2302,13 +2318,9 @@ fn update_assignment_range(
     if variable.r#type.is_2state() && !source_is_2state {
         value.0 = arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, value.0))?;
     }
-    let range_store = store.get_mut(&destination.id).ok_or_else(|| {
-        ParserError::illegal_context(
-            "assignment destination",
-            "destination variable is absent from the symbolic store",
-            Some(&destination.token),
-        )
-    })?;
+    let range_store = store
+        .entry(destination.id)
+        .or_insert_with(|| RangeStore::new(None, variable_width));
     range_store.update(access, Some(value)).map_err(|error| {
         range_store_error("assignment destination", error, Some(&destination.token))
     })?;
@@ -3385,6 +3397,46 @@ mod tests {
             .unwrap()
             .id
     }
+
+    #[test]
+    fn comb_symbolic_store_tracks_only_written_definitions() {
+        let code = r#"
+            module Top (
+                a: input logic<32>,
+                idx: input logic<5>,
+                q: output logic<1>,
+                r: output logic<4>
+            ) {
+                always_comb {
+                    q = a[idx];
+                    r = a[7:4];
+                }
+            }
+        "#;
+        let module = parse_top_module(code);
+        let comb = module
+            .declarations
+            .iter()
+            .find_map(|declaration| match declaration {
+                Declaration::Comb(comb) => Some(comb),
+                _ => None,
+            })
+            .unwrap();
+        let mut arena = SLTNodeArena::new();
+        let (paths, store, _, _, _) = parse_comb(&module, comb, &mut arena).unwrap();
+
+        let a = var_id_of(&module, &["a"]);
+        let idx = var_id_of(&module, &["idx"]);
+        let q = var_id_of(&module, &["q"]);
+        let r = var_id_of(&module, &["r"]);
+        assert_eq!(store.len(), 2);
+        assert!(!store.contains_key(&a));
+        assert!(!store.contains_key(&idx));
+        assert!(store.contains_key(&q));
+        assert!(store.contains_key(&r));
+        assert_eq!(paths.len(), 2);
+    }
+
     #[test]
     fn test_parse_comb_boundary_collection() {
         let code = r#"

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -2885,13 +2885,18 @@ fn eval_dynamic_select_offset(
         64,
         false,
     ))?;
-    let mut indices = Vec::new();
+    let mut indices =
+        Vec::with_capacity(geometry.dimension_count + usize::from(geometry.part.is_some()));
     let mut sources = HashSet::default();
     let mut boundaries = BoundaryMap::default();
 
-    let mut expressions = index.0.clone();
-    expressions.extend(select.0.clone());
-    for (dimension, expression) in expressions[..geometry.dimension_count].iter().enumerate() {
+    for (dimension, expression) in index
+        .0
+        .iter()
+        .chain(&select.0)
+        .take(geometry.dimension_count)
+        .enumerate()
+    {
         let ((node, node_sources), node_boundaries) =
             expr::eval_expression_in_context(module, store, expression, arena, None)?;
         sources.extend(node_sources);

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -3308,21 +3308,18 @@ fn combine_parts<A: Clone + PartialEq + Eq + Hash>(
         ));
     }
     if parts.len() == 1 {
-        let ((expr, sources), access) = &parts[0];
-        let w = get_width(*expr, arena);
+        let ((expr, sources), access) = parts
+            .into_iter()
+            .next()
+            .expect("the single symbolic part exists");
+        let w = get_width(expr, arena);
         if w == 0 {
-            return Ok((*expr, sources.clone()));
+            return Ok((expr, sources));
         }
         if access.lsb == 0 && access.msb == w - 1 {
-            return Ok((*expr, sources.clone()));
+            return Ok((expr, sources));
         } else {
-            return Ok((
-                arena.alloc(SLTNode::Slice {
-                    expr: *expr,
-                    access: *access,
-                })?,
-                sources.clone(),
-            ));
+            return Ok((arena.alloc(SLTNode::Slice { expr, access })?, sources));
         }
     }
 

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -1019,6 +1019,37 @@ fn merge_control_expr(
     }
 }
 
+fn materialize_aligned_symbolic_part(
+    id: VarId,
+    absolute: BitAccess,
+    value: &Option<(NodeId, HashSet<VarAtomBase<VarId>>)>,
+    relative: BitAccess,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<(NodeId, HashSet<VarAtomBase<VarId>>), SLTNodeFactsError> {
+    let Some((expr, sources)) = value else {
+        let input = arena.alloc(SLTNode::Input {
+            variable: id,
+            signed: false,
+            index: Vec::new(),
+            access: absolute,
+        })?;
+        let mut sources = HashSet::default();
+        sources.insert(VarAtomBase::new(id, absolute.lsb, absolute.msb));
+        return Ok((input, sources));
+    };
+
+    let width = get_width(*expr, arena);
+    let expr = if width == 0 || (relative.lsb == 0 && relative.msb == width - 1) {
+        *expr
+    } else {
+        arena.alloc(SLTNode::Slice {
+            expr: *expr,
+            access: relative,
+        })?
+    };
+    Ok((expr, sources.clone()))
+}
+
 fn merge_symbolic_versions(
     module: &Module,
     then_store: &SymbolicStore<VarId>,
@@ -1045,33 +1076,34 @@ fn merge_symbolic_versions(
             continue;
         }
 
+        let var = &module.variables[id];
+        let var_width = resolve_total_width(module, var)?;
+        let aligned_parts = t_range_store
+            .aligned_parts(e_range_store)
+            .map_err(|error| range_store_error("conditional merge", error, None))?;
+        let store_width = aligned_parts
+            .last()
+            .map_or(0, |(access, _, _)| access.msb + 1);
+        if store_width != var_width {
+            return Err(ParserError::illegal_context(
+                "conditional merge",
+                format!(
+                    "symbolic range width {store_width} differs from declared width {var_width}"
+                ),
+                None,
+            ));
+        }
+
         let mut merged_range_store = RangeStore {
             ranges: std::collections::BTreeMap::new(),
         };
-
-        let mut all_lsbs: BTreeSet<usize> = t_range_store.ranges.keys().cloned().collect();
-        all_lsbs.extend(e_range_store.ranges.keys().cloned());
-
-        let var = &module.variables[id];
-        let var_width = resolve_total_width(module, var)?;
-        let mut lsbs_vec: Vec<usize> = all_lsbs.into_iter().collect();
-        lsbs_vec.push(var_width);
-
-        for i in 0..lsbs_vec.len() - 1 {
-            let lsb = lsbs_vec[i];
-            let next_lsb = lsbs_vec[i + 1];
-            let access = BitAccess::new(lsb, next_lsb - 1);
-
-            let then_parts = t_range_store
-                .get_parts(access)
-                .map_err(|error| range_store_error("conditional merge", error, None))?;
-            let else_parts = e_range_store
-                .get_parts(access)
-                .map_err(|error| range_store_error("conditional merge", error, None))?;
-            let t_modified = then_parts.iter().any(|(v, _)| v.is_some());
-            let e_modified = else_parts.iter().any(|(v, _)| v.is_some());
-            let (t_expr, t_sources) = combine_parts_with_default(*id, lsb, then_parts, arena)?;
-            let (e_expr, e_sources) = combine_parts_with_default(*id, lsb, else_parts, arena)?;
+        for (access, (then_value, then_access), (else_value, else_access)) in aligned_parts {
+            let t_modified = then_value.is_some();
+            let e_modified = else_value.is_some();
+            let (t_expr, t_sources) =
+                materialize_aligned_symbolic_part(*id, access, then_value, then_access, arena)?;
+            let (e_expr, e_sources) =
+                materialize_aligned_symbolic_part(*id, access, else_value, else_access, arena)?;
 
             let result_val = if !t_modified && !e_modified {
                 None
@@ -1094,9 +1126,10 @@ fn merge_symbolic_versions(
                 ))
             };
 
-            merged_range_store
-                .ranges
-                .insert(lsb, (result_val, next_lsb - lsb, lsb));
+            merged_range_store.ranges.insert(
+                access.lsb,
+                (result_val, access.msb - access.lsb + 1, access.lsb),
+            );
         }
 
         merged_store.insert(*id, merged_range_store);
@@ -3435,6 +3468,50 @@ mod tests {
         assert!(store.contains_key(&q));
         assert!(store.contains_key(&r));
         assert_eq!(paths.len(), 2);
+    }
+
+    #[test]
+    fn conditional_merge_aligns_staggered_sparse_ranges() {
+        let code = r#"
+            module Top (
+                select: input logic,
+                base: input logic<8>,
+                then_value: input logic<4>,
+                else_value: input logic<4>,
+                q: output logic<8>
+            ) {
+                always_comb {
+                    q = base;
+                    if select {
+                        q[5:2] = then_value;
+                    } else {
+                        q[7:4] = else_value;
+                    }
+                }
+            }
+        "#;
+        let module = parse_top_module(code);
+        let comb = module
+            .declarations
+            .iter()
+            .find_map(|declaration| match declaration {
+                Declaration::Comb(comb) => Some(comb),
+                _ => None,
+            })
+            .unwrap();
+        let mut arena = SLTNodeArena::new();
+        let (_, store, _, _, _) = parse_comb(&module, comb, &mut arena).unwrap();
+
+        let q = var_id_of(&module, &["q"]);
+        let partition = store[&q]
+            .ranges
+            .iter()
+            .map(|(&lsb, (value, width, origin))| {
+                assert!(value.is_some());
+                (lsb, *width, *origin)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(partition, vec![(0, 2, 0), (2, 2, 2), (4, 2, 4), (6, 2, 6)]);
     }
 
     #[test]

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -2063,7 +2063,7 @@ fn eval_for_with_effects(
             let end = bit - 1;
             let access = BitAccess::new(start, end);
             let parts = original
-                .get_parts(access)
+                .get_parts_ref(access)
                 .map_err(|error| range_store_error("for-loop state", error, None))?;
             let (expr, sources) = combine_parts_with_default(id, access.lsb, parts, arena)?;
             loop_store
@@ -2134,8 +2134,12 @@ fn eval_for_with_effects(
                     "for-loop initial state",
                     Some(&for_stmt.token),
                 )?;
-                let (expr, sources) =
-                    combine_parts_with_default(target.id, target.access.lsb, parts, arena)?;
+                let (expr, sources) = combine_parts_with_default(
+                    target.id,
+                    target.access.lsb,
+                    parts.iter().map(|(value, access)| (value, *access)),
+                    arena,
+                )?;
                 initial_sources.extend(sources);
                 Ok(SLTForUpdate {
                     target: *target,
@@ -2842,7 +2846,7 @@ pub(super) fn function_output_value(
             Some(&call.comptime.token),
         )
     })?;
-    let parts = range_store.get_parts(access).map_err(|error| {
+    let parts = range_store.get_parts_ref(access).map_err(|error| {
         range_store_error("function output value", error, Some(&call.comptime.token))
     })?;
     let (output_expr, output_sources) = combine_parts_with_default(arg_id, 0, parts, arena)?;
@@ -3069,7 +3073,7 @@ fn eval_dynamic_assign(
     // Evaluate the variable's current state.
     // Sub-ranges that haven't been assigned yet will fall back to their initial input state.
     let old_parts = range_store
-        .get_parts(access_full)
+        .get_parts_ref(access_full)
         .map_err(|error| range_store_error("dynamic assignment", error, Some(&dst.token)))?;
     let (old_val, old_sources) = combine_parts_with_default(dst.id, 0, old_parts, arena)?;
     // Note: Partial dynamic updates are not treated as self-dependencies (latches)
@@ -3257,19 +3261,25 @@ fn eval_if(
     ))
 }
 
-pub(crate) fn combine_parts_with_default<A: Clone + PartialEq + Eq + Hash>(
+pub(crate) fn combine_parts_with_default<'a, A, I>(
     var_id: A,
     start_lsb: usize,
-    parts: Vec<(Option<(NodeId, HashSet<VarAtomBase<A>>)>, BitAccess)>,
+    parts: I,
     arena: &mut SLTNodeArena<A>,
-) -> Result<(NodeId, HashSet<VarAtomBase<A>>), SLTNodeFactsError> {
+) -> Result<(NodeId, HashSet<VarAtomBase<A>>), SLTNodeFactsError>
+where
+    A: Clone + PartialEq + Eq + Hash + 'a,
+    I: IntoIterator<Item = (&'a Option<(NodeId, HashSet<VarAtomBase<A>>)>, BitAccess)>,
+{
     let mut fixed_parts = Vec::new();
+    let mut total_sources = HashSet::default();
     let mut current_lsb = start_lsb;
     for (val_opt, access) in parts {
         let width = access.msb - access.lsb + 1;
         match val_opt {
             Some((expr, s)) => {
-                fixed_parts.push(((expr, s), access));
+                total_sources.extend(s.iter().cloned());
+                fixed_parts.push((*expr, access));
             }
             None => {
                 let input_node = arena.alloc(SLTNode::Input {
@@ -3278,25 +3288,17 @@ pub(crate) fn combine_parts_with_default<A: Clone + PartialEq + Eq + Hash>(
                     index: vec![],
                     access: BitAccess::new(current_lsb, current_lsb + width - 1),
                 })?;
-                let mut sources = HashSet::default();
-                sources.insert(VarAtomBase::new(
+                total_sources.insert(VarAtomBase::new(
                     var_id.clone(),
                     current_lsb,
                     current_lsb + width - 1,
                 ));
-                fixed_parts.push(((input_node, sources), BitAccess::new(0, width - 1)));
+                fixed_parts.push((input_node, BitAccess::new(0, width - 1)));
             }
         }
         current_lsb += width;
     }
-    combine_parts(fixed_parts, arena)
-}
-
-fn combine_parts<A: Clone + PartialEq + Eq + Hash>(
-    parts: Vec<((NodeId, HashSet<VarAtomBase<A>>), BitAccess)>,
-    arena: &mut SLTNodeArena<A>,
-) -> Result<(NodeId, HashSet<VarAtomBase<A>>), SLTNodeFactsError> {
-    if parts.is_empty() {
+    if fixed_parts.is_empty() {
         return Ok((
             arena.alloc(SLTNode::Constant(
                 BigUint::from(0u32),
@@ -3307,27 +3309,24 @@ fn combine_parts<A: Clone + PartialEq + Eq + Hash>(
             HashSet::default(),
         ));
     }
-    if parts.len() == 1 {
-        let ((expr, sources), access) = parts
+    if fixed_parts.len() == 1 {
+        let (expr, access) = fixed_parts
             .into_iter()
             .next()
             .expect("the single symbolic part exists");
         let w = get_width(expr, arena);
         if w == 0 {
-            return Ok((expr, sources));
+            return Ok((expr, total_sources));
         }
         if access.lsb == 0 && access.msb == w - 1 {
-            return Ok((expr, sources));
+            return Ok((expr, total_sources));
         } else {
-            return Ok((arena.alloc(SLTNode::Slice { expr, access })?, sources));
+            return Ok((arena.alloc(SLTNode::Slice { expr, access })?, total_sources));
         }
     }
 
     let mut concat_parts = Vec::new();
-    let mut total_sources = HashSet::default();
-
-    for ((expr, sources), access) in parts {
-        total_sources.extend(sources);
+    for (expr, access) in fixed_parts {
         let w = access.msb - access.lsb + 1;
         let slice = arena.alloc(SLTNode::Slice { expr, access })?;
         concat_parts.push((slice, w));

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -23,7 +23,7 @@ use crate::{
     HashMap, HashSet, LoweringPhase, ParserError,
     bitaccess::{
         PartSelectGeometry, celox_value_from_comptime, eval_constexpr, eval_var_select,
-        select_geometry,
+        eval_var_select_with_geometry, select_geometry,
     },
     function_call_has_arg,
     loop_provenance::LoopRecoveryCandidate,
@@ -2856,6 +2856,8 @@ pub(super) fn function_output_value(
 struct DynamicSelectOffset {
     node: NodeId,
     indices: Vec<SLTIndex>,
+    prefix_access: BitAccess,
+    selected_width: usize,
     sources: HashSet<VarAtomBase<VarId>>,
     boundaries: BoundaryMap<VarId>,
 }
@@ -3024,9 +3026,12 @@ fn eval_dynamic_select_offset(
         offset = arena.alloc(SLTNode::Binary(offset, BinaryOp::Add, term))?;
     }
 
+    let prefix_access = eval_var_select_with_geometry(index, select, &geometry)?;
     Ok(DynamicSelectOffset {
         node: offset,
         indices,
+        prefix_access,
+        selected_width: geometry.selected_width,
         sources,
         boundaries,
     })
@@ -3055,11 +3060,12 @@ fn eval_dynamic_assign(
             Some(&dst.token),
         )?
     };
+    let access_width = select_offset.selected_width;
+    let prefix_access = select_offset.prefix_access;
     boundaries = merge_boundaries(boundaries, select_offset.boundaries);
     all_sources.extend(select_offset.sources);
     let offset_node = select_offset.node;
 
-    let access_width = crate::bitaccess::get_access_width(module, dst.id, &dst.index, &dst.select)?;
     let var = &module.variables[&dst.id];
     let width = resolve_total_width(module, var)?;
     if width == 0 || access_width == 0 || access_width > width {
@@ -3134,7 +3140,6 @@ fn eval_dynamic_assign(
     let new_val_masked = arena.alloc(SLTNode::Binary(old_val, BinaryOp::And, mask_node))?;
     let final_val = arena.alloc(SLTNode::Binary(new_val_masked, BinaryOp::Or, new_val_term))?;
 
-    let prefix_access = eval_var_select(module, dst.id, &dst.index, &dst.select)?;
     let stored_expr = if prefix_access.lsb == 0 && prefix_access.msb == width - 1 {
         final_val
     } else {

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -245,7 +245,7 @@ pub fn parse_comb_with_loop_recovery(
 
     // 2. Symbolic Execution: Evaluate statements sequentially to update the symbolic state.
     let effect_initial_store =
-        statements_contain_runtime_effect(module, &decl.statements).then(|| current_store.clone());
+        statements_contain_runtime_effect(module, &decl.statements).then(|| current_store.fork());
     let (final_store, boundaries) = recover_unrolled::eval_statements(
         module,
         current_store,
@@ -772,7 +772,7 @@ fn eval_case_with_recovery(
 
         let (then_store, then_boundaries) = eval_statements_with_recovery(
             module,
-            store.clone(),
+            store.fork(),
             boundaries.clone(),
             &arm.body,
             arena,
@@ -792,7 +792,7 @@ fn eval_case_with_recovery(
         )?;
 
         Ok((
-            merge_symbolic_stores(
+            merge_symbolic_versions(
                 module,
                 &then_store,
                 &else_store,
@@ -868,7 +868,7 @@ fn eval_case(
         }
 
         let (then_store, then_boundaries) =
-            eval_statements(module, store.clone(), boundaries.clone(), &arm.body, arena)?;
+            eval_statements(module, store.fork(), boundaries.clone(), &arm.body, arena)?;
         let (else_store, else_boundaries) = eval_from_arm(
             module,
             store,
@@ -880,7 +880,7 @@ fn eval_case(
         )?;
 
         Ok((
-            merge_symbolic_stores(
+            merge_symbolic_versions(
                 module,
                 &then_store,
                 &else_store,
@@ -997,7 +997,7 @@ fn merge_control_expr(
     }
 }
 
-fn merge_symbolic_stores(
+fn merge_symbolic_versions(
     module: &Module,
     then_store: &SymbolicStore<VarId>,
     else_store: &SymbolicStore<VarId>,
@@ -1005,15 +1005,20 @@ fn merge_symbolic_stores(
     cond_sources: &HashSet<VarAtomBase<VarId>>,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<SymbolicStore<VarId>, ParserError> {
-    let mut merged_store = SymbolicStore::default();
-    merged_store.reserve(then_store.len());
-    for id in then_store.keys() {
-        let t_range_store = &then_store[id];
-        let e_range_store = &else_store[id];
+    // A branch clone is a symbolic version. Start with one version and only
+    // visit definitions whose copy-on-write entries diverged; shared pages and
+    // shared entries cannot need a phi.
+    let mut merged_store = then_store.fork();
+    for id in then_store.differing_keys(else_store) {
+        // Function-local state can be introduced while evaluating only the
+        // else branch. It is scoped to that branch and must not escape through
+        // this merge; the previous implementation likewise iterated then keys.
+        let Some(t_range_store) = then_store.get(&id) else {
+            continue;
+        };
+        let e_range_store = &else_store[&id];
 
         if t_range_store == e_range_store {
-            let inserted = merged_store.clone_entry_from(id, then_store);
-            debug_assert!(inserted);
             continue;
         }
 
@@ -1024,7 +1029,7 @@ fn merge_symbolic_stores(
         let mut all_lsbs: BTreeSet<usize> = t_range_store.ranges.keys().cloned().collect();
         all_lsbs.extend(e_range_store.ranges.keys().cloned());
 
-        let var = &module.variables[id];
+        let var = &module.variables[&id];
         let var_width = resolve_total_width(module, var)?;
         let mut lsbs_vec: Vec<usize> = all_lsbs.into_iter().collect();
         lsbs_vec.push(var_width);
@@ -1042,8 +1047,8 @@ fn merge_symbolic_stores(
                 .map_err(|error| range_store_error("conditional merge", error, None))?;
             let t_modified = then_parts.iter().any(|(v, _)| v.is_some());
             let e_modified = else_parts.iter().any(|(v, _)| v.is_some());
-            let (t_expr, t_sources) = combine_parts_with_default(*id, lsb, then_parts, arena)?;
-            let (e_expr, e_sources) = combine_parts_with_default(*id, lsb, else_parts, arena)?;
+            let (t_expr, t_sources) = combine_parts_with_default(id, lsb, then_parts, arena)?;
+            let (e_expr, e_sources) = combine_parts_with_default(id, lsb, else_parts, arena)?;
 
             let result_val = if !t_modified && !e_modified {
                 None
@@ -1071,7 +1076,7 @@ fn merge_symbolic_stores(
                 .insert(lsb, (result_val, next_lsb - lsb, lsb));
         }
 
-        merged_store.insert(*id, merged_range_store);
+        merged_store.insert(id, merged_range_store);
     }
 
     Ok(merged_store)
@@ -1094,7 +1099,7 @@ fn apply_loop_continue_guard(
             ..state
         })
     } else {
-        let merged_store = merge_symbolic_stores(
+        let merged_store = merge_symbolic_versions(
             module,
             &next_store,
             &base_store,
@@ -1299,7 +1304,7 @@ fn eval_loop_case(
         merged_sources.extend(else_state.continue_sources);
 
         Ok(LoopControlState {
-            store: merge_symbolic_stores(
+            store: merge_symbolic_versions(
                 module,
                 &then_state.store,
                 &else_state.store,
@@ -1377,7 +1382,7 @@ fn eval_loop_if(
     merged_sources.extend(else_state.continue_sources);
 
     Ok(LoopControlState {
-        store: merge_symbolic_stores(
+        store: merge_symbolic_versions(
             module,
             &then_state.store,
             &else_state.store,
@@ -3121,7 +3126,7 @@ fn eval_if_with_recovery(
     let else_guard = combine_active_guard(arena, active_guard, false_condition, &cond_sources)?;
     let (then_store, b_then) = eval_statements_with_recovery(
         module,
-        initial_store.clone(),
+        initial_store.fork(),
         boundaries.clone(),
         &stmt.true_side,
         arena,
@@ -3139,7 +3144,7 @@ fn eval_if_with_recovery(
     )?;
 
     Ok((
-        merge_symbolic_stores(
+        merge_symbolic_versions(
             module,
             &then_store,
             &else_store,
@@ -3177,7 +3182,7 @@ fn eval_if(
     }
 
     let (then_store, b_then) = stmt.true_side.iter().try_fold(
-        (initial_store.clone(), boundaries.clone()),
+        (initial_store.fork(), boundaries.clone()),
         |(s, b), step| eval_statement(module, s, b, step, arena),
     )?;
     let (else_store, b_else) = stmt
@@ -3188,7 +3193,7 @@ fn eval_if(
         })?;
 
     Ok((
-        merge_symbolic_stores(
+        merge_symbolic_versions(
             module,
             &then_store,
             &else_store,

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -163,7 +163,7 @@ fn collect_system_function_effect(
     // retroactively rebind inputs in an earlier operand or in the assertion
     // condition.  Reads after an operand write are already substituted by
     // `eval_expression_effectful` as that operand is lowered.
-    let observer_store = store.clone();
+    let observer_store = store.fork();
     let mut boundaries = BoundaryMap::default();
     let mut observer_args = Vec::new();
     let mut observed_inputs = HashSet::default();
@@ -398,7 +398,7 @@ fn collect_function_call_effects(
         ));
     };
 
-    let mut actual_store = store.clone();
+    let mut actual_store = store.fork();
     let mut formal_bindings = Vec::new();
     let ordered_inputs = super::ordered_function_inputs(function, &function_body, call)?;
     let mut later_input_writes = vec![HashMap::default(); ordered_inputs.len()];
@@ -454,7 +454,7 @@ fn collect_function_call_effects(
     // variables through nested output arguments.  Callee runtime effects must
     // therefore start from that advanced caller state, just like value
     // evaluation does, before formal bindings shadow their module entries.
-    let mut local_store = actual_store.clone();
+    let mut local_store = actual_store.fork();
     local_store.extend(formal_bindings);
 
     let final_local_store = if let Some(ret_id) = function_body.ret {
@@ -481,7 +481,7 @@ fn collect_function_call_effects(
     // the real collector-local caller store so later outputs observe earlier
     // writebacks without evaluating a destination effect twice.
     for (arg_id, destinations) in super::ordered_function_outputs(function, &function_body, call)? {
-        let mut destination_store = actual_store.clone();
+        let mut destination_store = actual_store.fork();
         let destination_width = checked_destination_width(
             module,
             destinations,
@@ -495,7 +495,7 @@ fn collect_function_call_effects(
             coerce_node_width(arena, output_expr, Some(destination_width), output_signed)?;
         let mut current_offset = 0;
         for destination in destinations.iter().rev() {
-            let mut collection_store = destination_store.clone();
+            let mut collection_store = destination_store.fork();
             for expression in destination
                 .index
                 .0
@@ -755,7 +755,7 @@ pub(crate) fn collect_expression_effects(
         }
         Expression::Binary(lhs, op, rhs, _) if matches!(op, Op::LogicAnd | Op::LogicOr) => {
             collect_expression_effects(module, store, lhs, arena, collector)?;
-            let mut rhs_store = store.clone();
+            let mut rhs_store = store.fork();
             let ((lhs_node, lhs_sources), _) =
                 eval_expression_effectful(module, &mut rhs_store, lhs, arena, None)?;
             let execute_rhs =
@@ -775,13 +775,13 @@ pub(crate) fn collect_expression_effects(
         }
         Expression::Binary(lhs, _, rhs, _) => {
             collect_expression_effects(module, store, lhs, arena, collector)?;
-            let mut rhs_store = store.clone();
+            let mut rhs_store = store.fork();
             let _ = eval_expression_effectful(module, &mut rhs_store, lhs, arena, None)?;
             collect_expression_effects(module, &rhs_store, rhs, arena, collector)
         }
         Expression::Ternary(cond, then_expr, else_expr, _) => {
             collect_expression_effects(module, store, cond, arena, collector)?;
-            let mut branch_store = store.clone();
+            let mut branch_store = store.fork();
             let ((cond_node, cond_sources), _) =
                 eval_expression_effectful(module, &mut branch_store, cond, arena, None)?;
 
@@ -802,7 +802,7 @@ pub(crate) fn collect_expression_effects(
                     collect_expression_effects(module, &branch_store, then_expr, arena, collector)
                 },
             )?;
-            let mut then_store = branch_store.clone();
+            let mut then_store = branch_store.fork();
             let _ = eval_expression_effectful(module, &mut then_store, then_expr, arena, None)?;
             let after_then = merge_symbolic_versions(
                 module,
@@ -825,7 +825,7 @@ pub(crate) fn collect_expression_effects(
             )
         }
         Expression::Concatenation(items, _) => {
-            let mut item_store = store.clone();
+            let mut item_store = store.fork();
             for (item_expr, _) in items {
                 collect_and_advance_expression(
                     module,
@@ -838,7 +838,7 @@ pub(crate) fn collect_expression_effects(
             Ok(())
         }
         Expression::ArrayLiteral(items, _) => {
-            let mut item_store = store.clone();
+            let mut item_store = store.fork();
             for item in items {
                 match item {
                     ArrayLiteralItem::Value(item_expr, _) => {
@@ -864,7 +864,7 @@ pub(crate) fn collect_expression_effects(
             Ok(())
         }
         Expression::StructConstructor(_, fields, _) => {
-            let mut field_store = store.clone();
+            let mut field_store = store.fork();
             for (_, field_expr) in fields {
                 collect_and_advance_expression(
                     module,
@@ -903,7 +903,7 @@ fn collect_assignment_effects(
     // eval_assign evaluates the RHS before resolving dynamic destinations.
     // Mirror that order in a collector-local store so observers in an index
     // see RHS output writes and later destination expressions see earlier ones.
-    let mut destination_store = store.clone();
+    let mut destination_store = store.fork();
     let ((rhs_expr, rhs_sources), _) =
         eval_assignment_rhs_effectful(module, &mut destination_store, assign, arena)?;
     let rhs_expected_width = checked_destination_width(
@@ -915,7 +915,7 @@ fn collect_assignment_effects(
     let rhs_is_2state = assign.expr.comptime().r#type.is_2state();
     let mut current_offset = 0;
     for destination in assign.dst.iter().rev() {
-        let mut collection_store = destination_store.clone();
+        let mut collection_store = destination_store.fork();
         for expression in destination
             .index
             .0
@@ -986,7 +986,7 @@ fn collect_case_pattern_effects(
             }
             CasePattern::Range { lo, hi, .. } => {
                 collect_expression_effects(module, store, lo, arena, collector)?;
-                let mut hi_store = store.clone();
+                let mut hi_store = store.fork();
                 let ((lo_matches, lo_sources), _) = {
                     let mut expression_store = expr::ExpressionStore::Effectful(&mut hi_store);
                     expr::eval_case_comparison(
@@ -1014,7 +1014,7 @@ fn collect_case_pattern_effects(
         }
     }
 
-    let mut pattern_store = store.clone();
+    let mut pattern_store = store.fork();
     let mut matched: Option<(NodeId, HashSet<VarAtomBase<VarId>>)> = None;
     for pattern in patterns {
         let execute_pattern = matched
@@ -1055,8 +1055,8 @@ fn collect_case_pattern_effects(
             )?;
         }
 
-        let base_store = pattern_store.clone();
-        let mut evaluated_store = base_store.clone();
+        let base_store = pattern_store.fork();
+        let mut evaluated_store = base_store.fork();
         let ((pattern_condition, pattern_sources), _) = eval_case_arm_condition_effectful(
             module,
             &mut evaluated_store,
@@ -1108,7 +1108,7 @@ fn collect_factor_effects(
 ) -> Result<(), ParserError> {
     match factor {
         Factor::Variable(_, index, select, _) => {
-            let mut position_store = store.clone();
+            let mut position_store = store.fork();
             for expr in index.0.iter().chain(select.0.iter()) {
                 collect_and_advance_expression(
                     module,
@@ -1153,7 +1153,7 @@ fn collect_function_body_effects(
     arena: &mut SLTNodeArena<VarId>,
     collector: &mut CombEffectCollector,
 ) -> Result<SymbolicStore<VarId>, ParserError> {
-    let initial_local_store = local_store.clone();
+    let initial_local_store = local_store.fork();
     fn collect_statements(
         module: &Module,
         mut state: FunctionControlState,
@@ -1185,7 +1185,7 @@ fn collect_function_body_effects(
             return collect_statements(module, state, &case_stmt.default, ret_id, arena, collector);
         };
 
-        let store = state.store.clone();
+        let store = state.store.fork();
         let live = state.live_expr;
         let live_sources = state.live_sources.clone();
         with_collector_guard(collector, arena, live, live_sources, |collector, arena| {
@@ -1200,7 +1200,7 @@ fn collect_function_body_effects(
             )
         })?;
 
-        let mut next_store = state.store.clone();
+        let mut next_store = state.store.fork();
         let ((cond_node, cond_sources), cond_bounds) = eval_case_arm_condition_effectful(
             module,
             &mut next_store,
@@ -1258,7 +1258,7 @@ fn collect_function_body_effects(
                 collect_statements(
                     module,
                     FunctionControlState {
-                        store: state.store.clone(),
+                        store: state.store.fork(),
                         boundaries: boundaries.clone(),
                         live_expr: state.live_expr,
                         live_sources: state.live_sources.clone(),
@@ -1381,7 +1381,7 @@ fn collect_function_body_effects(
         context_width: Option<usize>,
         arena: &mut SLTNodeArena<VarId>,
     ) -> Result<(FunctionControlState, NodeId, HashSet<VarAtomBase<VarId>>), ParserError> {
-        let mut next_store = state.store.clone();
+        let mut next_store = state.store.fork();
         let ((node, sources), boundaries) =
             eval_expression_effectful(module, &mut next_store, expression, arena, context_width)?;
         let state = apply_function_guard(
@@ -1503,7 +1503,7 @@ fn collect_function_body_effects(
         collector: &mut CombEffectCollector,
     ) -> Result<FunctionLoopControlState, ParserError> {
         let guard_state = state.clone();
-        let store = state.function.store.clone();
+        let store = state.function.store.fork();
         with_collector_guard(
             collector,
             arena,
@@ -1676,7 +1676,7 @@ fn collect_function_body_effects(
                 );
             };
 
-            let store = state.function.store.clone();
+            let store = state.function.store.fork();
             with_collector_guard(
                 collector,
                 arena,
@@ -1702,7 +1702,7 @@ fn collect_function_body_effects(
                     )
                 },
             )?;
-            let mut next_store = state.function.store.clone();
+            let mut next_store = state.function.store.fork();
             let ((cond_node, cond_sources), cond_bounds) = eval_case_arm_condition_effectful(
                 module,
                 &mut next_store,
@@ -1845,7 +1845,7 @@ fn collect_function_body_effects(
         }
 
         let guard_state = state.clone();
-        let store = state.function.store.clone();
+        let store = state.function.store.fork();
         with_collector_guard(
             collector,
             arena,
@@ -1950,13 +1950,13 @@ fn collect_function_body_effects(
         // Return-aware loops use this collector instead of
         // collect_comb_effects_for. Mirror bound evaluation here so bound
         // events are retained and the body sees output writes from both bounds.
-        let mut iter_store = state.store.clone();
+        let mut iter_store = state.store.fork();
         let (start_bound, end_bound) = for_range_bounds(&for_stmt.range);
         for bound in [start_bound, end_bound] {
             let ForBound::Expression(expression) = bound else {
                 continue;
             };
-            let store = iter_store.clone();
+            let store = iter_store.fork();
             with_collector_guard(
                 collector,
                 arena,
@@ -2016,7 +2016,7 @@ fn collect_function_body_effects(
             iter_store.insert(id, loop_store);
         }
         iter_store.insert(for_stmt.var_id, RangeStore::new(None, loop_width));
-        let iter_store_before = iter_store.clone();
+        let iter_store_before = iter_store.fork();
 
         let observer_start = collector.observers.len();
         let saved_loop_effects = collector.loop_effects.take();
@@ -2054,7 +2054,7 @@ fn collect_function_body_effects(
         // iteration state collected for function execution.
         let (mut result_store, boundaries) = eval_for(
             module,
-            state.store.clone(),
+            state.store.fork(),
             state.boundaries.clone(),
             for_stmt,
             arena,
@@ -2241,7 +2241,7 @@ fn collect_function_body_effects(
         match stmt {
             Statement::Assign(assign) => {
                 let guard_state = state.clone();
-                let store = state.store.clone();
+                let store = state.store.fork();
                 let live = state.live_expr;
                 let live_sources = state.live_sources.clone();
                 with_collector_guard(collector, arena, live, live_sources, |collector, arena| {
@@ -2266,7 +2266,7 @@ fn collect_function_body_effects(
             }
             Statement::SystemFunctionCall(call) => {
                 let guard_state = state.clone();
-                let mut next_store = state.store.clone();
+                let mut next_store = state.store.fork();
                 let live = state.live_expr;
                 let live_sources = state.live_sources.clone();
                 let effect_boundaries = with_collector_guard(
@@ -2296,7 +2296,7 @@ fn collect_function_body_effects(
             }
             Statement::FunctionCall(call) => {
                 let guard_state = state.clone();
-                let store = state.store.clone();
+                let store = state.store.fork();
                 let live = state.live_expr;
                 let live_sources = state.live_sources.clone();
                 with_collector_guard(collector, arena, live, live_sources, |collector, arena| {
@@ -2321,7 +2321,7 @@ fn collect_function_body_effects(
                 )
             }
             Statement::If(if_stmt) => {
-                let store = state.store.clone();
+                let store = state.store.fork();
                 let live = state.live_expr;
                 let live_sources = state.live_sources.clone();
                 with_collector_guard(collector, arena, live, live_sources, |collector, arena| {
@@ -2349,7 +2349,7 @@ fn collect_function_body_effects(
                         collect_statements(
                             module,
                             FunctionControlState {
-                                store: state.store.clone(),
+                                store: state.store.fork(),
                                 boundaries: boundaries.clone(),
                                 live_expr: state.live_expr,
                                 live_sources: state.live_sources.clone(),
@@ -2416,7 +2416,7 @@ fn collect_function_body_effects(
                 })
             }
             Statement::Case(case_stmt) => {
-                let store = state.store.clone();
+                let store = state.store.fork();
                 let live = state.live_expr;
                 let live_sources = state.live_sources.clone();
                 with_collector_guard(collector, arena, live, live_sources, |collector, arena| {
@@ -2448,7 +2448,7 @@ fn collect_function_body_effects(
                     return collect_function_for(module, state, for_stmt, ret_id, arena, collector);
                 }
                 let guard_state = state.clone();
-                let store = state.store.clone();
+                let store = state.store.fork();
                 let live = state.live_expr;
                 let live_sources = state.live_sources.clone();
                 with_collector_guard(collector, arena, live, live_sources, |collector, arena| {
@@ -2649,7 +2649,7 @@ pub(super) fn collect_comb_effects_statements(
                 collector.active_guard_sources = true_sources;
                 let side_store = collect_comb_effects_statements(
                     module,
-                    store.clone(),
+                    store.fork(),
                     &if_stmt.true_side,
                     arena,
                     collector,
@@ -2753,7 +2753,7 @@ fn collect_comb_effects_case(
         collector.active_guard = Some(true_guard);
         collector.active_guard_sources = true_sources;
         let side_store =
-            collect_comb_effects_statements(module, store.clone(), &arm.body, arena, collector)?;
+            collect_comb_effects_statements(module, store.fork(), &arm.body, arena, collector)?;
 
         let false_cond = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, cond_node))?;
         let false_guard = if let Some(active) = saved_guard {
@@ -2794,7 +2794,7 @@ fn collect_comb_effects_for(
     collector: &mut CombEffectCollector,
 ) -> Result<SymbolicStore<VarId>, ParserError> {
     let loop_width = for_stmt.var_type.total_width().unwrap_or(32);
-    let original_store = store.clone();
+    let original_store = store.fork();
     let (start_bound, end_bound) = for_range_bounds(&for_stmt.range);
     for bound in [start_bound, end_bound] {
         let ForBound::Expression(expression) = bound else {
@@ -2816,7 +2816,7 @@ fn collect_comb_effects_for(
             collect_dynamic_for_effects(module, &store, for_stmt, arena, collector)?;
         let (store, _, runner) = eval_for_with_effects(
             module,
-            original_store.clone(),
+            original_store.fork(),
             BoundaryMap::default(),
             for_stmt,
             arena,
@@ -2830,7 +2830,7 @@ fn collect_comb_effects_for(
             collect_dynamic_for_effects(module, &store, for_stmt, arena, collector)?;
         let (store, _, runner) = eval_for_with_effects(
             module,
-            original_store.clone(),
+            original_store.fork(),
             BoundaryMap::default(),
             for_stmt,
             arena,
@@ -2844,7 +2844,7 @@ fn collect_comb_effects_for(
             collect_dynamic_for_effects(module, &store, for_stmt, arena, collector)?;
         let (store, _, runner) = eval_for_with_effects(
             module,
-            original_store.clone(),
+            original_store.fork(),
             BoundaryMap::default(),
             for_stmt,
             arena,
@@ -2855,7 +2855,7 @@ fn collect_comb_effects_for(
     };
     let final_end = if *inclusive { end + 1 } else { end };
     for i in start..final_end {
-        let mut iter_store = store.clone();
+        let mut iter_store = store.fork();
         let node = arena.alloc(SLTNode::Constant(
             BigUint::from(i as u64),
             BigUint::from(0u8),
@@ -2890,7 +2890,7 @@ fn collect_dynamic_for_effects(
     let Some(loop_width) = for_stmt.var_type.total_width() else {
         return Ok((Vec::new(), collector.observers.len()));
     };
-    let mut iter_store = store.clone();
+    let mut iter_store = store.fork();
     let mut written_accesses = HashMap::default();
     collect_written_accesses(module, &for_stmt.body, &mut written_accesses)?;
     for (id, accesses) in written_accesses {

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -242,24 +242,25 @@ fn collect_system_function_effect(
         });
     let observed_ids: HashSet<_> = observed_inputs.iter().map(|atom| atom.id).collect();
     let position_ids: HashSet<_> = position_inputs.iter().map(|atom| atom.id).collect();
-    let preceding_writes: Vec<_> = store
-        .iter()
-        .flat_map(|(id, range_store)| {
-            range_store
-                .ranges
-                .iter()
-                .filter_map(move |(&lsb, (value, width, _))| {
-                    value
-                        .is_some()
-                        .then_some(VarAtomBase::new(*id, lsb, lsb + width - 1))
-                })
-        })
-        .collect();
-    let mut local_inputs = Vec::new();
-    for (id, range_store) in observer_store.iter() {
-        if !observed_ids.contains(id) {
-            continue;
+    let mut preceding_writes = Vec::new();
+    let mut written_before = Vec::new();
+    for (id, range_store) in store.iter() {
+        for (&lsb, (value, width, _)) in &range_store.ranges {
+            if value.is_none() {
+                continue;
+            }
+            let atom = VarAtomBase::new(*id, lsb, lsb + width - 1);
+            preceding_writes.push(atom);
+            if position_ids.contains(id) {
+                written_before.push(atom);
+            }
         }
+    }
+    let mut local_inputs = Vec::new();
+    for id in &observed_ids {
+        let Some(range_store) = observer_store.get(id) else {
+            continue;
+        };
         if guard.is_none() {
             let overlaps_observed_input =
                 range_store.ranges.iter().any(|(&lsb, (value, width, _))| {
@@ -315,21 +316,8 @@ fn collect_system_function_effect(
         local_inputs,
         observed_inputs: observed_inputs.into_iter().collect(),
         position_inputs: position_inputs.into_iter().collect(),
-        preceding_writes: preceding_writes.clone(),
-        written_before: store
-            .iter()
-            .filter(|(id, _)| position_ids.contains(id))
-            .flat_map(|(id, range_store)| {
-                range_store
-                    .ranges
-                    .iter()
-                    .filter_map(move |(&lsb, (value, width, _))| {
-                        value
-                            .is_some()
-                            .then_some(VarAtomBase::new(*id, lsb, lsb + width - 1))
-                    })
-            })
-            .collect(),
+        preceding_writes,
+        written_before,
         written_input_atoms: Vec::new(),
         written_inputs: Vec::new(),
         captured_in_loop: loop_effect.is_some(),

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -804,7 +804,7 @@ pub(crate) fn collect_expression_effects(
             )?;
             let mut then_store = branch_store.clone();
             let _ = eval_expression_effectful(module, &mut then_store, then_expr, arena, None)?;
-            let after_then = merge_symbolic_stores(
+            let after_then = merge_symbolic_versions(
                 module,
                 &then_store,
                 &branch_store,
@@ -1071,7 +1071,7 @@ fn collect_case_pattern_effects(
                 .map(|(_, sources)| sources)
                 .cloned()
                 .unwrap_or_default();
-            merge_symbolic_stores(
+            merge_symbolic_versions(
                 module,
                 &evaluated_store,
                 &base_store,
@@ -1308,7 +1308,7 @@ fn collect_function_body_effects(
         live_sources.extend(else_state.live_sources);
 
         Ok(FunctionControlState {
-            store: merge_symbolic_stores(
+            store: merge_symbolic_versions(
                 module,
                 &then_state.store,
                 &else_state.store,
@@ -1345,7 +1345,7 @@ fn collect_function_body_effects(
             }),
             Some(false) => Ok(state),
             None => {
-                let store = merge_symbolic_stores(
+                let store = merge_symbolic_versions(
                     module,
                     &next_store,
                     &state.store,
@@ -1446,7 +1446,7 @@ fn collect_function_body_effects(
             });
         }
 
-        let store = merge_symbolic_stores(
+        let store = merge_symbolic_versions(
             module,
             &next_function.store,
             &state.function.store,
@@ -1617,7 +1617,7 @@ fn collect_function_body_effects(
         live_sources.extend(else_state.function.live_sources);
         Ok(FunctionLoopControlState {
             function: FunctionControlState {
-                store: merge_symbolic_stores(
+                store: merge_symbolic_versions(
                     module,
                     &then_state.function.store,
                     &else_state.function.store,
@@ -1814,7 +1814,7 @@ fn collect_function_body_effects(
             live_sources.extend(else_state.function.live_sources);
             Ok(FunctionLoopControlState {
                 function: FunctionControlState {
-                    store: merge_symbolic_stores(
+                    store: merge_symbolic_versions(
                         module,
                         &then_state.function.store,
                         &else_state.function.store,
@@ -2397,7 +2397,7 @@ fn collect_function_body_effects(
                 live_sources.extend(false_state.live_sources.iter().copied());
 
                 Ok(FunctionControlState {
-                    store: merge_symbolic_stores(
+                    store: merge_symbolic_versions(
                         module,
                         &true_state.store,
                         &false_state.store,
@@ -2673,7 +2673,7 @@ pub(super) fn collect_comb_effects_statements(
                 )?;
                 collector.active_guard = saved_guard;
                 collector.active_guard_sources = saved_guard_sources;
-                store = merge_symbolic_stores(
+                store = merge_symbolic_versions(
                     module,
                     &side_store,
                     &else_store,
@@ -2777,7 +2777,7 @@ fn collect_comb_effects_case(
 
         collector.active_guard = saved_guard;
         collector.active_guard_sources = saved_guard_sources;
-        merge_symbolic_stores(module, &side_store, &else_store, cond_node, &sources, arena)
+        merge_symbolic_versions(module, &side_store, &else_store, cond_node, &sources, arena)
     }
 
     collect_expression_effects(module, &store, &case_stmt.case_target, arena, collector)?;

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -292,7 +292,7 @@ fn collect_system_function_effect(
             continue;
         }
         let parts = range_store
-            .get_parts(BitAccess::new(0, width - 1))
+            .get_parts_ref(BitAccess::new(0, width - 1))
             .map_err(|error| {
                 super::range_store_error(
                     "combinational observer capture",
@@ -1983,7 +1983,7 @@ fn collect_function_body_effects(
                     bit += 1;
                 }
                 let access = BitAccess::new(start, bit - 1);
-                let parts = original.get_parts(access).map_err(|error| {
+                let parts = original.get_parts_ref(access).map_err(|error| {
                     super::range_store_error(
                         "function observer for-loop state",
                         error,
@@ -2906,7 +2906,7 @@ fn collect_dynamic_for_effects(
             }
             let end = bit - 1;
             let access = BitAccess::new(start, end);
-            let parts = original.get_parts(access).map_err(|error| {
+            let parts = original.get_parts_ref(access).map_err(|error| {
                 super::range_store_error("observer for-loop state", error, Some(&for_stmt.token))
             })?;
             let (expr, sources) = combine_parts_with_default(id, access.lsb, parts, arena)?;

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -528,7 +528,7 @@ pub(super) fn eval_function_body_return(
         context_width: Option<usize>,
         arena: &mut SLTNodeArena<VarId>,
     ) -> Result<(FunctionControlState, NodeId, HashSet<VarAtomBase<VarId>>), ParserError> {
-        let mut next_store = state.store.clone();
+        let mut next_store = state.store.fork();
         let ((node, sources), boundaries) =
             eval_expression_effectful(module, &mut next_store, expression, arena, context_width)?;
         let state = apply_function_guard(
@@ -576,7 +576,7 @@ pub(super) fn eval_function_body_return(
         let then_state = eval_function_statements(
             module,
             FunctionControlState {
-                store: state.store.clone(),
+                store: state.store.fork(),
                 boundaries: state.boundaries.clone(),
                 live_expr: state.live_expr,
                 live_sources: state.live_sources.clone(),
@@ -701,7 +701,7 @@ pub(super) fn eval_function_body_return(
             let then_state = if_stmt.true_side.iter().try_fold(
                 FunctionLoopControlState {
                     function: FunctionControlState {
-                        store: state.function.store.clone(),
+                        store: state.function.store.fork(),
                         boundaries: state.function.boundaries.clone(),
                         live_expr: state.function.live_expr,
                         live_sources: state.function.live_sources.clone(),
@@ -786,7 +786,7 @@ pub(super) fn eval_function_body_return(
                     });
                 };
 
-                let mut next_store = state.function.store.clone();
+                let mut next_store = state.function.store.fork();
                 let ((cond_expr, cond_sources), cond_bounds) = eval_case_arm_condition_effectful(
                     module,
                     &mut next_store,
@@ -838,7 +838,7 @@ pub(super) fn eval_function_body_return(
                 let then_state = arm.body.iter().try_fold(
                     FunctionLoopControlState {
                         function: FunctionControlState {
-                            store: state.function.store.clone(),
+                            store: state.function.store.fork(),
                             boundaries: boundaries.clone(),
                             live_expr: state.function.live_expr,
                             live_sources: state.function.live_sources.clone(),
@@ -995,7 +995,7 @@ pub(super) fn eval_function_body_return(
         }
 
         let guard_state = state.clone();
-        let mut bound_store = state.store.clone();
+        let mut bound_store = state.store.fork();
         let (
             start,
             end,
@@ -1103,7 +1103,7 @@ pub(super) fn eval_function_body_return(
             arena,
         )?;
 
-        let mut symbolic_store = state.store.clone();
+        let mut symbolic_store = state.store.fork();
         let mut written_accesses = HashMap::default();
         collect_written_accesses(module, &for_stmt.body, &mut written_accesses)?;
         for (id, accesses) in &written_accesses {
@@ -1153,7 +1153,7 @@ pub(super) fn eval_function_body_return(
             symbolic_store.insert(*id, loop_store);
         }
         symbolic_store.insert(for_stmt.var_id, RangeStore::new(None, loop_width));
-        let iter_store_before = symbolic_store.clone();
+        let iter_store_before = symbolic_store.fork();
 
         let iter_state = for_stmt.body.iter().try_fold(
             FunctionLoopControlState {
@@ -1209,7 +1209,7 @@ pub(super) fn eval_function_body_return(
             })
             .collect::<Result<Vec<_>, ParserError>>()?;
 
-        let mut result_store = state.store.clone();
+        let mut result_store = state.store.fork();
         let loop_effective_continue = arena.alloc(SLTNode::Binary(
             iter_state.continue_expr,
             BinaryOp::And,
@@ -1392,7 +1392,7 @@ pub(super) fn eval_function_body_return(
             let then_state = if_stmt.true_side.iter().try_fold(
                 FunctionLoopControlState {
                     function: FunctionControlState {
-                        store: state.function.store.clone(),
+                        store: state.function.store.fork(),
                         boundaries: state.function.boundaries.clone(),
                         live_expr: state.function.live_expr,
                         live_sources: state.function.live_sources.clone(),
@@ -1505,7 +1505,7 @@ pub(super) fn eval_function_body_return(
                 });
             };
 
-            let mut next_store = state.function.store.clone();
+            let mut next_store = state.function.store.fork();
             let ((cond_expr, cond_sources), cond_bounds) = eval_case_arm_condition_effectful(
                 module,
                 &mut next_store,
@@ -1554,7 +1554,7 @@ pub(super) fn eval_function_body_return(
             let then_state = arm.body.iter().try_fold(
                 FunctionLoopControlState {
                     function: FunctionControlState {
-                        store: state.function.store.clone(),
+                        store: state.function.store.fork(),
                         boundaries: boundaries.clone(),
                         live_expr: state.function.live_expr,
                         live_sources: state.function.live_sources.clone(),
@@ -1788,7 +1788,7 @@ pub(super) fn eval_function_body_return(
                 return eval_function_statements(module, state, &case_stmt.default, ret_id, arena);
             };
 
-            let mut next_store = state.store.clone();
+            let mut next_store = state.store.fork();
             let ((cond_expr, cond_sources), cond_bounds) = eval_case_arm_condition_effectful(
                 module,
                 &mut next_store,
@@ -1832,7 +1832,7 @@ pub(super) fn eval_function_body_return(
             let then_state = eval_function_statements(
                 module,
                 FunctionControlState {
-                    store: state.store.clone(),
+                    store: state.store.fork(),
                     boundaries: boundaries.clone(),
                     live_expr: state.live_expr,
                     live_sources: state.live_sources.clone(),
@@ -1981,7 +1981,7 @@ pub(super) fn eval_function_body_return(
         }
     }
 
-    let mut local_store = caller_store.clone();
+    let mut local_store = caller_store.fork();
     let local_bounds = BoundaryMap::default();
     let mut written = HashMap::default();
 
@@ -2116,7 +2116,7 @@ fn eval_function_call_expression(
         }
     }
 
-    let mut local_store = store.current().clone();
+    let mut local_store = store.current().fork();
     for (arg_id, arg_node, sources, arg_width) in evaluated_inputs {
         local_store.insert(
             arg_id,
@@ -2303,8 +2303,8 @@ fn merge_short_circuit_case_condition(
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
     let ((lhs_node, mut sources), lhs_boundaries) = lhs;
-    let base_store = store.clone();
-    let mut rhs_store = base_store.clone();
+    let base_store = store.fork();
+    let mut rhs_store = base_store.fork();
     let ((rhs_node, rhs_sources), rhs_boundaries) = eval_rhs(&mut rhs_store, arena)?;
     let execute_rhs = short_circuit_rhs_guard(arena, lhs_node, is_and)?;
     *store = super::merge_symbolic_versions(
@@ -2563,8 +2563,8 @@ pub(super) fn eval_expression_in_context(
             let ((r_expr, r_sources), r_bounds) = if store.effectful_mut().is_some()
                 && matches!(op, Op::LogicAnd | Op::LogicOr)
             {
-                let base_store = store.current().clone();
-                let mut rhs_store = base_store.clone();
+                let base_store = store.current().fork();
+                let mut rhs_store = base_store.fork();
                 let mut rhs_state = ExpressionStore::Effectful(&mut rhs_store);
                 let rhs_value = eval_expression_in_context(
                     module,
@@ -2763,8 +2763,8 @@ pub(super) fn eval_expression_in_context(
                 ((then_expr, then_sources), then_bounds),
                 ((else_expr, else_sources), else_bounds),
             ) = if store.effectful_mut().is_some() {
-                let base_store = store.current().clone();
-                let mut then_store = base_store.clone();
+                let base_store = store.current().fork();
+                let mut then_store = base_store.fork();
                 let mut then_state = ExpressionStore::Effectful(&mut then_store);
                 let then_value = eval_expression_in_context(
                     module,

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -3112,6 +3112,7 @@ fn eval_factor(
                     indices: dynamic_indices,
                     sources: offset_sources,
                     boundaries: all_bounds,
+                    ..
                 } = super::eval_dynamic_select_offset(
                     module,
                     store,

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -492,7 +492,7 @@ pub(super) fn eval_function_body_return(
             }),
             Some(false) => Ok(state),
             None => {
-                let merged_store = merge_symbolic_stores(
+                let merged_store = merge_symbolic_versions(
                     module,
                     &next_store,
                     &state.store,
@@ -603,7 +603,7 @@ pub(super) fn eval_function_body_return(
         live_sources.extend(else_state.live_sources);
 
         Ok(FunctionControlState {
-            store: merge_symbolic_stores(
+            store: merge_symbolic_versions(
                 module,
                 &then_state.store,
                 &else_state.store,
@@ -647,7 +647,7 @@ pub(super) fn eval_function_body_return(
                     ..state
                 })
             } else {
-                let merged_store = merge_symbolic_stores(
+                let merged_store = merge_symbolic_versions(
                     module,
                     &next_function.store,
                     &state.function.store,
@@ -734,7 +734,7 @@ pub(super) fn eval_function_body_return(
 
             Ok(FunctionLoopControlState {
                 function: FunctionControlState {
-                    store: merge_symbolic_stores(
+                    store: merge_symbolic_versions(
                         module,
                         &then_state.function.store,
                         &else_state.function.store,
@@ -876,7 +876,7 @@ pub(super) fn eval_function_body_return(
 
                 Ok(FunctionLoopControlState {
                     function: FunctionControlState {
-                        store: merge_symbolic_stores(
+                        store: merge_symbolic_versions(
                             module,
                             &then_state.function.store,
                             &else_state.function.store,
@@ -1339,7 +1339,7 @@ pub(super) fn eval_function_body_return(
                 ..state
             })
         } else {
-            let merged_store = merge_symbolic_stores(
+            let merged_store = merge_symbolic_versions(
                 module,
                 &next_function.store,
                 &state.function.store,
@@ -1425,7 +1425,7 @@ pub(super) fn eval_function_body_return(
 
             FunctionLoopControlState {
                 function: FunctionControlState {
-                    store: merge_symbolic_stores(
+                    store: merge_symbolic_versions(
                         module,
                         &then_state.function.store,
                         &else_state.function.store,
@@ -1592,7 +1592,7 @@ pub(super) fn eval_function_body_return(
 
             Ok(FunctionLoopControlState {
                 function: FunctionControlState {
-                    store: merge_symbolic_stores(
+                    store: merge_symbolic_versions(
                         module,
                         &then_state.function.store,
                         &else_state.function.store,
@@ -1861,7 +1861,7 @@ pub(super) fn eval_function_body_return(
             live_sources.extend(else_state.live_sources);
 
             Ok(FunctionControlState {
-                store: merge_symbolic_stores(
+                store: merge_symbolic_versions(
                     module,
                     &then_state.store,
                     &else_state.store,
@@ -2307,7 +2307,7 @@ fn merge_short_circuit_case_condition(
     let mut rhs_store = base_store.clone();
     let ((rhs_node, rhs_sources), rhs_boundaries) = eval_rhs(&mut rhs_store, arena)?;
     let execute_rhs = short_circuit_rhs_guard(arena, lhs_node, is_and)?;
-    *store = super::merge_symbolic_stores(
+    *store = super::merge_symbolic_versions(
         module,
         &rhs_store,
         &base_store,
@@ -2584,7 +2584,7 @@ pub(super) fn eval_expression_in_context(
                 };
                 let shortcut = arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, shortcut_truth))?;
                 let execute_rhs = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, shortcut))?;
-                let merged_store = super::merge_symbolic_stores(
+                let merged_store = super::merge_symbolic_versions(
                     module,
                     &rhs_store,
                     &base_store,
@@ -2782,7 +2782,7 @@ pub(super) fn eval_expression_in_context(
                 let true_truth = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, not_cond))?;
                 let known_true = arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, true_truth))?;
                 let execute_then = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, known_false))?;
-                let after_then = super::merge_symbolic_stores(
+                let after_then = super::merge_symbolic_versions(
                     module,
                     &then_store,
                     &base_store,
@@ -2802,7 +2802,7 @@ pub(super) fn eval_expression_in_context(
                 )?;
 
                 let execute_else = arena.alloc(SLTNode::Unary(UnaryOp::LogicNot, known_true))?;
-                let final_store = super::merge_symbolic_stores(
+                let final_store = super::merge_symbolic_versions(
                     module,
                     &else_store,
                     &after_then,

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -1186,20 +1186,13 @@ pub(super) fn eval_function_body_return(
         let initial_updates: Vec<_> = updates
             .iter()
             .map(|(target, _, _)| {
-                let range_store = state.store.get(&target.id).ok_or_else(|| {
-                    ParserError::illegal_context(
-                        "function for-loop initial state",
-                        "state variable is absent from the symbolic store",
-                        Some(&for_stmt.token),
-                    )
-                })?;
-                let parts = range_store.get_parts(target.access).map_err(|error| {
-                    super::range_store_error(
-                        "function for-loop initial state",
-                        error,
-                        Some(&for_stmt.token),
-                    )
-                })?;
+                let parts = super::symbolic_parts_or_default(
+                    &state.store,
+                    target.id,
+                    target.access,
+                    "function for-loop initial state",
+                    Some(&for_stmt.token),
+                )?;
                 let (expr, _) =
                     combine_parts_with_default(target.id, target.access.lsb, parts, arena)?;
                 Ok(SLTForUpdate {
@@ -3062,25 +3055,36 @@ fn eval_factor(
                 var_bounds.insert(access.lsb);
                 var_bounds.insert(access_end);
 
-                let range_store = store.current().get(var_id).ok_or_else(|| {
-                    ParserError::illegal_context(
-                        "static variable read",
-                        "source variable is absent from the symbolic store",
-                        Some(&comptime.token),
-                    )
-                })?;
-                let parts = range_store.get_parts(access).map_err(|error| {
-                    super::range_store_error("static variable read", error, Some(&comptime.token))
-                })?;
-                // Check if any part of the requested access is unassigned (None)
-                // If so, we must depend on the variable's previous value (input).
-                // If all parts are Some(...), we only depend on the sources of those expressions.
-                let has_unassigned = parts.iter().any(|(val, _)| val.is_none());
-                let (expr, mut sources) =
-                    combine_parts_with_default(*var_id, access.lsb, parts, arena)?;
-                if has_unassigned {
+                let (expr, sources) = if let Some(range_store) = store.current().get(var_id) {
+                    let parts = range_store.get_parts(access).map_err(|error| {
+                        super::range_store_error(
+                            "static variable read",
+                            error,
+                            Some(&comptime.token),
+                        )
+                    })?;
+                    // If any requested part is unassigned, the result still
+                    // depends on that range's process input value.
+                    let has_unassigned = parts.iter().any(|(val, _)| val.is_none());
+                    let (expr, mut sources) =
+                        combine_parts_with_default(*var_id, access.lsb, parts, arena)?;
+                    if has_unassigned {
+                        sources.insert(VarAtomBase::new(*var_id, access.lsb, access.msb));
+                    }
+                    (expr, sources)
+                } else {
+                    // Read-only variables have no mutable symbolic definition.
+                    // Materialize their input range directly instead.
+                    let expr = arena.alloc(SLTNode::Input {
+                        variable: *var_id,
+                        signed: false,
+                        index: vec![],
+                        access,
+                    })?;
+                    let mut sources = HashSet::default();
                     sources.insert(VarAtomBase::new(*var_id, access.lsb, access.msb));
-                }
+                    (expr, sources)
+                };
                 // Symbolic substitution may replace this variable with an
                 // expression whose producer has different signedness. Width
                 // coercion follows the source variable's analyzer context,
@@ -3116,18 +3120,23 @@ fn eval_factor(
                 all_sources.extend(offset_sources);
 
                 // 2. Check SymbolicStore to determine if "already written"
-                let range_store = store.current().get(var_id).ok_or_else(|| {
-                    ParserError::illegal_context(
-                        "dynamic variable read",
-                        "source variable is absent from the symbolic store",
-                        Some(&comptime.token),
-                    )
-                })?;
                 let access_full = BitAccess::new(0, width - 1);
-                let parts = range_store.get_parts(access_full).map_err(|error| {
-                    super::range_store_error("dynamic variable read", error, Some(&comptime.token))
-                })?;
-                let is_unmodified = parts.iter().all(|(val, _)| val.is_none());
+                let parts = store
+                    .current()
+                    .get(var_id)
+                    .map(|range_store| {
+                        range_store.get_parts(access_full).map_err(|error| {
+                            super::range_store_error(
+                                "dynamic variable read",
+                                error,
+                                Some(&comptime.token),
+                            )
+                        })
+                    })
+                    .transpose()?;
+                let is_unmodified = parts
+                    .as_ref()
+                    .is_none_or(|parts| parts.iter().all(|(val, _)| val.is_none()));
 
                 let element_width =
                     crate::bitaccess::get_access_width(module, *var_id, index, select)?;
@@ -3157,8 +3166,12 @@ fn eval_factor(
                 } else {
                     // --- If already written ---
                     // Combine latest values in register and align with Shr
-                    let (current_expr, current_sources) =
-                        combine_parts_with_default(*var_id, 0, parts, arena)?;
+                    let (current_expr, current_sources) = combine_parts_with_default(
+                        *var_id,
+                        0,
+                        parts.expect("a modified variable has a symbolic range"),
+                        arena,
+                    )?;
                     all_sources.extend(current_sources);
 
                     let shifted =

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -469,7 +469,7 @@ pub(super) fn eval_function_body_return(
             )
         })?;
         let ret_parts = range_store
-            .get_parts(ret_access)
+            .get_parts_ref(ret_access)
             .map_err(|error| super::range_store_error("function return value", error, None))?;
         Ok(combine_parts_with_default(ret_id, 0, ret_parts, arena)?)
     }
@@ -1132,7 +1132,7 @@ pub(super) fn eval_function_body_return(
                 }
                 let end = bit - 1;
                 let access = BitAccess::new(start, end);
-                let parts = original.get_parts(access).map_err(|error| {
+                let parts = original.get_parts_ref(access).map_err(|error| {
                     super::range_store_error(
                         "function for-loop state",
                         error,
@@ -1193,8 +1193,12 @@ pub(super) fn eval_function_body_return(
                     "function for-loop initial state",
                     Some(&for_stmt.token),
                 )?;
-                let (expr, _) =
-                    combine_parts_with_default(target.id, target.access.lsb, parts, arena)?;
+                let (expr, _) = combine_parts_with_default(
+                    target.id,
+                    target.access.lsb,
+                    parts.iter().map(|(value, access)| (value, *access)),
+                    arena,
+                )?;
                 Ok(SLTForUpdate {
                     target: *target,
                     expr,
@@ -3056,7 +3060,7 @@ fn eval_factor(
                 var_bounds.insert(access_end);
 
                 let (expr, sources) = if let Some(range_store) = store.current().get(var_id) {
-                    let parts = range_store.get_parts(access).map_err(|error| {
+                    let parts = range_store.get_parts_ref(access).map_err(|error| {
                         super::range_store_error(
                             "static variable read",
                             error,
@@ -3125,7 +3129,7 @@ fn eval_factor(
                     .current()
                     .get(var_id)
                     .map(|range_store| {
-                        range_store.get_parts(access_full).map_err(|error| {
+                        range_store.get_parts_ref(access_full).map_err(|error| {
                             super::range_store_error(
                                 "dynamic variable read",
                                 error,

--- a/crates/celox-frontend-veryl/src/logic_tree/recover_unrolled.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/recover_unrolled.rs
@@ -1455,7 +1455,7 @@ fn recover_group(
             )
         })?;
         let parts = range_store
-            .get_parts(target.access)
+            .get_parts_ref(target.access)
             .map_err(|error| range_store_error("recovered loop initial state", error, None))?;
         if parts.iter().any(|(value, _)| value.is_none()) {
             return Ok(None);
@@ -1539,7 +1539,7 @@ fn expanded_outputs_are_count_idioms(
     targets
         .iter()
         .map(|target| {
-            let parts = store.get(&target.id)?.get_parts(target.access).ok()?;
+            let parts = store.get(&target.id)?.get_parts_ref(target.access).ok()?;
             let (output, _) =
                 combine_parts_with_default(target.id, target.access.lsb, parts, &mut scratch)
                     .ok()?;
@@ -1591,7 +1591,7 @@ fn prove_group(
     for target in &targets {
         let parts = initial_store
             .get(&target.id)?
-            .get_parts(target.access)
+            .get_parts_ref(target.access)
             .ok()?;
         if parts.iter().any(|(value, _)| value.is_none()) {
             return None;
@@ -1748,7 +1748,7 @@ fn prove_group(
         let Some(ranges) = initial_store.get(&source.id) else {
             continue;
         };
-        let parts = ranges.get_parts(source.access).ok()?;
+        let parts = ranges.get_parts_ref(source.access).ok()?;
         if parts.iter().any(|(value, _)| value.is_some()) {
             return None;
         }
@@ -1913,7 +1913,7 @@ fn eval_chunk_outputs_with_facts(
     let mut outputs = Vec::with_capacity(targets.len());
     let mut sources = HashSet::default();
     for target in targets {
-        let parts = store.get(&target.id)?.get_parts(target.access).ok()?;
+        let parts = store.get(&target.id)?.get_parts_ref(target.access).ok()?;
         let (output, output_sources) =
             combine_parts_with_default(target.id, target.access.lsb, parts, arena).ok()?;
         outputs.push(output);
@@ -1983,7 +1983,7 @@ fn eval_chunk_outputs_with_initial_store(
     let mut outputs = Vec::with_capacity(targets.len());
     let mut sources = HashSet::default();
     for target in targets {
-        let parts = store.get(&target.id)?.get_parts(target.access).ok()?;
+        let parts = store.get(&target.id)?.get_parts_ref(target.access).ok()?;
         let (output, output_sources) =
             combine_parts_with_default(target.id, target.access.lsb, parts, arena).ok()?;
         outputs.push(output);
@@ -2141,7 +2141,7 @@ fn whole_fold_matches_expansion(
             return None;
         }
         let access = BitAccess::new(0, width - 1);
-        let parts = mapped_initial.get(variable)?.get_parts(access).ok()?;
+        let parts = mapped_initial.get(variable)?.get_parts_ref(access).ok()?;
         if parts.iter().any(|(value, _)| value.is_none()) {
             continue;
         }
@@ -2242,7 +2242,7 @@ fn read_target_outputs(
     targets
         .iter()
         .map(|target| {
-            let parts = store.get(&target.id)?.get_parts(target.access).ok()?;
+            let parts = store.get(&target.id)?.get_parts_ref(target.access).ok()?;
             combine_parts_with_default(target.id, target.access.lsb, parts, arena)
                 .ok()
                 .map(|(output, _)| output)

--- a/crates/celox-frontend-veryl/src/logic_tree/recover_unrolled.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/recover_unrolled.rs
@@ -1745,10 +1745,10 @@ fn prove_group(
         if source.id == first_iteration.loop_var || target_ids.contains(&source.id) {
             continue;
         }
-        let parts = initial_store
-            .get(&source.id)?
-            .get_parts(source.access)
-            .ok()?;
+        let Some(ranges) = initial_store.get(&source.id) else {
+            continue;
+        };
+        let parts = ranges.get_parts(source.access).ok()?;
         if parts.iter().any(|(value, _)| value.is_some()) {
             return None;
         }
@@ -1941,7 +1941,9 @@ fn eval_chunk_outputs_with_initial_store(
         .iter()
         .filter(|variable| !rebound_ids.contains(variable))
     {
-        let ranges = initial_store.get(variable)?;
+        let Some(ranges) = initial_store.get(variable) else {
+            continue;
+        };
         for (value, _, _) in ranges.ranges.values() {
             let Some((root, sources)) = value else {
                 continue;
@@ -1960,7 +1962,8 @@ fn eval_chunk_outputs_with_initial_store(
             }
         }
     }
-    let mut store = map_symbolic_store_roots(initial_store, &variables, source_arena, arena)?;
+    let mut store =
+        map_symbolic_store_roots(module, initial_store, &variables, source_arena, arena)?;
     for target in targets {
         let width = resolve_total_width(module, module.variables.get(&target.id)?).ok()?;
         store.insert(target.id, RangeStore::new(None, width));
@@ -2090,6 +2093,7 @@ fn whole_fold_matches_expansion(
     let variables = proof_variable_ids(statements, targets)?;
     let mut proof_arena = SLTNodeArena::new();
     let mapped_initial = map_symbolic_store_roots(
+        module,
         initial_store,
         &variables,
         production_arena,
@@ -2099,7 +2103,7 @@ fn whole_fold_matches_expansion(
     let (expanded_store, _) = statements
         .iter()
         .try_fold(
-            (mapped_initial.clone(), BoundaryMap::default()),
+            (mapped_initial.fork(), BoundaryMap::default()),
             |(store, boundaries), statement| {
                 eval_statement(module, store, boundaries, statement, &mut proof_arena)
             },
@@ -2200,6 +2204,7 @@ fn whole_fold_matches_expansion(
 }
 
 fn map_symbolic_store_roots(
+    module: &Module,
     store: &SymbolicStore<VarId>,
     variables: &HashSet<VarId>,
     source_arena: &SLTNodeArena<VarId>,
@@ -2208,7 +2213,13 @@ fn map_symbolic_store_roots(
     let mut mapped = SymbolicStore::default();
     let mut cache = HashMap::default();
     for id in variables {
-        let mut range_store = store.get(id)?.clone();
+        let mut range_store = if let Some(range_store) = store.get(id) {
+            range_store.clone()
+        } else {
+            let variable = module.variables.get(id)?;
+            let width = resolve_total_width(module, variable).ok()?;
+            RangeStore::new(None, width)
+        };
         for (value, _, _) in range_store.ranges.values_mut() {
             let Some((node, _)) = value else {
                 continue;

--- a/crates/celox-frontend-veryl/src/logic_tree/recover_unrolled.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/recover_unrolled.rs
@@ -37,7 +37,7 @@ pub(super) fn eval_statements(
             let guarded_matches = matching_candidates(module, &if_stmt.true_side, candidates);
             if guarded_matches.len() == 1 {
                 let candidate = guarded_matches[0];
-                let store_before_probe = store.clone();
+                let store_before_probe = store.fork();
                 let ((guard, guard_sources), guard_boundaries) =
                     eval_expression_effectful(module, &mut store, &if_stmt.cond, arena, None)?;
                 let guard = procedural_condition(arena, guard)?;
@@ -1491,7 +1491,7 @@ fn recover_group(
 
     let total_width = get_width(group, arena);
     let mut next_msb = total_width;
-    let mut result_store = initial_store.clone();
+    let mut result_store = initial_store.fork();
     for target in &proof.targets {
         let width = target.access.msb - target.access.lsb + 1;
         next_msb -= width;
@@ -1529,7 +1529,7 @@ fn expanded_outputs_are_count_idioms(
     let (store, _) = statements
         .iter()
         .try_fold(
-            (initial_store.clone(), BoundaryMap::default()),
+            (initial_store.fork(), BoundaryMap::default()),
             |(store, boundaries), statement| {
                 eval_statement(module, store, boundaries, statement, &mut scratch)
             },

--- a/crates/celox-frontend-veryl/src/logic_tree/state.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/state.rs
@@ -9,7 +9,6 @@ use super::NodeId;
 pub type SymbolicStore<A> = celox_slt::SymbolicStore<A, NodeId>;
 pub type BoundaryMap<A> = celox_slt::BoundaryMap<A>;
 
-#[derive(Clone)]
 pub(super) struct LoopControlState {
     pub(super) store: SymbolicStore<VarId>,
     pub(super) boundaries: BoundaryMap<VarId>,
@@ -17,7 +16,17 @@ pub(super) struct LoopControlState {
     pub(super) continue_sources: HashSet<VarAtomBase<VarId>>,
 }
 
-#[derive(Clone)]
+impl Clone for LoopControlState {
+    fn clone(&self) -> Self {
+        Self {
+            store: self.store.fork(),
+            boundaries: self.boundaries.clone(),
+            continue_expr: self.continue_expr,
+            continue_sources: self.continue_sources.clone(),
+        }
+    }
+}
+
 pub(super) struct FunctionControlState {
     pub(super) store: SymbolicStore<VarId>,
     pub(super) boundaries: BoundaryMap<VarId>,
@@ -25,9 +34,29 @@ pub(super) struct FunctionControlState {
     pub(super) live_sources: HashSet<VarAtomBase<VarId>>,
 }
 
-#[derive(Clone)]
+impl Clone for FunctionControlState {
+    fn clone(&self) -> Self {
+        Self {
+            store: self.store.fork(),
+            boundaries: self.boundaries.clone(),
+            live_expr: self.live_expr,
+            live_sources: self.live_sources.clone(),
+        }
+    }
+}
+
 pub(super) struct FunctionLoopControlState {
     pub(super) function: FunctionControlState,
     pub(super) continue_expr: NodeId,
     pub(super) continue_sources: HashSet<VarAtomBase<VarId>>,
+}
+
+impl Clone for FunctionLoopControlState {
+    fn clone(&self) -> Self {
+        Self {
+            function: self.function.clone(),
+            continue_expr: self.continue_expr,
+            continue_sources: self.continue_sources.clone(),
+        }
+    }
 }

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -5,7 +5,8 @@ use crate::{
     BuildConfig, GlueAddr, GlueBlock, HashMap, HashSet, LoweringPhase, ModuleInitialMemoryValue,
     ParserError, RegionedVarAddr, SimModule,
     bitaccess::{
-        PartSelectGeometry, eval_var_select, get_access_width, is_static_access, select_geometry,
+        PartSelectGeometry, SelectGeometry, eval_var_select_with_geometry, is_static_access,
+        select_geometry,
     },
     bitslicer::BitSlicer,
     ff::FfParser,
@@ -60,6 +61,7 @@ pub struct ModuleParser<'a> {
 
 fn build_dynamic_output_glue(
     module: &Module,
+    geometry: &SelectGeometry,
     parent_store: &mut SymbolicStore<VarId>,
     parent_arena: &mut SLTNodeArena<VarId>,
     glue_arena: &mut SLTNodeArena<GlueAddr>,
@@ -80,7 +82,6 @@ fn build_dynamic_output_glue(
     ),
     ParserError,
 > {
-    let geometry = select_geometry(module, dst.id, &dst.index, &dst.select)?;
     let mut offset = glue_arena.alloc(SLTNode::Constant(
         BigUint::from(0u8),
         BigUint::from(0u8),
@@ -332,7 +333,7 @@ fn build_dynamic_output_glue(
         ))?;
     }
 
-    let access_width = get_access_width(module, dst.id, &dst.index, &dst.select)?;
+    let access_width = geometry.selected_width;
     let variable = &module.variables[&dst.id];
     let variable_width = resolve_total_width(module, variable)?;
     if variable_width == 0 || access_width == 0 || access_width > variable_width {
@@ -472,7 +473,7 @@ fn build_dynamic_output_glue(
         parent_shifted_rhs,
     ))?;
 
-    let prefix = eval_var_select(module, dst.id, &dst.index, &dst.select)?;
+    let prefix = eval_var_select_with_geometry(&dst.index, &dst.select, geometry)?;
     let result = if prefix == full_access {
         updated_value
     } else {
@@ -1315,8 +1316,10 @@ impl<'a> ModuleParser<'a> {
                         &mut destination_address_sources,
                     )?;
                 }
-                let prefix_access = eval_var_select(self.module, dst.id, &dst.index, &dst.select)?;
-                let part_width = get_access_width(self.module, dst.id, &dst.index, &dst.select)?;
+                let geometry = select_geometry(self.module, dst.id, &dst.index, &dst.select)?;
+                let prefix_access =
+                    eval_var_select_with_geometry(&dst.index, &dst.select, &geometry)?;
+                let part_width = geometry.selected_width;
 
                 // Extract this part from rhs_node
                 let slice_end = current_offset.checked_add(part_width).ok_or_else(|| {
@@ -1383,6 +1386,7 @@ impl<'a> ModuleParser<'a> {
                 } else {
                     build_dynamic_output_glue(
                         self.module,
+                        &geometry,
                         &mut destination_store,
                         &mut destination_arena,
                         &mut glue_arena,

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -1146,7 +1146,7 @@ impl<'a> ModuleParser<'a> {
             }
             let mut written_accesses = HashMap::default();
             collect_written_expression(self.module, &input.expr, &mut written_accesses)?;
-            let mut connection_store = parent_store.clone();
+            let mut connection_store = parent_store.fork();
             let ((expr_node, expr_sources), _bounds) = eval_assignment_expression_effectful(
                 self.module,
                 &mut connection_store,

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -98,11 +98,16 @@ fn build_dynamic_output_glue(
     let mut address_sources = HashSet::default();
     let mut preview_sources = preview_rhs_sources;
 
-    let mut index_exprs = dst.index.0.clone();
-    index_exprs.extend(dst.select.0.clone());
     let dim_limit = geometry.dimension_count;
 
-    for (dimension, index_expr) in index_exprs[..dim_limit].iter().enumerate() {
+    for (dimension, index_expr) in dst
+        .index
+        .0
+        .iter()
+        .chain(&dst.select.0)
+        .take(dim_limit)
+        .enumerate()
+    {
         let ((index, index_sources), _) = crate::logic_tree::eval_expression_effectful(
             module,
             parent_store,
@@ -159,7 +164,7 @@ fn build_dynamic_output_glue(
     }
 
     if let Some(part) = geometry.part {
-        let anchor_expr = index_exprs.last().ok_or_else(|| {
+        let anchor_expr = dst.select.0.last().ok_or_else(|| {
             ParserError::illegal_context(
                 "dynamic output port destination",
                 "part select is missing its anchor expression",

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -345,7 +345,7 @@ fn build_dynamic_output_glue(
             Some(&dst.token),
         )
     })?;
-    let parts = range_store.get_parts(full_access).map_err(|error| {
+    let parts = range_store.get_parts_ref(full_access).map_err(|error| {
         ParserError::illegal_context(
             "dynamic output port destination",
             error.to_string(),
@@ -685,16 +685,17 @@ fn build_parent_effect_glue(
 
                 let target_access = BitAccess::new(target_lsb, target_msb);
                 if let Some(initial_range_store) = initial_store.get(id) {
-                    let final_parts = range_store.get_parts(target_access).map_err(|error| {
-                        ParserError::illegal_context(
-                            "instance input function output",
-                            error.to_string(),
-                            None,
-                        )
-                    })?;
+                    let final_parts =
+                        range_store.get_parts_ref(target_access).map_err(|error| {
+                            ParserError::illegal_context(
+                                "instance input function output",
+                                error.to_string(),
+                                None,
+                            )
+                        })?;
                     let initial_parts =
                         initial_range_store
-                            .get_parts(target_access)
+                            .get_parts_ref(target_access)
                             .map_err(|error| {
                                 ParserError::illegal_context(
                                     "instance input function output",
@@ -1190,7 +1191,7 @@ impl<'a> ModuleParser<'a> {
                         continue;
                     };
                     for &access in accesses {
-                        for (value, _) in range_store.get_parts(access).map_err(|error| {
+                        for (value, _) in range_store.get_parts_ref(access).map_err(|error| {
                             ParserError::illegal_context(
                                 "instance input function output",
                                 error.to_string(),

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -338,13 +338,12 @@ fn build_dynamic_output_glue(
         ));
     }
     let full_access = BitAccess::new(0, variable_width - 1);
-    let range_store = parent_store.get(&dst.id).ok_or_else(|| {
-        ParserError::illegal_context(
-            "dynamic output port destination",
-            "destination variable is absent from the parent symbolic store",
-            Some(&dst.token),
-        )
-    })?;
+    // Keep the instance preview sparse. Untracked ranges represent the
+    // unmodified parent input and are materialized only for the destination
+    // touched by this dynamic connection.
+    let range_store = parent_store
+        .entry(dst.id)
+        .or_insert_with(|| RangeStore::new(None, variable_width));
     let parts = range_store.get_parts_ref(full_access).map_err(|error| {
         ParserError::illegal_context(
             "dynamic output port destination",
@@ -485,9 +484,7 @@ fn build_dynamic_output_glue(
             access: prefix,
         })?
     };
-    parent_store
-        .get_mut(&dst.id)
-        .expect("destination store entry checked above")
+    range_store
         .update(prefix, Some((preview_result, preview_sources)))
         .map_err(|error| {
             ParserError::illegal_context(
@@ -1115,24 +1112,9 @@ impl<'a> ModuleParser<'a> {
         let mut output_ports = Vec::new();
         let mut glue_arena = SLTNodeArena::<GlueAddr>::new();
 
-        // Parent context store
-        let mut parent_store = SymbolicStore::default();
-        for (id, var) in &self.module.variables {
-            let width = resolve_total_width(self.module, var)?;
-            if width == 0 {
-                parent_store.insert(*id, RangeStore::new(None, 0));
-                continue;
-            }
-            let initial_node = self.arena.alloc(SLTNode::Input {
-                variable: *id,
-                signed: var.r#type.signed,
-                index: vec![],
-                access: BitAccess::new(0, width - 1),
-            })?;
-            let mut sources = HashSet::default();
-            sources.insert(VarAtomBase::new(*id, 0, width - 1));
-            parent_store.insert(*id, RangeStore::new(Some((initial_node, sources)), width));
-        }
+        // Parent variables are implicit inputs until a connection expression
+        // writes them, so instance parsing only needs sparse, touched entries.
+        let parent_store = SymbolicStore::default();
 
         for input in &decl.inputs {
             let child_port_id = input.id;
@@ -1169,13 +1151,7 @@ impl<'a> ModuleParser<'a> {
                 let mut effects = CombEffectCollector::with_capture_namespace(
                     self.comb_runtime_event_sites.len() as u32,
                 );
-                let mut effect_store = SymbolicStore::default();
-                for (&id, variable) in &self.module.variables {
-                    effect_store.insert(
-                        id,
-                        RangeStore::new(None, resolve_total_width(self.module, variable)?),
-                    );
-                }
+                let effect_store = SymbolicStore::default();
                 collect_expression_effects(
                     self.module,
                     &effect_store,
@@ -1293,24 +1269,6 @@ impl<'a> ModuleParser<'a> {
             let mut current_offset = 0usize;
             let mut destination_arena = SLTNodeArena::<VarId>::new();
             let mut destination_store = SymbolicStore::default();
-            for (id, var) in &self.module.variables {
-                let parent_width = resolve_total_width(self.module, var)?;
-                if parent_width == 0 {
-                    destination_store.insert(*id, RangeStore::new(None, 0));
-                    continue;
-                }
-                let initial_node = destination_arena.alloc(SLTNode::Input {
-                    variable: *id,
-                    signed: var.r#type.signed,
-                    index: vec![],
-                    access: BitAccess::new(0, parent_width - 1),
-                })?;
-                let sources = std::iter::once(VarAtomBase::new(*id, 0, parent_width - 1)).collect();
-                destination_store.insert(
-                    *id,
-                    RangeStore::new(Some((initial_node, sources)), parent_width),
-                );
-            }
             let preview_rhs_node = destination_arena.alloc(SLTNode::Input {
                 variable: child_port_id,
                 signed: child_port.r#type.signed,
@@ -1325,12 +1283,6 @@ impl<'a> ModuleParser<'a> {
                 self.comb_runtime_event_sites.len() as u32,
             );
             let mut output_effect_store = SymbolicStore::default();
-            for (&id, variable) in &self.module.variables {
-                output_effect_store.insert(
-                    id,
-                    RangeStore::new(None, resolve_total_width(self.module, variable)?),
-                );
-            }
             // Iterate destinations from LSB (last in list for multi-dst assign usually? No wait)
             // `emit_multi_dst_assign` iterates `dsts.iter().rev()`.
             // So we strictly follow `emit_multi_dst_assign` logic.
@@ -1492,9 +1444,11 @@ impl<'a> ModuleParser<'a> {
                 })?;
                 let effect_sources =
                     std::iter::once(VarAtomBase::new(dst.id, access.lsb, access.msb)).collect();
+                let parent_width =
+                    resolve_total_width(self.module, &self.module.variables[&dst.id])?;
                 output_effect_store
-                    .get_mut(&dst.id)
-                    .expect("output effect store contains every parent variable")
+                    .entry(dst.id)
+                    .or_insert_with(|| RangeStore::new(None, parent_width))
                     .update(access, Some((effect_preview, effect_sources)))
                     .map_err(|error| {
                         ParserError::illegal_context(

--- a/crates/celox-frontend-veryl/src/types.rs
+++ b/crates/celox-frontend-veryl/src/types.rs
@@ -20,16 +20,27 @@ pub fn resolve_dims(
     shape: &[Option<usize>],
     kind: &str,
 ) -> Result<Vec<usize>, ParserError> {
-    shape
-        .iter()
-        .map(|dimension| {
-            dimension.ok_or_else(|| {
-                ParserError::unresolved_width(
-                    module,
-                    variable,
-                    format!("{kind} dimension in {}", variable.r#type),
-                )
-            })
-        })
-        .collect()
+    let mut dimensions = Vec::with_capacity(shape.len());
+    extend_resolved_dims(module, variable, shape, kind, &mut dimensions)?;
+    Ok(dimensions)
+}
+
+pub(crate) fn extend_resolved_dims(
+    module: &Module,
+    variable: &Variable,
+    shape: &[Option<usize>],
+    kind: &str,
+    dimensions: &mut Vec<usize>,
+) -> Result<(), ParserError> {
+    dimensions.reserve(shape.len());
+    for dimension in shape {
+        dimensions.push(dimension.ok_or_else(|| {
+            ParserError::unresolved_width(
+                module,
+                variable,
+                format!("{kind} dimension in {}", variable.r#type),
+            )
+        })?);
+    }
+    Ok(())
 }

--- a/crates/celox-slt/src/lower.rs
+++ b/crates/celox-slt/src/lower.rs
@@ -1123,6 +1123,8 @@ struct LoweringCostCache {
     owned_slice_lower_costs: Vec<Option<u128>>,
     contains_shared_nontrivial: Vec<Option<bool>>,
     is_speculatable_pure: Vec<Option<bool>>,
+    traversal_seen: Vec<bool>,
+    traversal_work: Vec<NodeId>,
     #[cfg(test)]
     analysis_node_visits: usize,
 }
@@ -3847,35 +3849,50 @@ impl SLTToSIRLowerer {
         honor_materialized: bool,
     ) {
         let node_count = arena.len();
-        let mut fanout = vec![0usize; node_count];
-        let mut initially_materialized = vec![false; node_count];
-        let mut visited = crate::HashSet::default();
-        let mut work = roots.to_vec();
-        while let Some(node) = work.pop() {
-            if !visited.insert(node) {
+        let mut cache = self.cost_cache.borrow_mut();
+        cache.tree_costs.clear();
+        cache.tree_costs.resize(node_count, None);
+        cache.contains_div_rem.clear();
+        cache.contains_div_rem.resize(node_count, None);
+        cache.fanout.clear();
+        cache.fanout.resize(node_count, 0);
+        cache.initially_materialized.clear();
+        cache.initially_materialized.resize(node_count, false);
+        cache.owned_costs.clear();
+        cache.owned_costs.resize(node_count, None);
+        cache.owned_slice_lower_costs.clear();
+        cache.owned_slice_lower_costs.resize(node_count, None);
+        cache.contains_shared_nontrivial.clear();
+        cache.contains_shared_nontrivial.resize(node_count, None);
+        cache.is_speculatable_pure.clear();
+        cache.is_speculatable_pure.resize(node_count, None);
+        cache.traversal_seen.clear();
+        cache.traversal_seen.resize(node_count, false);
+        cache.traversal_work.clear();
+        cache.traversal_work.extend_from_slice(roots);
+        #[cfg(test)]
+        {
+            cache.analysis_node_visits = 0;
+        }
+
+        while let Some(node) = cache.traversal_work.pop() {
+            if cache.traversal_seen[node.0] {
                 continue;
             }
+            cache.traversal_seen[node.0] = true;
+            #[cfg(test)]
+            {
+                cache.analysis_node_visits += 1;
+            }
             if honor_materialized && materialized.contains_key(&node) {
-                initially_materialized[node.0] = true;
+                cache.initially_materialized[node.0] = true;
                 continue;
             }
             for child in Self::node_children(node, arena) {
-                fanout[child.0] = fanout[child.0].saturating_add(1);
-                work.push(child);
+                cache.fanout[child.0] = cache.fanout[child.0].saturating_add(1);
+                cache.traversal_work.push(child);
             }
         }
-        *self.cost_cache.borrow_mut() = LoweringCostCache {
-            tree_costs: vec![None; node_count],
-            contains_div_rem: vec![None; node_count],
-            fanout,
-            initially_materialized,
-            owned_costs: vec![None; node_count],
-            owned_slice_lower_costs: vec![None; node_count],
-            contains_shared_nontrivial: vec![None; node_count],
-            is_speculatable_pure: vec![None; node_count],
-            #[cfg(test)]
-            analysis_node_visits: visited.len(),
-        };
         self.cache_insert_log.borrow_mut().clear();
     }
 

--- a/crates/celox-slt/src/range_store.rs
+++ b/crates/celox-slt/src/range_store.rs
@@ -245,14 +245,9 @@ impl<T: Clone + PartialEq + Eq> RangeStore<T> {
         self.split_at(access.lsb)?;
         self.split_at(end)?;
 
-        let keys_to_remove: Vec<usize> = self
-            .ranges
-            .range(access.lsb..=access.msb)
-            .map(|(&k, _)| k)
-            .collect();
-        for k in keys_to_remove {
-            self.ranges.remove(&k);
-        }
+        self.ranges
+            .extract_if(access.lsb..=access.msb, |_, _| true)
+            .for_each(drop);
 
         // When inserting a new range, record access.lsb as the origin
         self.ranges.insert(access.lsb, (value, width, access.lsb));
@@ -356,6 +351,26 @@ mod tests {
                 (60, BitAccess::new(0, 0)),
                 (61, BitAccess::new(0, 0)),
                 (62, BitAccess::new(0, 0)),
+            ]
+        );
+    }
+
+    #[test]
+    fn wide_update_replaces_all_covered_sparse_ranges() {
+        let mut store = RangeStore::new(0u8, 64);
+        for bit in 0..64 {
+            store.update(BitAccess::new(bit, bit), bit as u8).unwrap();
+        }
+
+        store.update(BitAccess::new(16, 47), 99).unwrap();
+
+        assert_eq!(store.ranges.len(), 33);
+        assert_eq!(
+            store.get_parts(BitAccess::new(15, 48)).unwrap(),
+            vec![
+                (15, BitAccess::new(0, 0)),
+                (99, BitAccess::new(0, 31)),
+                (48, BitAccess::new(0, 0)),
             ]
         );
     }

--- a/crates/celox-slt/src/range_store.rs
+++ b/crates/celox-slt/src/range_store.rs
@@ -32,18 +32,9 @@ pub struct RangeStore<T> {
     pub ranges: BTreeMap<usize, (T, usize, usize)>,
 }
 
-impl<T: Clone + PartialEq + Eq> RangeStore<T> {
-    pub fn new(initial: T, width: usize) -> Self {
-        let mut ranges = BTreeMap::new();
-        if width > 0 {
-            // In initial state, absolute position 0 and origin 0 match
-            ranges.insert(0, (initial, width, 0));
-        }
-        Self { ranges }
-    }
+pub type AlignedRangePart<'a, T, U> = (BitAccess, (&'a T, BitAccess), (&'a U, BitAccess));
 
-    /// Split the range at the specified bit position.
-    /// Even if split, origin_lsb (the 3rd element) is maintained.
+impl<T> RangeStore<T> {
     fn total_width(&self) -> Result<usize, RangeStoreError> {
         let Some((&last_lsb, (_, last_width, _))) = self.ranges.last_key_value() else {
             return Ok(0);
@@ -56,6 +47,132 @@ impl<T: Clone + PartialEq + Eq> RangeStore<T> {
         last_lsb
             .checked_add(*last_width)
             .ok_or_else(|| RangeStoreError::new("range store total width overflows usize"))
+    }
+
+    /// Align two sparse partitions in one ordered pass.
+    ///
+    /// Each returned absolute range is bounded by the next boundary from
+    /// either store. The accompanying accesses are relative to each value's
+    /// original placement, so callers can slice the values without searching
+    /// either map again.
+    pub fn aligned_parts<'a, U>(
+        &'a self,
+        other: &'a RangeStore<U>,
+    ) -> Result<Vec<AlignedRangePart<'a, T, U>>, RangeStoreError> {
+        let total_width = self.total_width()?;
+        let other_width = other.total_width()?;
+        if total_width != other_width {
+            return Err(RangeStoreError::new(format!(
+                "range store widths differ: {total_width} and {other_width}"
+            )));
+        }
+        if total_width == 0 {
+            return Ok(Vec::new());
+        }
+
+        let mut left_ranges = self.ranges.iter().peekable();
+        let mut right_ranges = other.ranges.iter().peekable();
+        let mut left = left_ranges
+            .next()
+            .ok_or_else(|| RangeStoreError::new("left range store is empty"))?;
+        let mut right = right_ranges
+            .next()
+            .ok_or_else(|| RangeStoreError::new("right range store is empty"))?;
+        if *left.0 != 0 || *right.0 != 0 {
+            return Err(RangeStoreError::new(
+                "range store does not begin at bit zero",
+            ));
+        }
+
+        let mut parts = Vec::with_capacity(self.ranges.len() + other.ranges.len());
+        let mut lsb = 0;
+        while lsb < total_width {
+            let left_boundary = left_ranges
+                .peek()
+                .map(|(next_lsb, _)| **next_lsb)
+                .unwrap_or(total_width);
+            let right_boundary = right_ranges
+                .peek()
+                .map(|(next_lsb, _)| **next_lsb)
+                .unwrap_or(total_width);
+            validate_range_boundary(left, left_boundary, total_width)?;
+            validate_range_boundary(right, right_boundary, total_width)?;
+
+            let next_lsb = left_boundary.min(right_boundary);
+            if next_lsb <= lsb {
+                return Err(RangeStoreError::new(
+                    "range store boundaries are not strictly ordered",
+                ));
+            }
+            let msb = next_lsb - 1;
+            let left_access = relative_access(left.1.2, lsb, msb)?;
+            let right_access = relative_access(right.1.2, lsb, msb)?;
+            parts.push((
+                BitAccess::new(lsb, msb),
+                (&left.1.0, left_access),
+                (&right.1.0, right_access),
+            ));
+
+            lsb = next_lsb;
+            if left_boundary == lsb && lsb < total_width {
+                left = left_ranges
+                    .next()
+                    .expect("a peeked left range boundary exists");
+            }
+            if right_boundary == lsb && lsb < total_width {
+                right = right_ranges
+                    .next()
+                    .expect("a peeked right range boundary exists");
+            }
+        }
+        Ok(parts)
+    }
+}
+
+fn validate_range_boundary<T>(
+    current: (&usize, &(T, usize, usize)),
+    next_lsb: usize,
+    total_width: usize,
+) -> Result<(), RangeStoreError> {
+    let (lsb, (_, width, _)) = current;
+    if *width == 0 {
+        return Err(RangeStoreError::new(format!(
+            "range at bit {lsb} has zero width"
+        )));
+    }
+    let end = lsb
+        .checked_add(*width)
+        .ok_or_else(|| RangeStoreError::new("range end overflows usize"))?;
+    if end != next_lsb || end > total_width {
+        return Err(RangeStoreError::new(format!(
+            "range at bit {lsb} does not end at the next boundary {next_lsb}"
+        )));
+    }
+    Ok(())
+}
+
+fn relative_access(
+    origin: usize,
+    absolute_lsb: usize,
+    absolute_msb: usize,
+) -> Result<BitAccess, RangeStoreError> {
+    let lsb = absolute_lsb
+        .checked_sub(origin)
+        .ok_or_else(|| RangeStoreError::new("range origin is above its aligned LSB"))?;
+    let msb = absolute_msb
+        .checked_sub(origin)
+        .ok_or_else(|| RangeStoreError::new("range origin is above its aligned MSB"))?;
+    Ok(BitAccess::new(lsb, msb))
+}
+
+impl<T: Clone + PartialEq + Eq> RangeStore<T> {
+    pub fn new(initial: T, width: usize) -> Self {
+        let mut ranges = BTreeMap::new();
+        if width > 0 {
+            // In initial state, absolute position 0 and origin 0 match
+            ranges.insert(0, (initial, width, 0));
+        }
+        Self { ranges }
     }
 
     fn validate_access(&self, access: BitAccess) -> Result<usize, RangeStoreError> {
@@ -79,6 +196,8 @@ impl<T: Clone + PartialEq + Eq> RangeStore<T> {
         Ok(width)
     }
 
+    /// Split the range at the specified bit position.
+    /// Even if split, origin_lsb (the 3rd element) is maintained.
     pub fn split_at(&mut self, bit: usize) -> Result<(), RangeStoreError> {
         if bit == 0 {
             return Ok(());
@@ -226,5 +345,55 @@ mod tests {
                 (62, BitAccess::new(0, 0)),
             ]
         );
+    }
+
+    #[test]
+    fn aligns_two_sparse_partitions_in_boundary_order() {
+        let mut left = RangeStore::new(0u8, 8);
+        left.update(BitAccess::new(2, 5), 1).unwrap();
+        let mut right = RangeStore::new(0u8, 8);
+        right.update(BitAccess::new(4, 7), 2).unwrap();
+
+        let parts = left
+            .aligned_parts(&right)
+            .unwrap()
+            .into_iter()
+            .map(|(absolute, (left, left_access), (right, right_access))| {
+                (absolute, (*left, left_access), (*right, right_access))
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            parts,
+            vec![
+                (
+                    BitAccess::new(0, 1),
+                    (0, BitAccess::new(0, 1)),
+                    (0, BitAccess::new(0, 1)),
+                ),
+                (
+                    BitAccess::new(2, 3),
+                    (1, BitAccess::new(0, 1)),
+                    (0, BitAccess::new(2, 3)),
+                ),
+                (
+                    BitAccess::new(4, 5),
+                    (1, BitAccess::new(2, 3)),
+                    (2, BitAccess::new(0, 1)),
+                ),
+                (
+                    BitAccess::new(6, 7),
+                    (0, BitAccess::new(6, 7)),
+                    (2, BitAccess::new(2, 3)),
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn aligning_partitions_rejects_different_widths() {
+        let left = RangeStore::new(0u8, 8);
+        let right = RangeStore::new(0u8, 9);
+
+        assert!(left.aligned_parts(&right).is_err());
     }
 }

--- a/crates/celox-slt/src/range_store.rs
+++ b/crates/celox-slt/src/range_store.rs
@@ -259,9 +259,12 @@ impl<T: Clone + PartialEq + Eq> RangeStore<T> {
         Ok(())
     }
 
-    /// Returns parts overlapping with the requested range.
+    /// Returns borrowed parts overlapping with the requested range.
     /// relative_access will be the relative position from the origin of that expression.
-    pub fn get_parts(&self, access: BitAccess) -> Result<Vec<(T, BitAccess)>, RangeStoreError> {
+    pub fn get_parts_ref(
+        &self,
+        access: BitAccess,
+    ) -> Result<Vec<(&T, BitAccess)>, RangeStoreError> {
         self.validate_access(access)?;
         let mut parts = Vec::new();
         let first_lsb = self
@@ -293,10 +296,20 @@ impl<T: Clone + PartialEq + Eq> RangeStore<T> {
                     RangeStoreError::new("range origin is above its overlapping MSB")
                 })?;
                 let relative_access = BitAccess::new(relative_lsb, relative_msb);
-                parts.push((expr.clone(), relative_access));
+                parts.push((expr, relative_access));
             }
         }
         Ok(parts)
+    }
+
+    /// Returns owned parts overlapping with the requested range.
+    pub fn get_parts(&self, access: BitAccess) -> Result<Vec<(T, BitAccess)>, RangeStoreError> {
+        self.get_parts_ref(access).map(|parts| {
+            parts
+                .into_iter()
+                .map(|(value, access)| (value.clone(), access))
+                .collect()
+        })
     }
 }
 

--- a/crates/celox-slt/src/symbolic_store.rs
+++ b/crates/celox-slt/src/symbolic_store.rs
@@ -12,8 +12,9 @@ type RangeEntry<A, N> = Arc<SymbolicRange<A, N>>;
 type StoreShard<A, N> = HashMap<A, RangeEntry<A, N>>;
 
 // A fixed page table keeps branch snapshots cheap without adding a persistent
-// collection dependency. Cloning a store shares every page; the first write to
-// one key copies only that key's page and then the touched RangeStore.
+// collection dependency. Empty pages allocate nothing. Forking shares every
+// populated page; the first write to one key copies only that key's page and
+// then the touched RangeStore.
 const STORE_SHARDS: usize = 64;
 
 fn shard_index(key: &(impl Hash + ?Sized)) -> usize {
@@ -30,14 +31,14 @@ fn shard_index(key: &(impl Hash + ?Sized)) -> usize {
 /// expected by the frontend.
 #[derive(Clone, Debug)]
 pub struct SymbolicStore<A, N> {
-    entries: [Arc<StoreShard<A, N>>; STORE_SHARDS],
+    entries: [Option<Arc<StoreShard<A, N>>>; STORE_SHARDS],
     len: usize,
 }
 
 impl<A, N> Default for SymbolicStore<A, N> {
     fn default() -> Self {
         Self {
-            entries: std::array::from_fn(|_| Arc::new(HashMap::default())),
+            entries: std::array::from_fn(|_| None),
             len: 0,
         }
     }
@@ -51,7 +52,7 @@ impl<A, N> SymbolicStore<A, N> {
     /// writes their page.
     pub fn fork(&self) -> Self {
         Self {
-            entries: std::array::from_fn(|index| Arc::clone(&self.entries[index])),
+            entries: std::array::from_fn(|index| self.entries[index].as_ref().map(Arc::clone)),
             len: self.len,
         }
     }
@@ -59,7 +60,7 @@ impl<A, N> SymbolicStore<A, N> {
 
 impl<A: Eq + Hash, N> SymbolicStore<A, N> {
     fn entry_arc(&self, key: &A) -> Option<&RangeEntry<A, N>> {
-        self.entries[shard_index(key)].get(key)
+        self.entries[shard_index(key)].as_deref()?.get(key)
     }
 
     pub fn len(&self) -> usize {
@@ -77,7 +78,8 @@ impl<A: Eq + Hash, N> SymbolicStore<A, N> {
     {
         let per_shard = additional.div_ceil(STORE_SHARDS);
         for shard in &mut self.entries {
-            Arc::make_mut(shard).reserve(per_shard);
+            Arc::make_mut(shard.get_or_insert_with(|| Arc::new(HashMap::default())))
+                .reserve(per_shard);
         }
     }
 
@@ -94,7 +96,9 @@ impl<A: Eq + Hash, N> SymbolicStore<A, N> {
         A: Clone,
         N: Clone,
     {
-        let shard = Arc::make_mut(&mut self.entries[shard_index(&key)]);
+        let shard = Arc::make_mut(
+            self.entries[shard_index(&key)].get_or_insert_with(|| Arc::new(HashMap::default())),
+        );
         let previous = shard.insert(key, Arc::new(value));
         if previous.is_none() {
             self.len += 1;
@@ -107,9 +111,17 @@ impl<A: Eq + Hash, N> SymbolicStore<A, N> {
         A: Clone,
         N: Clone,
     {
-        let removed = Arc::make_mut(&mut self.entries[shard_index(key)]).remove(key);
+        let index = shard_index(key);
+        let shard = self.entries[index].as_mut()?;
+        if !shard.contains_key(key) {
+            return None;
+        }
+        let removed = Arc::make_mut(shard).remove(key);
         if removed.is_some() {
             self.len -= 1;
+        }
+        if shard.is_empty() {
+            self.entries[index] = None;
         }
         removed
     }
@@ -182,8 +194,8 @@ impl<A: Eq + Hash, N> SymbolicStore<A, N> {
 }
 
 struct DifferingKeys<'a, A, N> {
-    left_shards: &'a [Arc<StoreShard<A, N>>; STORE_SHARDS],
-    right_shards: &'a [Arc<StoreShard<A, N>>; STORE_SHARDS],
+    left_shards: &'a [Option<Arc<StoreShard<A, N>>>; STORE_SHARDS],
+    right_shards: &'a [Option<Arc<StoreShard<A, N>>>; STORE_SHARDS],
     next_shard: usize,
     left_shard: Option<&'a StoreShard<A, N>>,
     right_shard: Option<&'a StoreShard<A, N>>,
@@ -199,8 +211,7 @@ impl<'a, A: Eq + Hash, N> Iterator for DifferingKeys<'a, A, N> {
             while let Some((key, left)) = self.left_entries.as_mut().and_then(Iterator::next) {
                 if self
                     .right_shard
-                    .expect("a diff iterator has a right shard")
-                    .get(key)
+                    .and_then(|right| right.get(key))
                     .is_none_or(|right| !Arc::ptr_eq(left, right))
                 {
                     return Some(key);
@@ -208,11 +219,7 @@ impl<'a, A: Eq + Hash, N> Iterator for DifferingKeys<'a, A, N> {
             }
 
             while let Some(key) = self.right_keys.as_mut().and_then(Iterator::next) {
-                if !self
-                    .left_shard
-                    .expect("a diff iterator has a left shard")
-                    .contains_key(key)
-                {
+                if self.left_shard.is_none_or(|left| !left.contains_key(key)) {
                     return Some(key);
                 }
             }
@@ -220,14 +227,18 @@ impl<'a, A: Eq + Hash, N> Iterator for DifferingKeys<'a, A, N> {
             let left = self.left_shards.get(self.next_shard)?;
             let right = &self.right_shards[self.next_shard];
             self.next_shard += 1;
-            if Arc::ptr_eq(left, right) {
+            if match (left, right) {
+                (None, None) => true,
+                (Some(left), Some(right)) => Arc::ptr_eq(left, right),
+                _ => false,
+            } {
                 continue;
             }
 
-            self.left_shard = Some(left);
-            self.right_shard = Some(right);
-            self.left_entries = Some(left.iter());
-            self.right_keys = Some(right.keys());
+            self.left_shard = left.as_deref();
+            self.right_shard = right.as_deref();
+            self.left_entries = left.as_deref().map(StoreShard::iter);
+            self.right_keys = right.as_deref().map(StoreShard::keys);
         }
     }
 }
@@ -237,7 +248,9 @@ impl<A: Clone + Eq + Hash, N: Clone> SymbolicStore<A, N> {
         let Some(value) = source.entry_arc(key) else {
             return false;
         };
-        let shard = Arc::make_mut(&mut self.entries[shard_index(key)]);
+        let shard = Arc::make_mut(
+            self.entries[shard_index(key)].get_or_insert_with(|| Arc::new(HashMap::default())),
+        );
         if shard.insert(key.clone(), Arc::clone(value)).is_none() {
             self.len += 1;
         }
@@ -247,15 +260,20 @@ impl<A: Clone + Eq + Hash, N: Clone> SymbolicStore<A, N> {
     pub fn entry(&mut self, key: A) -> Entry<'_, A, N> {
         let shard_index = shard_index(&key);
         Entry {
-            inner: Arc::make_mut(&mut self.entries[shard_index]).entry(key),
+            inner: Arc::make_mut(
+                self.entries[shard_index].get_or_insert_with(|| Arc::new(HashMap::default())),
+            )
+            .entry(key),
             len: &mut self.len,
         }
     }
 
     pub fn get_mut(&mut self, key: &A) -> Option<&mut SymbolicRange<A, N>> {
-        Arc::make_mut(&mut self.entries[shard_index(key)])
-            .get_mut(key)
-            .map(Arc::make_mut)
+        let shard = self.entries[shard_index(key)].as_mut()?;
+        if !shard.contains_key(key) {
+            return None;
+        }
+        Arc::make_mut(shard).get_mut(key).map(Arc::make_mut)
     }
 
     pub fn values_mut(&mut self) -> ValuesMut<'_, A, N> {
@@ -297,7 +315,7 @@ impl<A: Eq + Hash, N> Index<&A> for SymbolicStore<A, N> {
 }
 
 pub struct Iter<'a, A, N> {
-    shards: std::slice::Iter<'a, Arc<StoreShard<A, N>>>,
+    shards: std::slice::Iter<'a, Option<Arc<StoreShard<A, N>>>>,
     current: Option<std::collections::hash_map::Iter<'a, A, RangeEntry<A, N>>>,
     remaining: usize,
 }
@@ -311,7 +329,10 @@ impl<'a, A, N> Iterator for Iter<'a, A, N> {
                 self.remaining -= 1;
                 return Some((key, value.as_ref()));
             }
-            self.current = Some(self.shards.next()?.iter());
+            let Some(shard) = self.shards.next()?.as_deref() else {
+                continue;
+            };
+            self.current = Some(shard.iter());
         }
     }
 
@@ -323,7 +344,7 @@ impl<'a, A, N> Iterator for Iter<'a, A, N> {
 impl<A, N> ExactSizeIterator for Iter<'_, A, N> {}
 
 pub struct Values<'a, A, N> {
-    shards: std::slice::Iter<'a, Arc<StoreShard<A, N>>>,
+    shards: std::slice::Iter<'a, Option<Arc<StoreShard<A, N>>>>,
     current: Option<std::collections::hash_map::Values<'a, A, RangeEntry<A, N>>>,
     remaining: usize,
 }
@@ -337,7 +358,10 @@ impl<'a, A, N> Iterator for Values<'a, A, N> {
                 self.remaining -= 1;
                 return Some(value.as_ref());
             }
-            self.current = Some(self.shards.next()?.values());
+            let Some(shard) = self.shards.next()?.as_deref() else {
+                continue;
+            };
+            self.current = Some(shard.values());
         }
     }
 
@@ -349,7 +373,7 @@ impl<'a, A, N> Iterator for Values<'a, A, N> {
 impl<A, N> ExactSizeIterator for Values<'_, A, N> {}
 
 pub struct Keys<'a, A, N> {
-    shards: std::slice::Iter<'a, Arc<StoreShard<A, N>>>,
+    shards: std::slice::Iter<'a, Option<Arc<StoreShard<A, N>>>>,
     current: Option<std::collections::hash_map::Keys<'a, A, RangeEntry<A, N>>>,
     remaining: usize,
 }
@@ -363,7 +387,10 @@ impl<'a, A, N> Iterator for Keys<'a, A, N> {
                 self.remaining -= 1;
                 return Some(key);
             }
-            self.current = Some(self.shards.next()?.keys());
+            let Some(shard) = self.shards.next()?.as_deref() else {
+                continue;
+            };
+            self.current = Some(shard.keys());
         }
     }
 
@@ -375,7 +402,7 @@ impl<'a, A, N> Iterator for Keys<'a, A, N> {
 impl<A, N> ExactSizeIterator for Keys<'_, A, N> {}
 
 pub struct ValuesMut<'a, A: Clone, N: Clone> {
-    shards: std::slice::IterMut<'a, Arc<StoreShard<A, N>>>,
+    shards: std::slice::IterMut<'a, Option<Arc<StoreShard<A, N>>>>,
     current: Option<std::collections::hash_map::ValuesMut<'a, A, RangeEntry<A, N>>>,
     remaining: usize,
 }
@@ -389,7 +416,10 @@ impl<'a, A: Clone, N: Clone> Iterator for ValuesMut<'a, A, N> {
                 self.remaining -= 1;
                 return Some(Arc::make_mut(value));
             }
-            self.current = Some(Arc::make_mut(self.shards.next()?).values_mut());
+            let Some(shard) = self.shards.next()?.as_mut() else {
+                continue;
+            };
+            self.current = Some(Arc::make_mut(shard).values_mut());
         }
     }
 
@@ -434,6 +464,9 @@ impl<A: Clone + Eq + Hash, N: Clone> IntoIterator for SymbolicStore<A, N> {
     fn into_iter(self) -> Self::IntoIter {
         let mut values = Vec::with_capacity(self.len);
         for shard in self.entries {
+            let Some(shard) = shard else {
+                continue;
+            };
             let shard = Arc::try_unwrap(shard).unwrap_or_else(|shared| shared.as_ref().clone());
             values.extend(shard.into_iter().map(|(key, value)| {
                 let value = Arc::try_unwrap(value).unwrap_or_else(|shared| shared.as_ref().clone());
@@ -461,6 +494,29 @@ mod tests {
     use celox_design::BitAccess;
 
     use super::*;
+
+    #[test]
+    fn empty_store_allocates_no_shard_pages() {
+        let mut store = SymbolicStore::<u32, u32>::default();
+        assert!(store.entries.iter().all(Option::is_none));
+        assert!(store.get_mut(&7).is_none());
+        assert!(store.entries.iter().all(Option::is_none));
+
+        let branch = store.fork();
+        assert!(branch.entries.iter().all(Option::is_none));
+    }
+
+    #[test]
+    fn removing_a_last_entry_releases_its_shard_page() {
+        let mut store = SymbolicStore::<u32, u32>::default();
+        store.insert(7, RangeStore::new(None, 8));
+        let index = shard_index(&7);
+        assert!(store.entries[index].is_some());
+
+        assert!(store.remove(&7).is_some());
+        assert!(store.entries[index].is_none());
+        assert!(store.is_empty());
+    }
 
     #[test]
     fn cloned_store_copies_a_range_only_when_it_is_mutated() {
@@ -503,7 +559,11 @@ mod tests {
             .entries
             .iter()
             .zip(&branch.entries)
-            .filter(|(left, right)| Arc::ptr_eq(left, right))
+            .filter(|(left, right)| {
+                left.as_ref()
+                    .zip(right.as_ref())
+                    .is_some_and(|(left, right)| Arc::ptr_eq(left, right))
+            })
             .count();
         assert_eq!(shared_pages, STORE_SHARDS - 1);
         assert!(original.shares_entry_with(&branch, &7));

--- a/crates/celox-slt/src/symbolic_store.rs
+++ b/crates/celox-slt/src/symbolic_store.rs
@@ -1,122 +1,237 @@
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::ops::Index;
 use std::sync::Arc;
 
 use celox_design::VarAtomBase;
-use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
 
 use crate::RangeStore;
 
 type SymbolicRange<A, N> = RangeStore<Option<(N, HashSet<VarAtomBase<A>>)>>;
+type RangeEntry<A, N> = Arc<SymbolicRange<A, N>>;
+type StoreShard<A, N> = HashMap<A, RangeEntry<A, N>>;
 
-/// Symbolic state whose range maps are shared until one branch mutates them.
+// A fixed page table keeps branch snapshots cheap without adding a persistent
+// collection dependency. Cloning a store shares every page; the first write to
+// one key copies only that key's page and then the touched RangeStore.
+const STORE_SHARDS: usize = 64;
+
+fn shard_index(key: &(impl Hash + ?Sized)) -> usize {
+    let mut hasher = FxHasher::default();
+    key.hash(&mut hasher);
+    (hasher.finish() as usize) & (STORE_SHARDS - 1)
+}
+
+/// Statement-ordered symbolic state used while constructing SLT values.
 ///
-/// Branch evaluation frequently clones the complete store while changing only
-/// a handful of variables. Keeping the outer map independent preserves normal
-/// map value semantics; sharing each range map avoids deep-cloning untouched
-/// B-trees at every branch.
+/// Each clone is a cheap branch version: the fixed-size page table and every
+/// range remain shared until a definition mutates them. This gives conditional
+/// evaluation SSA-like snapshot semantics while preserving the map-shaped API
+/// expected by the frontend.
 #[derive(Clone, Debug)]
 pub struct SymbolicStore<A, N> {
-    entries: HashMap<A, Arc<SymbolicRange<A, N>>>,
+    entries: [Arc<StoreShard<A, N>>; STORE_SHARDS],
+    len: usize,
 }
 
 impl<A, N> Default for SymbolicStore<A, N> {
     fn default() -> Self {
         Self {
-            entries: HashMap::default(),
+            entries: std::array::from_fn(|_| Arc::new(HashMap::default())),
+            len: 0,
+        }
+    }
+}
+
+impl<A, N> SymbolicStore<A, N> {
+    /// Create an independent statement branch from the current symbolic version.
+    ///
+    /// The fixed page table makes this operation independent of the number of
+    /// variables in the module. Definitions remain shared until either branch
+    /// writes their page.
+    pub fn fork(&self) -> Self {
+        Self {
+            entries: std::array::from_fn(|index| Arc::clone(&self.entries[index])),
+            len: self.len,
         }
     }
 }
 
 impl<A: Eq + Hash, N> SymbolicStore<A, N> {
+    fn entry_arc(&self, key: &A) -> Option<&RangeEntry<A, N>> {
+        self.entries[shard_index(key)].get(key)
+    }
+
     pub fn len(&self) -> usize {
-        self.entries.len()
+        self.len
     }
 
     pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
+        self.len == 0
     }
 
-    pub fn reserve(&mut self, additional: usize) {
-        self.entries.reserve(additional);
+    pub fn reserve(&mut self, additional: usize)
+    where
+        A: Clone,
+        N: Clone,
+    {
+        let per_shard = additional.div_ceil(STORE_SHARDS);
+        for shard in &mut self.entries {
+            Arc::make_mut(shard).reserve(per_shard);
+        }
     }
 
     pub fn contains_key(&self, key: &A) -> bool {
-        self.entries.contains_key(key)
+        self.entry_arc(key).is_some()
     }
 
     pub fn get(&self, key: &A) -> Option<&SymbolicRange<A, N>> {
-        self.entries.get(key).map(AsRef::as_ref)
+        self.entry_arc(key).map(AsRef::as_ref)
     }
 
-    pub fn insert(
-        &mut self,
-        key: A,
-        value: SymbolicRange<A, N>,
-    ) -> Option<Arc<SymbolicRange<A, N>>> {
-        self.entries.insert(key, Arc::new(value))
+    pub fn insert(&mut self, key: A, value: SymbolicRange<A, N>) -> Option<RangeEntry<A, N>>
+    where
+        A: Clone,
+        N: Clone,
+    {
+        let shard = Arc::make_mut(&mut self.entries[shard_index(&key)]);
+        let previous = shard.insert(key, Arc::new(value));
+        if previous.is_none() {
+            self.len += 1;
+        }
+        previous
     }
 
-    pub fn remove(&mut self, key: &A) -> Option<Arc<SymbolicRange<A, N>>> {
-        self.entries.remove(key)
+    pub fn remove(&mut self, key: &A) -> Option<RangeEntry<A, N>>
+    where
+        A: Clone,
+        N: Clone,
+    {
+        let removed = Arc::make_mut(&mut self.entries[shard_index(key)]).remove(key);
+        if removed.is_some() {
+            self.len -= 1;
+        }
+        removed
     }
 
     pub fn iter(&self) -> Iter<'_, A, N> {
         Iter {
-            inner: self.entries.iter(),
+            shards: self.entries.iter(),
+            current: None,
+            remaining: self.len,
         }
     }
 
     pub fn values(&self) -> Values<'_, A, N> {
         Values {
-            inner: self.entries.values(),
+            shards: self.entries.iter(),
+            current: None,
+            remaining: self.len,
         }
     }
 
-    pub fn keys(&self) -> impl ExactSizeIterator<Item = &A> {
-        self.entries.keys()
+    pub fn keys(&self) -> Keys<'_, A, N> {
+        Keys {
+            shards: self.entries.iter(),
+            current: None,
+            remaining: self.len,
+        }
     }
 
     pub fn extend<I>(&mut self, values: I)
     where
+        A: Clone,
+        N: Clone,
         I: IntoIterator<Item = (A, SymbolicRange<A, N>)>,
     {
-        self.entries.extend(
-            values
-                .into_iter()
-                .map(|(key, value)| (key, Arc::new(value))),
-        );
+        for (key, value) in values {
+            self.insert(key, value);
+        }
+    }
+
+    /// Whether two branch versions still refer to the same definition for a key.
+    ///
+    /// A shared entry can bypass a deep RangeStore comparison during phi
+    /// construction, which is the common case for untouched variables.
+    pub fn shares_entry_with(&self, other: &Self, key: &A) -> bool {
+        match (self.entry_arc(key), other.entry_arc(key)) {
+            (Some(left), Some(right)) => Arc::ptr_eq(left, right),
+            (None, None) => true,
+            _ => false,
+        }
+    }
+
+    /// Keys whose symbolic definitions differ between two branch versions.
+    ///
+    /// Entire shared pages are skipped without visiting their keys. Within a
+    /// copied page, entries that still share the same range version are also
+    /// skipped. The returned sparse set is therefore the only set that can
+    /// require phi construction.
+    pub fn differing_keys(&self, other: &Self) -> Vec<A>
+    where
+        A: Clone,
+    {
+        let mut differing = Vec::new();
+        for (left_shard, right_shard) in self.entries.iter().zip(&other.entries) {
+            if Arc::ptr_eq(left_shard, right_shard) {
+                continue;
+            }
+            for (key, left) in left_shard.iter() {
+                if right_shard
+                    .get(key)
+                    .is_none_or(|right| !Arc::ptr_eq(left, right))
+                {
+                    differing.push(key.clone());
+                }
+            }
+            for key in right_shard.keys() {
+                if !left_shard.contains_key(key) {
+                    differing.push(key.clone());
+                }
+            }
+        }
+        differing
     }
 }
 
 impl<A: Clone + Eq + Hash, N: Clone> SymbolicStore<A, N> {
     pub fn clone_entry_from(&mut self, key: &A, source: &Self) -> bool {
-        let Some(value) = source.entries.get(key) else {
+        let Some(value) = source.entry_arc(key) else {
             return false;
         };
-        self.entries.insert(key.clone(), Arc::clone(value));
+        let shard = Arc::make_mut(&mut self.entries[shard_index(key)]);
+        if shard.insert(key.clone(), Arc::clone(value)).is_none() {
+            self.len += 1;
+        }
         true
     }
 
     pub fn entry(&mut self, key: A) -> Entry<'_, A, N> {
+        let shard_index = shard_index(&key);
         Entry {
-            inner: self.entries.entry(key),
+            inner: Arc::make_mut(&mut self.entries[shard_index]).entry(key),
+            len: &mut self.len,
         }
     }
 
     pub fn get_mut(&mut self, key: &A) -> Option<&mut SymbolicRange<A, N>> {
-        self.entries.get_mut(key).map(Arc::make_mut)
+        Arc::make_mut(&mut self.entries[shard_index(key)])
+            .get_mut(key)
+            .map(Arc::make_mut)
     }
 
     pub fn values_mut(&mut self) -> ValuesMut<'_, A, N> {
         ValuesMut {
-            inner: self.entries.values_mut(),
+            shards: self.entries.iter_mut(),
+            current: None,
+            remaining: self.len,
         }
     }
 }
 
 pub struct Entry<'a, A, N> {
-    inner: std::collections::hash_map::Entry<'a, A, Arc<SymbolicRange<A, N>>>,
+    inner: std::collections::hash_map::Entry<'a, A, RangeEntry<A, N>>,
+    len: &'a mut usize,
 }
 
 impl<'a, A: Clone, N: Clone> Entry<'a, A, N> {
@@ -126,7 +241,10 @@ impl<'a, A: Clone, N: Clone> Entry<'a, A, N> {
     ) -> &'a mut SymbolicRange<A, N> {
         let value = match self.inner {
             std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
-            std::collections::hash_map::Entry::Vacant(entry) => entry.insert(Arc::new(default())),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                *self.len += 1;
+                entry.insert(Arc::new(default()))
+            }
         };
         Arc::make_mut(value)
     }
@@ -136,76 +254,123 @@ impl<A: Eq + Hash, N> Index<&A> for SymbolicStore<A, N> {
     type Output = SymbolicRange<A, N>;
 
     fn index(&self, key: &A) -> &Self::Output {
-        self.entries.index(key)
+        self.get(key).expect("symbolic store key is absent")
     }
 }
 
 pub struct Iter<'a, A, N> {
-    inner: std::collections::hash_map::Iter<'a, A, Arc<SymbolicRange<A, N>>>,
+    shards: std::slice::Iter<'a, Arc<StoreShard<A, N>>>,
+    current: Option<std::collections::hash_map::Iter<'a, A, RangeEntry<A, N>>>,
+    remaining: usize,
 }
 
 impl<'a, A, N> Iterator for Iter<'a, A, N> {
     type Item = (&'a A, &'a SymbolicRange<A, N>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(|(key, value)| (key, value.as_ref()))
+        loop {
+            if let Some((key, value)) = self.current.as_mut().and_then(Iterator::next) {
+                self.remaining -= 1;
+                return Some((key, value.as_ref()));
+            }
+            self.current = Some(self.shards.next()?.iter());
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
+        (self.remaining, Some(self.remaining))
     }
 }
 
 impl<A, N> ExactSizeIterator for Iter<'_, A, N> {}
 
 pub struct Values<'a, A, N> {
-    inner: std::collections::hash_map::Values<'a, A, Arc<SymbolicRange<A, N>>>,
+    shards: std::slice::Iter<'a, Arc<StoreShard<A, N>>>,
+    current: Option<std::collections::hash_map::Values<'a, A, RangeEntry<A, N>>>,
+    remaining: usize,
 }
 
 impl<'a, A, N> Iterator for Values<'a, A, N> {
     type Item = &'a SymbolicRange<A, N>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(AsRef::as_ref)
+        loop {
+            if let Some(value) = self.current.as_mut().and_then(Iterator::next) {
+                self.remaining -= 1;
+                return Some(value.as_ref());
+            }
+            self.current = Some(self.shards.next()?.values());
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
+        (self.remaining, Some(self.remaining))
     }
 }
 
 impl<A, N> ExactSizeIterator for Values<'_, A, N> {}
 
+pub struct Keys<'a, A, N> {
+    shards: std::slice::Iter<'a, Arc<StoreShard<A, N>>>,
+    current: Option<std::collections::hash_map::Keys<'a, A, RangeEntry<A, N>>>,
+    remaining: usize,
+}
+
+impl<'a, A, N> Iterator for Keys<'a, A, N> {
+    type Item = &'a A;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(key) = self.current.as_mut().and_then(Iterator::next) {
+                self.remaining -= 1;
+                return Some(key);
+            }
+            self.current = Some(self.shards.next()?.keys());
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl<A, N> ExactSizeIterator for Keys<'_, A, N> {}
+
 pub struct ValuesMut<'a, A: Clone, N: Clone> {
-    inner: std::collections::hash_map::ValuesMut<'a, A, Arc<SymbolicRange<A, N>>>,
+    shards: std::slice::IterMut<'a, Arc<StoreShard<A, N>>>,
+    current: Option<std::collections::hash_map::ValuesMut<'a, A, RangeEntry<A, N>>>,
+    remaining: usize,
 }
 
 impl<'a, A: Clone, N: Clone> Iterator for ValuesMut<'a, A, N> {
     type Item = &'a mut SymbolicRange<A, N>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(Arc::make_mut)
+        loop {
+            if let Some(value) = self.current.as_mut().and_then(Iterator::next) {
+                self.remaining -= 1;
+                return Some(Arc::make_mut(value));
+            }
+            self.current = Some(Arc::make_mut(self.shards.next()?).values_mut());
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
+        (self.remaining, Some(self.remaining))
     }
 }
 
 impl<A: Clone, N: Clone> ExactSizeIterator for ValuesMut<'_, A, N> {}
 
 pub struct IntoIter<A, N> {
-    inner: std::collections::hash_map::IntoIter<A, Arc<SymbolicRange<A, N>>>,
+    inner: std::vec::IntoIter<(A, SymbolicRange<A, N>)>,
 }
 
-impl<A: Clone, N: Clone> Iterator for IntoIter<A, N> {
+impl<A, N> Iterator for IntoIter<A, N> {
     type Item = (A, SymbolicRange<A, N>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(|(key, value)| {
-            let value = Arc::try_unwrap(value).unwrap_or_else(|shared| shared.as_ref().clone());
-            (key, value)
-        })
+        self.inner.next()
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -213,7 +378,7 @@ impl<A: Clone, N: Clone> Iterator for IntoIter<A, N> {
     }
 }
 
-impl<A: Clone, N: Clone> ExactSizeIterator for IntoIter<A, N> {}
+impl<A, N> ExactSizeIterator for IntoIter<A, N> {}
 
 impl<'a, A: Eq + Hash, N> IntoIterator for &'a SymbolicStore<A, N> {
     type Item = (&'a A, &'a SymbolicRange<A, N>);
@@ -229,8 +394,16 @@ impl<A: Clone + Eq + Hash, N: Clone> IntoIterator for SymbolicStore<A, N> {
     type IntoIter = IntoIter<A, N>;
 
     fn into_iter(self) -> Self::IntoIter {
+        let mut values = Vec::with_capacity(self.len);
+        for shard in self.entries {
+            let shard = Arc::try_unwrap(shard).unwrap_or_else(|shared| shared.as_ref().clone());
+            values.extend(shard.into_iter().map(|(key, value)| {
+                let value = Arc::try_unwrap(value).unwrap_or_else(|shared| shared.as_ref().clone());
+                (key, value)
+            }));
+        }
         IntoIter {
-            inner: self.entries.into_iter(),
+            inner: values.into_iter(),
         }
     }
 }
@@ -256,7 +429,7 @@ mod tests {
         let mut original = SymbolicStore::<u32, u32>::default();
         original.insert(7, RangeStore::new(None, 8));
 
-        let mut branch = original.clone();
+        let mut branch = original.fork();
         branch
             .get_mut(&7)
             .unwrap()
@@ -271,5 +444,60 @@ mod tests {
             branch[&7].get_parts(BitAccess::new(0, 7)).unwrap()[0].0,
             Some((11, HashSet::default()))
         );
+        assert!(!original.shares_entry_with(&branch, &7));
+    }
+
+    #[test]
+    fn branch_write_copies_only_one_sparse_page() {
+        let mut original = SymbolicStore::<u32, u32>::default();
+        for key in 0..4096 {
+            original.insert(key, RangeStore::new(None, 8));
+        }
+
+        let mut branch = original.fork();
+        branch
+            .get_mut(&2048)
+            .unwrap()
+            .update(BitAccess::new(0, 0), Some((1, HashSet::default())))
+            .unwrap();
+
+        let shared_pages = original
+            .entries
+            .iter()
+            .zip(&branch.entries)
+            .filter(|(left, right)| Arc::ptr_eq(left, right))
+            .count();
+        assert_eq!(shared_pages, STORE_SHARDS - 1);
+        assert!(original.shares_entry_with(&branch, &7));
+        assert!(!original.shares_entry_with(&branch, &2048));
+        assert_eq!(original.differing_keys(&branch), vec![2048]);
+    }
+
+    #[test]
+    fn sharded_iterators_and_entry_api_preserve_map_semantics() {
+        let mut store = SymbolicStore::<u32, u32>::default();
+        for key in 0..256 {
+            store.entry(key).or_insert_with(|| RangeStore::new(None, 1));
+        }
+        assert_eq!(store.len(), 256);
+        assert_eq!(store.keys().count(), 256);
+        assert_eq!(store.values().count(), 256);
+        assert_eq!(store.iter().count(), 256);
+
+        for value in store.values_mut() {
+            value
+                .update(BitAccess::new(0, 0), Some((9, HashSet::default())))
+                .unwrap();
+        }
+        assert!(
+            store
+                .values()
+                .all(|value| value.get_parts(BitAccess::new(0, 0)).unwrap()[0].0
+                    == Some((9, HashSet::default())))
+        );
+
+        assert!(store.remove(&128).is_some());
+        assert_eq!(store.len(), 255);
+        assert_eq!(store.into_iter().count(), 255);
     }
 }

--- a/crates/celox-slt/src/symbolic_store.rs
+++ b/crates/celox-slt/src/symbolic_store.rs
@@ -165,32 +165,70 @@ impl<A: Eq + Hash, N> SymbolicStore<A, N> {
     ///
     /// Entire shared pages are skipped without visiting their keys. Within a
     /// copied page, entries that still share the same range version are also
-    /// skipped. The returned sparse set is therefore the only set that can
-    /// require phi construction.
-    pub fn differing_keys(&self, other: &Self) -> Vec<A>
-    where
-        A: Clone,
-    {
-        let mut differing = Vec::new();
-        for (left_shard, right_shard) in self.entries.iter().zip(&other.entries) {
-            if Arc::ptr_eq(left_shard, right_shard) {
-                continue;
-            }
-            for (key, left) in left_shard.iter() {
-                if right_shard
+    /// skipped. The returned sparse iterator is therefore the only set that
+    /// can require phi construction. Keys are borrowed directly from their
+    /// store version, so walking a diff does not allocate or clone addresses.
+    pub fn differing_keys<'a>(&'a self, other: &'a Self) -> impl Iterator<Item = &'a A> {
+        DifferingKeys {
+            left_shards: &self.entries,
+            right_shards: &other.entries,
+            next_shard: 0,
+            left_shard: None,
+            right_shard: None,
+            left_entries: None,
+            right_keys: None,
+        }
+    }
+}
+
+struct DifferingKeys<'a, A, N> {
+    left_shards: &'a [Arc<StoreShard<A, N>>; STORE_SHARDS],
+    right_shards: &'a [Arc<StoreShard<A, N>>; STORE_SHARDS],
+    next_shard: usize,
+    left_shard: Option<&'a StoreShard<A, N>>,
+    right_shard: Option<&'a StoreShard<A, N>>,
+    left_entries: Option<std::collections::hash_map::Iter<'a, A, RangeEntry<A, N>>>,
+    right_keys: Option<std::collections::hash_map::Keys<'a, A, RangeEntry<A, N>>>,
+}
+
+impl<'a, A: Eq + Hash, N> Iterator for DifferingKeys<'a, A, N> {
+    type Item = &'a A;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            while let Some((key, left)) = self.left_entries.as_mut().and_then(Iterator::next) {
+                if self
+                    .right_shard
+                    .expect("a diff iterator has a right shard")
                     .get(key)
                     .is_none_or(|right| !Arc::ptr_eq(left, right))
                 {
-                    differing.push(key.clone());
+                    return Some(key);
                 }
             }
-            for key in right_shard.keys() {
-                if !left_shard.contains_key(key) {
-                    differing.push(key.clone());
+
+            while let Some(key) = self.right_keys.as_mut().and_then(Iterator::next) {
+                if !self
+                    .left_shard
+                    .expect("a diff iterator has a left shard")
+                    .contains_key(key)
+                {
+                    return Some(key);
                 }
             }
+
+            let left = self.left_shards.get(self.next_shard)?;
+            let right = &self.right_shards[self.next_shard];
+            self.next_shard += 1;
+            if Arc::ptr_eq(left, right) {
+                continue;
+            }
+
+            self.left_shard = Some(left);
+            self.right_shard = Some(right);
+            self.left_entries = Some(left.iter());
+            self.right_keys = Some(right.keys());
         }
-        differing
     }
 }
 
@@ -470,7 +508,13 @@ mod tests {
         assert_eq!(shared_pages, STORE_SHARDS - 1);
         assert!(original.shares_entry_with(&branch, &7));
         assert!(!original.shares_entry_with(&branch, &2048));
-        assert_eq!(original.differing_keys(&branch), vec![2048]);
+        assert_eq!(
+            original
+                .differing_keys(&branch)
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![2048]
+        );
     }
 
     #[test]
@@ -493,11 +537,45 @@ mod tests {
             .update(BitAccess::new(4, 7), Some((2, HashSet::default())))
             .unwrap();
 
-        let mut differing = then_version.differing_keys(&else_version);
+        let mut differing = then_version
+            .differing_keys(&else_version)
+            .copied()
+            .collect::<Vec<_>>();
         differing.sort_unstable();
         assert_eq!(differing, vec![17, 900]);
-        assert_eq!(entry.differing_keys(&then_version), vec![17]);
-        assert_eq!(entry.differing_keys(&else_version), vec![900]);
+        assert_eq!(
+            entry
+                .differing_keys(&then_version)
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![17]
+        );
+        assert_eq!(
+            entry
+                .differing_keys(&else_version)
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![900]
+        );
+    }
+
+    #[test]
+    fn branch_diff_iterator_reports_insertions_and_removals_once() {
+        let mut left = SymbolicStore::<u32, u32>::default();
+        left.insert(1, RangeStore::new(None, 8));
+        left.insert(2, RangeStore::new(None, 8));
+
+        let mut right = left.fork();
+        right.remove(&1);
+        right.insert(3, RangeStore::new(None, 8));
+
+        let mut differing = left.differing_keys(&right).copied().collect::<Vec<_>>();
+        differing.sort_unstable();
+        assert_eq!(differing, vec![1, 3]);
+
+        let mut reverse = right.differing_keys(&left).copied().collect::<Vec<_>>();
+        reverse.sort_unstable();
+        assert_eq!(reverse, vec![1, 3]);
     }
 
     #[test]

--- a/crates/celox-slt/src/symbolic_store.rs
+++ b/crates/celox-slt/src/symbolic_store.rs
@@ -12,10 +12,11 @@ type RangeEntry<A, N> = Arc<SymbolicRange<A, N>>;
 type StoreShard<A, N> = HashMap<A, RangeEntry<A, N>>;
 
 // A fixed page table keeps branch snapshots cheap without adding a persistent
-// collection dependency. Empty pages allocate nothing. Forking shares every
-// populated page; the first write to one key copies only that key's page and
-// then the touched RangeStore.
+// collection dependency. Empty stores allocate nothing. Forking shares the
+// page table; the first write copies its small pointer array, then only the
+// touched page and RangeStore.
 const STORE_SHARDS: usize = 64;
+type StorePages<A, N> = [Option<Arc<StoreShard<A, N>>>; STORE_SHARDS];
 
 fn shard_index(key: &(impl Hash + ?Sized)) -> usize {
     let mut hasher = FxHasher::default();
@@ -25,20 +26,20 @@ fn shard_index(key: &(impl Hash + ?Sized)) -> usize {
 
 /// Statement-ordered symbolic state used while constructing SLT values.
 ///
-/// Each clone is a cheap branch version: the fixed-size page table and every
-/// range remain shared until a definition mutates them. This gives conditional
-/// evaluation SSA-like snapshot semantics while preserving the map-shaped API
-/// expected by the frontend.
+/// Each clone is a cheap branch version: the fixed-size page table, its pages,
+/// and every range remain shared until a definition mutates them. This gives
+/// conditional evaluation SSA-like snapshot semantics while preserving the
+/// map-shaped API expected by the frontend.
 #[derive(Clone, Debug)]
 pub struct SymbolicStore<A, N> {
-    entries: [Option<Arc<StoreShard<A, N>>>; STORE_SHARDS],
+    entries: Option<Arc<StorePages<A, N>>>,
     len: usize,
 }
 
 impl<A, N> Default for SymbolicStore<A, N> {
     fn default() -> Self {
         Self {
-            entries: std::array::from_fn(|_| None),
+            entries: None,
             len: 0,
         }
     }
@@ -47,12 +48,12 @@ impl<A, N> Default for SymbolicStore<A, N> {
 impl<A, N> SymbolicStore<A, N> {
     /// Create an independent statement branch from the current symbolic version.
     ///
-    /// The fixed page table makes this operation independent of the number of
+    /// The shared page table makes this operation independent of the number of
     /// variables in the module. Definitions remain shared until either branch
     /// writes their page.
     pub fn fork(&self) -> Self {
         Self {
-            entries: std::array::from_fn(|index| self.entries[index].as_ref().map(Arc::clone)),
+            entries: self.entries.as_ref().map(Arc::clone),
             len: self.len,
         }
     }
@@ -60,7 +61,9 @@ impl<A, N> SymbolicStore<A, N> {
 
 impl<A: Eq + Hash, N> SymbolicStore<A, N> {
     fn entry_arc(&self, key: &A) -> Option<&RangeEntry<A, N>> {
-        self.entries[shard_index(key)].as_deref()?.get(key)
+        self.entries.as_deref()?[shard_index(key)]
+            .as_deref()?
+            .get(key)
     }
 
     pub fn len(&self) -> usize {
@@ -76,8 +79,15 @@ impl<A: Eq + Hash, N> SymbolicStore<A, N> {
         A: Clone,
         N: Clone,
     {
+        if additional == 0 {
+            return;
+        }
         let per_shard = additional.div_ceil(STORE_SHARDS);
-        for shard in &mut self.entries {
+        let pages = Arc::make_mut(
+            self.entries
+                .get_or_insert_with(|| Arc::new(std::array::from_fn(|_| None))),
+        );
+        for shard in pages {
             Arc::make_mut(shard.get_or_insert_with(|| Arc::new(HashMap::default())))
                 .reserve(per_shard);
         }
@@ -96,8 +106,12 @@ impl<A: Eq + Hash, N> SymbolicStore<A, N> {
         A: Clone,
         N: Clone,
     {
+        let pages = Arc::make_mut(
+            self.entries
+                .get_or_insert_with(|| Arc::new(std::array::from_fn(|_| None))),
+        );
         let shard = Arc::make_mut(
-            self.entries[shard_index(&key)].get_or_insert_with(|| Arc::new(HashMap::default())),
+            pages[shard_index(&key)].get_or_insert_with(|| Arc::new(HashMap::default())),
         );
         let previous = shard.insert(key, Arc::new(value));
         if previous.is_none() {
@@ -112,23 +126,30 @@ impl<A: Eq + Hash, N> SymbolicStore<A, N> {
         N: Clone,
     {
         let index = shard_index(key);
-        let shard = self.entries[index].as_mut()?;
-        if !shard.contains_key(key) {
+        if !self.entries.as_deref()?[index]
+            .as_deref()?
+            .contains_key(key)
+        {
             return None;
         }
+        let pages = Arc::make_mut(self.entries.as_mut().expect("the page table exists"));
+        let shard = pages[index].as_mut().expect("the populated shard exists");
         let removed = Arc::make_mut(shard).remove(key);
         if removed.is_some() {
             self.len -= 1;
         }
         if shard.is_empty() {
-            self.entries[index] = None;
+            pages[index] = None;
+        }
+        if self.len == 0 {
+            self.entries = None;
         }
         removed
     }
 
     pub fn iter(&self) -> Iter<'_, A, N> {
         Iter {
-            shards: self.entries.iter(),
+            shards: self.entries.as_deref().map(|pages| pages.iter()),
             current: None,
             remaining: self.len,
         }
@@ -136,7 +157,7 @@ impl<A: Eq + Hash, N> SymbolicStore<A, N> {
 
     pub fn values(&self) -> Values<'_, A, N> {
         Values {
-            shards: self.entries.iter(),
+            shards: self.entries.as_deref().map(|pages| pages.iter()),
             current: None,
             remaining: self.len,
         }
@@ -144,7 +165,7 @@ impl<A: Eq + Hash, N> SymbolicStore<A, N> {
 
     pub fn keys(&self) -> Keys<'_, A, N> {
         Keys {
-            shards: self.entries.iter(),
+            shards: self.entries.as_deref().map(|pages| pages.iter()),
             current: None,
             remaining: self.len,
         }
@@ -181,10 +202,15 @@ impl<A: Eq + Hash, N> SymbolicStore<A, N> {
     /// can require phi construction. Keys are borrowed directly from their
     /// store version, so walking a diff does not allocate or clone addresses.
     pub fn differing_keys<'a>(&'a self, other: &'a Self) -> impl Iterator<Item = &'a A> {
+        let versions_match = match (&self.entries, &other.entries) {
+            (None, None) => true,
+            (Some(left), Some(right)) => Arc::ptr_eq(left, right),
+            _ => false,
+        };
         DifferingKeys {
-            left_shards: &self.entries,
-            right_shards: &other.entries,
-            next_shard: 0,
+            left_shards: self.entries.as_deref(),
+            right_shards: other.entries.as_deref(),
+            next_shard: if versions_match { STORE_SHARDS } else { 0 },
             left_shard: None,
             right_shard: None,
             left_entries: None,
@@ -194,8 +220,8 @@ impl<A: Eq + Hash, N> SymbolicStore<A, N> {
 }
 
 struct DifferingKeys<'a, A, N> {
-    left_shards: &'a [Option<Arc<StoreShard<A, N>>>; STORE_SHARDS],
-    right_shards: &'a [Option<Arc<StoreShard<A, N>>>; STORE_SHARDS],
+    left_shards: Option<&'a StorePages<A, N>>,
+    right_shards: Option<&'a StorePages<A, N>>,
     next_shard: usize,
     left_shard: Option<&'a StoreShard<A, N>>,
     right_shard: Option<&'a StoreShard<A, N>>,
@@ -224,8 +250,15 @@ impl<'a, A: Eq + Hash, N> Iterator for DifferingKeys<'a, A, N> {
                 }
             }
 
-            let left = self.left_shards.get(self.next_shard)?;
-            let right = &self.right_shards[self.next_shard];
+            if self.next_shard == STORE_SHARDS {
+                return None;
+            }
+            let left = self
+                .left_shards
+                .and_then(|shards| shards[self.next_shard].as_ref());
+            let right = self
+                .right_shards
+                .and_then(|shards| shards[self.next_shard].as_ref());
             self.next_shard += 1;
             if match (left, right) {
                 (None, None) => true,
@@ -235,10 +268,10 @@ impl<'a, A: Eq + Hash, N> Iterator for DifferingKeys<'a, A, N> {
                 continue;
             }
 
-            self.left_shard = left.as_deref();
-            self.right_shard = right.as_deref();
-            self.left_entries = left.as_deref().map(StoreShard::iter);
-            self.right_keys = right.as_deref().map(StoreShard::keys);
+            self.left_shard = left.map(|shard| shard.as_ref());
+            self.right_shard = right.map(|shard| shard.as_ref());
+            self.left_entries = left.map(|shard| shard.iter());
+            self.right_keys = right.map(|shard| shard.keys());
         }
     }
 }
@@ -248,8 +281,12 @@ impl<A: Clone + Eq + Hash, N: Clone> SymbolicStore<A, N> {
         let Some(value) = source.entry_arc(key) else {
             return false;
         };
+        let pages = Arc::make_mut(
+            self.entries
+                .get_or_insert_with(|| Arc::new(std::array::from_fn(|_| None))),
+        );
         let shard = Arc::make_mut(
-            self.entries[shard_index(key)].get_or_insert_with(|| Arc::new(HashMap::default())),
+            pages[shard_index(key)].get_or_insert_with(|| Arc::new(HashMap::default())),
         );
         if shard.insert(key.clone(), Arc::clone(value)).is_none() {
             self.len += 1;
@@ -259,9 +296,13 @@ impl<A: Clone + Eq + Hash, N: Clone> SymbolicStore<A, N> {
 
     pub fn entry(&mut self, key: A) -> Entry<'_, A, N> {
         let shard_index = shard_index(&key);
+        let pages = Arc::make_mut(
+            self.entries
+                .get_or_insert_with(|| Arc::new(std::array::from_fn(|_| None))),
+        );
         Entry {
             inner: Arc::make_mut(
-                self.entries[shard_index].get_or_insert_with(|| Arc::new(HashMap::default())),
+                pages[shard_index].get_or_insert_with(|| Arc::new(HashMap::default())),
             )
             .entry(key),
             len: &mut self.len,
@@ -269,16 +310,25 @@ impl<A: Clone + Eq + Hash, N: Clone> SymbolicStore<A, N> {
     }
 
     pub fn get_mut(&mut self, key: &A) -> Option<&mut SymbolicRange<A, N>> {
-        let shard = self.entries[shard_index(key)].as_mut()?;
-        if !shard.contains_key(key) {
+        let index = shard_index(key);
+        if !self.entries.as_deref()?[index]
+            .as_deref()?
+            .contains_key(key)
+        {
             return None;
         }
+        let pages = Arc::make_mut(self.entries.as_mut().expect("the page table exists"));
+        let shard = pages[index].as_mut().expect("the populated shard exists");
         Arc::make_mut(shard).get_mut(key).map(Arc::make_mut)
     }
 
     pub fn values_mut(&mut self) -> ValuesMut<'_, A, N> {
         ValuesMut {
-            shards: self.entries.iter_mut(),
+            shards: self
+                .entries
+                .as_mut()
+                .map(Arc::make_mut)
+                .map(|pages| pages.iter_mut()),
             current: None,
             remaining: self.len,
         }
@@ -315,7 +365,7 @@ impl<A: Eq + Hash, N> Index<&A> for SymbolicStore<A, N> {
 }
 
 pub struct Iter<'a, A, N> {
-    shards: std::slice::Iter<'a, Option<Arc<StoreShard<A, N>>>>,
+    shards: Option<std::slice::Iter<'a, Option<Arc<StoreShard<A, N>>>>>,
     current: Option<std::collections::hash_map::Iter<'a, A, RangeEntry<A, N>>>,
     remaining: usize,
 }
@@ -329,7 +379,7 @@ impl<'a, A, N> Iterator for Iter<'a, A, N> {
                 self.remaining -= 1;
                 return Some((key, value.as_ref()));
             }
-            let Some(shard) = self.shards.next()?.as_deref() else {
+            let Some(shard) = self.shards.as_mut()?.next()?.as_deref() else {
                 continue;
             };
             self.current = Some(shard.iter());
@@ -344,7 +394,7 @@ impl<'a, A, N> Iterator for Iter<'a, A, N> {
 impl<A, N> ExactSizeIterator for Iter<'_, A, N> {}
 
 pub struct Values<'a, A, N> {
-    shards: std::slice::Iter<'a, Option<Arc<StoreShard<A, N>>>>,
+    shards: Option<std::slice::Iter<'a, Option<Arc<StoreShard<A, N>>>>>,
     current: Option<std::collections::hash_map::Values<'a, A, RangeEntry<A, N>>>,
     remaining: usize,
 }
@@ -358,7 +408,7 @@ impl<'a, A, N> Iterator for Values<'a, A, N> {
                 self.remaining -= 1;
                 return Some(value.as_ref());
             }
-            let Some(shard) = self.shards.next()?.as_deref() else {
+            let Some(shard) = self.shards.as_mut()?.next()?.as_deref() else {
                 continue;
             };
             self.current = Some(shard.values());
@@ -373,7 +423,7 @@ impl<'a, A, N> Iterator for Values<'a, A, N> {
 impl<A, N> ExactSizeIterator for Values<'_, A, N> {}
 
 pub struct Keys<'a, A, N> {
-    shards: std::slice::Iter<'a, Option<Arc<StoreShard<A, N>>>>,
+    shards: Option<std::slice::Iter<'a, Option<Arc<StoreShard<A, N>>>>>,
     current: Option<std::collections::hash_map::Keys<'a, A, RangeEntry<A, N>>>,
     remaining: usize,
 }
@@ -387,7 +437,7 @@ impl<'a, A, N> Iterator for Keys<'a, A, N> {
                 self.remaining -= 1;
                 return Some(key);
             }
-            let Some(shard) = self.shards.next()?.as_deref() else {
+            let Some(shard) = self.shards.as_mut()?.next()?.as_deref() else {
                 continue;
             };
             self.current = Some(shard.keys());
@@ -402,7 +452,7 @@ impl<'a, A, N> Iterator for Keys<'a, A, N> {
 impl<A, N> ExactSizeIterator for Keys<'_, A, N> {}
 
 pub struct ValuesMut<'a, A: Clone, N: Clone> {
-    shards: std::slice::IterMut<'a, Option<Arc<StoreShard<A, N>>>>,
+    shards: Option<std::slice::IterMut<'a, Option<Arc<StoreShard<A, N>>>>>,
     current: Option<std::collections::hash_map::ValuesMut<'a, A, RangeEntry<A, N>>>,
     remaining: usize,
 }
@@ -416,7 +466,7 @@ impl<'a, A: Clone, N: Clone> Iterator for ValuesMut<'a, A, N> {
                 self.remaining -= 1;
                 return Some(Arc::make_mut(value));
             }
-            let Some(shard) = self.shards.next()?.as_mut() else {
+            let Some(shard) = self.shards.as_mut()?.next()?.as_mut() else {
                 continue;
             };
             self.current = Some(Arc::make_mut(shard).values_mut());
@@ -463,15 +513,19 @@ impl<A: Clone + Eq + Hash, N: Clone> IntoIterator for SymbolicStore<A, N> {
 
     fn into_iter(self) -> Self::IntoIter {
         let mut values = Vec::with_capacity(self.len);
-        for shard in self.entries {
-            let Some(shard) = shard else {
-                continue;
-            };
-            let shard = Arc::try_unwrap(shard).unwrap_or_else(|shared| shared.as_ref().clone());
-            values.extend(shard.into_iter().map(|(key, value)| {
-                let value = Arc::try_unwrap(value).unwrap_or_else(|shared| shared.as_ref().clone());
-                (key, value)
-            }));
+        if let Some(pages) = self.entries {
+            let pages = Arc::try_unwrap(pages).unwrap_or_else(|shared| shared.as_ref().clone());
+            for shard in pages {
+                let Some(shard) = shard else {
+                    continue;
+                };
+                let shard = Arc::try_unwrap(shard).unwrap_or_else(|shared| shared.as_ref().clone());
+                values.extend(shard.into_iter().map(|(key, value)| {
+                    let value =
+                        Arc::try_unwrap(value).unwrap_or_else(|shared| shared.as_ref().clone());
+                    (key, value)
+                }));
+            }
         }
         IntoIter {
             inner: values.into_iter(),
@@ -498,12 +552,12 @@ mod tests {
     #[test]
     fn empty_store_allocates_no_shard_pages() {
         let mut store = SymbolicStore::<u32, u32>::default();
-        assert!(store.entries.iter().all(Option::is_none));
+        assert!(store.entries.is_none());
         assert!(store.get_mut(&7).is_none());
-        assert!(store.entries.iter().all(Option::is_none));
+        assert!(store.entries.is_none());
 
         let branch = store.fork();
-        assert!(branch.entries.iter().all(Option::is_none));
+        assert!(branch.entries.is_none());
     }
 
     #[test]
@@ -511,10 +565,10 @@ mod tests {
         let mut store = SymbolicStore::<u32, u32>::default();
         store.insert(7, RangeStore::new(None, 8));
         let index = shard_index(&7);
-        assert!(store.entries[index].is_some());
+        assert!(store.entries.as_deref().unwrap()[index].is_some());
 
         assert!(store.remove(&7).is_some());
-        assert!(store.entries[index].is_none());
+        assert!(store.entries.is_none());
         assert!(store.is_empty());
     }
 
@@ -549,16 +603,25 @@ mod tests {
         }
 
         let mut branch = original.fork();
+        assert!(Arc::ptr_eq(
+            original.entries.as_ref().unwrap(),
+            branch.entries.as_ref().unwrap()
+        ));
         branch
             .get_mut(&2048)
             .unwrap()
             .update(BitAccess::new(0, 0), Some((1, HashSet::default())))
             .unwrap();
+        assert!(!Arc::ptr_eq(
+            original.entries.as_ref().unwrap(),
+            branch.entries.as_ref().unwrap()
+        ));
 
-        let shared_pages = original
-            .entries
+        let original_pages = original.entries.as_deref().unwrap();
+        let branch_pages = branch.entries.as_deref().unwrap();
+        let shared_pages = original_pages
             .iter()
-            .zip(&branch.entries)
+            .zip(branch_pages)
             .filter(|(left, right)| {
                 left.as_ref()
                     .zip(right.as_ref())

--- a/crates/celox-slt/src/symbolic_store.rs
+++ b/crates/celox-slt/src/symbolic_store.rs
@@ -474,6 +474,33 @@ mod tests {
     }
 
     #[test]
+    fn branch_versions_report_only_their_divergent_definitions() {
+        let mut entry = SymbolicStore::<u32, u32>::default();
+        for key in 0..1024 {
+            entry.insert(key, RangeStore::new(None, 8));
+        }
+
+        let mut then_version = entry.fork();
+        then_version
+            .get_mut(&17)
+            .unwrap()
+            .update(BitAccess::new(0, 3), Some((1, HashSet::default())))
+            .unwrap();
+        let mut else_version = entry.fork();
+        else_version
+            .get_mut(&900)
+            .unwrap()
+            .update(BitAccess::new(4, 7), Some((2, HashSet::default())))
+            .unwrap();
+
+        let mut differing = then_version.differing_keys(&else_version);
+        differing.sort_unstable();
+        assert_eq!(differing, vec![17, 900]);
+        assert_eq!(entry.differing_keys(&then_version), vec![17]);
+        assert_eq!(entry.differing_keys(&else_version), vec![900]);
+    }
+
+    #[test]
     fn sharded_iterators_and_entry_api_preserve_map_semantics() {
         let mut store = SymbolicStore::<u32, u32>::default();
         for key in 0..256 {


### PR DESCRIPTION
## Summary

- make symbolic branch state sparse and fork it with copy-on-write page tables
- stream and merge sparse symbolic diffs instead of materializing dense intermediate state
- initialize per-variable comb and instance state only when it is touched
- reuse lowering buffers and validated select geometry to avoid repeated allocation and shape evaluation

This keeps the existing SLT representation and focuses on making SLT construction easier to follow and cheaper, following the general direction of [veryl-lang/veryl#3161](https://github.com/veryl-lang/veryl/pull/3161).

## Why

SLT construction previously paid for variables and ranges that a branch did not touch. Forking symbolic state also cloned more storage than necessary, and several lowering paths rebuilt temporary range, dimension, stride, traversal, and cost buffers.

The new representation records only touched symbolic pages and ranges. Forks share page tables until mutation, while lowering paths consume sparse changes directly and reuse internal scratch storage.

## Impact

The profiling workload `profile_sorter 16` changed from:

- allocations: 14,194,846 -> 13,922,766 (about 1.92% fewer across the full compilation pipeline)
- peak heap: 63.41 MB -> about 58.0 MB (about 8.5% lower)

Focused hotspots improved more substantially:

- instance symbolic-state construction allocation stacks: about 89% fewer
- lowering cost-cache reset allocation stacks: about 98% fewer

`SelectGeometry` is an internal frontend API and no longer retains duplicate dimension data; callers that need dimensions derive them through the dedicated helper.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p celox-frontend-veryl --all-targets -- -D warnings`
- `cargo test --workspace --quiet`
- `cargo test -p celox-slt --lib`
- `cargo test -p celox-frontend-veryl --lib`
- `cargo test -p celox --test data_access --test hierarchy --test flip_flop`
- pre-push Biome, workspace `cargo check`, formatting, and submodule checks
