### PR TITLE
fix(release): generate changelog from pull requests

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -19,6 +19,12 @@ Pull request titles are the input to release automation:
 After 1.0, normal Semantic Versioning applies: fixes are patch releases,
 features are minor releases, and breaking changes are major releases.
 
+Changelog entries come from GitHub's merged pull requests, not from the raw
+commits reachable through a merge. A pull request therefore appears once under
+**What's Changed**, even when its branch contains multiple Conventional Commits.
+The pull request title is the release-note text and links back to the pull
+request.
+
 ## Automated release train
 
 Release Please maintains one release pull request against `master`. Every Monday

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,62 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "changelog-type": "github",
   "include-component-in-tag": false,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "last-release-sha": "516452b051e17b5bad06e6973787ab01bbd2f505",
-  "changelog-sections": [
-    {
-      "type": "feat",
-      "section": "Features",
-      "hidden": false
-    },
-    {
-      "type": "fix",
-      "section": "Bug Fixes",
-      "hidden": false
-    },
-    {
-      "type": "perf",
-      "section": "Performance Improvements",
-      "hidden": false
-    },
-    {
-      "type": "revert",
-      "section": "Reverts",
-      "hidden": false
-    },
-    {
-      "type": "docs",
-      "section": "Documentation",
-      "hidden": true
-    },
-    {
-      "type": "refactor",
-      "section": "Code Refactoring",
-      "hidden": true
-    },
-    {
-      "type": "test",
-      "section": "Tests",
-      "hidden": true
-    },
-    {
-      "type": "build",
-      "section": "Build System",
-      "hidden": true
-    },
-    {
-      "type": "ci",
-      "section": "Continuous Integration",
-      "hidden": true
-    },
-    {
-      "type": "chore",
-      "section": "Miscellaneous Chores",
-      "hidden": true
-    }
-  ],
   "packages": {
     ".": {
       "component": "celox",


### PR DESCRIPTION
## Summary

- generate Release Please changelogs from GitHub merged pull requests
- remove commit-based changelog section configuration
- document pull-request-only release note behavior

## Root cause

With merge commits, Release Please's default changelog generator traverses both the merge commit representing the pull request and the Conventional Commits on its second-parent branch. This caused the same change to appear once for the PR and again for its underlying commit.

Using the GitHub changelog generator makes the merged pull request the release-note unit, so each PR appears once and links back to the PR.

## Validation

- `node --test scripts/*.test.mjs`
- parsed and asserted the Release Please JSON configuration
- `git diff --check`
- previewed GitHub generated notes for `v0.2.0...master`; PRs #578 and #579 appeared once each and no commit links were emitted
- pre-push hook: submodule check, `cargo fmt --all -- --check`, Biome, and `cargo check --workspace --locked`