### PR TITLE
fix(x86): preserve nested output-array forwarding

### DIFF
--- a/crates/celox-backend-x86/src/backend/native/emit.rs
+++ b/crates/celox-backend-x86/src/backend/native/emit.rs
@@ -3012,6 +3012,7 @@ fn emit_inst(
 ) -> Result<bool, IcedError> {
     let mut bound_continuation = false;
     match inst {
+        MInst::X86Simd(X86SimdInst::Scratch128 { .. }) => {}
         MInst::X86Simd(X86SimdInst::Zero128 { dst }) => {
             match assignment
                 .x86_vector(*dst)
@@ -3037,7 +3038,12 @@ fn emit_inst(
                 }
             }
         }
-        MInst::X86Simd(X86SimdInst::Pack128 { dst, low, high }) => {
+        MInst::X86Simd(X86SimdInst::Pack128 {
+            dst,
+            low,
+            high,
+            scratch,
+        }) => {
             let low = preg_to_reg64(resolve(assignment, *low));
             let high = preg_to_reg64(resolve(assignment, *high));
             match assignment
@@ -3050,8 +3056,40 @@ fn emit_inst(
                     if low == high {
                         asm.punpcklqdq(destination, destination)?;
                     } else {
-                        asm.movq(xmm5, high)?;
-                        asm.punpcklqdq(destination, xmm5)?;
+                        let scratch = scratch.expect("verified pack scratch vector");
+                        match assignment
+                            .x86_vector(scratch)
+                            .expect("verified x86 vector scratch assignment")
+                        {
+                            X86VectorLocation::Register(register) => {
+                                let scratch = x86_vec_to_xmm(register);
+                                debug_assert_ne!(destination, scratch);
+                                asm.movq(scratch, high)?;
+                                asm.punpcklqdq(destination, scratch)?;
+                            }
+                            X86VectorLocation::Stack(stack_offset) => {
+                                asm.mov(
+                                    qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)),
+                                    low,
+                                )?;
+                                asm.mov(
+                                    qword_ptr(mem_operand(
+                                        BaseReg::StackFrame,
+                                        stack_offset
+                                            .checked_add(8)
+                                            .expect("verified vector spill offset fits i32"),
+                                    )),
+                                    high,
+                                )?;
+                                let source =
+                                    xmmword_ptr(mem_operand(BaseReg::StackFrame, stack_offset));
+                                if func.target_features.avx() {
+                                    asm.vmovdqu(destination, source)?;
+                                } else {
+                                    asm.movdqu(destination, source)?;
+                                }
+                            }
+                        }
                     }
                 }
                 X86VectorLocation::Stack(stack_offset) => {
@@ -5508,6 +5546,7 @@ fn log_mir_stats(label: &str, stage: &str, func: &super::mir::MFunction) {
                 MInst::X86Simd(X86SimdInst::Zero128 { .. })
                 | MInst::X86Simd(X86SimdInst::Pack128 { .. })
                 | MInst::X86Simd(X86SimdInst::Binary128 { .. }) => alu += 1,
+                MInst::X86Simd(X86SimdInst::Scratch128 { .. }) => {}
                 MInst::X86Simd(X86SimdInst::Load128 { base, .. }) => match base {
                     BaseReg::SimState => load_sim += 1,
                     BaseReg::StackFrame => load_stack += 1,

--- a/crates/celox-backend-x86/src/backend/native/emit.rs
+++ b/crates/celox-backend-x86/src/backend/native/emit.rs
@@ -3083,11 +3083,11 @@ fn emit_inst(
                                 )?;
                                 let source =
                                     xmmword_ptr(mem_operand(BaseReg::StackFrame, stack_offset));
-                                if func.target_features.avx() {
-                                    asm.vmovdqu(destination, source)?;
-                                } else {
-                                    asm.movdqu(destination, source)?;
-                                }
+                                // Pack128 otherwise uses legacy scalar/SSE
+                                // instructions. Keep this rare spill reload
+                                // baseline as well, so it cannot introduce an
+                                // untracked AVX requirement into the image.
+                                asm.movdqu(destination, source)?;
                             }
                         }
                     }
@@ -6082,6 +6082,59 @@ mod shift_encoding_tests {
             emitted.required_image_features
                 & (IMAGE_FEATURE_BMI2 | IMAGE_FEATURE_AVX | IMAGE_FEATURE_POPCNT),
             0
+        );
+    }
+
+    #[test]
+    fn spilled_pack_scratch_uses_baseline_move_without_avx_requirement() {
+        let mut vregs = VRegAllocator::new();
+        let low = vregs.alloc();
+        let high = vregs.alloc();
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 2]);
+        function.target_features = X86Features::for_test_with_avx(false, true);
+        let scratch = function.alloc_x86_vec();
+        let destination = function.alloc_x86_vec();
+        let mut block = MBlock::new(BlockId(0));
+        block.push(MInst::LoadImm { dst: low, value: 1 });
+        block.push(MInst::LoadImm {
+            dst: high,
+            value: 2,
+        });
+        block.push(MInst::X86Simd(X86SimdInst::Scratch128 { dst: scratch }));
+        block.push(MInst::X86Simd(X86SimdInst::Pack128 {
+            dst: destination,
+            low,
+            high,
+            scratch: Some(scratch),
+        }));
+        block.push(MInst::Return);
+        function.push_block(block);
+        function.verify();
+
+        let mut assignment = AssignmentMap::default();
+        assignment.set(low, PhysReg::RAX);
+        assignment.set(high, PhysReg::RBX);
+        assignment.set_x86_vector(scratch, X86VectorLocation::Stack(0));
+        assignment.set_x86_vector(destination, X86VectorLocation::Register(X86PhysVec(0)));
+
+        let emitted = emit(&function, &assignment, 16).unwrap();
+        assert_eq!(emitted.required_image_features & IMAGE_FEATURE_AVX, 0);
+
+        let mut decoder =
+            Decoder::new(64, &emitted.code[..emitted.text_size], DecoderOptions::NONE);
+        let mut instructions = Vec::new();
+        while decoder.can_decode() {
+            instructions.push(decoder.decode());
+        }
+        assert!(
+            instructions
+                .iter()
+                .any(|instruction| instruction.mnemonic() == Mnemonic::Movdqu)
+        );
+        assert!(
+            !instructions
+                .iter()
+                .any(|instruction| instruction.mnemonic() == Mnemonic::Vmovdqu)
         );
     }
 

