### PR TITLE
fix(playground): prevent browser freeze during run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,7 +404,7 @@ jobs:
   playground-browser:
     name: Playground Browser Test
     needs: [changes, rust]
-    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.javascript == 'true')
+    if: always() && (needs.changes.result != 'success' || needs.changes.outputs.javascript == 'true' || needs.changes.outputs.napi == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/crates/celox-frontend-veryl/src/hierarchy.rs
+++ b/crates/celox-frontend-veryl/src/hierarchy.rs
@@ -164,42 +164,63 @@ pub fn parse_ir_with_loop_provenance<'a>(
             (module_id, ir_module, inst_ids)
         })
         .collect::<Vec<_>>();
+    #[cfg(not(target_arch = "wasm32"))]
     let worker_count = tasks
         .len()
         .min(std::thread::available_parallelism().map_or(1, usize::from));
+    // Browser WASI cannot synchronously join the scoped threads used below.
+    // The whole frontend already runs in a dedicated browser worker, so keep
+    // module lowering serial inside the wasm module.
+    #[cfg(target_arch = "wasm32")]
+    let worker_count = 1;
     let next_task = AtomicUsize::new(0);
-    let parsed_modules = std::thread::scope(|scope| {
-        let handles = (0..worker_count)
-            .map(|_| {
-                scope.spawn(|| {
-                    resource_table::import_tables(&resource_snapshot);
-                    let mut parsed = Vec::new();
-                    loop {
-                        let task = next_task.fetch_add(1, Ordering::Relaxed);
-                        let Some(&(module_id, ir_module, inst_ids)) = tasks.get(task) else {
-                            break;
-                        };
-                        let module = ModuleParser::parse_with_loop_provenance(
-                            ir_module,
-                            loop_provenance,
-                            config,
-                            inst_ids,
-                        )?;
-                        parsed.push((module_id, module));
-                    }
-                    Ok::<_, ParserError>(parsed)
-                })
+    let parsed_modules = if worker_count <= 1 {
+        tasks
+            .iter()
+            .map(|&(module_id, ir_module, inst_ids)| {
+                ModuleParser::parse_with_loop_provenance(
+                    ir_module,
+                    loop_provenance,
+                    config,
+                    inst_ids,
+                )
+                .map(|module| (module_id, module))
             })
-            .collect::<Vec<_>>();
-        let mut parsed_modules = Vec::with_capacity(tasks.len());
-        for handle in handles {
-            let parsed = handle
-                .join()
-                .unwrap_or_else(|panic| std::panic::resume_unwind(panic))?;
-            parsed_modules.extend(parsed);
-        }
-        Ok::<_, ParserError>(parsed_modules)
-    })?;
+            .collect::<Result<Vec<_>, _>>()?
+    } else {
+        std::thread::scope(|scope| {
+            let handles = (0..worker_count)
+                .map(|_| {
+                    scope.spawn(|| {
+                        resource_table::import_tables(&resource_snapshot);
+                        let mut parsed = Vec::new();
+                        loop {
+                            let task = next_task.fetch_add(1, Ordering::Relaxed);
+                            let Some(&(module_id, ir_module, inst_ids)) = tasks.get(task) else {
+                                break;
+                            };
+                            let module = ModuleParser::parse_with_loop_provenance(
+                                ir_module,
+                                loop_provenance,
+                                config,
+                                inst_ids,
+                            )?;
+                            parsed.push((module_id, module));
+                        }
+                        Ok::<_, ParserError>(parsed)
+                    })
+                })
+                .collect::<Vec<_>>();
+            let mut parsed_modules = Vec::with_capacity(tasks.len());
+            for handle in handles {
+                let parsed = handle
+                    .join()
+                    .unwrap_or_else(|panic| std::panic::resume_unwind(panic))?;
+                parsed_modules.extend(parsed);
+            }
+            Ok::<_, ParserError>(parsed_modules)
+        })?
+    };
     for (module_id, mut sim_module) in parsed_modules {
         let ir_module = module_ir[&module_id];
         if let Some(symbols) = &symbols

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1581,6 +1581,16 @@ impl NativeSimulatorHandle {
         self.events_json.clone()
     }
 
+    /// Byte ranges whose value and mask planes must start as unknown (X).
+    #[napi(getter)]
+    pub fn four_state_init_regions_json(&self) -> String {
+        Self::build_four_state_init_regions_json(
+            &self.program,
+            self.program.layout(),
+            self.four_state,
+        )
+    }
+
     /// Returns the instance hierarchy as a JSON string.
     #[napi(getter)]
     pub fn hierarchy_json(&self) -> String {
@@ -1655,6 +1665,44 @@ impl NativeSimulatorHandle {
 
 #[cfg(target_arch = "wasm32")]
 impl NativeSimulatorHandle {
+    fn build_four_state_init_regions_json(
+        program: &celox::LaidOutProgram,
+        layout: &celox::MemoryLayout,
+        four_state: bool,
+    ) -> String {
+        if !four_state {
+            return "[]".to_string();
+        }
+
+        let mut regions = Vec::new();
+        for (addr, &offset) in &layout.offsets {
+            if program
+                .design
+                .state_objects
+                .get(addr)
+                .is_some_and(|metadata| metadata.is_4state)
+            {
+                regions.push((offset, celox::get_byte_size(layout.widths[addr])));
+            }
+        }
+        for (addr, &relative_offset) in &layout.working_offsets {
+            if program
+                .design
+                .state_objects
+                .get(addr)
+                .is_some_and(|metadata| metadata.is_4state)
+            {
+                regions.push((
+                    layout.working_base_offset + relative_offset,
+                    celox::get_byte_size(layout.widths[addr]),
+                ));
+            }
+        }
+        regions.sort_unstable();
+
+        serde_json::to_string(&regions).unwrap_or_else(|_| "[]".to_string())
+    }
+
     /// Build signal layout JSON from finalized SIR and MemoryLayout.
     /// Mirrors the layout format from celox-wasm.
     fn build_layout_json(

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1682,7 +1682,7 @@ impl NativeSimulatorHandle {
                 .get(addr)
                 .is_some_and(|metadata| metadata.is_4state)
             {
-                regions.push((offset, celox::get_byte_size(layout.widths[addr])));
+                regions.push((offset, layout.plane_size(addr)));
             }
         }
         for (addr, &relative_offset) in &layout.working_offsets {
@@ -1694,7 +1694,7 @@ impl NativeSimulatorHandle {
             {
                 regions.push((
                     layout.working_base_offset + relative_offset,
-                    celox::get_byte_size(layout.widths[addr]),
+                    layout.plane_size(addr),
                 ));
             }
         }

--- a/crates/celox-sir-opt/src/optimizer/pipeline/pass_manager.rs
+++ b/crates/celox-sir-opt/src/optimizer/pipeline/pass_manager.rs
@@ -91,13 +91,17 @@ impl ExecutionUnitPassManager {
         units: &mut Vec<ExecutionUnit<RegionedAbsoluteAddr>>,
         options: &PassOptions,
     ) {
+        #[cfg(not(target_arch = "wasm32"))]
         const MAX_PARALLEL_UNITS: usize = 4;
 
+        #[cfg(not(target_arch = "wasm32"))]
         let worker_count = units.len().min(
             std::thread::available_parallelism()
                 .map_or(1, usize::from)
                 .min(MAX_PARALLEL_UNITS),
         );
+        #[cfg(target_arch = "wasm32")]
+        let worker_count = 1;
         if worker_count <= 1 {
             for unit in units {
                 self.run(unit, options);

--- a/crates/celox-sir-opt/src/optimizer/pipeline/runner.rs
+++ b/crates/celox-sir-opt/src/optimizer/pipeline/runner.rs
@@ -179,6 +179,36 @@ pub(super) fn optimize_with_options(
     let comb_phase_start = timing.then(crate::timing::now);
     let comb_eu_count = program.sir.eval_comb.len();
     let sir = &mut *program.sir;
+    #[cfg(target_arch = "wasm32")]
+    {
+        for (i, eu) in sir.eval_comb.iter_mut().enumerate() {
+            if timing {
+                let inst_count: usize = eu.blocks.values().map(|b| b.instructions.len()).sum();
+                let block_count = eu.blocks.len();
+                tracing::debug!(
+                    "[phase] eval_comb eu[{i}]: blocks={block_count} insts={inst_count}"
+                );
+            }
+            comb_passes.run(eu, &options);
+        }
+
+        optimize_unit_groups_cached(&mut sir.eval_apply_ffs, &ff_passes, &options);
+        optimize_unit_groups_cached(&mut sir.eval_comb_apply_ffs, &comb_ff_passes, &options);
+        optimize_unit_groups_cached(&mut sir.eval_comb_apply_ffs, &comb_ff_late_passes, &options);
+        optimize_unified_commit_groups(
+            &mut sir.eval_apply_ffs,
+            on(SirPass::CommitSinking),
+            on(SirPass::InlineCommitForwarding),
+        );
+        optimize_unified_commit_groups(
+            &mut sir.eval_comb_apply_ffs,
+            on(SirPass::CommitSinking),
+            on(SirPass::InlineCommitForwarding),
+        );
+        optimize_unit_groups_cached(&mut sir.eval_apply_ffs, &ff_post_passes, &options);
+        optimize_unit_groups_cached(&mut sir.eval_comb_apply_ffs, &ff_post_passes, &options);
+    }
+    #[cfg(not(target_arch = "wasm32"))]
     std::thread::scope(|scope| {
         let comb_worker = scope.spawn(|| {
             for (i, eu) in sir.eval_comb.iter_mut().enumerate() {

--- a/packages/playground/src/celox-compiler-client.ts
+++ b/packages/playground/src/celox-compiler-client.ts
@@ -1,0 +1,94 @@
+import type {
+	CeloxCompilerRequest,
+	CeloxCompilerResponse,
+	CeloxSourceFile,
+	CompiledSimulator,
+} from "./celox-compiler-protocol.js";
+
+type PendingRequest = {
+	resolve: (value: unknown) => void;
+	reject: (reason: Error) => void;
+};
+
+type CompilerRequestBody<T = CeloxCompilerRequest> =
+	T extends CeloxCompilerRequest ? Omit<T, "id"> : never;
+
+export class CeloxCompilerClient {
+	readonly ready: Promise<void>;
+
+	private readonly worker: Worker;
+	private readonly pending = new Map<number, PendingRequest>();
+	private nextRequestId = 1;
+	private resolveReady!: () => void;
+	private rejectReady!: (reason: Error) => void;
+
+	constructor() {
+		this.ready = new Promise<void>((resolve, reject) => {
+			this.resolveReady = resolve;
+			this.rejectReady = reject;
+		});
+		this.worker = new Worker(
+			new URL("./celox-compiler-worker.ts", import.meta.url),
+			{ type: "module" },
+		);
+		this.worker.addEventListener("message", (event) => {
+			this.handleMessage(event.data as CeloxCompilerResponse);
+		});
+		this.worker.addEventListener("error", (event) => {
+			this.fail(new Error(event.message || "Celox compiler worker failed"));
+		});
+	}
+
+	async genTsFromSource(sources: CeloxSourceFile[]): Promise<string> {
+		return this.request<string>({ type: "genTsFromSource", sources });
+	}
+
+	async compile(
+		sources: CeloxSourceFile[],
+		top: string,
+		options: { fourState: boolean },
+	): Promise<CompiledSimulator> {
+		return this.request<CompiledSimulator>({
+			type: "compile",
+			sources,
+			top,
+			fourState: options.fourState,
+		});
+	}
+
+	private async request<T>(request: CompilerRequestBody): Promise<T> {
+		await this.ready;
+		const id = this.nextRequestId++;
+		const result = new Promise<T>((resolve, reject) => {
+			this.pending.set(id, {
+				resolve: resolve as (value: unknown) => void,
+				reject,
+			});
+		});
+		this.worker.postMessage({ ...request, id });
+		return result;
+	}
+
+	private handleMessage(message: CeloxCompilerResponse) {
+		if (message.type === "ready") {
+			this.resolveReady();
+			return;
+		}
+		if (message.type === "initError") {
+			this.fail(new Error(message.error));
+			return;
+		}
+
+		const pending = this.pending.get(message.id);
+		if (!pending) return;
+		this.pending.delete(message.id);
+		if (message.type === "result") pending.resolve(message.value);
+		else pending.reject(new Error(message.error));
+	}
+
+	private fail(error: Error) {
+		this.rejectReady(error);
+		for (const pending of this.pending.values()) pending.reject(error);
+		this.pending.clear();
+	}
+}

--- a/packages/playground/src/celox-compiler-client.ts
+++ b/packages/playground/src/celox-compiler-client.ts
@@ -10,6 +10,14 @@ type PendingRequest = {
 	reject: (reason: Error) => void;
 };
 
+type AnalysisBatch = {
+	sources: CeloxSourceFile[];
+	waiters: Array<{
+		resolve: (value: string) => void;
+		reject: (reason: Error) => void;
+	}>;
+};
+
 type CompilerRequestBody<T = CeloxCompilerRequest> =
 	T extends CeloxCompilerRequest ? Omit<T, "id"> : never;
 
@@ -21,6 +29,9 @@ export class CeloxCompilerClient {
 	private nextRequestId = 1;
 	private resolveReady!: () => void;
 	private rejectReady!: (reason: Error) => void;
+	private terminalError?: Error;
+	private analysisInFlight = false;
+	private queuedAnalysis?: AnalysisBatch;
 
 	constructor() {
 		this.ready = new Promise<void>((resolve, reject) => {
@@ -37,10 +48,31 @@ export class CeloxCompilerClient {
 		this.worker.addEventListener("error", (event) => {
 			this.fail(new Error(event.message || "Celox compiler worker failed"));
 		});
+		this.worker.addEventListener("messageerror", () => {
+			this.fail(new Error("Celox compiler worker sent an invalid message"));
+		});
 	}
 
 	async genTsFromSource(sources: CeloxSourceFile[]): Promise<string> {
 		return this.request<string>({ type: "genTsFromSource", sources });
+	}
+
+	genTsFromSourceLatest(sources: CeloxSourceFile[]): Promise<string> {
+		return new Promise<string>((resolve, reject) => {
+			const waiter = { resolve, reject };
+			if (!this.analysisInFlight) {
+				this.analysisInFlight = true;
+				void this.runAnalysis({ sources, waiters: [waiter] });
+				return;
+			}
+
+			if (this.queuedAnalysis) {
+				this.queuedAnalysis.sources = sources;
+				this.queuedAnalysis.waiters.push(waiter);
+			} else {
+				this.queuedAnalysis = { sources, waiters: [waiter] };
+			}
+		});
 	}
 
 	async compile(
@@ -57,7 +89,9 @@ export class CeloxCompilerClient {
 	}
 
 	private async request<T>(request: CompilerRequestBody): Promise<T> {
+		if (this.terminalError) throw this.terminalError;
 		await this.ready;
+		if (this.terminalError) throw this.terminalError;
 		const id = this.nextRequestId++;
 		const result = new Promise<T>((resolve, reject) => {
 			this.pending.set(id, {
@@ -67,6 +101,21 @@ export class CeloxCompilerClient {
 		});
 		this.worker.postMessage({ ...request, id });
 		return result;
+	}
+
+	private async runAnalysis(batch: AnalysisBatch) {
+		try {
+			const value = await this.genTsFromSource(batch.sources);
+			for (const waiter of batch.waiters) waiter.resolve(value);
+		} catch (error) {
+			const reason = error instanceof Error ? error : new Error(String(error));
+			for (const waiter of batch.waiters) waiter.reject(reason);
+		} finally {
+			const next = this.queuedAnalysis;
+			this.queuedAnalysis = undefined;
+			if (next) void this.runAnalysis(next);
+			else this.analysisInFlight = false;
+		}
 	}
 
 	private handleMessage(message: CeloxCompilerResponse) {
@@ -87,6 +136,8 @@ export class CeloxCompilerClient {
 	}
 
 	private fail(error: Error) {
+		if (this.terminalError) return;
+		this.terminalError = error;
 		this.rejectReady(error);
 		for (const pending of this.pending.values()) pending.reject(error);
 		this.pending.clear();

--- a/packages/playground/src/celox-compiler-protocol.ts
+++ b/packages/playground/src/celox-compiler-protocol.ts
@@ -4,6 +4,8 @@ export type CeloxSourceFile = {
 };
 
 export type CompiledSimulator = {
+	fourState: boolean;
+	fourStateInitRegions: Array<[offset: number, byteSize: number]>;
 	layout: Record<string, any>;
 	events: Record<string, number>;
 	totalSize: number;

--- a/packages/playground/src/celox-compiler-protocol.ts
+++ b/packages/playground/src/celox-compiler-protocol.ts
@@ -1,0 +1,32 @@
+export type CeloxSourceFile = {
+	content: string;
+	path: string;
+};
+
+export type CompiledSimulator = {
+	layout: Record<string, any>;
+	events: Record<string, number>;
+	totalSize: number;
+	combModule: WebAssembly.Module;
+	eventModules: Record<string, WebAssembly.Module>;
+};
+
+export type CeloxCompilerRequest =
+	| {
+			id: number;
+			type: "genTsFromSource";
+			sources: CeloxSourceFile[];
+	  }
+	| {
+			id: number;
+			type: "compile";
+			sources: CeloxSourceFile[];
+			top: string;
+			fourState: boolean;
+	  };
+
+export type CeloxCompilerResponse =
+	| { type: "ready" }
+	| { type: "initError"; error: string }
+	| { type: "result"; id: number; value: unknown }
+	| { type: "error"; id: number; error: string };

--- a/packages/playground/src/celox-compiler-worker.ts
+++ b/packages/playground/src/celox-compiler-worker.ts
@@ -32,6 +32,9 @@ try {
 			try {
 				const layout = JSON.parse(handle.layoutJson);
 				const events = JSON.parse(handle.eventsJson) as Record<string, number>;
+				const fourStateInitRegions = JSON.parse(
+					handle.fourStateInitRegionsJson,
+				) as Array<[number, number]>;
 				const combModule = new WebAssembly.Module(
 					new Uint8Array(handle.combWasmBytes()),
 				);
@@ -46,6 +49,8 @@ try {
 					}
 				}
 				const value: CompiledSimulator = {
+					fourState: request.fourState,
+					fourStateInitRegions,
 					layout,
 					events,
 					totalSize: handle.totalSize,

--- a/packages/playground/src/celox-compiler-worker.ts
+++ b/packages/playground/src/celox-compiler-worker.ts
@@ -1,0 +1,74 @@
+import type {
+	CeloxCompilerRequest,
+	CeloxCompilerResponse,
+	CompiledSimulator,
+} from "./celox-compiler-protocol.js";
+
+const workerScope = globalThis as unknown as {
+	addEventListener(
+		type: "message",
+		listener: (event: MessageEvent<CeloxCompilerRequest>) => void,
+	): void;
+	postMessage(message: CeloxCompilerResponse): void;
+};
+
+try {
+	const celox = await import("./celox-wasm-loader.js");
+
+	workerScope.addEventListener("message", (event) => {
+		const request = event.data;
+		try {
+			if (request.type === "genTsFromSource") {
+				const value = celox.genTsFromSource(request.sources);
+				workerScope.postMessage({ type: "result", id: request.id, value });
+				return;
+			}
+
+			const handle = new celox.NativeSimulatorHandle(
+				request.sources,
+				request.top,
+				{ fourState: request.fourState },
+			);
+			try {
+				const layout = JSON.parse(handle.layoutJson);
+				const events = JSON.parse(handle.eventsJson) as Record<string, number>;
+				const combModule = new WebAssembly.Module(
+					new Uint8Array(handle.combWasmBytes()),
+				);
+				const eventModules: Record<string, WebAssembly.Module> = {};
+				for (const name of Object.keys(events)) {
+					try {
+						eventModules[name] = new WebAssembly.Module(
+							new Uint8Array(handle.eventWasmBytes(name)),
+						);
+					} catch {
+						// An event without generated code is valid and has nothing to run.
+					}
+				}
+				const value: CompiledSimulator = {
+					layout,
+					events,
+					totalSize: handle.totalSize,
+					combModule,
+					eventModules,
+				};
+				workerScope.postMessage({ type: "result", id: request.id, value });
+			} finally {
+				handle.dispose();
+			}
+		} catch (error) {
+			workerScope.postMessage({
+				type: "error",
+				id: request.id,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	});
+
+	workerScope.postMessage({ type: "ready" });
+} catch (error) {
+	workerScope.postMessage({
+		type: "initError",
+		error: error instanceof Error ? error.message : String(error),
+	});
+}

--- a/packages/playground/src/celox-wasm-loader.d.ts
+++ b/packages/playground/src/celox-wasm-loader.d.ts
@@ -1,0 +1,17 @@
+import type { CeloxSourceFile } from "./celox-compiler-protocol.js";
+
+export function genTsFromSource(sources: CeloxSourceFile[]): string;
+
+export class NativeSimulatorHandle {
+	constructor(
+		sources: CeloxSourceFile[],
+		top: string,
+		options?: { fourState?: boolean },
+	);
+	readonly layoutJson: string;
+	readonly eventsJson: string;
+	readonly totalSize: number;
+	combWasmBytes(): Uint8Array;
+	eventWasmBytes(name: string): Uint8Array;
+	dispose(): void;
+}

--- a/packages/playground/src/celox-wasm-loader.d.ts
+++ b/packages/playground/src/celox-wasm-loader.d.ts
@@ -10,6 +10,7 @@ export class NativeSimulatorHandle {
 	);
 	readonly layoutJson: string;
 	readonly eventsJson: string;
+	readonly fourStateInitRegionsJson: string;
 	readonly totalSize: number;
 	combWasmBytes(): Uint8Array;
 	eventWasmBytes(name: string): Uint8Array;

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -1157,18 +1157,21 @@ function getVerylModel(): monaco.editor.ITextModel | null {
 	return null;
 }
 
-function getTestModels(): { path: string; model: monaco.editor.ITextModel }[] {
-	const target = runTargetEl.value;
+function snapshotTestSources(
+	target: string,
+): { path: string; source: string }[] {
 	if (target === "*") {
 		// All test files
-		const result: { path: string; model: monaco.editor.ITextModel }[] = [];
+		const result: { path: string; source: string }[] = [];
 		for (const [path, f] of files) {
-			if (isTestFile(path)) result.push({ path, model: f.model });
+			if (isTestFile(path)) {
+				result.push({ path, source: f.model.getValue() });
+			}
 		}
 		return result;
 	}
 	const f = files.get(target);
-	if (f) return [{ path: target, model: f.model }];
+	if (f) return [{ path: target, source: f.model.getValue() }];
 	return [];
 }
 
@@ -1392,6 +1395,14 @@ async function run() {
 	const targetPath = runTargetEl.value;
 	if (!targetPath) {
 		appendConsole("[error] No test file selected", "log-error");
+		statusEl.textContent = "Error";
+		runBtn.disabled = false;
+		return;
+	}
+	const runArgs = runArgsEl.value.trim();
+	const testSources = snapshotTestSources(targetPath);
+	if (testSources.length === 0) {
+		appendConsole("[error] No test files found", "log-error");
 		statusEl.textContent = "Error";
 		runBtn.disabled = false;
 		return;
@@ -1981,10 +1992,9 @@ async function run() {
 		};
 
 		// Parse vitest-style args (--grep "pattern")
-		const argsStr = runArgsEl.value.trim();
 		let grepPattern: RegExp | null = null;
-		if (argsStr) {
-			const grepMatch = argsStr.match(
+		if (runArgs) {
+			const grepMatch = runArgs.match(
 				/(?:--grep|-t)\s+(?:"([^"]+)"|'([^']+)'|(\S+))/,
 			);
 			if (grepMatch) {
@@ -2005,14 +2015,9 @@ async function run() {
 		const tests: TestEntry[] = [];
 
 		statusEl.textContent = "Running…";
-		const tsWorker = await monacoTypeScript.getTypeScriptWorker();
-		const testModels = getTestModels();
-		if (testModels.length === 0) throw new Error("No test files found");
 
-		for (const { path: testPath, model: tbMdl } of testModels) {
-			const client = await tsWorker(tbMdl.uri);
-			const output = await client.getEmitOutput(tbMdl.uri.toString());
-			const jsCode = transpileTestbench(tbMdl.getValue(), testPath, output);
+		for (const { path: testPath, source } of testSources) {
+			const jsCode = transpileTestbench(source, testPath);
 
 			const suiteStack: string[] = [];
 			function _describe(name: string, fn: () => void) {

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -11,7 +11,14 @@ import celoxTypesDts from "../../celox/dist/types.d.ts?raw";
 import celoxWasmBridgeDts from "../../celox/dist/wasm-bridge.d.ts?raw";
 import { CeloxCompilerClient } from "./celox-compiler-client.js";
 import { buildMonacoTestbenchCompilerOptions } from "./monaco-testbench-options.js";
-import { FourState, X, Z } from "./playground-runtime-helpers.js";
+import {
+	FourState,
+	initializeFourStateMemory,
+	type PlaygroundSignalValue,
+	writeSignalValue,
+	X,
+	Z,
+} from "./playground-runtime-helpers.js";
 import { transpileTestbench } from "./testbench-transpile.js";
 import {
 	buildVirtualModuleDts,
@@ -276,10 +283,34 @@ describe("Counter (Waveform)", () => {
     assign snapshot = a;
 }`,
 		testbench: `import { describe, it, expect } from "vitest";
-import { FourState, Simulator, X } from "@celox-sim/celox";
+import { FourState, Simulation, Simulator, X } from "@celox-sim/celox";
 import { FourStateDemo } from "../src/FourStateDemo.veryl";
 
 describe("FourStateDemo", () => {
+    it("keeps the default simulator in two-state mode", () => {
+        const sim = Simulator.create(FourStateDemo);
+
+        expect(sim.fourState("a").mask).toBe(0n);
+
+        sim.dispose();
+    });
+
+    it("starts unassigned simulator signals as X", () => {
+        const sim = Simulator.create(FourStateDemo, { fourState: true });
+
+        expect(sim.fourState("a").mask).toBe(0xffn);
+
+        sim.dispose();
+    });
+
+    it("starts unassigned simulation signals as X", () => {
+        const sim = Simulation.create(FourStateDemo, { fourState: true });
+
+        expect(sim.fourState("a").mask).toBe(0xffn);
+
+        sim.dispose();
+    });
+
     it("writes and reads all-X", () => {
         const sim = Simulator.create(FourStateDemo, { fourState: true });
 
@@ -1241,7 +1272,7 @@ function onVerylChange() {
 		if (celoxCompilerReady) {
 			try {
 				const result = JSON.parse(
-					await celoxCompiler.genTsFromSource([
+					await celoxCompiler.genTsFromSourceLatest([
 						{ content: source, path: "main.veryl" },
 					]),
 				);
@@ -1369,79 +1400,33 @@ async function run() {
 			}
 		})();
 
-		const compiled = await celoxCompiler.compile(
-			[{ content: verylSource, path: "main.veryl" }],
-			topName,
-			// One Run may create both 2-state and 4-state simulators. Compile the
-			// superset layout once; each factory still enforces its requested mode.
-			{ fourState: true },
-		);
-		const { layout, events, totalSize, combModule, eventModules } = compiled;
+		const sources = [{ content: verylSource, path: "main.veryl" }];
+		const [twoStateCompiled, fourStateCompiled] = await Promise.all([
+			celoxCompiler.compile(sources, topName, { fourState: false }),
+			celoxCompiler.compile(sources, topName, { fourState: true }),
+		]);
 		const t1 = performance.now();
 		appendConsole(
-			`[compile] ${(t1 - t0).toFixed(0)}ms — ${Object.keys(layout).length} signals, ${Object.keys(events).length} events`,
+			`[compile] ${(t1 - t0).toFixed(0)}ms — ${Object.keys(twoStateCompiled.layout).length} signals, ${Object.keys(twoStateCompiled.events).length} events`,
 			"log-success",
 		);
 
 		type PlaygroundSimulatorOptions = { fourState?: boolean };
-		type PlaygroundSignalValue =
-			| bigint
-			| number
-			| symbol
-			| { __fourState: true; value: bigint; mask: bigint };
-
-		function writeSignalValue(
-			view: DataView,
-			sig: any,
-			value: PlaygroundSignalValue,
-			fourStateEnabled: boolean,
-		) {
-			const isX = value === X;
-			const isZ = value === Z;
-			const isExplicitFourState =
-				typeof value === "object" &&
-				value !== null &&
-				value.__fourState === true;
-			if (
-				(isX || isZ || isExplicitFourState) &&
-				(!fourStateEnabled || !sig.is_4state)
-			) {
-				throw new Error("Cannot assign a 4-state value in 2-state mode");
-			}
-
-			const widthMask = (1n << BigInt(sig.width)) - 1n;
-			let data: bigint;
-			let mask: bigint;
-			if (isX) {
-				data = widthMask;
-				mask = widthMask;
-			} else if (isZ) {
-				data = 0n;
-				mask = widthMask;
-			} else if (isExplicitFourState) {
-				data = value.value & widthMask;
-				mask = value.mask & widthMask;
-			} else {
-				data = BigInt(value as bigint | number) & widthMask;
-				mask = 0n;
-			}
-
-			for (let i = 0; i < sig.byte_size; i++) {
-				view.setUint8(sig.offset + i, Number(data & 0xffn));
-				data >>= 8n;
-			}
-			if (sig.is_4state) {
-				for (let i = 0; i < sig.byte_size; i++) {
-					view.setUint8(sig.offset + sig.byte_size + i, Number(mask & 0xffn));
-					mask >>= 8n;
-				}
-			}
-		}
 
 		// Build simulation factory (creates fresh instance per call)
 		function createSim(options?: PlaygroundSimulatorOptions) {
+			const fourStateEnabled = options?.fourState === true;
+			const {
+				layout,
+				events,
+				totalSize,
+				combModule,
+				eventModules,
+				fourStateInitRegions,
+			} = fourStateEnabled ? fourStateCompiled : twoStateCompiled;
 			const pages = Math.max(1, Math.ceil(totalSize / 65536));
 			const memory = new WebAssembly.Memory({ initial: pages });
+			initializeFourStateMemory(memory, fourStateInitRegions);
 			const combInst = new WebAssembly.Instance(combModule, {
 				env: { memory },
 			});
@@ -1481,7 +1466,7 @@ async function run() {
 				set(_, prop: string, value: PlaygroundSignalValue) {
 					const sig = layout[prop];
 					if (!sig) throw new Error(`Signal '${prop}' not found`);
-					writeSignalValue(view, sig, value, options?.fourState === true);
+					writeSignalValue(view, sig, value, fourStateEnabled);
 					dirty = true;
 					return true;
 				},
@@ -1599,8 +1584,18 @@ async function run() {
 		//   4. Evaluate combinational logic
 		//   5. Reschedule recurring clocks with toggled value
 		function createSimulation(options?: PlaygroundSimulatorOptions) {
+			const fourStateEnabled = options?.fourState === true;
+			const {
+				layout,
+				events,
+				totalSize,
+				combModule,
+				eventModules,
+				fourStateInitRegions,
+			} = fourStateEnabled ? fourStateCompiled : twoStateCompiled;
 			const pages = Math.max(1, Math.ceil(totalSize / 65536));
 			const memory = new WebAssembly.Memory({ initial: pages });
+			initializeFourStateMemory(memory, fourStateInitRegions);
 			const combInst = new WebAssembly.Instance(combModule, {
 				env: { memory },
 			});
@@ -1660,7 +1655,7 @@ async function run() {
 
 			function writeSignal(name: string, val: number) {
 				const sig = layout[name];
-				if (sig) view.setUint8(sig.offset, val);
+				if (sig) writeSignalValue(view, sig, val, fourStateEnabled);
 			}
 
 			function resolveEvent(name: string): number {
@@ -1743,7 +1738,7 @@ async function run() {
 				set(_, prop: string, value: PlaygroundSignalValue) {
 					const sig = layout[prop];
 					if (!sig) throw new Error(`Signal '${prop}' not found`);
-					writeSignalValue(view, sig, value, options?.fourState === true);
+					writeSignalValue(view, sig, value, fourStateEnabled);
 					simDirty = true;
 					return true;
 				},

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -9,6 +9,7 @@ import celoxSimulatorDts from "../../celox/dist/simulator.d.ts?raw";
 // Import real .d.ts files from @celox-sim/celox for Monaco type injection
 import celoxTypesDts from "../../celox/dist/types.d.ts?raw";
 import celoxWasmBridgeDts from "../../celox/dist/wasm-bridge.d.ts?raw";
+import { CeloxCompilerClient } from "./celox-compiler-client.js";
 import { buildMonacoTestbenchCompilerOptions } from "./monaco-testbench-options.js";
 import { FourState, X, Z } from "./playground-runtime-helpers.js";
 import { transpileTestbench } from "./testbench-transpile.js";
@@ -1228,18 +1229,23 @@ function parseVerylErrors(errorMsg: string): monaco.editor.IMarkerData[] {
 
 // Update types + diagnostics when Veryl source changes
 let updateTimer: ReturnType<typeof setTimeout>;
+let updateRevision = 0;
 function onVerylChange() {
 	clearTimeout(updateTimer);
-	updateTimer = setTimeout(() => {
+	const revision = ++updateRevision;
+	updateTimer = setTimeout(async () => {
 		const source = getVerylSource();
 		const model = getVerylModel();
 
 		// Try WASM-based analysis (accurate types + diagnostics)
-		if (celox) {
+		if (celoxCompilerReady) {
 			try {
 				const result = JSON.parse(
-					celox.genTsFromSource([{ content: source, path: "main.veryl" }]),
+					await celoxCompiler.genTsFromSource([
+						{ content: source, path: "main.veryl" },
+					]),
 				);
+				if (revision !== updateRevision) return;
 				if (result.modules?.[0]?.ports) {
 					updateDutTypes(result.modules[0].ports);
 				}
@@ -1277,6 +1283,7 @@ function onVerylChange() {
 				}
 				return;
 			} catch (e: any) {
+				if (revision !== updateRevision) return;
 				// Analysis failed — show diagnostics
 				if (model) {
 					const markers = parseVerylErrors(e.message || String(e));
@@ -1287,6 +1294,7 @@ function onVerylChange() {
 		}
 
 		// Fallback: regex-based port extraction (no WASM needed)
+		if (revision !== updateRevision) return;
 		const ports = extractPortsFromSource(source);
 		if (Object.keys(ports).length > 0) {
 			updateDutTypes(ports);
@@ -1296,11 +1304,13 @@ function onVerylChange() {
 
 // ── WASM loading ────────────────────────────────────────
 
-let celox: any;
+const celoxCompiler = new CeloxCompilerClient();
+let celoxCompilerReady = false;
 
 async function init() {
 	try {
-		celox = await import("./celox-wasm-loader.js");
+		await celoxCompiler.ready;
+		celoxCompilerReady = true;
 		statusEl.textContent = "Ready";
 		runBtn.disabled = false;
 		onVerylChange(); // Initial type generation
@@ -1347,36 +1357,91 @@ async function run() {
 		const topName = topMatch[1];
 
 		const t0 = performance.now();
-		const genTsResult = (() => {
+		const genTsResult = await (async () => {
 			try {
 				return JSON.parse(
-					celox.genTsFromSource([{ content: verylSource, path: "main.veryl" }]),
+					await celoxCompiler.genTsFromSource([
+						{ content: verylSource, path: "main.veryl" },
+					]),
 				);
 			} catch {
 				return null;
 			}
 		})();
 
-		const handle = new celox.NativeSimulatorHandle(
+		const compiled = await celoxCompiler.compile(
 			[{ content: verylSource, path: "main.veryl" }],
 			topName,
+			// One Run may create both 2-state and 4-state simulators. Compile the
+			// superset layout once; each factory still enforces its requested mode.
+			{ fourState: true },
 		);
-		const layout = JSON.parse(handle.layoutJson);
-		const events = JSON.parse(handle.eventsJson);
-		const totalSize = handle.totalSize;
+		const { layout, events, totalSize, combModule, eventModules } = compiled;
 		const t1 = performance.now();
 		appendConsole(
 			`[compile] ${(t1 - t0).toFixed(0)}ms — ${Object.keys(layout).length} signals, ${Object.keys(events).length} events`,
 			"log-success",
 		);
 
+		type PlaygroundSimulatorOptions = { fourState?: boolean };
+		type PlaygroundSignalValue =
+			| bigint
+			| number
+			| symbol
+			| { __fourState: true; value: bigint; mask: bigint };
+
+		function writeSignalValue(
+			view: DataView,
+			sig: any,
+			value: PlaygroundSignalValue,
+			fourStateEnabled: boolean,
+		) {
+			const isX = value === X;
+			const isZ = value === Z;
+			const isExplicitFourState =
+				typeof value === "object" &&
+				value !== null &&
+				value.__fourState === true;
+			if (
+				(isX || isZ || isExplicitFourState) &&
+				(!fourStateEnabled || !sig.is_4state)
+			) {
+				throw new Error("Cannot assign a 4-state value in 2-state mode");
+			}
+
+			const widthMask = (1n << BigInt(sig.width)) - 1n;
+			let data: bigint;
+			let mask: bigint;
+			if (isX) {
+				data = widthMask;
+				mask = widthMask;
+			} else if (isZ) {
+				data = 0n;
+				mask = widthMask;
+			} else if (isExplicitFourState) {
+				data = value.value & widthMask;
+				mask = value.mask & widthMask;
+			} else {
+				data = BigInt(value as bigint | number) & widthMask;
+				mask = 0n;
+			}
+
+			for (let i = 0; i < sig.byte_size; i++) {
+				view.setUint8(sig.offset + i, Number(data & 0xffn));
+				data >>= 8n;
+			}
+			if (sig.is_4state) {
+				for (let i = 0; i < sig.byte_size; i++) {
+					view.setUint8(sig.offset + sig.byte_size + i, Number(mask & 0xffn));
+					mask >>= 8n;
+				}
+			}
+		}
+
 		// Build simulation factory (creates fresh instance per call)
-		function createSim() {
+		function createSim(options?: PlaygroundSimulatorOptions) {
 			const pages = Math.max(1, Math.ceil(totalSize / 65536));
 			const memory = new WebAssembly.Memory({ initial: pages });
-			const combModule = new WebAssembly.Module(
-				new Uint8Array(handle.combWasmBytes()),
-			);
 			const combInst = new WebAssembly.Instance(combModule, {
 				env: { memory },
 			});
@@ -1386,12 +1451,12 @@ async function run() {
 			const eventInsts: Record<number, WebAssembly.Instance> = {};
 			for (const name of eventNames) {
 				const id: number = events[name];
-				try {
-					const mod = new WebAssembly.Module(
-						new Uint8Array(handle.eventWasmBytes(name)),
-					);
-					eventInsts[id] = new WebAssembly.Instance(mod, { env: { memory } });
-				} catch {}
+				const eventModule = eventModules[name];
+				if (eventModule) {
+					eventInsts[id] = new WebAssembly.Instance(eventModule, {
+						env: { memory },
+					});
+				}
 			}
 			const defaultEventId = eventNames.length > 0 ? events[eventNames[0]] : -1;
 
@@ -1413,14 +1478,10 @@ async function run() {
 					if (sig.width < 64) v &= (1n << BigInt(sig.width)) - 1n;
 					return v;
 				},
-				set(_, prop: string, value: bigint) {
+				set(_, prop: string, value: PlaygroundSignalValue) {
 					const sig = layout[prop];
 					if (!sig) throw new Error(`Signal '${prop}' not found`);
-					let v = BigInt(value);
-					for (let i = 0; i < sig.byte_size; i++) {
-						view.setUint8(sig.offset + i, Number(v & 0xffn));
-						v >>= 8n;
-					}
+					writeSignalValue(view, sig, value, options?.fourState === true);
 					dirty = true;
 					return true;
 				},
@@ -1525,8 +1586,8 @@ async function run() {
 			.filter(Boolean);
 
 		const Simulator = {
-			create(_module: any) {
-				return createSim();
+			create(_module: any, options?: PlaygroundSimulatorOptions) {
+				return createSim(options);
 			},
 		};
 
@@ -1537,12 +1598,9 @@ async function run() {
 		//   3. Detect edges (posedge/negedge) and fire triggered FF handlers
 		//   4. Evaluate combinational logic
 		//   5. Reschedule recurring clocks with toggled value
-		function createSimulation() {
+		function createSimulation(options?: PlaygroundSimulatorOptions) {
 			const pages = Math.max(1, Math.ceil(totalSize / 65536));
 			const memory = new WebAssembly.Memory({ initial: pages });
-			const combModule = new WebAssembly.Module(
-				new Uint8Array(handle.combWasmBytes()),
-			);
 			const combInst = new WebAssembly.Instance(combModule, {
 				env: { memory },
 			});
@@ -1551,12 +1609,12 @@ async function run() {
 			const eventInsts: Record<number, WebAssembly.Instance> = {};
 			for (const name of eventNames) {
 				const id: number = events[name];
-				try {
-					const mod = new WebAssembly.Module(
-						new Uint8Array(handle.eventWasmBytes(name)),
-					);
-					eventInsts[id] = new WebAssembly.Instance(mod, { env: { memory } });
-				} catch {}
+				const eventModule = eventModules[name];
+				if (eventModule) {
+					eventInsts[id] = new WebAssembly.Instance(eventModule, {
+						env: { memory },
+					});
+				}
 			}
 
 			const view = new DataView(memory.buffer);
@@ -1682,14 +1740,10 @@ async function run() {
 					if (sig.width < 64) v &= (1n << BigInt(sig.width)) - 1n;
 					return v;
 				},
-				set(_, prop: string, value: bigint) {
+				set(_, prop: string, value: PlaygroundSignalValue) {
 					const sig = layout[prop];
 					if (!sig) throw new Error(`Signal '${prop}' not found`);
-					let v = BigInt(value);
-					for (let i = 0; i < sig.byte_size; i++) {
-						view.setUint8(sig.offset + i, Number(v & 0xffn));
-						v >>= 8n;
-					}
+					writeSignalValue(view, sig, value, options?.fourState === true);
 					simDirty = true;
 					return true;
 				},
@@ -1894,8 +1948,8 @@ async function run() {
 		}
 
 		const Simulation = {
-			create(_module: any) {
-				return createSimulation();
+			create(_module: any, options?: PlaygroundSimulatorOptions) {
+				return createSimulation(options);
 			},
 		};
 

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -278,9 +278,15 @@ describe("Counter (Waveform)", () => {
 		veryl: `module FourStateDemo (
     a: input logic<8>,
     b: input logic<8>,
+    array_input: input logic<1> [8],
     snapshot: output logic<8>,
+    array_snapshot: output logic<8>,
 ) {
     assign snapshot = a;
+
+    for i in 0..8 :g {
+        assign array_snapshot[i] = array_input[i];
+    }
 }`,
 		testbench: `import { describe, it, expect } from "vitest";
 import { FourState, Simulation, Simulator, X } from "@celox-sim/celox";
@@ -307,6 +313,16 @@ describe("FourStateDemo", () => {
         const sim = Simulation.create(FourStateDemo, { fourState: true });
 
         expect(sim.fourState("a").mask).toBe(0xffn);
+
+        sim.dispose();
+    });
+
+    it("starts every unpacked array element as X", () => {
+        const sim = Simulator.create(FourStateDemo, { fourState: true });
+
+        sim.tick();
+
+        expect(sim.fourState("array_snapshot").mask).toBe(0xffn);
 
         sim.dispose();
     });

--- a/packages/playground/src/playground-runtime-helpers.ts
+++ b/packages/playground/src/playground-runtime-helpers.ts
@@ -8,3 +8,72 @@ export function FourState(value: number | bigint, mask: number | bigint) {
 		mask: BigInt(mask),
 	};
 }
+
+export type PlaygroundSignalLayout = {
+	offset: number;
+	width: number;
+	byte_size: number;
+	is_4state: boolean;
+};
+
+export type PlaygroundSignalValue =
+	| bigint
+	| number
+	| symbol
+	| { __fourState: true; value: bigint; mask: bigint };
+
+export function initializeFourStateMemory(
+	memory: WebAssembly.Memory,
+	regions: Array<[offset: number, byteSize: number]>,
+) {
+	const bytes = new Uint8Array(memory.buffer);
+	for (const [offset, byteSize] of regions) {
+		bytes.fill(0xff, offset, offset + byteSize * 2);
+	}
+}
+
+export function writeSignalValue(
+	view: DataView,
+	sig: PlaygroundSignalLayout,
+	value: PlaygroundSignalValue,
+	fourStateEnabled: boolean,
+) {
+	const isX = value === X;
+	const isZ = value === Z;
+	const isExplicitFourState =
+		typeof value === "object" && value !== null && value.__fourState === true;
+	if (
+		(isX || isZ || isExplicitFourState) &&
+		(!fourStateEnabled || !sig.is_4state)
+	) {
+		throw new Error("Cannot assign a 4-state value in 2-state mode");
+	}
+
+	const widthMask = (1n << BigInt(sig.width)) - 1n;
+	let data: bigint;
+	let mask: bigint;
+	if (isX) {
+		data = widthMask;
+		mask = widthMask;
+	} else if (isZ) {
+		data = 0n;
+		mask = widthMask;
+	} else if (isExplicitFourState) {
+		data = value.value & widthMask;
+		mask = value.mask & widthMask;
+	} else {
+		data = BigInt(value as bigint | number) & widthMask;
+		mask = 0n;
+	}
+
+	for (let i = 0; i < sig.byte_size; i++) {
+		view.setUint8(sig.offset + i, Number(data & 0xffn));
+		data >>= 8n;
+	}
+	if (sig.is_4state) {
+		for (let i = 0; i < sig.byte_size; i++) {
+			view.setUint8(sig.offset + sig.byte_size + i, Number(mask & 0xffn));
+			mask >>= 8n;
+		}
+	}
+}

--- a/packages/playground/src/wasi-worker-browser.mjs
+++ b/packages/playground/src/wasi-worker-browser.mjs
@@ -1,4 +1,11 @@
-import { instantiateNapiModuleSync, MessageHandler, WASI, createFsProxy } from '@napi-rs/wasm-runtime'
+import {
+  instantiateNapiModuleSync,
+  MessageHandler,
+  WASI,
+  createFsProxy,
+  emnapiAsyncWorkPlugin,
+  emnapiTSFNPlugin,
+} from '@napi-rs/wasm-runtime'
 import { memfsExported as __memfsExported } from '@napi-rs/wasm-runtime/fs'
 
 const fs = createFsProxy(__memfsExported)
@@ -22,6 +29,7 @@ const handler = new MessageHandler({
     return instantiateNapiModuleSync(wasmModule, {
       childThread: true,
       wasi,
+      plugins: [emnapiAsyncWorkPlugin, emnapiTSFNPlugin],
       overwriteImports(importObject) {
         importObject.env = {
           ...importObject.env,

--- a/packages/playground/test/celox-compiler-client.test.ts
+++ b/packages/playground/test/celox-compiler-client.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { CeloxCompilerClient } from "../src/celox-compiler-client";
+
+type WorkerListener = (event: any) => void;
+
+class FakeWorker {
+	static instance: FakeWorker;
+
+	readonly messages: any[] = [];
+	private readonly listeners = new Map<string, WorkerListener[]>();
+
+	constructor() {
+		FakeWorker.instance = this;
+	}
+
+	addEventListener(type: string, listener: WorkerListener) {
+		const listeners = this.listeners.get(type) ?? [];
+		listeners.push(listener);
+		this.listeners.set(type, listeners);
+	}
+
+	postMessage(message: any) {
+		this.messages.push(message);
+	}
+
+	emit(type: string, event: any) {
+		for (const listener of this.listeners.get(type) ?? []) listener(event);
+	}
+}
+
+async function createReadyClient() {
+	const client = new CeloxCompilerClient();
+	FakeWorker.instance.emit("message", { data: { type: "ready" } });
+	await client.ready;
+	return { client, worker: FakeWorker.instance };
+}
+
+describe("CeloxCompilerClient", () => {
+	beforeEach(() => {
+		vi.stubGlobal("Worker", FakeWorker);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	test("coalesces queued diagnostics to the latest source", async () => {
+		const { client, worker } = await createReadyClient();
+		const first = client.genTsFromSourceLatest([
+			{ path: "main.veryl", content: "first" },
+		]);
+		const second = client.genTsFromSourceLatest([
+			{ path: "main.veryl", content: "second" },
+		]);
+		const latest = client.genTsFromSourceLatest([
+			{ path: "main.veryl", content: "latest" },
+		]);
+		await Promise.resolve();
+
+		expect(worker.messages).toHaveLength(1);
+		worker.emit("message", {
+			data: { type: "result", id: worker.messages[0].id, value: "first-result" },
+		});
+
+		await vi.waitFor(() => expect(worker.messages).toHaveLength(2));
+		expect(worker.messages[1].sources[0].content).toBe("latest");
+		worker.emit("message", {
+			data: { type: "result", id: worker.messages[1].id, value: "latest-result" },
+		});
+
+		await expect(first).resolves.toBe("first-result");
+		await expect(second).resolves.toBe("latest-result");
+		await expect(latest).resolves.toBe("latest-result");
+	});
+
+	test("rejects later requests after a terminal worker failure", async () => {
+		const { client, worker } = await createReadyClient();
+		const pending = client.genTsFromSource([
+			{ path: "main.veryl", content: "module Top {}" },
+		]);
+		await Promise.resolve();
+		const messageCount = worker.messages.length;
+		worker.emit("error", { message: "worker crashed" });
+
+		await expect(pending).rejects.toThrow("worker crashed");
+		await expect(
+			client.genTsFromSource([
+				{ path: "main.veryl", content: "module Next {}" },
+			]),
+		).rejects.toThrow("worker crashed");
+		expect(worker.messages).toHaveLength(messageCount);
+	});
+});

--- a/packages/playground/test/e2e/monaco-diagnostics.spec.ts
+++ b/packages/playground/test/e2e/monaco-diagnostics.spec.ts
@@ -1,21 +1,5 @@
-import { expect, type Page, test } from "@playwright/test";
-
-type PlaygroundTestMarker = {
-	code?: string | number;
-	message: string;
-};
-
-declare global {
-	interface Window {
-		__CELOX_PLAYGROUND_TEST_API__?: {
-			loadExample: (name: string) => void;
-			setFileContent: (path: string, content: string) => void;
-			getModelMarkers: (path: string) => PlaygroundTestMarker[];
-			getTypeScriptDiagnostics: (path: string) => Promise<PlaygroundTestMarker[]>;
-			getStatusText: () => string;
-		};
-	}
-}
+import { expect, test } from "@playwright/test";
+import { openPlayground } from "./playground.js";
 
 const bigintTestbench = `import { describe, it, expect } from "vitest";
 
@@ -26,43 +10,6 @@ describe("bigint literals", () => {
 	});
 });
 `;
-
-async function openPlayground(page: Page) {
-	const browserErrors: string[] = [];
-	page.on("console", (message) => {
-		if (message.type() === "error") browserErrors.push(message.text());
-	});
-	const pageError = new Promise<never>((_, reject) => {
-		page.on("pageerror", (error) => {
-			browserErrors.push(error.message);
-			reject(new Error(`Playground browser error: ${error.message}`));
-		});
-	});
-
-	const response = await page.goto("/");
-	expect(response?.headers()["cross-origin-opener-policy"]).toBe("same-origin");
-	expect(response?.headers()["cross-origin-embedder-policy"]).toBe(
-		"credentialless",
-	);
-	expect(await page.evaluate(() => window.crossOriginIsolated)).toBe(true);
-
-	await Promise.race([
-		page.waitForFunction(() => {
-			const api = window.__CELOX_PLAYGROUND_TEST_API__;
-			return api && api.getStatusText() !== "Loading WASM…";
-		}),
-		pageError,
-	]);
-	const status = await page.evaluate(() =>
-		window.__CELOX_PLAYGROUND_TEST_API__?.getStatusText(),
-	);
-	expect(
-		status,
-		`Browser errors: ${browserErrors.join("\n") || "none"}`,
-	).toBe("Ready");
-
-	return browserErrors;
-}
 
 test("playground starts and accepts bigint literals", async ({ page }) => {
 	const browserErrors = await openPlayground(page);
@@ -96,5 +43,5 @@ test("playground starts and accepts bigint literals", async ({ page }) => {
 			{ timeout: 60_000 },
 		)
 		.toBe(true);
-	expect(browserErrors).toEqual([]);
+	browserErrors.assertEmpty();
 });

--- a/packages/playground/test/e2e/playground.ts
+++ b/packages/playground/test/e2e/playground.ts
@@ -1,0 +1,70 @@
+import { expect, type Page } from "@playwright/test";
+
+export type PlaygroundTestMarker = {
+	code?: string | number;
+	message: string;
+};
+
+type PlaygroundTestApi = {
+	loadExample: (name: string) => void;
+	setFileContent: (path: string, content: string) => void;
+	getModelMarkers: (path: string) => PlaygroundTestMarker[];
+	getTypeScriptDiagnostics: (
+		path: string,
+	) => Promise<PlaygroundTestMarker[]>;
+	getStatusText: () => string;
+};
+
+declare global {
+	interface Window {
+		__CELOX_PLAYGROUND_TEST_API__?: PlaygroundTestApi;
+	}
+}
+
+export type BrowserErrorMonitor = {
+	errors: string[];
+	assertEmpty: () => void;
+};
+
+export async function openPlayground(
+	page: Page,
+): Promise<BrowserErrorMonitor> {
+	const errors: string[] = [];
+	page.on("console", (message) => {
+		if (message.type() === "error") errors.push(message.text());
+	});
+	const pageError = new Promise<never>((_, reject) => {
+		page.on("pageerror", (error) => {
+			errors.push(error.message);
+			reject(new Error(`Playground browser error: ${error.message}`));
+		});
+	});
+
+	const response = await page.goto("/");
+	expect(response?.headers()["cross-origin-opener-policy"]).toBe("same-origin");
+	expect(response?.headers()["cross-origin-embedder-policy"]).toBe(
+		"credentialless",
+	);
+	expect(await page.evaluate(() => window.crossOriginIsolated)).toBe(true);
+
+	await Promise.race([
+		page.waitForFunction(() => {
+			const api = window.__CELOX_PLAYGROUND_TEST_API__;
+			return api && api.getStatusText() !== "Loading WASM…";
+		}),
+		pageError,
+	]);
+	const status = await page.evaluate(() =>
+		window.__CELOX_PLAYGROUND_TEST_API__?.getStatusText(),
+	);
+	expect(status, `Browser errors: ${errors.join("\n") || "none"}`).toBe(
+		"Ready",
+	);
+
+	return {
+		errors,
+		assertEmpty() {
+			expect(errors).toEqual([]);
+		},
+	};
+}

--- a/packages/playground/test/e2e/run.spec.ts
+++ b/packages/playground/test/e2e/run.spec.ts
@@ -106,7 +106,7 @@ test("every bundled example runs successfully", async ({ page }) => {
 		counter: 2,
 		counter_sim: 2,
 		counter_vcd: 2,
-		four_state: 5,
+		four_state: 6,
 	})) {
 		await test.step(example, async () => {
 			await page.evaluate((name) => {

--- a/packages/playground/test/e2e/run.spec.ts
+++ b/packages/playground/test/e2e/run.spec.ts
@@ -101,20 +101,20 @@ test("every bundled example runs successfully", async ({ page }) => {
 	test.setTimeout(90_000);
 	const browserErrors = await openPlayground(page);
 
-	for (const example of [
-		"adder",
-		"counter",
-		"counter_sim",
-		"counter_vcd",
-		"four_state",
-	]) {
+	for (const [example, expectedPassed] of Object.entries({
+		adder: 2,
+		counter: 2,
+		counter_sim: 2,
+		counter_vcd: 2,
+		four_state: 5,
+	})) {
 		await test.step(example, async () => {
 			await page.evaluate((name) => {
 				const api = window.__CELOX_PLAYGROUND_TEST_API__;
 				if (!api) throw new Error("Missing playground test API");
 				api.loadExample(name);
 			}, example);
-			await runAndExpectPass(page);
+			await runAndExpectPass(page, expectedPassed);
 		});
 	}
 

--- a/packages/playground/test/e2e/run.spec.ts
+++ b/packages/playground/test/e2e/run.spec.ts
@@ -1,0 +1,134 @@
+import { expect, type Page, test } from "@playwright/test";
+import { openPlayground } from "./playground.js";
+
+const RUN_TIMEOUT_MS = 15_000;
+const MAX_MAIN_THREAD_GAP_MS = 1_000;
+
+const HIERARCHICAL_ADDER = `module Adder (
+    clk: input clock,
+    rst: input reset,
+    a:   input logic<16>,
+    b:   input logic<16>,
+    sum: output logic<17>,
+) {
+    inst u_leaf: AddLeaf (
+        a,
+        b,
+        sum,
+    );
+}
+
+module AddLeaf (
+    a:   input logic<16>,
+    b:   input logic<16>,
+    sum: output logic<17>,
+) {
+    assign sum = a + b;
+}
+`;
+
+async function runAndExpectPass(page: Page, expectedPassed = 2) {
+	await page.locator("#run").click();
+
+	try {
+		await page.waitForFunction(
+			() => {
+				const run = document.querySelector<HTMLButtonElement>("#run");
+				const status = document.querySelector("#status")?.textContent;
+				return run?.disabled === false && status !== "Ready";
+			},
+			undefined,
+			{ timeout: RUN_TIMEOUT_MS },
+		);
+	} catch {
+		const status = await page.locator("#status").textContent();
+		const output = await page.locator("#console").textContent();
+		throw new Error(
+			`Run did not finish within ${RUN_TIMEOUT_MS}ms (status: ${status ?? "missing"}).\n${output ?? ""}`,
+		);
+	}
+
+	const status = await page.locator("#status").textContent();
+	const output = await page.locator("#console").textContent();
+	expect(status, output ?? "No playground output").toBe("Done");
+	expect(output).toContain(`${expectedPassed} passed`);
+}
+
+test("Run stays responsive while compiling and finishes before the deadline", async ({
+	page,
+}) => {
+	const browserErrors = await openPlayground(page);
+
+	await page.evaluate(() => {
+		const scope = globalThis as typeof globalThis & {
+			__celoxHeartbeat?: { ticks: number; maxGapMs: number };
+		};
+		const heartbeat = { ticks: 0, maxGapMs: 0 };
+		scope.__celoxHeartbeat = heartbeat;
+		let previous = performance.now();
+		setInterval(() => {
+			const now = performance.now();
+			heartbeat.ticks++;
+			heartbeat.maxGapMs = Math.max(heartbeat.maxGapMs, now - previous);
+			previous = now;
+		}, 10);
+	});
+	await page.waitForFunction(
+		() =>
+			(
+				globalThis as typeof globalThis & {
+					__celoxHeartbeat?: { ticks: number };
+				}
+			).__celoxHeartbeat?.ticks,
+	);
+
+	await runAndExpectPass(page);
+
+	const heartbeat = await page.evaluate(
+		() =>
+			(
+				globalThis as typeof globalThis & {
+					__celoxHeartbeat?: { ticks: number; maxGapMs: number };
+				}
+			).__celoxHeartbeat,
+	);
+	expect(heartbeat?.ticks).toBeGreaterThan(1);
+	expect(heartbeat?.maxGapMs).toBeLessThan(MAX_MAIN_THREAD_GAP_MS);
+	browserErrors.assertEmpty();
+});
+
+test("every bundled example runs successfully", async ({ page }) => {
+	test.setTimeout(90_000);
+	const browserErrors = await openPlayground(page);
+
+	for (const example of [
+		"adder",
+		"counter",
+		"counter_sim",
+		"counter_vcd",
+		"four_state",
+	]) {
+		await test.step(example, async () => {
+			await page.evaluate((name) => {
+				const api = window.__CELOX_PLAYGROUND_TEST_API__;
+				if (!api) throw new Error("Missing playground test API");
+				api.loadExample(name);
+			}, example);
+			await runAndExpectPass(page);
+		});
+	}
+
+	browserErrors.assertEmpty();
+});
+
+test("a hierarchical design compiles and runs in the browser", async ({ page }) => {
+	const browserErrors = await openPlayground(page);
+	await page.evaluate((source) => {
+		const api = window.__CELOX_PLAYGROUND_TEST_API__;
+		if (!api) throw new Error("Missing playground test API");
+		api.setFileContent("src/Adder.veryl", source);
+	}, HIERARCHICAL_ADDER);
+
+	await runAndExpectPass(page);
+	browserErrors.assertEmpty();
+});

--- a/packages/playground/test/e2e/run.spec.ts
+++ b/packages/playground/test/e2e/run.spec.ts
@@ -29,7 +29,10 @@ module AddLeaf (
 
 async function runAndExpectPass(page: Page, expectedPassed = 2) {
 	await page.locator("#run").click();
+	await expectRunToPass(page, expectedPassed);
+}
 
+async function expectRunToPass(page: Page, expectedPassed = 2) {
 	try {
 		await page.waitForFunction(
 			() => {
@@ -130,5 +133,30 @@ test("a hierarchical design compiles and runs in the browser", async ({ page }) 
 	}, HIERARCHICAL_ADDER);
 
 	await runAndExpectPass(page);
+	browserErrors.assertEmpty();
+});
+
+test("Run uses the testbench snapshot from when it started", async ({ page }) => {
+	const browserErrors = await openPlayground(page);
+
+	await page.locator("#run").click();
+	await page.evaluate(() => {
+		const api = window.__CELOX_PLAYGROUND_TEST_API__;
+		if (!api) throw new Error("Missing playground test API");
+		api.setFileContent(
+			"test/adder.test.ts",
+			`import { describe, it, expect } from "vitest";
+describe("edited testbench", () => {
+    it("must not enter the active run", () => {
+        expect(1).toBe(2);
+    });
+});`,
+		);
+	});
+
+	await expectRunToPass(page);
+	expect(await page.locator("#console").textContent()).not.toContain(
+		"edited testbench",
+	);
 	browserErrors.assertEmpty();
 });

--- a/packages/playground/test/playground-runtime-helpers.test.ts
+++ b/packages/playground/test/playground-runtime-helpers.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "vitest";
 
-import { FourState, X, Z } from "../src/playground-runtime-helpers";
+import {
+	FourState,
+	initializeFourStateMemory,
+	writeSignalValue,
+	X,
+	Z,
+} from "../src/playground-runtime-helpers";
 
 describe("playground-runtime-helpers", () => {
 	test("provides 4-state sentinels compatible with celox runtime encoding", () => {
@@ -14,5 +20,35 @@ describe("playground-runtime-helpers", () => {
 			value: 0x05n,
 			mask: 0xf0n,
 		});
+	});
+
+	test("initializes 4-state value and mask planes to X", () => {
+		const memory = new WebAssembly.Memory({ initial: 1 });
+		initializeFourStateMemory(memory, [
+			[4, 1],
+			[8, 2],
+		]);
+
+		const bytes = new Uint8Array(memory.buffer);
+		expect([...bytes.slice(4, 6)]).toEqual([0xff, 0xff]);
+		expect([...bytes.slice(8, 12)]).toEqual([0xff, 0xff, 0xff, 0xff]);
+		expect([...bytes.slice(12, 14)]).toEqual([0, 0]);
+	});
+
+	test("clears a stale mask when writing a defined scheduled value", () => {
+		const memory = new WebAssembly.Memory({ initial: 1 });
+		const sig = {
+			offset: 0,
+			width: 8,
+			byte_size: 1,
+			is_4state: true,
+		};
+		initializeFourStateMemory(memory, [[0, 1]]);
+		const view = new DataView(memory.buffer);
+
+		writeSignalValue(view, sig, 0x35, true);
+
+		expect(view.getUint8(0)).toBe(0x35);
+		expect(view.getUint8(1)).toBe(0);
 	});
 });

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -38,4 +38,7 @@ export default defineConfig({
     target: "esnext",
     outDir: "dist",
   },
+  worker: {
+    format: "es",
+  },
 });


### PR DESCRIPTION
## Summary

- move Playground WASM loading, TypeScript generation, and simulator compilation to a dedicated browser worker
- avoid browser-incompatible synchronous thread joins in the Veryl frontend and SIR optimizer on wasm32
- restore 4-state values in the Playground simulator bridge
- strengthen Playwright coverage with a responsiveness deadline, every bundled example, hierarchical compilation, and browser error checks
- run Playground browser E2E for NAPI/WASM-affecting changes in CI

## Root cause

The browser WASI runtime cannot synchronously join the Rust worker threads used while lowering hierarchy and running optimizer passes. Pressing Run could therefore block the browser execution context. Compilation now stays off the UI thread, and wasm32 uses serial execution for those passes while native builds retain parallel execution.

## Impact

Run remains responsive and completes in the deployed Playground. The regression suite now detects a blocked main thread, a run that exceeds 15 seconds, browser errors, failures in bundled examples, and hierarchy-specific compilation failures.

## Validation

- `pnpm --filter @celox-sim/playground test:e2e` — 4 passed
- `pnpm --filter @celox-sim/playground test` — 19 passed, 5 skipped
- `pnpm --filter @celox-sim/playground test:wasm` — 6 passed
- `cargo test -p celox-frontend-veryl -p celox-sir-opt` — 490 passed
- `cargo check --workspace --locked`
- `cargo clippy -p celox-frontend-veryl -p celox-sir-opt --all-targets -- -D warnings`
- `pnpm run lint`
- `cargo fmt --all -- --check`