### PR TITLE
perf(slt): bound shared region slice lowering

### DIFF
--- a/crates/celox-slt/src/lower.rs
+++ b/crates/celox-slt/src/lower.rs
@@ -1122,6 +1122,7 @@ struct LoweringCostCache {
     owned_costs: Vec<Option<u128>>,
     owned_slice_lower_costs: Vec<Option<u128>>,
     contains_shared_nontrivial: Vec<Option<bool>>,
+    region_materialization_preserves_narrowing: Vec<Option<bool>>,
     is_speculatable_pure: Vec<Option<bool>>,
     traversal_seen: Vec<bool>,
     traversal_work: Vec<NodeId>,
@@ -3222,15 +3223,15 @@ impl SLTToSIRLowerer {
 
         // Region lowering deliberately pushes a slice through bitwise and Mux
         // nodes so a narrow consumer does not compute an unnecessarily wide
-        // value. A small read-modify-write value is better materialized when
-        // shared, however: recursively projecting both references expands a
-        // compact DAG as an exponential tree, while the ordinary lowering
-        // cache keeps its materialization linear. Limit this shortcut to one
-        // backend chunk so narrow projections of wide operations (notably Mul)
-        // do not accidentally pay for the full value.
+        // value. When shared, a cheap read-modify-write value is better
+        // materialized: recursively projecting both references expands
+        // a compact DAG as an exponential tree, while the ordinary lowering
+        // cache keeps its materialization linear. Restrict this shortcut to
+        // trees where it does not bypass narrow arithmetic lowering, so a
+        // narrow projection of a wide operation such as Mul does not
+        // accidentally pay for the full value.
         let shared_compound = allow_cache
             && env.is_none()
-            && Self::chunks(self.get_width(expr, arena)) == 1
             && self
                 .cost_cache
                 .borrow()
@@ -3238,7 +3239,7 @@ impl SLTToSIRLowerer {
                 .get(expr.0)
                 .is_some_and(|fanout| *fanout > 1)
             && Self::is_nontrivial_node(expr, arena);
-        if shared_compound {
+        if shared_compound && self.region_materialization_preserves_narrowing(expr, arena) {
             let full_value = self.lower_inner(builder, expr, arena, cache, env, allow_cache);
             if access.lsb == 0 && access.msb + 1 == self.get_width(expr, arena) {
                 return full_value;
@@ -3890,6 +3891,10 @@ impl SLTToSIRLowerer {
         cache.owned_slice_lower_costs.resize(node_count, None);
         cache.contains_shared_nontrivial.clear();
         cache.contains_shared_nontrivial.resize(node_count, None);
+        cache.region_materialization_preserves_narrowing.clear();
+        cache
+            .region_materialization_preserves_narrowing
+            .resize(node_count, None);
         cache.is_speculatable_pure.clear();
         cache.is_speculatable_pure.resize(node_count, None);
         cache.traversal_seen.clear();
@@ -3965,6 +3970,9 @@ impl SLTToSIRLowerer {
             cache.owned_costs.resize(arena.len(), None);
             cache.owned_slice_lower_costs.resize(arena.len(), None);
             cache.contains_shared_nontrivial.resize(arena.len(), None);
+            cache
+                .region_materialization_preserves_narrowing
+                .resize(arena.len(), None);
             cache.is_speculatable_pure.resize(arena.len(), None);
         }
     }
@@ -4139,6 +4147,57 @@ impl SLTToSIRLowerer {
             arena.get(node),
             SLTNode::Input { .. } | SLTNode::Constant(..)
         )
+    }
+
+    /// Whether full materialization preserves every arithmetic narrowing that
+    /// region lowering would perform. Nodes where region lowering already
+    /// stops may be materialized because doing so introduces no extra wide
+    /// operation; pointwise nodes recurse until reaching such a boundary.
+    fn region_materialization_preserves_narrowing<A: Hash + Eq + Clone>(
+        &self,
+        node: NodeId,
+        arena: &SLTNodeArena<A>,
+    ) -> bool {
+        self.prepare_cost_cache(arena);
+        if let Some(result) = self
+            .cost_cache
+            .borrow()
+            .region_materialization_preserves_narrowing[node.0]
+        {
+            return result;
+        }
+        self.note_analysis_visits(1);
+        let result = match arena.get(node) {
+            SLTNode::Binary(lhs, BinaryOp::And | BinaryOp::Or | BinaryOp::Xor, rhs) => {
+                self.region_materialization_preserves_narrowing(*lhs, arena)
+                    && self.region_materialization_preserves_narrowing(*rhs, arena)
+            }
+            SLTNode::Unary(UnaryOp::Ident | UnaryOp::ToTwoState | UnaryOp::BitNot, inner)
+            | SLTNode::Slice { expr: inner, .. } => {
+                self.region_materialization_preserves_narrowing(*inner, arena)
+            }
+            SLTNode::Mux {
+                then_expr,
+                else_expr,
+                ..
+            } => {
+                self.region_materialization_preserves_narrowing(*then_expr, arena)
+                    && self.region_materialization_preserves_narrowing(*else_expr, arena)
+            }
+            SLTNode::Binary(_, BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul, _) => false,
+            SLTNode::Input { .. }
+            | SLTNode::Constant(..)
+            | SLTNode::Binary(..)
+            | SLTNode::Unary(..)
+            | SLTNode::Capture { .. }
+            | SLTNode::Concat(..)
+            | SLTNode::ForFold { .. }
+            | SLTNode::ForFoldGroup { .. } => true,
+        };
+        self.cost_cache
+            .borrow_mut()
+            .region_materialization_preserves_narrowing[node.0] = Some(result);
+        result
     }
 
     /// Cost which is provably owned by this node in the current top-level DAG.
@@ -6401,48 +6460,50 @@ mod tests {
     fn region_slice_materializes_shared_rmw_versions_once() {
         const UPDATES: usize = 18;
 
-        let mut arena = SLTNodeArena::new();
-        let mut previous = input(&mut arena, 10, 8);
-        for update in 0..UPDATES {
-            let condition = input(&mut arena, 100 + update as u32, 1);
-            let payload = constant(&mut arena, 1 << (update % 8), 8);
-            let modified = arena
-                .alloc(SLTNode::Binary(previous, BinaryOp::Or, payload))
-                .unwrap();
-            previous = arena
-                .alloc(SLTNode::Mux {
-                    cond: condition,
-                    then_expr: modified,
-                    else_expr: previous,
+        for width in [8, 65] {
+            let mut arena = SLTNodeArena::new();
+            let mut previous = input(&mut arena, 10, width);
+            for update in 0..UPDATES {
+                let condition = input(&mut arena, 100 + update as u32, 1);
+                let payload = constant(&mut arena, 1 << (update % 8), width);
+                let modified = arena
+                    .alloc(SLTNode::Binary(previous, BinaryOp::Or, payload))
+                    .unwrap();
+                previous = arena
+                    .alloc(SLTNode::Mux {
+                        cond: condition,
+                        then_expr: modified,
+                        else_expr: previous,
+                    })
+                    .unwrap();
+            }
+            let bit = arena
+                .alloc(SLTNode::Slice {
+                    expr: previous,
+                    access: BitAccess::new(0, 0),
                 })
                 .unwrap();
-        }
-        let bit = arena
-            .alloc(SLTNode::Slice {
-                expr: previous,
-                access: BitAccess::new(0, 0),
-            })
-            .unwrap();
 
-        for four_state in [false, true] {
-            let mut builder = SIRBuilder::new();
-            SLTToSIRLowerer::new(four_state).lower(
-                &mut builder,
-                bit,
-                &arena,
-                &mut crate::HashMap::default(),
-            );
-            let eu = finish_lowering(builder);
-            let instructions = eu
-                .blocks
-                .values()
-                .map(|block| block.instructions.len())
-                .sum::<usize>();
+            for four_state in [false, true] {
+                let mut builder = SIRBuilder::new();
+                SLTToSIRLowerer::new(four_state).lower(
+                    &mut builder,
+                    bit,
+                    &arena,
+                    &mut crate::HashMap::default(),
+                );
+                let eu = finish_lowering(builder);
+                let instructions = eu
+                    .blocks
+                    .values()
+                    .map(|block| block.instructions.len())
+                    .sum::<usize>();
 
-            assert!(
-                instructions < 256,
-                "shared RMW DAG expanded to {instructions} instructions in four_state={four_state}"
-            );
+                assert!(
+                    instructions < 256,
+                    "{width}-bit shared RMW DAG expanded to {instructions} instructions in four_state={four_state}"
+                );
+            }
         }
     }
 

--- a/crates/celox-slt/src/lower.rs
+++ b/crates/celox-slt/src/lower.rs
@@ -3220,6 +3220,31 @@ impl SLTToSIRLowerer {
             return self.slice_reg(builder, full_value, access);
         }
 
+        // Region lowering deliberately pushes a slice through bitwise and Mux
+        // nodes so a narrow consumer does not compute an unnecessarily wide
+        // value.  Do not do that through a shared compound node, however: a
+        // read-modify-write chain commonly references its previous version in
+        // both Mux arms, and recursively projecting both references expands a
+        // compact DAG as an exponential tree.  Materializing the shared value
+        // once preserves the ordinary lowering cache's linear-DAG behavior;
+        // later projections reuse that snapshot and only emit their slice.
+        let shared_compound = allow_cache
+            && env.is_none()
+            && self
+                .cost_cache
+                .borrow()
+                .fanout
+                .get(expr.0)
+                .is_some_and(|fanout| *fanout > 1)
+            && Self::is_nontrivial_node(expr, arena);
+        if shared_compound {
+            let full_value = self.lower_inner(builder, expr, arena, cache, env, allow_cache);
+            if access.lsb == 0 && access.msb + 1 == self.get_width(expr, arena) {
+                return full_value;
+            }
+            return self.slice_reg(builder, full_value, access);
+        }
+
         match arena.get(expr) {
             SLTNode::Binary(lhs, BinaryOp::And, rhs)
                 if slt_const_u64(*lhs, arena) == Some(0)
@@ -6369,6 +6394,55 @@ mod tests {
             instruction,
             SIRInstruction::Binary(_, source, BinaryOp::Shr, _) if *source == snapshot
         )));
+    }
+
+    #[test]
+    fn region_slice_materializes_shared_rmw_versions_once() {
+        const UPDATES: usize = 18;
+
+        let mut arena = SLTNodeArena::new();
+        let mut previous = input(&mut arena, 10, 8);
+        for update in 0..UPDATES {
+            let condition = input(&mut arena, 100 + update as u32, 1);
+            let payload = constant(&mut arena, 1 << (update % 8), 8);
+            let modified = arena
+                .alloc(SLTNode::Binary(previous, BinaryOp::Or, payload))
+                .unwrap();
+            previous = arena
+                .alloc(SLTNode::Mux {
+                    cond: condition,
+                    then_expr: modified,
+                    else_expr: previous,
+                })
+                .unwrap();
+        }
+        let bit = arena
+            .alloc(SLTNode::Slice {
+                expr: previous,
+                access: BitAccess::new(0, 0),
+            })
+            .unwrap();
+
+        for four_state in [false, true] {
+            let mut builder = SIRBuilder::new();
+            SLTToSIRLowerer::new(four_state).lower(
+                &mut builder,
+                bit,
+                &arena,
+                &mut crate::HashMap::default(),
+            );
+            let eu = finish_lowering(builder);
+            let instructions = eu
+                .blocks
+                .values()
+                .map(|block| block.instructions.len())
+                .sum::<usize>();
+
+            assert!(
+                instructions < 256,
+                "shared RMW DAG expanded to {instructions} instructions in four_state={four_state}"
+            );
+        }
     }
 
     #[test]

--- a/crates/celox-slt/src/lower.rs
+++ b/crates/celox-slt/src/lower.rs
@@ -1122,7 +1122,6 @@ struct LoweringCostCache {
     owned_costs: Vec<Option<u128>>,
     owned_slice_lower_costs: Vec<Option<u128>>,
     contains_shared_nontrivial: Vec<Option<bool>>,
-    region_materialization_preserves_narrowing: Vec<Option<bool>>,
     is_speculatable_pure: Vec<Option<bool>>,
     traversal_seen: Vec<bool>,
     traversal_work: Vec<NodeId>,
@@ -1235,7 +1234,15 @@ pub struct SLTToSIRLowerer {
     unpacked_input_element_widths: crate::HashMap<NodeId, usize>,
     cost_cache: RefCell<LoweringCostCache>,
     cache_insert_log: RefCell<Vec<NodeId>>,
+    region_slice_cache: RefCell<crate::HashMap<(NodeId, BitAccess), RegisterId>>,
+    region_slice_cache_insert_log: RefCell<Vec<(NodeId, BitAccess)>>,
     mux_stats: Option<RefCell<MuxLowerStats>>,
+}
+
+#[derive(Clone, Copy)]
+struct LowerCacheTransaction {
+    node_insertions: usize,
+    region_slice_insertions: usize,
 }
 
 struct LowerEnv<'parent, A: Hash + Eq + Clone> {
@@ -1880,6 +1887,8 @@ impl SLTToSIRLowerer {
             unpacked_input_element_widths: crate::HashMap::default(),
             cost_cache: RefCell::new(LoweringCostCache::default()),
             cache_insert_log: RefCell::new(Vec::new()),
+            region_slice_cache: RefCell::new(crate::HashMap::default()),
+            region_slice_cache_insert_log: RefCell::new(Vec::new()),
             mux_stats: tracing::enabled!(tracing::Level::DEBUG)
                 .then(|| RefCell::new(MuxLowerStats::default())),
         }
@@ -3221,16 +3230,23 @@ impl SLTToSIRLowerer {
             return self.slice_reg(builder, full_value, access);
         }
 
-        // Region lowering deliberately pushes a slice through bitwise and Mux
-        // nodes so a narrow consumer does not compute an unnecessarily wide
-        // value. When shared, a cheap read-modify-write value is better
-        // materialized: recursively projecting both references expands
-        // a compact DAG as an exponential tree, while the ordinary lowering
-        // cache keeps its materialization linear. Restrict this shortcut to
-        // trees where it does not bypass narrow arithmetic lowering, so a
-        // narrow projection of a wide operation such as Mul does not
-        // accidentally pay for the full value.
-        let shared_compound = allow_cache
+        // Eliminate an annihilated expression before consulting the shared
+        // projection cache. Neither operand may be visited: it can contain a
+        // dead wide division or a loop-carried Input which would otherwise be
+        // rebuilt as a dynamic read from the current state version.
+        if let SLTNode::Binary(lhs, BinaryOp::And, rhs) = arena.get(expr)
+            && (slt_const_u64(*lhs, arena) == Some(0) || slt_const_u64(*rhs, arena) == Some(0))
+        {
+            let width = access.msb - access.lsb + 1;
+            let result = builder.alloc_bit(width, false);
+            builder.emit(SIRInstruction::Imm(result, SIRValue::new(0u8)));
+            return result;
+        }
+
+        // Cache the projection rather than materializing the full expression.
+        // Repeated references in a read-modify-write DAG then stay linear while
+        // wide arithmetic continues to operate on only the requested region.
+        let cache_projection = allow_cache
             && env.is_none()
             && self
                 .cost_cache
@@ -3239,29 +3255,14 @@ impl SLTToSIRLowerer {
                 .get(expr.0)
                 .is_some_and(|fanout| *fanout > 1)
             && Self::is_nontrivial_node(expr, arena);
-        if shared_compound && self.region_materialization_preserves_narrowing(expr, arena) {
-            let full_value = self.lower_inner(builder, expr, arena, cache, env, allow_cache);
-            if access.lsb == 0 && access.msb + 1 == self.get_width(expr, arena) {
-                return full_value;
-            }
-            return self.slice_reg(builder, full_value, access);
+        let projection_key = (expr, *access);
+        if cache_projection
+            && let Some(&projected) = self.region_slice_cache.borrow().get(&projection_key)
+        {
+            return projected;
         }
 
-        match arena.get(expr) {
-            SLTNode::Binary(lhs, BinaryOp::And, rhs)
-                if slt_const_u64(*lhs, arena) == Some(0)
-                    || slt_const_u64(*rhs, arena) == Some(0) =>
-            {
-                // Do this before recursively lowering either operand. In a
-                // loop-carried environment an otherwise dead Input would be
-                // rebuilt as a dynamic read from the current state version,
-                // preserving a dependency and a large amount of address/RMW
-                // code which bitwise zero annihilates in four-state logic too.
-                let width = access.msb - access.lsb + 1;
-                let result = builder.alloc_bit(width, false);
-                builder.emit(SIRInstruction::Imm(result, SIRValue::new(0u8)));
-                result
-            }
+        let result = match arena.get(expr) {
             SLTNode::Input {
                 variable,
                 index,
@@ -3395,7 +3396,21 @@ impl SLTToSIRLowerer {
                 let inner = self.lower_inner(builder, expr, arena, cache, env, allow_cache);
                 self.slice_reg(builder, inner, access)
             }
+        };
+
+        if cache_projection {
+            let previous = self
+                .region_slice_cache
+                .borrow_mut()
+                .insert(projection_key, result);
+            debug_assert!(previous.is_none());
+            if previous.is_none() {
+                self.region_slice_cache_insert_log
+                    .borrow_mut()
+                    .push(projection_key);
+            }
         }
+        result
     }
 
     fn zero_required_from_both(
@@ -3891,10 +3906,6 @@ impl SLTToSIRLowerer {
         cache.owned_slice_lower_costs.resize(node_count, None);
         cache.contains_shared_nontrivial.clear();
         cache.contains_shared_nontrivial.resize(node_count, None);
-        cache.region_materialization_preserves_narrowing.clear();
-        cache
-            .region_materialization_preserves_narrowing
-            .resize(node_count, None);
         cache.is_speculatable_pure.clear();
         cache.is_speculatable_pure.resize(node_count, None);
         cache.traversal_seen.clear();
@@ -3925,10 +3936,15 @@ impl SLTToSIRLowerer {
             }
         }
         self.cache_insert_log.borrow_mut().clear();
+        self.region_slice_cache.borrow_mut().clear();
+        self.region_slice_cache_insert_log.borrow_mut().clear();
     }
 
-    fn cache_transaction(&self) -> usize {
-        self.cache_insert_log.borrow().len()
+    fn cache_transaction(&self) -> LowerCacheTransaction {
+        LowerCacheTransaction {
+            node_insertions: self.cache_insert_log.borrow().len(),
+            region_slice_insertions: self.region_slice_cache_insert_log.borrow().len(),
+        }
     }
 
     #[cfg(test)]
@@ -3946,10 +3962,19 @@ impl SLTToSIRLowerer {
         self.cost_cache.borrow().analysis_node_visits
     }
 
-    fn rollback_cache(&self, cache: &mut crate::HashMap<NodeId, RegisterId>, transaction: usize) {
+    fn rollback_cache(
+        &self,
+        cache: &mut crate::HashMap<NodeId, RegisterId>,
+        transaction: LowerCacheTransaction,
+    ) {
         let mut log = self.cache_insert_log.borrow_mut();
-        for node in log.drain(transaction..) {
+        for node in log.drain(transaction.node_insertions..) {
             cache.remove(&node);
+        }
+        let mut region_log = self.region_slice_cache_insert_log.borrow_mut();
+        let mut region_cache = self.region_slice_cache.borrow_mut();
+        for key in region_log.drain(transaction.region_slice_insertions..) {
+            region_cache.remove(&key);
         }
     }
 
@@ -3970,9 +3995,6 @@ impl SLTToSIRLowerer {
             cache.owned_costs.resize(arena.len(), None);
             cache.owned_slice_lower_costs.resize(arena.len(), None);
             cache.contains_shared_nontrivial.resize(arena.len(), None);
-            cache
-                .region_materialization_preserves_narrowing
-                .resize(arena.len(), None);
             cache.is_speculatable_pure.resize(arena.len(), None);
         }
     }
@@ -4147,57 +4169,6 @@ impl SLTToSIRLowerer {
             arena.get(node),
             SLTNode::Input { .. } | SLTNode::Constant(..)
         )
-    }
-
-    /// Whether full materialization preserves every arithmetic narrowing that
-    /// region lowering would perform. Nodes where region lowering already
-    /// stops may be materialized because doing so introduces no extra wide
-    /// operation; pointwise nodes recurse until reaching such a boundary.
-    fn region_materialization_preserves_narrowing<A: Hash + Eq + Clone>(
-        &self,
-        node: NodeId,
-        arena: &SLTNodeArena<A>,
-    ) -> bool {
-        self.prepare_cost_cache(arena);
-        if let Some(result) = self
-            .cost_cache
-            .borrow()
-            .region_materialization_preserves_narrowing[node.0]
-        {
-            return result;
-        }
-        self.note_analysis_visits(1);
-        let result = match arena.get(node) {
-            SLTNode::Binary(lhs, BinaryOp::And | BinaryOp::Or | BinaryOp::Xor, rhs) => {
-                self.region_materialization_preserves_narrowing(*lhs, arena)
-                    && self.region_materialization_preserves_narrowing(*rhs, arena)
-            }
-            SLTNode::Unary(UnaryOp::Ident | UnaryOp::ToTwoState | UnaryOp::BitNot, inner)
-            | SLTNode::Slice { expr: inner, .. } => {
-                self.region_materialization_preserves_narrowing(*inner, arena)
-            }
-            SLTNode::Mux {
-                then_expr,
-                else_expr,
-                ..
-            } => {
-                self.region_materialization_preserves_narrowing(*then_expr, arena)
-                    && self.region_materialization_preserves_narrowing(*else_expr, arena)
-            }
-            SLTNode::Binary(_, BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul, _) => false,
-            SLTNode::Input { .. }
-            | SLTNode::Constant(..)
-            | SLTNode::Binary(..)
-            | SLTNode::Unary(..)
-            | SLTNode::Capture { .. }
-            | SLTNode::Concat(..)
-            | SLTNode::ForFold { .. }
-            | SLTNode::ForFoldGroup { .. } => true,
-        };
-        self.cost_cache
-            .borrow_mut()
-            .region_materialization_preserves_narrowing[node.0] = Some(result);
-        result
     }
 
     /// Cost which is provably owned by this node in the current top-level DAG.
@@ -5590,7 +5561,10 @@ impl SLTToSIRLowerer {
         // records before returning to the caller's global cache transaction.
         self.cache_insert_log
             .borrow_mut()
-            .truncate(local_cache_transaction);
+            .truncate(local_cache_transaction.node_insertions);
+        self.region_slice_cache_insert_log
+            .borrow_mut()
+            .truncate(local_cache_transaction.region_slice_insertions);
 
         let next_remaining = builder.alloc_bit(remaining_width, false);
         builder.emit(SIRInstruction::Binary(
@@ -6457,7 +6431,7 @@ mod tests {
     }
 
     #[test]
-    fn region_slice_materializes_shared_rmw_versions_once() {
+    fn region_slice_caches_shared_rmw_projections_once() {
         const UPDATES: usize = 18;
 
         for width in [8, 65] {
@@ -6563,10 +6537,193 @@ mod tests {
                 .collect::<Vec<_>>();
             assert_eq!(
                 multiply_widths,
-                [1, 1],
+                [1],
                 "wide multiply was materialized in four_state={four_state}"
             );
         }
+    }
+
+    #[test]
+    fn region_slice_caches_shared_rmw_with_arithmetic_payloads() {
+        const UPDATES: usize = 18;
+        const WIDTH: usize = 4096;
+
+        let mut arena = SLTNodeArena::new();
+        let mut previous = input(&mut arena, 10, WIDTH);
+        let one = constant(&mut arena, 1, WIDTH);
+        for update in 0..UPDATES {
+            let condition = input(&mut arena, 100 + update as u32, 1);
+            let payload_input = input(&mut arena, 200 + update as u32, WIDTH);
+            let payload = arena
+                .alloc(SLTNode::Binary(payload_input, BinaryOp::Add, one))
+                .unwrap();
+            let modified = arena
+                .alloc(SLTNode::Binary(previous, BinaryOp::Or, payload))
+                .unwrap();
+            previous = arena
+                .alloc(SLTNode::Mux {
+                    cond: condition,
+                    then_expr: modified,
+                    else_expr: previous,
+                })
+                .unwrap();
+        }
+        let bit = arena
+            .alloc(SLTNode::Slice {
+                expr: previous,
+                access: BitAccess::new(0, 0),
+            })
+            .unwrap();
+
+        for four_state in [false, true] {
+            let mut builder = SIRBuilder::new();
+            SLTToSIRLowerer::new(four_state).lower(
+                &mut builder,
+                bit,
+                &arena,
+                &mut crate::HashMap::default(),
+            );
+            let eu = finish_lowering(builder);
+            let instructions = eu
+                .blocks
+                .values()
+                .flat_map(|block| &block.instructions)
+                .collect::<Vec<_>>();
+
+            assert!(
+                instructions.len() < 512,
+                "arithmetic RMW DAG expanded to {} instructions in four_state={four_state}",
+                instructions.len()
+            );
+            assert!(instructions.iter().all(|instruction| !matches!(
+                instruction,
+                SIRInstruction::Binary(dst, _, BinaryOp::Add, _)
+                    if eu.register_map[dst].width() != 1
+            )));
+        }
+    }
+
+    #[test]
+    fn region_slice_annihilates_shared_zero_before_expensive_operands() {
+        const WIDTH: usize = 4096;
+
+        let mut arena = SLTNodeArena::new();
+        let dividend = input(&mut arena, 10, WIDTH);
+        let divisor = input(&mut arena, 20, WIDTH);
+        let division = arena
+            .alloc(SLTNode::Binary(dividend, BinaryOp::DivU, divisor))
+            .unwrap();
+        let zero = constant(&mut arena, 0, WIDTH);
+        let dead = arena
+            .alloc(SLTNode::Binary(division, BinaryOp::And, zero))
+            .unwrap();
+        let one = constant(&mut arena, 1, WIDTH);
+        let first_user = arena
+            .alloc(SLTNode::Binary(dead, BinaryOp::Or, one))
+            .unwrap();
+        let second_user = arena
+            .alloc(SLTNode::Binary(dead, BinaryOp::Xor, one))
+            .unwrap();
+        let first_bit = arena
+            .alloc(SLTNode::Slice {
+                expr: first_user,
+                access: BitAccess::new(0, 0),
+            })
+            .unwrap();
+        let second_bit = arena
+            .alloc(SLTNode::Slice {
+                expr: second_user,
+                access: BitAccess::new(0, 0),
+            })
+            .unwrap();
+        let root = arena
+            .alloc(SLTNode::Concat(vec![(first_bit, 1), (second_bit, 1)]))
+            .unwrap();
+
+        for four_state in [false, true] {
+            let mut builder = SIRBuilder::new();
+            SLTToSIRLowerer::new(four_state).lower(
+                &mut builder,
+                root,
+                &arena,
+                &mut crate::HashMap::default(),
+            );
+            let eu = finish_lowering(builder);
+
+            assert!(
+                eu.blocks
+                    .values()
+                    .all(
+                        |block| block.instructions.iter().all(|instruction| !matches!(
+                            instruction,
+                            SIRInstruction::Binary(_, _, BinaryOp::DivU, _)
+                                | SIRInstruction::Load(_, 10 | 20, _, _)
+                        ))
+                    )
+            );
+        }
+    }
+
+    #[test]
+    fn region_slice_skips_deep_dead_constant_mux_arm() {
+        const DEPTH: usize = 20_000;
+        const WIDTH: usize = 65;
+
+        let mut arena = SLTNodeArena::new();
+        let condition = constant(&mut arena, 0, 1);
+        let live = input(&mut arena, 10, WIDTH);
+        let dead_input = input(&mut arena, 20, WIDTH);
+        let dead = operation_chain(&mut arena, dead_input, BinaryOp::Xor, DEPTH, 100, WIDTH);
+        let shared = arena
+            .alloc(SLTNode::Mux {
+                cond: condition,
+                then_expr: dead,
+                else_expr: live,
+            })
+            .unwrap();
+        let one = constant(&mut arena, 1, WIDTH);
+        let first_user = arena
+            .alloc(SLTNode::Binary(shared, BinaryOp::And, one))
+            .unwrap();
+        let second_user = arena
+            .alloc(SLTNode::Binary(shared, BinaryOp::Xor, one))
+            .unwrap();
+        let first_bit = arena
+            .alloc(SLTNode::Slice {
+                expr: first_user,
+                access: BitAccess::new(0, 0),
+            })
+            .unwrap();
+        let second_bit = arena
+            .alloc(SLTNode::Slice {
+                expr: second_user,
+                access: BitAccess::new(0, 0),
+            })
+            .unwrap();
+        let root = arena
+            .alloc(SLTNode::Concat(vec![(first_bit, 1), (second_bit, 1)]))
+            .unwrap();
+
+        let mut builder = SIRBuilder::new();
+        SLTToSIRLowerer::new(false).lower(
+            &mut builder,
+            root,
+            &arena,
+            &mut crate::HashMap::default(),
+        );
+        let eu = finish_lowering(builder);
+        let instructions = eu
+            .blocks
+            .values()
+            .flat_map(|block| &block.instructions)
+            .collect::<Vec<_>>();
+
+        assert!(instructions.len() < 32);
+        assert!(
+            instructions
+                .iter()
+                .all(|instruction| !matches!(instruction, SIRInstruction::Load(_, 20, _, _)))
+        );
     }
 
     #[test]

--- a/crates/celox-slt/src/lower.rs
+++ b/crates/celox-slt/src/lower.rs
@@ -3222,14 +3222,15 @@ impl SLTToSIRLowerer {
 
         // Region lowering deliberately pushes a slice through bitwise and Mux
         // nodes so a narrow consumer does not compute an unnecessarily wide
-        // value.  Do not do that through a shared compound node, however: a
-        // read-modify-write chain commonly references its previous version in
-        // both Mux arms, and recursively projecting both references expands a
-        // compact DAG as an exponential tree.  Materializing the shared value
-        // once preserves the ordinary lowering cache's linear-DAG behavior;
-        // later projections reuse that snapshot and only emit their slice.
+        // value. A small read-modify-write value is better materialized when
+        // shared, however: recursively projecting both references expands a
+        // compact DAG as an exponential tree, while the ordinary lowering
+        // cache keeps its materialization linear. Limit this shortcut to one
+        // backend chunk so narrow projections of wide operations (notably Mul)
+        // do not accidentally pay for the full value.
         let shared_compound = allow_cache
             && env.is_none()
+            && Self::chunks(self.get_width(expr, arena)) == 1
             && self
                 .cost_cache
                 .borrow()
@@ -6441,6 +6442,68 @@ mod tests {
             assert!(
                 instructions < 256,
                 "shared RMW DAG expanded to {instructions} instructions in four_state={four_state}"
+            );
+        }
+    }
+
+    #[test]
+    fn region_slice_keeps_wide_shared_multiply_narrow() {
+        const WIDTH: usize = 4096;
+
+        let mut arena = SLTNodeArena::new();
+        let lhs = input(&mut arena, 10, WIDTH);
+        let rhs = input(&mut arena, 20, WIDTH);
+        let shared = arena
+            .alloc(SLTNode::Binary(lhs, BinaryOp::Mul, rhs))
+            .unwrap();
+        let ones = constant(&mut arena, 1, WIDTH);
+        let first_user = arena
+            .alloc(SLTNode::Binary(shared, BinaryOp::And, ones))
+            .unwrap();
+        let second_user = arena
+            .alloc(SLTNode::Binary(shared, BinaryOp::Xor, ones))
+            .unwrap();
+        let first_bit = arena
+            .alloc(SLTNode::Slice {
+                expr: first_user,
+                access: BitAccess::new(0, 0),
+            })
+            .unwrap();
+        let second_bit = arena
+            .alloc(SLTNode::Slice {
+                expr: second_user,
+                access: BitAccess::new(0, 0),
+            })
+            .unwrap();
+        let root = arena
+            .alloc(SLTNode::Concat(vec![(first_bit, 1), (second_bit, 1)]))
+            .unwrap();
+
+        for four_state in [false, true] {
+            let mut builder = SIRBuilder::new();
+            SLTToSIRLowerer::new(four_state).lower(
+                &mut builder,
+                root,
+                &arena,
+                &mut crate::HashMap::default(),
+            );
+            let eu = finish_lowering(builder);
+
+            let multiply_widths = eu
+                .blocks
+                .values()
+                .flat_map(|block| &block.instructions)
+                .filter_map(|instruction| match instruction {
+                    SIRInstruction::Binary(dst, _, BinaryOp::Mul, _) => {
+                        Some(eu.register_map[dst].width())
+                    }
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(
+                multiply_widths,
+                [1, 1],
+                "wide multiply was materialized in four_state={four_state}"
             );
         }
     }

--- a/crates/celox/tests/nested_write_perf.rs
+++ b/crates/celox/tests/nested_write_perf.rs
@@ -1,0 +1,47 @@
+use celox::Simulator;
+
+const NESTED_WRITE: &str = r#"
+pub module AdcGroupNestedWriteMre (
+    i_primary       : input  logic [8],
+    i_overflow      : input  logic [8],
+    i_primary_active: input  logic [2],
+    o_pop           : output logic [8],
+) {
+    always_comb {
+        for bank in 0..2 {
+            for lane in 0..4 {
+                let index: u32 = bank * 4 + lane;
+                o_pop[index] = 0;
+                if i_primary[index] {
+                    o_pop[index] = 1;
+                }
+                if i_overflow[index] && !i_primary_active[bank] {
+                    o_pop[index] = 1;
+                }
+            }
+        }
+    }
+}
+"#;
+
+#[test]
+fn nested_loop_partial_writes_compile_and_simulate() {
+    let mut sim = Simulator::builder(NESTED_WRITE, "AdcGroupNestedWriteMre")
+        .build()
+        .expect("nested partial writes should compile");
+    let i_primary = sim.signal("i_primary");
+    let i_overflow = sim.signal("i_overflow");
+    let i_primary_active = sim.signal("i_primary_active");
+    let o_pop = sim.signal("o_pop");
+
+    sim.modify(|io| {
+        io.set(i_primary, 0b0100_0001u8);
+        io.set(i_overflow, 0b1010_1010u8);
+        io.set(i_primary_active, 0b01u8);
+    })
+    .unwrap();
+
+    // Bank 0 is active, so only its primary request pops. Bank 1 admits
+    // overflow requests in addition to its primary request.
+    assert_eq!(sim.get(o_pop), 0b1110_0001u8.into());
+}


### PR DESCRIPTION
## Summary

- materialize shared compound SLT nodes once when lowering a region slice
- reuse the ordinary lowering cache instead of recursively expanding shared read-modify-write versions as a tree
- add a focused linear-growth regression test for both two-state and four-state lowering
- add the reported nested two-bank arbiter as an end-to-end compile and simulation regression test

## Root cause

Region-slice lowering pushes narrow slices through bitwise and mux nodes. In a conditional read-modify-write chain, each symbolic version is referenced from both mux arms. Re-projecting both references recursively expanded the compact shared DAG as an exponential tree.

For the reported reproducer, 229 SLT nodes became 20,621,809 SIR instructions and scheduler lowering took about 15.6 seconds. Materializing shared compound nodes once reduces this to 793 SIR instructions and about 1.6 ms of scheduler lowering; the end-to-end regression test completes in about 0.22 seconds.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p celox-slt --all-targets -- -D warnings`
- `cargo test -p celox-slt` (155 passed)
- `cargo test -p celox-frontend-veryl` (90 passed)
- `cargo test -p celox --test nested_write_perf --test simulator_api` (30 passed, 1 ignored)
- pre-push `cargo-check`, formatter, Biome, submodule, and clean-tree hooks
