### PR TITLE
perf(slt): reuse scheduler graph relations

### DIFF
--- a/crates/celox-analysis/src/dag_schedule.rs
+++ b/crates/celox-analysis/src/dag_schedule.rs
@@ -153,7 +153,11 @@ impl<'a> MappedUserRows<'a> {
             {
                 return Err(DagScheduleError::InvalidNode);
             }
-            validate_row(&users_by_external_node[external], local_by_external.len())?;
+            validate_mapped_user_row(
+                &users_by_external_node[external],
+                local_by_external,
+                external_by_local.len(),
+            )?;
         }
         Ok(Self {
             users_by_external_node,
@@ -504,6 +508,28 @@ fn validate_row(row: &[usize], node_count: usize) -> Result<(), DagScheduleError
             return Err(DagScheduleError::DuplicateDependency);
         }
         previous = Some(node);
+    }
+    Ok(())
+}
+
+fn validate_mapped_user_row(
+    row: &[usize],
+    local_by_external: &[usize],
+    local_node_count: usize,
+) -> Result<(), DagScheduleError> {
+    let mut previous = None;
+    for &external in row {
+        if external >= local_by_external.len() {
+            return Err(DagScheduleError::InvalidNode);
+        }
+        if previous.is_some_and(|previous| previous >= external) {
+            return Err(DagScheduleError::DuplicateDependency);
+        }
+        let local = local_by_external[external];
+        if local != usize::MAX && local >= local_node_count {
+            return Err(DagScheduleError::InvalidNode);
+        }
+        previous = Some(external);
     }
     Ok(())
 }
@@ -865,6 +891,16 @@ mod tests {
             ),
             Err(DagScheduleError::UsersAreNotReverseDependencies)
         );
+    }
+
+    #[test]
+    fn mapped_rows_reject_an_out_of_range_reverse_map_entry() {
+        let users = vec![vec![1], vec![]];
+
+        assert!(matches!(
+            MappedUserRows::new(&users, &[0], &[0, 1]),
+            Err(DagScheduleError::InvalidNode)
+        ));
     }
 
     #[test]

--- a/crates/celox-analysis/src/dag_schedule.rs
+++ b/crates/celox-analysis/src/dag_schedule.rs
@@ -28,8 +28,158 @@ pub enum DagScheduleError {
     DuplicateDependency,
     DuplicateToken,
     ValueIsNotDependency,
+    UsersAreNotReverseDependencies,
     Cycle,
     ArithmeticOverflow,
+}
+
+trait NodeRows {
+    fn len(&self) -> usize;
+    fn row(&self, node: usize) -> &[usize];
+}
+
+struct LocalNodeRows<'a>(&'a [Vec<usize>]);
+
+impl NodeRows for LocalNodeRows<'_> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn row(&self, node: usize) -> &[usize] {
+        &self.0[node]
+    }
+}
+
+/// Borrow rows indexed by a larger graph through a local-to-external node map.
+///
+/// The row values themselves are not remapped. This is suitable for stable
+/// global IDs such as materialization tokens.
+#[derive(Clone, Copy)]
+pub struct MappedNodeRows<'a> {
+    rows_by_external_node: &'a [Vec<usize>],
+    external_by_local: &'a [usize],
+}
+
+impl<'a> MappedNodeRows<'a> {
+    pub fn new(
+        rows_by_external_node: &'a [Vec<usize>],
+        external_by_local: &'a [usize],
+    ) -> Result<Self, DagScheduleError> {
+        if external_by_local
+            .iter()
+            .any(|external| *external >= rows_by_external_node.len())
+        {
+            return Err(DagScheduleError::InvalidNode);
+        }
+        Ok(Self {
+            rows_by_external_node,
+            external_by_local,
+        })
+    }
+}
+
+impl NodeRows for MappedNodeRows<'_> {
+    fn len(&self) -> usize {
+        self.external_by_local.len()
+    }
+
+    fn row(&self, node: usize) -> &[usize] {
+        &self.rows_by_external_node[self.external_by_local[node]]
+    }
+}
+
+trait UserRows {
+    type Iter<'a>: Iterator<Item = usize>
+    where
+        Self: 'a;
+
+    fn len(&self) -> usize;
+    fn users(&self, node: usize) -> Self::Iter<'_>;
+}
+
+struct LocalUserRows<'a>(&'a [Vec<usize>]);
+
+impl UserRows for LocalUserRows<'_> {
+    type Iter<'a>
+        = std::iter::Copied<std::slice::Iter<'a, usize>>
+    where
+        Self: 'a;
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn users(&self, node: usize) -> Self::Iter<'_> {
+        self.0[node].iter().copied()
+    }
+}
+
+struct MappedUserRowsIter<'a> {
+    external_users: std::slice::Iter<'a, usize>,
+    local_by_external: &'a [usize],
+    definition: usize,
+}
+
+impl Iterator for MappedUserRowsIter<'_> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.external_users.find_map(|external| {
+            let local = self.local_by_external[*external];
+            (local != usize::MAX && local != self.definition).then_some(local)
+        })
+    }
+}
+
+/// Borrow successor rows from a larger graph and expose only users mapped into
+/// the current local DAG.
+#[derive(Clone, Copy)]
+pub struct MappedUserRows<'a> {
+    users_by_external_node: &'a [Vec<usize>],
+    external_by_local: &'a [usize],
+    local_by_external: &'a [usize],
+}
+
+impl<'a> MappedUserRows<'a> {
+    pub fn new(
+        users_by_external_node: &'a [Vec<usize>],
+        external_by_local: &'a [usize],
+        local_by_external: &'a [usize],
+    ) -> Result<Self, DagScheduleError> {
+        for (local, &external) in external_by_local.iter().enumerate() {
+            if external >= users_by_external_node.len()
+                || external >= local_by_external.len()
+                || local_by_external[external] != local
+            {
+                return Err(DagScheduleError::InvalidNode);
+            }
+            validate_row(&users_by_external_node[external], local_by_external.len())?;
+        }
+        Ok(Self {
+            users_by_external_node,
+            external_by_local,
+            local_by_external,
+        })
+    }
+}
+
+impl UserRows for MappedUserRows<'_> {
+    type Iter<'a>
+        = MappedUserRowsIter<'a>
+    where
+        Self: 'a;
+
+    fn len(&self) -> usize {
+        self.external_by_local.len()
+    }
+
+    fn users(&self, node: usize) -> Self::Iter<'_> {
+        MappedUserRowsIter {
+            external_users: self.users_by_external_node[self.external_by_local[node]].iter(),
+            local_by_external: self.local_by_external,
+            definition: node,
+        }
+    }
 }
 
 /// Return a deterministic forward order for one DAG.
