### PR TITLE
perf(slt): reduce scheduler construction overhead

### DIFF
--- a/crates/celox-frontend-veryl/src/design_assembly.rs
+++ b/crates/celox-frontend-veryl/src/design_assembly.rs
@@ -1236,11 +1236,28 @@ fn expand_hierarchy(
     (expanded, instance_modules)
 }
 
+fn extend_boundaries(
+    boundaries: &mut HashMap<AbsoluteAddr, BTreeSet<usize>>,
+    source: AbsoluteAddr,
+    target: AbsoluteAddr,
+) -> bool {
+    if source == target || boundaries.get(&source).is_none_or(BTreeSet::is_empty) {
+        return false;
+    }
+    boundaries.entry(target).or_default();
+    let [Some(source), Some(target)] = boundaries.get_disjoint_mut([&source, &target]) else {
+        unreachable!("distinct boundary keys were inserted before lookup");
+    };
+    let old_len = target.len();
+    target.extend(source.iter().copied());
+    target.len() != old_len
+}
+
 fn propagate_boundaries(
     expanded: &HashMap<InstancePath, InstanceId>,
     instance_modules: &HashMap<InstanceId, ModuleId>,
     modules: &HashMap<ModuleId, SimModule>,
-) -> HashMap<AbsoluteAddr, std::collections::BTreeSet<usize>> {
+) -> HashMap<AbsoluteAddr, BTreeSet<usize>> {
     let mut current_boundaries = HashMap::default();
 
     // Initialize with local boundaries
@@ -1281,27 +1298,16 @@ fn propagate_boundaries(
                             };
 
                             // Collect boundaries from all parent variables connected to this port
-                            let mut incoming_boundaries = std::collections::BTreeSet::new();
                             for parent_var in parent_vars {
                                 let parent_abs = AbsoluteAddr {
                                     instance_id: *id,
                                     var_id: *parent_var,
                                 };
-                                if let Some(bounds) = current_boundaries.get(&parent_abs) {
-                                    for b in bounds {
-                                        incoming_boundaries.insert(*b);
-                                    }
-                                }
-                            }
-
-                            // Apply to child
-                            if !incoming_boundaries.is_empty() {
-                                let child_bounds = current_boundaries.entry(child_abs).or_default();
-                                let old_len = child_bounds.len();
-                                child_bounds.extend(incoming_boundaries);
-                                if child_bounds.len() != old_len {
-                                    changed = true;
-                                }
+                                changed |= extend_boundaries(
+                                    &mut current_boundaries,
+                                    parent_abs,
+                                    child_abs,
+                                );
                             }
                         }
                     }
@@ -1317,48 +1323,31 @@ fn propagate_boundaries(
                                 };
 
                                 // Child -> Parent
-                                if let Some(child_bounds) =
-                                    current_boundaries.get(&child_abs).cloned()
-                                {
-                                    for parent_var in parent_vars {
-                                        let parent_abs = AbsoluteAddr {
-                                            instance_id: *id,
-                                            var_id: *parent_var,
-                                        };
-                                        let parent_bounds =
-                                            current_boundaries.entry(parent_abs).or_default();
-                                        let old_len = parent_bounds.len();
-                                        parent_bounds.extend(child_bounds.clone());
-                                        if parent_bounds.len() != old_len {
-                                            changed = true;
-                                        }
-                                    }
-                                }
-
-                                // Parent -> Child (Sink -> Source propagation)
-                                // If the parent wire connected to this output has boundaries (e.g. used in slices),
-                                // those boundaries should propagate to the child output port so it drives them appropriately.
-                                let mut incoming_boundaries = std::collections::BTreeSet::new();
                                 for parent_var in parent_vars {
                                     let parent_abs = AbsoluteAddr {
                                         instance_id: *id,
                                         var_id: *parent_var,
                                     };
-                                    if let Some(bounds) = current_boundaries.get(&parent_abs) {
-                                        for b in bounds {
-                                            incoming_boundaries.insert(*b);
-                                        }
-                                    }
+                                    changed |= extend_boundaries(
+                                        &mut current_boundaries,
+                                        child_abs,
+                                        parent_abs,
+                                    );
                                 }
 
