### PR TITLE
fix(ci): allow ARM64 Cranelift Linux boot to finish

### DIFF
--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -297,7 +297,7 @@ jobs:
         shell: bash
         env:
           HELIODOR_RUNNERS: celox-cranelift
-          HELIODOR_TIMEOUT_SEC: "1800"
+          HELIODOR_TIMEOUT_SEC: "3600"
           HELIODOR_BUILD_CELOX_RUNNER: "0"
         run: set -o pipefail && bash scripts/run-heliodor-bench.sh run 2>&1 | tee heliodor-arm64-cranelift-output.txt
 


### PR DESCRIPTION
## Summary

- increase the nightly ARM64 Cranelift Heliodor timeout from 1800 to 3600 seconds
- retain the existing 120-minute job timeout and strict completion-marker validation

## Root cause

The Heliodor Linux dashboard has not received a new data point since August 5 because every scheduled publisher run has been blocked by the ARM64 Cranelift Linux boot timing out after 1800 seconds. The benchmark was still making forward progress near the end of the boot, but the failed dependency caused `Publish Linux boot benchmarks` to be skipped.

The latest run completed native ARM64 execution in about 758 seconds. Compared with the x86-64 native and Cranelift measurements from the same host run, ARM64 Cranelift is expected to need roughly 45 minutes, so the previous 30-minute allowance was insufficient. A 60-minute per-run bound still fits within the existing 120-minute job limit.

## Impact

Successful nightly runs can reach the publish job again, restoring Heliodor Linux dashboard updates while continuing to reject partial boots that do not emit the configured completion marker.

## Validation

- workflow YAML parse
- `bash scripts/tests/convert-heliodor-bench.sh`
- `node --test scripts/ci-changes.test.mjs`
- `git diff --check`
- pre-push submodule check
- pre-push Biome check
- pre-push Cargo formatting check
- pre-push `cargo check`
