### PR TITLE
fix(napi): preserve unpacked array port layout

### DIFF
--- a/crates/celox-napi/src/layout.rs
+++ b/crates/celox-napi/src/layout.rs
@@ -21,6 +21,10 @@ pub struct SignalLayout {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub array_dims: Vec<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub array_element_stride: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub array_plane_size: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub associated_clock: Option<String>,
 }
 
@@ -65,6 +69,11 @@ fn build_signal_layout_entry(ns: &NamedSignal, four_state_mode: bool) -> SignalL
         let element_width = ns.signal.width / ns.info.array_dims.iter().product::<usize>();
         (element_width, ns.info.array_dims.clone())
     };
+    let (array_element_stride, array_plane_size) = ns
+        .signal
+        .array_layout
+        .map(|layout| (Some(layout.element_stride), Some(layout.plane_size)))
+        .unwrap_or((None, None));
 
     SignalLayout {
         offset: ns.signal.offset,
@@ -74,6 +83,8 @@ fn build_signal_layout_entry(ns: &NamedSignal, four_state_mode: bool) -> SignalL
         direction,
         type_kind,
         array_dims,
+        array_element_stride,
+        array_plane_size,
         associated_clock: ns.associated_clock.clone(),
     }
 }

--- a/packages/celox/src/dut.test.ts
+++ b/packages/celox/src/dut.test.ts
@@ -762,6 +762,83 @@ describe("createDut — array ports", () => {
 		expect(dut.data.at(1)).toBe(0b111n);
 	});
 
