### PR TITLE
fix(ci): preserve develop sync conflict resolutions

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -87,6 +87,21 @@ jobs:
           # dependency graph before publishing a conflict-free merge.
           git config user.name "celox-release-bot"
           git config user.email "celox-release-bot@users.noreply.github.com"
+
+          # Snapshot the remote head before building a replacement. A raw
+          # master fallback or a synchronization already merged into develop is
+          # disposable. Any other head contains unresolved work, including a
+          # human conflict resolution, and must never be force-pushed away.
+          sync_ref="refs/heads/$SYNC_BRANCH"
+          remote_sync_sha="$(git ls-remote origin "$sync_ref" | cut -f1)"
+          if [ -n "$remote_sync_sha" ]; then
+            git fetch --no-tags origin "$sync_ref"
+            scripts/check-sync-branch-head.sh \
+              "$remote_sync_sha" \
+              "$master_sha" \
+              "$(git rev-parse origin/develop)"
+          fi
+
           git switch --force-create "$SYNC_BRANCH" origin/develop
 
           set +e
@@ -107,9 +122,7 @@ jobs:
             sync_sha="$master_sha"
           fi
 
-          # Do not replace a branch that moved after this run inspected it.
-          sync_ref="refs/heads/$SYNC_BRANCH"
-          remote_sync_sha="$(git ls-remote origin "$sync_ref" | cut -f1)"
+          # Also reject a concurrent update made after the snapshot above.
           git push origin \
             --force-with-lease="$sync_ref:$remote_sync_sha" \
             "$sync_sha:$sync_ref"

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -3,6 +3,9 @@ name: Sync Develop
 on:
   push:
     branches: [master]
+  pull_request_target:
+    types: [closed]
+    branches: [develop]
   workflow_dispatch:
 
 concurrency:
@@ -14,6 +17,11 @@ permissions: {}
 jobs:
   sync:
     name: Merge master into develop
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      (github.event.pull_request.merged == true &&
+       github.event.pull_request.head.ref == 'integration/master-to-develop' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     env:
       SYNC_BRANCH: integration/master-to-develop

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -113,7 +113,9 @@ jobs:
             cargo update -p veryl-analyzer
             cargo metadata --locked --format-version 1 --no-deps >/dev/null
             git add Cargo.lock
-            git commit -m "chore(develop): sync master"
+            git commit \
+              -m "chore(develop): sync master" \
+              -m "Celox-Sync-Automation: true"
             sync_sha="$(git rev-parse HEAD)"
           else
             # Keep non-dependency conflicts visible and actionable on the PR.

--- a/scripts/check-sync-branch-head.sh
+++ b/scripts/check-sync-branch-head.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 <sync-sha> <master-sha> <develop-sha>" >&2
+  exit 2
+fi
+
+sync_sha="$1"
+master_sha="$2"
+develop_sha="$3"
+
+for sha in "$sync_sha" "$master_sha" "$develop_sha"; do
+  if ! git cat-file -e "$sha^{commit}" 2>/dev/null; then
+    echo "sync branch guard: $sha is not an available commit" >&2
+    exit 2
+  fi
+done
+
+# A stale fallback points directly into master, while a completed synchronization
+# is reachable from develop. Anything else contains work that has not landed in
+# either branch, including a human conflict resolution, and must be preserved.
+if git merge-base --is-ancestor "$sync_sha" "$master_sha" \
+  || git merge-base --is-ancestor "$sync_sha" "$develop_sha"; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+Refusing to replace synchronization branch head $sync_sha.
+It contains commits that are not reachable from master ($master_sha) or develop
+($develop_sha). Preserve that work and update the synchronization branch from
+its current head instead of force-pushing a generated fallback.
+EOF
+exit 1

--- a/scripts/check-sync-branch-head.sh
+++ b/scripts/check-sync-branch-head.sh
@@ -18,11 +18,44 @@ for sha in "$sync_sha" "$master_sha" "$develop_sha"; do
   fi
 done
 
+is_pending_automation_merge() {
+  local _commit first_parent second_parent extra_parent
+  local author_email committer_email subject automation_marker
+
+  read -r _commit first_parent second_parent extra_parent \
+    < <(git rev-list --parents -n 1 "$sync_sha")
+  if [ -z "${first_parent:-}" ] \
+    || [ -z "${second_parent:-}" ] \
+    || [ -n "${extra_parent:-}" ]; then
+    return 1
+  fi
+
+  author_email="$(git show -s --format=%ae "$sync_sha")"
+  committer_email="$(git show -s --format=%ce "$sync_sha")"
+  subject="$(git show -s --format=%s "$sync_sha")"
+  automation_marker="$(
+    git show -s \
+      --format='%(trailers:key=Celox-Sync-Automation,valueonly)' \
+      "$sync_sha"
+  )"
+
+  [ "$author_email" = "celox-release-bot@users.noreply.github.com" ] \
+    && [ "$committer_email" = "celox-release-bot@users.noreply.github.com" ] \
+    && [ "$subject" = "chore(develop): sync master" ] \
+    && [ "$automation_marker" = "true" ] \
+    && git merge-base --is-ancestor "$first_parent" "$develop_sha" \
+    && git merge-base --is-ancestor "$second_parent" "$master_sha"
+}
+
 # A stale fallback points directly into master, while a completed synchronization
