### PR TITLE
feat(test): run Veryl output through SV frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Run SystemVerilog frontend tests
         if: needs.changes.result != 'success' || needs.changes.outputs.rust == 'true'
-        run: cargo test --locked -p celox --features systemverilog --test systemverilog
+        run: cargo test --locked -p celox --features systemverilog --tests
 
       - name: Run cocotb VPI end-to-end test
         if: needs.changes.result != 'success' || needs.changes.outputs.rust == 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,7 @@ dependencies = [
  "tracing",
  "veryl-analyzer",
  "veryl-component-sys",
+ "veryl-emitter",
  "veryl-metadata",
  "veryl-parser",
  "veryl-path",

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -78,6 +78,7 @@ proptest   = "1.10"
 test-case  = "3"
 tempfile.workspace = true
 veryl-std = { workspace = true }
+veryl-emitter = { workspace = true }
 veryl-simulator = { workspace = true }
 
 [[bench]]

--- a/crates/celox/tests/advanced_interface.rs
+++ b/crates/celox/tests/advanced_interface.rs
@@ -8,6 +8,7 @@ all_backends! {
 
     // Interface with multiple modport signals and bidirectional data flow.
     fn test_interface_bidirectional(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 interface Handshake {
 var req:  logic;
@@ -87,6 +88,7 @@ got:  got,
 
     // Multiple interface instances used in parallel.
     fn test_multiple_interface_instances(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 interface DataBus {
 var data: logic<8>;
@@ -149,6 +151,7 @@ inst r1: Reader (bus: bus1, out: o1);
 
     // Interface with wide (multi-bit) signals.
     fn test_interface_wide_signal(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 interface WideBus {
 var data: logic<32>;
@@ -200,6 +203,7 @@ inst dst_inst: Sink   (bus: wb, out: out);
     // Parametric interface array: verify array_dims are populated for parametric-type members.
     fn test_parametric_interface_array(sim) {
         @omit_veryl;
+        @ignore_on(sv);
         @setup { let code = r#"
 interface Bus::<T: type> {
 var data:  T;
@@ -250,6 +254,7 @@ assign out = bus[0].data + bus[1].data;
     // Tests that generic type parameters are correctly propagated across multiple
     // levels of the module hierarchy (a pattern that has been buggy in the past).
     fn test_transitive_generics(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 interface DataBus::<T: type> {
 var data: T;

--- a/crates/celox/tests/array_literal.rs
+++ b/crates/celox/tests/array_literal.rs
@@ -7,6 +7,7 @@ mod test_utils;
 all_backends! {
 
     fn test_array_literal_comb_assignment(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (o0: output logic<8>, o1: output logic<8>) {
 var a: logic<8> [2];
@@ -30,6 +31,7 @@ assign o1 = a[1];
     }
 
     fn test_array_literal_default_comb_assignment(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 o0: output logic<8>,
@@ -63,6 +65,7 @@ assign o3 = a[3];
     }
 
     fn test_array_literal_nested_default_multidim_assignment(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 o00: output logic<8>,
@@ -140,7 +143,7 @@ arr[0] = 8'hAB;
     }
 
     fn test_array_literal_single_element_size_one_array(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { // '{val} on a 1-element array should still assign that one element correctly.
 let code = r#"
 module Top (
@@ -208,6 +211,7 @@ arr[0][0] = 8'hAB;
     // '{default: 0} with no explicit elements: must produce exactly target_len elements.
     // Regression test for off-by-one where remaining was target_len - (x.len()-1).
     fn test_array_literal_default_only(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 o0: output logic<8>,
@@ -242,6 +246,7 @@ assign o3 = a[3];
 
     // Two explicit elements + default: remaining slots filled correctly.
     fn test_array_literal_two_explicit_plus_default(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 o0: output logic<8>,
@@ -276,6 +281,7 @@ assign o3 = a[3];
 
     // repeat + default: '{val repeat 2, default: 0} in a size-4 array.
     fn test_array_literal_repeat_plus_default(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 o0: output logic<8>,
@@ -310,7 +316,7 @@ assign o3 = a[3];
 
     // '{default: 0} in always_ff if_reset: array reset via default fill.
     fn test_array_literal_default_in_ff_reset(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
 clk: input clock,

--- a/crates/celox/tests/basic.rs
+++ b/crates/celox/tests/basic.rs
@@ -117,6 +117,7 @@ assign o = a;
     }
 
     fn test_comb_override_dependency(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (sel: input logic, val: input logic<8>, o: output logic<8>) {
 var tmp: logic<8>;
@@ -149,6 +150,7 @@ o = tmp;
     }
 
     fn test_always_comb_read_before_write_uses_previous_value(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     a: input logic,
@@ -181,7 +183,7 @@ module Top (
     }
 
     fn test_comb_function_call_early_return(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -245,6 +247,7 @@ module Top (
     }
 
     fn test_comb_function_call_partial_write_local_temp(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -274,6 +277,7 @@ module Top (
     }
 
     fn test_comb_function_call_local_and_return_width_coercion(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     sel: input logic,
@@ -312,6 +316,7 @@ module Top (
     }
 
     fn test_comb_function_call_constant_folded_if_return(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     q: output logic<8>,
@@ -334,7 +339,7 @@ module Top (
     }
 
     fn test_comb_function_call_return_inside_for(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
     d: input logic<4>,
@@ -369,6 +374,7 @@ module Top (
     }
 
     fn test_comb_function_call_break_inside_for(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<4>,
@@ -438,6 +444,7 @@ module Top (
     }
 
     fn test_comb_function_call_statement_with_output_argument(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -467,6 +474,7 @@ module Top (
     }
 
     fn test_comb_function_call_expression_with_output_argument(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -498,6 +506,7 @@ module Top (
     }
 
     fn test_comb_function_call_expression_output_is_visible_to_later_operand(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -527,6 +536,7 @@ module Top (
     }
 
     fn test_comb_function_call_expression_with_constant_input_keeps_output_write(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     q_return: output logic<8>,
@@ -555,6 +565,7 @@ module Top (
     }
 
     fn test_comb_function_call_expression_output_survives_system_function_wrapper(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -586,6 +597,7 @@ module Top (
     }
 
     fn test_comb_function_call_with_output_argument_in_display_argument(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -617,6 +629,7 @@ module Top (
     }
 
     fn test_comb_function_call_with_output_argument_in_index_expression(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     data: input logic<4>,
@@ -652,6 +665,7 @@ module Top (
     }
 
     fn test_comb_function_call_with_output_argument_in_destination_index(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     sel: input logic<2>,
@@ -685,7 +699,7 @@ module Top (
     }
 
     fn test_comb_function_call_expression_output_is_guarded_by_ternary(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
     sel: input logic,
@@ -727,7 +741,7 @@ module Top (
     }
 
     fn test_comb_function_call_expression_output_respects_short_circuit(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -768,6 +782,7 @@ module Top (
     }
 
     fn test_comb_function_call_with_output_argument_in_if_condition(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -806,6 +821,7 @@ module Top (
     }
 
     fn test_comb_function_call_with_output_argument_in_case_target(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -844,6 +860,7 @@ module Top (
     }
 
     fn test_comb_function_call_with_output_argument_in_loop_condition(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -879,7 +896,7 @@ module Top (
     }
 
     fn test_comb_nested_function_output_call_in_function_condition(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -922,7 +939,7 @@ module Top (
     fn test_comb_case_target_output_call_is_evaluated_once(sim) {
         // Veryl simulator 0.20.2 re-evaluates the effectful case target for
         // each arm, so the second comparison observes the first writeback.
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
     q: output logic<8>,
@@ -959,6 +976,7 @@ module Top (
     fn test_comb_loop_bound_output_call_writes_back_once(sim) {
         // Veryl simulator 0.20.2 accepts this program but drops the output
         // argument writeback from the runtime loop-bound expression.
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -995,7 +1013,7 @@ module Top (
     fn test_comb_value_system_function_statement_applies_argument_outputs(sim) {
         // Veryl simulator 0.20.2 rejects value-returning system functions in
         // statement position even though the analyzer accepts the source.
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -1030,7 +1048,7 @@ module Top (
     fn test_comb_value_system_function_after_dynamic_break_stays_inactive(sim) {
         // Veryl simulator 0.20.2 rejects value-returning system functions in
         // statement position even though the analyzer accepts the source.
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
     stop: input logic,
@@ -1075,6 +1093,7 @@ module Top (
     }
 
     fn test_comb_effectful_if_condition_after_dynamic_break_stays_inactive(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     stop: input logic,
@@ -1121,6 +1140,7 @@ module Top (
     }
 
     fn test_statement_call_inputs_follow_output_writeback_order(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -1162,7 +1182,7 @@ module Top (
     fn test_comb_effectful_case_after_dynamic_break_stays_inactive(sim) {
         // Veryl simulator 0.20.2 drops the case-target output writeback when
         // the case contains only a default arm with break.
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
     stop: input logic,
@@ -1211,7 +1231,7 @@ module Top (
     fn test_comb_function_condition_output_is_guarded_after_early_return(sim) {
         // Veryl simulator 0.20.2 does not preserve this nested early-return
         // behavior when the later condition contains an output call.
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
     sel: input logic,
@@ -1268,6 +1288,7 @@ module Top (
     }
 
     fn test_comb_function_call_statement_ignores_return_value(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -1296,6 +1317,7 @@ module Top (
     }
 
     fn test_comb_returning_output_function_reads_current_caller_store(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -1326,6 +1348,7 @@ module Top (
     }
 
     fn test_comb_returning_output_function_allows_nested_output_call(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -1361,7 +1384,7 @@ module Top (
     }
 
     fn test_comb_function_call_statement_preserves_return_control_flow(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -1391,7 +1414,7 @@ module Top (
     }
 
     fn test_comb_function_call_statement_preserves_conditional_return_control_flow(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
     sel: input logic,
@@ -1433,6 +1456,7 @@ module Top (
     }
 
     fn test_comb_nested_function_call_statement_with_output_argument(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -1469,6 +1493,7 @@ module Top (
     }
 
     fn test_comb_function_call_output_reads_current_caller_store(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -1498,6 +1523,7 @@ module Top (
     }
 
     fn test_comb_function_call_statement_with_output_argument_in_loop(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<8>,
@@ -1528,6 +1554,7 @@ module Top (
     }
 
     fn test_comb_function_call_output_bit_select_preserves_unwritten_loop_bits(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<4>,
@@ -1558,6 +1585,7 @@ module Top (
     }
 
     fn test_always_comb_blocking_assignment_chain(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (a: input logic<8>, o: output logic<8>) {
 var x: logic<8>;

--- a/crates/celox/tests/bitslice_param_repro.rs
+++ b/crates/celox/tests/bitslice_param_repro.rs
@@ -123,6 +123,7 @@ fn axl_read(sim: &mut Simulator, addr: u32) -> u32 {
 all_backends! {
 
     fn fill_one_literal_multi_branch(sim) {
+        @ignore_on(sv);
         @setup { // Verify '1 fill-literal: unwritten bits should be 1, not 0.
 let code = r#"
 module Top (

--- a/crates/celox/tests/bram_corruption.rs
+++ b/crates/celox/tests/bram_corruption.rs
@@ -44,6 +44,7 @@ module BramTdp #(
 all_backends! {
 
 fn bram_rewrite_no_corruption_all_opts(sim) {
+    @ignore_on(sv);
     @build Simulator::builder(BRAM_CODE, "BramTdp")
         .optimize_options(OptimizeOptions::all());
 
@@ -117,6 +118,7 @@ fn bram_rewrite_no_corruption_all_opts(sim) {
 }
 
 fn bram_rewrite_no_corruption_no_opts(sim) {
+    @ignore_on(sv);
     @build Simulator::builder(BRAM_CODE, "BramTdp")
         .optimize_options(OptimizeOptions::none());
 

--- a/crates/celox/tests/case_switch.rs
+++ b/crates/celox/tests/case_switch.rs
@@ -7,6 +7,7 @@ mod test_utils;
 all_backends! {
 
     fn test_case_basic_comb(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 sel: input logic<2>,
@@ -41,6 +42,7 @@ default: o = 8'hDD;
     }
 
     fn test_switch_basic_comb(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 a: input logic<8>,
@@ -75,6 +77,7 @@ default:    o = 8'hFF;
     }
 
     fn test_case_multiarm(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 sel: input logic<3>,
@@ -111,6 +114,7 @@ default:    o = 8'h00;
     }
 
     fn test_case_nested_in_if(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 en:  input logic,
@@ -151,6 +155,7 @@ o = 8'h00;
     }
 
     fn test_case_block_body(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 sel: input logic<2>,
@@ -266,6 +271,7 @@ module Top (
     }
 
     fn test_case_in_comb_function_output_argument(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     sel: input logic<2>,
@@ -303,6 +309,7 @@ module Top (
     }
 
     fn test_case_break_inside_comb_function_for(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     d: input logic<4>,

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -8,7 +8,7 @@ mod test_utils;
 all_backends! {
 fn test_comb_display_preserves_argument_value_before_later_output_writeback(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     d: input logic<8>,
@@ -44,7 +44,7 @@ module Top (
 
 fn test_comb_display_preserves_unbound_argument_with_local_bindings(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     d: input logic<8>,
@@ -87,7 +87,7 @@ module Top (
 
 fn test_comb_display_arguments_observe_output_call_writeback_order(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     d: input logic<8>,
@@ -122,7 +122,7 @@ module Top (
 
 fn test_comb_callee_observer_inputs_follow_output_writeback_order(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     d: input logic<8>,
@@ -166,7 +166,7 @@ module Top (
 
 fn test_comb_callee_observer_snapshots_formal_before_later_actual_writeback(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     d: input logic<8>,
@@ -209,7 +209,7 @@ module Top (
 
 fn test_comb_callee_observer_sees_actual_output_writeback_in_module_state(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     d: input logic<8>,
@@ -250,7 +250,7 @@ module Top (
 
 fn test_comb_callee_observer_converts_two_state_formal(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -284,7 +284,7 @@ module Top (
 
 fn test_comb_output_destination_observer_uses_return_aware_loop_value(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     d: input logic,
@@ -337,7 +337,7 @@ module Top (
 
 fn test_comb_runtime_effect_inside_if_condition_is_collected(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     d: input logic<8>,
@@ -381,7 +381,7 @@ module Top (
 
 fn test_comb_condition_runtime_effect_respects_short_circuit(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     and_enable: input logic,
@@ -433,7 +433,7 @@ module Top (
 
 fn test_comb_runtime_effect_inside_case_target_is_collected(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     d: input logic<2>,
@@ -478,7 +478,7 @@ module Top (
 
 fn test_comb_runtime_effect_inside_assignment_destination_is_collected(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     sel: input logic<2>,
@@ -520,7 +520,7 @@ module Top (
 
 fn test_comb_runtime_effect_inside_value_system_statement_is_collected(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     d: input logic<8>,
@@ -558,7 +558,7 @@ module Top (
 
 fn test_comb_observer_after_case_uses_selected_arm_store(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     sel: input logic<2>,
@@ -590,7 +590,7 @@ module Top (
 
 fn test_comb_runtime_effect_inside_loop_bound_is_collected(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     d: input logic<8>,
@@ -634,7 +634,7 @@ module Top (
 
 fn test_comb_display_follows_always_comb_sensitivity_after_settle(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<2>,
@@ -686,7 +686,7 @@ module Top (
 
 fn test_comb_display_survives_dead_store_elimination(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -727,7 +727,7 @@ module Top (
 
 fn test_comb_constant_display_runs_on_initial_eval_only(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -759,7 +759,7 @@ module Top (
 
 fn test_comb_constant_fatal_assert_runs_on_initial_eval(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top {
     always_comb {
@@ -789,7 +789,7 @@ module Top {
 
 fn test_comb_sensitive_display_runs_on_initial_eval(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -814,7 +814,7 @@ module Top (
 
 fn test_comb_sensitive_fatal_assert_runs_on_initial_eval(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -843,7 +843,7 @@ module Top (
 
 fn test_comb_runtime_event_drain_settles_dirty_comb_before_reading_events(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -872,7 +872,7 @@ module Top (
 
 fn test_comb_runtime_event_drain_handle_sees_captured_display(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -903,7 +903,7 @@ module Top (
 
 fn test_comb_runtime_event_drain_handle_sees_direct_set_capture(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -933,7 +933,7 @@ module Top (
 
 fn test_comb_runtime_event_drain_handle_starts_after_simulator_drain(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -970,7 +970,7 @@ module Top (
 
 fn test_comb_runtime_event_drain_handle_preserves_ff_before_comb_order(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -1017,7 +1017,7 @@ module Top (
 
 fn test_comb_runtime_event_drain_handle_drains_older_comb_before_later_ff(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -1064,7 +1064,7 @@ module Top (
 
 fn test_comb_assert_continue_follows_always_comb_sensitivity_after_settle(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<2>,
@@ -1115,7 +1115,7 @@ module Top (
 
 fn test_comb_assert_fatal_stops_comb_eval_and_keeps_event(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -1152,7 +1152,7 @@ module Top (
 
 fn test_comb_assert_fatal_inactive_site_does_not_error(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -1187,7 +1187,7 @@ module Top (
 
 fn test_comb_display_pending_events_drain_before_later_ff_events(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -1233,7 +1233,7 @@ module Top (
 
 fn test_comb_display_ff_triggered_comb_only_captures_active_sites(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -1285,7 +1285,7 @@ module Top (
 
 fn test_comb_display_tracks_downstream_comb_settle_sensitivity(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -1321,7 +1321,7 @@ module Top (
 
 fn test_comb_display_coalesces_sensitive_changes_before_observer_executes(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     src: input logic<8>,
@@ -1373,7 +1373,7 @@ fn test_comb_display_inside_writer_reactivates_after_assign_chain(sim) {
     @omit_veryl;
     // Veryl 0.20.3 falsely reports a CombinationalLoop: x[0] and x[1] have
     // non-overlapping longest static prefixes and are independent SV writers.
-    @ignore_on(native, cranelift, wasm);
+    @ignore_on(native, cranelift, wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -1415,7 +1415,7 @@ module Top (
 
 fn test_comb_display_inside_writer_reactivates_through_scalar_assign_chain(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -1457,7 +1457,7 @@ module Top (
 fn test_comb_display_inside_writer_reactivates_after_multi_stage_assign_chain(sim) {
     @omit_veryl;
     // Veryl 0.20.3 falsely reports a CombinationalLoop for independent bits.
-    @ignore_on(native, cranelift, wasm);
+    @ignore_on(native, cranelift, wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -1500,7 +1500,7 @@ module Top (
 fn test_comb_display_inside_writer_preserves_ordered_downstream_reactivations(sim) {
     @omit_veryl;
     // Veryl 0.20.3 falsely reports a CombinationalLoop for independent bits.
-    @ignore_on(native, cranelift, wasm);
+    @ignore_on(native, cranelift, wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -1544,7 +1544,7 @@ module Top (
 
 fn test_comb_display_inside_writer_reactivates_through_dynamic_index_read(sim) {
     @omit_veryl;
-    @ignore_on(native, cranelift, wasm);
+    @ignore_on(native, cranelift, wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -1600,7 +1600,7 @@ module Top (
 fn test_comb_display_guard_reactivates_after_assign_chain_changes_guard(sim) {
     @omit_veryl;
     // Veryl 0.20.3 falsely reports a CombinationalLoop for independent bits.
-    @ignore_on(native, cranelift, wasm);
+    @ignore_on(native, cranelift, wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -1638,7 +1638,7 @@ module Top (
 fn test_comb_assert_fatal_reactivates_after_assign_chain_changes_assert_input(sim) {
     @omit_veryl;
     // Veryl 0.20.3 falsely reports a CombinationalLoop for independent bits.
-    @ignore_on(native, cranelift, wasm);
+    @ignore_on(native, cranelift, wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -1680,7 +1680,7 @@ module Top (
 fn test_comb_multiple_observers_inside_writer_reactivate_in_statement_order(sim) {
     @omit_veryl;
     // Veryl 0.20.3 falsely reports a CombinationalLoop for independent bits.
-    @ignore_on(native, cranelift, wasm);
+    @ignore_on(native, cranelift, wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -1735,7 +1735,7 @@ module Top (
 
 fn test_comb_display_inside_dynamic_for_reactivates_after_assign_chain(sim) {
     @omit_veryl;
-    @ignore_on(native, cranelift, wasm);
+    @ignore_on(native, cranelift, wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -1793,7 +1793,7 @@ module Top (
 fn test_comb_display_inside_writer_reactivates_through_instance_port_chain(sim) {
     @omit_veryl;
     // Veryl 0.20.3 falsely reports a CombinationalLoop for independent bits.
-    @ignore_on(native, cranelift, wasm);
+    @ignore_on(native, cranelift, wasm, sv);
     @build Simulator::builder(r#"
 module Passthrough (
     i: input logic,
@@ -1846,7 +1846,7 @@ module Top (
 
 fn test_comb_display_after_ff_runtime_event_preserves_drain_order(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -1892,7 +1892,7 @@ module Top (
 
 fn test_comb_display_capture_defers_context_formatting_until_drain(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -1925,7 +1925,7 @@ module Top (
 
 fn test_comb_inactive_display_and_assert_do_not_leak_or_duplicate(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -1990,7 +1990,7 @@ module Top (
 
 fn test_comb_multiple_active_captures_skip_inactive_site_between_evals(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -2054,7 +2054,7 @@ module Top (
 
 fn test_comb_capture_before_dynamic_for_backedge_keeps_loop_state(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     count: input logic<4>,
@@ -2104,7 +2104,7 @@ module Top (
 
 fn test_comb_capture_after_branch_preserves_phi_args(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     sel: input logic,
@@ -2160,7 +2160,7 @@ module Top (
 
 fn test_comb_capture_preserves_wide_four_state_args(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<80>,
@@ -2198,7 +2198,7 @@ module Top (
 
 fn test_comb_display_inside_statement_function_call(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -2235,7 +2235,7 @@ module Top (
 
 fn test_outputless_statement_call_after_conditional_return_stays_inactive(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -2301,7 +2301,7 @@ module Top (
 
 fn test_outputless_statement_call_after_loop_return_stays_inactive(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -2379,7 +2379,7 @@ module Top (
 
 fn test_return_before_dynamic_loop_suppresses_loop_effects(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -2433,7 +2433,7 @@ module Top (
 
 fn test_function_loop_with_return_and_break_preserves_effects(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -2489,7 +2489,7 @@ module Top (
 
 fn test_function_break_keeps_post_loop_effect_live(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     value: input logic<8>,
@@ -2544,6 +2544,7 @@ module Top (
 }
 
 fn test_named_function_inputs_evaluate_in_source_order(sim) {
+    @ignore_on(sv);
     @build Simulator::builder(r#"
 module Top (
     value: input logic<8>,
@@ -2585,6 +2586,7 @@ module Top (
 }
 
 fn test_named_function_outputs_apply_in_source_order(sim) {
+    @ignore_on(sv);
     @build Simulator::builder(r#"
 module Top (
     tmp: output logic<8>,
@@ -2618,7 +2620,7 @@ module Top (
 
 fn test_nested_dynamic_function_loops_preserve_effect_runners(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -2716,7 +2718,7 @@ module Top (
 
 fn test_comb_display_inside_expression_function_call(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -2752,7 +2754,7 @@ module Top (
 
 fn test_comb_assert_inside_function_call_uses_caller_sensitivity(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -2803,7 +2805,7 @@ module Top (
 
 fn test_comb_display_keeps_static_unrolled_execution_count(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -2844,7 +2846,7 @@ module Top (
 
 fn test_comb_display_uses_statement_position_symbolic_values(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -2881,7 +2883,7 @@ module Top (
 
 fn test_comb_display_runtime_excludes_written_lhs_from_sensitivity(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -2936,7 +2938,7 @@ module Top (
 
 fn test_comb_display_snapshots_after_dynamic_bit_write_before_later_same_var_write(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     idx: input logic<3>,
@@ -2989,7 +2991,7 @@ module Top (
 
 fn test_comb_display_snapshots_after_dynamic_array_write_before_later_same_array_write(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     idx: input logic<2>,
@@ -3045,7 +3047,7 @@ module Top (
 
 fn test_comb_display_snapshots_between_dynamic_writes_to_same_var(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     base: input logic<8>,
@@ -3120,7 +3122,7 @@ module Top (
 
 fn test_comb_display_snapshots_repeated_full_var_writes(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -3165,7 +3167,7 @@ module Top (
 
 fn test_comb_display_snapshots_inside_if_branch(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     en: input logic,
@@ -3225,7 +3227,7 @@ module Top (
 
 fn test_comb_display_snapshots_repeated_writes_in_unrolled_loop(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -3269,7 +3271,7 @@ module Top (
 
 fn test_comb_display_snapshots_after_function_output_argument(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -3316,7 +3318,7 @@ module Top (
 
 fn test_comb_display_snapshots_after_multiple_function_output_arguments(sim) {
     @omit_veryl;
-    @ignore_on(native, cranelift, wasm);
+    @ignore_on(native, cranelift, wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -3367,7 +3369,7 @@ module Top (
 
 fn test_comb_display_snapshots_partial_overlap_position(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     lo: input logic<4>,
@@ -3408,7 +3410,7 @@ module Top (
 
 fn test_comb_display_snapshots_after_dynamic_for(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     count: input logic<4>,
@@ -3450,7 +3452,7 @@ module Top (
 
 fn test_comb_display_inside_dynamic_for_runs_each_iteration(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     count: input logic<4>,
@@ -3503,7 +3505,7 @@ module Top (
 
 fn test_comb_display_inside_dynamic_for_remaps_site_after_prior_comb_event(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     count: input logic<4>,
@@ -3563,7 +3565,7 @@ module Top (
 
 fn test_comb_display_inside_dynamic_for_preserves_repeated_identical_events(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     count: input logic<4>,
@@ -3600,7 +3602,7 @@ module Top (
 
 fn test_comb_display_inside_dynamic_for_with_multiple_updates_emits_once_per_iteration(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     count: input logic<4>,
@@ -3654,7 +3656,7 @@ module Top (
 
 fn test_comb_display_preserves_order_around_dynamic_for(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     count: input logic<4>,
@@ -3712,7 +3714,7 @@ module Top (
 
 fn test_comb_display_downstream_wide_store_enables_observer(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<128>,
@@ -3759,7 +3761,7 @@ module Top (
 
 fn test_comb_display_downstream_dynamic_write_crossing_word_boundary(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     idx: input logic<7>,
@@ -3805,7 +3807,7 @@ module Top (
 
 fn test_comb_display_store_coalesce_does_not_enable_unrelated_chunk(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     lo: input logic<8>,
@@ -3852,7 +3854,7 @@ module Top (
 
 fn test_comb_display_ff_to_downstream_comb_store_enables_observer(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -3900,7 +3902,7 @@ module Top (
 
 fn test_comb_display_port_alias_write_enables_downstream_observer(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Child (
     a: input logic<8>,
@@ -3949,7 +3951,7 @@ module Top (
 
 fn test_comb_display_four_state_mask_only_input_change_triggers(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -4005,7 +4007,7 @@ module Top (
 
 fn test_comb_display_unaligned_wide_store_enables_downstream_observer(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<127>,
@@ -4043,7 +4045,7 @@ module Top (
 
 fn test_comb_display_wide_four_state_mask_store_enables_downstream_observer(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<80>,
@@ -4105,7 +4107,7 @@ module Top (
 
 fn test_comb_display_function_output_dynamic_actual_excludes_only_prefix(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     idx: input logic,
@@ -4151,7 +4153,7 @@ module Top (
 
 fn test_comb_display_conditional_write_excludes_lhs_even_on_unwritten_branch(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     sel: input logic,
@@ -4198,7 +4200,7 @@ module Top (
 
 fn test_comb_display_dynamic_port_alias_write_excludes_only_prefix(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Child (
     a: input logic,
@@ -4261,7 +4263,7 @@ module Top (
 
 fn test_comb_display_duplicate_store_alias_keeps_capture_activation(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic<8>,
@@ -4302,7 +4304,7 @@ module Top (
 
 fn test_comb_expression_operands_observe_prior_output_write(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (a: input logic<8>, out: output logic<8>) {
     function write_tmp (x: input logic<8>, y: output logic<8>) -> logic<8> {
@@ -4333,7 +4335,7 @@ module Top (a: input logic<8>, out: output logic<8>) {
 
 fn test_comb_ternary_collects_only_executed_runtime_arm(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (sel: input logic, a: input logic<8>, b: input logic<8>, out: output logic<8>) {
     function left (x: input logic<8>) -> logic<8> {
@@ -4373,7 +4375,7 @@ module Top (sel: input logic, a: input logic<8>, b: input logic<8>, out: output 
 
 fn test_comb_runtime_effect_in_nested_function_actual_is_detected(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (a: input logic<8>, out: output logic<8>) {
     function inner (x: input logic<8>) -> logic<8> {
@@ -4401,7 +4403,7 @@ module Top (a: input logic<8>, out: output logic<8>) {
 
 fn test_comb_runtime_effect_in_function_output_destination_is_detected(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (index: input logic<2>, value: input logic<8>, out: output logic<8>) {
     function choose_index (
@@ -4445,7 +4447,7 @@ module Top (index: input logic<2>, value: input logic<8>, out: output logic<8>) 
 
 fn test_comb_if_merge_preserves_selected_output_write_for_later_observer(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (sel: input logic, a: input logic<8>, out: output logic<8>) {
     function set_tmp (x: input logic<8>, y: output logic<8>) {
@@ -4487,7 +4489,7 @@ module Top (sel: input logic, a: input logic<8>, out: output logic<8>) {
 
 fn test_comb_function_loop_bounds_apply_output_effects_left_to_right(sim) {
     // Veryl 0.20.3 executes the design but drops the function output effects.
-    @ignore_on(wasm, veryl);
+    @ignore_on(wasm, veryl, sv);
     @build Simulator::builder(r#"
 module Top (value: input logic<4>, out: output logic<8>) {
     function start_bound (x: input logic<4>, seen: output logic<8>) -> logic<4> {
@@ -4517,7 +4519,7 @@ module Top (value: input logic<4>, out: output logic<8>) {
 
 fn test_comb_function_loop_skips_conditions_after_break(sim) {
     // Veryl 0.20.3 executes the design but drops the function output effects.
-    @ignore_on(wasm, veryl);
+    @ignore_on(wasm, veryl, sv);
     @build Simulator::builder(r#"
 module Top (
     stop: input logic,
@@ -4578,7 +4580,7 @@ module Top (
 
 fn test_comb_function_output_preview_honors_loop_break(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     value: input logic<8>,
@@ -4631,7 +4633,7 @@ module Top (
 
 fn test_comb_outputless_function_output_preview_honors_loop_break(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     value: input logic<8>,
@@ -4682,7 +4684,7 @@ module Top (
 
 fn test_comb_return_aware_function_loop_collects_bound_effects(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (value: input logic<8>, out: output logic<8>) {
     function bound (x: input logic<8>, seen: output logic<8>) -> logic<2> {
@@ -4720,7 +4722,7 @@ module Top (value: input logic<8>, out: output logic<8>) {
 
 fn test_comb_variable_indices_observe_prior_index_output_write(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (value: input logic, out: output logic) {
     function set_index (x: input logic, seen: output logic) -> logic {
@@ -4754,7 +4756,7 @@ module Top (value: input logic, out: output logic) {
 
 fn test_comb_function_loop_bound_write_is_guarded_after_return(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (
     skip: input logic,
@@ -4803,7 +4805,7 @@ module Top (
 
 fn test_comb_concat_destination_observes_prior_destination_write(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (trigger: input logic, out: output logic<2>) {
     function observe (x: input logic) -> logic {
@@ -4830,7 +4832,7 @@ module Top (trigger: input logic, out: output logic<2>) {
 
 fn test_comb_function_output_concat_observes_prior_destination_write(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module Top (trigger: input logic, out: output logic<2>) {
     function observe (x: input logic) -> logic {

--- a/crates/celox/tests/compare_matrix.rs
+++ b/crates/celox/tests/compare_matrix.rs
@@ -239,6 +239,7 @@ all_backends! {
     // Tests that two different packages can instantiate the same generic module,
     // each getting a unique ModuleId.
     fn test_generic_module_instantiation(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 proto package DataType {
 type data;
@@ -303,6 +304,7 @@ inst wp: WordPass (i: c, o: d);
 
     // Tests proto package function resolution (E::gt → IntElement::gt).
     fn test_proto_function_basic(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 proto package Element {
 type data;
@@ -360,6 +362,7 @@ inst inner: GenericCompare::<IntElement> (a, b, r);
 
     // Tests proto constant (E::max_value) resolution.
     fn test_proto_const_max_value(sim) {
+        @ignore_on(sv);
         @setup { let code = format!(
 "{COMPARE_MATRIX_CODE}\n{}",
 r#"
@@ -388,7 +391,7 @@ inst t: TestConst::<IntElement> (out);
     // Tests the compare matrix scoring module (CompareMatrixStage1CM).
     // Input 4 values, verify scores reflect sorted order.
     fn test_compare_matrix_stage1cm(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = format!(
 "{COMPARE_MATRIX_CODE}\n{}",
 r#"
@@ -420,7 +423,7 @@ inst cm: CompareMatrixStage1CM::<IntElement> #(P: 4) (in_data, out_score);
 
     // Tests the compare matrix selector module (through wrapper, verifying parameter forwarding).
     fn test_compare_matrix_selector(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let top = r#"
 module Top #(
 param P: u32 = 4,
@@ -457,7 +460,7 @@ let code = format!("{COMPARE_MATRIX_CODE}\n{top}"); }
     // Tests full sorting via CompareMatrixStage1 (scoring + selection through wrapper chain).
     // Input unsorted values, output sorted ascending.
     fn test_compare_matrix_stage1_sort(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let top = r#"
 module Top #(
 param P: u32 = 4,
@@ -490,7 +493,7 @@ let code = format!("{COMPARE_MATRIX_CODE}\n{top}"); }
     // Tests the compare matrix merger.
     // Two sorted ascending arrays in, one merged sorted ascending array out.
     fn test_compare_matrix_merger(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let top = r#"
 module Top #(
 param A: u32 = 3,

--- a/crates/celox/tests/concat_operators.rs
+++ b/crates/celox/tests/concat_operators.rs
@@ -143,7 +143,7 @@ assign o = {(if sel ? a : b), (if !sel ? a : b)};
     }
 
     fn test_as_cast_in_concat(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
 a: input logic<16>,

--- a/crates/celox/tests/concatenation.rs
+++ b/crates/celox/tests/concatenation.rs
@@ -7,6 +7,7 @@ mod test_utils;
 all_backends! {
 
     fn test_lhs_concatenation_execution(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (val_in: input logic<16>) {
 var a: logic<8>;

--- a/crates/celox/tests/counter.rs
+++ b/crates/celox/tests/counter.rs
@@ -8,7 +8,7 @@ all_backends! {
 
     // Simple counter: increment on each tick, reset to 0
     fn test_counter_n4_basic(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
 clk: input clock,
@@ -64,7 +64,7 @@ else { cnt[i] += 1; }
 
     // Large counter array (similar to bench)
     fn test_counter_n100_wrap(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top #(param N: u32 = 100) (
 clk: input clock,
@@ -113,7 +113,7 @@ else { cnt[i] += 1; }
     }
 
     fn test_phase_state_ssa_preserves_eval_before_apply_and_four_state(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
     clk: input clock,

--- a/crates/celox/tests/data_access.rs
+++ b/crates/celox/tests/data_access.rs
@@ -18,6 +18,7 @@ fn setup_and_trace(code: &str, top: &str) -> celox::CompilationTrace {
 all_backends! {
 
     fn test_dynamic_index_read(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (i: input logic<2>, o: output logic<8>) {
 var a: logic<8> [4];
@@ -40,6 +41,7 @@ assign o = a[i];
     }
 
     fn test_dynamic_index_write(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (i: input logic<2>, val: input logic<8>, o: output logic<8>) {
 var a: logic<8> [4];
@@ -68,6 +70,7 @@ assign o = a[2];
     }
 
     fn test_multidimensional_access(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (i: input logic<8>, o: output logic<8>) {
 var a: logic<8> [4, 2];
@@ -92,6 +95,7 @@ assign o = a[1][0];
     }
 
     fn test_minus_colon_and_step_execution(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (a: input logic<8>, b: output logic<32>) {
 always_comb {
@@ -111,6 +115,7 @@ b[1 step 8] = a;
     }
 
     fn test_dynamic_slice_bullying(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (idx: input logic<2>, data: input logic<16>, o: output logic<4>) {
 var mem: logic<16>;
@@ -133,6 +138,7 @@ assign o = mem[idx*4 +: 4];
     }
 
     fn test_dynamic_minus_colon_and_step_read_write(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     minus_idx: input logic<4>,
@@ -201,7 +207,7 @@ assign o = tmp;
     }
 
     fn test_genvar_const_in_generate(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { // Genvar used as a simple expression inside a generate block
 // should produce per-instance constant values.
 let code = r#"
@@ -232,7 +238,7 @@ assign o[j] = j as u8 + 10;
     }
 
     fn test_genvar_dynamic_index_issue21(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { // Issue #21: dynamic indexing of unpacked array using genvar-based
 // expression should produce different values per generate instance.
 // Each generate instance uses genvar `j` to compute a dynamic index
@@ -282,6 +288,7 @@ assign o[j] = local_data[idx];
     }
 
     fn test_dynamic_index_with_bitslice(sim) {
+        @ignore_on(sv);
         @setup { // Regression: arr[dynamic_idx][hi:lo] produced wrong values because
 // the bit-select anchor was incorrectly added to the dynamic offset.
 let code = r#"
@@ -322,6 +329,7 @@ assign o_hi = regs[idx][63:32];
     }
 
     fn test_let_index_with_bitslice_write(sim) {
+        @ignore_on(sv);
         @setup { // Regression: using a `let`-bound variable as an array index combined
 // with a bitslice write (e.g. data[idx][63:32]) produced wrong values
 // because eval_dynamic_assign treated the Colon MSB anchor as a
@@ -358,6 +366,7 @@ o_lo = data[2][31:0];
     }
 
     fn test_let_index_with_bitslice_write_single(sim) {
+        @ignore_on(sv);
         @setup { // Minimal: single let index + bitslice write
 let code = r#"
 module Top (
@@ -386,6 +395,7 @@ o_lo = data[1][15:0];
     }
 
     fn test_ff_bit_select_in_generate_loop(sim) {
+        @ignore_on(sv);
         @setup { // Regression: bit-select inside always_ff in a generate loop (e.g. din[i][15])
 // produced wrong values because emit_offset_calc computed strides only from
 // array dimensions, causing bit indices to be multiplied by the array stride

--- a/crates/celox/tests/duplicate_varpath.rs
+++ b/crates/celox/tests/duplicate_varpath.rs
@@ -21,6 +21,7 @@ all_backends! {
 // The Veryl analyzer assigns different VarIds but identical VarPaths to these scoped
 // variables. Without the fix this panics during JIT compilation.
 fn test_duplicate_scoped_var_in_always_comb(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             sel : input  logic   ,
@@ -79,6 +80,7 @@ fn test_duplicate_scoped_var_in_always_comb(sim) {
 // internal vars, and always_comb inside uses `var flag: logic;` in multiple
 // for-loop scopes.
 fn test_duplicate_scoped_var_with_generate_for(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk   : input  clock  ,

--- a/crates/celox/tests/enum_type.rs
+++ b/crates/celox/tests/enum_type.rs
@@ -7,6 +7,7 @@ mod test_utils;
 all_backends! {
 
     fn test_enum_case_match(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 sel: input logic<2>,
@@ -46,6 +47,7 @@ default:     o = 8'h01;
     }
 
     fn test_enum_ff_state_machine(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 clk:   input clock,
@@ -123,6 +125,7 @@ assign state_out = state;
     // Enum-typed variables can be assigned from logic inputs
     // and compared against enum members.
     fn test_enum_assign_and_compare(sim) {
+        @ignore_on(sv);
         @setup {
             let code = r#"
         module Top (

--- a/crates/celox/tests/expression_semantics.rs
+++ b/crates/celox/tests/expression_semantics.rs
@@ -9,6 +9,7 @@ all_backends! {
         // Veryl 0.20.2's runtime loses signedness across a numeric size cast,
         // unlike SystemVerilog 6.24.1 and the SystemVerilog Veryl emits.
         @omit_veryl;
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -138,6 +139,7 @@ module Top (
 
     fn parent_context_and_self_determined_boundaries_match_between_comb_and_ff(sim) {
         @omit_veryl;
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -427,7 +429,7 @@ module Top (
         // Veryl simulator 0.20.2 loses the signed result of the same-width
         // `as i8` while lowering this comparison. `~a` itself is not the
         // failure: comparing it with a signed variable works there.
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -455,6 +457,7 @@ module Top (
     }
 
     fn aggregate_results_consume_the_unary_parent_context(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -487,6 +490,7 @@ module Top (
         // Veryl 0.20.3 leaves these calls unresolved in its simulator IR, so
         // the reference simulation cannot be constructed.
         @omit_veryl;
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -544,6 +548,7 @@ module Top (
 
     fn short_circuit_operators_skip_effectful_operands(sim) {
         @omit_veryl;
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -607,6 +612,7 @@ module Top (
 
     fn numeric_cast_preserves_four_state_sign_extension(sim) {
         @omit_veryl;
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,

--- a/crates/celox/tests/false_loop.rs
+++ b/crates/celox/tests/false_loop.rs
@@ -225,6 +225,7 @@ module Top (
 all_backends! {
 
 fn test_large_scc_dynamic_loop_convergence(sim) {
+    @ignore_on(sv);
     @setup {
     let chain_size = 20;
     let mut assignments = String::new();

--- a/crates/celox/tests/fifo_issue5.rs
+++ b/crates/celox/tests/fifo_issue5.rs
@@ -7,6 +7,7 @@ mod test_utils;
 all_backends! {
 
     fn test_fifo_issue5_subtract_overflow(sim) {
+        @ignore_on(sv);
         @setup { let ram = test_utils::veryl_std::source(&["ram", "ram.veryl"]);
 let fifo_ctrl =
 test_utils::veryl_std::source(&["fifo", "fifo_controller.veryl"]);

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -44,6 +44,7 @@ fn test_ff_nonblocking(sim) {
 }
 
 fn test_ff_static_and_dynamic_writes_share_sparse_state(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -90,7 +91,7 @@ fn test_ff_static_and_dynamic_writes_share_sparse_state(sim) {
 
 fn test_ff_runtime_display_and_assert_continue(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, a: input logic<8>, q: output logic<8>) {
             always_ff (clk) {
@@ -121,6 +122,7 @@ fn test_ff_runtime_display_and_assert_continue(sim) {
 }
 
 fn test_ff_assert_message_output_argument_is_eager(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -166,7 +168,7 @@ fn test_ff_assert_message_output_argument_is_eager(sim) {
 
 fn test_ff_assert_message_runtime_effect_is_eager(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, ok: input logic, d: input logic<8>) {
             function message_value (x: input logic<8>) -> logic<8> {
@@ -218,7 +220,7 @@ fn test_ff_assert_message_runtime_effect_is_eager(sim) {
 
 fn test_ff_unknown_ternary_retains_then_arm_output_state(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -277,7 +279,7 @@ fn test_ff_unknown_ternary_retains_then_arm_output_state(sim) {
 
 fn test_ff_ternary_runtime_effect_only_evaluates_selected_arm(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, choose: input logic, q: output logic<8>) {
             function observed_value (x: input logic<8>) -> logic<8> {
@@ -315,7 +317,7 @@ fn test_ff_ternary_runtime_effect_only_evaluates_selected_arm(sim) {
 
 fn test_ff_effectful_function_input_is_evaluated_once(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, d: input logic<8>, q: output logic<8>) {
             function inner (x: input logic<8>) -> logic<8> {
@@ -356,7 +358,7 @@ fn test_ff_effectful_function_input_is_evaluated_once(sim) {
 
 fn test_ff_assert_message_args_preserve_left_to_right_snapshots(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, effect: output logic<8>) {
             function update (
@@ -389,7 +391,7 @@ fn test_ff_assert_message_args_preserve_left_to_right_snapshots(sim) {
 
 fn test_ff_runtime_effect_function_snapshots_input_that_aliases_output(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, effect: output logic<8>, q: output logic<8>) {
             function observed (
@@ -425,7 +427,7 @@ fn test_ff_runtime_effect_function_snapshots_input_that_aliases_output(sim) {
 
 fn test_ff_case_pattern_runtime_effect_is_eager(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, ok: input logic, d: input logic<8>) {
             function observed_value (x: input logic<8>) -> logic<8> {
@@ -466,7 +468,7 @@ fn test_ff_case_pattern_runtime_effect_is_eager(sim) {
 
 fn test_ff_statement_function_materializes_effectful_case_controls(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, d: input logic<8>) {
             function observed (
@@ -511,7 +513,7 @@ fn test_ff_statement_function_materializes_effectful_case_controls(sim) {
 
 fn test_ff_case_controls_apply_nested_output_writes_to_function_state(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -572,7 +574,7 @@ fn test_ff_case_controls_apply_nested_output_writes_to_function_state(sim) {
 
 fn test_ff_case_skips_effectful_patterns_after_matching_arm(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, d: input logic<8>) {
             function observed (
@@ -612,7 +614,7 @@ fn test_ff_case_skips_effectful_patterns_after_matching_arm(sim) {
 
 fn test_ff_assignment_snapshots_dynamic_rhs_access(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, d: input logic<8>, q: output logic) {
             function observed (value: input logic<8>) -> logic {
@@ -648,7 +650,7 @@ fn test_ff_assignment_snapshots_dynamic_rhs_access(sim) {
 
 fn test_ff_assignment_substitutes_through_evaluating_system_function(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, d: input logic<8>, q: output logic<8>) {
             function observed (value: input logic<8>) -> logic<8> {
@@ -684,7 +686,7 @@ fn test_ff_assignment_substitutes_through_evaluating_system_function(sim) {
 
 fn test_ff_if_snapshots_dynamic_predicate_before_state_merge(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, d: input logic<2>, q: output logic) {
             function observed (value: input logic<2>) -> logic {
@@ -723,7 +725,7 @@ fn test_ff_if_snapshots_dynamic_predicate_before_state_merge(sim) {
 
 fn test_ff_case_snapshots_dynamic_target_before_state_merge(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, d: input logic<2>, q: output logic) {
             function observed (value: input logic<2>) -> logic {
@@ -763,7 +765,7 @@ fn test_ff_case_snapshots_dynamic_target_before_state_merge(sim) {
 
 fn test_ff_case_merges_nested_output_state_from_selected_arm(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -840,7 +842,7 @@ fn test_ff_case_merges_nested_output_state_from_selected_arm(sim) {
 
 fn test_ff_variable_select_captures_nested_output(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -896,7 +898,7 @@ fn test_ff_variable_select_captures_nested_output(sim) {
 
 fn test_ff_effectful_assignment_executes_only_on_selected_if_path(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -958,7 +960,7 @@ fn test_ff_effectful_assignment_executes_only_on_selected_if_path(sim) {
 
 fn test_ff_runtime_effect_after_conditional_return_uses_live_path(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1014,7 +1016,7 @@ fn test_ff_runtime_effect_after_conditional_return_uses_live_path(sim) {
 
 fn test_ff_case_after_conditional_return_preserves_returned_path(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1103,7 +1105,7 @@ fn test_ff_case_after_conditional_return_preserves_returned_path(sim) {
 
 fn test_ff_statement_call_evaluates_effectful_inputs(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, d: input logic<8>) {
             function observed (x: input logic<8>) -> logic<8> {
@@ -1139,7 +1141,7 @@ fn test_ff_statement_call_evaluates_effectful_inputs(sim) {
 
 fn test_ff_top_level_statement_call_evaluates_discarded_effectful_input(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, d: input logic<8>) {
             function observed (x: input logic<8>) -> logic<8> {
@@ -1170,7 +1172,7 @@ fn test_ff_top_level_statement_call_evaluates_discarded_effectful_input(sim) {
 
 fn test_ff_nested_runtime_event_output_updates_outer_function_state(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1219,7 +1221,7 @@ fn test_ff_nested_runtime_event_output_updates_outer_function_state(sim) {
 
 fn test_ff_nested_output_to_module_variable_survives_runtime_function(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1267,7 +1269,7 @@ fn test_ff_nested_output_to_module_variable_survives_runtime_function(sim) {
 
 fn test_ff_runtime_function_snapshots_nonlocal_read_before_later_write(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1321,7 +1323,7 @@ fn test_ff_runtime_function_snapshots_nonlocal_read_before_later_write(sim) {
 }
 
 fn test_ff_runtime_function_snapshots_input_before_callee_nonlocal_write(sim) {
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1354,7 +1356,7 @@ fn test_ff_runtime_function_snapshots_input_before_callee_nonlocal_write(sim) {
 }
 
 fn test_ff_runtime_function_snapshots_helper_input_before_callee_nonlocal_write(sim) {
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1392,7 +1394,7 @@ fn test_ff_runtime_function_snapshots_helper_input_before_callee_nonlocal_write(
 
 fn test_ff_outputless_nested_nonlocal_write_updates_later_event_argument(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1432,6 +1434,7 @@ fn test_ff_outputless_nested_nonlocal_write_updates_later_event_argument(sim) {
 }
 
 fn test_ff_statement_function_direct_nonlocal_assignment_is_observable(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1458,6 +1461,7 @@ fn test_ff_statement_function_direct_nonlocal_assignment_is_observable(sim) {
 }
 
 fn test_ff_skipped_conditional_nonlocal_write_preserves_prior_ff_assignment(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1491,6 +1495,7 @@ fn test_ff_skipped_conditional_nonlocal_write_preserves_prior_ff_assignment(sim)
 }
 
 fn test_ff_nonlocal_write_precedes_aliased_formal_output_copyout(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1517,6 +1522,7 @@ fn test_ff_nonlocal_write_precedes_aliased_formal_output_copyout(sim) {
 }
 
 fn test_ff_outputless_wrapper_nested_copyout_to_nonlocal_is_observable(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (clk: input clock, global_value: output logic<8>) {
             function set (written: output logic<8>) {
@@ -1541,6 +1547,7 @@ fn test_ff_outputless_wrapper_nested_copyout_to_nonlocal_is_observable(sim) {
 }
 
 fn test_ff_outputless_wrapper_expression_copyout_to_nonlocal_is_observable(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (clk: input clock, global_value: output logic<8>) {
             function set (
@@ -1570,6 +1577,7 @@ fn test_ff_outputless_wrapper_expression_copyout_to_nonlocal_is_observable(sim) 
 }
 
 fn test_ff_outputless_wrapper_indexed_copyout_to_nonlocal_is_observable(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (clk: input clock, global_value: output logic<8>) {
             function set (
@@ -1600,7 +1608,7 @@ fn test_ff_outputless_wrapper_indexed_copyout_to_nonlocal_is_observable(sim) {
 
 fn test_ff_outputless_wrapper_dynamic_indexed_copyout_to_nonlocal_is_observable(sim) {
     // Veryl 0.20.3 copies the output to the wrong dynamically selected bit.
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1636,6 +1644,7 @@ fn test_ff_outputless_wrapper_dynamic_indexed_copyout_to_nonlocal_is_observable(
 }
 
 fn test_ff_outputless_wrapper_direct_dynamic_nonlocal_assignment_is_observable(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1681,7 +1690,7 @@ fn test_ff_outputless_wrapper_direct_dynamic_nonlocal_assignment_is_observable(s
 
 fn test_ff_pure_helper_nonlocal_read_is_snapshotted_before_runtime_write(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, global_value: output logic<8>) {
             function read_global () -> logic<8> {
@@ -1724,6 +1733,7 @@ fn test_ff_pure_helper_nonlocal_read_is_snapshotted_before_runtime_write(sim) {
 }
 
 fn test_ff_dynamic_nonlocal_store_follows_pending_whole_write(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1752,7 +1762,7 @@ fn test_ff_dynamic_nonlocal_store_follows_pending_whole_write(sim) {
 
 fn test_ff_guarded_system_task_merges_definition_state(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1815,7 +1825,7 @@ fn test_ff_guarded_system_task_merges_definition_state(sim) {
 
 fn test_ff_nonlocal_source_ternary_preserves_unknown_merge(sim) {
     // Veryl 0.20.3 selects one arm instead of merging an X/Z condition.
-    @ignore_on(wasm, veryl);
+    @ignore_on(wasm, veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1849,7 +1859,7 @@ fn test_ff_nonlocal_source_ternary_preserves_unknown_merge(sim) {
 
 fn test_ff_statement_helper_dynamic_nonlocal_copyout_is_observable(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1888,7 +1898,7 @@ fn test_ff_statement_helper_dynamic_nonlocal_copyout_is_observable(sim) {
 
 fn test_ff_nested_dynamic_nonlocal_store_flushes_pending_outer_state(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1928,7 +1938,7 @@ fn test_ff_nested_dynamic_nonlocal_store_flushes_pending_outer_state(sim) {
 
 fn test_ff_retained_dynamic_copyout_does_not_repeat_nonlocal_body_write(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1968,7 +1978,7 @@ fn test_ff_retained_dynamic_copyout_does_not_repeat_nonlocal_body_write(sim) {
 
 fn test_ff_function_output_index_uses_final_nonlocal_state(sim) {
     // Veryl 0.20.3 resolves the output actual with the pre-call index.
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -1997,7 +2007,7 @@ fn test_ff_function_output_index_uses_final_nonlocal_state(sim) {
 
 fn test_ff_guarded_runtime_expression_merges_definition_state(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2056,7 +2066,7 @@ fn test_ff_guarded_runtime_expression_merges_definition_state(sim) {
 
 fn test_ff_short_circuit_nested_output_updates_only_when_rhs_runs(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2169,7 +2179,7 @@ fn test_ff_short_circuit_nested_output_updates_only_when_rhs_runs(sim) {
 
 fn test_ff_short_circuit_runtime_write_preserves_later_state_source(sim) {
     // Veryl 0.20.3 exposes the same-edge write to a later FF read.
-    @ignore_on(wasm, veryl);
+    @ignore_on(wasm, veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2219,7 +2229,7 @@ fn test_ff_short_circuit_runtime_write_preserves_later_state_source(sim) {
 
 fn test_ff_pure_predicate_output_updates_outer_function_state(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2270,7 +2280,7 @@ fn test_ff_pure_predicate_output_updates_outer_function_state(sim) {
 
 fn test_ff_nested_wrapper_predicate_output_updates_caller_state(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2328,7 +2338,7 @@ fn test_ff_nested_wrapper_predicate_output_updates_caller_state(sim) {
 
 fn test_ff_nested_call_predicate_uses_pre_copyout_input(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2388,7 +2398,7 @@ fn test_ff_nested_call_predicate_uses_pre_copyout_input(sim) {
 
 fn test_ff_bits_and_size_do_not_evaluate_output_writing_operand(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2442,7 +2452,7 @@ fn test_ff_bits_and_size_do_not_evaluate_output_writing_operand(sim) {
 
 fn test_ff_bits_and_size_operands_do_not_alias_earlier_array_argument(sim) {
     // Veryl 0.20.3 evaluates the $bits/$size operand and applies its effects.
-    @ignore_on(wasm, veryl);
+    @ignore_on(wasm, veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2487,7 +2497,7 @@ fn test_ff_bits_and_size_operands_do_not_alias_earlier_array_argument(sim) {
 
 fn test_ff_bits_and_size_array_dependencies_do_not_alias_later_write(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2525,7 +2535,7 @@ fn test_ff_bits_and_size_array_dependencies_do_not_alias_later_write(sim) {
 
 fn test_ff_statement_call_materializes_output_only_input_effect(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2578,7 +2588,7 @@ fn test_ff_statement_call_materializes_output_only_input_effect(sim) {
 
 fn test_ff_nested_statement_call_copies_outputs_in_declaration_order(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2622,7 +2632,7 @@ fn test_ff_nested_statement_call_copies_outputs_in_declaration_order(sim) {
 
 fn test_ff_nested_statement_call_coerces_output_to_actual_width(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2662,7 +2672,7 @@ fn test_ff_nested_statement_call_coerces_output_to_actual_width(sim) {
 
 fn test_ff_state_only_statement_call_materializes_nested_input_output(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2722,7 +2732,7 @@ fn test_ff_state_only_statement_call_materializes_nested_input_output(sim) {
 
 fn test_ff_statement_call_copies_outputs_in_declaration_order(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2775,7 +2785,7 @@ fn test_ff_statement_call_copies_outputs_in_declaration_order(sim) {
 
 fn test_ff_composite_runtime_arg_preserves_left_to_right_snapshot(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2825,7 +2835,7 @@ fn test_ff_composite_runtime_arg_preserves_left_to_right_snapshot(sim) {
 
 fn test_ff_nested_call_inputs_capture_outputs_in_declaration_order(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2893,7 +2903,7 @@ fn test_ff_nested_call_inputs_capture_outputs_in_declaration_order(sim) {
 
 fn test_ff_nested_call_freezes_all_outputs_before_copy_out(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -2942,7 +2952,7 @@ fn test_ff_nested_call_freezes_all_outputs_before_copy_out(sim) {
 
 fn test_ff_nested_call_output_preserves_conditional_early_return_path(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3017,7 +3027,7 @@ fn test_ff_nested_call_output_preserves_conditional_early_return_path(sim) {
 
 fn test_ff_short_circuit_state_reuses_evaluated_lhs(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3093,7 +3103,7 @@ fn test_ff_short_circuit_state_reuses_evaluated_lhs(sim) {
 
 fn test_ff_concatenation_effects_follow_source_order(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3161,7 +3171,7 @@ fn test_ff_concatenation_effects_follow_source_order(sim) {
 
 fn test_ff_materialized_formal_slice_uses_expression_context(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, d: input logic<8>, q: output logic<16>) {
             function inner (x: input logic<8>) -> logic<8> {
@@ -3196,7 +3206,7 @@ fn test_ff_materialized_formal_slice_uses_expression_context(sim) {
 
 fn test_ff_runtime_event_reads_updated_formal_slice(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3238,7 +3248,7 @@ fn test_ff_runtime_event_reads_updated_formal_slice(sim) {
 
 fn test_ff_case_assignment_is_visible_to_later_runtime_event(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3302,7 +3312,7 @@ fn test_ff_case_assignment_is_visible_to_later_runtime_event(sim) {
 
 fn test_ff_statement_function_with_output_emits_runtime_effect(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, d: input logic<8>, effect: output logic<8>) {
             function observed (
@@ -3336,7 +3346,7 @@ fn test_ff_statement_function_with_output_emits_runtime_effect(sim) {
 
 fn test_ff_effectful_if_predicate_is_evaluated_once(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3382,7 +3392,7 @@ fn test_ff_effectful_if_predicate_is_evaluated_once(sim) {
 
 fn test_ff_nested_output_is_captured_through_signed_cast(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3431,7 +3441,7 @@ fn test_ff_nested_output_is_captured_through_signed_cast(sim) {
 
 fn test_ff_effectful_function_inputs_follow_declaration_order(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, d: input logic<8>, q: output logic<8>) {
             function observed (
@@ -3509,6 +3519,7 @@ fn test_ff_effectful_function_inputs_follow_declaration_order(sim) {
 }
 
 fn test_ff_pure_input_is_snapshotted_before_later_effectful_input(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (clk: input clock, effect: output logic<8>, q: output logic<8>) {
             function update (
@@ -3544,7 +3555,7 @@ fn test_ff_pure_input_is_snapshotted_before_later_effectful_input(sim) {
 
 fn test_ff_runtime_event_arguments_use_per_argument_state(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3594,7 +3605,7 @@ fn test_ff_runtime_event_arguments_use_per_argument_state(sim) {
 
 fn test_ff_runtime_event_formal_uses_declared_type(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3631,7 +3642,7 @@ fn test_ff_runtime_event_formal_uses_declared_type(sim) {
 
 fn test_ff_unpacked_input_before_runtime_effect_stays_symbolically_bound(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3673,7 +3684,7 @@ fn test_ff_unpacked_input_before_runtime_effect_stays_symbolically_bound(sim) {
 }
 
 fn test_ff_effectful_array_item_output_is_not_a_read_alias(sim) {
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3710,7 +3721,7 @@ fn test_ff_effectful_array_item_output_is_not_a_read_alias(sim) {
 
 fn test_ff_symbolic_runtime_input_uses_declared_formal_type(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3742,7 +3753,7 @@ fn test_ff_symbolic_runtime_input_uses_declared_formal_type(sim) {
 
 fn test_ff_runtime_effectful_return_uses_declared_signed_type(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3787,7 +3798,7 @@ fn test_ff_runtime_effectful_return_uses_declared_signed_type(sim) {
 
 fn test_ff_runtime_effectful_output_uses_declared_formal_type(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3835,7 +3846,7 @@ fn test_ff_runtime_effectful_output_uses_declared_formal_type(sim) {
 
 fn test_ff_runtime_effectful_merge_preserves_signed_return_type(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3884,7 +3895,7 @@ fn test_ff_runtime_effectful_merge_preserves_signed_return_type(sim) {
 
 fn test_ff_runtime_effectful_local_assignment_uses_declared_type(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3925,7 +3936,7 @@ fn test_ff_runtime_effectful_local_assignment_uses_declared_type(sim) {
 
 fn test_ff_rewritten_runtime_event_argument_preserves_signedness(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -3960,7 +3971,7 @@ fn test_ff_rewritten_runtime_event_argument_preserves_signedness(sim) {
 
 fn test_ff_runtime_events_format_verilog_radices(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, a: input logic<8>) {
             always_ff (clk) {
@@ -3984,7 +3995,7 @@ fn test_ff_runtime_events_format_verilog_radices(sim) {
 
 fn test_ff_runtime_events_preserve_four_state_args(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, a: input logic<4>) {
             always_ff (clk) {
@@ -4018,7 +4029,7 @@ fn test_ff_runtime_events_preserve_four_state_args(sim) {
 
 fn test_ff_runtime_events_support_design_sized_arg_count(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4060,7 +4071,7 @@ fn test_ff_runtime_events_support_design_sized_arg_count(sim) {
 
 fn test_ff_runtime_events_support_wide_four_state_args(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, a: input logic<80>) {
             always_ff (clk) {
@@ -4091,7 +4102,7 @@ fn test_ff_runtime_events_support_wide_four_state_args(sim) {
 
 fn test_ff_runtime_event_drain_handle_can_run_during_simulation(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, a: input logic<16>) {
             always_ff (clk) {
@@ -4146,7 +4157,7 @@ fn test_ff_runtime_event_drain_handle_can_run_during_simulation(sim) {
 
 fn test_runtime_event_drain_handle_is_exclusive(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, a: input logic<8>) {
             always_ff (clk) {
@@ -4187,7 +4198,7 @@ fn test_runtime_event_drain_handle_is_exclusive(sim) {
 
 fn test_ff_runtime_fatal_assert_records_event(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock, a: input logic<8>) {
             always_ff (clk) {
@@ -4212,7 +4223,7 @@ fn test_ff_runtime_fatal_assert_records_event(sim) {
 
 fn test_ff_message_less_runtime_fatal_assert_uses_default_message(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (clk: input clock) {
             always_ff (clk) {
@@ -4235,6 +4246,7 @@ fn test_ff_message_less_runtime_fatal_assert_uses_default_message(sim) {
 }
 
 fn test_ff_runtime_for_bounds(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4291,6 +4303,7 @@ fn test_ff_runtime_for_bounds(sim) {
 }
 
 fn test_ff_runtime_for_bitwise_steps(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4338,7 +4351,7 @@ fn test_ff_runtime_for_bitwise_steps(sim) {
 fn test_ff_signed_xor_step_uses_loop_counter_width(sim) {
     // The Veryl simulator currently converts the signed dynamic start bound to an
     // unsigned runtime counter and executes zero iterations.
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4373,7 +4386,7 @@ fn test_ff_signed_xor_step_uses_loop_counter_width(sim) {
 }
 
 fn test_ff_i32_bitwise_steps_discard_bits_above_the_counter_width(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4419,7 +4432,7 @@ fn test_ff_i32_bitwise_steps_discard_bits_above_the_counter_width(sim) {
 }
 
 fn test_ff_i32_xor_step_with_only_high_bits_reports_true_loop(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4446,7 +4459,7 @@ fn test_ff_i32_xor_step_with_only_high_bits_reports_true_loop(sim) {
 }
 
 fn test_ff_i32_or_step_with_only_existing_low_bits_reports_true_loop(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4473,7 +4486,7 @@ fn test_ff_i32_or_step_with_only_existing_low_bits_reports_true_loop(sim) {
 }
 
 fn test_ff_i32_mul_step_overflow_reports_true_loop(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4502,7 +4515,7 @@ fn test_ff_i32_mul_step_overflow_reports_true_loop(sim) {
 }
 
 fn test_ff_i32_shl_step_overflow_reports_true_loop(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4531,6 +4544,7 @@ fn test_ff_i32_shl_step_overflow_reports_true_loop(sim) {
 }
 
 fn test_ff_runtime_for_break(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4593,7 +4607,7 @@ fn test_ff_constant_signed_bounds_in_unrolled_loops(sim) {
 }
 
 fn test_ff_runtime_for_dynamic_zero_start_mul_reports_true_loop(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4626,6 +4640,7 @@ fn test_ff_runtime_for_dynamic_zero_start_mul_reports_true_loop(sim) {
 }
 
 fn test_ff_runtime_for_zero_iteration_mul_loop_is_allowed(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4648,7 +4663,7 @@ fn test_ff_runtime_for_zero_iteration_mul_loop_is_allowed(sim) {
 }
 
 fn test_ff_runtime_for_terminal_inclusive_mul_loop_reports_true_loop(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4675,6 +4690,7 @@ fn test_ff_runtime_for_terminal_inclusive_mul_loop_reports_true_loop(sim) {
 }
 
 fn test_ff_runtime_reverse_step_matches_emitted_sv_order(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4707,6 +4723,7 @@ fn test_ff_runtime_reverse_step_matches_emitted_sv_order(sim) {
 }
 
 fn test_ff_runtime_reverse_exclusive_i32_upper_sentinel(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4741,7 +4758,7 @@ fn test_ff_runtime_reverse_min_i32_end_wraps_before_range_check(sim) {
     // veryl-simulator 0.20.2's non-JIT interpreter evaluates `end - 1` as i64
     // without truncating it to the signed 32-bit loop-counter width. It therefore
     // gets -2147483649 instead of wrapping to i32::MAX and skips the loop body.
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4774,7 +4791,7 @@ fn test_ff_runtime_reverse_min_i32_end_wraps_before_range_check(sim) {
 }
 
 fn test_ff_runtime_reverse_i32_step_truncation_reports_true_loop(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4807,6 +4824,7 @@ fn test_ff_runtime_reverse_i32_step_truncation_reports_true_loop(sim) {
 }
 
 fn test_ff_runtime_for_reverse_singleton_exits_cleanly(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4838,7 +4856,7 @@ fn test_ff_runtime_for_reverse_singleton_exits_cleanly(sim) {
 }
 
 fn test_ff_runtime_for_signed_inclusive_range_preserves_negative_bounds(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4870,6 +4888,7 @@ fn test_ff_runtime_for_signed_inclusive_range_preserves_negative_bounds(sim) {
 }
 
 fn test_ff_runtime_for_forward_overshoot_exits_without_wraparound(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -4900,6 +4919,7 @@ fn test_ff_runtime_for_forward_overshoot_exits_without_wraparound(sim) {
 }
 
 fn test_ff_runtime_for_unsigned_slice_bound_zero_extends_signed_source(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -5185,6 +5205,7 @@ fn test_ff_if_reset_with_nested_if(sim) {
 }
 
 fn test_ff_struct_constructor_expression(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (clk: input clock, in_a: input logic<8>, in_b: input logic<8>, out_a: output logic<8>, out_b: output logic<8>) {
             struct S {
@@ -5218,6 +5239,7 @@ fn test_ff_struct_constructor_expression(sim) {
 }
 
 fn test_ff_struct_constructor_expression_literal_order(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -5256,7 +5278,7 @@ fn test_ff_struct_constructor_expression_literal_order(sim) {
 }
 
 fn test_ff_struct_constructor_signed_member_extension(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -5284,6 +5306,7 @@ fn test_ff_struct_constructor_signed_member_extension(sim) {
 }
 
 fn test_ff_array_literal_expression_order(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -5309,7 +5332,7 @@ fn test_ff_array_literal_expression_order(sim) {
 }
 
 fn test_ff_array_literal_default_expression(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (clk: input clock, in_data: input logic<8>, out_data: output logic<8>[4]) {
             var r: logic<8>[4];
@@ -5334,6 +5357,7 @@ fn test_ff_array_literal_default_expression(sim) {
 }
 
 fn test_ff_array_literal_nested_default_multidim_expression(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -5385,6 +5409,7 @@ fn test_ff_function_call_expression(sim) {
 }
 
 fn test_ff_function_call_statement_with_output_argument(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (clk: input clock, in_a: input logic<8>, out_q: output logic<8>) {
             function f (x: input logic<8>, y: output logic<8>) {
@@ -5412,6 +5437,7 @@ fn test_ff_function_call_statement_with_output_argument(sim) {
 }
 
 fn test_ff_function_call_statement_with_output_argument_and_return_value(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (clk: input clock, in_a: input logic<8>, out_q1: output logic<8>, out_q2: output logic<8>) {
             function f (x: input logic<8>, y: output logic<8>) -> logic<8> {
@@ -5441,6 +5467,7 @@ fn test_ff_function_call_statement_with_output_argument_and_return_value(sim) {
 }
 
 fn test_ff_function_call_expression_with_output_argument_and_return_value(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (clk: input clock, in_a: input logic<8>, out_q1: output logic<8>, out_q2: output logic<8>) {
             function f (x: input logic<8>, y: output logic<8>) -> logic<8> {
@@ -5555,7 +5582,7 @@ fn test_ff_function_call_multistatement_body(sim) {
 }
 
 fn test_ff_function_call_indexed_argument_access(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (clk: input clock, in_a: input logic<8>[4], out_q: output logic<8>) {
             function f (x: input logic<8>[4]) -> logic<8> {
@@ -5582,6 +5609,7 @@ fn test_ff_function_call_indexed_argument_access(sim) {
 }
 
 fn test_ff_function_call_nested_output_statement_in_function_body(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (clk: input clock, in_a: input logic<8>, out_q: output logic<8>) {
             function f (x: input logic<8>, y: output logic<8>) {
@@ -5656,6 +5684,7 @@ fn test_ff_function_call_chained_range_access_on_argument(sim) {
 }
 
 fn test_ff_function_call_step_access_on_nonvariable_argument(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (clk: input clock, in_a: input logic<8>, out_q: output logic<4>) {
             function f (x: input logic<8>) -> logic<4> {
@@ -5696,6 +5725,7 @@ fn test_ff_function_call_nonvariable_argument_uses_formal_width_before_slice(sim
 }
 
 fn test_ff_function_call_nonvariable_argument_preserves_self_sized_overflow_before_coercion(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (clk: input clock, out_q: output logic) {
             function f (x: input logic<4>) -> logic {
@@ -5816,6 +5846,7 @@ fn test_ff_function_call_preserves_unsigned_formal_signedness_for_nonvariable_ac
 }
 
 fn test_ff_function_call_nonvariable_argument_uses_formal_shape_for_indexing(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -5847,7 +5878,7 @@ fn test_ff_function_call_nonvariable_argument_uses_formal_shape_for_indexing(sim
 }
 
 fn test_ff_function_call_array_literal_element_uses_formal_context_width(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -5879,6 +5910,7 @@ fn test_ff_function_call_array_literal_element_uses_formal_context_width(sim) {
 }
 
 fn test_ff_function_call_array_literal_supports_dynamic_multidim_indexing(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -5925,6 +5957,7 @@ fn test_ff_function_call_array_literal_supports_dynamic_multidim_indexing(sim) {
 }
 
 fn test_ff_function_call_array_literal_view_dominates_conditional_access(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -5956,6 +5989,7 @@ fn test_ff_function_call_array_literal_view_dominates_conditional_access(sim) {
 }
 
 fn test_ff_function_call_array_literal_effect_is_eager_in_ternary_arm(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6010,6 +6044,7 @@ fn test_ff_function_call_array_literal_effect_is_eager_in_ternary_arm(sim) {
 }
 
 fn test_ff_function_call_array_literal_effect_is_eager_in_short_circuit_rhs(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6086,6 +6121,7 @@ fn test_ff_function_call_array_literal_effect_is_eager_in_short_circuit_rhs(sim)
 }
 
 fn test_ff_function_call_array_literal_view_preserves_expression_order(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6126,6 +6162,7 @@ fn test_ff_function_call_array_literal_view_preserves_expression_order(sim) {
 }
 
 fn test_ff_function_call_array_literal_snapshots_scalar_before_later_write(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6164,7 +6201,7 @@ fn test_ff_function_call_array_literal_snapshots_scalar_before_later_write(sim) 
 }
 
 fn test_ff_function_call_array_literal_snapshots_scalar_before_callee_write(sim) {
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6200,7 +6237,7 @@ fn test_ff_function_call_array_literal_snapshots_scalar_before_callee_write(sim)
 
 fn test_ff_case_range_skips_effectful_upper_bound_when_lower_is_false(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6246,6 +6283,7 @@ fn test_ff_case_range_skips_effectful_upper_bound_when_lower_is_false(sim) {
 }
 
 fn test_ff_function_call_array_literal_branch_view_is_reused_after_merge(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6291,6 +6329,7 @@ fn test_ff_function_call_array_literal_branch_view_is_reused_after_merge(sim) {
 }
 
 fn test_ff_function_call_effectful_array_items_are_eager_before_conditional_access(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6349,6 +6388,7 @@ fn test_ff_function_call_effectful_array_items_are_eager_before_conditional_acce
 }
 
 fn test_ff_function_call_carries_branch_local_static_array_item_cache(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6395,6 +6435,7 @@ fn test_ff_function_call_carries_branch_local_static_array_item_cache(sim) {
 }
 
 fn test_ff_function_call_tracks_nested_static_array_read_through_branch(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6444,6 +6485,7 @@ fn test_ff_function_call_tracks_nested_static_array_read_through_branch(sim) {
 }
 
 fn test_ff_function_call_tracks_array_view_hidden_in_bound_literal(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6495,6 +6537,7 @@ fn test_ff_function_call_tracks_array_view_hidden_in_bound_literal(sim) {
 }
 
 fn test_ff_function_call_merges_nested_array_state_at_cache_completion(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6550,6 +6593,7 @@ fn test_ff_function_call_merges_nested_array_state_at_cache_completion(sim) {
 }
 
 fn test_ff_function_call_merges_nested_array_state_at_static_cache_completion(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6603,6 +6647,7 @@ fn test_ff_function_call_merges_nested_array_state_at_static_cache_completion(si
 }
 
 fn test_ff_function_call_merges_directly_forwarded_array_cache(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6659,6 +6704,7 @@ fn test_ff_function_call_merges_directly_forwarded_array_cache(sim) {
 }
 
 fn test_ff_function_call_tracks_array_reads_in_output_indices(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6715,6 +6761,7 @@ fn test_ff_function_call_tracks_array_reads_in_output_indices(sim) {
 }
 
 fn test_ff_function_call_tracks_nested_array_reads_in_output_indices(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6774,7 +6821,7 @@ fn test_ff_function_call_tracks_nested_array_reads_in_output_indices(sim) {
 }
 
 fn test_ff_function_call_restores_initialized_forwarded_alias_view(sim) {
-    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @ignore_on(veryl, sv); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6823,6 +6870,7 @@ fn test_ff_function_call_restores_initialized_forwarded_alias_view(sim) {
 }
 
 fn test_ff_function_call_merges_outer_array_view_across_nested_short_circuit(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6881,6 +6929,7 @@ fn test_ff_function_call_merges_outer_array_view_across_nested_short_circuit(sim
 }
 
 fn test_ff_function_call_forwards_array_literal_view_to_nested_call(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6916,7 +6965,7 @@ fn test_ff_function_call_forwards_array_literal_view_to_nested_call(sim) {
 }
 
 fn test_ff_function_call_keeps_array_view_active_for_output_index(sim) {
-    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @ignore_on(veryl, sv); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6950,7 +6999,7 @@ fn test_ff_function_call_keeps_array_view_active_for_output_index(sim) {
 }
 
 fn test_ff_function_call_restores_array_literal_view_after_reentrant_call(sim) {
-    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @ignore_on(veryl, sv); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -6973,7 +7022,7 @@ fn test_ff_function_call_restores_array_literal_view_after_reentrant_call(sim) {
 }
 
 fn test_ff_function_call_restores_nearest_array_view_after_deep_reentrant_call(sim) {
-    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @ignore_on(veryl, sv); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -7002,7 +7051,7 @@ fn test_ff_function_call_restores_nearest_array_view_after_deep_reentrant_call(s
 }
 
 fn test_ff_function_call_bits_and_size_evaluate_effectful_array_argument(sim) {
-    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @ignore_on(veryl, sv); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -7048,7 +7097,7 @@ fn test_ff_function_call_bits_and_size_evaluate_effectful_array_argument(sim) {
 }
 
 fn test_ff_function_call_nested_bits_evaluates_effectful_array_argument(sim) {
-    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @ignore_on(veryl, sv); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -7087,7 +7136,7 @@ fn test_ff_function_call_nested_bits_evaluates_effectful_array_argument(sim) {
 }
 
 fn test_ff_function_call_array_literal_view_preserves_source_order(sim) {
-    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @ignore_on(veryl, sv); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -7124,7 +7173,7 @@ fn test_ff_function_call_array_literal_view_preserves_source_order(sim) {
 }
 
 fn test_ff_function_call_snapshots_pure_array_items_before_later_effect(sim) {
-    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @ignore_on(veryl, sv); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"
         module Top (clk: input clock, q: output logic<8>, changing: output logic<8>) {
             function update (
@@ -7154,6 +7203,7 @@ fn test_ff_function_call_snapshots_pure_array_items_before_later_effect(sim) {
 }
 
 fn test_ff_function_call_converts_array_literal_view_for_wider_nested_formal(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -7186,6 +7236,7 @@ fn test_ff_function_call_converts_array_literal_view_for_wider_nested_formal(sim
 }
 
 fn test_ff_function_call_converts_forwarded_static_array_element(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -7211,6 +7262,7 @@ fn test_ff_function_call_converts_forwarded_static_array_element(sim) {
 }
 
 fn test_ff_function_call_array_literal_element_uses_element_width(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -7233,6 +7285,7 @@ fn test_ff_function_call_array_literal_element_uses_element_width(sim) {
 }
 
 fn test_ff_function_array_element_assignment_preserves_signedness(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -7257,6 +7310,7 @@ fn test_ff_function_array_element_assignment_preserves_signedness(sim) {
 }
 
 fn test_ff_function_call_array_literal_default_fill_matches_formal_shape(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -7279,7 +7333,7 @@ fn test_ff_function_call_array_literal_default_fill_matches_formal_shape(sim) {
 }
 
 fn test_ff_function_call_multidim_array_literal_default_fill_matches_formal_shape(sim) {
-    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @ignore_on(veryl, sv); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -7302,6 +7356,7 @@ fn test_ff_function_call_multidim_array_literal_default_fill_matches_formal_shap
 }
 
 fn test_ff_function_call_multidim_array_literal_indexing_preserves_element_order(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input clock,
@@ -7324,7 +7379,7 @@ fn test_ff_function_call_multidim_array_literal_indexing_preserves_element_order
 }
 
 fn test_ff_function_call_dynamic_multidim_indexing_accepts_array_valued_items(sim) {
-    @ignore_on(veryl); // https://github.com/veryl-lang/veryl/pull/3131
+    @ignore_on(veryl, sv); // https://github.com/veryl-lang/veryl/pull/3131
     @setup { let code = r#"
         module Top (
             clk: input clock,

--- a/crates/celox/tests/for_loop_unroll.rs
+++ b/crates/celox/tests/for_loop_unroll.rs
@@ -13,6 +13,7 @@ mod test_utils;
 all_backends! {
 
 fn test_for_loop_unroll_shift_register(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Delay #(param DELAY: u32 = 3, param WIDTH: u32 = 8) (
             i_clk: input clock,
@@ -58,6 +59,7 @@ fn test_for_loop_unroll_shift_register(sim) {
 }
 
 fn test_for_loop_unroll_break_in_always_ff(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             i_clk: input clock,

--- a/crates/celox/tests/four_state.rs
+++ b/crates/celox/tests/four_state.rs
@@ -117,7 +117,7 @@ fn test_four_state_initial_and_set(sim) {
 }
 
 fn test_ff_struct_logic_to_bit_coercion_clears_mask(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup {
     let code = r#"
         module Top (
@@ -154,7 +154,7 @@ fn test_ff_struct_logic_to_bit_coercion_clears_mask(sim) {
 }
 
 fn test_four_state_mixing(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup {
     let code = r#"
         module Top (
@@ -205,7 +205,7 @@ fn test_four_state_mixing(sim) {
 }
 
 fn test_four_state_mixing_propagation(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup {
     let code = r#"
         module Top (
@@ -767,7 +767,7 @@ fn test_four_state_always_comb_chain(sim) {
 // always_ff: X captured in FF, reset clears X
 // ==========================================================================
 fn test_four_state_ff_capture_and_reset(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup {
     let code = r#"
         module Top (
@@ -1817,7 +1817,7 @@ fn test_four_state_wide_comparison_with_x(sim) {
 // P2: Multi-bit selector (case) with X
 // ==========================================================================
 fn test_four_state_multibit_mux_with_x(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup {
     let code = r#"
         module Top (
@@ -1868,7 +1868,7 @@ fn test_four_state_multibit_mux_with_x(sim) {
 }
 
 fn test_four_state_procedural_case_x_uses_default(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup {
     let code = r#"
         module Top (
@@ -1901,7 +1901,7 @@ fn test_four_state_procedural_case_x_uses_default(sim) {
 }
 
 fn test_four_state_procedural_if_known_nonzero_with_x_is_true(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup {
     let code = r#"
         module Top (
@@ -2019,7 +2019,7 @@ fn test_four_state_width_widening_with_x(sim) {
 // P2: FF with conditional assignment + X
 // ==========================================================================
 fn test_four_state_ff_conditional_with_x(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup {
     let code = r#"
         module Top (
@@ -3653,7 +3653,7 @@ fn test_four_state_concat_chunk_boundary_x(sim) {
 // FF: synchronous reset + X
 // ==========================================================================
 fn test_four_state_ff_sync_reset_with_x(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup {
     let code = r#"
         module Top (

--- a/crates/celox/tests/four_state_expression_semantics.rs
+++ b/crates/celox/tests/four_state_expression_semantics.rs
@@ -7,6 +7,7 @@ mod test_utils;
 all_backends! {
     fn indeterminate_short_circuit_lhs_executes_effectful_rhs(sim) {
         @omit_veryl;
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     u: input logic,
@@ -41,7 +42,7 @@ module Top (
 
     fn indeterminate_ternary_executes_effectful_arms_in_order(sim) {
         // Veryl 0.20.3 retains the prior output effect after sel becomes known.
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(r#"
 module Top (
     sel: input logic,
@@ -97,6 +98,7 @@ module Top (
 
     fn logical_unknown_truth_table_matches_comb_and_ff(sim) {
         @omit_veryl;
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -167,6 +169,7 @@ module Top (
 
     fn ternary_unknown_condition_merges_branch_bits(sim) {
         @omit_veryl;
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -226,6 +229,7 @@ module Top (
 
     fn wide_logical_unknown_truth_table_uses_dominant_values(sim) {
         @omit_veryl;
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -293,6 +297,7 @@ module Top (
     }
 
     fn logical_not_known_one_dominates_unknown_bits(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -374,7 +379,7 @@ module Top (
 
     fn effectful_ternary_takes_known_true_branch_despite_unknown_bits(sim) {
         // Veryl 0.20.3 evaluates the false arm despite a known 1 in cond.
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -432,6 +437,7 @@ module Top (
 
     fn ff_procedural_control_uses_known_nonzero_truth(sim) {
         @omit_veryl;
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -547,6 +553,7 @@ module Top (
 
     fn ff_unknown_reset_is_not_active(sim) {
         @omit_veryl;
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -616,7 +623,7 @@ module Top (
 
     fn ff_assert_uses_procedural_four_state_truth(sim) {
         @omit_veryl;
-        @ignore_on(wasm);
+        @ignore_on(wasm, sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -662,7 +669,7 @@ module Top (
 
     fn comb_assert_uses_procedural_four_state_truth(sim) {
         @omit_veryl;
-        @ignore_on(wasm);
+        @ignore_on(wasm, sv);
         @build Simulator::builder(r#"
 module Top (
     cond: input logic<130>,
@@ -707,6 +714,7 @@ module Top (
     }
 
     fn wide_ternary_condition_known_one_dominates_unknown_bits(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -759,7 +767,7 @@ module Top (
 
     fn wide_ternary_unknown_condition_merges_every_arm_chunk(sim) {
         // Veryl 0.20.3 produces the wrong per-bit merge above 64 bits.
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,

--- a/crates/celox/tests/hierarchy.rs
+++ b/crates/celox/tests/hierarchy.rs
@@ -8,8 +8,9 @@ all_backends! {
 
     // For-loop instances: verify named_hierarchy groups them correctly
     // and child_signal access works.
-    fn test_for_loop_instance_hierarchy(sim) {
-        @omit_veryl;
+fn test_for_loop_instance_hierarchy(sim) {
+    @omit_veryl;
+    @ignore_on(sv);
         @setup { let code = r#"
 module Sub (
 clk: input '_ clock,
@@ -82,7 +83,8 @@ o_data: top_out
 
     }
 
-    fn test_instance_input_function_output_writeback(sim) {
+fn test_instance_input_function_output_writeback(sim) {
+    @ignore_on(sv);
         // veryl-simulator currently evaluates the connection value but does
         // not write the function output actual back to the parent variable.
         @setup { let code = r#"
@@ -126,7 +128,7 @@ assign seen_o = seen;
     fn test_instance_input_function_output_concat_dynamic_writeback(sim) {
         // veryl-simulator currently evaluates the connection value but does
         // not write the function output actual back to the parent variables.
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Child (
 i: input logic,
@@ -175,7 +177,8 @@ assign tmp_o = tmp;
 
     }
 
-    fn test_inactive_instance_input_output_call_adds_no_parent_driver(sim) {
+fn test_inactive_instance_input_output_call_adds_no_parent_driver(sim) {
+    @ignore_on(sv);
         @setup { let code = r#"
 module Child (
 i: input logic,
@@ -219,7 +222,7 @@ assign seen_o = seen;
         // veryl-simulator does not write the connection's function output
         // actual back; wasm does not currently expose runtime event draining.
         @omit_veryl;
-        @ignore_on(wasm);
+        @ignore_on(wasm, sv);
         @setup { let code = r#"
 module Child (
 i: input logic,
@@ -269,7 +272,7 @@ assign seen_o = seen;
     fn test_instance_output_dynamic_index_function_output_writeback(sim) {
         // veryl-simulator does not write the dynamic connection index call's
         // output actual back to the parent variable.
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Child (
 i: input logic,
@@ -314,7 +317,7 @@ assign tmp_o = tmp;
         // veryl-simulator does not write the dynamic connection index call's
         // output actual back; wasm does not currently expose runtime events.
         @omit_veryl;
-        @ignore_on(wasm);
+        @ignore_on(wasm, sv);
         @setup { let code = r#"
 module Child (i: input logic, o: output logic) {
 assign o = i;
@@ -362,7 +365,7 @@ assign tmp_o = tmp;
 
     fn test_instance_output_index_runtime_effect_tracks_plain_sibling_source(sim) {
         @omit_veryl;
-        @ignore_on(wasm);
+        @ignore_on(wasm, sv);
         @setup { let code = r#"
 module Child (i: input logic, o: output logic) {
 assign o = i;
@@ -407,7 +410,7 @@ assign mem_o = mem;
     fn test_instance_output_dynamic_index_composes_aliasing_writeback(sim) {
         // veryl-simulator does not write the dynamic connection index call's
         // output actual back to the parent array.
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Child (i: input logic, o: output logic) {
 assign o = i;
@@ -441,7 +444,7 @@ assign mem_o = mem;
     }
 
     fn test_instance_output_concat_advances_each_destination(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Child (i: input logic<2>, o: output logic<2>) {
 assign o = i;
@@ -474,7 +477,7 @@ assign tmp_o = tmp;
 
     fn test_instance_output_concat_runtime_effect_observes_prior_slice(sim) {
         @omit_veryl;
-        @ignore_on(wasm);
+        @ignore_on(wasm, sv);
         @setup { let code = r#"
 module Child (i: input logic<2>, o: output logic<2>) {
 assign o = i;
@@ -516,7 +519,7 @@ assign tmp_o = tmp;
 
     fn test_instance_output_index_runtime_effect_triggers_on_child_change(sim) {
         @omit_veryl;
-        @ignore_on(wasm);
+        @ignore_on(wasm, sv);
         @setup { let code = r#"
 module Child (i: input logic, o: output logic) {
 assign o = i;
@@ -560,7 +563,7 @@ assign mem_o = mem;
 
     fn test_instance_output_index_effect_triggers_when_two_state_parent_is_unchanged(sim) {
         @omit_veryl;
-        @ignore_on(wasm);
+        @ignore_on(wasm, sv);
         @setup { let code = r#"
 module Child (mode: input logic<2>, o: output logic) {
 always_comb {
@@ -715,7 +718,8 @@ o_fill
 
     }
 
-    fn test_dynamic_output_port_rmw_preserves_unselected_bits(sim) {
+fn test_dynamic_output_port_rmw_preserves_unselected_bits(sim) {
+    @ignore_on(sv);
         @setup { let code = r#"
 module Child (
 a: input logic<2>,
@@ -769,7 +773,8 @@ assign out = mem;
 
     }
 
-    fn test_dynamic_output_port_converts_four_state_child_to_two_state_parent(sim) {
+fn test_dynamic_output_port_converts_four_state_child_to_two_state_parent(sim) {
+    @ignore_on(sv);
         @setup { let code = r#"
 module Child (y: output logic) {
 assign y = 1'bx;
@@ -790,7 +795,8 @@ assign out = mem;
 
     }
 
-    fn test_dynamic_minus_colon_output_port_rmw(sim) {
+fn test_dynamic_minus_colon_output_port_rmw(sim) {
+    @ignore_on(sv);
         @setup { let code = r#"
 module Child (a: input logic<2>, y: output logic<2>) {
 assign y = a;
@@ -817,7 +823,8 @@ assign out = mem;
 
     }
 
-    fn test_dynamic_step_output_port_rmw(sim) {
+fn test_dynamic_step_output_port_rmw(sim) {
+    @ignore_on(sv);
         @setup { let code = r#"
 module Child (a: input logic<2>, y: output logic<2>) {
 assign y = a;
@@ -844,8 +851,9 @@ assign out = mem;
 
     }
 
-    fn test_dynamic_prefix_colon_output_port_allows_zero_lsb(sim) {
-        @omit_veryl;
+fn test_dynamic_prefix_colon_output_port_allows_zero_lsb(sim) {
+    @omit_veryl;
+    @ignore_on(sv);
         @setup { let code = r#"
 module Child (a: input logic<8>, y: output logic<8>) {
 assign y = a;
@@ -951,7 +959,7 @@ inst u_sub: Sub ( i: 8'h0F, o: o );
 
     fn test_hierarchical_concat_feedback_runtime(sim) {
         @omit_veryl;
-        @ignore_on(native, cranelift, wasm);
+        @ignore_on(native, cranelift, wasm, sv);
         @setup { let code = r#"
 module Child (
 a: input logic<2>,
@@ -990,7 +998,7 @@ assign out = v[0];
 
     fn test_hierarchical_concat_feedback_runtime_multi_observe(sim) {
         @omit_veryl;
-        @ignore_on(native, cranelift, wasm);
+        @ignore_on(native, cranelift, wasm, sv);
         @setup { let code = r#"
 module Child (
 a: input logic<2>,
@@ -1029,7 +1037,7 @@ assign out1 = v[1];
 
     fn test_hierarchical_concat_feedback_with_constant_middle_bit(sim) {
         @omit_veryl;
-        @ignore_on(native, cranelift, wasm);
+        @ignore_on(native, cranelift, wasm, sv);
         @setup { let code = r#"
 module Child (
 a: input logic<3>,
@@ -1070,7 +1078,7 @@ assign mid = v[1];
 
     fn test_hierarchical_dynamic_index_feedback_runtime(sim) {
         @omit_veryl;
-        @ignore_on(native, cranelift, wasm);
+        @ignore_on(native, cranelift, wasm, sv);
         @setup { let code = r#"
 module ChildFb (
 a: input logic<3>,
@@ -1145,7 +1153,7 @@ assign out_dyn = d;
 
     fn test_hierarchical_dual_dynamic_readers_feedback_runtime(sim) {
         @omit_veryl;
-        @ignore_on(native, cranelift, wasm);
+        @ignore_on(native, cranelift, wasm, sv);
         @setup { let code = r#"
 module ChildFb (
 a: input logic<3>,
@@ -1241,7 +1249,7 @@ assign out1 = d1;
     }
 
     fn test_hierarchical_overlapping_partial_write_dynamic_index_runtime(sim) {
-        @ignore_on(native, cranelift, wasm);
+        @ignore_on(native, cranelift, wasm, sv);
         @setup { let code = r#"
 module ChildFb (
 a: input logic<3>,
@@ -1345,7 +1353,7 @@ assign out_v1 = v[1];
     }
 
     fn test_hierarchical_concat_then_overlap_dynamic_index_runtime(sim) {
-        @ignore_on(native, cranelift, wasm);
+        @ignore_on(native, cranelift, wasm, sv);
         @setup { let code = r#"
 module ChildFb (
 a: input logic<3>,

--- a/crates/celox/tests/initial_readmem.rs
+++ b/crates/celox/tests/initial_readmem.rs
@@ -18,6 +18,7 @@ all_backends! {
 
 fn test_initial_readmemh_loads_unpacked_array(sim) {
     @omit_veryl;
+    @ignore_on(sv);
     @setup {
         let mem_path = temp_mem_file("readmemh", "12\n34\n56\n78\n");
         let code = format!(r#"
@@ -47,6 +48,7 @@ fn test_initial_readmemh_loads_unpacked_array(sim) {
 
 fn test_initial_readmemh_supports_comments_address_and_xz(sim) {
     @omit_veryl;
+    @ignore_on(sv);
     @setup {
         let mem_path = temp_mem_file(
             "readmemh_xz",
@@ -79,6 +81,7 @@ fn test_initial_readmemh_supports_comments_address_and_xz(sim) {
 
 fn test_initial_readmemh_supports_const_if(sim) {
     @omit_veryl;
+    @ignore_on(sv);
     @setup {
         let hex_path = temp_mem_file("readmemh_if", "21\n43\n65\n87\n");
         let other_path = temp_mem_file("readmemh_if_dead", "00\n00\n00\n00\n");
@@ -104,6 +107,7 @@ fn test_initial_readmemh_supports_const_if(sim) {
 
 fn test_initial_readmemh_supports_const_for(sim) {
     @omit_veryl;
+    @ignore_on(sv);
     @setup {
         let mem_path = temp_mem_file("readmemh_for", "11\n22\n33\n44\n");
         let code = format!(r#"
@@ -128,6 +132,7 @@ fn test_initial_readmemh_supports_const_for(sim) {
 
 fn test_initial_readmemh_supports_indexed_destination(sim) {
     @omit_veryl;
+    @ignore_on(sv);
     @setup {
         let mem_path = temp_mem_file("readmemh_indexed", "aa\nbb\n");
         let code = format!(r#"
@@ -157,6 +162,7 @@ fn test_initial_readmemh_supports_indexed_destination(sim) {
 
 fn test_initial_readmemh_multiple_files_merge_in_order(sim) {
     @omit_veryl;
+    @ignore_on(sv);
     @setup {
         let first_path = temp_mem_file("readmemh_multi_first", "11\n22\n33\n44\n");
         let second_path = temp_mem_file("readmemh_multi_second", "aa\nbb\n");

--- a/crates/celox/tests/interface.rs
+++ b/crates/celox/tests/interface.rs
@@ -6,6 +6,7 @@ mod test_utils;
 
 all_backends! {
     fn test_interface_connection(sim) {
+        @ignore_on(sv);
         @setup {
             let code = r#"
     interface Bus {

--- a/crates/celox/tests/linear_sorter_pull.rs
+++ b/crates/celox/tests/linear_sorter_pull.rs
@@ -143,7 +143,7 @@ pub module Top #(
 all_backends! {
 
     fn test_sorter_push_pop_empty(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(sorter_code(), "Top");
     let clk = sim.event("clk");
     let rst = sim.signal("rst");
@@ -228,6 +228,7 @@ all_backends! {
     // Focused test: push one element, then pop it.
     // The empty flag should go 1 → 0 → 1 across the three phases.
     fn test_sorter_empty_flag_single_push_pop(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(sorter_code(), "Top");
     let clk = sim.event("clk");
     let rst = sim.signal("rst");
@@ -288,7 +289,7 @@ all_backends! {
 
     // Test: push+pop simultaneously — count should not change.
     fn test_sorter_simultaneous_push_pop(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(sorter_code(), "Top");
     let clk = sim.event("clk");
     let rst = sim.signal("rst");

--- a/crates/celox/tests/linear_sorter_pull_mre.rs
+++ b/crates/celox/tests/linear_sorter_pull_mre.rs
@@ -52,7 +52,7 @@ fn pull_until_empty<B: celox::SimBackend>(
 
 all_backends! {
 fn bit_array_index_64_ff_roundtrips(sim) {
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module BitArrayIndex64 (
     clk: input clock,
@@ -98,7 +98,7 @@ module BitArrayIndex64 (
 }
 
 fn word_array_index_64_ff_roundtrips(sim) {
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(r#"
 module WordArrayIndex64 (
     clk: input clock,
@@ -145,7 +145,7 @@ module WordArrayIndex64 (
 
 fn linear_sorter_pull_late_minima_drain_once_in_sorted_order(sim) {
     @omit_veryl;
-    @ignore_on(wasm);
+    @ignore_on(wasm, sv);
     @build Simulator::builder(SOURCE, "LinearSorterPullMreU16")
         .param("DEPTH", DEPTH as u64)
         .reset_type(celox::ResetType::AsyncLow);

--- a/crates/celox/tests/loop_idiom.rs
+++ b/crates/celox/tests/loop_idiom.rs
@@ -79,6 +79,7 @@ fn optimized_sir_recovers_expanded_bit_count_loops() {
 all_backends! {
 
 fn test_recovered_bit_count_loop_semantics(sim) {
+    @ignore_on(sv);
     @setup { let code = CODE; }
     @build Simulator::builder(code, "Top");
     let bits = sim.signal("bits");

--- a/crates/celox/tests/multi_clock.rs
+++ b/crates/celox/tests/multi_clock.rs
@@ -8,7 +8,7 @@ all_backends! {
 
     // Two independent clock domains: each FF only advances on its own clock.
     fn test_independent_clock_domains(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
 clk_a: input  'a clock,
@@ -80,7 +80,7 @@ assign qb = rb;
     // A counter in one clock domain feeding into another (CDC pattern).
     // Tests that domains are truly independent.
     fn test_clock_domain_crossing_pattern(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
 clk_fast: input  'a clock,

--- a/crates/celox/tests/nba_cross_block.rs
+++ b/crates/celox/tests/nba_cross_block.rs
@@ -10,7 +10,7 @@ all_backends! {
     // In RTL, two always_ff blocks on the same clock should both read OLD values
     // (pre-edge) and write NEW values (post-edge), regardless of textual order.
     fn test_nba_separate_blocks_swap(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (clk: input clock, rst: input reset, a: output logic<8>, b: output logic<8>) {
 var r1: logic<8>;
@@ -79,6 +79,7 @@ assign b = r2;
     // Test pipeline pattern across 3 separate always_ff blocks.
     // d → stage1 → stage2 → stage3 should take 3 clock cycles.
     fn test_nba_separate_blocks_pipeline(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (clk: input clock, d: input logic<8>, q: output logic<8>) {
 var stage1: logic<8>;

--- a/crates/celox/tests/nba_cross_block_empty.rs
+++ b/crates/celox/tests/nba_cross_block_empty.rs
@@ -10,6 +10,7 @@ all_backends! {
     // Block 1 updates `count`. Block 2 reads `count` to set `r_empty`.
     // NBA semantics: r_empty should see the OLD count value.
     fn test_same_module_count_and_empty_ff(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 clk  : input  clock    ,

--- a/crates/celox/tests/nba_dynamic_array.rs
+++ b/crates/celox/tests/nba_dynamic_array.rs
@@ -7,6 +7,7 @@ mod test_utils;
 all_backends! {
 
     fn test_subbyte_arithmetic_padding_does_not_corrupt_concat(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     bound: input  logic<4>,
@@ -53,6 +54,7 @@ module Top (
     }
 
     fn test_child_dynamic_ff_read_reaches_parent_after_same_edge_enable(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Cache (
     clk  : input  clock,
@@ -113,6 +115,7 @@ module Top (
     }
 
     fn test_static_ff_writes_are_applied_after_all_rhs_evaluation(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     clk : input  clock,
@@ -168,6 +171,7 @@ module Top (
     // state. A dynamic array write in one block must not become visible to a
     // read in another block until all blocks for the edge have evaluated.
     fn test_dynamic_array_write_is_deferred_across_ff_blocks(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     clk  : input  clock,
@@ -235,6 +239,7 @@ module Top (
     }
 
     fn test_partial_sparse_chunks_do_not_overlap_adjacent_variables(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     clk  : input  clock,
@@ -284,6 +289,7 @@ module Top (
     }
 
     fn test_always_ff_let_bindings_are_visible_immediately(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     clk: input  clock,
@@ -317,6 +323,7 @@ module Top (
     }
 
     fn test_wide_dynamic_ff_checkpoint_round_trip(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     clk    : input  clock,
@@ -385,7 +392,7 @@ module Top (
     }
 
     fn test_unaligned_309_bit_dynamic_ff_round_trip(sim) {
-        @ignore_on(wasm);
+        @ignore_on(wasm, sv);
         @setup { let code = r#"
 module Top (
     clk    : input  clock,
@@ -484,6 +491,7 @@ module Top (
     }
 
     fn test_packed_rat_checkpoint_round_trip(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     clk    : input  clock,
@@ -551,6 +559,7 @@ module Top (
     }
 
     fn test_dynamic_ff_array_partial_squash_preserves_head_and_branch(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     clk        : input  clock,
@@ -629,6 +638,7 @@ module Top (
     }
 
     fn test_line_write_loop_updates_large_sparse_ff_array(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     clk  : input  clock,

--- a/crates/celox/tests/operators.rs
+++ b/crates/celox/tests/operators.rs
@@ -296,6 +296,7 @@ assign o_or  = |a;
     }
 
     fn test_pow_operator_constant_exponent(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (a: input logic<8>, o: output logic<8>) {
 assign o = a ** 3;
@@ -314,6 +315,7 @@ assign o = a ** 3;
     }
 
     fn test_as_operator_passthrough(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (a: input logic<8>, o: output logic<8>) {
 assign o = a as u8;
@@ -329,6 +331,7 @@ assign o = a as u8;
     }
 
     fn test_pow_operator_constant_exponent_ff(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (clk: input clock, a: input logic<8>, o: output logic<8>) {
 var r: logic<8>;
@@ -350,6 +353,7 @@ assign o = r;
     }
 
     fn test_pow_operator_runtime_exponent_comb_and_ff(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     clk: input clock,
@@ -402,6 +406,7 @@ module Top (
     }
 
     fn test_pow_operator_runtime_signed_and_unknown_operands(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     clk: input clock,
@@ -458,7 +463,7 @@ module Top (
     }
 
     fn test_signed_comparison_after_as_cast(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (a: input logic<8>, b: input logic<8>, y: output logic) {
 assign y = (a as i8) <: (b as i8);
@@ -482,7 +487,7 @@ assign y = (a as i8) <: (b as i8);
     fn test_cast_signed_to_unsigned_affects_comparison(sim) {
         // Veryl 0.20.2's runtime keeps the source signedness for this cast;
         // the analyzer and emitted SystemVerilog make the result unsigned.
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (a: input i8, b: input i8, y: output logic) {
 assign y = (a as u8) <: (b as u8);
@@ -504,6 +509,7 @@ assign y = (a as u8) <: (b as u8);
     }
 
     fn test_symbolic_store_preserves_declared_state_signedness(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     sel:           input  logic,
@@ -551,6 +557,7 @@ module Top (
     }
 
     fn test_unsigned_type_cast_does_not_inherit_source_signedness(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
     sel:       input  logic,
@@ -815,6 +822,7 @@ assign q = r;
 
     // XNOR in always_comb: ~(a ^ b)
     fn test_comb_bitxnor(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 a: input  logic<8>,
@@ -849,7 +857,7 @@ assign y = a ~^ b;
 
     // XNOR in always_ff.
     fn test_ff_bitxnor(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
 clk: input  clock,
@@ -1106,7 +1114,7 @@ assign y = r;
     }
 
     fn test_mixed_signed_unsigned_comparison(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { // Mixed signed/unsigned should be treated as unsigned (Clause 11.8.1)
 let code = r#"
 module Top (

--- a/crates/celox/tests/packed_scatter_store.rs
+++ b/crates/celox/tests/packed_scatter_store.rs
@@ -46,6 +46,7 @@ fn packed_pattern() -> BigUint {
 all_backends! {
 
 fn packed_scatter_last_lane_does_not_touch_adjacent_storage(sim) {
+    @ignore_on(sv);
     @setup { let code = scatter_source(); }
     @build SimulatorBuilder::new(&code, "Top").optimize(true);
 

--- a/crates/celox/tests/proto_package.rs
+++ b/crates/celox/tests/proto_package.rs
@@ -13,6 +13,7 @@ all_backends! {
     // Uses a combinational circuit to test that `<:` on PKG::Item resolves
     // correctly to the builtin less-than operator.
     fn test_proto_package_builtin_comparison(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 proto package ItemProto {
 type Item;
@@ -69,6 +70,7 @@ inst c: Comparator::<ItemU16> (a, b, a_lt);
     // Positive control: proto package with an explicit `lt` function works correctly.
     // This confirms that proto package function dispatch is functional.
     fn test_proto_package_with_custom_function(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 proto package ItemProto {
 type Item;

--- a/crates/celox/tests/recovered_unrolled_fold.rs
+++ b/crates/celox/tests/recovered_unrolled_fold.rs
@@ -38,6 +38,7 @@ const MULTI_STATE_LOOP: &str = r#"
 all_backends! {
 
 fn recovered_unrolled_store_forward_selects_older_entry(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module StoreShadow (
             store_idx : input  logic<5>,
@@ -153,6 +154,7 @@ fn recovered_unrolled_store_forward_selects_older_entry(sim) {
 }
 
 fn recovered_unrolled_multi_state_priority(sim) {
+    @ignore_on(sv);
     @setup { let code = MULTI_STATE_LOOP; }
     @build SimulatorBuilder::new(code, "Top");
 
@@ -181,6 +183,7 @@ fn recovered_unrolled_multi_state_priority(sim) {
 }
 
 fn recovered_unrolled_guard_uses_procedural_four_state_truth(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             cond : input  logic<8>,

--- a/crates/celox/tests/shift_bug_test.rs
+++ b/crates/celox/tests/shift_bug_test.rs
@@ -64,6 +64,7 @@ assign o = r;
     }
 
     fn test_shift_in_for_loop(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 clk: input clock,
@@ -93,7 +94,7 @@ o = a << 4;
     }
 
     fn test_shift_ifreset_for(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let code = r#"
 module Top (
 clk: input  clock,
@@ -237,6 +238,7 @@ assign o = r;
     }
 
     fn test_shift_to_array_by_loop_index(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 clk: input clock,
@@ -275,6 +277,7 @@ assign o3 = arr[3];
     }
 
     fn test_shift_with_wide_const_amount(sim) {
+        @ignore_on(sv);
         @setup { // For loop unrolling creates 32-bit const shift amounts.
 // Ensure the shift result width is determined by the LHS, not widened by the RHS.
 let code = r#"

--- a/crates/celox/tests/signed_divrem.rs
+++ b/crates/celox/tests/signed_divrem.rs
@@ -7,7 +7,7 @@ mod test_utils;
 all_backends! {
     fn signed_divrem_i8(sim) {
         // Veryl 0.20.3 ignores the explicit unsigned cast in division.
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(r#"
 module Top (
     a: input i8,

--- a/crates/celox/tests/simulator_api.rs
+++ b/crates/celox/tests/simulator_api.rs
@@ -36,6 +36,7 @@ assign s = a + b;
 
     // Test that `modify` triggers combinational re-evaluation immediately.
     fn test_modify_triggers_comb_reevaluation(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 sel: input  logic,
@@ -207,6 +208,7 @@ assign x0 = x[0];
     }
 
     fn test_concat_with_dynamic_index_runtime(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 a: input logic<4>,

--- a/crates/celox/tests/state_cast_semantics.rs
+++ b/crates/celox/tests/state_cast_semantics.rs
@@ -7,6 +7,7 @@ mod test_utils;
 all_backends! {
     fn type_cast_clears_unknown_bits_in_comb_and_ff(sim) {
         @omit_veryl;
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -87,6 +88,7 @@ module Top (
 
     fn constant_type_cast_clears_unknown_bits(sim) {
         @omit_veryl;
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -120,6 +122,7 @@ module Top (
 
     fn function_formal_type_clears_unknown_bits(sim) {
         @omit_veryl;
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -158,6 +161,7 @@ module Top (
     }
 
     fn signed_four_state_function_formal_preserves_unknown_bits(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -198,7 +202,7 @@ module Top (
 
     fn implicit_assignment_to_bit_clears_unknowns_without_mutating_source(sim) {
         // Veryl 0.20.3 retains the X/Z mask when assigning logic to bit.
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,

--- a/crates/celox/tests/std_delay.rs
+++ b/crates/celox/tests/std_delay.rs
@@ -8,6 +8,7 @@ all_backends! {
 
     // DELAY=0: passthrough (no delay)
     fn test_delay_zero(sim) {
+        @ignore_on(sv);
         @setup { let top = r#"
 module Top (
 clk: input  clock,
@@ -39,6 +40,7 @@ let code = format!("{}\n{top}", test_utils::veryl_std::source(&["delay", "delay.
 
     // DELAY=1: one cycle delay
     fn test_delay_one(sim) {
+        @ignore_on(sv);
         @setup { let top = r#"
 module Top (
 clk: input  clock,
@@ -87,6 +89,7 @@ let code = format!("{}\n{top}", test_utils::veryl_std::source(&["delay", "delay.
 
     // DELAY=3: three cycle pipeline
     fn test_delay_three(sim) {
+        @ignore_on(sv);
         @setup { let top = r#"
 module Top (
 clk: input  clock,

--- a/crates/celox/tests/std_fifo.rs
+++ b/crates/celox/tests/std_fifo.rs
@@ -71,6 +71,7 @@ all_backends! {
 // After reset, FIFO should be empty
 fn test_fifo_initial_empty(sim) {
     @omit_veryl;
+    @ignore_on(sv);
     @setup { let code = fifo_source(); }
     @build Simulator::builder(&code, "Top");
     reset(&mut sim);
@@ -91,6 +92,7 @@ fn test_fifo_initial_empty(sim) {
 // Push one item, verify not empty, pop it back
 fn test_fifo_push_pop_single(sim) {
     @omit_veryl;
+    @ignore_on(sv);
     @setup { let code = fifo_source(); }
     @build Simulator::builder(&code, "Top");
     reset(&mut sim);
@@ -136,6 +138,7 @@ fn test_fifo_push_pop_single(sim) {
 // Push until full (DEPTH=4), verify full flag
 fn test_fifo_full(sim) {
     @omit_veryl;
+    @ignore_on(sv);
     @setup { let code = fifo_source(); }
     @build Simulator::builder(&code, "Top");
     reset(&mut sim);
@@ -165,6 +168,7 @@ fn test_fifo_full(sim) {
 // Push 4 items then pop all, verify FIFO ordering
 fn test_fifo_ordering(sim) {
     @omit_veryl;
+    @ignore_on(sv);
     @setup { let code = fifo_source(); }
     @build Simulator::builder(&code, "Top");
     reset(&mut sim);
@@ -204,6 +208,7 @@ fn test_fifo_ordering(sim) {
 // Clear resets the FIFO to empty
 fn test_fifo_clear(sim) {
     @omit_veryl;
+    @ignore_on(sv);
     @setup { let code = fifo_source(); }
     @build Simulator::builder(&code, "Top");
     reset(&mut sim);

--- a/crates/celox/tests/std_mux.rs
+++ b/crates/celox/tests/std_mux.rs
@@ -9,7 +9,7 @@ all_backends! {
     // Build-only smoke test: mux with selector_pkg requires `calc_select_width`
     // evaluation while resolving module parameters and widths.
     fn test_mux_build_smoke(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let top = r#"
 module Top (
 i_select: input  logic<2>,
@@ -49,7 +49,7 @@ let code = format!(
     // Build-only smoke test: binary demux also depends on selector_pkg compile-time
     // width resolution through `calc_select_width`.
     fn test_demux_build_smoke(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @setup { let top = r#"
 module Top (
 i_select: input  logic<2>,

--- a/crates/celox/tests/std_ram.rs
+++ b/crates/celox/tests/std_ram.rs
@@ -8,6 +8,7 @@ all_backends! {
 
     // Dual-port RAM: write via port A, read via port B (BUFFER_OUT=false, combinational read)
     fn test_ram_write_read(sim) {
+        @ignore_on(sv);
         @setup { let top = r#"
 module Top (
 clk  : input  clock,
@@ -105,6 +106,7 @@ let code = format!("{}\n{top}", test_utils::veryl_std::source(&["ram", "ram.very
 
     // Overwrite same address and verify latest value
     fn test_ram_overwrite(sim) {
+        @ignore_on(sv);
         @setup { let top = r#"
 module Top (
 clk  : input  clock,
@@ -184,6 +186,7 @@ let code = format!("{}\n{top}", test_utils::veryl_std::source(&["ram", "ram.very
 
     // RAM with USE_RESET=true: clear via i_clr
     fn test_ram_reset_and_clear(sim) {
+        @ignore_on(sv);
         @setup { let top = r#"
 module Top (
 clk   : input  clock,

--- a/crates/celox/tests/struct_constructor.rs
+++ b/crates/celox/tests/struct_constructor.rs
@@ -7,6 +7,7 @@ mod test_utils;
 all_backends! {
 
     fn test_struct_constructor_comb_assignment(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 a: input logic<4>,
@@ -38,6 +39,7 @@ o = S'{x: a, y: b};
     }
 
     fn test_struct_constructor_member_width_adjustment(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 narrow: input logic<4>,

--- a/crates/celox/tests/synth_dynamic_loop.rs
+++ b/crates/celox/tests/synth_dynamic_loop.rs
@@ -8,6 +8,7 @@ mod test_utils;
 all_backends! {
 
 fn test_expression_bounds_in_synth_for_loops(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top #(
             param LIMIT: u32 = 4,
@@ -55,6 +56,7 @@ fn test_expression_bounds_in_synth_for_loops(sim) {
 }
 
 fn test_constant_break_in_synth_comb_loop(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             sum: output logic<32>,
@@ -111,6 +113,7 @@ fn test_constant_signed_bounds_in_unrolled_synth_loops(sim) {
 }
 
 fn test_runtime_bounds_in_synth_for_loops(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             count: input logic<32>,
@@ -166,6 +169,7 @@ fn test_runtime_bounds_in_synth_for_loops(sim) {
 }
 
 fn test_runtime_bitwise_steps_in_synth_for_loops(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             or_end: input logic<32>,
@@ -209,7 +213,7 @@ fn test_runtime_bitwise_steps_in_synth_for_loops(sim) {
 fn test_signed_xor_step_uses_loop_counter_width(sim) {
     // The Veryl simulator currently converts the signed dynamic start bound to an
     // unsigned runtime counter and executes zero iterations.
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             wide_end: input signed logic<128>,
@@ -239,7 +243,7 @@ fn test_signed_xor_step_uses_loop_counter_width(sim) {
 }
 
 fn test_i32_bitwise_steps_discard_bits_above_the_counter_width(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             or_end: input signed logic<128>,
@@ -283,7 +287,7 @@ fn test_i32_bitwise_steps_discard_bits_above_the_counter_width(sim) {
 }
 
 fn test_i32_xor_step_with_only_high_bits_reports_true_loop(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             end_bound: input logic<32>,
@@ -305,7 +309,7 @@ fn test_i32_xor_step_with_only_high_bits_reports_true_loop(sim) {
 }
 
 fn test_i32_or_step_with_only_existing_low_bits_reports_true_loop(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             end_bound: input logic<32>,
@@ -327,7 +331,7 @@ fn test_i32_or_step_with_only_existing_low_bits_reports_true_loop(sim) {
 }
 
 fn test_i32_mul_step_overflow_reports_true_loop(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             end_bound: input signed logic<64>,
@@ -349,7 +353,7 @@ fn test_i32_mul_step_overflow_reports_true_loop(sim) {
 }
 
 fn test_i32_shl_step_overflow_reports_true_loop(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             end_bound: input signed logic<64>,
@@ -371,7 +375,7 @@ fn test_i32_shl_step_overflow_reports_true_loop(sim) {
 }
 
 fn test_runtime_bounds_terminal_inclusive_mul_loop_reports_true_loop(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             count: input logic<32>,
@@ -393,6 +397,7 @@ fn test_runtime_bounds_terminal_inclusive_mul_loop_reports_true_loop(sim) {
 }
 
 fn test_runtime_reverse_step_matches_emitted_sv_order(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             start: input signed logic<64>,
@@ -419,7 +424,7 @@ fn test_runtime_reverse_step_matches_emitted_sv_order(sim) {
 }
 
 fn test_runtime_reverse_i32_step_truncation_reports_true_loop(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             start: input signed logic<64>,
@@ -444,6 +449,7 @@ fn test_runtime_reverse_i32_step_truncation_reports_true_loop(sim) {
 }
 
 fn test_runtime_break_in_synth_comb_loop(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             count: input logic<32>,
@@ -471,6 +477,7 @@ fn test_runtime_break_in_synth_comb_loop(sim) {
 }
 
 fn test_runtime_break_after_assign_in_synth_comb_loop(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             count: input logic<32>,
@@ -499,6 +506,7 @@ fn test_runtime_break_after_assign_in_synth_comb_loop(sim) {
 }
 
 fn test_runtime_if_without_break_in_synth_comb_loop(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             count: input logic<32>,
@@ -528,6 +536,7 @@ fn test_runtime_if_without_break_in_synth_comb_loop(sim) {
 }
 
 fn test_runtime_bounds_stalled_step_with_break_exits_cleanly(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             start: input logic<32>,
@@ -561,7 +570,7 @@ fn test_runtime_bounds_stalled_step_with_break_exits_cleanly(sim) {
 }
 
 fn test_runtime_bounds_stalled_step_with_break_guard_false_reports_true_loop(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             start: input logic<32>,
@@ -593,7 +602,7 @@ fn test_runtime_bounds_stalled_step_with_break_guard_false_reports_true_loop(sim
 }
 
 fn test_runtime_bounds_signed_inclusive_range_preserves_negative_bounds(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             start: input logic<32>,
@@ -626,6 +635,7 @@ fn test_runtime_bounds_signed_inclusive_range_preserves_negative_bounds(sim) {
 }
 
 fn test_runtime_bounds_truncate_loop_var_to_declared_width(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             count: input logic<32>,
@@ -652,6 +662,7 @@ fn test_runtime_bounds_truncate_loop_var_to_declared_width(sim) {
 }
 
 fn test_constant_bounds_preserve_wide_limit_above_loop_width(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             start: input logic<32>,
@@ -678,6 +689,7 @@ fn test_constant_bounds_preserve_wide_limit_above_loop_width(sim) {
 }
 
 fn test_runtime_bounds_track_initial_seed_dependency(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             seed: input logic<32>,
@@ -711,6 +723,7 @@ fn test_runtime_bounds_track_initial_seed_dependency(sim) {
 }
 
 fn test_runtime_bounds_preserve_pre_loop_bits_for_partial_updates(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             seed: input logic<2>,
@@ -740,6 +753,7 @@ fn test_runtime_bounds_preserve_pre_loop_bits_for_partial_updates(sim) {
 }
 
 fn test_runtime_bounds_reconstruct_wide_loop_carried_reads_from_partial_state(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             seed: input logic<2>,
@@ -769,6 +783,7 @@ fn test_runtime_bounds_reconstruct_wide_loop_carried_reads_from_partial_state(si
 }
 
 fn test_runtime_bounds_preserve_untouched_high_bits_for_dynamic_index_reads(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             seed: input logic<2>,
@@ -804,6 +819,7 @@ fn test_runtime_bounds_preserve_untouched_high_bits_for_dynamic_index_reads(sim)
 }
 
 fn test_runtime_bounds_reverse_singleton_exits_cleanly(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             start: input logic<32>,
@@ -831,6 +847,7 @@ fn test_runtime_bounds_reverse_singleton_exits_cleanly(sim) {
 }
 
 fn test_runtime_bounds_track_initial_seed_dependency_across_module_boundary(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Child (
             seed: input logic<32>,
@@ -878,6 +895,7 @@ fn test_runtime_bounds_track_initial_seed_dependency_across_module_boundary(sim)
 }
 
 fn test_runtime_break_condition_dependency_across_module_boundary(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Child (
             sel: input logic,
@@ -928,7 +946,7 @@ fn test_runtime_break_condition_dependency_across_module_boundary(sim) {
 }
 
 fn test_runtime_bounds_stalled_step_reports_true_loop(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             start: input logic<32>,
@@ -954,6 +972,7 @@ fn test_runtime_bounds_stalled_step_reports_true_loop(sim) {
 }
 
 fn test_runtime_bounds_preserve_loop_carried_state_for_indexed_reads(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             count: input logic<32>,
@@ -980,6 +999,7 @@ fn test_runtime_bounds_preserve_loop_carried_state_for_indexed_reads(sim) {
 }
 
 fn test_runtime_bounds_forward_overshoot_exits_without_wraparound(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             start: input logic<32>,
@@ -1009,6 +1029,7 @@ fn test_runtime_bounds_forward_overshoot_exits_without_wraparound(sim) {
 }
 
 fn test_runtime_bounds_large_additive_step_exits_without_wraparound(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             start: input logic<32>,
@@ -1038,6 +1059,7 @@ fn test_runtime_bounds_large_additive_step_exits_without_wraparound(sim) {
 }
 
 fn test_runtime_bounds_inclusive_max_bound_runs_full_range(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             count: input logic<8>,

--- a/crates/celox/tests/system_function.rs
+++ b/crates/celox/tests/system_function.rs
@@ -33,7 +33,7 @@ module Top (
     }
 
     fn test_comb_function_body_onehot_system_function(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(r#"
 module Top (
     d: input logic<8>,
@@ -66,6 +66,7 @@ module Top (
     }
 
     fn test_direct_comb_bits_system_function(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     d: input logic<8>,
@@ -82,7 +83,7 @@ module Top (
     }
 
     fn test_direct_comb_size_system_function(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(r#"
 module Top (
     d: input logic<8>[4],
@@ -127,7 +128,7 @@ module Top (
     }
 
     fn test_comb_function_body_clog2_system_function(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(r#"
 module Top (
     d: input logic<8>,
@@ -161,7 +162,7 @@ module Top (
     }
 
     fn test_comb_function_body_bits_size_system_functions(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(r#"
 module Top (
     d: input logic<8>[4],
@@ -194,6 +195,7 @@ module Top (
     }
 
     fn test_direct_comb_signed_system_function_sign_extends_to_context(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     d: input logic<8>,
@@ -213,6 +215,7 @@ module Top (
     }
 
     fn test_direct_comb_unsigned_system_function_zero_extends_to_context(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     d: input logic<8>,
@@ -232,7 +235,7 @@ module Top (
     }
 
     fn test_direct_comb_signed_unsigned_system_functions_affect_comparison(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(r#"
 module Top (
     d: input logic<8>,
@@ -262,6 +265,7 @@ module Top (
     }
 
     fn test_comb_function_body_signed_unsigned_system_functions(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     d: input logic<8>,
@@ -297,6 +301,7 @@ module Top (
     }
 
     fn test_direct_comb_bits_type_system_function(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     q: output logic<32>,
@@ -312,6 +317,7 @@ module Top (
     }
 
     fn test_direct_ff_bits_system_function(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -332,6 +338,7 @@ module Top (
     }
 
     fn test_direct_ff_bits_type_system_function(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -351,7 +358,7 @@ module Top (
     }
 
     fn test_direct_ff_bits_array_system_function(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -372,7 +379,7 @@ module Top (
     }
 
     fn test_direct_ff_size_system_function(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -393,6 +400,7 @@ module Top (
     }
 
     fn test_direct_ff_size_type_system_function(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -484,7 +492,7 @@ module Top (
     }
 
     fn test_ff_function_body_clog2_system_function(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -521,6 +529,7 @@ module Top (
     }
 
     fn test_direct_ff_signed_system_function(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -543,6 +552,7 @@ module Top (
     }
 
     fn test_direct_ff_signed_system_function_sign_extends_to_context(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -565,6 +575,7 @@ module Top (
     }
 
     fn test_direct_ff_unsigned_system_function(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -587,6 +598,7 @@ module Top (
     }
 
     fn test_direct_ff_unsigned_system_function_zero_extends_to_context(sim) {
+        @ignore_on(sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,
@@ -639,7 +651,7 @@ module Top (
     }
 
     fn test_ff_function_body_onehot_system_function(sim) {
-        @ignore_on(veryl);
+        @ignore_on(veryl, sv);
         @build Simulator::builder(r#"
 module Top (
     clk: input clock,

--- a/crates/celox/tests/test_unimplemented_paths.rs
+++ b/crates/celox/tests/test_unimplemented_paths.rs
@@ -36,7 +36,7 @@ fn wide_dynamic_shift_works(sim) {
 // Dynamic offset Store with 4-state mask: array write with variable index
 // on a logic (4-state) type must correctly store the mask.
 fn dynamic_mask_store(sim) {
-    @ignore_on(veryl);
+    @ignore_on(veryl, sv);
     @setup { let code = r#"
         module Top (
             clk: input '_ clock,

--- a/crates/celox/tests/test_utils/mod.rs
+++ b/crates/celox/tests/test_utils/mod.rs
@@ -1,89 +1,136 @@
 pub mod veryl_sim;
+pub mod veryl_sv;
 
 #[path = "../fixtures/veryl_std.rs"]
 #[allow(dead_code)]
 pub mod veryl_std;
 
-/// Generates four `#[test]` functions (native, cranelift, wasm, veryl) per test.
+/// Generates native, cranelift, wasm, and Veryl reference tests, plus an SV
+/// frontend test when the `systemverilog` feature is enabled.
 ///
 /// ```rust
 /// all_backends! {
-///     // Simple
 ///     fn test_a(sim) {
 ///         @build Simulator::builder(r#"..."#, "Top");
 ///         assert_eq!(sim.get(sim.signal("o")), 1u8.into());
 ///     }
-///
-///     // With setup (variables survive into body)
-///     fn test_b(sim) {
-///         @setup { let code = format!("{SRC}\n{extra}"); }
-///         @build Simulator::builder(&code, "Top");
-///         assert_eq!(sim.get(sim.signal("o")), 1u8.into());
-///     }
-///
-///     // Ignore only when the backend constructs and runs the design but its
-///     // observable result differs from the expected behavior.
-///     fn test_c(sim) {
-///         @ignore_on(wasm);
-///         @build Simulator::builder(r#"..."#, "Top");
-///         assert_eq!(sim.get(sim.signal("o")), 1u8.into());
-///     }
-///
-///     fn test_d(sim) {
-///         @ignore_on(wasm, cranelift);
-///         @setup { let code = format!("..."); }
-///         @build Simulator::builder(&code, "Top");
-///         assert_eq!(sim.get(sim.signal("o")), 1u8.into());
-///     }
-///
-///     // Omit only the Veryl variant when the reference simulation cannot be
-///     // constructed or the shared Rust test body does not apply to its API.
-///     fn test_e(sim) {
-///         @omit_veryl;
-///         @build Simulator::builder(r#"..."#, "Top");
-///     }
 /// }
 /// ```
 macro_rules! all_backends {
-    // ── internal: emit veryl test ───────────────────────────────────
+    // ── internal: add #[ignore] when a backend is in the ignore list ──
+    (@with_ignore native; (); { $($item:tt)* }) => { $($item)* };
+    (@with_ignore native; (native $(, $rest:ident)*); { $($item:tt)* }) => {
+        #[ignore]
+        $($item)*
+    };
+    (@with_ignore native; ($first:ident $(, $rest:ident)*); { $($item:tt)* }) => {
+        all_backends!(@with_ignore native; ($($rest),*); { $($item)* });
+    };
+
+    (@with_ignore cranelift; (); { $($item:tt)* }) => { $($item)* };
+    (@with_ignore cranelift; (cranelift $(, $rest:ident)*); { $($item:tt)* }) => {
+        #[ignore]
+        $($item)*
+    };
+    (@with_ignore cranelift; ($first:ident $(, $rest:ident)*); { $($item:tt)* }) => {
+        all_backends!(@with_ignore cranelift; ($($rest),*); { $($item)* });
+    };
+
+    (@with_ignore wasm; (); { $($item:tt)* }) => { $($item)* };
+    (@with_ignore wasm; (wasm $(, $rest:ident)*); { $($item:tt)* }) => {
+        #[ignore]
+        $($item)*
+    };
+    (@with_ignore wasm; ($first:ident $(, $rest:ident)*); { $($item:tt)* }) => {
+        all_backends!(@with_ignore wasm; ($($rest),*); { $($item)* });
+    };
+
+    (@with_ignore sv; (); { $($item:tt)* }) => { $($item)* };
+    (@with_ignore sv; (sv $(, $rest:ident)*); { $($item:tt)* }) => {
+        #[ignore]
+        $($item)*
+    };
+    (@with_ignore sv; ($first:ident $(, $rest:ident)*); { $($item:tt)* }) => {
+        all_backends!(@with_ignore sv; ($($rest),*); { $($item)* });
+    };
+
+    (@with_ignore veryl; (); { $($item:tt)* }) => { $($item)* };
+    (@with_ignore veryl; (veryl $(, $rest:ident)*); { $($item:tt)* }) => {
+        #[ignore]
+        $($item)*
+    };
+    (@with_ignore veryl; ($first:ident $(, $rest:ident)*); { $($item:tt)* }) => {
+        all_backends!(@with_ignore veryl; ($($rest),*); { $($item)* });
+    };
+
+    // ── internal: emit the SV frontend test ─────────────────────────
+    (@sv_fn
+        $(#[$meta:meta])* fn $name:ident ($sim:ident)
+        ignore_list { $ignore_list:tt }
+        setup { $($setup:tt)* }
+        build { $builder:expr }
+        body { $($body:tt)* }
+    ) => {
+        all_backends!(@with_ignore sv; $ignore_list; {
+            #[cfg(feature = "systemverilog")]
+            #[test]
+            $(#[$meta])*
+            #[allow(unused_mut, unused_variables)]
+            fn sv() {
+                $($setup)*
+                let __builder = { $builder };
+                let __emitted = test_utils::veryl_sv::emit_veryl_sources(__builder.sources());
+                let __sv_sources = __emitted.as_sv_sources();
+                let mut $sim = celox::Simulator::from_sv_sources(
+                    __sv_sources,
+                    __builder.top(),
+                )
+                .four_state(__builder.four_state_enabled())
+                .build()
+                .unwrap();
+                $($body)*
+            }
+        });
+    };
+
+    // ── internal: emit the Veryl reference test ─────────────────────
     (@veryl_fn
         $(#[$meta:meta])* fn $name:ident ($sim:ident)
-        veryl_extra { $(#[$va:meta])* }
+        ignore_list { $ignore_list:tt }
         emit
         setup { $($setup:tt)* }
         build { $builder:expr }
         body { $($body:tt)* }
     ) => {
-        #[test]
-        $(#[$meta])*
-        $(#[$va])*
-        #[allow(unused_mut, unused_variables)]
-        fn veryl() {
-            $($setup)*
-            let __builder = { $builder };
-            let mut $sim = test_utils::veryl_sim::build_veryl_adapter(
-                __builder.sources(), __builder.top(), __builder.four_state_enabled()
-            );
-            $($body)*
-        }
+        all_backends!(@with_ignore veryl; $ignore_list; {
+            #[test]
+            $(#[$meta])*
+            #[allow(unused_mut, unused_variables)]
+            fn veryl() {
+                $($setup)*
+                let __builder = { $builder };
+                let mut $sim = test_utils::veryl_sim::build_veryl_adapter(
+                    __builder.sources(),
+                    __builder.top(),
+                    __builder.four_state_enabled(),
+                );
+                $($body)*
+            }
+        });
     };
-    // ── internal: omit veryl test (incompatible API) ────────────────
     (@veryl_fn
         $(#[$meta:meta])* fn $name:ident ($sim:ident)
-        veryl_extra { $(#[$va:meta])* }
+        ignore_list { $ignore_list:tt }
         skip
         setup { $($setup:tt)* }
         build { $builder:expr }
         body { $($body:tt)* }
-    ) => { /* veryl variant not emitted */ };
+    ) => {};
 
-    // ── internal: implementation with per-backend ignore ─────────────
+    // ── internal: generate each backend ─────────────────────────────
     (@impl
         $(#[$meta:meta])* fn $name:ident ($sim:ident)
-        native_extra { $(#[$na:meta])* }
-        cranelift_extra { $(#[$ca:meta])* }
-        wasm_extra { $(#[$wa:meta])* }
-        veryl_extra { $(#[$va:meta])* }
+        ignore_list { $ignore_list:tt }
         veryl_mode { $veryl_mode:ident }
         setup { $($setup:tt)* }
         build { $builder:expr }
@@ -92,43 +139,54 @@ macro_rules! all_backends {
         mod $name {
             use super::*;
 
-            #[test]
-            #[cfg(any(
-                target_arch = "x86_64",
-                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
-            ))]
-            $(#[$meta])*
-            $(#[$na])*
-            #[allow(unused_mut, unused_variables)]
-            fn native() {
-                $($setup)*
-                let mut $sim = { $builder }.build_native().unwrap();
-                $($body)*
-            }
+            all_backends!(@with_ignore native; $ignore_list; {
+                #[test]
+                #[cfg(any(
+                    target_arch = "x86_64",
+                    all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                ))]
+                $(#[$meta])*
+                #[allow(unused_mut, unused_variables)]
+                fn native() {
+                    $($setup)*
+                    let mut $sim = { $builder }.build_native().unwrap();
+                    $($body)*
+                }
+            });
 
-            #[test]
-            $(#[$meta])*
-            $(#[$ca])*
-            #[allow(unused_mut, unused_variables)]
-            fn cranelift() {
-                $($setup)*
-                let mut $sim = { $builder }.build_cranelift().unwrap();
-                $($body)*
-            }
+            all_backends!(@with_ignore cranelift; $ignore_list; {
+                #[test]
+                $(#[$meta])*
+                #[allow(unused_mut, unused_variables)]
+                fn cranelift() {
+                    $($setup)*
+                    let mut $sim = { $builder }.build_cranelift().unwrap();
+                    $($body)*
+                }
+            });
 
-            #[test]
-            $(#[$meta])*
-            $(#[$wa])*
-            #[allow(unused_mut, unused_variables)]
-            fn wasm() {
-                $($setup)*
-                let mut $sim = { $builder }.build_wasm().unwrap();
-                $($body)*
-            }
+            all_backends!(@with_ignore wasm; $ignore_list; {
+                #[test]
+                $(#[$meta])*
+                #[allow(unused_mut, unused_variables)]
+                fn wasm() {
+                    $($setup)*
+                    let mut $sim = { $builder }.build_wasm().unwrap();
+                    $($body)*
+                }
+            });
+
+            all_backends!(@sv_fn
+                $(#[$meta])* fn $name ($sim)
+                ignore_list { $ignore_list }
+                setup { $($setup)* }
+                build { $builder }
+                body { $($body)* }
+            );
 
             all_backends!(@veryl_fn
                 $(#[$meta])* fn $name ($sim)
-                veryl_extra { $(#[$va])* }
+                ignore_list { $ignore_list }
                 $veryl_mode
                 setup { $($setup)* }
                 build { $builder }
@@ -137,384 +195,17 @@ macro_rules! all_backends {
         }
     };
 
-    // ── internal: resolve @ignore_on into per-backend extra attrs ────
-    //
-    // Helper: given a comma-separated list of backend names inside parens,
-    // set #[ignore] on each named backend and leave the rest empty.
-    // We enumerate all combinations up to 4 backends.
-
-    // ── single backend ──
-    (@resolve_ignore (wasm) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (cranelift) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { #[ignore] } wasm_extra { } veryl_extra { } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (native) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { } wasm_extra { } veryl_extra { } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (veryl) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { } wasm_extra { } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-
-    // ── two backends ──
-    (@resolve_ignore (wasm, cranelift) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (cranelift, wasm) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (native, wasm) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (wasm, native) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (native, cranelift) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { } veryl_extra { } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (cranelift, native) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { } veryl_extra { } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (native, veryl) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { } wasm_extra { } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (veryl, native) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { } wasm_extra { } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (cranelift, veryl) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { #[ignore] } wasm_extra { } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (veryl, cranelift) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { #[ignore] } wasm_extra { } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (wasm, veryl) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { } wasm_extra { #[ignore] } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (veryl, wasm) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { } wasm_extra { #[ignore] } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-
-    // ── three backends ──
-    (@resolve_ignore (wasm, cranelift, veryl) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (wasm, veryl, cranelift) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (cranelift, wasm, veryl) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (cranelift, veryl, wasm) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (veryl, wasm, cranelift) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (veryl, cranelift, wasm) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (native, wasm, veryl) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { } wasm_extra { #[ignore] } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (native, veryl, wasm) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { } wasm_extra { #[ignore] } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (wasm, native, veryl) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { } wasm_extra { #[ignore] } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (wasm, veryl, native) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { } wasm_extra { #[ignore] } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (veryl, native, wasm) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { } wasm_extra { #[ignore] } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (veryl, wasm, native) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { } wasm_extra { #[ignore] } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (native, cranelift, veryl) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (native, veryl, cranelift) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (cranelift, native, veryl) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (cranelift, veryl, native) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (veryl, native, cranelift) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (veryl, cranelift, native) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { } veryl_extra { #[ignore] } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (native, cranelift, wasm) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (native, wasm, cranelift) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (cranelift, native, wasm) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (cranelift, wasm, native) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (wasm, native, cranelift) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore (wasm, cranelift, native) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { emit }
-            $($rest)*
-        );
-    };
-
-    // ── internal: @impl_with_ignore → @impl passthrough ─────────────
-    (@impl_with_ignore
-        native_extra { $(#[$na:meta])* }
-        cranelift_extra { $(#[$ca:meta])* }
-        wasm_extra { $(#[$wa:meta])* }
-        veryl_extra { $(#[$va:meta])* }
-        veryl_mode { $veryl_mode:ident }
-        $(#[$meta:meta])* fn $name:ident ($sim:ident)
-        setup { $($setup:tt)* }
-        build { $builder:expr }
-        body { $($body:tt)* }
-    ) => {
-        all_backends!(@impl
-            $(#[$meta])* fn $name ($sim)
-            native_extra { $(#[$na])* }
-            cranelift_extra { $(#[$ca])* }
-            wasm_extra { $(#[$wa])* }
-            veryl_extra { $(#[$va])* }
-            veryl_mode { $veryl_mode }
-            setup { $($setup)* }
-            build { $builder }
-            body { $($body)* }
-        );
-    };
-
-    // ── internal: resolve @ignore_on with forced omit_veryl ──────────
-    (@resolve_ignore_omit_veryl (wasm) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { skip }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore_omit_veryl (cranelift) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { #[ignore] } wasm_extra { } veryl_extra { } veryl_mode { skip }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore_omit_veryl (native) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { } wasm_extra { } veryl_extra { } veryl_mode { skip }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore_omit_veryl (wasm, cranelift) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { skip }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore_omit_veryl (cranelift, wasm) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { skip }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore_omit_veryl (native, wasm) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { skip }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore_omit_veryl (wasm, native) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { skip }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore_omit_veryl (native, cranelift) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { } veryl_extra { } veryl_mode { skip }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore_omit_veryl (cranelift, native) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { } veryl_extra { } veryl_mode { skip }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore_omit_veryl (native, cranelift, wasm) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { skip }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore_omit_veryl (native, wasm, cranelift) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { skip }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore_omit_veryl (cranelift, native, wasm) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { skip }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore_omit_veryl (cranelift, wasm, native) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { skip }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore_omit_veryl (wasm, native, cranelift) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { skip }
-            $($rest)*
-        );
-    };
-    (@resolve_ignore_omit_veryl (wasm, cranelift, native) -> $($rest:tt)*) => {
-        all_backends!(@impl_with_ignore
-            native_extra { #[ignore] } cranelift_extra { #[ignore] } wasm_extra { #[ignore] } veryl_extra { } veryl_mode { skip }
-            $($rest)*
-        );
-    };
-
-    // ── internal: dispatch per body shape ────────────────────────────
+    // ── internal: dispatch per body shape ───────────────────────────
 
     // @omit_veryl + @ignore_on + @setup + @build
     (@dispatch
         $(#[$meta:meta])* fn $name:ident ($sim:ident)
         { @omit_veryl; @ignore_on $ignore_list:tt; @setup { $($setup:tt)* } @build $builder:expr; $($body:tt)* }
     ) => {
-        all_backends!(@resolve_ignore_omit_veryl $ignore_list ->
+        all_backends!(@impl
             $(#[$meta])* fn $name ($sim)
+            ignore_list { $ignore_list }
+            veryl_mode { skip }
             setup { $($setup)* }
             build { $builder }
             body { $($body)* }
@@ -526,8 +217,10 @@ macro_rules! all_backends {
         $(#[$meta:meta])* fn $name:ident ($sim:ident)
         { @omit_veryl; @ignore_on $ignore_list:tt; @build $builder:expr; $($body:tt)* }
     ) => {
-        all_backends!(@resolve_ignore_omit_veryl $ignore_list ->
+        all_backends!(@impl
             $(#[$meta])* fn $name ($sim)
+            ignore_list { $ignore_list }
+            veryl_mode { skip }
             setup { }
             build { $builder }
             body { $($body)* }
@@ -541,10 +234,7 @@ macro_rules! all_backends {
     ) => {
         all_backends!(@impl
             $(#[$meta])* fn $name ($sim)
-            native_extra { }
-            cranelift_extra { }
-            wasm_extra { }
-            veryl_extra { }
+            ignore_list { () }
             veryl_mode { skip }
             setup { $($setup)* }
             build { $builder }
@@ -559,10 +249,7 @@ macro_rules! all_backends {
     ) => {
         all_backends!(@impl
             $(#[$meta])* fn $name ($sim)
-            native_extra { }
-            cranelift_extra { }
-            wasm_extra { }
-            veryl_extra { }
+            ignore_list { () }
             veryl_mode { skip }
             setup { }
             build { $builder }
@@ -575,8 +262,10 @@ macro_rules! all_backends {
         $(#[$meta:meta])* fn $name:ident ($sim:ident)
         { @ignore_on $ignore_list:tt; @setup { $($setup:tt)* } @build $builder:expr; $($body:tt)* }
     ) => {
-        all_backends!(@resolve_ignore $ignore_list ->
+        all_backends!(@impl
             $(#[$meta])* fn $name ($sim)
+            ignore_list { $ignore_list }
+            veryl_mode { emit }
             setup { $($setup)* }
             build { $builder }
             body { $($body)* }
@@ -588,8 +277,10 @@ macro_rules! all_backends {
         $(#[$meta:meta])* fn $name:ident ($sim:ident)
         { @ignore_on $ignore_list:tt; @build $builder:expr; $($body:tt)* }
     ) => {
-        all_backends!(@resolve_ignore $ignore_list ->
+        all_backends!(@impl
             $(#[$meta])* fn $name ($sim)
+            ignore_list { $ignore_list }
+            veryl_mode { emit }
             setup { }
             build { $builder }
             body { $($body)* }
@@ -603,10 +294,7 @@ macro_rules! all_backends {
     ) => {
         all_backends!(@impl
             $(#[$meta])* fn $name ($sim)
-            native_extra { }
-            cranelift_extra { }
-            wasm_extra { }
-            veryl_extra { }
+            ignore_list { () }
             veryl_mode { emit }
             setup { $($setup)* }
             build { $builder }
@@ -621,10 +309,7 @@ macro_rules! all_backends {
     ) => {
         all_backends!(@impl
             $(#[$meta])* fn $name ($sim)
-            native_extra { }
-            cranelift_extra { }
-            wasm_extra { }
-            veryl_extra { }
+            ignore_list { () }
             veryl_mode { emit }
             setup { }
             build { $builder }

--- a/crates/celox/tests/test_utils/veryl_sv.rs
+++ b/crates/celox/tests/test_utils/veryl_sv.rs
@@ -1,0 +1,99 @@
+//! Helpers for compiling Veryl test sources through the emitted SystemVerilog
+//! frontend.
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+
+use veryl_analyzer::{Analyzer, Context, attribute_table, ir::Ir, symbol_table};
+use veryl_emitter::Emitter;
+use veryl_metadata::Metadata;
+use veryl_parser::Parser;
+
+/// Owned SystemVerilog sources produced from a set of Veryl sources.
+pub struct EmittedSources {
+    sources: Vec<(String, PathBuf)>,
+}
+
+impl EmittedSources {
+    /// Borrow the emitted sources in the form accepted by Celox's SV builder.
+    pub fn as_sv_sources(&self) -> Vec<(&str, &Path)> {
+        self.sources
+            .iter()
+            .map(|(source, path)| (source.as_str(), path.as_path()))
+            .collect()
+    }
+}
+
+/// Analyze and emit every Veryl source in `sources` as SystemVerilog.
+pub fn emit_veryl_sources(sources: &[(&str, &Path)]) -> EmittedSources {
+    symbol_table::clear();
+    attribute_table::clear();
+
+    let mut metadata = Metadata::create_default("prj").unwrap();
+    // Celox's Veryl frontend uses unprefixed module names for in-memory test
+    // sources, so make the emitted hierarchy use the same names.
+    metadata.build.omit_project_prefix = true;
+    metadata.build.strip_comments = true;
+
+    let analyzer = Analyzer::new(&metadata);
+    let mut parsed_sources = Vec::with_capacity(sources.len());
+
+    for (code, path) in sources {
+        let parsed = Parser::parse(code, path).unwrap_or_else(|error| {
+            panic!("failed to parse Veryl source {}: {error}", path.display())
+        });
+        let errors = analyzer.analyze_pass1("prj", &parsed.veryl);
+        assert!(
+            !errors.iter().any(|error| error.is_error()),
+            "Veryl analyze_pass1 errors in {}: {errors:?}",
+            path.display()
+        );
+        parsed_sources.push((*code, *path, parsed));
+    }
+
+    let errors = Analyzer::analyze_post_pass1();
+    assert!(
+        !errors.iter().any(|error| error.is_error()),
+        "Veryl analyze_post_pass1 errors: {errors:?}"
+    );
+
+    let mut context = Context::default();
+    let mut ir = Ir::default();
+    for (_, _, parsed) in &parsed_sources {
+        let errors = analyzer.analyze_pass2(&parsed.veryl, &mut context, Some(&mut ir));
+        assert!(
+            !errors.iter().any(|error| error.is_error()),
+            "Veryl analyze_pass2 errors: {errors:?}"
+        );
+    }
+
+    let errors = Analyzer::analyze_post_pass2(&ir);
+    assert!(
+        !errors.iter().any(|error| error.is_error()),
+        "Veryl analyze_post_pass2 errors: {errors:?}"
+    );
+
+    let emitted = parsed_sources
+        .into_iter()
+        .enumerate()
+        .map(|(index, (code, source_path, parsed))| {
+            let output_path = emitted_path(index, source_path);
+            let map_path = output_path.with_extension("sv.map");
+            let mut emitter = Emitter::new(&metadata, "prj", source_path, &output_path, &map_path);
+            emitter.emit(&parsed.veryl, code);
+            (emitter.as_str().to_string(), output_path)
+        })
+        .collect();
+
+    EmittedSources { sources: emitted }
+}
+
+fn emitted_path(index: usize, source_path: &Path) -> PathBuf {
+    if source_path.as_os_str().is_empty() {
+        PathBuf::from(format!("source_{index}.sv"))
+    } else {
+        let mut path = source_path.to_path_buf();
+        path.set_extension("sv");
+        path
+    }
+}

--- a/crates/celox/tests/true_loop.rs
+++ b/crates/celox/tests/true_loop.rs
@@ -11,6 +11,7 @@ all_backends! {
 // assign passes the analyzer (no UnassignVariable), and true_loop
 // declaration allows the SIR scheduler to accept the cycle.
 fn test_converging_true_loop_with_assign(sim) {
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (i: input logic<2>, o: output logic<2>) {
             var v: logic<2>;
@@ -39,6 +40,7 @@ fn test_converging_true_loop_with_assign(sim) {
 fn test_true_loop_oscillation_detected(sim) {
     // The Veryl adapter cannot apply Celox's explicit true-loop guard config.
     @omit_veryl;
+    @ignore_on(sv);
     @setup {
     // v[0] = ~v[1] & a, v[1] = v[0]
     // When a=1: v[0]=~v[1], v[1]=v[0] → oscillates (0,0)→(1,0)→(1,1)→(0,1)→(0,0)→...
@@ -71,6 +73,7 @@ fn test_true_loop_oscillation_detected(sim) {
 fn test_runtime_true_loop_reports_only_failing_scc(sim) {
     // The Veryl adapter cannot apply Celox's explicit true-loop guard config.
     @omit_veryl;
+    @ignore_on(sv);
     @setup {
     let code = r#"
         module Top (

--- a/crates/celox/tests/wide_context_width.rs
+++ b/crates/celox/tests/wide_context_width.rs
@@ -75,6 +75,7 @@ assign o = a - b;
     }
 
     fn test_wide_context_shift_left(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 i: input  logic<64>,
@@ -126,6 +127,7 @@ o = 64'hffff_ffff_ffff_ffff + 64'h1;
     }
 
     fn test_wide_runtime_shift_width_behavior(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 i: input  logic<64>,
@@ -208,6 +210,7 @@ o = 32'hffff_ffff + 1;
     }
 
     fn test_wide_context_multiplication_boundary(sim) {
+        @ignore_on(sv);
         @setup { // 64-bit * 64-bit in 128-bit context
 let code = r#"
 module Top (

--- a/crates/celox/tests/wide_operators.rs
+++ b/crates/celox/tests/wide_operators.rs
@@ -563,6 +563,7 @@ assign r = a % b;
 
     // 128-bit XNOR in always_comb.
     fn test_wide_comb_bitxnor(sim) {
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 a: input  logic<128>,

--- a/crates/celox/tests/wide_shift_mem.rs
+++ b/crates/celox/tests/wide_shift_mem.rs
@@ -706,6 +706,7 @@ assign o = a >> amt;
     // Without padding, load_or_default reads uninitialised memory beyond the
     // source slot, producing garbage in the upper chunks.
     fn test_narrow_source_wide_dest_shift_left(sim) {
+        @ignore_on(sv);
         @setup { // dst is 512-bit (8 chunks), lhs is 256-bit (4 chunks).
 // common_logical_width = max(512, 256, 64) = 512 → num_chunks = 8.
 // Source slot must be 8 chunks with chunks 4..7 zeroed.
@@ -751,6 +752,7 @@ assign o = (a as 512) << amt;
     }
 
     fn test_narrow_source_wide_dest_shift_right(sim) {
+        @ignore_on(sv);
         @setup { // dst is 512-bit, lhs is 256-bit (cast up).
 // Right-shifting should see zeros in the upper chunks, not garbage.
 let code = r#"


### PR DESCRIPTION
## Summary

- Run `all_backends!` Veryl test sources through `veryl-emitter` and Celox's SystemVerilog frontend.
- Add `@ignore_on(sv)` for cases unsupported by the current SV frontend.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p celox --tests --features systemverilog`
- `cargo test -p celox --features systemverilog --tests --quiet`
- `cargo clippy -p celox --tests --features systemverilog --no-deps`