+	test.each([
+		[20, 3, 0xabcden, 0x54321n],
+		[34, 5, 0x1_12345678n, 0x2_abcdef01n],
+	])(
+		"native element-strided %i-bit writes do not overwrite the next element",
+		(elementWidth, elementStride, value, nextValue) => {
+			const buffer = makeBuffer(64);
+			const layout: Record<string, SignalLayout> = {
+				data: {
+					offset: 2,
+					width: elementWidth,
+					byteSize: elementStride,
+					is4state: false,
+					direction: "input",
+					arrayElementStride: elementStride,
+					arrayPlaneSize: elementStride * 3,
+				},
+			};
+			const ports: Record<string, PortInfo> = {
+				data: {
+					direction: "input",
+					type: "logic",
+					width: elementWidth,
+					arrayDims: [3],
+				},
+			};
+			const dut = createDut<{
+				data: { at(i: number): bigint; set(i: number, v: bigint): void };
+			}>(buffer, layout, ports, mockHandle(), { dirty: false });
+
+			dut.data.set(2, nextValue);
+			dut.data.set(1, value);
+
+			expect(dut.data.at(1)).toBe(value);
+			expect(dut.data.at(2)).toBe(nextValue);
+		},
+	);
+
+	test("native element-strided wide 4-state writes stay within each plane slot", () => {
+		const buffer = makeBuffer(64);
+		const layout: Record<string, SignalLayout> = {
+			data: {
+				offset: 2,
+				width: 34,
+				byteSize: 5,
+				is4state: true,
+				direction: "input",
+				arrayElementStride: 5,
+				arrayPlaneSize: 15,
+			},
+		};
+		const ports: Record<string, PortInfo> = {
+			data: {
+				direction: "input",
+				type: "logic",
+				width: 34,
+				arrayDims: [3],
+				is4state: true,
+			},
+		};
+		const dut = createDut<{
+			data: {
+				at(i: number): bigint;
+				set(i: number, v: FourStateSignalValue): void;
+			};
+		}>(buffer, layout, ports, mockHandle(), { dirty: false });
+		const view = new DataView(buffer);
+
+		dut.data.set(2, FourState(0x2_abcdef01n, 0x1_23456789n));
+		dut.data.set(1, FourState(0x1_12345678n, 0x2_3456789an));
+
+		expect(dut.data.at(2)).toBe(0x2_abcdef01n);
+		expect(
+			Array.from({ length: 5 }, (_, i) => view.getUint8(2 + 15 + 2 * 5 + i)),
+		).toEqual([0x89, 0x67, 0x45, 0x23, 0x01]);
+	});
+
 	test("1-bit elements (logic [N]): bit-packed read/write", () => {
 		// logic[4]: 4 elements of 1 bit each = 1 byte total in native memory
 		const buffer = makeBuffer(64);

--- a/packages/celox/src/dut.test.ts
+++ b/packages/celox/src/dut.test.ts
@@ -694,6 +694,74 @@ describe("createDut — array ports", () => {
 		expect(dut.data.length).toBe(4);
 	});
 
+	test("native element-strided sub-byte elements use separate slots", () => {
+		const buffer = makeBuffer(64);
+		const layout: Record<string, SignalLayout> = {
+			bits: {
+				offset: 4,
+				width: 1,
+				byteSize: 1,
+				is4state: false,
+				direction: "input",
+				arrayElementStride: 1,
+				arrayPlaneSize: 4,
+			},
+		};
+		const ports: Record<string, PortInfo> = {
+			bits: { direction: "input", type: "logic", width: 1, arrayDims: [4] },
+		};
+		const dut = createDut<{
+			bits: { at(i: number): bigint; set(i: number, v: bigint): void };
+		}>(buffer, layout, ports, mockHandle(), { dirty: false });
+
+		dut.bits.set(1, 1n);
+		dut.bits.set(3, 1n);
+
+		const view = new DataView(buffer);
+		expect(view.getUint8(4)).toBe(0);
+		expect(view.getUint8(5)).toBe(1);
+		expect(view.getUint8(6)).toBe(0);
+		expect(view.getUint8(7)).toBe(1);
+		expect(dut.bits.at(1)).toBe(1n);
+		expect(dut.bits.at(3)).toBe(1n);
+	});
+
+	test("native element-strided 4-state arrays use the reported mask plane", () => {
+		const buffer = makeBuffer(64);
+		const layout: Record<string, SignalLayout> = {
+			data: {
+				offset: 2,
+				width: 3,
+				byteSize: 1,
+				is4state: true,
+				direction: "input",
+				arrayElementStride: 1,
+				arrayPlaneSize: 3,
+			},
+		};
+		const ports: Record<string, PortInfo> = {
+			data: {
+				direction: "input",
+				type: "logic",
+				width: 3,
+				arrayDims: [3],
+				is4state: true,
+			},
+		};
+		const dut = createDut<{
+			data: { at(i: number): bigint; set(i: number, v: unknown): void };
+		}>(buffer, layout, ports, mockHandle(), { dirty: false });
+
+		dut.data.set(1, X);
+
+		const view = new DataView(buffer);
+		expect(view.getUint8(3)).toBe(0b111);
+		expect(view.getUint8(6)).toBe(0b111);
+		expect(view.getUint8(2)).toBe(0);
+		expect(view.getUint8(5)).toBe(0);
+		expect(dut.data.at(1)).toBe(0b111n);
+	});
+
 	test("1-bit elements (logic [N]): bit-packed read/write", () => {
 		// logic[4]: 4 elements of 1 bit each = 1 byte total in native memory
 		const buffer = makeBuffer(64);

--- a/packages/celox/src/dut.ts
+++ b/packages/celox/src/dut.ts
@@ -76,7 +76,7 @@ function writeNumber(
 	}
 }
 
-/** Read a wide value (≥ 54 bits) as BigInt, little-endian. */
+/** Read a value as BigInt, little-endian, using exactly byteSize bytes. */
 function readBigInt(view: DataView, offset: number, byteSize: number): bigint {
 	let result = 0n;
 	// Read 8 bytes at a time, then remaining bytes
@@ -96,7 +96,7 @@ function readBigInt(view: DataView, offset: number, byteSize: number): bigint {
 	return result;
 }
 
-/** Write a wide value (≥ 54 bits) as BigInt, little-endian. */
+/** Write a value as BigInt, little-endian, using exactly byteSize bytes. */
 function writeBigInt(
 	view: DataView,
 	offset: number,
@@ -635,13 +635,18 @@ function createArrayDut(
 		const elementStride = baseSig.arrayElementStride;
 		const elementByteSize = Math.ceil(elementWidth / 8);
 		const planeSize = baseSig.arrayPlaneSize;
-		const elementSignal = (i: number, mask: boolean): SignalLayout => ({
-			offset: baseOffset + (mask ? planeSize : 0) + i * elementStride,
-			width: elementWidth,
-			byteSize: elementByteSize,
-			is4state: false,
-			direction: baseSig.direction,
-		});
+		const elementMask = (1n << BigInt(elementWidth)) - 1n;
+		const elementOffset = (i: number, mask: boolean): number =>
+			baseOffset + (mask ? planeSize : 0) + i * elementStride;
+		const readElement = (i: number, mask: boolean): bigint =>
+			readBigInt(view, elementOffset(i, mask), elementByteSize) & elementMask;
+		const writeElement = (i: number, mask: boolean, value: bigint): void =>
+			writeBigInt(
+				view,
+				elementOffset(i, mask),
+				elementByteSize,
+				value & elementMask,
+			);
 
 		return {
 			length: totalElements,
@@ -652,7 +657,7 @@ function createArrayDut(
 					handle.evalComb();
 					state.dirty = false;
 				}
-				return readSignal(view, elementSignal(i, false));
+				return readElement(i, false);
 			},
 
 			set(i: number, value: bigint | number | symbol | FourStateValue): void {
@@ -661,34 +666,31 @@ function createArrayDut(
 					throw new Error("Cannot write to output array port");
 				}
 
-				const valueSignal = elementSignal(i, false);
-				const maskSignal = elementSignal(i, true);
-				const allOnes = (1n << BigInt(elementWidth)) - 1n;
 				if (value === Symbol.for("veryl:X")) {
 					if (!is4state) {
 						throw new Error("Array port is not 4-state; cannot assign X");
 					}
-					writeSignal(view, valueSignal, allOnes);
-					writeSignal(view, maskSignal, allOnes);
+					writeElement(i, false, elementMask);
+					writeElement(i, true, elementMask);
 				} else if (value === Symbol.for("veryl:Z")) {
 					if (!is4state) {
 						throw new Error("Array port is not 4-state; cannot assign Z");
 					}
-					writeSignal(view, valueSignal, 0n);
-					writeSignal(view, maskSignal, allOnes);
+					writeElement(i, false, 0n);
+					writeElement(i, true, elementMask);
 				} else if (isFourStateValue(value)) {
 					if (!is4state) {
 						throw new Error(
 							"Array port is not 4-state; cannot assign FourState",
 						);
 					}
-					writeSignal(view, valueSignal, value.value);
-					writeSignal(view, maskSignal, value.mask);
+					writeElement(i, false, value.value);
+					writeElement(i, true, value.mask);
 				} else {
 					const bigVal =
 						typeof value === "bigint" ? value : BigInt(value as number);
-					writeSignal(view, valueSignal, bigVal);
-					if (is4state) writeSignal(view, maskSignal, 0n);
+					writeElement(i, false, bigVal);
+					if (is4state) writeElement(i, true, 0n);
 				}
 				state.dirty = true;
 			},

--- a/packages/celox/src/dut.ts
+++ b/packages/celox/src/dut.ts
@@ -628,6 +628,73 @@ function createArrayDut(
 	const totalValueBytes = Math.ceil((totalElements * elementWidth) / 8);
 	const maskBase = baseOffset + totalValueBytes;
 
+	if (
+		baseSig.arrayElementStride !== undefined &&
+		baseSig.arrayPlaneSize !== undefined
+	) {
+		const elementStride = baseSig.arrayElementStride;
+		const elementByteSize = Math.ceil(elementWidth / 8);
+		const planeSize = baseSig.arrayPlaneSize;
+		const elementSignal = (i: number, mask: boolean): SignalLayout => ({
+			offset: baseOffset + (mask ? planeSize : 0) + i * elementStride,
+			width: elementWidth,
+			byteSize: elementByteSize,
+			is4state: false,
+			direction: baseSig.direction,
+		});
+
+		return {
+			length: totalElements,
+
+			at(i: number): bigint {
+				if (state.disposed) throw new Error("Simulator has been disposed");
+				if (state.dirty && !isInput) {
+					handle.evalComb();
+					state.dirty = false;
+				}
+				return readSignal(view, elementSignal(i, false));
+			},
+
+			set(i: number, value: bigint | number | symbol | FourStateValue): void {
+				if (state.disposed) throw new Error("Simulator has been disposed");
+				if (isOutput) {
+					throw new Error("Cannot write to output array port");
+				}
+
+				const valueSignal = elementSignal(i, false);
+				const maskSignal = elementSignal(i, true);
+				const allOnes = (1n << BigInt(elementWidth)) - 1n;
+				if (value === Symbol.for("veryl:X")) {
+					if (!is4state) {
+						throw new Error("Array port is not 4-state; cannot assign X");
+					}
+					writeSignal(view, valueSignal, allOnes);
+					writeSignal(view, maskSignal, allOnes);
+				} else if (value === Symbol.for("veryl:Z")) {
+					if (!is4state) {
+						throw new Error("Array port is not 4-state; cannot assign Z");
+					}
+					writeSignal(view, valueSignal, 0n);
+					writeSignal(view, maskSignal, allOnes);
+				} else if (isFourStateValue(value)) {
+					if (!is4state) {
+						throw new Error(
+							"Array port is not 4-state; cannot assign FourState",
+						);
+					}
+					writeSignal(view, valueSignal, value.value);
+					writeSignal(view, maskSignal, value.mask);
+				} else {
+					const bigVal =
+						typeof value === "bigint" ? value : BigInt(value as number);
+					writeSignal(view, valueSignal, bigVal);
+					if (is4state) writeSignal(view, maskSignal, 0n);
+				}
+				state.dirty = true;
+			},
+		};
+	}
+
 	if (elementWidth < 8) {
 		// Sub-byte elements: use optimised number-based bit-packed I/O.
 		return {

--- a/packages/celox/src/e2e.test.ts
+++ b/packages/celox/src/e2e.test.ts
@@ -2672,6 +2672,107 @@ describe("E2E: Proto package ordering (issue #22)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Bug fix: constant indexing of unpacked array inputs from always_ff
+// ---------------------------------------------------------------------------
+
+const UNPACKED_ARRAY_INPUT_INDEX_SOURCE = `
+module UnpackedArrayInputIndex (
+    clk: input clock,
+    rst: input reset,
+    i_valid: input logic [2],
+    i_data: input logic<8> [2],
+    o_valid: output logic,
+    o_data: output logic<8>,
+) {
+    always_ff (clk, rst) {
+        if_reset {
+            o_valid = 0;
+            o_data = 0;
+        } else {
+            o_valid = 0;
+            if i_valid[0] {
+                o_valid = 1;
+                o_data = i_data[0];
+            }
+            if i_valid[1] {
+                o_valid = 1;
+                o_data = i_data[1];
+            }
+        }
+    }
+}
+`;
+
+describe("E2E: constant indexing of unpacked array inputs", () => {
+	test.each([
+		[0, 0x11n],
+		[1, 0xa5n],
+	])("element %i is readable from always_ff", (index, value) => {
+		interface Ports {
+			rst: bigint;
+			i_valid: {
+				at(i: number): bigint;
+				set(i: number, value: bigint): void;
+			};
+			i_data: {
+				at(i: number): bigint;
+				set(i: number, value: bigint): void;
+			};
+			readonly o_valid: bigint;
+			readonly o_data: bigint;
+		}
+
+		const sim = Simulator.create<Ports>(
+			{
+				__celox_module: true,
+				name: "UnpackedArrayInputIndex",
+				sources: [{ path: "", content: UNPACKED_ARRAY_INPUT_INDEX_SOURCE }],
+				ports: {
+					clk: { direction: "input", type: "clock", width: 1 },
+					rst: { direction: "input", type: "reset", width: 1 },
+					i_valid: {
+						direction: "input",
+						type: "logic",
+						width: 1,
+						arrayDims: [2],
+					},
+					i_data: {
+						direction: "input",
+						type: "logic",
+						width: 8,
+						arrayDims: [2],
+					},
+					o_valid: { direction: "output", type: "logic", width: 1 },
+					o_data: { direction: "output", type: "logic", width: 8 },
+				},
+				events: ["clk"],
+			},
+			{ __nativeCreate: createSimulatorBridge(loadNativeAddon()) },
+		);
+
+		sim.dut.rst = 0n;
+		for (let i = 0; i < 2; i++) {
+			sim.dut.i_valid.set(i, 0n);
+			sim.dut.i_data.set(i, 0n);
+		}
+		sim.tick();
+		sim.tick();
+		sim.dut.rst = 1n;
+		sim.tick();
+
+		sim.dut.i_valid.set(index, 1n);
+		sim.dut.i_data.set(index, value);
+		expect(sim.dut.i_valid.at(index)).toBe(1n);
+		expect(sim.dut.i_data.at(index)).toBe(value);
+		sim.tick();
+
+		expect(sim.dut.o_valid).toBe(1n);
+		expect(sim.dut.o_data).toBe(value);
+		sim.dispose();
+	});
+});
+
+// ---------------------------------------------------------------------------
 // Bug fix: non-byte-aligned unpacked array port (logic<34> [N])
 // ---------------------------------------------------------------------------
 

--- a/packages/celox/src/napi-helpers.ts
+++ b/packages/celox/src/napi-helpers.ts
@@ -455,6 +455,8 @@ interface RawSignalLayout {
 	direction: string;
 	type_kind: string;
 	array_dims?: number[];
+	array_element_stride?: number;
+	array_plane_size?: number;
 	associated_clock?: string;
 }
 
@@ -492,6 +494,8 @@ export function parseNapiLayout(json: string): {
 			byteSize: r.byte_size > 0 ? r.byte_size : Math.ceil(r.width / 8),
 			is4state: r.is_4state,
 			direction: r.direction as SignalLayout["direction"],
+			arrayElementStride: r.array_element_stride,
+			arrayPlaneSize: r.array_plane_size,
 		};
 		const entry: SignalLayout & {
 			typeKind: string;
@@ -698,6 +702,8 @@ function convertHierarchyNode(
 			byteSize: r.byte_size > 0 ? r.byte_size : Math.ceil(r.width / 8),
 			is4state: r.is_4state,
 			direction: r.direction as SignalLayout["direction"],
+			arrayElementStride: r.array_element_stride,
+			arrayPlaneSize: r.array_plane_size,
 		};
 		const entry: SignalLayout & { typeKind: string; arrayDims?: number[] } = {
 			...sl,
@@ -826,6 +832,8 @@ function parseLegacyLayout(json: string): Record<string, SignalLayout> {
 			byteSize: r.byte_size > 0 ? r.byte_size : Math.ceil(r.width / 8),
 			is4state: r.is_4state,
 			direction: r.direction as SignalLayout["direction"],
+			arrayElementStride: r.array_element_stride,
+			arrayPlaneSize: r.array_plane_size,
 		};
 	}
 	return result;

--- a/packages/celox/src/types.ts
+++ b/packages/celox/src/types.ts
@@ -63,9 +63,13 @@ export interface SignalLayout {
 	readonly width: number;
 	/** Number of bytes occupied (ceil(width/8)). */
 	readonly byteSize: number;
-	/** If true, an equal-sized mask follows immediately after the value. */
+	/** If true, a mask plane follows the value plane. */
 	readonly is4state: boolean;
 	readonly direction: "input" | "output" | "inout" | "internal";
+	/** Byte stride between unpacked-array elements in native memory. */
+	readonly arrayElementStride?: number;
+	/** Byte size of one unpacked-array value or mask plane. */
+	readonly arrayPlaneSize?: number;
 	/** The Veryl type kind (e.g. "clock", "reset_async_high", "logic"). */
 	readonly typeKind?: string;
 	/** For reset signals, the name of the associated clock (from FfDeclaration). */


### PR DESCRIPTION
## Summary

- expose native unpacked-array element stride and plane size through the N-API layout metadata
- make TypeScript DUT array accessors honor element-strided native layouts while retaining the packed-layout fallback
- add unit and end-to-end coverage for sub-byte, 4-state, and `Simulator.create` array indexing

## Root cause

The native backend lays out unpacked-array elements in independently padded slots, but the N-API layout JSON discarded the element stride and value/mask plane size. The TypeScript DUT therefore treated those inputs as packed arrays, so writes to element 1 did not reach the storage read by constant indexing in `always_ff`.

## Impact

Constant indexing of unpacked-array input ports now reads and writes the native slots consistently, including 4-state mask planes. Existing layouts without the new metadata continue using the previous packed representation.

## Validation

- `vitest run packages/celox/src` — 162 tests passed
- `tsc -p packages/celox/tsconfig.json`
- `biome check` on the changed TypeScript files
- `cargo test -p celox-napi` — 21 tests passed
- `cargo clippy -p celox-napi --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- pre-push hook: submodule check, formatting, Biome, workspace `cargo check`, clean-tree check