-# is reachable from develop. Anything else contains work that has not landed in
-# either branch, including a human conflict resolution, and must be preserved.
+# is reachable from develop. A marked merge produced by the workflow is also
+# disposable while its PR is pending, provided both of its parents still belong
+# to the expected branch histories. Anything else contains work that has not
+# landed in either branch, including a human conflict resolution, and must be
+# preserved.
 if git merge-base --is-ancestor "$sync_sha" "$master_sha" \
-  || git merge-base --is-ancestor "$sync_sha" "$develop_sha"; then
+  || git merge-base --is-ancestor "$sync_sha" "$develop_sha" \
+  || is_pending_automation_merge; then
   exit 0
 fi
 

--- a/scripts/check-sync-branch-head.sh
+++ b/scripts/check-sync-branch-head.sh
@@ -38,21 +38,24 @@ is_pending_automation_merge() {
       --format='%(trailers:key=Celox-Sync-Automation,valueonly)' \
       "$sync_sha"
   )"
+  if [ -n "$automation_marker" ] && [ "$automation_marker" != "true" ]; then
+    return 1
+  fi
 
   [ "$author_email" = "celox-release-bot@users.noreply.github.com" ] \
     && [ "$committer_email" = "celox-release-bot@users.noreply.github.com" ] \
     && [ "$subject" = "chore(develop): sync master" ] \
-    && [ "$automation_marker" = "true" ] \
     && git merge-base --is-ancestor "$first_parent" "$develop_sha" \
     && git merge-base --is-ancestor "$second_parent" "$master_sha"
 }
 
 # A stale fallback points directly into master, while a completed synchronization
-# is reachable from develop. A marked merge produced by the workflow is also
-# disposable while its PR is pending, provided both of its parents still belong
-# to the expected branch histories. Anything else contains work that has not
-# landed in either branch, including a human conflict resolution, and must be
-# preserved.
+# is reachable from develop. A merge produced by the workflow is also disposable
+# while its PR is pending, provided its identity and both parents match the
+# expected branch histories. Accept an absent automation marker for pending
+# merges created by the workflow version immediately before marker rollout.
+# Anything else contains work that has not landed in either branch, including a
+# human conflict resolution, and must be preserved.
 if git merge-base --is-ancestor "$sync_sha" "$master_sha" \
   || git merge-base --is-ancestor "$sync_sha" "$develop_sha" \
   || is_pending_automation_merge; then