-                                if !incoming_boundaries.is_empty() {
-                                    let child_bounds =
-                                        current_boundaries.entry(child_abs).or_default();
-                                    let old_len = child_bounds.len();
-                                    child_bounds.extend(incoming_boundaries);
-                                    if child_bounds.len() != old_len {
-                                        changed = true;
-                                    }
+                                // Parent -> Child (Sink -> Source propagation)
+                                // If the parent wire connected to this output has boundaries (e.g. used in slices),
+                                // those boundaries should propagate to the child output port so it drives them appropriately.
+                                for parent_var in parent_vars {
+                                    let parent_abs = AbsoluteAddr {
+                                        instance_id: *id,
+                                        var_id: *parent_var,
+                                    };
+                                    changed |= extend_boundaries(
+                                        &mut current_boundaries,
+                                        parent_abs,
+                                        child_abs,
+                                    );
                                 }
                             }
                         }

--- a/crates/celox-frontend-veryl/src/flattening.rs
+++ b/crates/celox-frontend-veryl/src/flattening.rs
@@ -512,10 +512,65 @@ fn collect_inputs_with_window<A: Hash + Eq + Clone + Debug>(
     }
 }
 
+enum UncoveredWindows {
+    Empty,
+    One(BitAccess),
+    Multiple(Vec<BitAccess>),
+}
+
+impl UncoveredWindows {
+    fn push(&mut self, window: BitAccess) {
+        match std::mem::replace(self, Self::Empty) {
+            Self::Empty => *self = Self::One(window),
+            Self::One(first) => *self = Self::Multiple(vec![first, window]),
+            Self::Multiple(mut windows) => {
+                windows.push(window);
+                *self = Self::Multiple(windows);
+            }
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        matches!(self, Self::Empty)
+    }
+}
+
+enum UncoveredWindowsIter {
+    Empty,
+    One(std::option::IntoIter<BitAccess>),
+    Multiple(std::vec::IntoIter<BitAccess>),
+}
+
+impl Iterator for UncoveredWindowsIter {
+    type Item = BitAccess;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Empty => None,
+            Self::One(window) => window.next(),
+            Self::Multiple(windows) => windows.next(),
+        }
+    }
+}
+
+impl IntoIterator for UncoveredWindows {
+    type Item = BitAccess;
+    type IntoIter = UncoveredWindowsIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Self::Empty => UncoveredWindowsIter::Empty,
+            Self::One(window) => UncoveredWindowsIter::One(Some(window).into_iter()),
+            Self::Multiple(windows) => UncoveredWindowsIter::Multiple(windows.into_iter()),
+        }
+    }
+}
+
 /// Add `requested` to a sorted union of covered intervals and return only the
