### PR TITLE
feat(veryl): support runtime power exponents

### DIFF
--- a/crates/celox-frontend-veryl/src/ff/expression.rs
+++ b/crates/celox-frontend-veryl/src/ff/expression.rs
@@ -3832,16 +3832,6 @@ impl<'a> FfParser<'a> {
             binary_semantics(*op, lhs_width, rhs_width, lhs_signed, rhs_signed, context);
 
         if matches!(op, Op::Pow) {
-            let Some(exp) = self.get_constant_value(right) else {
-                return Err(ParserError::unsupported(
-                    68,
-                    LoweringPhase::FfLowering,
-                    "pow non-constant exponent",
-                    format!("{:?}", right),
-                    Some(&right.token_range()),
-                ));
-            };
-
             let width = semantics.result_width;
             self.parse_expression_in_context(
                 left,
@@ -3856,20 +3846,20 @@ impl<'a> FfParser<'a> {
                 .stack
                 .pop_back()
                 .expect("Invalid LHS for power operation");
-
-            let result = if exp == 0 {
-                let one = ir_builder.alloc_bit(width, false);
-                ir_builder.emit(SIRInstruction::Imm(one, SIRValue::new(1u32)));
-                one
-            } else {
-                let mut acc = base;
-                for _ in 1..exp {
-                    let next = ir_builder.alloc_logic(width);
-                    ir_builder.emit(SIRInstruction::Binary(next, acc, BinaryOp::Mul, base));
-                    acc = next;
-                }
-                acc
-            };
+            self.parse_expression_in_context(
+                right,
+                targets,
+                domain,
+                convert,
+                sources,
+                ir_builder,
+                semantics.rhs_context,
+            )?;
+            let exponent = self
+                .stack
+                .pop_back()
+                .expect("Invalid RHS for power operation");
+            let result = self.lower_runtime_pow(base, exponent, width, rhs_signed, ir_builder);
 
             let result = if let Some(context) = context {
                 self.cast_reg_width_ext(ir_builder, result, context.width, context.signed)
@@ -3911,6 +3901,165 @@ impl<'a> FfParser<'a> {
             self.stack.push_back(result);
         }
         Ok(())
+    }
+
+    fn lower_runtime_pow<A>(
+        &self,
+        base: RegisterId,
+        exponent: RegisterId,
+        width: usize,
+        exponent_signed: bool,
+        ir_builder: &mut SIRBuilder<A>,
+    ) -> RegisterId {
+        let exponent_width = ir_builder.register(&exponent).width();
+        debug_assert!(width > 0);
+        debug_assert!(exponent_width > 0);
+
+        let mut constant = |value: BigUint, mask: BigUint| {
+            let reg = ir_builder.alloc_logic(width);
+            ir_builder.emit(SIRInstruction::Imm(
+                reg,
+                SIRValue::new_four_state(value, mask),
+            ));
+            reg
+        };
+        let zero = constant(BigUint::from(0u8), BigUint::from(0u8));
+        let one = constant(BigUint::from(1u8), BigUint::from(0u8));
+        let width_mask = (BigUint::from(1u8) << width) - BigUint::from(1u8);
+        let minus_one = constant(width_mask.clone(), BigUint::from(0u8));
+        let unknown = constant(BigUint::from(0u8), width_mask);
+
+        // Exponentiation by squaring keeps the generated SIR linear in the
+        // exponent width instead of in its runtime value.
+        let mut result = one;
+        let mut factor = base;
+        let exponent_lsb = ir_builder.alloc_logic(1);
+        ir_builder.emit(SIRInstruction::Slice(exponent_lsb, exponent, 0, 1));
+        let magnitude_width = exponent_width - usize::from(exponent_signed);
+        for bit_index in 0..magnitude_width {
+            let bit = ir_builder.alloc_logic(1);
+            ir_builder.emit(SIRInstruction::Slice(bit, exponent, bit_index, 1));
+
+            let product = ir_builder.alloc_logic(width);
+            ir_builder.emit(SIRInstruction::Binary(
+                product,
+                result,
+                BinaryOp::Mul,
+                factor,
+            ));
+            let next = ir_builder.alloc_logic(width);
+            ir_builder.emit(SIRInstruction::Mux(next, bit, product, result));
+            result = next;
+
+            if bit_index + 1 != magnitude_width {
+                let squared = ir_builder.alloc_logic(width);
+                ir_builder.emit(SIRInstruction::Binary(
+                    squared,
+                    factor,
+                    BinaryOp::Mul,
+                    factor,
+                ));
+                factor = squared;
+            }
+        }
+
+        if exponent_signed {
+            let sign = ir_builder.alloc_logic(1);
+            ir_builder.emit(SIRInstruction::Slice(sign, exponent, exponent_width - 1, 1));
+            let base_is_zero = ir_builder.alloc_logic(1);
+            ir_builder.emit(SIRInstruction::Binary(
+                base_is_zero,
+                base,
+                BinaryOp::Eq,
+                zero,
+            ));
+            let base_is_one = ir_builder.alloc_logic(1);
+            ir_builder.emit(SIRInstruction::Binary(base_is_one, base, BinaryOp::Eq, one));
+            let base_is_minus_one = ir_builder.alloc_logic(1);
+            ir_builder.emit(SIRInstruction::Binary(
+                base_is_minus_one,
+                base,
+                BinaryOp::Eq,
+                minus_one,
+            ));
+            let minus_one_result = ir_builder.alloc_logic(width);
+            ir_builder.emit(SIRInstruction::Mux(
+                minus_one_result,
+                exponent_lsb,
+                minus_one,
+                one,
+            ));
+            let nonunit = ir_builder.alloc_logic(width);
+            ir_builder.emit(SIRInstruction::Mux(
+                nonunit,
+                base_is_minus_one,
+                minus_one_result,
+                zero,
+            ));
+            let negative_nonzero = ir_builder.alloc_logic(width);
+            ir_builder.emit(SIRInstruction::Mux(
+                negative_nonzero,
+                base_is_one,
+                one,
+                nonunit,
+            ));
+            let negative_result = ir_builder.alloc_logic(width);
+            ir_builder.emit(SIRInstruction::Mux(
+                negative_result,
+                base_is_zero,
+                unknown,
+                negative_nonzero,
+            ));
+            let selected = ir_builder.alloc_logic(width);
+            ir_builder.emit(SIRInstruction::Mux(selected, sign, negative_result, result));
+            result = selected;
+        }
+
+        // IEEE power semantics produce an entirely unknown result if either
+        // operand contains X/Z. Comparing each operand with its two-state
+        // image is known one exactly when it has no unknown bits; muxing
+        // against all-X expands any unknown predicate to the result width.
+        let base_two_state = ir_builder.alloc_bit(width, false);
+        ir_builder.emit(SIRInstruction::Unary(
+            base_two_state,
+            UnaryOp::ToTwoState,
+            base,
+        ));
+        let exponent_two_state = ir_builder.alloc_bit(exponent_width, false);
+        ir_builder.emit(SIRInstruction::Unary(
+            exponent_two_state,
+            UnaryOp::ToTwoState,
+            exponent,
+        ));
+        let base_known = ir_builder.alloc_logic(1);
+        ir_builder.emit(SIRInstruction::Binary(
+            base_known,
+            base,
+            BinaryOp::Eq,
+            base_two_state,
+        ));
+        let exponent_known = ir_builder.alloc_logic(1);
+        ir_builder.emit(SIRInstruction::Binary(
+            exponent_known,
+            exponent,
+            BinaryOp::Eq,
+            exponent_two_state,
+        ));
+        let operands_known = ir_builder.alloc_logic(1);
+        ir_builder.emit(SIRInstruction::Binary(
+            operands_known,
+            base_known,
+            BinaryOp::LogicAnd,
+            exponent_known,
+        ));
+        let final_result = ir_builder.alloc_logic(width);
+        ir_builder.emit(SIRInstruction::Mux(
+            final_result,
+            operands_known,
+            result,
+            unknown,
+        ));
+        final_result
     }
 
     pub(super) fn parse_unary<A>(

--- a/crates/celox-frontend-veryl/src/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree.rs
@@ -1789,9 +1789,6 @@ pub(super) fn collect_written_expression(
         Expression::Unary(_, inner, _) => collect_written_expression(module, inner, out),
         Expression::Binary(lhs, op, rhs, _) => {
             collect_written_expression(module, lhs, out)?;
-            if matches!(op, Op::Pow) {
-                return Ok(());
-            }
             let lhs_value = eval_fully_known_constexpr(lhs);
             let skips_rhs = match op {
                 Op::LogicAnd => lhs_value
@@ -3806,7 +3803,7 @@ mod tests {
     }
 
     #[test]
-    fn test_collect_written_accesses_excludes_repeat_and_pow_constexpr_operands() {
+    fn test_collect_written_accesses_excludes_repeat_but_includes_runtime_pow_operand() {
         let code = r#"
             module Top (
                 d: input logic<8>,
@@ -3912,7 +3909,7 @@ mod tests {
         }
 
         assert!(!written.contains_key(&var_id_of(&module, &["repeat_output"])));
-        assert!(!written.contains_key(&var_id_of(&module, &["pow_output"])));
+        assert!(written.contains_key(&var_id_of(&module, &["pow_output"])));
     }
 
     #[test]

--- a/crates/celox-frontend-veryl/src/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/effect.rs
@@ -704,7 +704,6 @@ pub(crate) fn expression_contains_runtime_effect(module: &Module, expression: &E
             Factor::Value(_) | Factor::Anonymous(_) | Factor::Unknown(_) => false,
         },
         Expression::Unary(_, inner, _) => expression_contains_runtime_effect(module, inner),
-        Expression::Binary(lhs, Op::Pow, _, _) => expression_contains_runtime_effect(module, lhs),
         Expression::Binary(lhs, _, rhs, _) => {
             expression_contains_runtime_effect(module, lhs)
                 || expression_contains_runtime_effect(module, rhs)
@@ -759,9 +758,6 @@ pub(crate) fn collect_expression_effects(
                     collect_expression_effects(module, &rhs_store, rhs, arena, collector)
                 },
             )
-        }
-        Expression::Binary(lhs, Op::Pow, _, _) => {
-            collect_expression_effects(module, store, lhs, arena, collector)
         }
         Expression::Binary(lhs, _, rhs, _) => {
             collect_expression_effects(module, store, lhs, arena, collector)?;
@@ -2511,9 +2507,6 @@ fn collect_expression_position_inputs(
 ) -> Result<(), ParserError> {
     match expr {
         Expression::Term(factor) => collect_factor_position_inputs(module, factor, out),
-        Expression::Binary(lhs, Op::Pow, _, _) => {
-            collect_expression_position_inputs(module, lhs, out)
-        }
         Expression::Binary(lhs, _, rhs, _) => {
             collect_expression_position_inputs(module, lhs, out)?;
             collect_expression_position_inputs(module, rhs, out)

--- a/crates/celox-frontend-veryl/src/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/logic_tree/expr.rs
@@ -2516,35 +2516,19 @@ pub(super) fn eval_expression_in_context(
             let semantics =
                 binary_semantics(*op, lhs_width, rhs_width, lhs_signed, rhs_signed, context);
 
-            // `pow`: currently lowered for constant exponent only.
             if matches!(op, Op::Pow) {
                 let ((l_expr, l_sources), l_bounds) =
                     eval_expression_in_context(module, store, lhs, arena, semantics.lhs_context)?;
-                let Some(exp) = eval_constexpr(rhs).and_then(|x| x.to_u64().map(|v| v as usize))
-                else {
-                    return Err(ParserError::unsupported(
-                        67,
-                        LoweringPhase::CombLowering,
-                        "pow non-constant exponent",
-                        format!("{:?}", rhs),
-                        Some(&rhs.token_range()),
-                    ));
-                };
-                let lhs_width = get_width(l_expr, arena);
-                let result_node = if exp == 0 {
-                    arena.alloc(SLTNode::Constant(
-                        BigUint::from(1u8),
-                        BigUint::from(0u32),
-                        lhs_width,
-                        false,
-                    ))?
-                } else {
-                    let mut acc = l_expr;
-                    for _ in 1..exp {
-                        acc = arena.alloc(SLTNode::Binary(acc, BinaryOp::Mul, l_expr))?;
-                    }
-                    acc
-                };
+                let ((r_expr, r_sources), r_bounds) =
+                    eval_expression_in_context(module, store, rhs, arena, semantics.rhs_context)?;
+                let result_node = lower_runtime_pow(
+                    arena,
+                    l_expr,
+                    r_expr,
+                    semantics.result_width,
+                    rhs_signed,
+                    semantics.result_signed,
+                )?;
                 let result_node = coerce_node_width(
                     arena,
                     result_node,
@@ -2553,7 +2537,9 @@ pub(super) fn eval_expression_in_context(
                         .map(|context| context.signed)
                         .unwrap_or(semantics.result_signed),
                 )?;
-                return Ok(((result_node, l_sources), l_bounds));
+                let mut sources = l_sources;
+                sources.extend(r_sources);
+                return Ok(((result_node, sources), merge_boundaries(l_bounds, r_bounds)));
             }
             let ((l_expr, l_sources), l_bounds) =
                 eval_expression_in_context(module, store, lhs, arena, semantics.lhs_context)?;
@@ -3250,6 +3236,108 @@ pub(super) fn merge_boundaries(
         base.entry(id).or_default().extend(bits);
     }
     base
+}
+
+fn lower_runtime_pow<A: Hash + Eq + Clone>(
+    arena: &mut SLTNodeArena<A>,
+    base: NodeId,
+    exponent: NodeId,
+    width: usize,
+    exponent_signed: bool,
+    result_signed: bool,
+) -> Result<NodeId, SLTNodeFactsError> {
+    let exponent_width = get_width(exponent, arena);
+    debug_assert!(width > 0);
+    debug_assert!(exponent_width > 0);
+
+    let constant = |arena: &mut SLTNodeArena<A>, value: BigUint, mask: BigUint| {
+        arena.alloc(SLTNode::Constant(value, mask, width, result_signed))
+    };
+    let zero = constant(arena, BigUint::from(0u8), BigUint::from(0u8))?;
+    let one = constant(arena, BigUint::from(1u8), BigUint::from(0u8))?;
+    let width_mask = (BigUint::from(1u8) << width) - BigUint::from(1u8);
+    let minus_one = constant(arena, width_mask.clone(), BigUint::from(0u8))?;
+    let unknown = constant(arena, BigUint::from(0u8), width_mask)?;
+
+    // Exponentiation by squaring keeps the generated graph linear in the
+    // exponent width instead of in its runtime value.
+    let mut result = one;
+    let mut factor = base;
+    let exponent_lsb = arena.alloc(SLTNode::Slice {
+        expr: exponent,
+        access: BitAccess::new(0, 0),
+    })?;
+    let magnitude_width = exponent_width - usize::from(exponent_signed);
+    for bit_index in 0..magnitude_width {
+        let bit = arena.alloc(SLTNode::Slice {
+            expr: exponent,
+            access: BitAccess::new(bit_index, bit_index),
+        })?;
+        let product = arena.alloc(SLTNode::Binary(result, BinaryOp::Mul, factor))?;
+        result = arena.alloc(SLTNode::Mux {
+            cond: bit,
+            then_expr: product,
+            else_expr: result,
+        })?;
+        if bit_index + 1 != magnitude_width {
+            factor = arena.alloc(SLTNode::Binary(factor, BinaryOp::Mul, factor))?;
+        }
+    }
+
+    if exponent_signed {
+        let sign = arena.alloc(SLTNode::Slice {
+            expr: exponent,
+            access: BitAccess::new(exponent_width - 1, exponent_width - 1),
+        })?;
+        let base_is_zero = arena.alloc(SLTNode::Binary(base, BinaryOp::Eq, zero))?;
+        let base_is_one = arena.alloc(SLTNode::Binary(base, BinaryOp::Eq, one))?;
+        let base_is_minus_one = arena.alloc(SLTNode::Binary(base, BinaryOp::Eq, minus_one))?;
+        let minus_one_result = arena.alloc(SLTNode::Mux {
+            cond: exponent_lsb,
+            then_expr: minus_one,
+            else_expr: one,
+        })?;
+        let negative_nonzero = arena.alloc(SLTNode::Mux {
+            cond: base_is_minus_one,
+            then_expr: minus_one_result,
+            else_expr: zero,
+        })?;
+        let negative_nonzero = arena.alloc(SLTNode::Mux {
+            cond: base_is_one,
+            then_expr: one,
+            else_expr: negative_nonzero,
+        })?;
+        let negative_result = arena.alloc(SLTNode::Mux {
+            cond: base_is_zero,
+            then_expr: unknown,
+            else_expr: negative_nonzero,
+        })?;
+        result = arena.alloc(SLTNode::Mux {
+            cond: sign,
+            then_expr: negative_result,
+            else_expr: result,
+        })?;
+    }
+
+    // IEEE power semantics produce an entirely unknown result if either
+    // operand contains X/Z. Comparing each operand with its two-state image is
+    // known one exactly when it has no unknown bits; muxing against all-X
+    // expands any unknown predicate to the complete result width.
+    let base_two_state = arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, base))?;
+    let exponent_two_state = arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, exponent))?;
+    let base_known = arena.alloc(SLTNode::Binary(base, BinaryOp::Eq, base_two_state))?;
+    let exponent_known =
+        arena.alloc(SLTNode::Binary(exponent, BinaryOp::Eq, exponent_two_state))?;
+    let operands_known = arena.alloc(SLTNode::Binary(
+        base_known,
+        BinaryOp::LogicAnd,
+        exponent_known,
+    ))?;
+    arena.alloc(SLTNode::Mux {
+        cond: operands_known,
+        then_expr: result,
+        else_expr: unknown,
+    })
 }
 
 pub fn coerce_node_width<A: Hash + Eq + Clone>(

--- a/crates/celox-frontend-veryl/src/module.rs
+++ b/crates/celox-frontend-veryl/src/module.rs
@@ -602,9 +602,6 @@ fn collect_parent_output_address_sources(
         Expression::Unary(_, inner, _) => {
             collect_parent_output_address_sources(module, store, inner, arena, out)
         }
-        Expression::Binary(lhs, veryl_analyzer::ir::Op::Pow, _, _) => {
-            collect_parent_output_address_sources(module, store, lhs, arena, out)
-        }
         Expression::Binary(lhs, _, rhs, _) => {
             collect_parent_output_address_sources(module, store, lhs, arena, out)?;
             collect_parent_output_address_sources(module, store, rhs, arena, out)
@@ -2550,7 +2547,7 @@ mod tests {
     }
 
     #[test]
-    fn output_address_sources_skip_power_exponent() {
+    fn output_address_sources_include_runtime_power_exponent() {
         let mut module = parse_top_module(
             r#"
 module Top (
@@ -2615,7 +2612,7 @@ module Top (
             &mut sources,
         )
         .unwrap();
-        assert!(!sources.contains_key(&data_id));
+        assert!(sources.contains_key(&data_id));
     }
 
     #[test]

--- a/crates/celox/tests/operators.rs
+++ b/crates/celox/tests/operators.rs
@@ -349,6 +349,114 @@ assign o = r;
 
     }
 
+    fn test_pow_operator_runtime_exponent_comb_and_ff(sim) {
+        @setup { let code = r#"
+module Top (
+    clk: input clock,
+    base: input logic<8>,
+    exponent: input logic<4>,
+    comb_o: output logic<8>,
+    ff_o: output logic<8>,
+    comb_seen: output logic<4>,
+    ff_seen: output logic<4>,
+) {
+    function observe_exponent (
+        value: input logic<4>,
+        observed: output logic<4>,
+    ) -> logic<4> {
+        observed = value;
+        return value;
+    }
+    assign comb_o = base ** observe_exponent(exponent, comb_seen);
+    always_ff (clk) {
+        ff_o = base ** observe_exponent(exponent, ff_seen);
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top");
+    let clk = sim.event("clk");
+    let base = sim.signal("base");
+    let exponent = sim.signal("exponent");
+    let comb_o = sim.signal("comb_o");
+    let ff_o = sim.signal("ff_o");
+    let comb_seen = sim.signal("comb_seen");
+    let ff_seen = sim.signal("ff_seen");
+
+    for (base_value, exponent_value, expected) in [
+        (3u8, 4u8, 81u8),
+        (7u8, 0u8, 1u8),
+        (2u8, 8u8, 0u8),
+    ] {
+        sim.modify(|io| {
+            io.set(base, base_value);
+            io.set(exponent, exponent_value);
+        })
+        .unwrap();
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get(comb_o), expected.into());
+        assert_eq!(sim.get(ff_o), expected.into());
+        assert_eq!(sim.get(comb_seen), exponent_value.into());
+        assert_eq!(sim.get(ff_seen), exponent_value.into());
+    }
+
+    }
+
+    fn test_pow_operator_runtime_signed_and_unknown_operands(sim) {
+        @setup { let code = r#"
+module Top (
+    clk: input clock,
+    base: input signed logic<8>,
+    exponent: input signed logic<4>,
+    comb_o: output signed logic<8>,
+    ff_o: output signed logic<8>,
+) {
+    assign comb_o = base ** exponent;
+    always_ff (clk) {
+        ff_o = base ** exponent;
+    }
+}
+"#; }
+        @build Simulator::builder(code, "Top").four_state(true);
+    let clk = sim.event("clk");
+    let base = sim.signal("base");
+    let exponent = sim.signal("exponent");
+    let comb_o = sim.signal("comb_o");
+    let ff_o = sim.signal("ff_o");
+
+    for (base_value, exponent_value, expected) in [
+        (2u8, 0x0fu8, 0u8),  // 2 ** -1
+        (1u8, 0x0du8, 1u8),  // 1 ** -3
+        (0xffu8, 0x0du8, 0xffu8), // -1 ** -3
+        (0xffu8, 0x0eu8, 1u8), // -1 ** -2
+    ] {
+        sim.modify(|io| {
+            io.set(base, base_value);
+            io.set(exponent, exponent_value);
+        })
+        .unwrap();
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get(comb_o), expected.into());
+        assert_eq!(sim.get(ff_o), expected.into());
+    }
+
+    let full_unknown = BigUint::from(0xffu8);
+    sim.modify(|io| {
+        io.set_four_state(base, BigUint::from(0u8), BigUint::from(0u8));
+        io.set_four_state(exponent, BigUint::from(2u8), BigUint::from(1u8));
+    })
+    .unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(
+        sim.get_four_state(comb_o),
+        (full_unknown.clone(), full_unknown.clone())
+    );
+    assert_eq!(
+        sim.get_four_state(ff_o),
+        (full_unknown.clone(), full_unknown)
+    );
+
+    }
+
     fn test_signed_comparison_after_as_cast(sim) {
         @ignore_on(veryl);
         @setup { let code = r#"


### PR DESCRIPTION
## Summary

- lower runtime power exponents in both combinational and FF paths
- use exponentiation by squaring so generated IR scales with exponent width
- preserve signed negative-exponent and four-state X/Z semantics
- include exponent-side reads, writes, and function-call effects in dependency analysis

## Why

The Veryl frontend only lowered `**` when the exponent was compile-time constant. Legal runtime exponents returned `ParserError::Unsupported` from both comb and FF lowering, and analysis intentionally skipped the exponent operand.

This removes that unsupported path while keeping runtime behavior aligned with Veryl's constant evaluator across native, Cranelift, wasm, and Veryl reference execution.

## Validation

- `cargo test -p celox --test operators --no-fail-fast`
- `cargo test -p celox-frontend-veryl --lib --no-fail-fast`
- `cargo test -p celox --test expression_semantics --test four_state_expression_semantics --test system_function --no-fail-fast`
- `cargo clippy -p celox-frontend-veryl -p celox --tests -- -D warnings`
- pre-push hook: submodule check, cargo fmt, Biome, cargo check, clean tree