--- a/scripts/check-sync-branch-head.test.mjs
+++ b/scripts/check-sync-branch-head.test.mjs
@@ -57,6 +57,42 @@ test("sync branch guard preserves unresolved branch work", (t) => {
     /Refusing to replace synchronization branch head/,
   );
 
+  // Bot identity and subject alone are insufficient; only this workflow's
+  // explicit marker makes a pending merge disposable.
+  git("switch", "--quiet", "-c", "unmarked-sync", develop);
+  git(
+    "-c",
+    "user.name=celox-release-bot",
+    "-c",
+    "user.email=celox-release-bot@users.noreply.github.com",
+    "merge",
+    "--quiet",
+    "--no-ff",
+    oldMaster,
+    "-m",
+    "chore(develop): sync master",
+  );
+  const unmarked = git("rev-parse", "HEAD");
+  assert.equal(check(unmarked, master, develop).status, 1);
+
+  // A marked merge made by the workflow remains replaceable while its PR is
+  // pending, so a newer master push cannot leave synchronization stalled.
+  git("switch", "--quiet", "-c", "automated-sync", develop);
+  git(
+    "-c",
+    "user.name=celox-release-bot",
+    "-c",
+    "user.email=celox-release-bot@users.noreply.github.com",
+    "merge",
+    "--quiet",
+    "--no-ff",
+    oldMaster,
+    "-m",
+    "chore(develop): sync master\n\nCelox-Sync-Automation: true",
+  );
+  const automated = git("rev-parse", "HEAD");
+  assert.equal(check(automated, master, develop).status, 0);
+
   // Once the synchronization head has landed in develop, it is disposable.
   git("branch", "--force", "develop", resolved);
   assert.equal(check(resolved, master, resolved).status, 0);

--- a/scripts/check-sync-branch-head.test.mjs
+++ b/scripts/check-sync-branch-head.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -9,6 +9,25 @@ import { fileURLToPath } from "node:url";
 const guard = fileURLToPath(
   new URL("./check-sync-branch-head.sh", import.meta.url),
 );
+
+test("sync workflow retries after its preserved pull request lands", () => {
+  const workflow = readFileSync(
+    new URL("../.github/workflows/sync-develop.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    workflow,
+    /pull_request_target:\n\s+types: \[closed\]\n\s+branches: \[develop\]/,
+  );
+  assert.match(
+    workflow,
+    /github\.event\.pull_request\.head\.ref == 'integration\/master-to-develop'/,
+  );
+  assert.match(
+    workflow,
+    /github\.event\.pull_request\.head\.repo\.full_name == github\.repository/,
+  );
+});
 
 test("sync branch guard preserves unresolved branch work", (t) => {
   const repository = mkdtempSync(join(tmpdir(), "celox-sync-branch-head-"));
@@ -57,8 +76,8 @@ test("sync branch guard preserves unresolved branch work", (t) => {
     /Refusing to replace synchronization branch head/,
   );
 
-  // Bot identity and subject alone are insufficient; only this workflow's
-  // explicit marker makes a pending merge disposable.
+  // Accept a pre-marker merge from the previous workflow version during
+  // rollout, provided bot identity, subject, and both parents still match.
   git("switch", "--quiet", "-c", "unmarked-sync", develop);
   git(
     "-c",
@@ -73,7 +92,7 @@ test("sync branch guard preserves unresolved branch work", (t) => {
     "chore(develop): sync master",
   );
   const unmarked = git("rev-parse", "HEAD");
-  assert.equal(check(unmarked, master, develop).status, 1);
+  assert.equal(check(unmarked, master, develop).status, 0);
 
   // A marked merge made by the workflow remains replaceable while its PR is
   // pending, so a newer master push cannot leave synchronization stalled.

--- a/scripts/check-sync-branch-head.test.mjs
+++ b/scripts/check-sync-branch-head.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const guard = fileURLToPath(
+  new URL("./check-sync-branch-head.sh", import.meta.url),
+);
+
+test("sync branch guard preserves unresolved branch work", (t) => {
+  const repository = mkdtempSync(join(tmpdir(), "celox-sync-branch-head-"));
+  t.after(() => rmSync(repository, { recursive: true, force: true }));
+
+  const git = (...args) =>
+    execFileSync("git", args, { cwd: repository, encoding: "utf8" }).trim();
+  const commitFile = (path, contents, message) => {
+    writeFileSync(join(repository, path), `${contents}\n`);
+    git("add", path);
+    git("commit", "--quiet", "-m", message);
+  };
+  const check = (sync, master, develop) =>
+    spawnSync(guard, [sync, master, develop], {
+      cwd: repository,
+      encoding: "utf8",
+    });
+
+  git("init", "--quiet", "--initial-branch=master");
+  git("config", "user.name", "Sync Guard Test");
+  git("config", "user.email", "sync-guard@example.com");
+
+  commitFile("common.txt", "base", "base");
+  git("branch", "develop");
+  commitFile("master.txt", "master-1", "master one");
+  const oldMaster = git("rev-parse", "HEAD");
+  commitFile("master.txt", "master-2", "master two");
+  const master = git("rev-parse", "HEAD");
+
+  git("switch", "--quiet", "develop");
+  commitFile("develop.txt", "develop", "develop work");
+  const develop = git("rev-parse", "HEAD");
+
+  // A stale raw-master fallback is safe to replace with the newer master.
+  assert.equal(check(oldMaster, master, develop).status, 0);
+
+  // A merge containing both sides represents an unresolved synchronization
+  // head, including a human conflict resolution, so it must be preserved.
+  git("switch", "--quiet", "-c", "resolved-sync", develop);
+  git("merge", "--quiet", "--no-ff", oldMaster, "-m", "resolve sync conflicts");
+  const resolved = git("rev-parse", "HEAD");
+  const blockedResolution = check(resolved, master, develop);
+  assert.equal(blockedResolution.status, 1);
+  assert.match(
+    blockedResolution.stderr,
+    /Refusing to replace synchronization branch head/,
+  );
+
+  // Once the synchronization head has landed in develop, it is disposable.
+  git("branch", "--force", "develop", resolved);
+  assert.equal(check(resolved, master, resolved).status, 0);
+
+  // Arbitrary branch work based on master must also survive automation.
+  git("switch", "--quiet", "-c", "manual-work", oldMaster);
+  commitFile("manual.txt", "preserve-me", "manual sync work");
+  const manual = git("rev-parse", "HEAD");
+  assert.equal(check(manual, master, develop).status, 1);
+});


### PR DESCRIPTION
## Summary

- refuse to replace a develop synchronization head that contains work not reachable from `master` or `develop`
- snapshot the remote synchronization SHA before rebuilding the branch and use that snapshot for `--force-with-lease`
- add a Git-history regression test covering stale fallbacks, unresolved synchronization merges, merged heads, and arbitrary branch work

## Root cause

The workflow read the synchronization branch SHA immediately before force-pushing and used that current value as the lease expectation. When a contributor pushed a conflict-resolution merge, the next synchronization run accepted that commit as its lease value, reset the synchronization branch to `master` after another merge conflict, and force-pushed over the resolution.

## Impact

Manual conflict resolutions and other unmerged synchronization work are now preserved. The workflow fails with an actionable diagnostic instead of replacing a divergent synchronization head.

## Validation

- `node --test scripts/*.test.mjs` (47 tests)
- `bash -n scripts/check-sync-branch-head.sh`
- syntax check of the workflow's embedded Bash step
- YAML parse of `.github/workflows/sync-develop.yml`
- reproduced the original SHAs: `c7a5dc9` is rejected while stale raw-master fallback `879f5fa` is allowed
- pre-push hook: submodule check, Biome, cargo fmt, cargo check, clean-tree