-/// portions which were not already covered.
-fn claim_uncovered_window(covered: &mut Vec<BitAccess>, requested: BitAccess) -> Vec<BitAccess> {
-    let mut uncovered = Vec::new();
+/// portions which were not already covered. The common zero- and one-window
+/// cases stay inline; only a fragmented result allocates a buffer.
+fn claim_uncovered_window(covered: &mut Vec<BitAccess>, requested: BitAccess) -> UncoveredWindows {
+    let mut uncovered = UncoveredWindows::Empty;
     let mut cursor = requested.lsb;
     for range in covered.iter().copied() {
         if range.msb < cursor {
@@ -729,6 +784,44 @@ mod tests {
     };
     use veryl_metadata::Metadata;
     use veryl_parser::{Parser, resource_table::StrId};
+
+    #[test]
+    fn uncovered_windows_inline_empty_and_single_results() {
+        let mut covered = vec![BitAccess::new(0, 3)];
+
+        assert_eq!(
+            claim_uncovered_window(&mut covered, BitAccess::new(1, 2))
+                .into_iter()
+                .collect::<Vec<_>>(),
+            Vec::<BitAccess>::new()
+        );
+        assert_eq!(covered, vec![BitAccess::new(0, 3)]);
+
+        assert_eq!(
+            claim_uncovered_window(&mut covered, BitAccess::new(2, 6))
+                .into_iter()
+                .collect::<Vec<_>>(),
+            vec![BitAccess::new(4, 6)]
+        );
+        assert_eq!(covered, vec![BitAccess::new(0, 6)]);
+    }
+
+    #[test]
+    fn uncovered_windows_allocate_only_for_fragmented_results() {
+        let mut covered = vec![BitAccess::new(2, 3), BitAccess::new(6, 7)];
+
+        assert_eq!(
+            claim_uncovered_window(&mut covered, BitAccess::new(0, 9))
+                .into_iter()
+                .collect::<Vec<_>>(),
+            vec![
+                BitAccess::new(0, 1),
+                BitAccess::new(4, 5),
+                BitAccess::new(8, 9),
+            ]
+        );
+        assert_eq!(covered, vec![BitAccess::new(0, 9)]);
+    }
 
     fn setup(code: &str) -> (HashMap<ModuleId, SimModule>, HashMap<StrId, ModuleId>, Ir) {
         symbol_table::clear();

--- a/crates/celox-slt/src/scheduler.rs
+++ b/crates/celox-slt/src/scheduler.rs
@@ -2369,7 +2369,8 @@ pub enum ClockSortError<Addr: Display + Debug + Eq + Hash + Clone, E> {
 }
 
 enum ScheduledWork {
-    Comb(Vec<usize>),
+    CombPath(usize),
+    CombScc(Vec<usize>),
     /// A dependency-ordered run of state publications selected by one SLT
     /// condition.  The path scheduler has already fixed the order; lowering
     /// only preserves the exclusivity which would otherwise become several
@@ -2579,24 +2580,17 @@ fn form_scheduled_guard_regions<A: Clone + Eq + Hash>(
     let mut result = Vec::with_capacity(work.len());
     let mut pending = work.into_iter().peekable();
     while let Some(item) = pending.next() {
-        let ScheduledWork::Comb(first) = item else {
+        let ScheduledWork::CombPath(first_path) = item else {
             result.push(item);
             continue;
         };
-        let [first_path] = first.as_slice() else {
-            result.push(ScheduledWork::Comb(first));
-            continue;
-        };
-        let Some((condition, _, _)) = scheduled_root_mux(&input[*first_path], arena) else {
-            result.push(ScheduledWork::Comb(first));
+        let Some((condition, _, _)) = scheduled_root_mux(&input[first_path], arena) else {
+            result.push(ScheduledWork::CombPath(first_path));
             continue;
         };
 
-        let mut paths = vec![*first_path];
-        while let Some(ScheduledWork::Comb(next)) = pending.peek() {
-            let [next_path] = next.as_slice() else {
-                break;
-            };
+        let mut paths = vec![first_path];
+        while let Some(ScheduledWork::CombPath(next_path)) = pending.peek() {
             if scheduled_root_mux(&input[*next_path], arena)
                 .is_none_or(|(next_condition, _, _)| next_condition != condition)
             {
@@ -2616,11 +2610,7 @@ fn form_scheduled_guard_regions<A: Clone + Eq + Hash>(
         {
             result.push(ScheduledWork::GuardedComb { condition, paths });
         } else {
-            result.extend(
-                paths
-                    .into_iter()
-                    .map(|path| ScheduledWork::Comb(vec![path])),
-            );
+            result.extend(paths.into_iter().map(ScheduledWork::CombPath));
         }
     }
     result
@@ -3077,7 +3067,7 @@ fn schedule_acyclic_path_region(
     materialization_tokens: &[Vec<usize>],
     token_weights: &[usize],
     local_by_path: &mut [usize],
-) -> Option<Vec<Vec<usize>>> {
+) -> Option<Vec<usize>> {
     for (local, &path) in paths.iter().enumerate() {
         if path >= local_by_path.len() || local_by_path[path] != usize::MAX {
             for &mapped in &paths[..local] {
@@ -3122,7 +3112,7 @@ fn schedule_acyclic_path_region(
             token_weights,
         )
         .ok()?;
-        Some(order.into_iter().map(|local| vec![paths[local]]).collect())
+        Some(order.into_iter().map(|local| paths[local]).collect())
     })();
 
     for &path in paths {
@@ -3141,7 +3131,7 @@ fn schedule_logic_path_regions<Addr: Clone + Eq + Hash>(
     materialization_tokens: &[Vec<usize>],
     token_weights: &[usize],
     input: &[LogicPath<Addr>],
-) -> Option<Vec<Vec<usize>>> {
+) -> Option<Vec<ScheduledWork>> {
     if dependencies.len() != value_dependencies.len()
         || dependencies.len() != materialization_tokens.len()
         || dependencies.len() < input.len()
@@ -3152,20 +3142,27 @@ fn schedule_logic_path_regions<Addr: Clone + Eq + Hash>(
     let mut result = Vec::with_capacity(topological_sccs.len());
     let mut pending = Vec::new();
     let flush = |pending: &mut Vec<usize>,
-                 result: &mut Vec<Vec<usize>>,
+                 result: &mut Vec<ScheduledWork>,
                  local_by_path: &mut [usize]|
      -> Option<()> {
         if pending.is_empty() {
             return Some(());
         }
-        result.extend(schedule_acyclic_path_region(
+        let ordered = schedule_acyclic_path_region(
             pending,
             dependencies,
             value_dependencies,
             materialization_tokens,
             token_weights,
             local_by_path,
-        )?);
+        )?;
+        result.extend(ordered.into_iter().map(|path| {
+            if path < input.len() {
+                ScheduledWork::CombPath(path)
+            } else {
+                ScheduledWork::Ff(path - input.len())
+            }
+        }));
         pending.clear();
         Some(())
     };
@@ -3178,7 +3175,17 @@ fn schedule_logic_path_regions<Addr: Clone + Eq + Hash>(
             pending.push(*path);
         } else {
             flush(&mut pending, &mut result, &mut local_by_path)?;
-            result.push(scc);
+            if let [path] = scc.as_slice() {
+                if *path < input.len() {
+                    result.push(ScheduledWork::CombPath(*path));
+                } else {
+                    result.push(ScheduledWork::Ff(*path - input.len()));
+                }
+            } else if scc.iter().all(|path| *path < input.len()) {
+                result.push(ScheduledWork::CombScc(scc));
+            } else {
+                return None;
+            }
         }
     }
     flush(&mut pending, &mut result, &mut local_by_path)?;
@@ -3336,7 +3343,7 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
         stable_topological_sccs(ctx.sccs, &adj, &path_domains).ok_or(ClockSortError::Scheduler(
             SchedulerError::InvalidDependencyGraph,
         ))?;
-    let scheduled_nodes = schedule_logic_path_regions(
+    let scheduled_work = schedule_logic_path_regions(
         topological_sccs,
         &adj,
         &value_users,
@@ -3347,20 +3354,6 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
     .ok_or(ClockSortError::Scheduler(
         SchedulerError::InvalidDependencyGraph,
     ))?;
-    let mut scheduled_work = Vec::with_capacity(scheduled_nodes.len());
-    for nodes in scheduled_nodes {
-        if nodes.iter().all(|node| *node < n) {
-            scheduled_work.push(ScheduledWork::Comb(nodes));
-        } else if let [node] = nodes.as_slice()
-            && *node >= n
-        {
-            scheduled_work.push(ScheduledWork::Ff(*node - n));
-        } else {
-            return Err(ClockSortError::Scheduler(
-                SchedulerError::InvalidDependencyGraph,
-            ));
-        }
-    }
     let scheduled_work = form_scheduled_guard_regions(scheduled_work, &input, arena, four_state);
 
     let mut builder = SIRBuilder::new();
@@ -3416,8 +3409,13 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
     // 4. Lower each scheduled component, selecting static unrolling or
     // dynamic convergence for cyclic SCCs.
     for work in scheduled_work {
-        let scc = match work {
-            ScheduledWork::Comb(scc) => scc,
+        let singleton;
+        let scc = match &work {
+            ScheduledWork::CombPath(path) => {
+                singleton = [*path];
+                singleton.as_slice()
+            }
+            ScheduledWork::CombScc(scc) => scc.as_slice(),
             ScheduledWork::GuardedComb { condition, paths } => {
                 flush_pending_fold_paths(
                     &mut pending_fold_indices,
@@ -3436,8 +3434,8 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
                 emit_scheduled_guard_region(
                     &lowerer,
                     &mut builder,
-                    condition,
-                    &paths,
+                    *condition,
+                    paths,
                     &input,
                     arena,
                     &mut lower_cache,
@@ -3466,7 +3464,7 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
                     .ok_or(ClockSortError::Scheduler(
                         SchedulerError::InvalidDependencyGraph,
                     ))?
-                    .lower(index, &direct_ff_writes_by_action[index], &mut builder)
+                    .lower(*index, &direct_ff_writes_by_action[*index], &mut builder)
                     .map_err(ClockSortError::Lowering)?;
                 // Any directly published range is ordered after all of its
                 // old-state readers. Other FF state stays invisible in
@@ -3478,7 +3476,7 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
         };
         let component = component_by_path[scc[0]];
         let mut user_safety_limit = None;
-        for &v_idx in &scc {
+        for &v_idx in scc {
             for &u_idx in &adj[v_idx] {
                 if component_by_path[u_idx] == component {
                     if let (Some(v_target), Some(u_target)) =
@@ -3512,7 +3510,7 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
             );
             pending_fold_roots.clear();
             let mut authorized = user_safety_limit.is_some();
-            'check_scc: for &v_idx in &scc {
+            'check_scc: for &v_idx in scc {
                 for &u_idx in &adj[v_idx] {
                     if component_by_path[u_idx] == component
                         && input[v_idx]
@@ -3531,13 +3529,13 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
             if !authorized {
                 return Err(ClockSortError::Scheduler(
                     SchedulerError::CombinationalLoop {
-                        blocks: scc.into_iter().map(|idx| input[idx].clone()).collect(),
+                        blocks: scc.iter().map(|idx| input[*idx].clone()).collect(),
                     },
                 ));
             }
 
             // FAS Sort
-            let optimized_scc_order = greedy_fas_sort(&scc, &adj);
+            let optimized_scc_order = greedy_fas_sort(scc, &adj);
             let force_strategy_b = user_safety_limit.is_some();
             let iterations = calculate_required_iterations(&adj, &optimized_scc_order);
             let total_ops_estimate = optimized_scc_order.len().saturating_mul(iterations);


### PR DESCRIPTION
## Summary

- represent singleton scheduled paths inline and allocate owned buffers only for real SCCs and grouped guard regions
- keep zero- and one-range uncovered-window results inline during dependency collection
- propagate hierarchy boundaries directly between map entries without cloning temporary `BTreeSet` values

## Motivation

This is a follow-up to #580. After making SLT construction sparse, profiling still showed short-lived allocations in path scheduling, input-window memoization, and hierarchical boundary propagation. These changes remove those ownership buffers without changing scheduling or boundary semantics.

## Impact

On the `profile_sorter 16` heaptrack workload, allocations decreased from 13,922,766 to approximately 13,903,465 (about 19.3k fewer allocations for this stacked change).

## Validation

- `cargo test --workspace --quiet`
- `cargo test -p celox-slt --lib`
- `cargo test -p celox-frontend-veryl --lib`
- `cargo test -p celox --test data_access --test hierarchy`
- `cargo clippy -p celox-slt --all-targets -- -D warnings`
- `cargo clippy -p celox-frontend-veryl --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- repository pre-push checks