@@ -57,38 +207,142 @@ pub fn schedule_min_live_values_and_tokens(
     tokens_by_node: &[Vec<usize>],
     token_weights: &[usize],
 ) -> Result<Vec<usize>, DagScheduleError> {
+    let tokens_by_node = LocalNodeRows(tokens_by_node);
+    let token_users = validate_inputs(
+        dependencies,
+        value_dependencies,
+        &tokens_by_node,
+        token_weights,
+    )?;
     let node_count = dependencies.len();
-    if value_dependencies.len() != node_count || tokens_by_node.len() != node_count {
-        return Err(DagScheduleError::Shape);
-    }
-
     let mut successors = vec![Vec::<usize>::new(); node_count];
-    let mut indegree = vec![0usize; node_count];
     let mut value_users = vec![Vec::<usize>::new(); node_count];
-    let mut token_users = vec![Vec::<usize>::new(); token_weights.len()];
     for user in 0..node_count {
-        validate_row(&dependencies[user], node_count)?;
-        validate_row(&value_dependencies[user], node_count)?;
-        validate_token_row(&tokens_by_node[user], token_weights.len())?;
-        if value_dependencies[user]
-            .iter()
-            .any(|value| dependencies[user].binary_search(value).is_err())
-        {
-            return Err(DagScheduleError::ValueIsNotDependency);
-        }
-        indegree[user] = dependencies[user].len();
         for &definition in &dependencies[user] {
             successors[definition].push(user);
         }
         for &definition in &value_dependencies[user] {
             value_users[definition].push(user);
         }
-        for &token in &tokens_by_node[user] {
+    }
+    schedule_with_users(
+        dependencies,
+        value_dependencies,
+        &tokens_by_node,
+        token_weights,
+        &token_users,
+        &LocalUserRows(&successors),
+        &LocalUserRows(&value_users),
+    )
+}
+
+/// Schedule a local DAG while borrowing reverse-edge and token rows from a
+/// larger graph.
+///
+/// This avoids reconstructing successor and value-user adjacency when the
+/// caller already owns those relations. The mapped user rows must be the exact
+/// reverse of `dependencies` and `value_dependencies`, respectively.
+pub fn schedule_min_live_values_and_tokens_with_mapped_rows(
+    dependencies: &[Vec<usize>],
+    value_dependencies: &[Vec<usize>],
+    tokens_by_node: MappedNodeRows<'_>,
+    token_weights: &[usize],
+    successors: MappedUserRows<'_>,
+    value_users: MappedUserRows<'_>,
+) -> Result<Vec<usize>, DagScheduleError> {
+    let token_users = validate_inputs(
+        dependencies,
+        value_dependencies,
+        &tokens_by_node,
+        token_weights,
+    )?;
+    validate_reverse_users(&successors, dependencies)?;
+    validate_reverse_users(&value_users, value_dependencies)?;
+    schedule_with_users(
+        dependencies,
+        value_dependencies,
+        &tokens_by_node,
+        token_weights,
+        &token_users,
+        &successors,
+        &value_users,
+    )
+}
+
+fn validate_inputs<T: NodeRows>(
+    dependencies: &[Vec<usize>],
+    value_dependencies: &[Vec<usize>],
+    tokens_by_node: &T,
+    token_weights: &[usize],
+) -> Result<Vec<Vec<usize>>, DagScheduleError> {
+    let node_count = dependencies.len();
+    if value_dependencies.len() != node_count || tokens_by_node.len() != node_count {
+        return Err(DagScheduleError::Shape);
+    }
+    let mut token_users = vec![Vec::<usize>::new(); token_weights.len()];
+    for user in 0..node_count {
+        validate_row(&dependencies[user], node_count)?;
+        validate_row(&value_dependencies[user], node_count)?;
+        validate_token_row(tokens_by_node.row(user), token_weights.len())?;
+        if value_dependencies[user]
+            .iter()
+            .any(|value| dependencies[user].binary_search(value).is_err())
+        {
+            return Err(DagScheduleError::ValueIsNotDependency);
+        }
+        for &token in tokens_by_node.row(user) {
             token_users[token].push(user);
         }
     }
+    Ok(token_users)
+}
 
-    let (topological, entry_depth) = topological_order(&successors, indegree)?;
+fn validate_reverse_users<U: UserRows>(
+    users: &U,
+    dependencies: &[Vec<usize>],
+) -> Result<(), DagScheduleError> {
+    if users.len() != dependencies.len() {
+        return Err(DagScheduleError::Shape);
+    }
+    let expected_edges = dependencies.iter().try_fold(0usize, |total, row| {
+        total
+            .checked_add(row.len())
+            .ok_or(DagScheduleError::ArithmeticOverflow)
+    })?;
+    let mut actual_edges = 0usize;
+    for definition in 0..users.len() {
+        for user in users.users(definition) {
+            if dependencies[user].binary_search(&definition).is_err() {
+                return Err(DagScheduleError::UsersAreNotReverseDependencies);
+            }
+            actual_edges = actual_edges
+                .checked_add(1)
+                .ok_or(DagScheduleError::ArithmeticOverflow)?;
+        }
+    }
+    if actual_edges != expected_edges {
+        return Err(DagScheduleError::UsersAreNotReverseDependencies);
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn schedule_with_users<T: NodeRows, S: UserRows, V: UserRows>(
+    dependencies: &[Vec<usize>],
+    value_dependencies: &[Vec<usize>],
+    tokens_by_node: &T,
+    token_weights: &[usize],
+    token_users: &[Vec<usize>],
+    successors: &S,
+    value_users: &V,
+) -> Result<Vec<usize>, DagScheduleError> {
+    let node_count = dependencies.len();
+    if successors.len() != node_count || value_users.len() != node_count {
+        return Err(DagScheduleError::Shape);
+    }
+    let indegree = dependencies.iter().map(Vec::len).collect();
+
+    let (topological, entry_depth) = topological_order(successors, indegree)?;
     let mut exit_depth = vec![1usize; node_count];
     for &node in topological.iter().rev() {
         let successor_depth = exit_depth[node]
@@ -99,7 +353,9 @@ pub fn schedule_min_live_values_and_tokens(
         }
     }
 
-    let mut unscheduled_users = successors.iter().map(Vec::len).collect::<Vec<_>>();
+    let mut unscheduled_users = (0..node_count)
+        .map(|node| successors.users(node).count())
+        .collect::<Vec<_>>();
     let mut live = vec![false; node_count];
     let mut remaining_token_users = token_users.iter().map(Vec::len).collect::<Vec<_>>();
     let mut live_tokens = vec![false; token_weights.len()];
@@ -142,7 +398,7 @@ pub fn schedule_min_live_values_and_tokens(
             update_for_value(
                 selected,
                 1,
-                &value_users,
+                value_users,
                 &entry_depth,
                 &exit_depth,
                 &mut deltas,
@@ -156,7 +412,7 @@ pub fn schedule_min_live_values_and_tokens(
                 update_for_value(
                     definition,
                     -1,
-                    &value_users,
+                    value_users,
                     &entry_depth,
                     &exit_depth,
                     &mut deltas,
@@ -165,7 +421,7 @@ pub fn schedule_min_live_values_and_tokens(
                 )?;
             }
         }
-        for &token in &tokens_by_node[selected] {
+        for &token in tokens_by_node.row(selected) {
             let before = remaining_token_users[token];
             remaining_token_users[token] = before
                 .checked_sub(1)
@@ -184,7 +440,7 @@ pub fn schedule_min_live_values_and_tokens(
                 update_for_token(
                     token,
                     adjustment,
-                    &token_users,
+                    token_users,
                     &entry_depth,
                     &exit_depth,
                     &mut deltas,
@@ -195,7 +451,7 @@ pub fn schedule_min_live_values_and_tokens(
                 update_for_token(
                     token,
                     -weight,
-                    &token_users,
+                    token_users,
                     &entry_depth,
                     &exit_depth,
                     &mut deltas,
@@ -266,8 +522,8 @@ fn validate_token_row(row: &[usize], token_count: usize) -> Result<(), DagSchedu
     Ok(())
 }
 
-fn topological_order(
-    successors: &[Vec<usize>],
+fn topological_order<U: UserRows>(
+    successors: &U,
     mut indegree: Vec<usize>,
 ) -> Result<(Vec<usize>, Vec<usize>), DagScheduleError> {
     let mut ready = BTreeSet::new();
@@ -283,7 +539,7 @@ fn topological_order(
         let next_depth = entry_depth[node]
             .checked_add(1)
             .ok_or(DagScheduleError::ArithmeticOverflow)?;
-        for &successor in &successors[node] {
+        for successor in successors.users(node) {
             entry_depth[successor] = entry_depth[successor].max(next_depth);
             indegree[successor] = indegree[successor]
                 .checked_sub(1)
@@ -300,11 +556,11 @@ fn topological_order(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn insert_ready(
+fn insert_ready<T: NodeRows>(
     node: usize,
     dependencies: &[Vec<usize>],
     value_dependencies: &[Vec<usize>],
-    tokens_by_node: &[Vec<usize>],
+    tokens_by_node: &T,
     token_weights: &[usize],
     live: &[bool],
     live_tokens: &[bool],
@@ -331,7 +587,8 @@ fn insert_ready(
                 .and_then(|removed| missing.checked_sub(removed))
         })
         .ok_or(DagScheduleError::ArithmeticOverflow)?;
-    let token_delta = tokens_by_node[node]
+    let token_delta = tokens_by_node
+        .row(node)
         .iter()
         .try_fold(0isize, |delta, &token| {
             let contribution = if !live_tokens[token] && remaining_token_users[token] > 1 {
@@ -419,21 +676,17 @@ fn remove_ready(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn update_for_value(
+fn update_for_value<U: UserRows>(
     value: usize,
     adjustment: isize,
-    value_users: &[Vec<usize>],
+    value_users: &U,
     entry_depth: &[usize],
     exit_depth: &[usize],
     deltas: &mut [isize],
     present: &[bool],
     ready: &mut BTreeSet<(isize, Reverse<usize>, Reverse<usize>, Reverse<usize>)>,
 ) -> Result<(), DagScheduleError> {
-    for candidate in value_users[value]
-        .iter()
-        .copied()
-        .chain(std::iter::once(value))
-    {
+    for candidate in value_users.users(value).chain(std::iter::once(value)) {
         if !present[candidate] {
             continue;
         }
@@ -558,6 +811,60 @@ mod tests {
             vec![0, 1, 2]
         );
         assert_eq!(maximum_live(&[0, 1, 2], &values), 0);
+    }
+
+    #[test]
+    fn mapped_rows_match_owned_reverse_relations() {
+        let dependencies = vec![vec![], vec![0], vec![0, 1]];
+        let values = dependencies.clone();
+        let tokens = vec![vec![0], vec![0, 1], vec![1]];
+        let expected =
+            schedule_min_live_values_and_tokens(&dependencies, &values, &tokens, &[2, 1]).unwrap();
+
+        let external_by_local = vec![4, 1, 3];
+        let local_by_external = vec![usize::MAX, 1, usize::MAX, 2, 0];
+        let mut external_users = vec![Vec::new(); 5];
+        external_users[1] = vec![3];
+        external_users[4] = vec![1, 3];
+        let mut external_tokens = vec![Vec::new(); 5];
+        external_tokens[4] = vec![0];
+        external_tokens[1] = vec![0, 1];
+        external_tokens[3] = vec![1];
+
+        let actual = schedule_min_live_values_and_tokens_with_mapped_rows(
+            &dependencies,
+            &values,
+            MappedNodeRows::new(&external_tokens, &external_by_local).unwrap(),
+            &[2, 1],
+            MappedUserRows::new(&external_users, &external_by_local, &local_by_external).unwrap(),
+            MappedUserRows::new(&external_users, &external_by_local, &local_by_external).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn mapped_rows_reject_an_incomplete_reverse_relation() {
+        let dependencies = vec![vec![], vec![0]];
+        let external_by_local = vec![0, 1];
+        let local_by_external = vec![0, 1];
+        let missing_users = vec![Vec::new(), Vec::new()];
+        let empty_tokens = vec![Vec::new(), Vec::new()];
+        let users =
+            MappedUserRows::new(&missing_users, &external_by_local, &local_by_external).unwrap();
+
+        assert_eq!(
+            schedule_min_live_values_and_tokens_with_mapped_rows(
+                &dependencies,
+                &dependencies,
+                MappedNodeRows::new(&empty_tokens, &external_by_local).unwrap(),
+                &[],
+                users,
+                users,
+            ),
+            Err(DagScheduleError::UsersAreNotReverseDependencies)
+        );
     }
 
     #[test]

--- a/crates/celox-analysis/src/dag_schedule.rs
+++ b/crates/celox-analysis/src/dag_schedule.rs
@@ -155,8 +155,8 @@ impl<'a> MappedUserRows<'a> {
             }
             validate_mapped_user_row(
                 &users_by_external_node[external],
+                external_by_local,
                 local_by_external,
-                external_by_local.len(),
             )?;
         }
         Ok(Self {
@@ -514,8 +514,8 @@ fn validate_row(row: &[usize], node_count: usize) -> Result<(), DagScheduleError
 
 fn validate_mapped_user_row(
     row: &[usize],
+    external_by_local: &[usize],
     local_by_external: &[usize],
-    local_node_count: usize,
 ) -> Result<(), DagScheduleError> {
     let mut previous = None;
     for &external in row {
@@ -526,7 +526,9 @@ fn validate_mapped_user_row(
             return Err(DagScheduleError::DuplicateDependency);
         }
         let local = local_by_external[external];
-        if local != usize::MAX && local >= local_node_count {
+        if local != usize::MAX
+            && (local >= external_by_local.len() || external_by_local[local] != external)
+        {
             return Err(DagScheduleError::InvalidNode);
         }
         previous = Some(external);
@@ -899,6 +901,16 @@ mod tests {
 
         assert!(matches!(
             MappedUserRows::new(&users, &[0], &[0, 1]),
+            Err(DagScheduleError::InvalidNode)
+        ));
+    }
+
+    #[test]
+    fn mapped_rows_reject_an_alias_in_the_reverse_map() {
+        let users = vec![vec![1], vec![]];
+
+        assert!(matches!(
+            MappedUserRows::new(&users, &[0], &[0, 0]),
             Err(DagScheduleError::InvalidNode)
         ));
     }

--- a/crates/celox-analysis/src/dag_schedule.rs
+++ b/crates/celox-analysis/src/dag_schedule.rs
@@ -131,7 +131,6 @@ impl GraphRows for LocalGraphRows<'_> {
 struct MappedGraphRowsIter<'a> {
     external_nodes: std::slice::Iter<'a, usize>,
     local_by_external: &'a [usize],
-    row: usize,
 }
 
 impl Iterator for MappedGraphRowsIter<'_> {
@@ -140,7 +139,7 @@ impl Iterator for MappedGraphRowsIter<'_> {
     fn next(&mut self) -> Option<Self::Item> {
         self.external_nodes.find_map(|external| {
             let local = self.local_by_external[*external];
-            (local != usize::MAX && local != self.row).then_some(local)
+            (local != usize::MAX).then_some(local)
         })
     }
 }
@@ -195,15 +194,13 @@ impl GraphRows for MappedGraphRows<'_> {
         MappedGraphRowsIter {
             external_nodes: self.rows_by_external_node[self.external_by_local[row]].iter(),
             local_by_external: self.local_by_external,
-            row,
         }
     }
 
     fn contains(&self, row: usize, node: usize) -> bool {
-        row != node
-            && self.rows_by_external_node[self.external_by_local[row]]
-                .binary_search(&self.external_by_local[node])
-                .is_ok()
+        self.rows_by_external_node[self.external_by_local[row]]
+            .binary_search(&self.external_by_local[node])
+            .is_ok()
     }
 }
 
@@ -953,6 +950,35 @@ mod tests {
             MappedGraphRows::new(&users, &[0], &[0, 0]),
             Err(DagScheduleError::InvalidNode)
         ));
+    }
+
+    #[test]
+    fn mapped_rows_preserve_self_edges_for_cycle_detection() {
+        let dependencies = vec![vec![0]];
+        let values = vec![vec![]];
+        let tokens = vec![vec![]];
+        let external_by_local = [0];
+        let local_by_external = [0];
+        let mapped_dependencies =
+            MappedGraphRows::new(&dependencies, &external_by_local, &local_by_external).unwrap();
+        let mapped_values =
+            MappedGraphRows::new(&values, &external_by_local, &local_by_external).unwrap();
+
+        assert_eq!(
+            schedule_min_live_values_and_tokens(&dependencies, &values, &tokens, &[]),
+            Err(DagScheduleError::Cycle)
+        );
+        assert_eq!(
+            schedule_min_live_values_and_tokens_with_mapped_rows(
+                mapped_dependencies,
+                mapped_values,
+                MappedNodeRows::new(&tokens, &external_by_local).unwrap(),
+                &[],
+                mapped_dependencies,
+                mapped_values,
+            ),
+            Err(DagScheduleError::Cycle)
+        );
     }
 
     #[test]

--- a/crates/celox-analysis/src/dag_schedule.rs
+++ b/crates/celox-analysis/src/dag_schedule.rs
@@ -88,18 +88,28 @@ impl NodeRows for MappedNodeRows<'_> {
     }
 }
 
-trait UserRows {
+trait GraphRows {
     type Iter<'a>: Iterator<Item = usize>
     where
         Self: 'a;
 
     fn len(&self) -> usize;
-    fn users(&self, node: usize) -> Self::Iter<'_>;
+    fn nodes(&self, row: usize) -> Self::Iter<'_>;
+    fn contains(&self, row: usize, node: usize) -> bool;
 }
 
-struct LocalUserRows<'a>(&'a [Vec<usize>]);
+struct LocalGraphRows<'a>(&'a [Vec<usize>]);
 
-impl UserRows for LocalUserRows<'_> {
+impl<'a> LocalGraphRows<'a> {
+    fn new(rows: &'a [Vec<usize>]) -> Result<Self, DagScheduleError> {
+        for row in rows {
+            validate_row(row, rows.len())?;
+        }
+        Ok(Self(rows))
+    }
+}
+
+impl GraphRows for LocalGraphRows<'_> {
     type Iter<'a>
         = std::iter::Copied<std::slice::Iter<'a, usize>>
     where
@@ -109,67 +119,71 @@ impl UserRows for LocalUserRows<'_> {
         self.0.len()
     }
 
-    fn users(&self, node: usize) -> Self::Iter<'_> {
-        self.0[node].iter().copied()
+    fn nodes(&self, row: usize) -> Self::Iter<'_> {
+        self.0[row].iter().copied()
+    }
+
+    fn contains(&self, row: usize, node: usize) -> bool {
+        self.0[row].binary_search(&node).is_ok()
     }
 }
 
-struct MappedUserRowsIter<'a> {
-    external_users: std::slice::Iter<'a, usize>,
+struct MappedGraphRowsIter<'a> {
+    external_nodes: std::slice::Iter<'a, usize>,
     local_by_external: &'a [usize],
-    definition: usize,
+    row: usize,
 }
 
-impl Iterator for MappedUserRowsIter<'_> {
+impl Iterator for MappedGraphRowsIter<'_> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.external_users.find_map(|external| {
+        self.external_nodes.find_map(|external| {
             let local = self.local_by_external[*external];
-            (local != usize::MAX && local != self.definition).then_some(local)
+            (local != usize::MAX && local != self.row).then_some(local)
         })
     }
 }
 
-/// Borrow successor rows from a larger graph and expose only users mapped into
+/// Borrow adjacency rows from a larger graph and expose only nodes mapped into
 /// the current local DAG.
 #[derive(Clone, Copy)]
-pub struct MappedUserRows<'a> {
-    users_by_external_node: &'a [Vec<usize>],
+pub struct MappedGraphRows<'a> {
+    rows_by_external_node: &'a [Vec<usize>],
     external_by_local: &'a [usize],
     local_by_external: &'a [usize],
 }
 
-impl<'a> MappedUserRows<'a> {
+impl<'a> MappedGraphRows<'a> {
     pub fn new(
-        users_by_external_node: &'a [Vec<usize>],
+        rows_by_external_node: &'a [Vec<usize>],
         external_by_local: &'a [usize],
         local_by_external: &'a [usize],
     ) -> Result<Self, DagScheduleError> {
         for (local, &external) in external_by_local.iter().enumerate() {
-            if external >= users_by_external_node.len()
+            if external >= rows_by_external_node.len()
                 || external >= local_by_external.len()
                 || local_by_external[external] != local
             {
                 return Err(DagScheduleError::InvalidNode);
             }
             validate_mapped_user_row(
-                &users_by_external_node[external],
+                &rows_by_external_node[external],
                 external_by_local,
                 local_by_external,
             )?;
         }
         Ok(Self {
-            users_by_external_node,
+            rows_by_external_node,
             external_by_local,
             local_by_external,
         })
     }
 }
 
-impl UserRows for MappedUserRows<'_> {
+impl GraphRows for MappedGraphRows<'_> {
     type Iter<'a>
-        = MappedUserRowsIter<'a>
+        = MappedGraphRowsIter<'a>
     where
         Self: 'a;
 
@@ -177,12 +191,19 @@ impl UserRows for MappedUserRows<'_> {
         self.external_by_local.len()
     }
 
-    fn users(&self, node: usize) -> Self::Iter<'_> {
-        MappedUserRowsIter {
-            external_users: self.users_by_external_node[self.external_by_local[node]].iter(),
+    fn nodes(&self, row: usize) -> Self::Iter<'_> {
+        MappedGraphRowsIter {
+            external_nodes: self.rows_by_external_node[self.external_by_local[row]].iter(),
             local_by_external: self.local_by_external,
-            definition: node,
+            row,
         }
+    }
+
+    fn contains(&self, row: usize, node: usize) -> bool {
+        row != node
+            && self.rows_by_external_node[self.external_by_local[row]]
+                .binary_search(&self.external_by_local[node])
+                .is_ok()
     }
 }
 
@@ -211,10 +232,12 @@ pub fn schedule_min_live_values_and_tokens(
     tokens_by_node: &[Vec<usize>],
     token_weights: &[usize],
 ) -> Result<Vec<usize>, DagScheduleError> {
+    let dependencies = LocalGraphRows::new(dependencies)?;
+    let value_dependencies = LocalGraphRows::new(value_dependencies)?;
     let tokens_by_node = LocalNodeRows(tokens_by_node);
     let token_users = validate_inputs(
-        dependencies,
-        value_dependencies,
+        &dependencies,
+        &value_dependencies,
         &tokens_by_node,
         token_weights,
     )?;
@@ -222,49 +245,18 @@ pub fn schedule_min_live_values_and_tokens(
     let mut successors = vec![Vec::<usize>::new(); node_count];
     let mut value_users = vec![Vec::<usize>::new(); node_count];
     for user in 0..node_count {
-        for &definition in &dependencies[user] {
+        for definition in dependencies.nodes(user) {
             successors[definition].push(user);
         }
-        for &definition in &value_dependencies[user] {
+        for definition in value_dependencies.nodes(user) {
             value_users[definition].push(user);
         }
     }
+    let successors = LocalGraphRows::new(&successors)?;
+    let value_users = LocalGraphRows::new(&value_users)?;
     schedule_with_users(
-        dependencies,
-        value_dependencies,
-        &tokens_by_node,
-        token_weights,
-        &token_users,
-        &LocalUserRows(&successors),
-        &LocalUserRows(&value_users),
-    )
-}
-
-/// Schedule a local DAG while borrowing reverse-edge and token rows from a
-/// larger graph.
-///
-/// This avoids reconstructing successor and value-user adjacency when the
-/// caller already owns those relations. The mapped user rows must be the exact
-/// reverse of `dependencies` and `value_dependencies`, respectively.
-pub fn schedule_min_live_values_and_tokens_with_mapped_rows(
-    dependencies: &[Vec<usize>],
-    value_dependencies: &[Vec<usize>],
-    tokens_by_node: MappedNodeRows<'_>,
-    token_weights: &[usize],
-    successors: MappedUserRows<'_>,
-    value_users: MappedUserRows<'_>,
-) -> Result<Vec<usize>, DagScheduleError> {
-    let token_users = validate_inputs(
-        dependencies,
-        value_dependencies,
-        &tokens_by_node,
-        token_weights,
-    )?;
-    validate_reverse_users(&successors, dependencies)?;
-    validate_reverse_users(&value_users, value_dependencies)?;
-    schedule_with_users(
-        dependencies,
-        value_dependencies,
+        &dependencies,
+        &value_dependencies,
         &tokens_by_node,
         token_weights,
         &token_users,
@@ -273,9 +265,42 @@ pub fn schedule_min_live_values_and_tokens_with_mapped_rows(
     )
 }
 
-fn validate_inputs<T: NodeRows>(
-    dependencies: &[Vec<usize>],
-    value_dependencies: &[Vec<usize>],
+/// Schedule a local DAG while borrowing dependency, user, and token rows from
+/// a larger graph.
+///
+/// This avoids reconstructing either direction of the hard- and value-edge
+/// adjacency. The mapped user rows must be the exact reverse of the mapped
+/// dependency rows.
+pub fn schedule_min_live_values_and_tokens_with_mapped_rows(
+    dependencies: MappedGraphRows<'_>,
+    value_dependencies: MappedGraphRows<'_>,
+    tokens_by_node: MappedNodeRows<'_>,
+    token_weights: &[usize],
+    successors: MappedGraphRows<'_>,
+    value_users: MappedGraphRows<'_>,
+) -> Result<Vec<usize>, DagScheduleError> {
+    let token_users = validate_inputs(
+        &dependencies,
+        &value_dependencies,
+        &tokens_by_node,
+        token_weights,
+    )?;
+    validate_reverse_users(&successors, &dependencies)?;
+    validate_reverse_users(&value_users, &value_dependencies)?;
+    schedule_with_users(
+        &dependencies,
+        &value_dependencies,
+        &tokens_by_node,
+        token_weights,
+        &token_users,
+        &successors,
+        &value_users,
+    )
+}
+
+fn validate_inputs<D: GraphRows, V: GraphRows, T: NodeRows>(
+    dependencies: &D,
+    value_dependencies: &V,
     tokens_by_node: &T,
     token_weights: &[usize],
 ) -> Result<Vec<Vec<usize>>, DagScheduleError> {
@@ -285,12 +310,10 @@ fn validate_inputs<T: NodeRows>(
     }
     let mut token_users = vec![Vec::<usize>::new(); token_weights.len()];
     for user in 0..node_count {
-        validate_row(&dependencies[user], node_count)?;
-        validate_row(&value_dependencies[user], node_count)?;
         validate_token_row(tokens_by_node.row(user), token_weights.len())?;
-        if value_dependencies[user]
-            .iter()
-            .any(|value| dependencies[user].binary_search(value).is_err())
+        if value_dependencies
+            .nodes(user)
+            .any(|value| !dependencies.contains(user, value))
         {
             return Err(DagScheduleError::ValueIsNotDependency);
         }
@@ -301,22 +324,22 @@ fn validate_inputs<T: NodeRows>(
     Ok(token_users)
 }
 
-fn validate_reverse_users<U: UserRows>(
+fn validate_reverse_users<U: GraphRows, D: GraphRows>(
     users: &U,
-    dependencies: &[Vec<usize>],
+    dependencies: &D,
 ) -> Result<(), DagScheduleError> {
     if users.len() != dependencies.len() {
         return Err(DagScheduleError::Shape);
     }
-    let expected_edges = dependencies.iter().try_fold(0usize, |total, row| {
+    let expected_edges = (0..dependencies.len()).try_fold(0usize, |total, row| {
         total
-            .checked_add(row.len())
+            .checked_add(dependencies.nodes(row).count())
             .ok_or(DagScheduleError::ArithmeticOverflow)
     })?;
     let mut actual_edges = 0usize;
     for definition in 0..users.len() {
-        for user in users.users(definition) {
-            if dependencies[user].binary_search(&definition).is_err() {
+        for user in users.nodes(definition) {
+            if !dependencies.contains(user, definition) {
                 return Err(DagScheduleError::UsersAreNotReverseDependencies);
             }
             actual_edges = actual_edges
@@ -331,20 +354,22 @@ fn validate_reverse_users<U: UserRows>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn schedule_with_users<T: NodeRows, S: UserRows, V: UserRows>(
-    dependencies: &[Vec<usize>],
-    value_dependencies: &[Vec<usize>],
+fn schedule_with_users<D: GraphRows, V: GraphRows, T: NodeRows, S: GraphRows, U: GraphRows>(
+    dependencies: &D,
+    value_dependencies: &V,
     tokens_by_node: &T,
     token_weights: &[usize],
     token_users: &[Vec<usize>],
     successors: &S,
-    value_users: &V,
+    value_users: &U,
 ) -> Result<Vec<usize>, DagScheduleError> {
     let node_count = dependencies.len();
     if successors.len() != node_count || value_users.len() != node_count {
         return Err(DagScheduleError::Shape);
     }
-    let indegree = dependencies.iter().map(Vec::len).collect();
+    let indegree = (0..node_count)
+        .map(|node| dependencies.nodes(node).count())
+        .collect();
 
     let (topological, entry_depth) = topological_order(successors, indegree)?;
     let mut exit_depth = vec![1usize; node_count];
@@ -352,13 +377,13 @@ fn schedule_with_users<T: NodeRows, S: UserRows, V: UserRows>(
         let successor_depth = exit_depth[node]
             .checked_add(1)
             .ok_or(DagScheduleError::ArithmeticOverflow)?;
-        for &dependency in &dependencies[node] {
+        for dependency in dependencies.nodes(node) {
             exit_depth[dependency] = exit_depth[dependency].max(successor_depth);
         }
     }
 
     let mut unscheduled_users = (0..node_count)
-        .map(|node| successors.users(node).count())
+        .map(|node| successors.nodes(node).count())
         .collect::<Vec<_>>();
     let mut live = vec![false; node_count];
     let mut remaining_token_users = token_users.iter().map(Vec::len).collect::<Vec<_>>();
@@ -410,7 +435,7 @@ fn schedule_with_users<T: NodeRows, S: UserRows, V: UserRows>(
                 &mut ready,
             )?;
         }
-        for &definition in &value_dependencies[selected] {
+        for definition in value_dependencies.nodes(selected) {
             if !live[definition] {
                 live[definition] = true;
                 update_for_value(
@@ -466,7 +491,7 @@ fn schedule_with_users<T: NodeRows, S: UserRows, V: UserRows>(
                 live_tokens[token] = false;
             }
         }
-        for &dependency in &dependencies[selected] {
+        for dependency in dependencies.nodes(selected) {
             unscheduled_users[dependency] = unscheduled_users[dependency]
                 .checked_sub(1)
                 .ok_or(DagScheduleError::ArithmeticOverflow)?;
@@ -550,7 +575,7 @@ fn validate_token_row(row: &[usize], token_count: usize) -> Result<(), DagSchedu
     Ok(())
 }
 
-fn topological_order<U: UserRows>(
+fn topological_order<U: GraphRows>(
     successors: &U,
     mut indegree: Vec<usize>,
 ) -> Result<(Vec<usize>, Vec<usize>), DagScheduleError> {
@@ -567,7 +592,7 @@ fn topological_order<U: UserRows>(
         let next_depth = entry_depth[node]
             .checked_add(1)
             .ok_or(DagScheduleError::ArithmeticOverflow)?;
-        for successor in successors.users(node) {
+        for successor in successors.nodes(node) {
             entry_depth[successor] = entry_depth[successor].max(next_depth);
             indegree[successor] = indegree[successor]
                 .checked_sub(1)
@@ -584,10 +609,10 @@ fn topological_order<U: UserRows>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn insert_ready<T: NodeRows>(
+fn insert_ready<D: GraphRows, V: GraphRows, T: NodeRows>(
     node: usize,
-    dependencies: &[Vec<usize>],
-    value_dependencies: &[Vec<usize>],
+    dependencies: &D,
+    value_dependencies: &V,
     tokens_by_node: &T,
     token_weights: &[usize],
     live: &[bool],
@@ -602,9 +627,9 @@ fn insert_ready<T: NodeRows>(
     if present[node] {
         return Err(DagScheduleError::DuplicateDependency);
     }
-    let missing = value_dependencies[node]
-        .iter()
-        .filter(|definition| !live[**definition])
+    let missing = value_dependencies
+        .nodes(node)
+        .filter(|definition| !live[*definition])
         .count();
     let removed = usize::from(live[node]);
     let value_delta = isize::try_from(missing)
@@ -636,9 +661,9 @@ fn insert_ready<T: NodeRows>(
         .checked_add(token_delta)
         .ok_or(DagScheduleError::ArithmeticOverflow)?;
     debug_assert!(
-        value_dependencies[node]
-            .iter()
-            .all(|value| dependencies[node].binary_search(value).is_ok())
+        value_dependencies
+            .nodes(node)
+            .all(|value| dependencies.contains(node, value))
     );
     deltas[node] = delta;
     present[node] = true;
@@ -704,7 +729,7 @@ fn remove_ready(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn update_for_value<U: UserRows>(
+fn update_for_value<U: GraphRows>(
     value: usize,
     adjustment: isize,
     value_users: &U,
@@ -714,7 +739,7 @@ fn update_for_value<U: UserRows>(
     present: &[bool],
     ready: &mut BTreeSet<(isize, Reverse<usize>, Reverse<usize>, Reverse<usize>)>,
 ) -> Result<(), DagScheduleError> {
-    for candidate in value_users.users(value).chain(std::iter::once(value)) {
+    for candidate in value_users.nodes(value).chain(std::iter::once(value)) {
         if !present[candidate] {
             continue;
         }
@@ -854,18 +879,31 @@ mod tests {
         let mut external_users = vec![Vec::new(); 5];
         external_users[1] = vec![3];
         external_users[4] = vec![1, 3];
+        let mut external_dependencies = vec![Vec::new(); 5];
+        external_dependencies[1] = vec![4];
+        external_dependencies[3] = vec![1, 4];
         let mut external_tokens = vec![Vec::new(); 5];
         external_tokens[4] = vec![0];
         external_tokens[1] = vec![0, 1];
         external_tokens[3] = vec![1];
 
         let actual = schedule_min_live_values_and_tokens_with_mapped_rows(
-            &dependencies,
-            &values,
+            MappedGraphRows::new(
+                &external_dependencies,
+                &external_by_local,
+                &local_by_external,
+            )
+            .unwrap(),
+            MappedGraphRows::new(
+                &external_dependencies,
+                &external_by_local,
+                &local_by_external,
+            )
+            .unwrap(),
             MappedNodeRows::new(&external_tokens, &external_by_local).unwrap(),
             &[2, 1],
-            MappedUserRows::new(&external_users, &external_by_local, &local_by_external).unwrap(),
-            MappedUserRows::new(&external_users, &external_by_local, &local_by_external).unwrap(),
+            MappedGraphRows::new(&external_users, &external_by_local, &local_by_external).unwrap(),
+            MappedGraphRows::new(&external_users, &external_by_local, &local_by_external).unwrap(),
         )
         .unwrap();
 
@@ -879,13 +917,15 @@ mod tests {
         let local_by_external = vec![0, 1];
         let missing_users = vec![Vec::new(), Vec::new()];
         let empty_tokens = vec![Vec::new(), Vec::new()];
+        let dependencies =
+            MappedGraphRows::new(&dependencies, &external_by_local, &local_by_external).unwrap();
         let users =
-            MappedUserRows::new(&missing_users, &external_by_local, &local_by_external).unwrap();
+            MappedGraphRows::new(&missing_users, &external_by_local, &local_by_external).unwrap();
 
         assert_eq!(
             schedule_min_live_values_and_tokens_with_mapped_rows(
-                &dependencies,
-                &dependencies,
+                dependencies,
+                dependencies,
                 MappedNodeRows::new(&empty_tokens, &external_by_local).unwrap(),
                 &[],
                 users,
@@ -900,7 +940,7 @@ mod tests {
         let users = vec![vec![1], vec![]];
 
         assert!(matches!(
-            MappedUserRows::new(&users, &[0], &[0, 1]),
+            MappedGraphRows::new(&users, &[0], &[0, 1]),
             Err(DagScheduleError::InvalidNode)
         ));
     }
@@ -910,7 +950,7 @@ mod tests {
         let users = vec![vec![1], vec![]];
 
         assert!(matches!(
-            MappedUserRows::new(&users, &[0], &[0, 0]),
+            MappedGraphRows::new(&users, &[0], &[0, 0]),
             Err(DagScheduleError::InvalidNode)
         ));
     }

--- a/crates/celox-slt/src/scheduler.rs
+++ b/crates/celox-slt/src/scheduler.rs
@@ -2,7 +2,7 @@ use crate::{
     HashMap, HashSet, LogicPath, LogicPathTarget, NodeId, SLTNode, SLTNodeArena, SLTNodeFactsError,
 };
 use celox_analysis::dag_schedule::{
-    MappedNodeRows, MappedUserRows, schedule_min_live_values_and_tokens_with_mapped_rows,
+    MappedGraphRows, MappedNodeRows, schedule_min_live_values_and_tokens_with_mapped_rows,
 };
 use celox_analysis::interval::{DisjointIntervalError, DisjointIntervalMap, ExactInterval};
 use celox_design::{BinaryOp, BitAccess, RuntimeErrorInfo, UnaryOp, VarAtomBase};
@@ -561,12 +561,44 @@ fn add_acyclic_ff_write_order_edges(
 /// A variable target is one bit-range MemoryDef. A current-value source is a
 /// MemoryUse of every overlapping definition; a previous-value source is a
 /// live-on-entry use plus an anti-dependence which keeps that use before an
-/// overlapping definition. `successors` contains all semantic edges while
-/// `value_users` contains only Def-to-Use edges which can become a forwarded
-/// value during later lowering. Both tables are indexed by the predecessor.
+/// overlapping definition. `dependencies` contains all semantic edges while
+/// `values` contains only Def-to-Use edges which can become a forwarded value
+/// during later lowering. Both relations retain their forward and reverse
+/// adjacency so regional scheduling can borrow either direction.
 struct LogicPathMemorySsa {
-    successors: Vec<Vec<usize>>,
-    value_users: Vec<Vec<usize>>,
+    dependencies: LogicPathEdges,
+    values: LogicPathEdges,
+}
+
+struct LogicPathEdges {
+    users: Vec<Vec<usize>>,
+    predecessors: Vec<Vec<usize>>,
+}
+
+impl LogicPathEdges {
+    fn new(node_count: usize) -> Self {
+        Self {
+            users: vec![Vec::new(); node_count],
+            predecessors: vec![Vec::new(); node_count],
+        }
+    }
+
+    fn resize(&mut self, node_count: usize) {
+        self.users.resize_with(node_count, Vec::new);
+        self.predecessors.resize_with(node_count, Vec::new);
+    }
+
+    fn push(&mut self, predecessor: usize, user: usize) {
+        self.users[predecessor].push(user);
+        self.predecessors[user].push(predecessor);
+    }
+
+    fn canonicalize(&mut self) {
+        for row in self.users.iter_mut().chain(&mut self.predecessors) {
+            row.sort_unstable();
+            row.dedup();
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -617,8 +649,8 @@ where
         }
     };
 
-    let mut successors = vec![Vec::new(); input.len()];
-    let mut value_users = vec![Vec::new(); input.len()];
+    let mut dependencies = LogicPathEdges::new(input.len());
+    let mut values = LogicPathEdges::new(input.len());
     for (user, path) in input.iter().enumerate() {
         for source in &path.sources {
             let Some((start, length)) = bit_interval(source.access) else {
@@ -628,8 +660,8 @@ where
                 .overlapping(&source.id, start, length)
                 .map_err(|_| SchedulerError::InvalidDependencyGraph)?;
             for definition in reaching {
-                successors[definition].push(user);
-                value_users[definition].push(user);
+                dependencies.push(definition, user);
+                values.push(definition, user);
             }
         }
 
@@ -644,26 +676,20 @@ where
                 .overlapping(&source.id, start, length)
                 .map_err(|_| SchedulerError::InvalidDependencyGraph)?;
             for definition in reaching.filter(|definition| *definition != user) {
-                successors[user].push(definition);
+                dependencies.push(user, definition);
             }
         }
         for target in &path.order_before {
             if target.0 < input.len() && target.0 != user {
-                successors[user].push(target.0);
+                dependencies.push(user, target.0);
             }
         }
     }
-    for edges in &mut successors {
-        edges.sort_unstable();
-        edges.dedup();
-    }
-    for edges in &mut value_users {
-        edges.sort_unstable();
-        edges.dedup();
-    }
+    dependencies.canonicalize();
+    values.canonicalize();
     Ok(LogicPathMemorySsa {
-        successors,
-        value_users,
+        dependencies,
+        values,
     })
 }
 
@@ -724,14 +750,8 @@ where
         row.dedup();
     }
 
-    let mut predecessors = vec![Vec::new(); input.len()];
-    for (definition, users) in memory.successors.iter().enumerate() {
-        for &user in users {
-            predecessors[user].push(definition);
-        }
-    }
     while let Some(path) = work.pop() {
-        for &predecessor in &predecessors[path] {
+        for &predecessor in &memory.dependencies.predecessors[path] {
             if !std::mem::replace(&mut required_comb[predecessor], true) {
                 work.push(predecessor);
             }
@@ -3064,8 +3084,8 @@ fn direct_ff_write_ranges<Addr: Copy + Eq + Hash>(
 
 fn schedule_acyclic_path_region(
     paths: &[usize],
-    dependencies: &[Vec<usize>],
-    value_dependencies: &[Vec<usize>],
+    dependencies: &LogicPathEdges,
+    values: &LogicPathEdges,
     materialization_tokens: &[Vec<usize>],
     token_weights: &[usize],
     local_by_path: &mut [usize],
@@ -3081,36 +3101,16 @@ fn schedule_acyclic_path_region(
     }
 
     let result = (|| {
-        let mut local_dependencies = vec![Vec::<usize>::new(); paths.len()];
-        let mut local_values = vec![Vec::<usize>::new(); paths.len()];
-        for (definition, &path) in paths.iter().enumerate() {
-            for &user_path in dependencies.get(path)? {
-                let user = *local_by_path.get(user_path)?;
-                if user != usize::MAX && definition != user {
-                    local_dependencies[user].push(definition);
-                }
-            }
-            for &user_path in value_dependencies.get(path)? {
-                let user = *local_by_path.get(user_path)?;
-                if user != usize::MAX && definition != user {
-                    local_values[user].push(definition);
-                }
-            }
-        }
-        for row in &mut local_dependencies {
-            row.sort_unstable();
-            row.dedup();
-        }
-        for row in &mut local_values {
-            row.sort_unstable();
-            row.dedup();
-        }
+        let dependency_predecessors =
+            MappedGraphRows::new(&dependencies.predecessors, paths, local_by_path).ok()?;
+        let value_predecessors =
+            MappedGraphRows::new(&values.predecessors, paths, local_by_path).ok()?;
         let tokens = MappedNodeRows::new(materialization_tokens, paths).ok()?;
-        let successors = MappedUserRows::new(dependencies, paths, local_by_path).ok()?;
-        let value_users = MappedUserRows::new(value_dependencies, paths, local_by_path).ok()?;
+        let successors = MappedGraphRows::new(&dependencies.users, paths, local_by_path).ok()?;
+        let value_users = MappedGraphRows::new(&values.users, paths, local_by_path).ok()?;
         let order = schedule_min_live_values_and_tokens_with_mapped_rows(
-            &local_dependencies,
-            &local_values,
+            dependency_predecessors,
+            value_predecessors,
             tokens,
             token_weights,
             successors,
@@ -3131,19 +3131,19 @@ fn schedule_acyclic_path_region(
 /// across an iteration or externally visible effect.
 fn schedule_logic_path_regions<Addr: Clone + Eq + Hash>(
     topological_sccs: Vec<Vec<usize>>,
-    dependencies: &[Vec<usize>],
-    value_dependencies: &[Vec<usize>],
+    dependencies: &LogicPathEdges,
+    values: &LogicPathEdges,
     materialization_tokens: &[Vec<usize>],
     token_weights: &[usize],
     input: &[LogicPath<Addr>],
 ) -> Option<Vec<ScheduledWork>> {
-    if dependencies.len() != value_dependencies.len()
-        || dependencies.len() != materialization_tokens.len()
-        || dependencies.len() < input.len()
+    if dependencies.users.len() != values.users.len()
+        || dependencies.users.len() != materialization_tokens.len()
+        || dependencies.users.len() < input.len()
     {
         return None;
     }
-    let mut local_by_path = vec![usize::MAX; dependencies.len()];
+    let mut local_by_path = vec![usize::MAX; dependencies.users.len()];
     let mut result = Vec::with_capacity(topological_sccs.len());
     let mut pending = Vec::new();
     let flush = |pending: &mut Vec<usize>,
@@ -3156,7 +3156,7 @@ fn schedule_logic_path_regions<Addr: Clone + Eq + Hash>(
         let ordered = schedule_acyclic_path_region(
             pending,
             dependencies,
-            value_dependencies,
+            values,
             materialization_tokens,
             token_weights,
             local_by_path,
@@ -3174,7 +3174,7 @@ fn schedule_logic_path_regions<Addr: Clone + Eq + Hash>(
 
     for scc in topological_sccs {
         if let [path] = scc.as_slice()
-            && !dependencies[*path].contains(path)
+            && !dependencies.users[*path].contains(path)
             && (*path >= input.len() || !logic_path_is_scheduling_barrier(&input[*path]))
         {
             pending.push(*path);
@@ -3261,8 +3261,8 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
     let (mut materialization_tokens, token_weights) =
         logic_path_materialization_tokens(&input, arena);
     let LogicPathMemorySsa {
-        successors: mut adj,
-        mut value_users,
+        mut dependencies,
+        mut values,
     } = build_logic_path_memory_ssa(&input).map_err(ClockSortError::Scheduler)?;
 
     // FF actions are ordinary sinks in the existing comb dependency graph.
@@ -3273,14 +3273,14 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
         .map_or(0, |lowering| lowering.summaries().len());
     let mut direct_ff_writes_by_action = vec![Vec::new(); ff_count];
     if let Some(plan) = &ff_plan {
-        adj.resize_with(n + ff_count, Vec::new);
-        value_users.resize_with(n + ff_count, Vec::new);
+        dependencies.resize(n + ff_count);
+        values.resize(n + ff_count);
         materialization_tokens.resize_with(n + ff_count, Vec::new);
         for (ff_index, predecessors) in plan.comb_value_predecessors.iter().enumerate() {
             let ff_node = n + ff_index;
             for &definition in predecessors {
-                adj[definition].push(ff_node);
-                value_users[definition].push(ff_node);
+                dependencies.push(definition, ff_node);
+                values.push(definition, ff_node);
             }
         }
         let write_order_edges = plan
@@ -3302,8 +3302,13 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
-        let retained =
-            add_acyclic_ff_write_order_edges(&mut adj, write_order_edges.iter().flatten().copied());
+        let retained = add_acyclic_ff_write_order_edges(
+            &mut dependencies.users,
+            write_order_edges.iter().flatten().copied(),
+        );
+        for &(predecessor, user) in &retained {
+            dependencies.predecessors[user].push(predecessor);
+        }
         direct_ff_writes_by_action = direct_ff_write_ranges(
             &input,
             ff.as_deref()
@@ -3315,10 +3320,8 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
             var_widths,
             unpacked_element_widths,
         );
-        for edges in adj.iter_mut().chain(&mut value_users) {
-            edges.sort_unstable();
-            edges.dedup();
-        }
+        dependencies.canonicalize();
+        values.canonicalize();
     }
     let direct_ff_writes = direct_ff_writes_by_action
         .iter()
@@ -3338,20 +3341,20 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
     };
     for i in 0..(n + ff_count) {
         if ctx.indices[i].is_none() {
-            strong_connect(i, &adj, &mut ctx);
+            strong_connect(i, &dependencies.users, &mut ctx);
         }
     }
     let fold_group_schedule_index = build_fold_group_schedule_index(&input, arena);
     let mut path_domains = logic_path_scheduling_domains(&input, &fold_group_schedule_index);
     path_domains.resize(n + ff_count, None);
     let (topological_sccs, component_by_path) =
-        stable_topological_sccs(ctx.sccs, &adj, &path_domains).ok_or(ClockSortError::Scheduler(
-            SchedulerError::InvalidDependencyGraph,
-        ))?;
+        stable_topological_sccs(ctx.sccs, &dependencies.users, &path_domains).ok_or(
+            ClockSortError::Scheduler(SchedulerError::InvalidDependencyGraph),
+        )?;
     let scheduled_work = schedule_logic_path_regions(
         topological_sccs,
-        &adj,
-        &value_users,
+        &dependencies,
+        &values,
         &materialization_tokens,
         &token_weights,
         &input,
@@ -3359,6 +3362,9 @@ fn sort_impl<Addr: Clone + Eq + Ord + Hash + Debug + Copy + Display, E>(
     .ok_or(ClockSortError::Scheduler(
         SchedulerError::InvalidDependencyGraph,
     ))?;
+    let adj = dependencies.users;
+    drop(dependencies.predecessors);
+    drop(values);
     let scheduled_work = form_scheduled_guard_regions(scheduled_work, &input, arena, four_state);
 
     let mut builder = SIRBuilder::new();
@@ -4453,9 +4459,14 @@ mod tests {
         let paths = vec![previous_user, writer];
 
         let memory_ssa = build_logic_path_memory_ssa(&paths).unwrap();
-        assert_eq!(memory_ssa.successors, vec![vec![1], vec![]]);
+        assert_eq!(memory_ssa.dependencies.users, vec![vec![1], vec![]]);
+        assert_eq!(memory_ssa.dependencies.predecessors, vec![vec![], vec![0]]);
         assert_eq!(
-            memory_ssa.value_users,
+            memory_ssa.values.users,
+            vec![Vec::<usize>::new(), Vec::new()]
+        );
+        assert_eq!(
+            memory_ssa.values.predecessors,
             vec![Vec::<usize>::new(), Vec::new()]
         );
 
@@ -4492,8 +4503,19 @@ mod tests {
         user.sources = [VarAtomBase::new(10, 2, 5)].into_iter().collect();
 
         let memory_ssa = build_logic_path_memory_ssa(&[low, high, user]).unwrap();
-        assert_eq!(memory_ssa.successors, vec![vec![2], vec![2], vec![]]);
-        assert_eq!(memory_ssa.value_users, vec![vec![2], vec![2], vec![]]);
+        assert_eq!(
+            memory_ssa.dependencies.users,
+            vec![vec![2], vec![2], vec![]]
+        );
+        assert_eq!(
+            memory_ssa.dependencies.predecessors,
+            vec![vec![], vec![], vec![0, 1]]
+        );
+        assert_eq!(memory_ssa.values.users, vec![vec![2], vec![2], vec![]]);
+        assert_eq!(
+            memory_ssa.values.predecessors,
+            vec![vec![], vec![], vec![0, 1]]
+        );
     }
 
     fn fixed_group_path(

--- a/crates/celox-slt/src/scheduler.rs
+++ b/crates/celox-slt/src/scheduler.rs
@@ -1,7 +1,9 @@
 use crate::{
     HashMap, HashSet, LogicPath, LogicPathTarget, NodeId, SLTNode, SLTNodeArena, SLTNodeFactsError,
 };
-use celox_analysis::dag_schedule::schedule_min_live_values_and_tokens;
+use celox_analysis::dag_schedule::{
+    MappedNodeRows, MappedUserRows, schedule_min_live_values_and_tokens_with_mapped_rows,
+};
 use celox_analysis::interval::{DisjointIntervalError, DisjointIntervalMap, ExactInterval};
 use celox_design::{BinaryOp, BitAccess, RuntimeErrorInfo, UnaryOp, VarAtomBase};
 use celox_sir::{
@@ -3081,9 +3083,7 @@ fn schedule_acyclic_path_region(
     let result = (|| {
         let mut local_dependencies = vec![Vec::<usize>::new(); paths.len()];
         let mut local_values = vec![Vec::<usize>::new(); paths.len()];
-        let mut local_tokens = vec![Vec::<usize>::new(); paths.len()];
         for (definition, &path) in paths.iter().enumerate() {
-            local_tokens[definition] = materialization_tokens.get(path)?.clone();
             for &user_path in dependencies.get(path)? {
                 let user = *local_by_path.get(user_path)?;
                 if user != usize::MAX && definition != user {
@@ -3105,11 +3105,16 @@ fn schedule_acyclic_path_region(
             row.sort_unstable();
             row.dedup();
         }
-        let order = schedule_min_live_values_and_tokens(
+        let tokens = MappedNodeRows::new(materialization_tokens, paths).ok()?;
+        let successors = MappedUserRows::new(dependencies, paths, local_by_path).ok()?;
+        let value_users = MappedUserRows::new(value_dependencies, paths, local_by_path).ok()?;
+        let order = schedule_min_live_values_and_tokens_with_mapped_rows(
             &local_dependencies,
             &local_values,
-            &local_tokens,
+            tokens,
             token_weights,
+            successors,
+            value_users,
         )
         .ok()?;
         Some(order.into_iter().map(|local| paths[local]).collect())


### PR DESCRIPTION
## Summary

- add borrowed mapped graph-row views to the DAG scheduler
- retain hard and value relations in both predecessor and user directions
- borrow all four adjacency directions when scheduling acyclic path regions
- avoid cloning materialization-token rows and rebuilding local predecessor rows
- validate mapped row ranges, aliases, and exact reverse relations

## Motivation

The SLT scheduler already owns the global dependency graph, but acyclic-region scheduling rebuilt hard- and value-predecessor rows into region-local vectors, sorted them, and deduplicated them. FF planning independently transposed the same dependency graph.

This PR keeps each LogicPath relation bidirectional from construction onward. Regional scheduling maps the existing global rows into local DAG IDs through borrowed iterators, and drops reverse/value tables as soon as scheduling completes.

## Impact

On the 16-way sorter profiling workload, compared with #581:

- allocations: 13,903,465 → 13,849,606 (-53,859)
- the predecessor-row change alone removes 46,392 allocations from the immediately preceding PR revision
- peak heap remains around 58 MiB across compared runs

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p celox-analysis -p celox-slt --all-targets -- -D warnings`
- `cargo test -p celox-analysis --lib`
- `cargo test -p celox-slt --lib`
- `cargo test -p celox --test data_access --test hierarchy`
- `cargo test --workspace --quiet`
- `sorter_tree_compilation_scales`
- heaptrack profiling with `profile_sorter 16`
- normal pre-push hook: submodule check, Rust formatting, Biome, workspace cargo check, clean-tree check