--- a/crates/celox-backend-x86/src/backend/native/features.rs
+++ b/crates/celox-backend-x86/src/backend/native/features.rs
@@ -105,9 +105,14 @@ impl X86Features {
 
     #[cfg(test)]
     pub(crate) const fn for_test(bmi2: bool) -> Self {
+        Self::for_test_with_avx(bmi2, false)
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn for_test_with_avx(bmi2: bool, avx: bool) -> Self {
         Self {
             bmi2,
-            avx: false,
+            avx,
             popcnt: false,
             state_base: StateBaseStrategy::R15,
         }

--- a/crates/celox-backend-x86/src/backend/native/memory_effect.rs
+++ b/crates/celox-backend-x86/src/backend/native/memory_effect.rs
@@ -227,7 +227,8 @@ fn sparse_mark_ranges(inst: &MInst) -> Option<[MemoryRange; 1]> {
 
 pub(crate) fn reads(inst: &MInst) -> MemoryEffects {
     match inst {
-        MInst::X86Simd(X86SimdInst::Zero128 { .. })
+        MInst::X86Simd(X86SimdInst::Scratch128 { .. })
+        | MInst::X86Simd(X86SimdInst::Zero128 { .. })
         | MInst::X86Simd(X86SimdInst::Pack128 { .. })
         | MInst::X86Simd(X86SimdInst::Binary128 { .. }) => MemoryEffects::NONE,
         MInst::X86Simd(X86SimdInst::Load128 { base, offset, .. }) => {
@@ -314,7 +315,8 @@ pub(crate) fn reads(inst: &MInst) -> MemoryEffects {
 
 pub(crate) fn writes(inst: &MInst) -> MemoryEffects {
     match inst {
-        MInst::X86Simd(X86SimdInst::Zero128 { .. })
+        MInst::X86Simd(X86SimdInst::Scratch128 { .. })
+        | MInst::X86Simd(X86SimdInst::Zero128 { .. })
         | MInst::X86Simd(X86SimdInst::Pack128 { .. })
         | MInst::X86Simd(X86SimdInst::Binary128 { .. })
         | MInst::X86Simd(X86SimdInst::Load128 { .. }) => MemoryEffects::NONE,

--- a/crates/celox-backend-x86/src/backend/native/mir.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir.rs
@@ -627,6 +627,11 @@ impl SparseCommitDescriptor {
 /// legal or profitable for this target.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum X86SimdInst {
+    /// A short-lived vector temporary owned by the following recipe.
+    ///
+    /// This is a virtual value rather than a fixed physical register so the
+    /// vector allocator can keep it disjoint from the recipe's live inputs.
+    Scratch128 { dst: X86VecReg },
     /// `dst = <0, 0>`, emitted with a dependency-breaking x86 zero idiom.
     Zero128 { dst: X86VecReg },
     /// `dst = <low, high>`, with each scalar becoming one 64-bit lane.
@@ -634,6 +639,8 @@ pub enum X86SimdInst {
         dst: X86VecReg,
         low: VReg,
         high: VReg,
+        /// Required when `low != high`; defined immediately before this pack.
+        scratch: Option<X86VecReg>,
     },
     /// `dst = load 16 bytes [base + offset]`.
     Load128 {
@@ -659,7 +666,8 @@ pub enum X86SimdInst {
 impl X86SimdInst {
     pub fn def(self) -> Option<X86VecReg> {
         match self {
-            Self::Zero128 { dst }
+            Self::Scratch128 { dst }
+            | Self::Zero128 { dst }
             | Self::Pack128 { dst, .. }
             | Self::Load128 { dst, .. }
             | Self::Binary128 { dst, .. } => Some(dst),
@@ -669,7 +677,8 @@ impl X86SimdInst {
 
     pub fn uses(self) -> [Option<X86VecReg>; 2] {
         match self {
-            Self::Zero128 { .. } | Self::Pack128 { .. } | Self::Load128 { .. } => [None, None],
+            Self::Scratch128 { .. } | Self::Zero128 { .. } | Self::Load128 { .. } => [None, None],
+            Self::Pack128 { scratch, .. } => [scratch, None],
             Self::Binary128 { lhs, rhs, .. } => [Some(lhs), Some(rhs)],
             Self::Store128 { src, .. } => [Some(src), None],
         }
@@ -1083,11 +1092,22 @@ pub enum MInst {
 impl fmt::Display for MInst {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            MInst::X86Simd(X86SimdInst::Scratch128 { dst }) => {
+                write!(f, "{dst} = x86.scratch.v128")
+            }
             MInst::X86Simd(X86SimdInst::Zero128 { dst }) => {
                 write!(f, "{dst} = x86.zero.v128")
             }
-            MInst::X86Simd(X86SimdInst::Pack128 { dst, low, high }) => {
-                write!(f, "{dst} = x86.pack.v2i64 {low}, {high}")
+            MInst::X86Simd(X86SimdInst::Pack128 {
+                dst,
+                low,
+                high,
+                scratch,
+            }) => {
+                write!(
+                    f,
+                    "{dst} = x86.pack.v2i64 {low}, {high} [scratch={scratch:?}]"
+                )
             }
             MInst::X86Simd(X86SimdInst::Load128 { dst, base, offset }) => {
                 write!(f, "{dst} = x86.load.v128 [{base} + {offset}]")
@@ -1634,6 +1654,7 @@ impl MInst {
             MInst::Mov { src, .. } | MInst::Mov32 { src, .. } => Uses::one(*src),
             MInst::X86Simd(X86SimdInst::Pack128 { low, high, .. }) => Uses::two(*low, *high),
             MInst::LoadImm { .. }
+            | MInst::X86Simd(X86SimdInst::Scratch128 { .. })
             | MInst::X86Simd(X86SimdInst::Zero128 { .. })
             | MInst::X86Simd(X86SimdInst::Load128 { .. })
             | MInst::X86Simd(X86SimdInst::Binary128 { .. })
@@ -2041,6 +2062,7 @@ impl MInst {
                 }
             }
             MInst::LoadImm { .. }
+            | MInst::X86Simd(X86SimdInst::Scratch128 { .. })
             | MInst::X86Simd(X86SimdInst::Zero128 { .. })
             | MInst::X86Simd(X86SimdInst::Load128 { .. })
             | MInst::X86Simd(X86SimdInst::Binary128 { .. })

--- a/crates/celox-backend-x86/src/backend/native/regalloc/unified.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/unified.rs
@@ -369,6 +369,7 @@ fn next_use_bucket(next_use: u32) -> &'static str {
 
 fn inst_opcode(inst: &MInst) -> &'static str {
     match inst {
+        MInst::X86Simd(X86SimdInst::Scratch128 { .. }) => "x86_scratch_v128",
         MInst::X86Simd(X86SimdInst::Zero128 { .. }) => "x86_zero_v128",
         MInst::X86Simd(X86SimdInst::Pack128 { .. }) => "x86_pack_v2i64",
         MInst::X86Simd(X86SimdInst::Load128 { .. }) => "x86_load_v128",

--- a/crates/celox-backend-x86/src/backend/native/x86_slp.rs
+++ b/crates/celox-backend-x86/src/backend/native/x86_slp.rs
@@ -705,6 +705,14 @@ fn select_store_fanout_packs(func: &mut MFunction, stats: &mut SlpStats) {
                     if plan.zero {
                         replacement.push(MInst::X86Simd(X86SimdInst::Zero128 { dst: vector }));
                         stats.vector_zeroes += 1;
+                    } else if plan.low == plan.high {
+                        replacement.push(MInst::X86Simd(X86SimdInst::Pack128 {
+                            dst: vector,
+                            low: plan.low,
+                            high: plan.high,
+                            scratch: None,
+                        }));
+                        stats.vector_packs += 1;
                     } else {
                         let scratch =
                             scratch.expect("non-zero pack with distinct lanes has vector scratch");
@@ -1418,6 +1426,47 @@ mod tests {
                 .filter(|inst| matches!(inst, MInst::X86Simd(X86SimdInst::Store128 { .. })))
                 .count(),
             4
+        );
+        func.verify();
+    }
+
+    #[test]
+    fn scalar_splat_with_four_store_destinations_is_packed_without_scratch() {
+        let mut scalar = VRegAllocator::new();
+        let value = scalar.alloc();
+        let mut block = MBlock::new(BlockId(0));
+        block.push(MInst::LoadImm {
+            dst: value,
+            value: 1,
+        });
+        for offset in [32, 64, 96, 128] {
+            for lane_offset in [0, 8] {
+                block.push(MInst::Store {
+                    base: BaseReg::SimState,
+                    offset: offset + lane_offset,
+                    src: value,
+                    size: OpSize::S64,
+                });
+            }
+        }
+        block.push(MInst::Return);
+        let mut func = MFunction::new(scalar, vec![SpillDesc::transient()]);
+        func.blocks.push(block);
+
+        let stats = select(&mut func);
+
+        assert_eq!(stats.vector_packs, 1);
+        assert_eq!(stats.vector_stores, 4);
+        assert_eq!(stats.scalar_instructions_removed, 2);
+        assert!(func.blocks[0].insts.iter().any(|inst| matches!(
+            inst,
+            MInst::X86Simd(X86SimdInst::Pack128 { scratch: None, .. })
+        )));
+        assert!(
+            !func.blocks[0]
+                .insts
+                .iter()
+                .any(|inst| matches!(inst, MInst::X86Simd(X86SimdInst::Scratch128 { .. })))
         );
         func.verify();
     }

--- a/crates/celox-backend-x86/src/backend/native/x86_slp.rs
+++ b/crates/celox-backend-x86/src/backend/native/x86_slp.rs
@@ -676,15 +676,19 @@ fn select_store_fanout_packs(func: &mut MFunction, stats: &mut SlpStats) {
         }
     }
 
-    let mut by_block = BTreeMap::<usize, Vec<(X86VecReg, PackPairPlan)>>::new();
+    let mut by_block = BTreeMap::<usize, Vec<(X86VecReg, Option<X86VecReg>, PackPairPlan)>>::new();
     for plan in pack_plans {
         let vector = func.alloc_x86_vec();
-        by_block.entry(plan.block).or_default().push((vector, plan));
+        let scratch = (!plan.zero && plan.low != plan.high).then(|| func.alloc_x86_vec());
+        by_block
+            .entry(plan.block)
+            .or_default()
+            .push((vector, scratch, plan));
     }
     let mut replacements_by_block = BTreeMap::<usize, HashMap<usize, Vec<MInst>>>::new();
     for (block_index, plans) in by_block {
         let replacements = replacements_by_block.entry(block_index).or_default();
-        for (vector, plan) in plans {
+        for (vector, scratch, plan) in plans {
             let store_pair_count = plan.store_pairs.len();
             let pack_cost = if plan.zero {
                 1
@@ -702,10 +706,14 @@ fn select_store_fanout_packs(func: &mut MFunction, stats: &mut SlpStats) {
                         replacement.push(MInst::X86Simd(X86SimdInst::Zero128 { dst: vector }));
                         stats.vector_zeroes += 1;
                     } else {
+                        let scratch =
+                            scratch.expect("non-zero pack with distinct lanes has vector scratch");
+                        replacement.push(MInst::X86Simd(X86SimdInst::Scratch128 { dst: scratch }));
                         replacement.push(MInst::X86Simd(X86SimdInst::Pack128 {
                             dst: vector,
                             low: plan.low,
                             high: plan.high,
+                            scratch: Some(scratch),
                         }));
                         stats.vector_packs += 1;
                     }
@@ -747,17 +755,30 @@ pub(crate) struct X86VectorAllocation {
 /// emitted body. The fused native tick loop owns XMM0..XMM14; a
 /// standalone body keeps XMM9..XMM14 available for ABI-boundary GPR saves.
 ///
-/// XMM5 is reserved as an explicit emission scratch. SIMD recipes use it for
-/// the second lane of a pack and for stack operands, so assigning it to a live
-/// vector would silently clobber that vector while another recipe is emitted.
+/// SIMD recipes model their short-lived vector temporaries explicitly, so the
+/// allocator can use every physical register without hiding a post-RA clobber.
+/// The older stack recipes still use XMM5 as an emission scratch; reserve it
+/// only when a first coloring both spills a vector and assigns a live vector to
+/// that register.
 pub(crate) fn allocate(
     func: &MFunction,
     scalar_spill_bytes: u32,
     tick_loop: bool,
 ) -> X86VectorAllocation {
     let register_limit = if tick_loop { 15u8 } else { 9u8 };
-    let registers = (0..register_limit)
-        .map(X86PhysVec)
+    let registers = (0..register_limit).map(X86PhysVec).collect::<Vec<_>>();
+    let first = allocate_from_registers(func, scalar_spill_bytes, &registers);
+    if first.spilled_values == 0
+        || !first
+            .assignments
+            .iter()
+            .any(|(_, location)| matches!(location, X86VectorLocation::Register(X86PhysVec(5))))
+    {
+        return first;
+    }
+
+    let registers = registers
+        .into_iter()
         .filter(|register| register.0 != 5)
         .collect::<Vec<_>>();
     allocate_from_registers(func, scalar_spill_bytes, &registers)
@@ -1239,8 +1260,8 @@ mod tests {
         let assignment = allocate(&func, 24, true);
 
         assert_eq!(assignment.assignments.len(), 16);
-        // XMM5 is reserved for executable vector recipes, leaving fourteen
-        // allocatable registers in the fused tick loop.
+        // Once vector stack recipes are needed, XMM5 is reserved for their
+        // emission scratch and the remaining pressure spills two values.
         assert_eq!(assignment.spilled_values, 2);
         assert_eq!(assignment.spill_bytes, 32);
         assert!(
@@ -1252,7 +1273,7 @@ mod tests {
     }
 
     #[test]
-    fn fused_vector_pressure_reserves_xmm5_for_emission_scratch() {
+    fn fused_vector_pressure_uses_all_registers_without_a_temporary() {
         let mut func = MFunction::new(VRegAllocator::new(), Vec::new());
         let vectors = (0..15).map(|_| func.alloc_x86_vec()).collect::<Vec<_>>();
         let mut block = MBlock::new(BlockId(0));
@@ -1275,7 +1296,7 @@ mod tests {
 
         let assignment = allocate(&func, 0, true);
 
-        assert_eq!(assignment.spilled_values, 1);
+        assert_eq!(assignment.spilled_values, 0);
         assert_eq!(
             assignment
                 .assignments
@@ -1285,12 +1306,59 @@ mod tests {
                     X86VectorLocation::Stack(_) => None,
                 })
                 .collect::<HashSet<_>>(),
-            (0..15).filter(|register| *register != 5).collect()
+            (0..15).collect()
         );
-        assert!(matches!(
-            assignment.assignments.last(),
-            Some((_, X86VectorLocation::Stack(0)))
-        ));
+    }
+
+    #[test]
+    fn pack_scratch_is_colored_separately_from_the_packed_destination() {
+        let mut scalar = VRegAllocator::new();
+        let low = scalar.alloc();
+        let high = scalar.alloc();
+        let mut func = MFunction::new(scalar, vec![SpillDesc::transient(); 2]);
+        let scratch_value = func.alloc_x86_vec();
+        let destination_value = func.alloc_x86_vec();
+        let mut block = MBlock::new(BlockId(0));
+        block.push(MInst::LoadImm { dst: low, value: 1 });
+        block.push(MInst::LoadImm {
+            dst: high,
+            value: 2,
+        });
+        block.push(MInst::X86Simd(X86SimdInst::Scratch128 {
+            dst: scratch_value,
+        }));
+        block.push(MInst::X86Simd(X86SimdInst::Pack128 {
+            dst: destination_value,
+            low,
+            high,
+            scratch: Some(scratch_value),
+        }));
+        block.push(MInst::X86Simd(X86SimdInst::Store128 {
+            base: BaseReg::SimState,
+            offset: 32,
+            src: destination_value,
+        }));
+        block.push(MInst::Return);
+        func.blocks.push(block);
+
+        func.verify();
+        let assignment = allocate(&func, 0, true);
+        let scratch = assignment
+            .assignments
+            .iter()
+            .find(|(value, _)| *value == scratch_value)
+            .map(|(_, location)| *location)
+            .expect("scratch assignment");
+        let destination = assignment
+            .assignments
+            .iter()
+            .find(|(value, _)| *value == destination_value)
+            .map(|(_, location)| *location)
+            .expect("destination assignment");
+
+        assert!(matches!(scratch, X86VectorLocation::Register(_)));
+        assert!(matches!(destination, X86VectorLocation::Register(_)));
+        assert_ne!(scratch, destination);
     }
 
     #[test]
@@ -1332,6 +1400,14 @@ mod tests {
                 .insts
                 .iter()
                 .filter(|inst| matches!(inst, MInst::X86Simd(X86SimdInst::Pack128 { .. })))
+                .count(),
+            1
+        );
+        assert_eq!(
+            func.blocks[0]
+                .insts
+                .iter()
+                .filter(|inst| matches!(inst, MInst::X86Simd(X86SimdInst::Scratch128 { .. })))
                 .count(),
             1
         );

--- a/crates/celox-backend-x86/src/backend/native/x86_slp.rs
+++ b/crates/celox-backend-x86/src/backend/native/x86_slp.rs
@@ -747,28 +747,17 @@ pub(crate) struct X86VectorAllocation {
 /// emitted body. The fused native tick loop owns XMM0..XMM14; a
 /// standalone body keeps XMM9..XMM14 available for ABI-boundary GPR saves.
 ///
-/// If an interval must spill, allocation is repeated with XMM5 reserved as an
-/// explicit emission scratch. This lets pressure use every register when it
-/// fits while retaining a finite executable fallback when it does not.
+/// XMM5 is reserved as an explicit emission scratch. SIMD recipes use it for
+/// the second lane of a pack and for stack operands, so assigning it to a live
+/// vector would silently clobber that vector while another recipe is emitted.
 pub(crate) fn allocate(
     func: &MFunction,
     scalar_spill_bytes: u32,
     tick_loop: bool,
 ) -> X86VectorAllocation {
     let register_limit = if tick_loop { 15u8 } else { 9u8 };
-    let registers = (0..register_limit).map(X86PhysVec).collect::<Vec<_>>();
-    let first = allocate_from_registers(func, scalar_spill_bytes, &registers);
-    if first.spilled_values == 0
-        || !first
-            .assignments
-            .iter()
-            .any(|(_, location)| matches!(location, X86VectorLocation::Register(X86PhysVec(5))))
-    {
-        return first;
-    }
-
-    let registers = registers
-        .into_iter()
+    let registers = (0..register_limit)
+        .map(X86PhysVec)
         .filter(|register| register.0 != 5)
         .collect::<Vec<_>>();
     allocate_from_registers(func, scalar_spill_bytes, &registers)
@@ -1250,8 +1239,8 @@ mod tests {
         let assignment = allocate(&func, 24, true);
 
         assert_eq!(assignment.assignments.len(), 16);
-        // One register is reserved for executable stack-to-stack vector
-        // recipes once pressure exceeds all fifteen architectural registers.
+        // XMM5 is reserved for executable vector recipes, leaving fourteen
+        // allocatable registers in the fused tick loop.
         assert_eq!(assignment.spilled_values, 2);
         assert_eq!(assignment.spill_bytes, 32);
         assert!(
@@ -1263,7 +1252,7 @@ mod tests {
     }
 
     #[test]
-    fn fused_vector_pressure_can_use_xmm6_through_xmm14() {
+    fn fused_vector_pressure_reserves_xmm5_for_emission_scratch() {
         let mut func = MFunction::new(VRegAllocator::new(), Vec::new());
         let vectors = (0..15).map(|_| func.alloc_x86_vec()).collect::<Vec<_>>();
         let mut block = MBlock::new(BlockId(0));
@@ -1286,7 +1275,7 @@ mod tests {
 
         let assignment = allocate(&func, 0, true);
 
-        assert_eq!(assignment.spilled_values, 0);
+        assert_eq!(assignment.spilled_values, 1);
         assert_eq!(
             assignment
                 .assignments
@@ -1296,8 +1285,12 @@ mod tests {
                     X86VectorLocation::Stack(_) => None,
                 })
                 .collect::<HashSet<_>>(),
-            (0..15).collect()
+            (0..15).filter(|register| *register != 5).collect()
         );
+        assert!(matches!(
+            assignment.assignments.last(),
+            Some((_, X86VectorLocation::Stack(0)))
+        ));
     }
 
     #[test]

--- a/packages/celox/src/e2e.test.ts
+++ b/packages/celox/src/e2e.test.ts
@@ -540,13 +540,26 @@ describe("E2E: nested output-array forwarding", () => {
 		sim.dut.rst = 1n;
 
 		const dut = sim.dut as any;
-		const generated = dut.source.source.source.value.at(1);
-		const forwarded = dut.source.source.value.at(1);
+		const generated = Array.from({ length: 14 }, (_, index) =>
+			dut.source.source.source.value.at(index),
+		);
+		const forwardA = Array.from({ length: 14 }, (_, index) =>
+			dut.source.source.value.at(index),
+		);
+		const forwardB = Array.from({ length: 14 }, (_, index) =>
+			dut.source.value.at(index),
+		);
+		const forwarded = Array.from({ length: 14 }, (_, index) =>
+			dut.value.at(index),
+		);
 		sim.dispose();
 
 		const allOnes = (1n << 64n) - 1n;
-		expect(generated).toBe(allOnes);
-		expect(forwarded).toBe(generated);
+		const expected = Array.from({ length: 14 }, () => allOnes);
+		expect(generated).toEqual(expected);
+		expect(forwardA).toEqual(generated);
+		expect(forwardB).toEqual(forwardA);
+		expect(forwarded).toEqual(forwardB);
 	});
 });
 

--- a/packages/celox/src/e2e.test.ts
+++ b/packages/celox/src/e2e.test.ts
@@ -81,6 +81,76 @@ module Counter (
 }
 `;
 
+// Regression: preserve every lane when a wide SIMD store forwards an unpacked
+// output array through multiple module instances. Fourteen 64-bit elements
+// exercise the native SLP path that previously aliased its scratch XMM register
+// with a live forwarding vector.
+const NESTED_OUTPUT_ARRAY_SOURCE = `
+module Element (
+    clk:   input  clock,
+    rst:   input  reset,
+    value: output logic<64>,
+) {
+    var value_r: logic<64>;
+    assign value = value_r;
+    always_ff {
+        if_reset {
+            value_r = -1;
+        }
+    }
+}
+
+module GeneratedArray (
+    clk:   input  clock,
+    rst:   input  reset,
+    value: output logic<64> [14],
+) {
+    for i in 0..14: elements {
+        inst element: Element (
+            clk,
+            rst,
+            value: value[i],
+        );
+    }
+}
+
+module ForwardA (
+    clk:   input  clock,
+    rst:   input  reset,
+    value: output logic<64> [14],
+) {
+    inst source: GeneratedArray (
+        clk,
+        rst,
+        value,
+    );
+}
+
+module ForwardB (
+    clk:   input  clock,
+    rst:   input  reset,
+    value: output logic<64> [14],
+) {
+    inst source: ForwardA (
+        clk,
+        rst,
+        value,
+    );
+}
+
+module NestedOutputArrayMre (
+    clk:   input  clock,
+    rst:   input  reset,
+    value: output logic<64> [14],
+) {
+    inst source: ForwardB (
+        clk,
+        rst,
+        value,
+    );
+}
+`;
+
 const MULTIPLEXER_SOURCE = `
 module Mux4 (
     sel: input logic<2>,
@@ -438,6 +508,45 @@ describe("E2E: Simulator.create (backward compat)", () => {
 		expect(sim.dut.sum).toBe(300n);
 
 		sim.dispose();
+	});
+});
+
+describe("E2E: nested output-array forwarding", () => {
+	test("forwards every generated 64-bit output-array element", () => {
+		const addon = loadNativeAddon();
+		const sim = Simulator.create<{ rst: bigint }>(
+			{
+				__celox_module: true,
+				name: "NestedOutputArrayMre",
+				sources: [{ path: "", content: NESTED_OUTPUT_ARRAY_SOURCE }],
+				ports: {
+					clk: { direction: "input", type: "clock", width: 1 },
+					rst: { direction: "input", type: "reset", width: 1 },
+					value: {
+						direction: "output",
+						type: "logic",
+						width: 64,
+						arrayDims: [14],
+					},
+				},
+				events: ["clk"],
+			},
+			{ __nativeCreate: createSimulatorBridge(addon) },
+		);
+
+		sim.dut.rst = 0n;
+		sim.tick();
+		sim.tick();
+		sim.dut.rst = 1n;
+
+		const dut = sim.dut as any;
+		const generated = dut.source.source.source.value.at(1);
+		const forwarded = dut.source.source.value.at(1);
+		sim.dispose();
+
+		const allOnes = (1n << 64n) - 1n;
+		expect(generated).toBe(allOnes);
+		expect(forwarded).toBe(generated);
 	});
 });
 


### PR DESCRIPTION
## Summary

- model Pack128's short-lived XMM scratch as a virtual MIR value
- let vector allocation use every XMM register when no vector spill is needed
- reserve XMM5 only for the existing stack-spill recipes that still use it as an emission scratch
- add regression coverage for 14 generated 64-bit output elements forwarded through three wrappers

## Root cause

x86 SLP used XMM5 as a pack scratch register while allowing live vector values to be assigned to XMM5. A later pack clobbered the vector before its fanout stores, so the generated array was correct while nested forwarded outputs became zero.

The fix makes the pack scratch visible to vector liveness and coloring. This avoids a permanent register reservation while keeping the legacy stack-spill scratch path safe under pressure.

## Validation

- `cargo test`
- `cargo test -p celox-backend-x86 --lib`
- `cargo test -p celox --test hierarchy`
- `cargo test -p celox --test sorter_tree_perf sorter_tree_compilation_scales`
- `pnpm --filter @celox-sim/celox exec vitest run --no-file-parallelism`
- `pnpm --filter @celox-sim/celox run build`
- pre-push hook: cargo-fmt, Biome, cargo-check
