### PR TITLE
feat(frontend-sv): support fixed unpacked arrays

### DIFF
--- a/crates/celox-frontend-sv/src/lowering.rs
+++ b/crates/celox-frontend-sv/src/lowering.rs
@@ -3991,6 +3991,19 @@ fn dynamic_array_base_has_stride(
             dynamic_array_base_has_stride(left, element_width, constants, parameter_types)
                 || dynamic_array_base_has_stride(right, element_width, constants, parameter_types)
         }
+        sv::ir::ConstExpr::Mux {
+            then_expr,
+            else_expr,
+            ..
+        } => {
+            dynamic_array_base_has_stride(then_expr, element_width, constants, parameter_types)
+                || dynamic_array_base_has_stride(
+                    else_expr,
+                    element_width,
+                    constants,
+                    parameter_types,
+                )
+        }
         _ => false,
     }
 }
@@ -4750,23 +4763,25 @@ fn emit_ff_assignment_stores(
                     parameter_types,
                     element_width,
                 )?;
-                let store_value = match assignment.condition() {
+                let element_count = variable.width.checked_div(element_width)?;
+                let (index, valid) = dynamic_array_index_guard_sir(builder, index, element_count)?;
+                let old = builder.alloc_logic(target_width);
+                builder.emit(SIRInstruction::Load(
+                    old,
+                    RegionedVarAddrBase {
+                        region: WORKING_REGION,
+                        var_id: target_id,
+                    },
+                    SIROffset::Element {
+                        index,
+                        element_width,
+                        bit_offset: 0,
+                        dynamic_bit_offset: None,
+                    },
+                    target_width,
+                ));
+                let selected_value = match assignment.condition() {
                     Some(condition) => {
-                        let old = builder.alloc_logic(target_width);
-                        builder.emit(SIRInstruction::Load(
-                            old,
-                            RegionedVarAddrBase {
-                                region: WORKING_REGION,
-                                var_id: target_id,
-                            },
-                            SIROffset::Element {
-                                index,
-                                element_width,
-                                bit_offset: 0,
-                                dynamic_bit_offset: None,
-                            },
-                            target_width,
-                        ));
                         let condition = lower_procedural_condition(
                             builder,
                             condition,
@@ -4781,6 +4796,8 @@ fn emit_ff_assignment_stores(
                     }
                     None => rhs,
                 };
+                let store_value = builder.alloc_logic(target_width);
+                builder.emit(SIRInstruction::Mux(store_value, valid, selected_value, old));
                 builder.emit(SIRInstruction::Store(
                     RegionedVarAddrBase {
                         region: WORKING_REGION,

--- a/crates/celox-frontend-sv/src/lowering.rs
+++ b/crates/celox-frontend-sv/src/lowering.rs
@@ -1685,7 +1685,7 @@ fn lower_dynamic_output_glue(
     let sv::ir::Expr::Select { expr, msb, lsb, .. } = actual_expr else {
         return Ok(None);
     };
-    let Some((parent_signal_id, element_width)) = dynamic_array_element_selection(
+    let Some((parent_signal_id, element_width, access)) = dynamic_array_element_subselection(
         expr,
         msb,
         lsb,
@@ -1731,7 +1731,8 @@ fn lower_dynamic_output_glue(
         index: Vec::new(),
         access: BitAccess::new(0, child_var.width - 1),
     })?;
-    let child_expr = coerce_node_width(arena, child_node, Some(element_width), child_var.signed)?;
+    let target_width = access.msb - access.lsb + 1;
+    let child_expr = coerce_node_width(arena, child_node, Some(target_width), child_var.signed)?;
     let old = arena.alloc(SLTNode::Input {
         variable: GlueAddr::Parent(parent_signal_id),
         signed: parent_var.signed,
@@ -1752,9 +1753,19 @@ fn lower_dynamic_output_glue(
             false,
         ))?;
         let condition = arena.alloc(SLTNode::Binary(offset, BinaryOp::EqCase, element_literal))?;
+        let Some(updated_element) = replace_slt_slice(
+            arena,
+            old_element,
+            child_expr,
+            access.lsb,
+            target_width,
+            element_width,
+        ) else {
+            return Ok(None);
+        };
         let updated = arena.alloc(SLTNode::Mux {
             cond: condition,
-            then_expr: child_expr,
+            then_expr: updated_element,
             else_expr: old_element,
         })?;
         parts.push((updated, element_width));
@@ -1945,8 +1956,13 @@ fn lower_glue_parent_expr(
                         access,
                     })
                     .ok()?;
-                let node =
-                    guard_dynamic_array_read_slt(arena, valid, node, access.msb - access.lsb + 1)?;
+                let node = guard_dynamic_array_read_slt(
+                    arena,
+                    valid,
+                    node,
+                    access.msb - access.lsb + 1,
+                    variable.is_4state,
+                )?;
                 sources.insert(VarAtomBase::new(
                     GlueAddr::Parent(id),
                     0,
@@ -3017,8 +3033,8 @@ fn lower_dynamic_array_write_expr(
     ))
 }
 
-fn replace_slt_slice(
-    arena: &mut SLTNodeArena<SourceVarId>,
+fn replace_slt_slice<A: std::hash::Hash + Eq + Clone>(
+    arena: &mut SLTNodeArena<A>,
     current: NodeId,
     replacement: NodeId,
     lsb: usize,
@@ -3358,8 +3374,13 @@ fn lower_expr_with_context(
                         access,
                     })
                     .ok()?;
-                let node =
-                    guard_dynamic_array_read_slt(arena, valid, node, access.msb - access.lsb + 1)?;
+                let node = guard_dynamic_array_read_slt(
+                    arena,
+                    valid,
+                    node,
+                    access.msb - access.lsb + 1,
+                    variable.is_4state,
+                )?;
                 sources.insert(VarAtomBase::new(id, 0, variable.width.checked_sub(1)?));
                 return Some((
                     coerce_node_width(
@@ -3902,48 +3923,6 @@ fn expr_from_const_expr(expr: &sv::ir::ConstExpr) -> Option<sv::ir::Expr> {
     })
 }
 
-fn const_expr_adds_constant(
-    expr: &sv::ir::ConstExpr,
-    base: &sv::ir::ConstExpr,
-    value: i128,
-    constants: &HashMap<String, i128>,
-    parameter_types: &HashMap<String, (usize, bool)>,
-) -> bool {
-    let sv::ir::ConstExpr::Binary { left, op, right } = expr else {
-        return false;
-    };
-    *op == sv::ir::BinaryOp::Add
-        && ((left.as_ref() == base
-            && sv::typecheck::eval_const_expr_with_types(right, constants, parameter_types)
-                == Some(value))
-            || (right.as_ref() == base
-                && sv::typecheck::eval_const_expr_with_types(left, constants, parameter_types)
-                    == Some(value)))
-}
-
-fn dynamic_array_element_selection(
-    expr: &sv::ir::Expr,
-    msb: &sv::ir::ConstExpr,
-    lsb: &sv::ir::ConstExpr,
-    variables: &HashMap<SourceVarId, SvVariable>,
-    name_to_id: &HashMap<String, SourceVarId>,
-    constants: &HashMap<String, i128>,
-    parameter_types: &HashMap<String, (usize, bool)>,
-) -> Option<(SourceVarId, usize)> {
-    let sv::ir::Expr::Ident(name) = expr else {
-        return None;
-    };
-    dynamic_array_element_access(
-        name,
-        msb,
-        lsb,
-        variables,
-        name_to_id,
-        constants,
-        parameter_types,
-    )
-}
-
 fn dynamic_array_element_subselection(
     expr: &sv::ir::Expr,
     msb: &sv::ir::ConstExpr,
@@ -4096,36 +4075,6 @@ fn dynamic_array_element_lvalue(
     (access.msb < element_width).then_some((id, element_width, offset, access))
 }
 
-fn dynamic_array_element_access(
-    name: &str,
-    msb: &sv::ir::ConstExpr,
-    lsb: &sv::ir::ConstExpr,
-    variables: &HashMap<SourceVarId, SvVariable>,
-    name_to_id: &HashMap<String, SourceVarId>,
-    constants: &HashMap<String, i128>,
-    parameter_types: &HashMap<String, (usize, bool)>,
-) -> Option<(SourceVarId, usize)> {
-    let id = *name_to_id.get(name)?;
-    let variable = variables.get(&id)?;
-    let element_width = unpacked_element_width(variable).filter(|width| *width != 0)?;
-    let is_dynamic = sv::typecheck::eval_const_expr_with_types(msb, constants, parameter_types)
-        .is_none()
-        || sv::typecheck::eval_const_expr_with_types(lsb, constants, parameter_types).is_none();
-    if !is_dynamic
-        || (element_width > 1
-            && !const_expr_adds_constant(
-                msb,
-                lsb,
-                i128::try_from(element_width - 1).ok()?,
-                constants,
-                parameter_types,
-            ))
-    {
-        return None;
-    }
-    Some((id, element_width))
-}
-
 fn lower_dynamic_array_element_index_slt(
     offset: &sv::ir::ConstExpr,
     variables: &HashMap<SourceVarId, SvVariable>,
@@ -4213,8 +4162,13 @@ fn guard_dynamic_array_read_slt<A: std::hash::Hash + Eq + Clone>(
     valid: NodeId,
     value: NodeId,
     value_width: usize,
+    is_4state: bool,
 ) -> Option<NodeId> {
-    let unknown_mask = (BigUint::from(1u8) << value_width) - BigUint::from(1u8);
+    let unknown_mask = if is_4state {
+        (BigUint::from(1u8) << value_width) - BigUint::from(1u8)
+    } else {
+        BigUint::default()
+    };
     let unknown = arena
         .alloc(SLTNode::Constant(
             BigUint::default(),
@@ -4318,13 +4272,18 @@ fn guard_dynamic_array_read_sir(
     valid: celox_sir::RegisterId,
     value: celox_sir::RegisterId,
     value_width: usize,
+    is_4state: bool,
 ) -> celox_sir::RegisterId {
     let unknown = builder.alloc_logic(value_width);
-    let unknown_mask = (BigUint::from(1u8) << value_width) - BigUint::from(1u8);
-    builder.emit(SIRInstruction::Imm(
-        unknown,
-        SIRValue::new_four_state(BigUint::default(), unknown_mask),
-    ));
+    if is_4state {
+        let unknown_mask = (BigUint::from(1u8) << value_width) - BigUint::from(1u8);
+        builder.emit(SIRInstruction::Imm(
+            unknown,
+            SIRValue::new_four_state(BigUint::default(), unknown_mask),
+        ));
+    } else {
+        builder.emit(SIRInstruction::Imm(unknown, SIRValue::new(0u8)));
+    }
     let guarded = builder.alloc_logic(value_width);
     builder.emit(SIRInstruction::Mux(guarded, valid, value, unknown));
     guarded
@@ -5523,7 +5482,8 @@ fn lower_expr_to_sir_with_context(
                     element_width,
                 )?;
                 let width = access.msb - access.lsb + 1;
-                let element_count = variables.get(&id)?.width.checked_div(element_width)?;
+                let variable = variables.get(&id)?;
+                let element_count = variable.width.checked_div(element_width)?;
                 let (index, valid) = dynamic_array_index_guard_sir(builder, index, element_count)?;
                 let reg = builder.alloc_logic(width);
                 builder.emit(SIRInstruction::Load(
@@ -5540,7 +5500,8 @@ fn lower_expr_to_sir_with_context(
                     },
                     width,
                 ));
-                let reg = guard_dynamic_array_read_sir(builder, valid, reg, width);
+                let reg =
+                    guard_dynamic_array_read_sir(builder, valid, reg, width, variable.is_4state);
                 return resize_sir_register(
                     builder,
                     reg,

--- a/crates/celox-frontend-sv/src/lowering.rs
+++ b/crates/celox-frontend-sv/src/lowering.rs
@@ -2172,7 +2172,8 @@ fn signal_type_from_sv(
                     constants,
                     parameter_types,
                 )?;
-                acc.checked_mul(left.abs_diff(right) as usize + 1)
+                let width = usize::try_from(left.abs_diff(right)).ok()?.checked_add(1)?;
+                acc.checked_mul(width)
             })
             .or_else(|| typ.resolved_width())
             .ok_or_else(|| {
@@ -2194,14 +2195,21 @@ fn signal_type_from_sv(
                 constants,
                 parameter_types,
             )?;
-            usize::try_from(left.abs_diff(right) + 1).ok()
+            usize::try_from(left.abs_diff(right))
+                .ok()
+                .and_then(|width| width.checked_add(1))
         })
         .collect::<Option<Vec<_>>>()
         .ok_or_else(|| {
             sv::AnalyzerError::Unsupported("unresolved unpacked array dimension".to_string())
         })?;
+    let element_count = array_dims
+        .iter()
+        .copied()
+        .try_fold(1usize, usize::checked_mul)
+        .ok_or_else(|| sv::AnalyzerError::Unsupported("signal width overflow".to_string()))?;
     let width = packed_width
-        .checked_mul(array_dims.iter().copied().product())
+        .checked_mul(element_count)
         .ok_or_else(|| sv::AnalyzerError::Unsupported("signal width overflow".to_string()))?;
     let signed = typ.is_signed();
     let is_4state = !matches!(typ.kind(), sv::ir::TypeKind::Bit);
@@ -3095,10 +3103,12 @@ fn unpacked_element_width(variable: &SvVariable) -> Option<usize> {
     if variable.array_dims.is_empty() {
         return None;
     }
-    let element_count = variable.array_dims.iter().copied().product::<usize>();
-    (element_count != 0)
-        .then(|| variable.width.checked_div(element_count))
-        .flatten()
+    let element_count = variable
+        .array_dims
+        .iter()
+        .copied()
+        .try_fold(1usize, usize::checked_mul)?;
+    (element_count != 0).then(|| variable.width.checked_div(element_count))?
 }
 
 fn sv_memory_offset(variable: &SvVariable, bit_offset: usize, width: usize) -> SIROffset {

--- a/crates/celox-frontend-sv/src/lowering.rs
+++ b/crates/celox-frontend-sv/src/lowering.rs
@@ -4222,6 +4222,33 @@ fn lower_expr_to_sir_with_context(
             lsb,
             signed,
         } => {
+            let msb = sv::typecheck::eval_const_expr_with_types(msb, constants, parameter_types)?;
+            let lsb = sv::typecheck::eval_const_expr_with_types(lsb, constants, parameter_types)?;
+            let (msb, lsb) = packed_expr_select_offsets(expr, msb, lsb, variables, name_to_id)?;
+            let high = msb.max(lsb);
+            let low = msb.min(lsb);
+            let width = high - low + 1;
+            if let sv::ir::Expr::Ident(name) = &**expr
+                && let Some(var) = name_to_id.get(name).and_then(|id| variables.get(id))
+                && !var.array_dims.is_empty()
+            {
+                let reg = builder.alloc_logic(width);
+                builder.emit(SIRInstruction::Load(
+                    reg,
+                    RegionedVarAddrBase {
+                        region: STABLE_REGION,
+                        var_id: *name_to_id.get(name)?,
+                    },
+                    sv_memory_offset(var, low, width),
+                    width,
+                ));
+                return resize_sir_register(
+                    builder,
+                    reg,
+                    context_width.unwrap_or(width),
+                    context_signed.unwrap_or(*signed),
+                );
+            }
             let inner = lower_expr_to_sir_with_context(
                 builder,
                 expr,
@@ -4232,12 +4259,6 @@ fn lower_expr_to_sir_with_context(
                 None,
                 None,
             )?;
-            let msb = sv::typecheck::eval_const_expr_with_types(msb, constants, parameter_types)?;
-            let lsb = sv::typecheck::eval_const_expr_with_types(lsb, constants, parameter_types)?;
-            let (msb, lsb) = packed_expr_select_offsets(expr, msb, lsb, variables, name_to_id)?;
-            let high = msb.max(lsb);
-            let low = msb.min(lsb);
-            let width = high - low + 1;
             let reg = builder.alloc_logic(width);
             builder.emit(SIRInstruction::Slice(reg, inner, low, width));
             resize_sir_register(

--- a/crates/celox-frontend-sv/src/lowering.rs
+++ b/crates/celox-frontend-sv/src/lowering.rs
@@ -2680,7 +2680,7 @@ fn lower_comb_process(
         }
         let allow_dynamic_array_write = process.kind() == sv::ir::CombProcessKind::AlwaysComb;
         let previous_array = if allow_dynamic_array_write {
-            if let Some((id, _, _)) = dynamic_array_element_lvalue(
+            if let Some((id, _, _, _)) = dynamic_array_element_lvalue(
                 assignment.lhs_value(),
                 variables,
                 name_to_id,
@@ -2895,19 +2895,20 @@ fn lower_dynamic_array_write_expr(
     HashSet<VarAtomBase<SourceVarId>>,
     HashSet<VarAtomBase<SourceVarId>>,
 )> {
-    let (id, element_width, offset) =
+    let (id, element_width, offset, access) =
         dynamic_array_element_lvalue(lvalue, variables, name_to_id, constants, parameter_types)?;
     let variable = variables.get(&id)?;
     let element_count = variable.width.checked_div(element_width)?;
     if element_count == 0 {
         return None;
     }
-    let target_width = variable.width;
+    let array_width = variable.width;
+    let target_width = access.msb - access.lsb + 1;
     let (rhs_node, mut sources) = if let sv::ir::Expr::Literal(literal) = rhs
         && let Some(fill) = unbased_fill_literal(literal)
     {
         (
-            lower_unbased_fill_literal_slt(arena, fill, element_width)?,
+            lower_unbased_fill_literal_slt(arena, fill, target_width)?,
             HashSet::default(),
         )
     } else {
@@ -2918,7 +2919,7 @@ fn lower_dynamic_array_write_expr(
             constants,
             parameter_types,
             arena,
-            Some(element_width),
+            Some(target_width),
             Some(sv_expr_is_signed_with_parameters(
                 rhs,
                 variables,
@@ -2930,7 +2931,7 @@ fn lower_dynamic_array_write_expr(
     let rhs_node = coerce_node_width(
         arena,
         rhs_node,
-        Some(element_width),
+        Some(target_width),
         sv_expr_is_signed_with_parameters(rhs, variables, name_to_id, parameter_types),
     )
     .ok()?;
@@ -2949,7 +2950,7 @@ fn lower_dynamic_array_write_expr(
         sources.extend(previous_array.address_sources.iter().copied());
         (previous_array.expr, previous_array.previous_sources.clone())
     } else {
-        let previous_sources = [VarAtomBase::new(id, 0, target_width.checked_sub(1)?)]
+        let previous_sources = [VarAtomBase::new(id, 0, array_width.checked_sub(1)?)]
             .into_iter()
             .collect();
         let old = arena
@@ -2957,7 +2958,7 @@ fn lower_dynamic_array_write_expr(
                 variable: id,
                 signed: variable.signed,
                 index: Vec::new(),
-                access: BitAccess::new(0, target_width - 1),
+                access: BitAccess::new(0, array_width - 1),
             })
             .ok()?;
         (old, previous_sources)
@@ -2986,10 +2987,18 @@ fn lower_dynamic_array_write_expr(
                 element_literal,
             ))
             .ok()?;
+        let updated_element = replace_slt_slice(
+            arena,
+            old_element,
+            rhs_node,
+            access.lsb,
+            target_width,
+            element_width,
+        )?;
         let updated = arena
             .alloc(SLTNode::Mux {
                 cond: condition,
-                then_expr: rhs_node,
+                then_expr: updated_element,
                 else_expr: old_element,
             })
             .ok()?;
@@ -3001,11 +3010,51 @@ fn lower_dynamic_array_write_expr(
         arena.alloc(SLTNode::Concat(parts)).ok()?
     };
     Some((
-        LogicPathTarget::Var(VarAtomBase::new(id, 0, target_width - 1)),
+        LogicPathTarget::Var(VarAtomBase::new(id, 0, array_width - 1)),
         expr,
         sources,
         previous_sources,
     ))
+}
+
+fn replace_slt_slice(
+    arena: &mut SLTNodeArena<SourceVarId>,
+    current: NodeId,
+    replacement: NodeId,
+    lsb: usize,
+    replacement_width: usize,
+    total_width: usize,
+) -> Option<NodeId> {
+    if lsb == 0 && replacement_width == total_width {
+        return Some(replacement);
+    }
+    let end = lsb.checked_add(replacement_width)?;
+    if end > total_width {
+        return None;
+    }
+
+    let mut parts = Vec::with_capacity(3);
+    if end < total_width {
+        let upper_width = total_width - end;
+        let upper = arena
+            .alloc(SLTNode::Slice {
+                expr: current,
+                access: BitAccess::new(end, total_width - 1),
+            })
+            .ok()?;
+        parts.push((upper, upper_width));
+    }
+    parts.push((replacement, replacement_width));
+    if lsb != 0 {
+        let lower = arena
+            .alloc(SLTNode::Slice {
+                expr: current,
+                access: BitAccess::new(0, lsb - 1),
+            })
+            .ok()?;
+        parts.push((lower, lsb));
+    }
+    arena.alloc(SLTNode::Concat(parts)).ok()
 }
 
 fn lower_assignment(
@@ -4014,20 +4063,37 @@ fn dynamic_array_element_lvalue(
     name_to_id: &HashMap<String, SourceVarId>,
     constants: &HashMap<String, i128>,
     parameter_types: &HashMap<String, (usize, bool)>,
-) -> Option<(SourceVarId, usize, sv::ir::ConstExpr)> {
+) -> Option<(SourceVarId, usize, sv::ir::ConstExpr, BitAccess)> {
     let sv::ir::LValue::Select { name, msb, lsb, .. } = lvalue else {
         return None;
     };
-    let (id, element_width) = dynamic_array_element_access(
-        name,
-        msb,
-        lsb,
-        variables,
-        name_to_id,
-        constants,
-        parameter_types,
-    )?;
-    Some((id, element_width, lsb.clone()))
+    let id = *name_to_id.get(name)?;
+    let variable = variables.get(&id)?;
+    let element_width = unpacked_element_width(variable).filter(|width| *width != 0)?;
+    let is_dynamic = sv::typecheck::eval_const_expr_with_types(msb, constants, parameter_types)
+        .is_none()
+        || sv::typecheck::eval_const_expr_with_types(lsb, constants, parameter_types).is_none();
+    if !is_dynamic {
+        return None;
+    }
+    let (msb_base, msb_offset) = split_dynamic_array_offset(msb, constants, parameter_types)?;
+    let (lsb_base, lsb_offset) = split_dynamic_array_offset(lsb, constants, parameter_types)?;
+    if msb_base != lsb_base
+        || (element_width > 1
+            && !dynamic_array_base_has_stride(
+                msb_base,
+                i128::try_from(element_width).ok()?,
+                constants,
+                parameter_types,
+            ))
+    {
+        return None;
+    }
+    let offset = lsb.clone();
+    let msb = usize::try_from(msb_offset).ok()?;
+    let lsb = usize::try_from(lsb_offset).ok()?;
+    let access = BitAccess::new(msb.min(lsb), msb.max(lsb));
+    (access.msb < element_width).then_some((id, element_width, offset, access))
 }
 
 fn dynamic_array_element_access(
@@ -4103,27 +4169,27 @@ fn dynamic_array_index_guard_slt<A: std::hash::Hash + Eq + Clone>(
     index: NodeId,
     element_count: usize,
 ) -> Option<(NodeId, NodeId)> {
-    let mut valid = None;
-    for element in 0..element_count {
-        let element_literal = arena
-            .alloc(SLTNode::Constant(
-                BigUint::from(element),
-                BigUint::default(),
-                64,
-                false,
-            ))
-            .ok()?;
-        let matches = arena
-            .alloc(SLTNode::Binary(index, BinaryOp::EqCase, element_literal))
-            .ok()?;
-        valid = Some(match valid {
-            Some(previous) => arena
-                .alloc(SLTNode::Binary(previous, BinaryOp::Or, matches))
-                .ok()?,
-            None => matches,
-        });
-    }
-    let valid = valid?;
+    let element_count = BigUint::from(element_count);
+    let two_state_index = arena
+        .alloc(SLTNode::Unary(UnaryOp::ToTwoState, index))
+        .ok()?;
+    let known = arena
+        .alloc(SLTNode::Binary(index, BinaryOp::EqCase, two_state_index))
+        .ok()?;
+    let bound = arena
+        .alloc(SLTNode::Constant(
+            element_count,
+            BigUint::default(),
+            64,
+            false,
+        ))
+        .ok()?;
+    let in_range = arena
+        .alloc(SLTNode::Binary(index, BinaryOp::LtU, bound))
+        .ok()?;
+    let valid = arena
+        .alloc(SLTNode::Binary(known, BinaryOp::LogicAnd, in_range))
+        .ok()?;
     let zero = arena
         .alloc(SLTNode::Constant(
             BigUint::default(),
@@ -4210,35 +4276,36 @@ fn dynamic_array_index_guard_sir(
     index: celox_sir::RegisterId,
     element_count: usize,
 ) -> Option<(celox_sir::RegisterId, celox_sir::RegisterId)> {
-    let mut valid = None;
-    for element in 0..element_count {
-        let element_literal = builder.alloc_bit(64, false);
-        builder.emit(SIRInstruction::Imm(
-            element_literal,
-            SIRValue::new(u64::try_from(element).ok()?),
-        ));
-        let matches = builder.alloc_bit(1, false);
-        builder.emit(SIRInstruction::Binary(
-            matches,
-            index,
-            BinaryOp::EqCase,
-            element_literal,
-        ));
-        valid = Some(match valid {
-            Some(previous) => {
-                let combined = builder.alloc_bit(1, false);
-                builder.emit(SIRInstruction::Binary(
-                    combined,
-                    previous,
-                    BinaryOp::Or,
-                    matches,
-                ));
-                combined
-            }
-            None => matches,
-        });
-    }
-    let valid = valid?;
+    let element_count = u64::try_from(element_count).ok()?;
+    let two_state_index = builder.alloc_bit(64, false);
+    builder.emit(SIRInstruction::Unary(
+        two_state_index,
+        UnaryOp::ToTwoState,
+        index,
+    ));
+    let known = builder.alloc_bit(1, false);
+    builder.emit(SIRInstruction::Binary(
+        known,
+        index,
+        BinaryOp::EqCase,
+        two_state_index,
+    ));
+    let bound = builder.alloc_bit(64, false);
+    builder.emit(SIRInstruction::Imm(bound, SIRValue::new(element_count)));
+    let in_range = builder.alloc_bit(1, false);
+    builder.emit(SIRInstruction::Binary(
+        in_range,
+        index,
+        BinaryOp::LtU,
+        bound,
+    ));
+    let valid = builder.alloc_bit(1, false);
+    builder.emit(SIRInstruction::Binary(
+        valid,
+        known,
+        BinaryOp::LogicAnd,
+        in_range,
+    ));
     let zero = builder.alloc_bit(64, false);
     builder.emit(SIRInstruction::Imm(zero, SIRValue::new(0u8)));
     let safe_index = builder.alloc_bit(64, false);
@@ -4554,7 +4621,7 @@ fn ff_targets(
             dynamic_array_element_lvalue(lvalue, variables, name_to_id, constants, parameter_types);
         let target = lvalue_atom(lvalue, variables, name_to_id, constants, parameter_types)
             .or_else(|| {
-                dynamic.as_ref().and_then(|(id, _, _)| {
+                dynamic.as_ref().and_then(|(id, _, _, _)| {
                     variables
                         .get(id)
                         .and_then(|variable| variable.width.checked_sub(1))
@@ -4652,7 +4719,7 @@ fn emit_ff_assignment_stores(
             );
             let target = lvalue_atom(lvalue, variables, name_to_id, constants, parameter_types)
                 .or_else(|| {
-                    dynamic.as_ref().and_then(|(id, _, _)| {
+                    dynamic.as_ref().and_then(|(id, _, _, _)| {
                         variables
                             .get(id)
                             .and_then(|variable| variable.width.checked_sub(1))
@@ -4664,7 +4731,7 @@ fn emit_ff_assignment_stores(
             }
             let target_width = dynamic.as_ref().map_or_else(
                 || target.access.msb - target.access.lsb + 1,
-                |(_, width, _)| *width,
+                |(_, _, _, access)| access.msb - access.lsb + 1,
             );
             let rhs_expr = expr_for_state_mode(assignment.assignment().rhs(), four_state);
             let rhs = match &rhs_expr {
@@ -4737,7 +4804,7 @@ fn emit_ff_assignment_stores(
                 builder.emit(SIRInstruction::Unary(two_state, UnaryOp::ToTwoState, rhs));
                 two_state
             };
-            if let Some((_, element_width, offset)) = dynamic {
+            if let Some((_, element_width, offset, access)) = dynamic {
                 // Flush preceding static assignments before a dynamic store so
                 // the direct element write observes the current working value.
                 if value_dirty {
@@ -4775,7 +4842,7 @@ fn emit_ff_assignment_stores(
                     SIROffset::Element {
                         index,
                         element_width,
-                        bit_offset: 0,
+                        bit_offset: access.lsb,
                         dynamic_bit_offset: None,
                     },
                     target_width,
@@ -4806,7 +4873,7 @@ fn emit_ff_assignment_stores(
                     SIROffset::Element {
                         index,
                         element_width,
-                        bit_offset: 0,
+                        bit_offset: access.lsb,
                         dynamic_bit_offset: None,
                     },
                     target_width,

--- a/crates/celox-frontend-sv/src/lowering.rs
+++ b/crates/celox-frontend-sv/src/lowering.rs
@@ -49,6 +49,7 @@ struct SvVariable {
     signed: bool,
     is_4state: bool,
     packed_ranges: Vec<(i128, i128)>,
+    array_dims: Vec<usize>,
     domain_kind: DomainKind,
     kind: VariableKind,
     type_kind: PortTypeKind,
@@ -66,7 +67,7 @@ impl SvVariable {
                 is_4state: self.is_4state,
                 kind: self.domain_kind,
                 type_kind: self.type_kind,
-                array_dims: Vec::new(),
+                array_dims: self.array_dims.clone(),
             },
             packed_dims: self
                 .packed_ranges
@@ -802,6 +803,7 @@ fn lower_module_with_overrides(
             signed: type_info.signed,
             is_4state: type_info.is_4state,
             packed_ranges: type_info.packed_ranges,
+            array_dims: type_info.array_dims,
             domain_kind: DomainKind::Other,
             kind,
             type_kind: type_info.type_kind,
@@ -844,6 +846,7 @@ fn lower_module_with_overrides(
             signed: type_info.signed,
             is_4state: type_info.is_4state,
             packed_ranges: type_info.packed_ranges,
+            array_dims: type_info.array_dims,
             domain_kind: DomainKind::Other,
             kind: VariableKind::Variable,
             type_kind: type_info.type_kind,
@@ -1381,6 +1384,7 @@ fn ensure_parent_output_signals(
             signed: false,
             is_4state: true,
             packed_ranges: Vec::new(),
+            array_dims: Vec::new(),
             domain_kind: DomainKind::Other,
             kind: VariableKind::Variable,
             type_kind: PortTypeKind::Logic,
@@ -2143,6 +2147,7 @@ struct SvSignalType {
     signed: bool,
     is_4state: bool,
     packed_ranges: Vec<(i128, i128)>,
+    array_dims: Vec<usize>,
     type_kind: PortTypeKind,
 }
 
@@ -2151,7 +2156,7 @@ fn signal_type_from_sv(
     constants: &HashMap<String, i128>,
     parameter_types: &HashMap<String, (usize, bool)>,
 ) -> Result<SvSignalType, sv::AnalyzerError> {
-    let width = if typ.packed_ranges().is_empty() {
+    let packed_width = if typ.packed_ranges().is_empty() {
         1
     } else {
         typ.packed_ranges()
@@ -2175,6 +2180,29 @@ fn signal_type_from_sv(
             })?
             .max(1)
     };
+    let array_dims = typ
+        .unpacked_ranges()
+        .iter()
+        .map(|range| {
+            let left = sv::typecheck::eval_const_expr_with_types(
+                range.left(),
+                constants,
+                parameter_types,
+            )?;
+            let right = sv::typecheck::eval_const_expr_with_types(
+                range.right(),
+                constants,
+                parameter_types,
+            )?;
+            usize::try_from(left.abs_diff(right) + 1).ok()
+        })
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(|| {
+            sv::AnalyzerError::Unsupported("unresolved unpacked array dimension".to_string())
+        })?;
+    let width = packed_width
+        .checked_mul(array_dims.iter().copied().product())
+        .ok_or_else(|| sv::AnalyzerError::Unsupported("signal width overflow".to_string()))?;
     let signed = typ.is_signed();
     let is_4state = !matches!(typ.kind(), sv::ir::TypeKind::Bit);
     let packed_ranges = typ
@@ -2205,6 +2233,7 @@ fn signal_type_from_sv(
         signed,
         is_4state,
         packed_ranges,
+        array_dims,
         type_kind,
     })
 }
@@ -3047,6 +3076,11 @@ fn select_sources<A: std::hash::Hash + Eq + Clone>(
 }
 
 fn packed_index_offset(variable: &SvVariable, index: i128) -> Option<usize> {
+    if !variable.array_dims.is_empty() {
+        return usize::try_from(index)
+            .ok()
+            .filter(|offset| *offset < variable.width);
+    }
     let offset = match variable.packed_ranges.as_slice() {
         [(left, right)] if left >= right => index.checked_sub(*right)?,
         [(_, right)] => right.checked_sub(index)?,
@@ -3055,6 +3089,33 @@ fn packed_index_offset(variable: &SvVariable, index: i128) -> Option<usize> {
     usize::try_from(offset)
         .ok()
         .filter(|offset| *offset < variable.width)
+}
+
+fn unpacked_element_width(variable: &SvVariable) -> Option<usize> {
+    if variable.array_dims.is_empty() {
+        return None;
+    }
+    let element_count = variable.array_dims.iter().copied().product::<usize>();
+    (element_count != 0)
+        .then(|| variable.width.checked_div(element_count))
+        .flatten()
+}
+
+fn sv_memory_offset(variable: &SvVariable, bit_offset: usize, width: usize) -> SIROffset {
+    match unpacked_element_width(variable) {
+        Some(element_width)
+            if element_width != 0
+                && width > element_width
+                && bit_offset.is_multiple_of(element_width)
+                && width.is_multiple_of(element_width) =>
+        {
+            SIROffset::PackedElements {
+                bit_offset,
+                element_width,
+            }
+        }
+        _ => SIROffset::Static(bit_offset),
+    }
 }
 
 fn packed_expr_select_offsets(
@@ -3443,7 +3504,7 @@ fn emit_ff_assignment_stores(
                 region: WORKING_REGION,
                 var_id: target_id,
             },
-            SIROffset::Static(0),
+            sv_memory_offset(variables.get(&target_id)?, 0, width),
             width,
         ));
         for assignment in process.assignments() {
@@ -4088,7 +4149,7 @@ fn lower_expr_to_sir_with_context(
                     region: STABLE_REGION,
                     var_id: id,
                 },
-                SIROffset::Static(0),
+                sv_memory_offset(var, 0, var.width),
                 var.width,
             ));
             resize_sir_register(

--- a/crates/celox-frontend-sv/src/lowering.rs
+++ b/crates/celox-frontend-sv/src/lowering.rs
@@ -26,8 +26,8 @@ use celox_sir::{
     SIRValue, merge_sir_eus,
 };
 use celox_slt::{
-    CombObserver, GlueBlockBase, LogicPath, LogicPathTarget, SLTIndex, SLTIndexKind, SLTNode,
-    SLTNodeArena,
+    CombObserver, GlueBlockBase, LogicPath, LogicPathTarget, NodeId, SLTIndex, SLTIndexKind,
+    SLTNode, SLTNodeArena,
 };
 use celox_sv_analyzer as sv;
 use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -1758,6 +1758,57 @@ fn lower_glue_parent_expr(
             lsb,
             signed,
         } => {
+            if let Some((id, element_width)) = dynamic_array_element_selection(
+                expr,
+                msb,
+                lsb,
+                variables,
+                name_to_id,
+                constants,
+                parameter_types,
+            ) {
+                let (offset, mut sources, mut source_ids) = lower_dynamic_array_element_index_glue(
+                    lsb,
+                    variables,
+                    name_to_id,
+                    constants,
+                    parameter_types,
+                    arena,
+                    element_width,
+                )?;
+                let variable = variables.get(&id)?;
+                let node = arena
+                    .alloc(SLTNode::Input {
+                        variable: GlueAddr::Parent(id),
+                        signed: *signed,
+                        index: vec![SLTIndex {
+                            node: offset,
+                            stride: element_width,
+                            kind: SLTIndexKind::Unpacked { element_width },
+                        }],
+                        access: BitAccess::new(0, element_width - 1),
+                    })
+                    .ok()?;
+                sources.insert(VarAtomBase::new(
+                    GlueAddr::Parent(id),
+                    0,
+                    variable.width.checked_sub(1)?,
+                ));
+                source_ids.push(id);
+                source_ids.sort();
+                source_ids.dedup();
+                return Some((
+                    coerce_node_width(
+                        arena,
+                        node,
+                        context_width,
+                        context_signed.unwrap_or(*signed),
+                    )
+                    .ok()?,
+                    sources,
+                    source_ids,
+                ));
+            }
             let (inner, sources, source_ids) = lower_glue_parent_expr(
                 expr,
                 variables,
@@ -2219,6 +2270,44 @@ fn lower_glue_parent_expr(
     }
 }
 
+fn lower_dynamic_array_element_index_glue(
+    offset: &sv::ir::ConstExpr,
+    variables: &HashMap<SourceVarId, SvVariable>,
+    name_to_id: &HashMap<String, SourceVarId>,
+    constants: &HashMap<String, i128>,
+    parameter_types: &HashMap<String, (usize, bool)>,
+    arena: &mut SLTNodeArena<GlueAddr>,
+    element_width: usize,
+) -> Option<(NodeId, HashSet<VarAtomBase<GlueAddr>>, Vec<SourceVarId>)> {
+    let offset_expr = expr_from_const_expr(offset)?;
+    let (offset, sources, source_ids) = lower_glue_parent_expr(
+        &offset_expr,
+        variables,
+        name_to_id,
+        constants,
+        parameter_types,
+        arena,
+        None,
+        None,
+    )?;
+    let element_index = if element_width == 1 {
+        offset
+    } else {
+        let divisor = arena
+            .alloc(SLTNode::Constant(
+                BigUint::from(element_width),
+                BigUint::default(),
+                64,
+                false,
+            ))
+            .ok()?;
+        arena
+            .alloc(SLTNode::Binary(offset, BinaryOp::DivU, divisor))
+            .ok()?
+    };
+    Some((element_index, sources, source_ids))
+}
+
 fn next_var_id(next_id: &mut SourceVarId) -> SourceVarId {
     let id = *next_id;
     next_id.0 += 1;
@@ -2345,6 +2434,48 @@ fn signal_type_from_sv(
     })
 }
 
+struct PreviousArrayValue {
+    expr: NodeId,
+    sources: HashSet<VarAtomBase<SourceVarId>>,
+    previous_sources: HashSet<VarAtomBase<SourceVarId>>,
+    address_sources: HashSet<VarAtomBase<SourceVarId>>,
+}
+
+fn lower_previous_array_value(
+    id: SourceVarId,
+    width: usize,
+    paths: &[LogicPath<SourceVarId>],
+) -> Result<Option<PreviousArrayValue>, sv::AnalyzerError> {
+    let mut matching = paths
+        .iter()
+        .filter(|path| path.target.var().is_some_and(|target| target.id == id));
+    let Some(path) = matching.next() else {
+        return Ok(None);
+    };
+    let Some(target) = path.target.var() else {
+        unreachable!("matching path must have a variable target");
+    };
+    if target.access
+        != BitAccess::new(
+            0,
+            width.checked_sub(1).ok_or_else(|| {
+                sv::AnalyzerError::Unsupported("zero-width unpacked array".to_string())
+            })?,
+        )
+    {
+        return Err(sv::AnalyzerError::Unsupported(
+            "dynamic unpacked-array assignment after an earlier partial assignment to the same array is unsupported"
+                .to_string(),
+        ));
+    }
+    Ok(Some(PreviousArrayValue {
+        expr: path.expr,
+        sources: path.sources.clone(),
+        previous_sources: path.previous_sources.clone(),
+        address_sources: path.address_sources.clone(),
+    }))
+}
+
 fn lower_comb_process(
     process: &sv::ir::CombProcess,
     variables: &HashMap<SourceVarId, SvVariable>,
@@ -2389,6 +2520,30 @@ fn lower_comb_process(
         {
             continue;
         }
+        let allow_dynamic_array_write = process.kind() == sv::ir::CombProcessKind::AlwaysComb;
+        let previous_array = if allow_dynamic_array_write {
+            if let Some((id, _, _)) = dynamic_array_element_lvalue(
+                assignment.lhs_value(),
+                variables,
+                name_to_id,
+                constants,
+                parameter_types,
+            ) {
+                let width = variables
+                    .get(&id)
+                    .map(|variable| variable.width)
+                    .ok_or_else(|| {
+                        sv::AnalyzerError::Unsupported(
+                            "dynamic unpacked-array assignment target".to_string(),
+                        )
+                    })?;
+                lower_previous_array_value(id, width, &paths)?
+            } else {
+                None
+            }
+        } else {
+            None
+        };
         let path = lower_assignment(
             assignment,
             variables,
@@ -2397,6 +2552,8 @@ fn lower_comb_process(
             parameter_types,
             arena,
             four_state,
+            allow_dynamic_array_write,
+            previous_array.as_ref(),
         )?;
         merge_overlapping_comb_path(&mut paths, path, arena)?;
     }
@@ -2511,12 +2668,26 @@ fn overlay_comb_paths(
     if uses_later {
         sources.extend(later.sources);
     }
+    let mut previous_sources = HashSet::default();
+    if uses_previous {
+        previous_sources.extend(previous.previous_sources);
+    }
+    if uses_later {
+        previous_sources.extend(later.previous_sources);
+    }
+    let mut address_sources = HashSet::default();
+    if uses_previous {
+        address_sources.extend(previous.address_sources);
+    }
+    if uses_later {
+        address_sources.extend(later.address_sources);
+    }
     Ok(LogicPath {
         target: LogicPathTarget::Var(VarAtomBase::new(previous_target.id, access.lsb, access.msb)),
         expr,
         sources,
-        address_sources: HashSet::default(),
-        previous_sources: HashSet::default(),
+        address_sources,
+        previous_sources,
         local_inputs: Vec::new(),
         order_before: HashSet::default(),
         comb_capture_enable_sites: Vec::new(),
@@ -2559,6 +2730,7 @@ fn lower_dynamic_array_write_expr(
     constants: &HashMap<String, i128>,
     parameter_types: &HashMap<String, (usize, bool)>,
     arena: &mut SLTNodeArena<SourceVarId>,
+    previous_array: Option<&PreviousArrayValue>,
 ) -> Option<(
     LogicPathTarget<SourceVarId>,
     celox_slt::NodeId,
@@ -2614,17 +2786,24 @@ fn lower_dynamic_array_write_expr(
         element_width,
     )?;
     sources.extend(index_sources);
-    let previous_sources = [VarAtomBase::new(id, 0, target_width.checked_sub(1)?)]
-        .into_iter()
-        .collect();
-    let old = arena
-        .alloc(SLTNode::Input {
-            variable: id,
-            signed: variable.signed,
-            index: Vec::new(),
-            access: BitAccess::new(0, target_width - 1),
-        })
-        .ok()?;
+    let (old, previous_sources) = if let Some(previous_array) = previous_array {
+        sources.extend(previous_array.sources.iter().copied());
+        sources.extend(previous_array.address_sources.iter().copied());
+        (previous_array.expr, previous_array.previous_sources.clone())
+    } else {
+        let previous_sources = [VarAtomBase::new(id, 0, target_width.checked_sub(1)?)]
+            .into_iter()
+            .collect();
+        let old = arena
+            .alloc(SLTNode::Input {
+                variable: id,
+                signed: variable.signed,
+                index: Vec::new(),
+                access: BitAccess::new(0, target_width - 1),
+            })
+            .ok()?;
+        (old, previous_sources)
+    };
     let mut parts = Vec::with_capacity(element_count);
     for element in (0..element_count).rev() {
         let lsb = element.checked_mul(element_width)?;
@@ -2679,17 +2858,22 @@ fn lower_assignment(
     parameter_types: &HashMap<String, (usize, bool)>,
     arena: &mut SLTNodeArena<SourceVarId>,
     four_state: bool,
+    allow_dynamic_array_write: bool,
+    previous_array: Option<&PreviousArrayValue>,
 ) -> Result<LogicPath<SourceVarId>, sv::AnalyzerError> {
     let rhs = expr_for_state_mode(assignment.rhs(), four_state);
-    if let Some((target, expr, sources, previous_sources)) = lower_dynamic_array_write_expr(
-        assignment.lhs_value(),
-        &rhs,
-        variables,
-        name_to_id,
-        constants,
-        parameter_types,
-        arena,
-    ) {
+    if allow_dynamic_array_write
+        && let Some((target, expr, sources, previous_sources)) = lower_dynamic_array_write_expr(
+            assignment.lhs_value(),
+            &rhs,
+            variables,
+            name_to_id,
+            constants,
+            parameter_types,
+            arena,
+            previous_array,
+        )
+    {
         let target_width = target
             .var()
             .map(|target| target.access.msb - target.access.lsb + 1)

--- a/crates/celox-frontend-sv/src/lowering.rs
+++ b/crates/celox-frontend-sv/src/lowering.rs
@@ -287,7 +287,7 @@ fn child_output_driver_ranges(
             let Some(actual_expr) = connection.actual_expr.as_ref() else {
                 continue;
             };
-            let Some((actual_id, access)) = output_lvalue_access(
+            let Some(accesses) = output_lvalue_accesses(
                 actual_expr,
                 &module.variables,
                 &module.signal_names,
@@ -299,11 +299,13 @@ fn child_output_driver_ranges(
                 }
                 continue;
             };
-            if actual_id == signal_id {
-                drivers.push((
-                    drivers.len(),
-                    Some((access.lsb as i128, access.msb as i128)),
-                ));
+            for (actual_id, access) in accesses {
+                if actual_id == signal_id {
+                    drivers.push((
+                        drivers.len(),
+                        Some((access.lsb as i128, access.msb as i128)),
+                    ));
+                }
             }
         }
     }
@@ -1602,7 +1604,7 @@ fn build_instance_glue(
                     output_ports.push(dynamic_output);
                     continue;
                 }
-                let Some((parent_signal_id, access)) = output_lvalue_access(
+                let Some(accesses) = output_lvalue_accesses(
                     actual_expr,
                     parent_variables,
                     parent_signal_names,
@@ -1617,48 +1619,79 @@ fn build_instance_glue(
                         None,
                     ));
                 };
-                let parent_var = &parent_variables[&parent_signal_id];
-                let target_width = access.msb - access.lsb + 1;
-                let child_node = arena.alloc(SLTNode::Input {
+                let target_width = accesses.iter().try_fold(0usize, |width, (_, access)| {
+                    width.checked_add(access.msb - access.lsb + 1)
+                });
+                let Some(target_width) = target_width.filter(|target_width| *target_width != 0)
+                else {
+                    return Err(ParserError::unsupported(
+                        64,
+                        LoweringPhase::SimulatorParser,
+                        "systemverilog output port lvalue connection",
+                        format!("{formal} -> {actual}: {actual_expr:?}"),
+                        None,
+                    ));
+                };
+                let child_input = arena.alloc(SLTNode::Input {
                     variable: GlueAddr::Child(*child_port_id),
                     signed: child_var.signed,
                     index: Vec::new(),
                     access: BitAccess::new(0, width - 1),
                 })?;
-                let mut expr = coerce_node_width(
+                let child_node = coerce_node_width(
                     &mut arena,
-                    child_node,
+                    child_input,
                     Some(target_width),
                     child_var.signed,
                 )?;
-                if !parent_var.is_4state {
-                    expr = arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, expr))?;
+                let mut child_lsb = target_width;
+                for (parent_signal_id, access) in accesses {
+                    let parent_var = &parent_variables[&parent_signal_id];
+                    let part_width = access.msb - access.lsb + 1;
+                    child_lsb -= part_width;
+                    let child_expr = if child_lsb == 0 && part_width == target_width {
+                        child_node
+                    } else {
+                        arena.alloc(SLTNode::Slice {
+                            expr: child_node,
+                            access: BitAccess::new(child_lsb, child_lsb + part_width - 1),
+                        })?
+                    };
+                    let mut expr = coerce_node_width(
+                        &mut arena,
+                        child_expr,
+                        Some(part_width),
+                        child_var.signed,
+                    )?;
+                    if !parent_var.is_4state {
+                        expr = arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, expr))?;
+                    }
+                    let mut sources = HashSet::default();
+                    sources.insert(VarAtomBase::new(
+                        GlueAddr::Child(*child_port_id),
+                        0,
+                        width - 1,
+                    ));
+                    output_ports.push((
+                        vec![parent_signal_id],
+                        LogicPath {
+                            target: LogicPathTarget::Var(VarAtomBase::new(
+                                GlueAddr::Parent(parent_signal_id),
+                                access.lsb,
+                                access.msb,
+                            )),
+                            expr,
+                            sources,
+                            address_sources: HashSet::default(),
+                            previous_sources: HashSet::default(),
+                            local_inputs: Vec::new(),
+                            order_before: HashSet::default(),
+                            comb_capture_enable_sites: Vec::new(),
+                            comb_capture_enable_always: false,
+                            pre_lower_nodes: Vec::new(),
+                        },
+                    ));
                 }
-                let mut sources = HashSet::default();
-                sources.insert(VarAtomBase::new(
-                    GlueAddr::Child(*child_port_id),
-                    0,
-                    width - 1,
-                ));
-                output_ports.push((
-                    vec![parent_signal_id],
-                    LogicPath {
-                        target: LogicPathTarget::Var(VarAtomBase::new(
-                            GlueAddr::Parent(parent_signal_id),
-                            access.lsb,
-                            access.msb,
-                        )),
-                        expr,
-                        sources,
-                        address_sources: HashSet::default(),
-                        previous_sources: HashSet::default(),
-                        local_inputs: Vec::new(),
-                        order_before: HashSet::default(),
-                        comb_capture_enable_sites: Vec::new(),
-                        comb_capture_enable_always: false,
-                        pre_lower_nodes: Vec::new(),
-                    },
-                ));
             }
             VariableKind::Inout => {
                 return Err(unsupported_sv_inout(child_var.path.join(".")));
@@ -1856,6 +1889,35 @@ fn output_lvalue_access(
             (access.msb < variable.width).then_some((id, access))
         }
         _ => None,
+    }
+}
+
+fn output_lvalue_accesses(
+    expr: &sv::ir::Expr,
+    variables: &HashMap<SourceVarId, SvVariable>,
+    name_to_id: &HashMap<String, SourceVarId>,
+    constants: &HashMap<String, i128>,
+    parameter_types: &HashMap<String, (usize, bool)>,
+) -> Option<Vec<(SourceVarId, BitAccess)>> {
+    match expr {
+        sv::ir::Expr::Concat(parts) if !parts.is_empty() => {
+            let mut accesses = Vec::new();
+            for part in parts {
+                accesses.extend(output_lvalue_accesses(
+                    part,
+                    variables,
+                    name_to_id,
+                    constants,
+                    parameter_types,
+                )?);
+            }
+            Some(accesses)
+        }
+        sv::ir::Expr::Resize { expr, .. } => {
+            output_lvalue_accesses(expr, variables, name_to_id, constants, parameter_types)
+        }
+        _ => output_lvalue_access(expr, variables, name_to_id, constants, parameter_types)
+            .map(|access| vec![access]),
     }
 }
 
@@ -4202,7 +4264,7 @@ fn dynamic_array_element_lvalue(
     };
     let id = *name_to_id.get(name)?;
     let variable = variables.get(&id)?;
-    let element_width = unpacked_element_width(variable).filter(|width| *width != 0)?;
+    let packed_element_width = unpacked_element_width(variable).filter(|width| *width != 0)?;
     let is_dynamic = sv::typecheck::eval_const_expr_with_types(msb, constants, parameter_types)
         .is_none()
         || sv::typecheck::eval_const_expr_with_types(lsb, constants, parameter_types).is_none();
@@ -4211,21 +4273,24 @@ fn dynamic_array_element_lvalue(
     }
     let (msb_base, msb_offset) = split_dynamic_array_offset(msb, constants, parameter_types)?;
     let (lsb_base, lsb_offset) = split_dynamic_array_offset(lsb, constants, parameter_types)?;
-    if msb_base != lsb_base
-        || (element_width > 1
-            && !dynamic_array_base_has_stride(
-                msb_base,
-                i128::try_from(element_width).ok()?,
-                constants,
-                parameter_types,
-            ))
-    {
+    if msb_base != lsb_base {
         return None;
     }
     let offset = lsb.clone();
     let msb = usize::try_from(msb_offset).ok()?;
     let lsb = usize::try_from(lsb_offset).ok()?;
     let access = BitAccess::new(msb.min(lsb), msb.max(lsb));
+    let element_width = dynamic_array_selection_width(variable, access, packed_element_width)?;
+    if element_width > 1
+        && !dynamic_array_base_has_stride(
+            msb_base,
+            i128::try_from(element_width).ok()?,
+            constants,
+            parameter_types,
+        )
+    {
+        return None;
+    }
     (access.msb < element_width).then_some((id, element_width, offset, access))
 }
 
@@ -5032,6 +5097,111 @@ fn emit_ff_assignment_stores(
                 )?;
                 let element_count = variable.width.checked_div(element_width)?;
                 let (index, valid) = dynamic_array_index_guard_sir(builder, index, element_count)?;
+                let packed_element_width = unpacked_element_width(variable)?;
+                if element_width != packed_element_width {
+                    if access.lsb != 0 || target_width != element_width {
+                        return None;
+                    }
+                    let inner_count = element_width.checked_div(packed_element_width)?;
+                    let inner_count_value = builder.alloc_bit(64, false);
+                    builder.emit(SIRInstruction::Imm(
+                        inner_count_value,
+                        SIRValue::new(u64::try_from(inner_count).ok()?),
+                    ));
+                    let scaled_index = builder.alloc_bit(64, false);
+                    builder.emit(SIRInstruction::Binary(
+                        scaled_index,
+                        index,
+                        BinaryOp::Mul,
+                        inner_count_value,
+                    ));
+                    for inner_index in 0..inner_count {
+                        let element_index = if inner_index == 0 {
+                            scaled_index
+                        } else {
+                            let inner_index_value = builder.alloc_bit(64, false);
+                            builder.emit(SIRInstruction::Imm(
+                                inner_index_value,
+                                SIRValue::new(u64::try_from(inner_index).ok()?),
+                            ));
+                            let element_index = builder.alloc_bit(64, false);
+                            builder.emit(SIRInstruction::Binary(
+                                element_index,
+                                scaled_index,
+                                BinaryOp::Add,
+                                inner_index_value,
+                            ));
+                            element_index
+                        };
+                        let old = builder.alloc_logic(packed_element_width);
+                        builder.emit(SIRInstruction::Load(
+                            old,
+                            RegionedVarAddrBase {
+                                region: WORKING_REGION,
+                                var_id: target_id,
+                            },
+                            SIROffset::Element {
+                                index: element_index,
+                                element_width: packed_element_width,
+                                bit_offset: 0,
+                                dynamic_bit_offset: None,
+                            },
+                            packed_element_width,
+                        ));
+                        let rhs_part = builder.alloc_logic(packed_element_width);
+                        builder.emit(SIRInstruction::Slice(
+                            rhs_part,
+                            rhs,
+                            inner_index * packed_element_width,
+                            packed_element_width,
+                        ));
+                        let selected_value = match assignment.condition() {
+                            Some(condition) => {
+                                let condition = lower_procedural_condition(
+                                    builder,
+                                    condition,
+                                    variables,
+                                    name_to_id,
+                                    constants,
+                                    parameter_types,
+                                )?;
+                                let mux = builder.alloc_logic(packed_element_width);
+                                builder.emit(SIRInstruction::Mux(mux, condition, rhs_part, old));
+                                mux
+                            }
+                            None => rhs_part,
+                        };
+                        let store_value = builder.alloc_logic(packed_element_width);
+                        builder.emit(SIRInstruction::Mux(store_value, valid, selected_value, old));
+                        builder.emit(SIRInstruction::Store(
+                            RegionedVarAddrBase {
+                                region: WORKING_REGION,
+                                var_id: target_id,
+                            },
+                            SIROffset::Element {
+                                index: element_index,
+                                element_width: packed_element_width,
+                                bit_offset: 0,
+                                dynamic_bit_offset: None,
+                            },
+                            packed_element_width,
+                            store_value,
+                            Vec::new(),
+                            Vec::new(),
+                        ));
+                    }
+                    value = builder.alloc_logic(width);
+                    builder.emit(SIRInstruction::Load(
+                        value,
+                        RegionedVarAddrBase {
+                            region: WORKING_REGION,
+                            var_id: target_id,
+                        },
+                        sv_memory_offset(variable, 0, width),
+                        width,
+                    ));
+                    continue;
+                }
                 let old = builder.alloc_logic(target_width);
                 builder.emit(SIRInstruction::Load(
                     old,

--- a/crates/celox-frontend-sv/src/lowering.rs
+++ b/crates/celox-frontend-sv/src/lowering.rs
@@ -1944,18 +1944,15 @@ fn lower_glue_parent_expr(
                 let variable = variables.get(&id)?;
                 let element_count = variable.width.checked_div(element_width)?;
                 let (offset, valid) = dynamic_array_index_guard_slt(arena, offset, element_count)?;
-                let node = arena
-                    .alloc(SLTNode::Input {
-                        variable: GlueAddr::Parent(id),
-                        signed: *signed,
-                        index: vec![SLTIndex {
-                            node: offset,
-                            stride: element_width,
-                            kind: SLTIndexKind::Unpacked { element_width },
-                        }],
-                        access,
-                    })
-                    .ok()?;
+                let node = lower_dynamic_array_selection_slt(
+                    arena,
+                    GlueAddr::Parent(id),
+                    *signed,
+                    offset,
+                    access,
+                    element_width,
+                    variable,
+                )?;
                 let node = guard_dynamic_array_read_slt(
                     arena,
                     valid,
@@ -3362,18 +3359,15 @@ fn lower_expr_with_context(
                 let variable = variables.get(&id)?;
                 let element_count = variable.width.checked_div(element_width)?;
                 let (offset, valid) = dynamic_array_index_guard_slt(arena, offset, element_count)?;
-                let node = arena
-                    .alloc(SLTNode::Input {
-                        variable: id,
-                        signed: *signed,
-                        index: vec![SLTIndex {
-                            node: offset,
-                            stride: element_width,
-                            kind: SLTIndexKind::Unpacked { element_width },
-                        }],
-                        access,
-                    })
-                    .ok()?;
+                let node = lower_dynamic_array_selection_slt(
+                    arena,
+                    id,
+                    *signed,
+                    offset,
+                    access,
+                    element_width,
+                    variable,
+                )?;
                 let node = guard_dynamic_array_read_slt(
                     arena,
                     valid,
@@ -3856,6 +3850,106 @@ fn unpacked_element_width(variable: &SvVariable) -> Option<usize> {
     (element_count != 0).then(|| variable.width.checked_div(element_count))?
 }
 
+fn dynamic_array_selection_width(
+    variable: &SvVariable,
+    access: BitAccess,
+    packed_element_width: usize,
+) -> Option<usize> {
+    let access_width = access.msb.checked_sub(access.lsb)?.checked_add(1)?;
+    let element_width = packed_element_width.max(access_width);
+    (element_width.is_multiple_of(packed_element_width)
+        && variable.width.is_multiple_of(element_width)
+        && access.msb < element_width)
+        .then_some(element_width)
+}
+
+fn dynamic_array_index_kind(variable: &SvVariable, element_width: usize) -> SLTIndexKind {
+    if unpacked_element_width(variable) == Some(element_width) {
+        SLTIndexKind::Unpacked { element_width }
+    } else {
+        SLTIndexKind::Packed
+    }
+}
+
+fn lower_dynamic_array_selection_slt<A: std::hash::Hash + Eq + Clone>(
+    arena: &mut SLTNodeArena<A>,
+    variable: A,
+    signed: bool,
+    index: NodeId,
+    access: BitAccess,
+    element_width: usize,
+    variable_info: &SvVariable,
+) -> Option<NodeId> {
+    let packed_element_width = unpacked_element_width(variable_info)?;
+    if element_width == packed_element_width {
+        return arena
+            .alloc(SLTNode::Input {
+                variable,
+                signed,
+                index: vec![SLTIndex {
+                    node: index,
+                    stride: element_width,
+                    kind: dynamic_array_index_kind(variable_info, element_width),
+                }],
+                access,
+            })
+            .ok();
+    }
+    if access.lsb != 0 || access.msb.checked_add(1)? != element_width {
+        return None;
+    }
+    let inner_count = element_width.checked_div(packed_element_width)?;
+    let inner_count_literal = arena
+        .alloc(SLTNode::Constant(
+            BigUint::from(inner_count),
+            BigUint::default(),
+            64,
+            false,
+        ))
+        .ok()?;
+    let scaled_index = arena
+        .alloc(SLTNode::Binary(index, BinaryOp::Mul, inner_count_literal))
+        .ok()?;
+    let mut nodes = Vec::with_capacity(inner_count);
+    for inner_index in (0..inner_count).rev() {
+        let node = if inner_index == 0 {
+            scaled_index
+        } else {
+            let inner_index_literal = arena
+                .alloc(SLTNode::Constant(
+                    BigUint::from(inner_index),
+                    BigUint::default(),
+                    64,
+                    false,
+                ))
+                .ok()?;
+            arena
+                .alloc(SLTNode::Binary(
+                    scaled_index,
+                    BinaryOp::Add,
+                    inner_index_literal,
+                ))
+                .ok()?
+        };
+        let node = arena
+            .alloc(SLTNode::Input {
+                variable: variable.clone(),
+                signed,
+                index: vec![SLTIndex {
+                    node,
+                    stride: packed_element_width,
+                    kind: SLTIndexKind::Unpacked {
+                        element_width: packed_element_width,
+                    },
+                }],
+                access: BitAccess::new(0, packed_element_width - 1),
+            })
+            .ok()?;
+        nodes.push((node, packed_element_width));
+    }
+    arena.alloc(SLTNode::Concat(nodes)).ok()
+}
+
 fn sv_memory_offset(variable: &SvVariable, bit_offset: usize, width: usize) -> SIROffset {
     match unpacked_element_width(variable) {
         Some(element_width)
@@ -3937,31 +4031,33 @@ fn dynamic_array_element_subselection(
     };
     let id = *name_to_id.get(name)?;
     let variable = variables.get(&id)?;
-    let element_width = unpacked_element_width(variable).filter(|width| *width != 0)?;
+    let packed_element_width = unpacked_element_width(variable).filter(|width| *width != 0)?;
     let is_dynamic = sv::typecheck::eval_const_expr_with_types(msb, constants, parameter_types)
         .is_none()
         || sv::typecheck::eval_const_expr_with_types(lsb, constants, parameter_types).is_none();
     if !is_dynamic {
         return None;
     }
-    let element_width_value = i128::try_from(element_width).ok()?;
     let (msb_base, msb_offset) = split_dynamic_array_offset(msb, constants, parameter_types)?;
     let (lsb_base, lsb_offset) = split_dynamic_array_offset(lsb, constants, parameter_types)?;
-    if msb_base != lsb_base
-        || (element_width > 1
-            && !dynamic_array_base_has_stride(
-                msb_base,
-                element_width_value,
-                constants,
-                parameter_types,
-            ))
-    {
+    if msb_base != lsb_base {
         return None;
     }
     let msb = usize::try_from(msb_offset).ok()?;
     let lsb = usize::try_from(lsb_offset).ok()?;
     let access = BitAccess::new(msb.min(lsb), msb.max(lsb));
-    (access.msb < element_width).then_some((id, element_width, access))
+    let element_width = dynamic_array_selection_width(variable, access, packed_element_width)?;
+    if element_width > 1
+        && !dynamic_array_base_has_stride(
+            msb_base,
+            i128::try_from(element_width).ok()?,
+            constants,
+            parameter_types,
+        )
+    {
+        return None;
+    }
+    Some((id, element_width, access))
 }
 
 fn split_dynamic_array_offset<'a>(
@@ -4223,6 +4319,85 @@ fn lower_dynamic_array_element_index(
         divisor,
     ));
     Some(index)
+}
+
+fn lower_dynamic_array_selection_sir(
+    builder: &mut SIRBuilder<RegionedVarAddr>,
+    address: RegionedVarAddr,
+    index: celox_sir::RegisterId,
+    access: BitAccess,
+    element_width: usize,
+    variable: &SvVariable,
+) -> Option<celox_sir::RegisterId> {
+    let packed_element_width = unpacked_element_width(variable)?;
+    let width = access.msb.checked_sub(access.lsb)?.checked_add(1)?;
+    if element_width == packed_element_width {
+        let result = builder.alloc_logic(width);
+        builder.emit(SIRInstruction::Load(
+            result,
+            address,
+            SIROffset::Element {
+                index,
+                element_width,
+                bit_offset: access.lsb,
+                dynamic_bit_offset: None,
+            },
+            width,
+        ));
+        return Some(result);
+    }
+    if access.lsb != 0 || access.msb.checked_add(1)? != element_width {
+        return None;
+    }
+    let inner_count = element_width.checked_div(packed_element_width)?;
+    let inner_count_value = builder.alloc_bit(64, false);
+    builder.emit(SIRInstruction::Imm(
+        inner_count_value,
+        SIRValue::new(u64::try_from(inner_count).ok()?),
+    ));
+    let scaled_index = builder.alloc_bit(64, false);
+    builder.emit(SIRInstruction::Binary(
+        scaled_index,
+        index,
+        BinaryOp::Mul,
+        inner_count_value,
+    ));
+    let mut values = Vec::with_capacity(inner_count);
+    for inner_index in (0..inner_count).rev() {
+        let element_index = if inner_index == 0 {
+            scaled_index
+        } else {
+            let inner_index_value = builder.alloc_bit(64, false);
+            builder.emit(SIRInstruction::Imm(
+                inner_index_value,
+                SIRValue::new(u64::try_from(inner_index).ok()?),
+            ));
+            let element_index = builder.alloc_bit(64, false);
+            builder.emit(SIRInstruction::Binary(
+                element_index,
+                scaled_index,
+                BinaryOp::Add,
+                inner_index_value,
+            ));
+            element_index
+        };
+        let value = builder.alloc_logic(packed_element_width);
+        builder.emit(SIRInstruction::Load(
+            value,
+            address,
+            SIROffset::Element {
+                index: element_index,
+                element_width: packed_element_width,
+                bit_offset: 0,
+                dynamic_bit_offset: None,
+            },
+            packed_element_width,
+        ));
+        values.push(value);
+    }
+    let result = builder.alloc_logic(width);
+    builder.emit(SIRInstruction::Concat(result, values));
+    Some(result)
 }
 
 fn dynamic_array_index_guard_sir(
@@ -5485,21 +5660,17 @@ fn lower_expr_to_sir_with_context(
                 let variable = variables.get(&id)?;
                 let element_count = variable.width.checked_div(element_width)?;
                 let (index, valid) = dynamic_array_index_guard_sir(builder, index, element_count)?;
-                let reg = builder.alloc_logic(width);
-                builder.emit(SIRInstruction::Load(
-                    reg,
+                let reg = lower_dynamic_array_selection_sir(
+                    builder,
                     RegionedVarAddrBase {
                         region: STABLE_REGION,
                         var_id: id,
                     },
-                    SIROffset::Element {
-                        index,
-                        element_width,
-                        bit_offset: access.lsb,
-                        dynamic_bit_offset: None,
-                    },
-                    width,
-                ));
+                    index,
+                    access,
+                    element_width,
+                    variable,
+                )?;
                 let reg =
                     guard_dynamic_array_read_sir(builder, valid, reg, width, variable.is_4state);
                 return resize_sir_register(

--- a/crates/celox-frontend-sv/src/lowering.rs
+++ b/crates/celox-frontend-sv/src/lowering.rs
@@ -1212,10 +1212,16 @@ fn expr_for_state_mode(expr: &sv::ir::Expr, four_state: bool) -> sv::ir::Expr {
             }
         }
         sv::ir::Expr::Ident(_) | sv::ir::Expr::Literal(_) => expr.clone(),
-        sv::ir::Expr::Select { expr, msb, lsb } => sv::ir::Expr::Select {
+        sv::ir::Expr::Select {
+            expr,
+            msb,
+            lsb,
+            signed,
+        } => sv::ir::Expr::Select {
             expr: Box::new(expr_for_state_mode(expr, four_state)),
             msb: msb.clone(),
             lsb: lsb.clone(),
+            signed: *signed,
         },
         sv::ir::Expr::Concat(parts) => sv::ir::Expr::Concat(
             parts
@@ -1663,7 +1669,12 @@ fn lower_glue_parent_expr(
                 vec![id],
             ))
         }
-        sv::ir::Expr::Select { expr, msb, lsb } => {
+        sv::ir::Expr::Select {
+            expr,
+            msb,
+            lsb,
+            signed,
+        } => {
             let (inner, sources, source_ids) = lower_glue_parent_expr(
                 expr,
                 variables,
@@ -1689,8 +1700,13 @@ fn lower_glue_parent_expr(
                 .ok()?;
             let sources = select_sources(expr, sources, access)?;
             Some((
-                coerce_node_width(arena, node, context_width, context_signed.unwrap_or(false))
-                    .ok()?,
+                coerce_node_width(
+                    arena,
+                    node,
+                    context_width,
+                    context_signed.unwrap_or(*signed),
+                )
+                .ok()?,
                 sources,
                 source_ids,
             ))
@@ -2652,7 +2668,12 @@ fn lower_expr_with_context(
                 sources,
             ))
         }
-        sv::ir::Expr::Select { expr, msb, lsb } => {
+        sv::ir::Expr::Select {
+            expr,
+            msb,
+            lsb,
+            signed,
+        } => {
             let (inner, mut sources) = lower_expr(
                 expr,
                 variables,
@@ -2686,8 +2707,13 @@ fn lower_expr_with_context(
                 .ok()?;
             sources = select_sources(expr, sources, access)?;
             Some((
-                coerce_node_width(arena, node, context_width, context_signed.unwrap_or(false))
-                    .ok()?,
+                coerce_node_width(
+                    arena,
+                    node,
+                    context_width,
+                    context_signed.unwrap_or(*signed),
+                )
+                .ok()?,
                 sources,
             ))
         }
@@ -3756,10 +3782,10 @@ fn sv_glue_expr_is_signed(
             sv::typecheck::parse_integral_literal(literal).is_some_and(|literal| literal.signed)
         }
         sv::ir::Expr::Resize { signed, .. } => *signed,
-        sv::ir::Expr::Select { .. }
-        | sv::ir::Expr::Concat(_)
-        | sv::ir::Expr::RepeatConcat { .. }
-        | sv::ir::Expr::Call { .. } => false,
+        sv::ir::Expr::Select { signed, .. } => *signed,
+        sv::ir::Expr::Concat(_) | sv::ir::Expr::RepeatConcat { .. } | sv::ir::Expr::Call { .. } => {
+            false
+        }
         sv::ir::Expr::Unary { op, expr } => {
             matches!(
                 op,
@@ -3812,10 +3838,10 @@ fn sv_expr_is_signed_with_parameters(
             sv::typecheck::parse_integral_literal(literal).is_some_and(|literal| literal.signed)
         }
         sv::ir::Expr::Resize { signed, .. } => *signed,
-        sv::ir::Expr::Select { .. }
-        | sv::ir::Expr::Concat(_)
-        | sv::ir::Expr::RepeatConcat { .. }
-        | sv::ir::Expr::Call { .. } => false,
+        sv::ir::Expr::Select { signed, .. } => *signed,
+        sv::ir::Expr::Concat(_) | sv::ir::Expr::RepeatConcat { .. } | sv::ir::Expr::Call { .. } => {
+            false
+        }
         sv::ir::Expr::Unary { op, expr } => {
             matches!(
                 op,
@@ -4190,7 +4216,12 @@ fn lower_expr_to_sir_with_context(
                 context_signed.unwrap_or(signed),
             )
         }
-        sv::ir::Expr::Select { expr, msb, lsb } => {
+        sv::ir::Expr::Select {
+            expr,
+            msb,
+            lsb,
+            signed,
+        } => {
             let inner = lower_expr_to_sir_with_context(
                 builder,
                 expr,
@@ -4213,7 +4244,7 @@ fn lower_expr_to_sir_with_context(
                 builder,
                 reg,
                 context_width.unwrap_or(width),
-                context_signed.unwrap_or(false),
+                context_signed.unwrap_or(*signed),
             )
         }
         sv::ir::Expr::Resize {
@@ -4662,6 +4693,7 @@ mod tests {
             expr: Box::new(sv::ir::Expr::Ident("a".to_string())),
             msb: sv::ir::ConstExpr::Literal("15".to_string()),
             lsb: sv::ir::ConstExpr::Literal("8".to_string()),
+            signed: false,
         };
         let nested_sources = HashSet::from_iter([VarAtomBase::new(1u8, 8, 15)]);
         let narrowed = select_sources(&nested, nested_sources, BitAccess::new(0, 0)).unwrap();

--- a/crates/celox-frontend-sv/src/lowering.rs
+++ b/crates/celox-frontend-sv/src/lowering.rs
@@ -3070,6 +3070,50 @@ fn replace_slt_slice<A: std::hash::Hash + Eq + Clone>(
     arena.alloc(SLTNode::Concat(parts)).ok()
 }
 
+fn permute_reversed_lvalue_rhs_slt(
+    lvalue: &sv::ir::LValue,
+    expr: NodeId,
+    target_width: usize,
+    constants: &HashMap<String, i128>,
+    parameter_types: &HashMap<String, (usize, bool)>,
+    arena: &mut SLTNodeArena<SourceVarId>,
+) -> Option<NodeId> {
+    let sv::ir::LValue::Select {
+        array_slice_width: Some(array_slice_width),
+        array_slice_reversed: true,
+        ..
+    } = lvalue
+    else {
+        return Some(expr);
+    };
+    let element_width = usize::try_from(sv::typecheck::eval_const_expr_with_types(
+        array_slice_width,
+        constants,
+        parameter_types,
+    )?)
+    .ok()
+    .filter(|width| *width != 0)?;
+    if !target_width.is_multiple_of(element_width) {
+        return None;
+    }
+    let element_count = target_width / element_width;
+    if element_count <= 1 {
+        return Some(expr);
+    }
+    let mut parts = Vec::with_capacity(element_count);
+    for lsb in (0..target_width).step_by(element_width) {
+        let msb = lsb.checked_add(element_width)?.checked_sub(1)?;
+        let part = arena
+            .alloc(SLTNode::Slice {
+                expr,
+                access: BitAccess::new(lsb, msb),
+            })
+            .ok()?;
+        parts.push((part, element_width));
+    }
+    arena.alloc(SLTNode::Concat(parts)).ok()
+}
+
 fn lower_assignment(
     assignment: &sv::ir::Assignment,
     variables: &HashMap<SourceVarId, SvVariable>,
@@ -3205,6 +3249,20 @@ fn lower_assignment(
     .map_err(|error| {
         sv::AnalyzerError::Unsupported(format!(
             "combinational assignment width coercion for `{}`: {error}",
+            assignment.lhs()
+        ))
+    })?;
+    expr = permute_reversed_lvalue_rhs_slt(
+        assignment.lhs_value(),
+        expr,
+        target_width,
+        constants,
+        parameter_types,
+        arena,
+    )
+    .ok_or_else(|| {
+        sv::AnalyzerError::Unsupported(format!(
+            "combinational assignment lvalue order for `{}`",
             assignment.lhs()
         ))
     })?;
@@ -4929,6 +4987,14 @@ fn emit_ff_assignment_stores(
                     )?
                 }
             };
+            let rhs = permute_reversed_lvalue_rhs_sir(
+                builder,
+                lvalue,
+                rhs,
+                target_width,
+                constants,
+                parameter_types,
+            )?;
             let rhs = if variables.get(&target.id)?.is_4state
                 && (four_state || !expr_is_unknown_literal(&rhs_expr))
             {
@@ -5142,6 +5208,47 @@ fn replace_sir_slice(
     }
 
     let result = builder.alloc_logic(total_width);
+    builder.emit(SIRInstruction::Concat(result, parts));
+    Some(result)
+}
+
+fn permute_reversed_lvalue_rhs_sir(
+    builder: &mut SIRBuilder<RegionedVarAddr>,
+    lvalue: &sv::ir::LValue,
+    rhs: celox_sir::RegisterId,
+    target_width: usize,
+    constants: &HashMap<String, i128>,
+    parameter_types: &HashMap<String, (usize, bool)>,
+) -> Option<celox_sir::RegisterId> {
+    let sv::ir::LValue::Select {
+        array_slice_width: Some(array_slice_width),
+        array_slice_reversed: true,
+        ..
+    } = lvalue
+    else {
+        return Some(rhs);
+    };
+    let element_width = usize::try_from(sv::typecheck::eval_const_expr_with_types(
+        array_slice_width,
+        constants,
+        parameter_types,
+    )?)
+    .ok()
+    .filter(|width| *width != 0)?;
+    if !target_width.is_multiple_of(element_width) {
+        return None;
+    }
+    let element_count = target_width / element_width;
+    if element_count <= 1 {
+        return Some(rhs);
+    }
+    let mut parts = Vec::with_capacity(element_count);
+    for lsb in (0..target_width).step_by(element_width) {
+        let part = builder.alloc_logic(element_width);
+        builder.emit(SIRInstruction::Slice(part, rhs, lsb, element_width));
+        parts.push(part);
+    }
+    let result = builder.alloc_logic(target_width);
     builder.emit(SIRInstruction::Concat(result, parts));
     Some(result)
 }

--- a/crates/celox-frontend-sv/src/lowering.rs
+++ b/crates/celox-frontend-sv/src/lowering.rs
@@ -185,7 +185,7 @@ fn validate_specialized_instance_net_drivers(
             .iter()
             .filter(|port| port.direction() == sv::ir::PortDirection::Input)
         {
-            if child_output_driver_count(module, port.name(), module_ids, modules) != 0 {
+            if !child_output_driver_ranges(module, port.name(), module_ids, modules).is_empty() {
                 return Err(sv::AnalyzerError::Unsupported(format!(
                     "write to input port `{}`",
                     port.name()
@@ -208,9 +208,9 @@ fn validate_specialized_instance_net_drivers(
                     .map(|port| (port.name(), false)),
             );
         for (signal_name, require_driver) in net_names {
-            let child_driver_count =
-                child_output_driver_count(module, signal_name, module_ids, modules);
-            validate_net_driver_ranges(module, signal_name, child_driver_count, require_driver)?;
+            let child_driver_ranges =
+                child_output_driver_ranges(module, signal_name, module_ids, modules);
+            validate_net_driver_ranges(module, signal_name, &child_driver_ranges, require_driver)?;
         }
 
         let variable_names = module
@@ -228,15 +228,21 @@ fn validate_specialized_instance_net_drivers(
                     .map(|port| port.name()),
             );
         for signal_name in variable_names {
-            let child_driver_count =
-                child_output_driver_count(module, signal_name, module_ids, modules);
+            let child_driver_ranges =
+                child_output_driver_ranges(module, signal_name, module_ids, modules);
             let local_drivers = local_driver_ranges(
                 &module.source,
                 signal_name,
                 &module.constants,
                 &module.parameter_types,
             );
-            if child_driver_count > 1 || child_driver_count == 1 && !local_drivers.is_empty() {
+            let child_overlaps = driver_ranges_overlap(&child_driver_ranges);
+            let child_local_overlap = child_driver_ranges.iter().any(|(_, child_range)| {
+                local_drivers
+                    .iter()
+                    .any(|(_, local_range)| net_driver_ranges_overlap(*child_range, *local_range))
+            });
+            if child_overlaps || child_local_overlap {
                 return Err(sv::AnalyzerError::Unsupported(format!(
                     "multiple variable drivers for `{signal_name}`"
                 )));
@@ -246,36 +252,58 @@ fn validate_specialized_instance_net_drivers(
     Ok(())
 }
 
-fn child_output_driver_count(
+fn child_output_driver_ranges(
     module: &LoweredSvModule,
     signal_name: &str,
     module_ids: &HashMap<LoweredSvModuleKey, ModuleId>,
     modules: &HashMap<ModuleId, LoweredSvModule>,
-) -> usize {
-    module
-        .instances
-        .iter()
-        .filter_map(|instance| {
-            let key = LoweredSvModuleKey::instance_key(instance);
-            let child_id = module_ids.get(&key)?;
-            Some((instance, modules.get(child_id)?))
-        })
-        .flat_map(|(instance, child)| {
-            instance.port_connections.iter().filter(move |connection| {
-                connection
-                    .actual_expr
-                    .as_ref()
-                    .is_some_and(|expr| output_connection_targets_signal(expr, signal_name))
-                    && child.source.ports().iter().any(|port| {
-                        port.name() == connection.formal
-                            && matches!(
-                                port.direction(),
-                                sv::ir::PortDirection::Output | sv::ir::PortDirection::Inout
-                            )
-                    })
-            })
-        })
-        .count()
+) -> Vec<(usize, Option<(i128, i128)>)> {
+    let Some(signal_id) = module.signal_names.get(signal_name).copied() else {
+        return Vec::new();
+    };
+    let mut drivers = Vec::new();
+    for instance in &module.instances {
+        let key = LoweredSvModuleKey::instance_key(instance);
+        let Some(child_id) = module_ids.get(&key).copied() else {
+            continue;
+        };
+        let Some(child) = modules.get(&child_id) else {
+            continue;
+        };
+        for connection in &instance.port_connections {
+            if !child.source.ports().iter().any(|port| {
+                port.name() == connection.formal
+                    && matches!(
+                        port.direction(),
+                        sv::ir::PortDirection::Output | sv::ir::PortDirection::Inout
+                    )
+            }) {
+                continue;
+            }
+            let Some(actual_expr) = connection.actual_expr.as_ref() else {
+                continue;
+            };
+            let Some((actual_id, access)) = output_lvalue_access(
+                actual_expr,
+                &module.variables,
+                &module.signal_names,
+                &module.constants,
+                &module.parameter_types,
+            ) else {
+                if output_connection_targets_signal(actual_expr, signal_name) {
+                    drivers.push((drivers.len(), None));
+                }
+                continue;
+            };
+            if actual_id == signal_id {
+                drivers.push((
+                    drivers.len(),
+                    Some((access.lsb as i128, access.msb as i128)),
+                ));
+            }
+        }
+    }
+    drivers
 }
 
 fn output_connection_targets_signal(expr: &sv::ir::Expr, signal_name: &str) -> bool {
@@ -294,7 +322,7 @@ fn output_connection_targets_signal(expr: &sv::ir::Expr, signal_name: &str) -> b
 fn validate_net_driver_ranges(
     module: &LoweredSvModule,
     signal_name: &str,
-    child_driver_count: usize,
+    child_driver_ranges: &[(usize, Option<(i128, i128)>)],
     require_driver: bool,
 ) -> Result<(), sv::AnalyzerError> {
     let local_drivers = local_driver_ranges(
@@ -308,20 +336,33 @@ fn validate_net_driver_ranges(
             .iter()
             .any(|right| left.0 != right.0 && net_driver_ranges_overlap(left.1, right.1))
     });
-    if child_driver_count > 1
-        || child_driver_count == 1 && !local_drivers.is_empty()
+    let child_local_overlap = child_driver_ranges.iter().any(|(_, child_range)| {
+        local_drivers
+            .iter()
+            .any(|(_, local_range)| net_driver_ranges_overlap(*child_range, *local_range))
+    });
+    if driver_ranges_overlap(child_driver_ranges)
+        || child_local_overlap
         || overlapping_local_drivers
     {
         return Err(sv::AnalyzerError::Unsupported(format!(
             "multiple net drivers for `{signal_name}`"
         )));
     }
-    if require_driver && child_driver_count == 0 && local_drivers.is_empty() {
+    if require_driver && child_driver_ranges.is_empty() && local_drivers.is_empty() {
         return Err(sv::AnalyzerError::Unsupported(format!(
             "undriven net declaration `{signal_name}`"
         )));
     }
     Ok(())
+}
+
+fn driver_ranges_overlap(drivers: &[(usize, Option<(i128, i128)>)]) -> bool {
+    drivers.iter().enumerate().any(|(index, left)| {
+        drivers[index + 1..]
+            .iter()
+            .any(|right| net_driver_ranges_overlap(left.1, right.1))
+    })
 }
 
 fn validate_variable_driver_ranges(
@@ -1539,7 +1580,13 @@ fn build_instance_glue(
                 let Some(actual_expr) = connection.actual_expr.as_ref() else {
                     continue;
                 };
-                let Some(actual) = simple_output_lvalue_ident(actual_expr) else {
+                let Some((parent_signal_id, access)) = output_lvalue_access(
+                    actual_expr,
+                    parent_variables,
+                    parent_signal_names,
+                    parent_constants,
+                    parent_parameter_types,
+                ) else {
                     return Err(ParserError::unsupported(
                         64,
                         LoweringPhase::SimulatorParser,
@@ -1548,10 +1595,8 @@ fn build_instance_glue(
                         None,
                     ));
                 };
-                let Some(parent_signal_id) = parent_signal_names.get(actual).copied() else {
-                    continue;
-                };
                 let parent_var = &parent_variables[&parent_signal_id];
+                let target_width = access.msb - access.lsb + 1;
                 let child_node = arena.alloc(SLTNode::Input {
                     variable: GlueAddr::Child(*child_port_id),
                     signed: child_var.signed,
@@ -1561,7 +1606,7 @@ fn build_instance_glue(
                 let mut expr = coerce_node_width(
                     &mut arena,
                     child_node,
-                    Some(parent_var.width),
+                    Some(target_width),
                     child_var.signed,
                 )?;
                 if !parent_var.is_4state {
@@ -1578,8 +1623,8 @@ fn build_instance_glue(
                     LogicPath {
                         target: LogicPathTarget::Var(VarAtomBase::new(
                             GlueAddr::Parent(parent_signal_id),
-                            0,
-                            parent_var.width - 1,
+                            access.lsb,
+                            access.msb,
                         )),
                         expr,
                         sources,
@@ -1607,6 +1652,41 @@ fn simple_output_lvalue_ident(expr: &sv::ir::Expr) -> Option<&str> {
     match expr {
         sv::ir::Expr::Ident(name) => Some(name),
         sv::ir::Expr::Resize { expr, .. } => simple_output_lvalue_ident(expr),
+        _ => None,
+    }
+}
+
+fn output_lvalue_access(
+    expr: &sv::ir::Expr,
+    variables: &HashMap<SourceVarId, SvVariable>,
+    name_to_id: &HashMap<String, SourceVarId>,
+    constants: &HashMap<String, i128>,
+    parameter_types: &HashMap<String, (usize, bool)>,
+) -> Option<(SourceVarId, BitAccess)> {
+    match expr {
+        sv::ir::Expr::Ident(name) => {
+            let id = *name_to_id.get(name)?;
+            let variable = variables.get(&id)?;
+            Some((id, BitAccess::new(0, variable.width.checked_sub(1)?)))
+        }
+        sv::ir::Expr::Resize { expr, .. } => {
+            output_lvalue_access(expr, variables, name_to_id, constants, parameter_types)
+        }
+        sv::ir::Expr::Select { expr, msb, lsb, .. } => {
+            let sv::ir::Expr::Ident(name) = &**expr else {
+                return None;
+            };
+            let id = *name_to_id.get(name)?;
+            let variable = variables.get(&id)?;
+            if variable.array_dims.is_empty() {
+                return None;
+            }
+            let msb = sv::typecheck::eval_const_expr_with_types(msb, constants, parameter_types)?;
+            let lsb = sv::typecheck::eval_const_expr_with_types(lsb, constants, parameter_types)?;
+            let (msb, lsb) = packed_expr_select_offsets(expr, msb, lsb, variables, name_to_id)?;
+            let access = BitAccess::new(msb.min(lsb), msb.max(lsb));
+            (access.msb < variable.width).then_some((id, access))
+        }
         _ => None,
     }
 }

--- a/crates/celox-frontend-sv/src/lowering.rs
+++ b/crates/celox-frontend-sv/src/lowering.rs
@@ -1583,6 +1583,21 @@ fn build_instance_glue(
                 let Some(actual_expr) = connection.actual_expr.as_ref() else {
                     continue;
                 };
+                if let Some(dynamic_output) = lower_dynamic_output_glue(
+                    actual_expr,
+                    parent_variables,
+                    parent_signal_names,
+                    parent_constants,
+                    parent_parameter_types,
+                    *child_port_id,
+                    child_var,
+                    &mut arena,
+                    &formal,
+                    actual,
+                )? {
+                    output_ports.push(dynamic_output);
+                    continue;
+                }
                 let Some((parent_signal_id, access)) = output_lvalue_access(
                     actual_expr,
                     parent_variables,
@@ -1649,6 +1664,132 @@ fn build_instance_glue(
     }
 
     Ok((input_ports, output_ports, arena))
+}
+
+fn lower_dynamic_output_glue(
+    actual_expr: &sv::ir::Expr,
+    parent_variables: &HashMap<SourceVarId, SvVariable>,
+    parent_signal_names: &HashMap<String, SourceVarId>,
+    parent_constants: &HashMap<String, i128>,
+    parent_parameter_types: &HashMap<String, (usize, bool)>,
+    child_port_id: SourceVarId,
+    child_var: &SvVariable,
+    arena: &mut SLTNodeArena<GlueAddr>,
+    formal: &str,
+    actual: &str,
+) -> Result<Option<(Vec<SourceVarId>, LogicPath<GlueAddr>)>, ParserError> {
+    let sv::ir::Expr::Select { expr, msb, lsb, .. } = actual_expr else {
+        return Ok(None);
+    };
+    let Some((parent_signal_id, element_width)) = dynamic_array_element_selection(
+        expr,
+        msb,
+        lsb,
+        parent_variables,
+        parent_signal_names,
+        parent_constants,
+        parent_parameter_types,
+    ) else {
+        return Ok(None);
+    };
+    let parent_var = &parent_variables[&parent_signal_id];
+    let (offset, index_sources, index_source_ids) = lower_dynamic_array_element_index_glue(
+        lsb,
+        parent_variables,
+        parent_signal_names,
+        parent_constants,
+        parent_parameter_types,
+        arena,
+        element_width,
+    )
+    .ok_or_else(|| {
+        ParserError::unsupported(
+            64,
+            LoweringPhase::SimulatorParser,
+            "systemverilog output port lvalue connection",
+            format!("{formal} -> {actual}: {actual_expr:?}"),
+            None,
+        )
+    })?;
+    let element_count = parent_var.width / element_width;
+    let child_node = arena.alloc(SLTNode::Input {
+        variable: GlueAddr::Child(child_port_id),
+        signed: child_var.signed,
+        index: Vec::new(),
+        access: BitAccess::new(0, child_var.width - 1),
+    })?;
+    let child_expr = coerce_node_width(arena, child_node, Some(element_width), child_var.signed)?;
+    let old = arena.alloc(SLTNode::Input {
+        variable: GlueAddr::Parent(parent_signal_id),
+        signed: parent_var.signed,
+        index: Vec::new(),
+        access: BitAccess::new(0, parent_var.width - 1),
+    })?;
+    let mut parts = Vec::with_capacity(element_count);
+    for element in (0..element_count).rev() {
+        let lsb = element * element_width;
+        let old_element = arena.alloc(SLTNode::Slice {
+            expr: old,
+            access: BitAccess::new(lsb, lsb + element_width - 1),
+        })?;
+        let element_literal = arena.alloc(SLTNode::Constant(
+            BigUint::from(element),
+            BigUint::default(),
+            64,
+            false,
+        ))?;
+        let condition = arena.alloc(SLTNode::Binary(offset, BinaryOp::EqCase, element_literal))?;
+        let updated = arena.alloc(SLTNode::Mux {
+            cond: condition,
+            then_expr: child_expr,
+            else_expr: old_element,
+        })?;
+        parts.push((updated, element_width));
+    }
+    let mut expr = if parts.len() == 1 {
+        parts[0].0
+    } else {
+        arena.alloc(SLTNode::Concat(parts))?
+    };
+    if !parent_var.is_4state {
+        expr = arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, expr))?;
+    }
+    let mut sources = index_sources.clone();
+    sources.insert(VarAtomBase::new(
+        GlueAddr::Child(child_port_id),
+        0,
+        child_var.width - 1,
+    ));
+    let previous_sources = [VarAtomBase::new(
+        GlueAddr::Parent(parent_signal_id),
+        0,
+        parent_var.width - 1,
+    )]
+    .into_iter()
+    .collect();
+    let mut source_ids = index_source_ids;
+    source_ids.push(parent_signal_id);
+    source_ids.sort();
+    source_ids.dedup();
+    Ok(Some((
+        source_ids,
+        LogicPath {
+            target: LogicPathTarget::Var(VarAtomBase::new(
+                GlueAddr::Parent(parent_signal_id),
+                0,
+                parent_var.width - 1,
+            )),
+            expr,
+            sources,
+            address_sources: index_sources,
+            previous_sources,
+            local_inputs: Vec::new(),
+            order_before: HashSet::default(),
+            comb_capture_enable_sites: Vec::new(),
+            comb_capture_enable_always: false,
+            pre_lower_nodes: Vec::new(),
+        },
+    )))
 }
 
 fn simple_output_lvalue_ident(expr: &sv::ir::Expr) -> Option<&str> {
@@ -1758,7 +1899,7 @@ fn lower_glue_parent_expr(
             lsb,
             signed,
         } => {
-            if let Some((id, element_width)) = dynamic_array_element_selection(
+            if let Some((id, element_width, access)) = dynamic_array_element_subselection(
                 expr,
                 msb,
                 lsb,
@@ -1786,7 +1927,7 @@ fn lower_glue_parent_expr(
                             stride: element_width,
                             kind: SLTIndexKind::Unpacked { element_width },
                         }],
-                        access: BitAccess::new(0, element_width - 1),
+                        access,
                     })
                     .ok()?;
                 sources.insert(VarAtomBase::new(
@@ -2824,7 +2965,7 @@ fn lower_dynamic_array_write_expr(
         let condition = arena
             .alloc(SLTNode::Binary(
                 element_index,
-                BinaryOp::Eq,
+                BinaryOp::EqCase,
                 element_literal,
             ))
             .ok()?;
@@ -3118,7 +3259,7 @@ fn lower_expr_with_context(
             lsb,
             signed,
         } => {
-            if let Some((id, element_width)) = dynamic_array_element_selection(
+            if let Some((id, element_width, access)) = dynamic_array_element_subselection(
                 expr,
                 msb,
                 lsb,
@@ -3146,7 +3287,7 @@ fn lower_expr_with_context(
                             stride: element_width,
                             kind: SLTIndexKind::Unpacked { element_width },
                         }],
-                        access: BitAccess::new(0, element_width - 1),
+                        access,
                     })
                     .ok()?;
                 sources.insert(VarAtomBase::new(id, 0, variable.width.checked_sub(1)?));
@@ -3731,6 +3872,106 @@ fn dynamic_array_element_selection(
         constants,
         parameter_types,
     )
+}
+
+fn dynamic_array_element_subselection(
+    expr: &sv::ir::Expr,
+    msb: &sv::ir::ConstExpr,
+    lsb: &sv::ir::ConstExpr,
+    variables: &HashMap<SourceVarId, SvVariable>,
+    name_to_id: &HashMap<String, SourceVarId>,
+    constants: &HashMap<String, i128>,
+    parameter_types: &HashMap<String, (usize, bool)>,
+) -> Option<(SourceVarId, usize, BitAccess)> {
+    let sv::ir::Expr::Ident(name) = expr else {
+        return None;
+    };
+    let id = *name_to_id.get(name)?;
+    let variable = variables.get(&id)?;
+    let element_width = unpacked_element_width(variable).filter(|width| *width != 0)?;
+    let is_dynamic = sv::typecheck::eval_const_expr_with_types(msb, constants, parameter_types)
+        .is_none()
+        || sv::typecheck::eval_const_expr_with_types(lsb, constants, parameter_types).is_none();
+    if !is_dynamic {
+        return None;
+    }
+    let element_width_value = i128::try_from(element_width).ok()?;
+    let (msb_base, msb_offset) = split_dynamic_array_offset(msb, constants, parameter_types)?;
+    let (lsb_base, lsb_offset) = split_dynamic_array_offset(lsb, constants, parameter_types)?;
+    if msb_base != lsb_base
+        || (element_width > 1
+            && !dynamic_array_base_has_stride(
+                msb_base,
+                element_width_value,
+                constants,
+                parameter_types,
+            ))
+    {
+        return None;
+    }
+    let msb = usize::try_from(msb_offset).ok()?;
+    let lsb = usize::try_from(lsb_offset).ok()?;
+    let access = BitAccess::new(msb.min(lsb), msb.max(lsb));
+    (access.msb < element_width).then_some((id, element_width, access))
+}
+
+fn split_dynamic_array_offset<'a>(
+    expr: &'a sv::ir::ConstExpr,
+    constants: &HashMap<String, i128>,
+    parameter_types: &HashMap<String, (usize, bool)>,
+) -> Option<(&'a sv::ir::ConstExpr, i128)> {
+    if sv::typecheck::eval_const_expr_with_types(expr, constants, parameter_types).is_some() {
+        return None;
+    }
+    if let sv::ir::ConstExpr::Binary { left, op, right } = expr
+        && *op == sv::ir::BinaryOp::Add
+    {
+        if let Some(offset) =
+            sv::typecheck::eval_const_expr_with_types(right, constants, parameter_types)
+            && sv::typecheck::eval_const_expr_with_types(left, constants, parameter_types).is_none()
+        {
+            return Some((left, offset));
+        }
+        if let Some(offset) =
+            sv::typecheck::eval_const_expr_with_types(left, constants, parameter_types)
+            && sv::typecheck::eval_const_expr_with_types(right, constants, parameter_types)
+                .is_none()
+        {
+            return Some((right, offset));
+        }
+    }
+    Some((expr, 0))
+}
+
+fn dynamic_array_base_has_stride(
+    expr: &sv::ir::ConstExpr,
+    element_width: i128,
+    constants: &HashMap<String, i128>,
+    parameter_types: &HashMap<String, (usize, bool)>,
+) -> bool {
+    match expr {
+        sv::ir::ConstExpr::Binary { left, op, right } => {
+            if *op == sv::ir::BinaryOp::Mul {
+                let left_value =
+                    sv::typecheck::eval_const_expr_with_types(left, constants, parameter_types);
+                let right_value =
+                    sv::typecheck::eval_const_expr_with_types(right, constants, parameter_types);
+                if left_value.is_some_and(|value| value > 0 && value % element_width == 0)
+                    && right_value.is_none()
+                {
+                    return true;
+                }
+                if right_value.is_some_and(|value| value > 0 && value % element_width == 0)
+                    && left_value.is_none()
+                {
+                    return true;
+                }
+            }
+            dynamic_array_base_has_stride(left, element_width, constants, parameter_types)
+                || dynamic_array_base_has_stride(right, element_width, constants, parameter_types)
+        }
+        _ => false,
+    }
 }
 
 fn dynamic_array_element_lvalue(
@@ -4836,7 +5077,7 @@ fn sv_expr_natural_width(
                 .unwrap_or(sv::typecheck::parse_integral_literal(literal)?.width),
         ),
         sv::ir::Expr::Select { expr, msb, lsb, .. } => {
-            if let Some((_, element_width)) = dynamic_array_element_selection(
+            if let Some((_, _, access)) = dynamic_array_element_subselection(
                 expr,
                 msb,
                 lsb,
@@ -4845,7 +5086,7 @@ fn sv_expr_natural_width(
                 constants,
                 parameter_types,
             ) {
-                return Some(element_width);
+                return Some(access.msb - access.lsb + 1);
             }
             let msb = sv::typecheck::eval_const_expr_with_types(msb, constants, parameter_types)?;
             let lsb = sv::typecheck::eval_const_expr_with_types(lsb, constants, parameter_types)?;
@@ -5032,7 +5273,7 @@ fn lower_expr_to_sir_with_context(
             lsb,
             signed,
         } => {
-            if let Some((id, element_width)) = dynamic_array_element_selection(
+            if let Some((id, element_width, access)) = dynamic_array_element_subselection(
                 expr,
                 msb,
                 lsb,
@@ -5050,7 +5291,8 @@ fn lower_expr_to_sir_with_context(
                     parameter_types,
                     element_width,
                 )?;
-                let reg = builder.alloc_logic(element_width);
+                let width = access.msb - access.lsb + 1;
+                let reg = builder.alloc_logic(width);
                 builder.emit(SIRInstruction::Load(
                     reg,
                     RegionedVarAddrBase {
@@ -5060,15 +5302,15 @@ fn lower_expr_to_sir_with_context(
                     SIROffset::Element {
                         index,
                         element_width,
-                        bit_offset: 0,
+                        bit_offset: access.lsb,
                         dynamic_bit_offset: None,
                     },
-                    element_width,
+                    width,
                 ));
                 return resize_sir_register(
                     builder,
                     reg,
-                    context_width.unwrap_or(element_width),
+                    context_width.unwrap_or(width),
                     context_signed.unwrap_or(*signed),
                 );
             }

--- a/crates/celox-frontend-sv/src/lowering.rs
+++ b/crates/celox-frontend-sv/src/lowering.rs
@@ -51,6 +51,7 @@ struct SvVariable {
     width: usize,
     signed: bool,
     is_4state: bool,
+    is_net: bool,
     packed_ranges: Vec<(i128, i128)>,
     array_dims: Vec<usize>,
     domain_kind: DomainKind,
@@ -846,6 +847,7 @@ fn lower_module_with_overrides(
             width: type_info.width,
             signed: type_info.signed,
             is_4state: type_info.is_4state,
+            is_net: port.is_net(),
             packed_ranges: type_info.packed_ranges,
             array_dims: type_info.array_dims,
             domain_kind: DomainKind::Other,
@@ -889,6 +891,7 @@ fn lower_module_with_overrides(
             width: type_info.width,
             signed: type_info.signed,
             is_4state: type_info.is_4state,
+            is_net: signal.is_net(),
             packed_ranges: type_info.packed_ranges,
             array_dims: type_info.array_dims,
             domain_kind: DomainKind::Other,
@@ -1433,6 +1436,7 @@ fn ensure_parent_output_signals(
             width: 1,
             signed: false,
             is_4state: true,
+            is_net: true,
             packed_ranges: Vec::new(),
             array_dims: Vec::new(),
             domain_kind: DomainKind::Other,
@@ -1693,6 +1697,15 @@ fn lower_dynamic_output_glue(
         return Ok(None);
     };
     let parent_var = &parent_variables[&parent_signal_id];
+    if parent_var.is_net {
+        return Err(ParserError::unsupported(
+            64,
+            LoweringPhase::SimulatorParser,
+            "dynamic child output connection to a net",
+            format!("{formal} -> {actual}: {actual_expr:?}"),
+            None,
+        ));
+    }
     let (offset, index_sources, index_source_ids) = lower_dynamic_array_element_index_glue(
         lsb,
         parent_variables,
@@ -1918,6 +1931,8 @@ fn lower_glue_parent_expr(
                     element_width,
                 )?;
                 let variable = variables.get(&id)?;
+                let element_count = variable.width.checked_div(element_width)?;
+                let (offset, valid) = dynamic_array_index_guard_slt(arena, offset, element_count)?;
                 let node = arena
                     .alloc(SLTNode::Input {
                         variable: GlueAddr::Parent(id),
@@ -1930,6 +1945,8 @@ fn lower_glue_parent_expr(
                         access,
                     })
                     .ok()?;
+                let node =
+                    guard_dynamic_array_read_slt(arena, valid, node, access.msb - access.lsb + 1)?;
                 sources.insert(VarAtomBase::new(
                     GlueAddr::Parent(id),
                     0,
@@ -3278,6 +3295,8 @@ fn lower_expr_with_context(
                     element_width,
                 )?;
                 let variable = variables.get(&id)?;
+                let element_count = variable.width.checked_div(element_width)?;
+                let (offset, valid) = dynamic_array_index_guard_slt(arena, offset, element_count)?;
                 let node = arena
                     .alloc(SLTNode::Input {
                         variable: id,
@@ -3290,6 +3309,8 @@ fn lower_expr_with_context(
                         access,
                     })
                     .ok()?;
+                let node =
+                    guard_dynamic_array_read_slt(arena, valid, node, access.msb - access.lsb + 1)?;
                 sources.insert(VarAtomBase::new(id, 0, variable.width.checked_sub(1)?));
                 return Some((
                     coerce_node_width(
@@ -4064,6 +4085,74 @@ fn lower_dynamic_array_element_index_slt(
     Some((element_index, sources))
 }
 
+fn dynamic_array_index_guard_slt<A: std::hash::Hash + Eq + Clone>(
+    arena: &mut SLTNodeArena<A>,
+    index: NodeId,
+    element_count: usize,
+) -> Option<(NodeId, NodeId)> {
+    let mut valid = None;
+    for element in 0..element_count {
+        let element_literal = arena
+            .alloc(SLTNode::Constant(
+                BigUint::from(element),
+                BigUint::default(),
+                64,
+                false,
+            ))
+            .ok()?;
+        let matches = arena
+            .alloc(SLTNode::Binary(index, BinaryOp::EqCase, element_literal))
+            .ok()?;
+        valid = Some(match valid {
+            Some(previous) => arena
+                .alloc(SLTNode::Binary(previous, BinaryOp::Or, matches))
+                .ok()?,
+            None => matches,
+        });
+    }
+    let valid = valid?;
+    let zero = arena
+        .alloc(SLTNode::Constant(
+            BigUint::default(),
+            BigUint::default(),
+            64,
+            false,
+        ))
+        .ok()?;
+    let safe_index = arena
+        .alloc(SLTNode::Mux {
+            cond: valid,
+            then_expr: index,
+            else_expr: zero,
+        })
+        .ok()?;
+    Some((safe_index, valid))
+}
+
+fn guard_dynamic_array_read_slt<A: std::hash::Hash + Eq + Clone>(
+    arena: &mut SLTNodeArena<A>,
+    valid: NodeId,
+    value: NodeId,
+    value_width: usize,
+) -> Option<NodeId> {
+    let unknown_mask = (BigUint::from(1u8) << value_width) - BigUint::from(1u8);
+    let unknown = arena
+        .alloc(SLTNode::Constant(
+            BigUint::default(),
+            unknown_mask,
+            value_width,
+            false,
+        ))
+        .ok()?;
+    arena
+        .alloc(SLTNode::Mux {
+            cond: valid,
+            then_expr: value,
+            else_expr: unknown,
+        })
+        .ok()
+}
+
 fn lower_dynamic_array_element_index(
     builder: &mut SIRBuilder<RegionedVarAddr>,
     offset: &sv::ir::ConstExpr,
@@ -4101,6 +4190,64 @@ fn lower_dynamic_array_element_index(
         divisor,
     ));
     Some(index)
+}
+
+fn dynamic_array_index_guard_sir(
+    builder: &mut SIRBuilder<RegionedVarAddr>,
+    index: celox_sir::RegisterId,
+    element_count: usize,
+) -> Option<(celox_sir::RegisterId, celox_sir::RegisterId)> {
+    let mut valid = None;
+    for element in 0..element_count {
+        let element_literal = builder.alloc_bit(64, false);
+        builder.emit(SIRInstruction::Imm(
+            element_literal,
+            SIRValue::new(u64::try_from(element).ok()?),
+        ));
+        let matches = builder.alloc_bit(1, false);
+        builder.emit(SIRInstruction::Binary(
+            matches,
+            index,
+            BinaryOp::EqCase,
+            element_literal,
+        ));
+        valid = Some(match valid {
+            Some(previous) => {
+                let combined = builder.alloc_bit(1, false);
+                builder.emit(SIRInstruction::Binary(
+                    combined,
+                    previous,
+                    BinaryOp::Or,
+                    matches,
+                ));
+                combined
+            }
+            None => matches,
+        });
+    }
+    let valid = valid?;
+    let zero = builder.alloc_bit(64, false);
+    builder.emit(SIRInstruction::Imm(zero, SIRValue::new(0u8)));
+    let safe_index = builder.alloc_bit(64, false);
+    builder.emit(SIRInstruction::Mux(safe_index, valid, index, zero));
+    Some((safe_index, valid))
+}
+
+fn guard_dynamic_array_read_sir(
+    builder: &mut SIRBuilder<RegionedVarAddr>,
+    valid: celox_sir::RegisterId,
+    value: celox_sir::RegisterId,
+    value_width: usize,
+) -> celox_sir::RegisterId {
+    let unknown = builder.alloc_logic(value_width);
+    let unknown_mask = (BigUint::from(1u8) << value_width) - BigUint::from(1u8);
+    builder.emit(SIRInstruction::Imm(
+        unknown,
+        SIRValue::new_four_state(BigUint::default(), unknown_mask),
+    ));
+    let guarded = builder.alloc_logic(value_width);
+    builder.emit(SIRInstruction::Mux(guarded, valid, value, unknown));
+    guarded
 }
 
 type SvFfBlocks = (
@@ -5292,6 +5439,8 @@ fn lower_expr_to_sir_with_context(
                     element_width,
                 )?;
                 let width = access.msb - access.lsb + 1;
+                let element_count = variables.get(&id)?.width.checked_div(element_width)?;
+                let (index, valid) = dynamic_array_index_guard_sir(builder, index, element_count)?;
                 let reg = builder.alloc_logic(width);
                 builder.emit(SIRInstruction::Load(
                     reg,
@@ -5307,6 +5456,7 @@ fn lower_expr_to_sir_with_context(
                     },
                     width,
                 ));
+                let reg = guard_dynamic_array_read_sir(builder, valid, reg, width);
                 return resize_sir_register(
                     builder,
                     reg,

--- a/crates/celox-frontend-sv/src/lowering.rs
+++ b/crates/celox-frontend-sv/src/lowering.rs
@@ -25,7 +25,10 @@ use celox_sir::{
     BlockId, ExecutionUnit, RegisterType, SIRBuilder, SIRInstruction, SIROffset, SIRTerminator,
     SIRValue, merge_sir_eus,
 };
-use celox_slt::{CombObserver, GlueBlockBase, LogicPath, LogicPathTarget, SLTNode, SLTNodeArena};
+use celox_slt::{
+    CombObserver, GlueBlockBase, LogicPath, LogicPathTarget, SLTIndex, SLTIndexKind, SLTNode,
+    SLTNodeArena,
+};
 use celox_sv_analyzer as sv;
 use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use num_bigint::BigUint;
@@ -2548,6 +2551,126 @@ fn expr_references_ident(expr: &sv::ir::Expr, name: &str) -> bool {
     }
 }
 
+fn lower_dynamic_array_write_expr(
+    lvalue: &sv::ir::LValue,
+    rhs: &sv::ir::Expr,
+    variables: &HashMap<SourceVarId, SvVariable>,
+    name_to_id: &HashMap<String, SourceVarId>,
+    constants: &HashMap<String, i128>,
+    parameter_types: &HashMap<String, (usize, bool)>,
+    arena: &mut SLTNodeArena<SourceVarId>,
+) -> Option<(
+    LogicPathTarget<SourceVarId>,
+    celox_slt::NodeId,
+    HashSet<VarAtomBase<SourceVarId>>,
+    HashSet<VarAtomBase<SourceVarId>>,
+)> {
+    let (id, element_width, offset) =
+        dynamic_array_element_lvalue(lvalue, variables, name_to_id, constants, parameter_types)?;
+    let variable = variables.get(&id)?;
+    let element_count = variable.width.checked_div(element_width)?;
+    if element_count == 0 {
+        return None;
+    }
+    let target_width = variable.width;
+    let (rhs_node, mut sources) = if let sv::ir::Expr::Literal(literal) = rhs
+        && let Some(fill) = unbased_fill_literal(literal)
+    {
+        (
+            lower_unbased_fill_literal_slt(arena, fill, element_width)?,
+            HashSet::default(),
+        )
+    } else {
+        lower_expr_with_context(
+            rhs,
+            variables,
+            name_to_id,
+            constants,
+            parameter_types,
+            arena,
+            Some(element_width),
+            Some(sv_expr_is_signed_with_parameters(
+                rhs,
+                variables,
+                name_to_id,
+                parameter_types,
+            )),
+        )?
+    };
+    let rhs_node = coerce_node_width(
+        arena,
+        rhs_node,
+        Some(element_width),
+        sv_expr_is_signed_with_parameters(rhs, variables, name_to_id, parameter_types),
+    )
+    .ok()?;
+    let (element_index, index_sources) = lower_dynamic_array_element_index_slt(
+        &offset,
+        variables,
+        name_to_id,
+        constants,
+        parameter_types,
+        arena,
+        element_width,
+    )?;
+    sources.extend(index_sources);
+    let previous_sources = [VarAtomBase::new(id, 0, target_width.checked_sub(1)?)]
+        .into_iter()
+        .collect();
+    let old = arena
+        .alloc(SLTNode::Input {
+            variable: id,
+            signed: variable.signed,
+            index: Vec::new(),
+            access: BitAccess::new(0, target_width - 1),
+        })
+        .ok()?;
+    let mut parts = Vec::with_capacity(element_count);
+    for element in (0..element_count).rev() {
+        let lsb = element.checked_mul(element_width)?;
+        let old_element = arena
+            .alloc(SLTNode::Slice {
+                expr: old,
+                access: BitAccess::new(lsb, lsb + element_width - 1),
+            })
+            .ok()?;
+        let element_literal = arena
+            .alloc(SLTNode::Constant(
+                BigUint::from(element),
+                BigUint::default(),
+                64,
+                false,
+            ))
+            .ok()?;
+        let condition = arena
+            .alloc(SLTNode::Binary(
+                element_index,
+                BinaryOp::Eq,
+                element_literal,
+            ))
+            .ok()?;
+        let updated = arena
+            .alloc(SLTNode::Mux {
+                cond: condition,
+                then_expr: rhs_node,
+                else_expr: old_element,
+            })
+            .ok()?;
+        parts.push((updated, element_width));
+    }
+    let expr = if parts.len() == 1 {
+        parts[0].0
+    } else {
+        arena.alloc(SLTNode::Concat(parts)).ok()?
+    };
+    Some((
+        LogicPathTarget::Var(VarAtomBase::new(id, 0, target_width - 1)),
+        expr,
+        sources,
+        previous_sources,
+    ))
+}
+
 fn lower_assignment(
     assignment: &sv::ir::Assignment,
     variables: &HashMap<SourceVarId, SvVariable>,
@@ -2557,6 +2680,64 @@ fn lower_assignment(
     arena: &mut SLTNodeArena<SourceVarId>,
     four_state: bool,
 ) -> Result<LogicPath<SourceVarId>, sv::AnalyzerError> {
+    let rhs = expr_for_state_mode(assignment.rhs(), four_state);
+    if let Some((target, expr, sources, previous_sources)) = lower_dynamic_array_write_expr(
+        assignment.lhs_value(),
+        &rhs,
+        variables,
+        name_to_id,
+        constants,
+        parameter_types,
+        arena,
+    ) {
+        let target_width = target
+            .var()
+            .map(|target| target.access.msb - target.access.lsb + 1)
+            .ok_or_else(|| {
+                sv::AnalyzerError::Unsupported(format!(
+                    "combinational assignment target `{}`",
+                    assignment.lhs()
+                ))
+            })?;
+        let mut expr = coerce_node_width(
+            arena,
+            expr,
+            Some(target_width),
+            sv_expr_is_signed_with_parameters(&rhs, variables, name_to_id, parameter_types),
+        )
+        .map_err(|error| {
+            sv::AnalyzerError::Unsupported(format!(
+                "combinational assignment width coercion for `{}`: {error}",
+                assignment.lhs()
+            ))
+        })?;
+        let target_is_two_state = target
+            .var()
+            .and_then(|target| variables.get(&target.id))
+            .is_some_and(|variable| !variable.is_4state);
+        if target_is_two_state || (!four_state && expr_is_unknown_literal(&rhs)) {
+            expr = arena
+                .alloc(SLTNode::Unary(UnaryOp::ToTwoState, expr))
+                .map_err(|error| {
+                    sv::AnalyzerError::Unsupported(format!(
+                        "two-state conversion for `{}`: {error}",
+                        assignment.lhs()
+                    ))
+                })?;
+        }
+        return Ok(LogicPath {
+            target,
+            expr,
+            sources,
+            address_sources: HashSet::default(),
+            previous_sources,
+            local_inputs: Vec::new(),
+            order_before: HashSet::default(),
+            comb_capture_enable_sites: Vec::new(),
+            comb_capture_enable_always: false,
+            pre_lower_nodes: Vec::new(),
+        });
+    }
     let target = lower_lvalue_target(
         assignment.lhs_value(),
         variables,
@@ -2579,7 +2760,6 @@ fn lower_assignment(
                 assignment.lhs()
             ))
         })?;
-    let rhs = expr_for_state_mode(assignment.rhs(), four_state);
     let (expr, sources) = if let sv::ir::Expr::Literal(literal) = &rhs
         && let Some(fill) = unbased_fill_literal(literal)
     {
@@ -2754,6 +2934,49 @@ fn lower_expr_with_context(
             lsb,
             signed,
         } => {
+            if let Some((id, element_width)) = dynamic_array_element_selection(
+                expr,
+                msb,
+                lsb,
+                variables,
+                name_to_id,
+                constants,
+                parameter_types,
+            ) {
+                let (offset, mut sources) = lower_dynamic_array_element_index_slt(
+                    lsb,
+                    variables,
+                    name_to_id,
+                    constants,
+                    parameter_types,
+                    arena,
+                    element_width,
+                )?;
+                let variable = variables.get(&id)?;
+                let node = arena
+                    .alloc(SLTNode::Input {
+                        variable: id,
+                        signed: *signed,
+                        index: vec![SLTIndex {
+                            node: offset,
+                            stride: element_width,
+                            kind: SLTIndexKind::Unpacked { element_width },
+                        }],
+                        access: BitAccess::new(0, element_width - 1),
+                    })
+                    .ok()?;
+                sources.insert(VarAtomBase::new(id, 0, variable.width.checked_sub(1)?));
+                return Some((
+                    coerce_node_width(
+                        arena,
+                        node,
+                        context_width,
+                        context_signed.unwrap_or(*signed),
+                    )
+                    .ok()?,
+                    sources,
+                ));
+            }
             let (inner, mut sources) = lower_expr(
                 expr,
                 variables,
@@ -3252,6 +3475,209 @@ fn packed_expr_select_offsets(
     Some((usize::try_from(msb).ok()?, usize::try_from(lsb).ok()?))
 }
 
+fn expr_from_const_expr(expr: &sv::ir::ConstExpr) -> Option<sv::ir::Expr> {
+    Some(match expr {
+        sv::ir::ConstExpr::Literal(value) => sv::ir::Expr::Literal(value.clone()),
+        sv::ir::ConstExpr::Ident(name) => sv::ir::Expr::Ident(name.clone()),
+        sv::ir::ConstExpr::Select { expr, bit } => sv::ir::Expr::Select {
+            expr: Box::new(expr_from_const_expr(expr)?),
+            msb: (**bit).clone(),
+            lsb: (**bit).clone(),
+            signed: false,
+        },
+        sv::ir::ConstExpr::Function { .. } => return None,
+        sv::ir::ConstExpr::Unary { op, expr } => sv::ir::Expr::Unary {
+            op: *op,
+            expr: Box::new(expr_from_const_expr(expr)?),
+        },
+        sv::ir::ConstExpr::Binary { left, op, right } => sv::ir::Expr::Binary {
+            left: Box::new(expr_from_const_expr(left)?),
+            op: *op,
+            right: Box::new(expr_from_const_expr(right)?),
+        },
+        sv::ir::ConstExpr::Mux {
+            condition,
+            then_expr,
+            else_expr,
+        } => sv::ir::Expr::Mux {
+            condition: Box::new(expr_from_const_expr(condition)?),
+            then_expr: Box::new(expr_from_const_expr(then_expr)?),
+            else_expr: Box::new(expr_from_const_expr(else_expr)?),
+        },
+    })
+}
+
+fn const_expr_adds_constant(
+    expr: &sv::ir::ConstExpr,
+    base: &sv::ir::ConstExpr,
+    value: i128,
+    constants: &HashMap<String, i128>,
+    parameter_types: &HashMap<String, (usize, bool)>,
+) -> bool {
+    let sv::ir::ConstExpr::Binary { left, op, right } = expr else {
+        return false;
+    };
+    *op == sv::ir::BinaryOp::Add
+        && ((left.as_ref() == base
+            && sv::typecheck::eval_const_expr_with_types(right, constants, parameter_types)
+                == Some(value))
+            || (right.as_ref() == base
+                && sv::typecheck::eval_const_expr_with_types(left, constants, parameter_types)
+                    == Some(value)))
+}
+
+fn dynamic_array_element_selection(
+    expr: &sv::ir::Expr,
+    msb: &sv::ir::ConstExpr,
+    lsb: &sv::ir::ConstExpr,
+    variables: &HashMap<SourceVarId, SvVariable>,
+    name_to_id: &HashMap<String, SourceVarId>,
+    constants: &HashMap<String, i128>,
+    parameter_types: &HashMap<String, (usize, bool)>,
+) -> Option<(SourceVarId, usize)> {
+    let sv::ir::Expr::Ident(name) = expr else {
+        return None;
+    };
+    dynamic_array_element_access(
+        name,
+        msb,
+        lsb,
+        variables,
+        name_to_id,
+        constants,
+        parameter_types,
+    )
+}
+
+fn dynamic_array_element_lvalue(
+    lvalue: &sv::ir::LValue,
+    variables: &HashMap<SourceVarId, SvVariable>,
+    name_to_id: &HashMap<String, SourceVarId>,
+    constants: &HashMap<String, i128>,
+    parameter_types: &HashMap<String, (usize, bool)>,
+) -> Option<(SourceVarId, usize, sv::ir::ConstExpr)> {
+    let sv::ir::LValue::Select { name, msb, lsb, .. } = lvalue else {
+        return None;
+    };
+    let (id, element_width) = dynamic_array_element_access(
+        name,
+        msb,
+        lsb,
+        variables,
+        name_to_id,
+        constants,
+        parameter_types,
+    )?;
+    Some((id, element_width, lsb.clone()))
+}
+
+fn dynamic_array_element_access(
+    name: &str,
+    msb: &sv::ir::ConstExpr,
+    lsb: &sv::ir::ConstExpr,
+    variables: &HashMap<SourceVarId, SvVariable>,
+    name_to_id: &HashMap<String, SourceVarId>,
+    constants: &HashMap<String, i128>,
+    parameter_types: &HashMap<String, (usize, bool)>,
+) -> Option<(SourceVarId, usize)> {
+    let id = *name_to_id.get(name)?;
+    let variable = variables.get(&id)?;
+    let element_width = unpacked_element_width(variable).filter(|width| *width != 0)?;
+    let is_dynamic = sv::typecheck::eval_const_expr_with_types(msb, constants, parameter_types)
+        .is_none()
+        || sv::typecheck::eval_const_expr_with_types(lsb, constants, parameter_types).is_none();
+    if !is_dynamic
+        || (element_width > 1
+            && !const_expr_adds_constant(
+                msb,
+                lsb,
+                i128::try_from(element_width - 1).ok()?,
+                constants,
+                parameter_types,
+            ))
+    {
+        return None;
+    }
+    Some((id, element_width))
+}
+
+fn lower_dynamic_array_element_index_slt(
+    offset: &sv::ir::ConstExpr,
+    variables: &HashMap<SourceVarId, SvVariable>,
+    name_to_id: &HashMap<String, SourceVarId>,
+    constants: &HashMap<String, i128>,
+    parameter_types: &HashMap<String, (usize, bool)>,
+    arena: &mut SLTNodeArena<SourceVarId>,
+    element_width: usize,
+) -> Option<(celox_slt::NodeId, HashSet<VarAtomBase<SourceVarId>>)> {
+    let offset_expr = expr_from_const_expr(offset)?;
+    let (offset, sources) = lower_expr_with_context(
+        &offset_expr,
+        variables,
+        name_to_id,
+        constants,
+        parameter_types,
+        arena,
+        None,
+        None,
+    )?;
+    let element_index = if element_width == 1 {
+        offset
+    } else {
+        let divisor = arena
+            .alloc(SLTNode::Constant(
+                BigUint::from(element_width),
+                BigUint::default(),
+                64,
+                false,
+            ))
+            .ok()?;
+        arena
+            .alloc(SLTNode::Binary(offset, BinaryOp::DivU, divisor))
+            .ok()?
+    };
+    Some((element_index, sources))
+}
+
+fn lower_dynamic_array_element_index(
+    builder: &mut SIRBuilder<RegionedVarAddr>,
+    offset: &sv::ir::ConstExpr,
+    variables: &HashMap<SourceVarId, SvVariable>,
+    name_to_id: &HashMap<String, SourceVarId>,
+    constants: &HashMap<String, i128>,
+    parameter_types: &HashMap<String, (usize, bool)>,
+    element_width: usize,
+) -> Option<celox_sir::RegisterId> {
+    let offset_expr = expr_from_const_expr(offset)?;
+    let offset = lower_expr_to_sir_with_context(
+        builder,
+        &offset_expr,
+        variables,
+        name_to_id,
+        constants,
+        parameter_types,
+        None,
+        None,
+    )?;
+    let offset = resize_sir_register(builder, offset, 64, false)?;
+    if element_width == 1 {
+        return Some(offset);
+    }
+    let divisor = builder.alloc_bit(64, false);
+    builder.emit(SIRInstruction::Imm(
+        divisor,
+        SIRValue::new(element_width as u64),
+    ));
+    let index = builder.alloc_bit(64, false);
+    builder.emit(SIRInstruction::Binary(
+        index,
+        offset,
+        BinaryOp::DivU,
+        divisor,
+    ));
+    Some(index)
+}
+
 type SvFfBlocks = (
     HashMap<TriggerSet<SourceVarId>, ExecutionUnit<RegionedVarAddr>>,
     HashMap<TriggerSet<SourceVarId>, ExecutionUnit<RegionedVarAddr>>,
@@ -3538,13 +3964,18 @@ fn ff_targets(
 ) -> Option<Vec<VarAtomBase<SourceVarId>>> {
     let mut targets = Vec::new();
     for assignment in process.assignments() {
-        let target = lvalue_atom(
-            assignment.assignment().lhs_value(),
-            variables,
-            name_to_id,
-            constants,
-            parameter_types,
-        )?;
+        let lvalue = assignment.assignment().lhs_value();
+        let dynamic =
+            dynamic_array_element_lvalue(lvalue, variables, name_to_id, constants, parameter_types);
+        let target = lvalue_atom(lvalue, variables, name_to_id, constants, parameter_types)
+            .or_else(|| {
+                dynamic.as_ref().and_then(|(id, _, _)| {
+                    variables
+                        .get(id)
+                        .and_then(|variable| variable.width.checked_sub(1))
+                        .map(|msb| VarAtomBase::new(*id, 0, msb))
+                })
+            })?;
         if !targets.contains(&target) {
             targets.push(target);
         }
@@ -3609,7 +4040,8 @@ fn emit_ff_assignment_stores(
     }
 
     for target_id in target_ids {
-        let width = variables.get(&target_id)?.width;
+        let variable = variables.get(&target_id)?;
+        let width = variable.width;
         let mut value = builder.alloc_logic(width);
         builder.emit(SIRInstruction::Load(
             value,
@@ -3620,21 +4052,35 @@ fn emit_ff_assignment_stores(
                 region: WORKING_REGION,
                 var_id: target_id,
             },
-            sv_memory_offset(variables.get(&target_id)?, 0, width),
+            sv_memory_offset(variable, 0, width),
             width,
         ));
+        let mut value_dirty = false;
         for assignment in process.assignments() {
-            let target = lvalue_atom(
-                assignment.assignment().lhs_value(),
+            let lvalue = assignment.assignment().lhs_value();
+            let dynamic = dynamic_array_element_lvalue(
+                lvalue,
                 variables,
                 name_to_id,
                 constants,
                 parameter_types,
-            )?;
+            );
+            let target = lvalue_atom(lvalue, variables, name_to_id, constants, parameter_types)
+                .or_else(|| {
+                    dynamic.as_ref().and_then(|(id, _, _)| {
+                        variables
+                            .get(id)
+                            .and_then(|variable| variable.width.checked_sub(1))
+                            .map(|msb| VarAtomBase::new(*id, 0, msb))
+                    })
+                })?;
             if target.id != target_id {
                 continue;
             }
-            let target_width = target.access.msb - target.access.lsb + 1;
+            let target_width = dynamic.as_ref().map_or_else(
+                || target.access.msb - target.access.lsb + 1,
+                |(_, width, _)| *width,
+            );
             let rhs_expr = expr_for_state_mode(assignment.assignment().rhs(), four_state);
             let rhs = match &rhs_expr {
                 sv::ir::Expr::Literal(literal) => match unbased_fill_literal(literal) {
@@ -3706,6 +4152,91 @@ fn emit_ff_assignment_stores(
                 builder.emit(SIRInstruction::Unary(two_state, UnaryOp::ToTwoState, rhs));
                 two_state
             };
+            if let Some((_, element_width, offset)) = dynamic {
+                // Flush preceding static assignments before a dynamic store so
+                // the direct element write observes the current working value.
+                if value_dirty {
+                    builder.emit(SIRInstruction::Store(
+                        RegionedVarAddrBase {
+                            region: WORKING_REGION,
+                            var_id: target_id,
+                        },
+                        sv_memory_offset(variable, 0, width),
+                        width,
+                        value,
+                        Vec::new(),
+                        Vec::new(),
+                    ));
+                    value_dirty = false;
+                }
+                let index = lower_dynamic_array_element_index(
+                    builder,
+                    &offset,
+                    variables,
+                    name_to_id,
+                    constants,
+                    parameter_types,
+                    element_width,
+                )?;
+                let store_value = match assignment.condition() {
+                    Some(condition) => {
+                        let old = builder.alloc_logic(target_width);
+                        builder.emit(SIRInstruction::Load(
+                            old,
+                            RegionedVarAddrBase {
+                                region: WORKING_REGION,
+                                var_id: target_id,
+                            },
+                            SIROffset::Element {
+                                index,
+                                element_width,
+                                bit_offset: 0,
+                                dynamic_bit_offset: None,
+                            },
+                            target_width,
+                        ));
+                        let condition = lower_procedural_condition(
+                            builder,
+                            condition,
+                            variables,
+                            name_to_id,
+                            constants,
+                            parameter_types,
+                        )?;
+                        let mux = builder.alloc_logic(target_width);
+                        builder.emit(SIRInstruction::Mux(mux, condition, rhs, old));
+                        mux
+                    }
+                    None => rhs,
+                };
+                builder.emit(SIRInstruction::Store(
+                    RegionedVarAddrBase {
+                        region: WORKING_REGION,
+                        var_id: target_id,
+                    },
+                    SIROffset::Element {
+                        index,
+                        element_width,
+                        bit_offset: 0,
+                        dynamic_bit_offset: None,
+                    },
+                    target_width,
+                    store_value,
+                    Vec::new(),
+                    Vec::new(),
+                ));
+                value = builder.alloc_logic(width);
+                builder.emit(SIRInstruction::Load(
+                    value,
+                    RegionedVarAddrBase {
+                        region: WORKING_REGION,
+                        var_id: target_id,
+                    },
+                    sv_memory_offset(variable, 0, width),
+                    width,
+                ));
+                continue;
+            }
             let assigned =
                 replace_sir_slice(builder, value, rhs, target.access.lsb, target_width, width)?;
             value = match assignment.condition() {
@@ -3724,6 +4255,10 @@ fn emit_ff_assignment_stores(
                 }
                 None => assigned,
             };
+            value_dirty = true;
+        }
+        if !value_dirty {
+            continue;
         }
         for target in targets.iter().filter(|target| target.id == target_id) {
             let target_width = target.access.msb - target.access.lsb + 1;
@@ -3744,7 +4279,7 @@ fn emit_ff_assignment_stores(
                     region: WORKING_REGION,
                     var_id: target_id,
                 },
-                sv_memory_offset(variables.get(&target_id)?, target.access.lsb, target_width),
+                sv_memory_offset(variable, target.access.lsb, target_width),
                 target_width,
                 store_value,
                 Vec::new(),
@@ -4116,7 +4651,18 @@ fn sv_expr_natural_width(
                 .map(|_| 1)
                 .unwrap_or(sv::typecheck::parse_integral_literal(literal)?.width),
         ),
-        sv::ir::Expr::Select { msb, lsb, .. } => {
+        sv::ir::Expr::Select { expr, msb, lsb, .. } => {
+            if let Some((_, element_width)) = dynamic_array_element_selection(
+                expr,
+                msb,
+                lsb,
+                variables,
+                name_to_id,
+                constants,
+                parameter_types,
+            ) {
+                return Some(element_width);
+            }
             let msb = sv::typecheck::eval_const_expr_with_types(msb, constants, parameter_types)?;
             let lsb = sv::typecheck::eval_const_expr_with_types(lsb, constants, parameter_types)?;
             usize::try_from(msb.abs_diff(lsb)).ok()?.checked_add(1)
@@ -4302,6 +4848,46 @@ fn lower_expr_to_sir_with_context(
             lsb,
             signed,
         } => {
+            if let Some((id, element_width)) = dynamic_array_element_selection(
+                expr,
+                msb,
+                lsb,
+                variables,
+                name_to_id,
+                constants,
+                parameter_types,
+            ) {
+                let index = lower_dynamic_array_element_index(
+                    builder,
+                    lsb,
+                    variables,
+                    name_to_id,
+                    constants,
+                    parameter_types,
+                    element_width,
+                )?;
+                let reg = builder.alloc_logic(element_width);
+                builder.emit(SIRInstruction::Load(
+                    reg,
+                    RegionedVarAddrBase {
+                        region: STABLE_REGION,
+                        var_id: id,
+                    },
+                    SIROffset::Element {
+                        index,
+                        element_width,
+                        bit_offset: 0,
+                        dynamic_bit_offset: None,
+                    },
+                    element_width,
+                ));
+                return resize_sir_register(
+                    builder,
+                    reg,
+                    context_width.unwrap_or(element_width),
+                    context_signed.unwrap_or(*signed),
+                );
+            }
             let msb = sv::typecheck::eval_const_expr_with_types(msb, constants, parameter_types)?;
             let lsb = sv::typecheck::eval_const_expr_with_types(lsb, constants, parameter_types)?;
             let (msb, lsb) = packed_expr_select_offsets(expr, msb, lsb, variables, name_to_id)?;

--- a/crates/celox-frontend-sv/src/lowering.rs
+++ b/crates/celox-frontend-sv/src/lowering.rs
@@ -3664,7 +3664,7 @@ fn emit_ff_assignment_stores(
                     region: WORKING_REGION,
                     var_id: target_id,
                 },
-                SIROffset::Static(target.access.lsb),
+                sv_memory_offset(variables.get(&target_id)?, target.access.lsb, target_width),
                 target_width,
                 store_value,
                 Vec::new(),

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -181,6 +181,13 @@ impl Module {
             return Err(AnalyzerError::Unsupported("ref port direction".to_string()));
         }
         let signals = signals_from_module_node(node.clone(), syntax_tree, &const_env)?;
+        for r#type in ports
+            .iter()
+            .map(Port::r#type)
+            .chain(signals.iter().map(Signal::r#type))
+        {
+            validate_unpacked_dimension_sizes(r#type.unpacked_ranges(), &const_env)?;
+        }
         if let Some(parameter) = parameters.iter().find(|parameter| {
             ports.iter().any(|port| port.name() == parameter.name())
                 || signals
@@ -444,6 +451,83 @@ fn static_for_loop_iterations(
         },
     );
     (eval_ast_const_expr(&condition, &loop_env) == Some(0)).then_some((name, values))
+}
+
+fn validate_static_for_loops_in_statement_or_null(
+    statement: &sv_parser::StatementOrNull,
+    syntax_tree: &SyntaxTree,
+    const_env: &HashMap<String, i128>,
+) -> Result<(), AnalyzerError> {
+    if let sv_parser::StatementOrNull::Statement(statement) = statement {
+        validate_static_for_loops_in_statement(statement, syntax_tree, const_env)?;
+    }
+    Ok(())
+}
+
+fn validate_static_for_loops_in_statement(
+    statement: &sv_parser::Statement,
+    syntax_tree: &SyntaxTree,
+    const_env: &HashMap<String, i128>,
+) -> Result<(), AnalyzerError> {
+    match &statement.nodes.2 {
+        sv_parser::StatementItem::ProceduralTimingControlStatement(timing) => {
+            validate_static_for_loops_in_statement_or_null(
+                &timing.nodes.1,
+                syntax_tree,
+                const_env,
+            )?;
+        }
+        sv_parser::StatementItem::SeqBlock(block) => {
+            for statement in &block.nodes.3 {
+                validate_static_for_loops_in_statement_or_null(statement, syntax_tree, const_env)?;
+            }
+        }
+        sv_parser::StatementItem::ConditionalStatement(conditional) => {
+            validate_static_for_loops_in_statement_or_null(
+                &conditional.nodes.3,
+                syntax_tree,
+                const_env,
+            )?;
+            for (_, _, _, branch) in &conditional.nodes.4 {
+                validate_static_for_loops_in_statement_or_null(branch, syntax_tree, const_env)?;
+            }
+            if let Some((_, branch)) = &conditional.nodes.5 {
+                validate_static_for_loops_in_statement_or_null(branch, syntax_tree, const_env)?;
+            }
+        }
+        sv_parser::StatementItem::CaseStatement(case) => {
+            let sv_parser::CaseStatement::Normal(case) = &**case else {
+                return Ok(());
+            };
+            for item in std::iter::once(&case.nodes.3).chain(case.nodes.4.iter()) {
+                let statement = match item {
+                    sv_parser::CaseItem::NonDefault(item) => &item.nodes.2,
+                    sv_parser::CaseItem::Default(item) => &item.nodes.2,
+                };
+                validate_static_for_loops_in_statement_or_null(statement, syntax_tree, const_env)?;
+            }
+        }
+        sv_parser::StatementItem::LoopStatement(loop_statement) => {
+            let (name, values) = static_for_loop_iterations(loop_statement, syntax_tree, const_env)
+                .ok_or_else(|| {
+                    AnalyzerError::Unsupported("procedural loop inside always_ff".to_string())
+                })?;
+            let sv_parser::LoopStatement::For(loop_statement) = &**loop_statement else {
+                unreachable!();
+            };
+            for value in values {
+                let mut loop_env = const_env.clone();
+                loop_env.insert(name.clone(), value);
+                validate_static_for_loops_in_statement_or_null(
+                    &loop_statement.nodes.2,
+                    syntax_tree,
+                    &loop_env,
+                )?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 fn for_loop_initialization(
@@ -732,6 +816,9 @@ fn reject_silently_ignored_constructs(
                         "blocking assignment inside always_ff".to_string(),
                     ));
                 }
+                if matches!(always.nodes.0, sv_parser::AlwaysKeyword::AlwaysFf(_)) {
+                    validate_static_for_loops_in_statement(&always.nodes.1, syntax_tree, const_env)?;
+                }
                 if matches!(always.nodes.0, sv_parser::AlwaysKeyword::AlwaysFf(_))
                     && body.clone().into_iter().any(|node| {
                         matches!(
@@ -757,20 +844,6 @@ fn reject_silently_ignored_constructs(
                 {
                     return Err(AnalyzerError::Unsupported(
                         "procedural loop inside always_comb".to_string(),
-                    ));
-                }
-                if matches!(always.nodes.0, sv_parser::AlwaysKeyword::AlwaysFf(_))
-                    && body.clone().into_iter().any(|node| {
-                        matches!(
-                            node,
-                            RefNode::LoopStatement(loop_statement)
-                                if static_for_loop_iterations(loop_statement, syntax_tree, const_env)
-                                    .is_none()
-                        )
-                    })
-                {
-                    return Err(AnalyzerError::Unsupported(
-                        "procedural loop inside always_ff".to_string(),
                     ));
                 }
                 if matches!(always.nodes.0, sv_parser::AlwaysKeyword::AlwaysComb(_))
@@ -1789,11 +1862,28 @@ impl PackedRange {
 pub struct UnpackedRange {
     left: ConstExpr,
     right: ConstExpr,
+    size: Option<ConstExpr>,
 }
 
 impl UnpackedRange {
     fn new(left: ConstExpr, right: ConstExpr) -> Self {
-        Self { left, right }
+        Self {
+            left,
+            right,
+            size: None,
+        }
+    }
+
+    fn sized(size: ConstExpr) -> Self {
+        Self {
+            left: ConstExpr::Literal("0".to_string()),
+            right: ConstExpr::Binary {
+                left: Box::new(size.clone()),
+                op: BinaryOp::Sub,
+                right: Box::new(ConstExpr::Literal("1".to_string())),
+            },
+            size: Some(size),
+        }
     }
 
     pub fn left(&self) -> &ConstExpr {
@@ -1802,6 +1892,10 @@ impl UnpackedRange {
 
     pub fn right(&self) -> &ConstExpr {
         &self.right
+    }
+
+    fn size(&self) -> Option<&ConstExpr> {
+        self.size.as_ref()
     }
 }
 
@@ -8888,43 +8982,52 @@ fn unpacked_ranges_from_dimensions(
 ) -> Result<Vec<UnpackedRange>, AnalyzerError> {
     dimensions
         .iter()
-        .map(|dimension| {
-            let (left, right) = match dimension {
-                sv_parser::UnpackedDimension::Range(range) => {
-                    let constant_range = &range.nodes.0.nodes.1;
-                    let left = const_expr_from_ref_node(
-                        RefNode::ConstantExpression(&constant_range.nodes.0),
-                        syntax_tree,
-                    );
-                    let right = const_expr_from_ref_node(
-                        RefNode::ConstantExpression(&constant_range.nodes.2),
-                        syntax_tree,
-                    );
-                    (left, right)
+        .map(|dimension| match dimension {
+            sv_parser::UnpackedDimension::Range(range) => {
+                let constant_range = &range.nodes.0.nodes.1;
+                let left = const_expr_from_ref_node(
+                    RefNode::ConstantExpression(&constant_range.nodes.0),
+                    syntax_tree,
+                );
+                let right = const_expr_from_ref_node(
+                    RefNode::ConstantExpression(&constant_range.nodes.2),
+                    syntax_tree,
+                );
+                match (left, right) {
+                    (Some(left), Some(right)) => Ok(UnpackedRange::new(left, right)),
+                    _ => Err(AnalyzerError::Unsupported(
+                        "unresolved unpacked array dimension".to_string(),
+                    )),
                 }
-                sv_parser::UnpackedDimension::Expression(expression) => {
-                    let size = const_expr_from_ref_node(
-                        RefNode::ConstantExpression(&expression.nodes.0.nodes.1),
-                        syntax_tree,
-                    );
-                    (
-                        Some(ConstExpr::Literal("0".to_string())),
-                        size.map(|size| ConstExpr::Binary {
-                            left: Box::new(size),
-                            op: BinaryOp::Sub,
-                            right: Box::new(ConstExpr::Literal("1".to_string())),
-                        }),
-                    )
-                }
-            };
-            match (left, right) {
-                (Some(left), Some(right)) => Ok(UnpackedRange::new(left, right)),
-                _ => Err(AnalyzerError::Unsupported(
-                    "unresolved unpacked array dimension".to_string(),
-                )),
+            }
+            sv_parser::UnpackedDimension::Expression(expression) => {
+                let size = const_expr_from_ref_node(
+                    RefNode::ConstantExpression(&expression.nodes.0.nodes.1),
+                    syntax_tree,
+                );
+                size.map(UnpackedRange::sized).ok_or_else(|| {
+                    AnalyzerError::Unsupported("unresolved unpacked array dimension".to_string())
+                })
             }
         })
         .collect()
+}
+
+fn validate_unpacked_dimension_sizes(
+    ranges: &[UnpackedRange],
+    const_env: &HashMap<String, i128>,
+) -> Result<(), AnalyzerError> {
+    if ranges.iter().any(|range| {
+        range
+            .size()
+            .and_then(|size| eval_ast_const_expr(size, const_env))
+            .is_some_and(|size| size <= 0)
+    }) {
+        return Err(AnalyzerError::Unsupported(
+            "nonpositive unpacked array dimension".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 fn unpacked_ranges_from_variable_dimensions(

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -7359,13 +7359,13 @@ fn conditional_assignments_from_statement(
                         signed: true,
                     },
                 );
-                loop_packed_dimensions.const_env = loop_const_env;
+                loop_packed_dimensions.const_env = loop_const_env.clone();
                 let start = assignments.len();
                 conditional_assignments_from_statement_or_null(
                     body,
                     condition.clone(),
                     syntax_tree,
-                    &loop_env,
+                    &loop_const_env,
                     &loop_packed_dimensions,
                     assignments,
                 )?;
@@ -8342,6 +8342,7 @@ fn flatten_variable_select(
     }
 
     let mut offset = ConstExpr::Literal("0".to_string());
+    let mut valid = None;
     for (index, value) in indices[..unpacked_count].iter().enumerate() {
         if const_expr_is_out_of_range(
             value,
@@ -8351,6 +8352,51 @@ fn flatten_variable_select(
         ) {
             return None;
         }
+        let dimension = &dimensions.unpacked[index];
+        let descending = ConstExpr::Binary {
+            left: Box::new(dimension.left.clone()),
+            op: BinaryOp::Ge,
+            right: Box::new(dimension.right.clone()),
+        };
+        let descending_valid = ConstExpr::Binary {
+            left: Box::new(ConstExpr::Binary {
+                left: Box::new(value.clone()),
+                op: BinaryOp::Ge,
+                right: Box::new(dimension.right.clone()),
+            }),
+            op: BinaryOp::LogicAnd,
+            right: Box::new(ConstExpr::Binary {
+                left: Box::new(value.clone()),
+                op: BinaryOp::Le,
+                right: Box::new(dimension.left.clone()),
+            }),
+        };
+        let ascending_valid = ConstExpr::Binary {
+            left: Box::new(ConstExpr::Binary {
+                left: Box::new(value.clone()),
+                op: BinaryOp::Ge,
+                right: Box::new(dimension.left.clone()),
+            }),
+            op: BinaryOp::LogicAnd,
+            right: Box::new(ConstExpr::Binary {
+                left: Box::new(value.clone()),
+                op: BinaryOp::Le,
+                right: Box::new(dimension.right.clone()),
+            }),
+        };
+        let dimension_valid = ConstExpr::Mux {
+            condition: Box::new(descending),
+            then_expr: Box::new(descending_valid),
+            else_expr: Box::new(ascending_valid),
+        };
+        valid = Some(match valid {
+            Some(previous) => ConstExpr::Binary {
+                left: Box::new(previous),
+                op: BinaryOp::LogicAnd,
+                right: Box::new(dimension_valid),
+            },
+            None => dimension_valid,
+        });
         let mut stride_parts = dimensions.unpacked[index + 1..]
             .iter()
             .map(|dimension| dimension.width.clone())
@@ -8373,6 +8419,24 @@ fn flatten_variable_select(
             }
         };
         offset = add_expr(offset, term);
+    }
+    if let Some(valid) = valid {
+        let mut total_width_parts = dimensions
+            .unpacked
+            .iter()
+            .map(|dimension| dimension.width.clone())
+            .collect::<Vec<_>>();
+        total_width_parts.extend(
+            dimensions
+                .packed
+                .iter()
+                .map(|dimension| dimension.width.clone()),
+        );
+        offset = ConstExpr::Mux {
+            condition: Box::new(valid),
+            then_expr: Box::new(offset),
+            else_expr: Box::new(product_expr(&total_width_parts)),
+        };
     }
     Some((offset, indices[unpacked_count..].to_vec()))
 }

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -7764,12 +7764,6 @@ fn lvalue_from_select(
         .iter()
         .map(|bit_select| const_expr_from_expr(&bit_select.nodes.1, syntax_tree))
         .collect::<Option<Vec<_>>>()?;
-    if packed_dimensions
-        .get(&name)
-        .is_some_and(|dimensions| !indices.is_empty() && indices.len() < dimensions.unpacked.len())
-    {
-        return None;
-    }
     if let Some(range) = &select.nodes.2 {
         let sv_parser::PartSelectRange::ConstantRange(range) = &range.nodes.1 else {
             return None;
@@ -7825,6 +7819,25 @@ fn lvalue_from_select(
                 lsb: array_offset,
                 signed: dimensions.signed,
             });
+        } else if let Some(dimensions) = packed_dimensions.get(&name)
+            && !dimensions.unpacked.is_empty()
+            && !indices.is_empty()
+            && indices.len() < dimensions.unpacked.len()
+        {
+            let width = remaining_unpacked_selection_width(dimensions, indices.len());
+            return Some(LValue::Select {
+                name,
+                msb: add_expr(
+                    array_offset.clone(),
+                    ConstExpr::Binary {
+                        left: Box::new(width),
+                        op: BinaryOp::Sub,
+                        right: Box::new(ConstExpr::Literal("1".to_string())),
+                    },
+                ),
+                lsb: array_offset,
+                signed: dimensions.signed,
+            });
         }
     }
     if !indices.is_empty()
@@ -7863,12 +7876,6 @@ fn lvalue_from_constant_select(
             )
         })
         .collect::<Option<Vec<_>>>()?;
-    if packed_dimensions
-        .get(&name)
-        .is_some_and(|dimensions| !indices.is_empty() && indices.len() < dimensions.unpacked.len())
-    {
-        return None;
-    }
     if let Some(range) = &select.nodes.2 {
         let sv_parser::ConstantPartSelectRange::ConstantRange(range) = &range.nodes.1 else {
             return None;
@@ -7911,6 +7918,25 @@ fn lvalue_from_constant_select(
                     .map(|dimension| dimension.width.clone())
                     .collect::<Vec<_>>(),
             );
+            return Some(LValue::Select {
+                name,
+                msb: add_expr(
+                    array_offset.clone(),
+                    ConstExpr::Binary {
+                        left: Box::new(width),
+                        op: BinaryOp::Sub,
+                        right: Box::new(ConstExpr::Literal("1".to_string())),
+                    },
+                ),
+                lsb: array_offset,
+                signed: dimensions.signed,
+            });
+        } else if let Some(dimensions) = packed_dimensions.get(&name)
+            && !dimensions.unpacked.is_empty()
+            && !indices.is_empty()
+            && indices.len() < dimensions.unpacked.len()
+        {
+            let width = remaining_unpacked_selection_width(dimensions, indices.len());
             return Some(LValue::Select {
                 name,
                 msb: add_expr(

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -432,17 +432,13 @@ fn static_for_loop_iterations(
                 signed: true,
             },
         );
-        if eval_ast_const_expr(&condition, &loop_env)? == 0 {
+        let condition_value = eval_ast_const_expr(&condition, &loop_env)?;
+        if condition_value == 0 {
             return Some((name, values));
         }
         values.push(value);
-        value = coerce_for_loop_index_value(next_for_loop_value(
-            step,
-            &name,
-            value,
-            syntax_tree,
-            &loop_env,
-        )?)?;
+        let next = next_for_loop_value(step, &name, value, syntax_tree, &loop_env);
+        value = coerce_for_loop_index_value(next?)?;
     }
 
     let mut loop_env = const_env.clone();
@@ -534,6 +530,14 @@ fn validate_static_for_loops_in_statement(
             for value in values {
                 let mut loop_env = const_env.clone();
                 loop_env.insert(name.clone(), value);
+                insert_parameter_type_markers(
+                    &mut loop_env,
+                    &name,
+                    ExprType {
+                        width: 32,
+                        signed: true,
+                    },
+                );
                 validate_static_for_loops_in_statement_or_null(
                     &loop_statement.nodes.2,
                     syntax_tree,
@@ -665,8 +669,19 @@ fn cast_zero_type(
         return None;
     };
     let literal = typecheck::parse_integral_literal(&literal)?;
-    (literal.value == 0u8.into() && literal.mask == 0u8.into())
-        .then(|| cast_target_type(&cast.nodes.0, syntax_tree, const_env, type_aliases))?
+    if literal.value != 0u8.into() || literal.mask != 0u8.into() {
+        return None;
+    }
+    let target_type = cast_target_type(&cast.nodes.0, syntax_tree, const_env, type_aliases)?;
+    let signed = if matches!(cast.nodes.0, sv_parser::CastingType::ConstantPrimary(_)) {
+        literal.signed
+    } else {
+        target_type.signed
+    };
+    Some(ExprType {
+        signed,
+        ..target_type
+    })
 }
 
 fn constant_cast_zero_type(
@@ -683,8 +698,19 @@ fn constant_cast_zero_type(
         return None;
     };
     let literal = typecheck::parse_integral_literal(&literal)?;
-    (literal.value == 0u8.into() && literal.mask == 0u8.into())
-        .then(|| cast_target_type(&cast.nodes.0, syntax_tree, const_env, type_aliases))?
+    if literal.value != 0u8.into() || literal.mask != 0u8.into() {
+        return None;
+    }
+    let target_type = cast_target_type(&cast.nodes.0, syntax_tree, const_env, type_aliases)?;
+    let signed = if matches!(cast.nodes.0, sv_parser::CastingType::ConstantPrimary(_)) {
+        literal.signed
+    } else {
+        target_type.signed
+    };
+    Some(ExprType {
+        signed,
+        ..target_type
+    })
 }
 
 fn typed_zero_literal(r#type: ExprType) -> String {
@@ -720,18 +746,26 @@ fn next_for_loop_value(
             if for_loop_variable_lvalue_name(&step.nodes.0, syntax_tree)? != name {
                 return None;
             }
-            let operator = syntax_tree.get_str(&step.nodes.1.nodes.0)?;
+            let operator = syntax_tree.get_str(&step.nodes.1.nodes.0)?.trim();
             let rhs = const_expr_from_expr(&step.nodes.2, syntax_tree)?;
-            let rhs = eval_ast_const_expr(&rhs, const_env)?;
-            match operator {
-                "=" => Some(rhs),
-                "+=" => value.checked_add(rhs),
-                "-=" => value.checked_sub(rhs),
-                "*=" => value.checked_mul(rhs),
-                "/=" => (rhs != 0).then(|| value / rhs),
-                "%=" => (rhs != 0).then(|| value % rhs),
-                _ => None,
+            if operator == "=" {
+                return eval_ast_const_expr(&rhs, const_env);
             }
+            let op = match operator {
+                "+=" => BinaryOp::Add,
+                "-=" => BinaryOp::Sub,
+                "*=" => BinaryOp::Mul,
+                "/=" => BinaryOp::Div,
+                "%=" => BinaryOp::Mod,
+                _ => return None,
+            };
+            let lhs = ConstExpr::Literal(format_typed_parameter_literal(value, 32, true));
+            let expression = ConstExpr::Binary {
+                left: Box::new(lhs),
+                op,
+                right: Box::new(rhs),
+            };
+            eval_ast_const_expr(&expression, const_env)
         }
         sv_parser::ForStepAssignment::IncOrDecExpression(step) => {
             let (lvalue, operator) = match &**step {
@@ -8306,6 +8340,26 @@ fn expr_select_from_select(
                     signed: dimensions.signed,
                 });
             }
+            if let Some(dimensions) = packed_dimensions.get(name)
+                && !dimensions.unpacked.is_empty()
+                && packed_indices.is_empty()
+                && indices.len() < dimensions.unpacked.len()
+            {
+                let width = remaining_unpacked_selection_width(dimensions, indices.len());
+                return Some(Expr::Select {
+                    expr: Box::new(base),
+                    msb: add_expr(
+                        array_offset.clone(),
+                        ConstExpr::Binary {
+                            left: Box::new(width),
+                            op: BinaryOp::Sub,
+                            right: Box::new(ConstExpr::Literal("1".to_string())),
+                        },
+                    ),
+                    lsb: array_offset,
+                    signed: dimensions.signed,
+                });
+            }
         }
     }
     if indices.len() == 1 {
@@ -8337,13 +8391,11 @@ fn flatten_variable_select(
 ) -> Option<(ConstExpr, Vec<ConstExpr>)> {
     let dimensions = packed_dimensions.get(name)?;
     let unpacked_count = dimensions.unpacked.len();
-    if indices.len() < unpacked_count {
-        return None;
-    }
+    let selected_unpacked_count = indices.len().min(unpacked_count);
 
     let mut offset = ConstExpr::Literal("0".to_string());
     let mut valid = None;
-    for (index, value) in indices[..unpacked_count].iter().enumerate() {
+    for (index, value) in indices[..selected_unpacked_count].iter().enumerate() {
         if const_expr_is_out_of_range(
             value,
             &dimensions.unpacked[index].left,
@@ -8438,7 +8490,24 @@ fn flatten_variable_select(
             else_expr: Box::new(product_expr(&total_width_parts)),
         };
     }
-    Some((offset, indices[unpacked_count..].to_vec()))
+    Some((offset, indices[selected_unpacked_count..].to_vec()))
+}
+
+fn remaining_unpacked_selection_width(
+    dimensions: &VariableDimensions,
+    selected_unpacked_count: usize,
+) -> ConstExpr {
+    let mut parts = dimensions.unpacked[selected_unpacked_count..]
+        .iter()
+        .map(|dimension| dimension.width.clone())
+        .collect::<Vec<_>>();
+    parts.extend(
+        dimensions
+            .packed
+            .iter()
+            .map(|dimension| dimension.width.clone()),
+    );
+    product_expr(&parts)
 }
 
 fn flatten_select_range(
@@ -8457,6 +8526,9 @@ fn flatten_select_range(
         && !dimensions.packed[0].normalize_single
     {
         return Some((msb, lsb));
+    }
+    if indices.len() < dimensions.unpacked.len() {
+        return None;
     }
     let (array_offset, packed_indices) = flatten_variable_select(name, indices, packed_dimensions)?;
     let dimension = dimensions.packed.get(packed_indices.len())?;

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -2578,6 +2578,10 @@ fn substitute_signal_local_constants(signals: &mut [Signal], const_env: &HashMap
         for range in &mut signal.r#type.unpacked_ranges {
             range.left = substitute_const_expr_constants(range.left.clone(), const_env);
             range.right = substitute_const_expr_constants(range.right.clone(), const_env);
+            range.size = range
+                .size
+                .take()
+                .map(|size| substitute_const_expr_constants(size, const_env));
         }
     }
 }
@@ -8252,7 +8256,15 @@ fn expr_from_primary_with_types(
                         signed: false,
                     })
                 }
-                Some(sv_parser::RangeExpression::Expression(_)) => None,
+                Some(sv_parser::RangeExpression::Expression(bit)) => {
+                    let bit = const_expr_from_expr(bit, syntax_tree)?;
+                    Some(Expr::Select {
+                        expr: Box::new(base),
+                        msb: bit.clone(),
+                        lsb: bit,
+                        signed: false,
+                    })
+                }
             }
         }
         sv_parser::Primary::MultipleConcatenation(concat) => {
@@ -8490,12 +8502,10 @@ fn expr_select_from_select(
         }
     }
     if indices.len() == 1 {
-        let Expr::Ident(name) = &base else {
-            return None;
-        };
-        if packed_dimensions
-            .get(name)
-            .is_some_and(|dimensions| !dimensions.unpacked.is_empty())
+        if let Expr::Ident(name) = &base
+            && packed_dimensions
+                .get(name)
+                .is_some_and(|dimensions| !dimensions.unpacked.is_empty())
         {
             return None;
         }

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -8317,6 +8317,15 @@ fn expr_select_from_select(
                 signed: false,
             });
         };
+        if let Some(expr) = expr_from_unpacked_select_range(
+            name,
+            &indices,
+            msb.clone(),
+            lsb.clone(),
+            packed_dimensions,
+        ) {
+            return Some(expr);
+        }
         (msb, lsb) = flatten_select_range(name, &indices, msb, lsb, packed_dimensions)?;
         return Some(Expr::Select {
             expr: Box::new(base),
@@ -8517,6 +8526,91 @@ fn flatten_variable_select(
         };
     }
     Some((offset, indices[selected_unpacked_count..].to_vec()))
+}
+
+fn expr_from_unpacked_select_range(
+    name: &str,
+    indices: &[ConstExpr],
+    msb: ConstExpr,
+    lsb: ConstExpr,
+    packed_dimensions: &PackedDimensions,
+) -> Option<Expr> {
+    let dimensions = packed_dimensions.get(name)?;
+    let dimension = dimensions.unpacked.get(indices.len())?;
+    if const_expr_is_out_of_range(
+        &msb,
+        &dimension.left,
+        &dimension.right,
+        &packed_dimensions.const_env,
+    ) || const_expr_is_out_of_range(
+        &lsb,
+        &dimension.left,
+        &dimension.right,
+        &packed_dimensions.const_env,
+    ) {
+        return None;
+    }
+    let (array_offset, packed_indices) = flatten_variable_select(name, indices, packed_dimensions)?;
+    if !packed_indices.is_empty() {
+        return None;
+    }
+    let msb_value = eval_ast_const_expr(&msb, &packed_dimensions.const_env)?;
+    let lsb_value = eval_ast_const_expr(&lsb, &packed_dimensions.const_env)?;
+    let stride = product_expr(
+        &dimensions.unpacked[indices.len() + 1..]
+            .iter()
+            .map(|dimension| dimension.width.clone())
+            .chain(
+                dimensions
+                    .packed
+                    .iter()
+                    .map(|dimension| dimension.width.clone()),
+            )
+            .collect::<Vec<_>>(),
+    );
+    let stride_minus_one = ConstExpr::Binary {
+        left: Box::new(stride.clone()),
+        op: BinaryOp::Sub,
+        right: Box::new(ConstExpr::Literal("1".to_string())),
+    };
+    // Concat parts are ordered from most-significant to least-significant.
+    // Walking from the slice lsb toward its msb preserves the array element
+    // order when the slice direction is reversed.
+    let mut parts = Vec::new();
+    let mut value = lsb_value;
+    let step = if value <= msb_value { 1 } else { -1 };
+    loop {
+        let offset = unpacked_index_offset(dimension, ConstExpr::Literal(value.to_string()));
+        let offset = if is_one(&stride) {
+            offset
+        } else {
+            ConstExpr::Binary {
+                left: Box::new(offset),
+                op: BinaryOp::Mul,
+                right: Box::new(stride.clone()),
+            }
+        };
+        let msb = add_expr(
+            array_offset.clone(),
+            add_expr(offset.clone(), stride_minus_one.clone()),
+        );
+        let lsb = add_expr(array_offset.clone(), offset);
+        parts.push(Expr::Select {
+            expr: Box::new(Expr::Ident(name.to_string())),
+            msb,
+            lsb,
+            signed: dimensions.signed,
+        });
+        if value == msb_value {
+            break;
+        }
+        value = value.checked_add(step)?;
+    }
+    match parts.len() {
+        0 => None,
+        1 => parts.pop(),
+        _ => Some(Expr::Concat(parts)),
+    }
 }
 
 fn remaining_unpacked_selection_width(

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -164,7 +164,8 @@ impl Module {
             apply_parameter_overrides(&mut parameters, parameter_overrides)?;
         }
         let const_env = const_env_from_parameters(&parameters);
-        reject_silently_ignored_constructs(node.clone(), syntax_tree, &const_env)?;
+        let type_aliases = type_aliases_from_module_node(node.clone(), syntax_tree)?;
+        reject_silently_ignored_constructs(node.clone(), syntax_tree, &const_env, &type_aliases)?;
         let ports = ports_from_module_node(node.clone(), syntax_tree)?;
         let mut port_names = HashSet::default();
         if let Some(port) = ports.iter().find(|port| !port_names.insert(port.name())) {
@@ -192,7 +193,7 @@ impl Module {
             )));
         }
         let packed_dimensions =
-            packed_dimensions_from_ports_and_signals(&ports, &signals, &const_env);
+            packed_dimensions_from_ports_and_signals(&ports, &signals, &const_env, &type_aliases);
         let mut instances =
             instances_from_module_node(node.clone(), syntax_tree, &const_env, &packed_dimensions)?;
         let mut instance_names = HashSet::default();
@@ -466,94 +467,91 @@ fn for_loop_index_type_is_supported(data_type: &sv_parser::DataType) -> bool {
 fn cast_target_type(
     casting_type: &sv_parser::CastingType,
     syntax_tree: &SyntaxTree,
+    const_env: &HashMap<String, i128>,
+    type_aliases: &HashMap<String, Type>,
 ) -> Option<ExprType> {
     if let Some(r#type) = integer_atom_expr_type(RefNode::CastingType(casting_type)) {
         return Some(r#type);
     }
-    let sv_parser::CastingType::ConstantPrimary(primary) = casting_type else {
+    match casting_type {
+        sv_parser::CastingType::SimpleType(simple_type) => {
+            let sv_parser::SimpleType::PsTypeIdentifier(identifier) = simple_type.as_ref() else {
+                return None;
+            };
+            let name = identifier_text(RefNode::TypeIdentifier(&identifier.nodes.1), syntax_tree)?;
+            expr_type_from_type(type_aliases.get(&name)?, const_env)
+        }
+        sv_parser::CastingType::ConstantPrimary(primary) => {
+            let target = const_expr_from_ref_node(RefNode::ConstantPrimary(primary), syntax_tree)?;
+            if let ConstExpr::Ident(name) = &target {
+                return expr_type_from_type(type_aliases.get(name)?, const_env);
+            }
+            let width = eval_ast_const_expr(&target, const_env)?;
+            Some(ExprType {
+                width: usize::try_from(width).ok()?.max(1),
+                signed: false,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn expr_type_from_type(r#type: &Type, const_env: &HashMap<String, i128>) -> Option<ExprType> {
+    if !r#type.unpacked_ranges().is_empty() {
         return None;
-    };
-    let width = eval_ast_const_expr(
-        &const_expr_from_ref_node(RefNode::ConstantPrimary(primary), syntax_tree)?,
-        &HashMap::default(),
-    )?;
+    }
+    let width = r#type
+        .packed_ranges()
+        .iter()
+        .try_fold(1usize, |width, range| {
+            let left = eval_ast_const_expr(range.left(), const_env)?;
+            let right = eval_ast_const_expr(range.right(), const_env)?;
+            width.checked_mul(usize::try_from(left.abs_diff(right)).ok()?.checked_add(1)?)
+        })?;
     Some(ExprType {
-        width: usize::try_from(width).ok()?.max(1),
-        signed: false,
+        width: width.max(1),
+        signed: r#type.is_signed(),
     })
 }
 
-fn cast_target_is_named_type(
-    casting_type: &sv_parser::CastingType,
+fn cast_is_supported(
+    cast: &sv_parser::Cast,
     syntax_tree: &SyntaxTree,
+    const_env: &HashMap<String, i128>,
+    type_aliases: &HashMap<String, Type>,
 ) -> bool {
-    if matches!(
-        casting_type,
-        sv_parser::CastingType::SimpleType(simple_type)
-            if matches!(
-                simple_type.as_ref(),
-                sv_parser::SimpleType::PsTypeIdentifier(_)
-            )
-    ) {
-        return true;
-    }
-    let sv_parser::CastingType::ConstantPrimary(primary) = casting_type else {
-        return false;
-    };
-    matches!(
-        const_expr_from_ref_node(RefNode::ConstantPrimary(primary), syntax_tree),
-        Some(ConstExpr::Ident(_))
-    )
+    cast_zero_type(cast, syntax_tree, const_env, type_aliases).is_some()
 }
 
-fn cast_is_zero_literal(cast: &sv_parser::Cast, syntax_tree: &SyntaxTree) -> bool {
-    matches!(
-        const_expr_from_expr(&cast.nodes.2.nodes.1, syntax_tree),
-        Some(ConstExpr::Literal(literal))
-            if typecheck::parse_integral_literal(&literal).is_some_and(|literal| {
-                literal.value == 0u8.into() && literal.mask == 0u8.into()
-            })
-    )
+fn constant_cast_is_supported(
+    cast: &sv_parser::ConstantCast,
+    syntax_tree: &SyntaxTree,
+    const_env: &HashMap<String, i128>,
+    type_aliases: &HashMap<String, Type>,
+) -> bool {
+    constant_cast_zero_type(cast, syntax_tree, const_env, type_aliases).is_some()
 }
 
-fn constant_cast_is_zero_literal(cast: &sv_parser::ConstantCast, syntax_tree: &SyntaxTree) -> bool {
-    matches!(
-        const_expr_from_ref_node(
-            RefNode::ConstantExpression(&cast.nodes.2.nodes.1),
-            syntax_tree,
-        ),
-        Some(ConstExpr::Literal(literal))
-            if typecheck::parse_integral_literal(&literal).is_some_and(|literal| {
-                literal.value == 0u8.into() && literal.mask == 0u8.into()
-            })
-    )
-}
-
-fn cast_is_supported(cast: &sv_parser::Cast, syntax_tree: &SyntaxTree) -> bool {
-    cast_zero_type(cast, syntax_tree).is_some()
-        || (cast_is_zero_literal(cast, syntax_tree)
-            && cast_target_is_named_type(&cast.nodes.0, syntax_tree))
-}
-
-fn constant_cast_is_supported(cast: &sv_parser::ConstantCast, syntax_tree: &SyntaxTree) -> bool {
-    constant_cast_zero_type(cast, syntax_tree).is_some()
-        || (constant_cast_is_zero_literal(cast, syntax_tree)
-            && cast_target_is_named_type(&cast.nodes.0, syntax_tree))
-}
-
-fn cast_zero_type(cast: &sv_parser::Cast, syntax_tree: &SyntaxTree) -> Option<ExprType> {
+fn cast_zero_type(
+    cast: &sv_parser::Cast,
+    syntax_tree: &SyntaxTree,
+    const_env: &HashMap<String, i128>,
+    type_aliases: &HashMap<String, Type>,
+) -> Option<ExprType> {
     let ConstExpr::Literal(literal) = const_expr_from_expr(&cast.nodes.2.nodes.1, syntax_tree)?
     else {
         return None;
     };
     let literal = typecheck::parse_integral_literal(&literal)?;
     (literal.value == 0u8.into() && literal.mask == 0u8.into())
-        .then(|| cast_target_type(&cast.nodes.0, syntax_tree))?
+        .then(|| cast_target_type(&cast.nodes.0, syntax_tree, const_env, type_aliases))?
 }
 
 fn constant_cast_zero_type(
     cast: &sv_parser::ConstantCast,
     syntax_tree: &SyntaxTree,
+    const_env: &HashMap<String, i128>,
+    type_aliases: &HashMap<String, Type>,
 ) -> Option<ExprType> {
     let ConstExpr::Literal(literal) = const_expr_from_ref_node(
         RefNode::ConstantExpression(&cast.nodes.2.nodes.1),
@@ -564,7 +562,7 @@ fn constant_cast_zero_type(
     };
     let literal = typecheck::parse_integral_literal(&literal)?;
     (literal.value == 0u8.into() && literal.mask == 0u8.into())
-        .then(|| cast_target_type(&cast.nodes.0, syntax_tree))?
+        .then(|| cast_target_type(&cast.nodes.0, syntax_tree, const_env, type_aliases))?
 }
 
 fn typed_zero_literal(r#type: ExprType) -> String {
@@ -635,6 +633,7 @@ fn reject_silently_ignored_constructs(
     node: RefNode<'_>,
     syntax_tree: &SyntaxTree,
     const_env: &HashMap<String, i128>,
+    type_aliases: &HashMap<String, Type>,
 ) -> Result<(), AnalyzerError> {
     let inactive_nodes = inactive_conditional_generate_nodes(node.clone(), syntax_tree, const_env);
     let has_leaking_conditional_generate_local =
@@ -645,10 +644,14 @@ fn reject_silently_ignored_constructs(
             continue;
         }
         match child {
-            RefNode::Cast(cast) if !cast_is_supported(cast, syntax_tree) => {
+            RefNode::Cast(cast)
+                if !cast_is_supported(cast, syntax_tree, const_env, type_aliases) =>
+            {
                 return Err(AnalyzerError::Unsupported("cast expression".to_string()));
             }
-            RefNode::ConstantCast(cast) if !constant_cast_is_supported(cast, syntax_tree) => {
+            RefNode::ConstantCast(cast)
+                if !constant_cast_is_supported(cast, syntax_tree, const_env, type_aliases) =>
+            {
                 return Err(AnalyzerError::Unsupported("constant cast expression".to_string()));
             }
             RefNode::AnsiPortDeclarationNet(port) if port.nodes.3.is_some() => {
@@ -3310,13 +3313,19 @@ type VariablePackedDimensions = HashMap<String, VariableDimensions>;
 struct PackedDimensions {
     variables: VariablePackedDimensions,
     const_env: HashMap<String, i128>,
+    type_aliases: HashMap<String, Type>,
 }
 
 impl PackedDimensions {
-    fn new(variables: VariablePackedDimensions, const_env: &HashMap<String, i128>) -> Self {
+    fn new(
+        variables: VariablePackedDimensions,
+        const_env: &HashMap<String, i128>,
+        type_aliases: &HashMap<String, Type>,
+    ) -> Self {
         Self {
             variables,
             const_env: const_env.clone(),
+            type_aliases: type_aliases.clone(),
         }
     }
 }
@@ -3339,6 +3348,7 @@ fn packed_dimensions_from_ports_and_signals(
     ports: &[Port],
     signals: &[Signal],
     const_env: &HashMap<String, i128>,
+    type_aliases: &HashMap<String, Type>,
 ) -> PackedDimensions {
     let mut dimensions = HashMap::default();
     for port in ports {
@@ -3361,7 +3371,7 @@ fn packed_dimensions_from_ports_and_signals(
             },
         );
     }
-    PackedDimensions::new(dimensions, const_env)
+    PackedDimensions::new(dimensions, const_env, type_aliases)
 }
 
 fn packed_dimension_widths(ranges: &[PackedRange]) -> Vec<PackedDimension> {
@@ -7567,7 +7577,7 @@ fn lvalue_from_select(
         .collect::<Option<Vec<_>>>()?;
     if packed_dimensions
         .get(&name)
-        .is_some_and(|dimensions| indices.len() < dimensions.unpacked.len())
+        .is_some_and(|dimensions| !indices.is_empty() && indices.len() < dimensions.unpacked.len())
     {
         return None;
     }
@@ -7651,7 +7661,7 @@ fn lvalue_from_constant_select(
         .collect::<Option<Vec<_>>>()?;
     if packed_dimensions
         .get(&name)
-        .is_some_and(|dimensions| indices.len() < dimensions.unpacked.len())
+        .is_some_and(|dimensions| !indices.is_empty() && indices.len() < dimensions.unpacked.len())
     {
         return None;
     }
@@ -7931,15 +7941,17 @@ fn expr_from_primary_with_types(
                 syntax_tree,
                 packed_dimensions,
             )?;
-            if let Some(r#type) = cast_zero_type(cast, syntax_tree) {
-                Some(Expr::Resize {
-                    expr: Box::new(expr),
-                    width: r#type.width,
-                    signed: r#type.signed,
-                })
-            } else {
-                cast_target_is_named_type(&cast.nodes.0, syntax_tree).then_some(expr)
-            }
+            cast_zero_type(
+                cast,
+                syntax_tree,
+                &packed_dimensions.const_env,
+                &packed_dimensions.type_aliases,
+            )
+            .map(|r#type| Expr::Resize {
+                expr: Box::new(expr),
+                width: r#type.width,
+                signed: r#type.signed,
+            })
         }
         sv_parser::Primary::MintypmaxExpression(expr) => match &expr.nodes.0.nodes.1 {
             sv_parser::MintypmaxExpression::Expression(expr) => {
@@ -8930,16 +8942,8 @@ fn const_expr_from_ref_node(node: RefNode<'_>, syntax_tree: &SyntaxTree) -> Opti
                 })
             }
             sv_parser::ConstantPrimary::ConstantCast(cast) => {
-                if let Some(r#type) = constant_cast_zero_type(cast, syntax_tree) {
-                    Some(ConstExpr::Literal(typed_zero_literal(r#type)))
-                } else if cast_target_is_named_type(&cast.nodes.0, syntax_tree) {
-                    const_expr_from_ref_node(
-                        RefNode::ConstantExpression(&cast.nodes.2.nodes.1),
-                        syntax_tree,
-                    )
-                } else {
-                    None
-                }
+                constant_cast_zero_type(cast, syntax_tree, &HashMap::default(), &HashMap::default())
+                    .map(|r#type| ConstExpr::Literal(typed_zero_literal(r#type)))
             }
             sv_parser::ConstantPrimary::MintypmaxExpression(expr) => match &expr.nodes.0.nodes.1 {
                 sv_parser::ConstantMintypmaxExpression::Unary(expr) => {

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -2048,6 +2048,8 @@ pub enum LValue {
         msb: ConstExpr,
         lsb: ConstExpr,
         signed: bool,
+        array_slice_width: Option<ConstExpr>,
+        array_slice_reversed: bool,
     },
 }
 
@@ -5221,7 +5223,9 @@ fn function_expr_from_statement(
                     let op = syntax_tree.get_str(&assignment.nodes.1.nodes.0.nodes.0);
                     let rhs = match (&lhs, rhs, op) {
                         (_, Some(rhs), Some("=")) => Some(rhs),
-                        (Some(lhs), Some(rhs), Some(op)) => assignment_op_expr(lhs, op, rhs),
+                        (Some(lhs), Some(rhs), Some(op)) => {
+                            assignment_op_expr(lhs, op, rhs, packed_dimensions)
+                        }
                         _ => None,
                     };
                     (lhs, rhs)
@@ -6292,11 +6296,16 @@ fn substitute_lvalue_constants(lvalue: LValue, const_env: &HashMap<String, i128>
             msb,
             lsb,
             signed,
+            array_slice_width,
+            array_slice_reversed,
         } => LValue::Select {
             name,
             msb: substitute_const_expr_constants(msb, const_env),
             lsb: substitute_const_expr_constants(lsb, const_env),
             signed,
+            array_slice_width: array_slice_width
+                .map(|width| substitute_const_expr_constants(width, const_env)),
+            array_slice_reversed,
         },
     }
 }
@@ -7646,9 +7655,11 @@ fn assignments_from_statement(
                 );
                 match (lhs, rhs, op) {
                     (Some(lhs), Some(rhs), Some("=")) => vec![Assignment::new(lhs, rhs)],
-                    (Some(lhs), Some(rhs), Some(op)) => assignment_op_expr(&lhs, op, rhs)
-                        .map(|rhs| vec![Assignment::new(lhs, rhs)])
-                        .unwrap_or_default(),
+                    (Some(lhs), Some(rhs), Some(op)) => {
+                        assignment_op_expr(&lhs, op, rhs, packed_dimensions)
+                            .map(|rhs| vec![Assignment::new(lhs, rhs)])
+                            .unwrap_or_default()
+                    }
                     _ => Vec::new(),
                 }
             }
@@ -7679,7 +7690,12 @@ fn assignments_from_statement_or_null(
     }
 }
 
-fn assignment_op_expr(lhs: &LValue, op: &str, rhs: Expr) -> Option<Expr> {
+fn assignment_op_expr(
+    lhs: &LValue,
+    op: &str,
+    rhs: Expr,
+    packed_dimensions: &PackedDimensions,
+) -> Option<Expr> {
     let op = match op.strip_suffix('=')? {
         "+" => BinaryOp::Add,
         "-" => BinaryOp::Sub,
@@ -7696,27 +7712,77 @@ fn assignment_op_expr(lhs: &LValue, op: &str, rhs: Expr) -> Option<Expr> {
         _ => return None,
     };
     Some(guard_zero_divisions(Expr::Binary {
-        left: Box::new(expr_from_lvalue(lhs)),
+        left: Box::new(expr_from_lvalue(lhs, packed_dimensions)),
         op,
         right: Box::new(rhs),
     }))
 }
 
-fn expr_from_lvalue(lhs: &LValue) -> Expr {
-    match lhs {
-        LValue::Ident(name) => Expr::Ident(name.clone()),
+fn expr_from_lvalue(lhs: &LValue, packed_dimensions: &PackedDimensions) -> Expr {
+    let (base, array_slice_width, array_slice_reversed, signed) = match lhs {
+        LValue::Ident(name) => return Expr::Ident(name.clone()),
         LValue::Select {
             name,
             msb,
             lsb,
             signed,
-        } => Expr::Select {
-            expr: Box::new(Expr::Ident(name.clone())),
-            msb: msb.clone(),
-            lsb: lsb.clone(),
-            signed: *signed,
-        },
+            array_slice_width,
+            array_slice_reversed,
+        } => (
+            Expr::Select {
+                expr: Box::new(Expr::Ident(name.clone())),
+                msb: msb.clone(),
+                lsb: lsb.clone(),
+                signed: *signed,
+            },
+            array_slice_width,
+            *array_slice_reversed,
+            *signed,
+        ),
+    };
+    if !array_slice_reversed {
+        return base;
     }
+    let Some(array_slice_width) = array_slice_width else {
+        return base;
+    };
+    let Some(element_width) = eval_ast_const_expr(array_slice_width, &packed_dimensions.const_env)
+        .and_then(|width| usize::try_from(width).ok())
+        .filter(|width| *width != 0)
+    else {
+        return base;
+    };
+    let Expr::Select { msb, lsb, .. } = &base else {
+        return base;
+    };
+    let Some(total_width) = eval_ast_const_expr(msb, &packed_dimensions.const_env)
+        .and_then(|msb| {
+            eval_ast_const_expr(lsb, &packed_dimensions.const_env)
+                .and_then(|lsb| usize::try_from(msb.abs_diff(lsb)).ok())
+        })
+        .and_then(|width| width.checked_add(1))
+    else {
+        return base;
+    };
+    if total_width % element_width != 0 || total_width == element_width {
+        return base;
+    }
+    let mut parts = Vec::new();
+    for offset in (0..total_width).step_by(element_width) {
+        let Some(part_msb) = offset
+            .checked_add(element_width)
+            .and_then(|value| value.checked_sub(1))
+        else {
+            return base;
+        };
+        parts.push(Expr::Select {
+            expr: Box::new(base.clone()),
+            msb: ConstExpr::Literal(part_msb.to_string()),
+            lsb: ConstExpr::Literal(offset.to_string()),
+            signed,
+        });
+    }
+    Expr::Concat(parts)
 }
 
 fn net_lvalue_from_node(
@@ -7772,12 +7838,17 @@ fn lvalue_from_select(
             const_expr_from_ref_node(RefNode::ConstantExpression(&range.nodes.0), syntax_tree)?;
         let mut lsb =
             const_expr_from_ref_node(RefNode::ConstantExpression(&range.nodes.2), syntax_tree)?;
+        let (array_slice_width, array_slice_reversed) =
+            unpacked_select_range_metadata(&name, &indices, &msb, &lsb, packed_dimensions)
+                .map_or((None, false), |(width, reversed)| (Some(width), reversed));
         (msb, lsb) = flatten_select_range(&name, &indices, msb, lsb, packed_dimensions)?;
         return Some(LValue::Select {
             name,
             msb,
             lsb,
             signed: false,
+            array_slice_width,
+            array_slice_reversed,
         });
     }
 
@@ -7793,6 +7864,8 @@ fn lvalue_from_select(
                     msb: add_expr(array_offset.clone(), msb),
                     lsb: add_expr(array_offset, lsb),
                     signed: false,
+                    array_slice_width: None,
+                    array_slice_reversed: false,
                 });
             }
         } else if let Some(dimensions) = packed_dimensions.get(&name)
@@ -7818,6 +7891,8 @@ fn lvalue_from_select(
                 ),
                 lsb: array_offset,
                 signed: dimensions.signed,
+                array_slice_width: None,
+                array_slice_reversed: false,
             });
         } else if let Some(dimensions) = packed_dimensions.get(&name)
             && !dimensions.unpacked.is_empty()
@@ -7837,6 +7912,8 @@ fn lvalue_from_select(
                 ),
                 lsb: array_offset,
                 signed: dimensions.signed,
+                array_slice_width: None,
+                array_slice_reversed: false,
             });
         }
     }
@@ -7854,6 +7931,8 @@ fn lvalue_from_select(
             msb: bit.clone(),
             lsb: bit,
             signed: false,
+            array_slice_width: None,
+            array_slice_reversed: false,
         });
     }
 
@@ -7884,12 +7963,17 @@ fn lvalue_from_constant_select(
             const_expr_from_ref_node(RefNode::ConstantExpression(&range.nodes.0), syntax_tree)?;
         let mut lsb =
             const_expr_from_ref_node(RefNode::ConstantExpression(&range.nodes.2), syntax_tree)?;
+        let (array_slice_width, array_slice_reversed) =
+            unpacked_select_range_metadata(&name, &indices, &msb, &lsb, packed_dimensions)
+                .map_or((None, false), |(width, reversed)| (Some(width), reversed));
         (msb, lsb) = flatten_select_range(&name, &indices, msb, lsb, packed_dimensions)?;
         return Some(LValue::Select {
             name,
             msb,
             lsb,
             signed: false,
+            array_slice_width,
+            array_slice_reversed,
         });
     }
 
@@ -7905,6 +7989,8 @@ fn lvalue_from_constant_select(
                     msb: add_expr(array_offset.clone(), msb),
                     lsb: add_expr(array_offset, lsb),
                     signed: false,
+                    array_slice_width: None,
+                    array_slice_reversed: false,
                 });
             }
         } else if let Some(dimensions) = packed_dimensions.get(&name)
@@ -7930,6 +8016,8 @@ fn lvalue_from_constant_select(
                 ),
                 lsb: array_offset,
                 signed: dimensions.signed,
+                array_slice_width: None,
+                array_slice_reversed: false,
             });
         } else if let Some(dimensions) = packed_dimensions.get(&name)
             && !dimensions.unpacked.is_empty()
@@ -7949,6 +8037,8 @@ fn lvalue_from_constant_select(
                 ),
                 lsb: array_offset,
                 signed: dimensions.signed,
+                array_slice_width: None,
+                array_slice_reversed: false,
             });
         }
     }
@@ -7966,6 +8056,8 @@ fn lvalue_from_constant_select(
             msb: bit.clone(),
             lsb: bit,
             signed: false,
+            array_slice_width: None,
+            array_slice_reversed: false,
         });
     }
 
@@ -8611,6 +8703,55 @@ fn expr_from_unpacked_select_range(
         1 => parts.pop(),
         _ => Some(Expr::Concat(parts)),
     }
+}
+
+fn unpacked_select_range_metadata(
+    name: &str,
+    indices: &[ConstExpr],
+    msb: &ConstExpr,
+    lsb: &ConstExpr,
+    packed_dimensions: &PackedDimensions,
+) -> Option<(ConstExpr, bool)> {
+    let dimensions = packed_dimensions.get(name)?;
+    let dimension = dimensions.unpacked.get(indices.len())?;
+    if const_expr_is_out_of_range(
+        msb,
+        &dimension.left,
+        &dimension.right,
+        &packed_dimensions.const_env,
+    ) || const_expr_is_out_of_range(
+        lsb,
+        &dimension.left,
+        &dimension.right,
+        &packed_dimensions.const_env,
+    ) {
+        return None;
+    }
+    let (_, packed_indices) = flatten_variable_select(name, indices, packed_dimensions)?;
+    if !packed_indices.is_empty() {
+        return None;
+    }
+    let msb_offset = eval_ast_const_expr(
+        &unpacked_index_offset(dimension, msb.clone()),
+        &packed_dimensions.const_env,
+    )?;
+    let lsb_offset = eval_ast_const_expr(
+        &unpacked_index_offset(dimension, lsb.clone()),
+        &packed_dimensions.const_env,
+    )?;
+    let stride = product_expr(
+        &dimensions.unpacked[indices.len() + 1..]
+            .iter()
+            .map(|dimension| dimension.width.clone())
+            .chain(
+                dimensions
+                    .packed
+                    .iter()
+                    .map(|dimension| dimension.width.clone()),
+            )
+            .collect::<Vec<_>>(),
+    );
+    Some((stride, msb_offset > lsb_offset))
 }
 
 fn remaining_unpacked_selection_width(

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -434,13 +434,34 @@ fn for_loop_initialization(
             let value = const_expr_from_expr(&assignment.2, syntax_tree)?;
             Some((name, value))
         }
-        sv_parser::ForInitialization::ListOfVariableAssignments(assignments) => {
-            let assignment = assignments.nodes.0.contents().into_iter().next()?;
-            let name = for_loop_variable_lvalue_name(&assignment.nodes.0, syntax_tree)?;
-            let value = const_expr_from_expr(&assignment.nodes.2, syntax_tree)?;
-            Some((name, value))
-        }
+        // An assignment-style initializer targets a variable in the enclosing
+        // procedural scope. Its initialization and loop steps are observable
+        // assignments, so it cannot be treated as a declaration-scoped
+        // compile-time unrolling constant.
+        sv_parser::ForInitialization::ListOfVariableAssignments(_) => None,
     }
+}
+
+fn integral_literal_is_zero(literal: &str) -> bool {
+    typecheck::parse_integral_literal(literal)
+        .is_some_and(|literal| literal.value == 0u8.into() && literal.mask == 0u8.into())
+}
+
+fn cast_is_zero_literal(cast: &sv_parser::Cast, syntax_tree: &SyntaxTree) -> bool {
+    matches!(
+        const_expr_from_expr(&cast.nodes.2.nodes.1, syntax_tree),
+        Some(ConstExpr::Literal(literal)) if integral_literal_is_zero(&literal)
+    )
+}
+
+fn constant_cast_is_zero_literal(cast: &sv_parser::ConstantCast, syntax_tree: &SyntaxTree) -> bool {
+    matches!(
+        const_expr_from_ref_node(
+            RefNode::ConstantExpression(&cast.nodes.2.nodes.1),
+            syntax_tree,
+        ),
+        Some(ConstExpr::Literal(literal)) if integral_literal_is_zero(&literal)
+    )
 }
 
 fn for_loop_variable_lvalue_name(
@@ -513,6 +534,12 @@ fn reject_silently_ignored_constructs(
             continue;
         }
         match child {
+            RefNode::Cast(cast) if !cast_is_zero_literal(cast, syntax_tree) => {
+                return Err(AnalyzerError::Unsupported("cast expression".to_string()));
+            }
+            RefNode::ConstantCast(cast) if !constant_cast_is_zero_literal(cast, syntax_tree) => {
+                return Err(AnalyzerError::Unsupported("constant cast expression".to_string()));
+            }
             RefNode::AnsiPortDeclarationNet(port) if port.nodes.3.is_some() => {
                 return Err(AnalyzerError::Unsupported(
                     "ANSI port default value".to_string(),
@@ -1940,7 +1967,7 @@ fn ports_from_module_node(
     syntax_tree: &SyntaxTree,
 ) -> Result<Vec<Port>, AnalyzerError> {
     let mut ports = Vec::new();
-    let type_aliases = type_aliases_from_module_node(node.clone(), syntax_tree);
+    let type_aliases = type_aliases_from_module_node(node.clone(), syntax_tree)?;
     let mut inherited_direction = PortDirection::Unspecified;
     let mut inherited_type = Type::implicit();
     for child in node {
@@ -2088,7 +2115,7 @@ fn signals_from_module_node(
     const_env: &HashMap<String, i128>,
 ) -> Result<Vec<Signal>, AnalyzerError> {
     let mut signals = Vec::new();
-    let type_aliases = type_aliases_from_module_node(node.clone(), syntax_tree);
+    let type_aliases = type_aliases_from_module_node(node.clone(), syntax_tree)?;
     for item in module_non_port_items(node) {
         signals_from_non_port_module_item(
             item,
@@ -2368,7 +2395,7 @@ fn signals_from_type_alias_instantiation(
 fn type_aliases_from_module_node(
     node: RefNode<'_>,
     syntax_tree: &SyntaxTree,
-) -> HashMap<String, Type> {
+) -> Result<HashMap<String, Type>, AnalyzerError> {
     let mut aliases = HashMap::default();
     if let Some(parameter_port_list) = module_parameter_port_list(node.clone()) {
         if let RefNode::ParameterPortList(parameter_port_list) = parameter_port_list {
@@ -2396,7 +2423,7 @@ fn type_aliases_from_module_node(
         };
         match declaration {
             sv_parser::PackageOrGenerateItemDeclaration::DataDeclaration(declaration) => {
-                add_type_alias_from_data_declaration(declaration, syntax_tree, &mut aliases);
+                add_type_alias_from_data_declaration(declaration, syntax_tree, &mut aliases)?;
             }
             sv_parser::PackageOrGenerateItemDeclaration::LocalParameterDeclaration(localparam) => {
                 add_type_aliases_from_localparam(&localparam.0, syntax_tree, &mut aliases);
@@ -2413,29 +2440,34 @@ fn type_aliases_from_module_node(
         };
         add_type_alias_from_type_assignment(assignment, syntax_tree, &mut aliases);
     }
-    aliases
+    Ok(aliases)
 }
 
 fn add_type_alias_from_data_declaration(
     declaration: &sv_parser::DataDeclaration,
     syntax_tree: &SyntaxTree,
     aliases: &mut HashMap<String, Type>,
-) {
+) -> Result<(), AnalyzerError> {
     let sv_parser::DataDeclaration::TypeDeclaration(declaration) = declaration else {
-        return;
+        return Ok(());
     };
     let sv_parser::TypeDeclaration::DataType(declaration) = &**declaration else {
-        return;
+        return Ok(());
     };
     let Some(name) = identifier_text(RefNode::TypeIdentifier(&declaration.nodes.2), syntax_tree)
     else {
-        return;
+        return Ok(());
     };
     let Some(r#type) = type_from_ref_node(RefNode::DataType(&declaration.nodes.1), syntax_tree)
     else {
-        return;
+        return Ok(());
     };
+    let r#type = type_with_unpacked_ranges(
+        r#type,
+        unpacked_ranges_from_variable_dimensions(&declaration.nodes.3, syntax_tree)?,
+    );
     aliases.insert(name, r#type);
+    Ok(())
 }
 
 fn add_type_aliases_from_parameter_port_list(
@@ -3382,7 +3414,7 @@ fn instances_from_module_node(
     const_env: &HashMap<String, i128>,
     packed_dimensions: &PackedDimensions,
 ) -> Result<Vec<Instance>, AnalyzerError> {
-    let type_aliases = type_aliases_from_module_node(node.clone(), syntax_tree);
+    let type_aliases = type_aliases_from_module_node(node.clone(), syntax_tree)?;
     let mut instances = Vec::new();
     for item in module_non_port_items(node) {
         instances_from_non_port_module_item(
@@ -3643,6 +3675,11 @@ fn instances_from_module_instantiation(
         .map(|parameter| parameter.name().to_string())
         .collect();
     for instance in instantiation.nodes.2.contents() {
+        if !instance.nodes.0.nodes.1.is_empty() {
+            return Err(AnalyzerError::Unsupported(
+                "module instance array".to_string(),
+            ));
+        }
         let name = identifier_text(
             RefNode::InstanceIdentifier(&instance.nodes.0.nodes.0),
             syntax_tree,
@@ -3800,7 +3837,7 @@ fn functions_from_module_node(
     packed_dimensions: &PackedDimensions,
 ) -> Result<HashMap<String, Function>, AnalyzerError> {
     let mut functions = HashMap::default();
-    let type_aliases = type_aliases_from_module_node(node.clone(), syntax_tree);
+    let type_aliases = type_aliases_from_module_node(node.clone(), syntax_tree)?;
     let inactive_nodes = inactive_conditional_generate_nodes(node.clone(), syntax_tree, const_env);
     for child in node {
         if inactive_nodes.iter().any(|inactive| inactive == &child) {
@@ -7620,9 +7657,9 @@ fn expr_from_primary_with_types(
         sv_parser::Primary::FunctionSubroutineCall(call) => {
             expr_from_function_subroutine_call(call, syntax_tree, packed_dimensions)
         }
-        sv_parser::Primary::Cast(cast) => {
+        sv_parser::Primary::Cast(cast) => cast_is_zero_literal(cast, syntax_tree).then(|| {
             expr_from_expression_with_types(&cast.nodes.2.nodes.1, syntax_tree, packed_dimensions)
-        }
+        })?,
         sv_parser::Primary::MintypmaxExpression(expr) => match &expr.nodes.0.nodes.1 {
             sv_parser::MintypmaxExpression::Expression(expr) => {
                 expr_from_expression_with_types(expr, syntax_tree, packed_dimensions)
@@ -8560,10 +8597,14 @@ fn const_expr_from_ref_node(node: RefNode<'_>, syntax_tree: &SyntaxTree) -> Opti
                         .map(ConstExpr::Ident)
                 })
             }
-            sv_parser::ConstantPrimary::ConstantCast(cast) => const_expr_from_ref_node(
-                RefNode::ConstantExpression(&cast.nodes.2.nodes.1),
-                syntax_tree,
-            ),
+            sv_parser::ConstantPrimary::ConstantCast(cast) => {
+                constant_cast_is_zero_literal(cast, syntax_tree).then(|| {
+                    const_expr_from_ref_node(
+                        RefNode::ConstantExpression(&cast.nodes.2.nodes.1),
+                        syntax_tree,
+                    )
+                })?
+            }
             sv_parser::ConstantPrimary::MintypmaxExpression(expr) => match &expr.nodes.0.nodes.1 {
                 sv_parser::ConstantMintypmaxExpression::Unary(expr) => {
                     const_expr_from_ref_node(RefNode::ConstantExpression(expr), syntax_tree)

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -5,6 +5,7 @@
 //! Celox runtime IR.
 
 use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use std::ops::{Deref, DerefMut};
 
 use sv_parser::{Locate, RefNode, SyntaxTree, unwrap_node};
 
@@ -190,7 +191,8 @@ impl Module {
                 parameter.name()
             )));
         }
-        let packed_dimensions = packed_dimensions_from_ports_and_signals(&ports, &signals);
+        let packed_dimensions =
+            packed_dimensions_from_ports_and_signals(&ports, &signals, &const_env);
         let mut instances =
             instances_from_module_node(node.clone(), syntax_tree, &const_env, &packed_dimensions)?;
         let mut instance_names = HashSet::default();
@@ -3302,11 +3304,41 @@ struct VariableDimensions {
     signed: bool,
 }
 
-type PackedDimensions = HashMap<String, VariableDimensions>;
+type VariablePackedDimensions = HashMap<String, VariableDimensions>;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct PackedDimensions {
+    variables: VariablePackedDimensions,
+    const_env: HashMap<String, i128>,
+}
+
+impl PackedDimensions {
+    fn new(variables: VariablePackedDimensions, const_env: &HashMap<String, i128>) -> Self {
+        Self {
+            variables,
+            const_env: const_env.clone(),
+        }
+    }
+}
+
+impl Deref for PackedDimensions {
+    type Target = VariablePackedDimensions;
+
+    fn deref(&self) -> &Self::Target {
+        &self.variables
+    }
+}
+
+impl DerefMut for PackedDimensions {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.variables
+    }
+}
 
 fn packed_dimensions_from_ports_and_signals(
     ports: &[Port],
     signals: &[Signal],
+    const_env: &HashMap<String, i128>,
 ) -> PackedDimensions {
     let mut dimensions = HashMap::default();
     for port in ports {
@@ -3329,7 +3361,7 @@ fn packed_dimensions_from_ports_and_signals(
             },
         );
     }
-    dimensions
+    PackedDimensions::new(dimensions, const_env)
 }
 
 fn packed_dimension_widths(ranges: &[PackedRange]) -> Vec<PackedDimension> {
@@ -4535,7 +4567,7 @@ fn function_local_packed_dimensions_from_block_items(
     items: &[sv_parser::BlockItemDeclaration],
     syntax_tree: &SyntaxTree,
     type_aliases: &HashMap<String, Type>,
-) -> Option<PackedDimensions> {
+) -> Option<VariablePackedDimensions> {
     function_local_packed_dimensions_from_block_item_iter(items.iter(), syntax_tree, type_aliases)
 }
 
@@ -4543,7 +4575,7 @@ fn function_local_packed_dimensions_from_block_item_iter<'a>(
     items: impl IntoIterator<Item = &'a sv_parser::BlockItemDeclaration>,
     syntax_tree: &SyntaxTree,
     type_aliases: &HashMap<String, Type>,
-) -> Option<PackedDimensions> {
+) -> Option<VariablePackedDimensions> {
     let mut dimensions = HashMap::default();
     for item in items {
         let sv_parser::BlockItemDeclaration::Data(item) = item else {
@@ -7674,7 +7706,7 @@ fn lvalue_from_constant_select(
 }
 
 fn expr_from_expression(expr: &sv_parser::Expression, syntax_tree: &SyntaxTree) -> Option<Expr> {
-    expr_from_expression_with_types(expr, syntax_tree, &HashMap::default())
+    expr_from_expression_with_types(expr, syntax_tree, &PackedDimensions::default())
 }
 
 fn expr_from_expression_with_types(
@@ -7802,7 +7834,7 @@ fn guard_zero_divisions(expr: Expr) -> Expr {
 }
 
 fn expr_from_primary(primary: &sv_parser::Primary, syntax_tree: &SyntaxTree) -> Option<Expr> {
-    expr_from_primary_with_types(primary, syntax_tree, &HashMap::default())
+    expr_from_primary_with_types(primary, syntax_tree, &PackedDimensions::default())
 }
 
 fn expr_from_primary_with_types(
@@ -8106,6 +8138,7 @@ fn flatten_variable_select(
             value,
             &dimensions.unpacked[index].left,
             &dimensions.unpacked[index].right,
+            &packed_dimensions.const_env,
         ) {
             return None;
         }
@@ -8292,11 +8325,16 @@ fn unpacked_index_offset(dimension: &UnpackedDimension, index: ConstExpr) -> Con
     }
 }
 
-fn const_expr_is_out_of_range(index: &ConstExpr, left: &ConstExpr, right: &ConstExpr) -> bool {
+fn const_expr_is_out_of_range(
+    index: &ConstExpr,
+    left: &ConstExpr,
+    right: &ConstExpr,
+    const_env: &HashMap<String, i128>,
+) -> bool {
     let (Some(index), Some(left), Some(right)) = (
-        eval_ast_const_expr(index, &HashMap::default()),
-        eval_ast_const_expr(left, &HashMap::default()),
-        eval_ast_const_expr(right, &HashMap::default()),
+        eval_ast_const_expr(index, const_env),
+        eval_ast_const_expr(left, const_env),
+        eval_ast_const_expr(right, const_env),
     ) else {
         return false;
     };

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -404,7 +404,10 @@ fn static_for_loop_iterations(
         .and_then(|(name, value)| Some((name, eval_ast_const_expr(&value, const_env)?)))?;
     i32::try_from(initial_value).ok()?;
     let condition = const_expr_from_expr(condition.as_ref()?, syntax_tree)?;
-    let step = step.as_ref()?.nodes.0.contents().into_iter().next()?;
+    let steps = step.as_ref()?.nodes.0.contents();
+    let [step] = steps.as_slice() else {
+        return None;
+    };
 
     let mut values = Vec::new();
     let mut value = initial_value;
@@ -4088,13 +4091,19 @@ fn validate_function_return_type(
             let sv_parser::DataTypeOrVoid::DataType(data_type) = &**data_type else {
                 return Ok(());
             };
-            value_type_from_data_type(data_type, syntax_tree, const_env, type_aliases).is_none()
+            let r#type = type_from_ref_node(RefNode::DataType(data_type), syntax_tree)
+                .or_else(|| type_alias_from_data_type(data_type, syntax_tree, type_aliases));
+            r#type
+                .as_ref()
+                .is_some_and(|r#type| !r#type.unpacked_ranges().is_empty())
+                || value_type_from_data_type(data_type, syntax_tree, const_env, type_aliases)
+                    .is_none()
         }
         sv_parser::FunctionDataTypeOrImplicit::ImplicitDataType(_) => false,
     };
     if unsupported {
         Err(AnalyzerError::Unsupported(
-            "unsupported function return data type".to_string(),
+            "unsupported function return data type or unpacked dimension".to_string(),
         ))
     } else {
         Ok(())
@@ -4571,6 +4580,9 @@ fn function_local_types_from_block_item_iter<'a>(
             signals_from_data_declaration(&item.nodes.1, syntax_tree, type_aliases).ok()?;
         for signal in signals {
             let r#type = signal.r#type();
+            if !r#type.unpacked_ranges().is_empty() {
+                return None;
+            }
             let width = if r#type.packed_ranges().is_empty() {
                 1
             } else {
@@ -7827,7 +7839,30 @@ fn expr_from_primary_with_types(
                 .into_iter()
                 .map(|expr| expr_from_expression_with_types(expr, syntax_tree, packed_dimensions))
                 .collect::<Option<Vec<_>>>()?;
-            (!parts.is_empty()).then_some(Expr::Concat(parts))
+            let base = (!parts.is_empty()).then_some(Expr::Concat(parts))?;
+            match concat.nodes.1.as_ref().map(|range| &range.nodes.1) {
+                None => Some(base),
+                Some(sv_parser::RangeExpression::PartSelectRange(range)) => {
+                    let sv_parser::PartSelectRange::ConstantRange(range) = &**range else {
+                        return None;
+                    };
+                    let msb = const_expr_from_ref_node(
+                        RefNode::ConstantExpression(&range.nodes.0),
+                        syntax_tree,
+                    )?;
+                    let lsb = const_expr_from_ref_node(
+                        RefNode::ConstantExpression(&range.nodes.2),
+                        syntax_tree,
+                    )?;
+                    Some(Expr::Select {
+                        expr: Box::new(base),
+                        msb,
+                        lsb,
+                        signed: false,
+                    })
+                }
+                Some(sv_parser::RangeExpression::Expression(_)) => None,
+            }
         }
         sv_parser::Primary::MultipleConcatenation(concat) => {
             let (count, repeated) = &concat.nodes.0.nodes.0.nodes.1;
@@ -7974,7 +8009,12 @@ fn expr_select_from_select(
         let mut lsb =
             const_expr_from_ref_node(RefNode::ConstantExpression(&range.nodes.2), syntax_tree)?;
         let Expr::Ident(name) = &base else {
-            return None;
+            return indices.is_empty().then_some(Expr::Select {
+                expr: Box::new(base),
+                msb,
+                lsb,
+                signed: false,
+            });
         };
         (msb, lsb) = flatten_select_range(name, &indices, msb, lsb, packed_dimensions)?;
         return Some(Expr::Select {
@@ -8105,6 +8145,13 @@ fn flatten_select_range(
     let Some(dimensions) = packed_dimensions.get(name) else {
         return indices.is_empty().then_some((msb, lsb));
     };
+    if indices.is_empty()
+        && dimensions.unpacked.is_empty()
+        && dimensions.packed.len() == 1
+        && !dimensions.packed[0].normalize_single
+    {
+        return Some((msb, lsb));
+    }
     let (array_offset, packed_indices) = flatten_variable_select(name, indices, packed_dimensions)?;
     let dimension = dimensions.packed.get(packed_indices.len())?;
     msb = packed_index_offset(dimension, msb);
@@ -8640,7 +8687,9 @@ fn type_with_fallback_ranges(
 }
 
 fn type_with_unpacked_ranges(mut r#type: Type, ranges: Vec<UnpackedRange>) -> Type {
-    r#type.unpacked_ranges.extend(ranges);
+    let mut unpacked_ranges = ranges;
+    unpacked_ranges.extend(r#type.unpacked_ranges);
+    r#type.unpacked_ranges = unpacked_ranges;
     r#type
 }
 

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -8536,6 +8536,86 @@ fn remaining_unpacked_selection_width(
     product_expr(&parts)
 }
 
+fn flatten_unpacked_select_range(
+    name: &str,
+    indices: &[ConstExpr],
+    msb: ConstExpr,
+    lsb: ConstExpr,
+    dimensions: &VariableDimensions,
+    packed_dimensions: &PackedDimensions,
+) -> Option<(ConstExpr, ConstExpr)> {
+    let dimension = dimensions.unpacked.get(indices.len())?;
+    if const_expr_is_out_of_range(
+        &msb,
+        &dimension.left,
+        &dimension.right,
+        &packed_dimensions.const_env,
+    ) || const_expr_is_out_of_range(
+        &lsb,
+        &dimension.left,
+        &dimension.right,
+        &packed_dimensions.const_env,
+    ) {
+        return None;
+    }
+    let (array_offset, packed_indices) = flatten_variable_select(name, indices, packed_dimensions)?;
+    if !packed_indices.is_empty() {
+        return None;
+    }
+    let msb_offset = unpacked_index_offset(dimension, msb);
+    let lsb_offset = unpacked_index_offset(dimension, lsb);
+    let stride = product_expr(
+        &dimensions.unpacked[indices.len() + 1..]
+            .iter()
+            .map(|dimension| dimension.width.clone())
+            .chain(
+                dimensions
+                    .packed
+                    .iter()
+                    .map(|dimension| dimension.width.clone()),
+            )
+            .collect::<Vec<_>>(),
+    );
+    let scale = |offset: ConstExpr| {
+        if is_one(&stride) {
+            offset
+        } else {
+            ConstExpr::Binary {
+                left: Box::new(offset),
+                op: BinaryOp::Mul,
+                right: Box::new(stride.clone()),
+            }
+        }
+    };
+    let stride_minus_one = ConstExpr::Binary {
+        left: Box::new(stride.clone()),
+        op: BinaryOp::Sub,
+        right: Box::new(ConstExpr::Literal("1".to_string())),
+    };
+    let descending = ConstExpr::Binary {
+        left: Box::new(msb_offset.clone()),
+        op: BinaryOp::Ge,
+        right: Box::new(lsb_offset.clone()),
+    };
+    let high = ConstExpr::Mux {
+        condition: Box::new(descending.clone()),
+        then_expr: Box::new(add_expr(
+            scale(msb_offset.clone()),
+            stride_minus_one.clone(),
+        )),
+        else_expr: Box::new(add_expr(scale(lsb_offset.clone()), stride_minus_one)),
+    };
+    let low = ConstExpr::Mux {
+        condition: Box::new(descending),
+        then_expr: Box::new(scale(lsb_offset)),
+        else_expr: Box::new(scale(msb_offset)),
+    };
+    Some((
+        add_expr(array_offset.clone(), high),
+        add_expr(array_offset, low),
+    ))
+}
+
 fn flatten_select_range(
     name: &str,
     indices: &[ConstExpr],
@@ -8554,7 +8634,14 @@ fn flatten_select_range(
         return Some((msb, lsb));
     }
     if indices.len() < dimensions.unpacked.len() {
-        return None;
+        return flatten_unpacked_select_range(
+            name,
+            indices,
+            msb,
+            lsb,
+            dimensions,
+            packed_dimensions,
+        );
     }
     let (array_offset, packed_indices) = flatten_variable_select(name, indices, packed_dimensions)?;
     let dimension = dimensions.packed.get(packed_indices.len())?;
@@ -8617,6 +8704,16 @@ fn flatten_packed_select(
 ) -> Option<(ConstExpr, ConstExpr)> {
     let variable_dimensions = packed_dimensions.get(name)?;
     let dimensions = &variable_dimensions.packed;
+    if dimensions.is_empty() {
+        if variable_dimensions.unpacked.is_empty() || indices.len() != 1 {
+            return None;
+        }
+        let zero = ConstExpr::Literal("0".to_string());
+        if eval_ast_const_expr(&indices[0], &packed_dimensions.const_env) != Some(0) {
+            return None;
+        }
+        return Some((zero.clone(), zero));
+    }
     if indices.is_empty()
         || indices.len() > dimensions.len()
         || (variable_dimensions.unpacked.is_empty()

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -7210,13 +7210,15 @@ fn conditional_assignments_from_statement(
             for value in values {
                 let mut loop_env = const_env.clone();
                 loop_env.insert(name.clone(), value);
+                let mut loop_packed_dimensions = packed_dimensions.clone();
+                loop_packed_dimensions.const_env = loop_env.clone();
                 let start = assignments.len();
                 conditional_assignments_from_statement_or_null(
                     body,
                     condition.clone(),
                     syntax_tree,
                     &loop_env,
-                    packed_dimensions,
+                    &loop_packed_dimensions,
                     assignments,
                 )?;
                 for assignment in &mut assignments[start..] {
@@ -7631,6 +7633,13 @@ fn lvalue_from_select(
             });
         }
     }
+    if !indices.is_empty()
+        && packed_dimensions
+            .get(&name)
+            .is_some_and(|dimensions| !dimensions.unpacked.is_empty())
+    {
+        return None;
+    }
     if indices.len() == 1 {
         let bit = indices[0].clone();
         return Some(LValue::Select {
@@ -7714,6 +7723,13 @@ fn lvalue_from_constant_select(
                 lsb: array_offset,
             });
         }
+    }
+    if !indices.is_empty()
+        && packed_dimensions
+            .get(&name)
+            .is_some_and(|dimensions| !dimensions.unpacked.is_empty())
+    {
+        return None;
     }
     if indices.len() == 1 {
         let bit = indices[0].clone();

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -402,6 +402,7 @@ fn static_for_loop_iterations(
     let (initialization, _, condition, _, step) = &loop_statement.nodes.1.nodes.1;
     let (name, initial_value) = for_loop_initialization(initialization.as_ref()?, syntax_tree)
         .and_then(|(name, value)| Some((name, eval_ast_const_expr(&value, const_env)?)))?;
+    i32::try_from(initial_value).ok()?;
     let condition = const_expr_from_expr(condition.as_ref()?, syntax_tree)?;
     let step = step.as_ref()?.nodes.0.contents().into_iter().next()?;
 
@@ -415,6 +416,7 @@ fn static_for_loop_iterations(
         }
         values.push(value);
         value = next_for_loop_value(step, &name, value, syntax_tree, &loop_env)?;
+        i32::try_from(value).ok()?;
     }
 
     let mut loop_env = const_env.clone();
@@ -429,6 +431,9 @@ fn for_loop_initialization(
     match initialization {
         sv_parser::ForInitialization::Declaration(declaration) => {
             let declaration = declaration.nodes.0.contents().into_iter().next()?;
+            if !for_loop_index_type_is_supported(&declaration.nodes.1) {
+                return None;
+            }
             let assignment = declaration.nodes.2.contents().into_iter().next()?;
             let name = identifier_text(RefNode::VariableIdentifier(&assignment.0), syntax_tree)?;
             let value = const_expr_from_expr(&assignment.2, syntax_tree)?;
@@ -442,15 +447,67 @@ fn for_loop_initialization(
     }
 }
 
-fn integral_literal_is_zero(literal: &str) -> bool {
-    typecheck::parse_integral_literal(literal)
-        .is_some_and(|literal| literal.value == 0u8.into() && literal.mask == 0u8.into())
+fn for_loop_index_type_is_supported(data_type: &sv_parser::DataType) -> bool {
+    matches!(
+        data_type,
+        sv_parser::DataType::Atom(data_type)
+            if matches!(
+                data_type.nodes.0,
+                sv_parser::IntegerAtomType::Int(_) | sv_parser::IntegerAtomType::Integer(_)
+            ) && !matches!(data_type.nodes.1, Some(sv_parser::Signing::Unsigned(_)))
+    )
+}
+
+fn cast_target_type(
+    casting_type: &sv_parser::CastingType,
+    syntax_tree: &SyntaxTree,
+) -> Option<ExprType> {
+    if let Some(r#type) = integer_atom_expr_type(RefNode::CastingType(casting_type)) {
+        return Some(r#type);
+    }
+    let sv_parser::CastingType::ConstantPrimary(primary) = casting_type else {
+        return None;
+    };
+    let width = eval_ast_const_expr(
+        &const_expr_from_ref_node(RefNode::ConstantPrimary(primary), syntax_tree)?,
+        &HashMap::default(),
+    )?;
+    Some(ExprType {
+        width: usize::try_from(width).ok()?.max(1),
+        signed: false,
+    })
+}
+
+fn cast_target_is_named_type(
+    casting_type: &sv_parser::CastingType,
+    syntax_tree: &SyntaxTree,
+) -> bool {
+    if matches!(
+        casting_type,
+        sv_parser::CastingType::SimpleType(simple_type)
+            if matches!(
+                simple_type.as_ref(),
+                sv_parser::SimpleType::PsTypeIdentifier(_)
+            )
+    ) {
+        return true;
+    }
+    let sv_parser::CastingType::ConstantPrimary(primary) = casting_type else {
+        return false;
+    };
+    matches!(
+        const_expr_from_ref_node(RefNode::ConstantPrimary(primary), syntax_tree),
+        Some(ConstExpr::Ident(_))
+    )
 }
 
 fn cast_is_zero_literal(cast: &sv_parser::Cast, syntax_tree: &SyntaxTree) -> bool {
     matches!(
         const_expr_from_expr(&cast.nodes.2.nodes.1, syntax_tree),
-        Some(ConstExpr::Literal(literal)) if integral_literal_is_zero(&literal)
+        Some(ConstExpr::Literal(literal))
+            if typecheck::parse_integral_literal(&literal).is_some_and(|literal| {
+                literal.value == 0u8.into() && literal.mask == 0u8.into()
+            })
     )
 }
 
@@ -460,7 +517,56 @@ fn constant_cast_is_zero_literal(cast: &sv_parser::ConstantCast, syntax_tree: &S
             RefNode::ConstantExpression(&cast.nodes.2.nodes.1),
             syntax_tree,
         ),
-        Some(ConstExpr::Literal(literal)) if integral_literal_is_zero(&literal)
+        Some(ConstExpr::Literal(literal))
+            if typecheck::parse_integral_literal(&literal).is_some_and(|literal| {
+                literal.value == 0u8.into() && literal.mask == 0u8.into()
+            })
+    )
+}
+
+fn cast_is_supported(cast: &sv_parser::Cast, syntax_tree: &SyntaxTree) -> bool {
+    cast_zero_type(cast, syntax_tree).is_some()
+        || (cast_is_zero_literal(cast, syntax_tree)
+            && cast_target_is_named_type(&cast.nodes.0, syntax_tree))
+}
+
+fn constant_cast_is_supported(cast: &sv_parser::ConstantCast, syntax_tree: &SyntaxTree) -> bool {
+    constant_cast_zero_type(cast, syntax_tree).is_some()
+        || (constant_cast_is_zero_literal(cast, syntax_tree)
+            && cast_target_is_named_type(&cast.nodes.0, syntax_tree))
+}
+
+fn cast_zero_type(cast: &sv_parser::Cast, syntax_tree: &SyntaxTree) -> Option<ExprType> {
+    let ConstExpr::Literal(literal) = const_expr_from_expr(&cast.nodes.2.nodes.1, syntax_tree)?
+    else {
+        return None;
+    };
+    let literal = typecheck::parse_integral_literal(&literal)?;
+    (literal.value == 0u8.into() && literal.mask == 0u8.into())
+        .then(|| cast_target_type(&cast.nodes.0, syntax_tree))?
+}
+
+fn constant_cast_zero_type(
+    cast: &sv_parser::ConstantCast,
+    syntax_tree: &SyntaxTree,
+) -> Option<ExprType> {
+    let ConstExpr::Literal(literal) = const_expr_from_ref_node(
+        RefNode::ConstantExpression(&cast.nodes.2.nodes.1),
+        syntax_tree,
+    )?
+    else {
+        return None;
+    };
+    let literal = typecheck::parse_integral_literal(&literal)?;
+    (literal.value == 0u8.into() && literal.mask == 0u8.into())
+        .then(|| cast_target_type(&cast.nodes.0, syntax_tree))?
+}
+
+fn typed_zero_literal(r#type: ExprType) -> String {
+    format!(
+        "{}'{}d0",
+        r#type.width,
+        if r#type.signed { "s" } else { "" }
     )
 }
 
@@ -534,10 +640,10 @@ fn reject_silently_ignored_constructs(
             continue;
         }
         match child {
-            RefNode::Cast(cast) if !cast_is_zero_literal(cast, syntax_tree) => {
+            RefNode::Cast(cast) if !cast_is_supported(cast, syntax_tree) => {
                 return Err(AnalyzerError::Unsupported("cast expression".to_string()));
             }
-            RefNode::ConstantCast(cast) if !constant_cast_is_zero_literal(cast, syntax_tree) => {
+            RefNode::ConstantCast(cast) if !constant_cast_is_supported(cast, syntax_tree) => {
                 return Err(AnalyzerError::Unsupported("constant cast expression".to_string()));
             }
             RefNode::AnsiPortDeclarationNet(port) if port.nodes.3.is_some() => {
@@ -1923,6 +2029,7 @@ pub enum Expr {
         expr: Box<Expr>,
         msb: ConstExpr,
         lsb: ConstExpr,
+        signed: bool,
     },
     Concat(Vec<Expr>),
     RepeatConcat {
@@ -2387,7 +2494,11 @@ fn signals_from_type_alias_instantiation(
             syntax_tree,
         )
         .ok_or_else(|| AnalyzerError::Unsupported("unsupported signal identifier".to_string()))?;
-        signals.push(Signal::new(name, r#type.clone()));
+        let signal_type = type_with_unpacked_ranges(
+            r#type.clone(),
+            unpacked_ranges_from_dimensions(&instance.nodes.0.nodes.1, syntax_tree)?,
+        );
+        signals.push(Signal::new(name, signal_type));
     }
     Ok(signals)
 }
@@ -2932,6 +3043,7 @@ fn const_expr_to_expr(expr: ConstExpr) -> Expr {
             expr: Box::new(const_expr_to_expr(*expr)),
             msb: (*bit).clone(),
             lsb: *bit,
+            signed: false,
         },
         ConstExpr::Function { name, args } => Expr::Call {
             name,
@@ -3184,6 +3296,7 @@ struct UnpackedDimension {
 struct VariableDimensions {
     packed: Vec<PackedDimension>,
     unpacked: Vec<UnpackedDimension>,
+    signed: bool,
 }
 
 type PackedDimensions = HashMap<String, VariableDimensions>;
@@ -3199,6 +3312,7 @@ fn packed_dimensions_from_ports_and_signals(
             VariableDimensions {
                 packed: packed_dimension_widths(port.r#type().packed_ranges()),
                 unpacked: unpacked_dimension_widths(port.r#type().unpacked_ranges()),
+                signed: port.r#type().is_signed(),
             },
         );
     }
@@ -3208,6 +3322,7 @@ fn packed_dimensions_from_ports_and_signals(
             VariableDimensions {
                 packed: packed_dimension_widths(signal.r#type().packed_ranges()),
                 unpacked: unpacked_dimension_widths(signal.r#type().unpacked_ranges()),
+                signed: signal.r#type().is_signed(),
             },
         );
     }
@@ -3415,6 +3530,30 @@ fn instances_from_module_node(
     packed_dimensions: &PackedDimensions,
 ) -> Result<Vec<Instance>, AnalyzerError> {
     let type_aliases = type_aliases_from_module_node(node.clone(), syntax_tree)?;
+    for child in node.clone() {
+        let RefNode::ModuleInstantiation(instantiation) = child else {
+            continue;
+        };
+        let module_name = identifier_text(
+            RefNode::ModuleIdentifier(&instantiation.nodes.0),
+            syntax_tree,
+        )
+        .ok_or_else(|| {
+            AnalyzerError::Unsupported("unsupported module instantiation identifier".to_string())
+        })?;
+        if !type_aliases.contains_key(&module_name)
+            && instantiation
+                .nodes
+                .2
+                .contents()
+                .iter()
+                .any(|instance| !instance.nodes.0.nodes.1.is_empty())
+        {
+            return Err(AnalyzerError::Unsupported(
+                "module instance array".to_string(),
+            ));
+        }
+    }
     let mut instances = Vec::new();
     for item in module_non_port_items(node) {
         instances_from_non_port_module_item(
@@ -3675,11 +3814,6 @@ fn instances_from_module_instantiation(
         .map(|parameter| parameter.name().to_string())
         .collect();
     for instance in instantiation.nodes.2.contents() {
-        if !instance.nodes.0.nodes.1.is_empty() {
-            return Err(AnalyzerError::Unsupported(
-                "module instance array".to_string(),
-            ));
-        }
         let name = identifier_text(
             RefNode::InstanceIdentifier(&instance.nodes.0.nodes.0),
             syntax_tree,
@@ -3978,6 +4112,19 @@ fn validate_function_formal_types(
             && value_type_from_data_type_or_implicit(node, syntax_tree, const_env, type_aliases)
                 .is_none()
     };
+    let has_unpacked_dimensions =
+        |node: &sv_parser::DataTypeOrImplicit, dimensions: &[sv_parser::VariableDimension]| {
+            !dimensions.is_empty()
+                || type_from_ref_node(RefNode::DataTypeOrImplicit(node), syntax_tree)
+                    .or_else(|| {
+                        type_alias_from_ref_node(
+                            RefNode::DataTypeOrImplicit(node),
+                            syntax_tree,
+                            type_aliases,
+                        )
+                    })
+                    .is_some_and(|r#type| !r#type.unpacked_ranges().is_empty())
+        };
     let invalid = match &declaration.nodes.2 {
         sv_parser::FunctionBodyDeclaration::WithPort(body) => {
             body.nodes.3.nodes.1.as_ref().is_some_and(|ports| {
@@ -3989,7 +4136,12 @@ fn validate_function_formal_types(
                     // A type-only item can be the parser's representation of
                     // the shorthand `input logic a, b`; only validate entries
                     // that actually carry a formal identifier here.
-                    .any(|port| port.nodes.4.is_some() && unsupported(&port.nodes.3))
+                    .any(|port| {
+                        port.nodes.4.as_ref().is_some_and(|(_, dimensions, _)| {
+                            unsupported(&port.nodes.3)
+                                || has_unpacked_dimensions(&port.nodes.3, dimensions)
+                        })
+                    })
             })
         }
         sv_parser::FunctionBodyDeclaration::WithoutPort(body) => body.nodes.4.iter().any(|item| {
@@ -3997,11 +4149,19 @@ fn validate_function_formal_types(
                 return false;
             };
             unsupported(&port.nodes.3)
+                || port
+                    .nodes
+                    .4
+                    .nodes
+                    .0
+                    .contents()
+                    .iter()
+                    .any(|(_, dimensions, _)| has_unpacked_dimensions(&port.nodes.3, dimensions))
         }),
     };
     if invalid {
         Err(AnalyzerError::Unsupported(
-            "unsupported function formal data type".to_string(),
+            "unsupported function formal data type or unpacked dimension".to_string(),
         ))
     } else {
         Ok(())
@@ -4243,6 +4403,7 @@ fn function_from_declaration(
                     VariableDimensions {
                         packed: param.packed_dimensions.clone(),
                         unpacked: Vec::new(),
+                        signed: param.signed,
                     },
                 )
             }));
@@ -4298,6 +4459,7 @@ fn function_from_declaration(
                     VariableDimensions {
                         packed: param.packed_dimensions.clone(),
                         unpacked: Vec::new(),
+                        signed: param.signed,
                     },
                 )
             }));
@@ -4386,6 +4548,7 @@ fn function_local_packed_dimensions_from_block_item_iter<'a>(
                 VariableDimensions {
                     packed: function_packed_dimension_widths(signal.r#type().packed_ranges()),
                     unpacked: unpacked_dimension_widths(signal.r#type().unpacked_ranges()),
+                    signed: signal.r#type().is_signed(),
                 },
             )
         }));
@@ -5928,7 +6091,12 @@ fn substitute_expr_constants_with_parameter_literals(
             })
             .unwrap_or(Expr::Ident(name)),
         Expr::Literal(value) => Expr::Literal(value),
-        Expr::Select { expr, msb, lsb } => Expr::Select {
+        Expr::Select {
+            expr,
+            msb,
+            lsb,
+            signed,
+        } => Expr::Select {
             expr: Box::new(substitute_expr_constants_with_parameter_literals(
                 *expr,
                 const_env,
@@ -5936,6 +6104,7 @@ fn substitute_expr_constants_with_parameter_literals(
             )),
             msb: substitute_const_expr_constants(msb, const_env),
             lsb: substitute_const_expr_constants(lsb, const_env),
+            signed,
         },
         Expr::Concat(parts) => Expr::Concat(
             parts
@@ -6115,7 +6284,8 @@ fn expr_signedness(
         Expr::Literal(literal) => {
             typecheck::parse_integral_literal(literal).map(|literal| literal.signed)
         }
-        Expr::Select { .. } | Expr::Concat(_) | Expr::RepeatConcat { .. } => Some(false),
+        Expr::Select { signed, .. } => Some(*signed),
+        Expr::Concat(_) | Expr::RepeatConcat { .. } => Some(false),
         Expr::Resize { signed, .. } => Some(*signed),
         Expr::Unary { op, expr } => {
             if matches!(
@@ -6178,7 +6348,12 @@ fn expand_expr_calls(
     match expr {
         Expr::Ident(name) => Expr::Ident(name),
         Expr::Literal(value) => Expr::Literal(value),
-        Expr::Select { expr, msb, lsb } => Expr::Select {
+        Expr::Select {
+            expr,
+            msb,
+            lsb,
+            signed,
+        } => Expr::Select {
             expr: Box::new(expand_expr_calls(
                 *expr,
                 functions,
@@ -6188,6 +6363,7 @@ fn expand_expr_calls(
             )),
             msb,
             lsb,
+            signed,
         },
         Expr::Concat(parts) => Expr::Concat(
             parts
@@ -6378,10 +6554,16 @@ fn substitute_expr_idents(expr: Expr, env: &HashMap<String, Expr>) -> Expr {
     match expr {
         Expr::Ident(name) => env.get(&name).cloned().unwrap_or(Expr::Ident(name)),
         Expr::Literal(value) => Expr::Literal(value),
-        Expr::Select { expr, msb, lsb } => Expr::Select {
+        Expr::Select {
+            expr,
+            msb,
+            lsb,
+            signed,
+        } => Expr::Select {
             expr: Box::new(substitute_expr_idents(*expr, env)),
             msb,
             lsb,
+            signed,
         },
         Expr::Concat(parts) => Expr::Concat(
             parts
@@ -7289,6 +7471,7 @@ fn expr_from_lvalue(lhs: &LValue) -> Expr {
             expr: Box::new(Expr::Ident(name.clone())),
             msb: msb.clone(),
             lsb: lsb.clone(),
+            signed: false,
         },
     }
 }
@@ -7539,10 +7722,16 @@ fn expr_from_expression_with_types_raw(
 fn guard_zero_divisions(expr: Expr) -> Expr {
     match expr {
         Expr::Ident(_) | Expr::Literal(_) => expr,
-        Expr::Select { expr, msb, lsb } => Expr::Select {
+        Expr::Select {
+            expr,
+            msb,
+            lsb,
+            signed,
+        } => Expr::Select {
             expr: Box::new(guard_zero_divisions(*expr)),
             msb,
             lsb,
+            signed,
         },
         Expr::Concat(parts) => Expr::Concat(parts.into_iter().map(guard_zero_divisions).collect()),
         Expr::RepeatConcat { count, parts } => Expr::RepeatConcat {
@@ -7657,9 +7846,22 @@ fn expr_from_primary_with_types(
         sv_parser::Primary::FunctionSubroutineCall(call) => {
             expr_from_function_subroutine_call(call, syntax_tree, packed_dimensions)
         }
-        sv_parser::Primary::Cast(cast) => cast_is_zero_literal(cast, syntax_tree).then(|| {
-            expr_from_expression_with_types(&cast.nodes.2.nodes.1, syntax_tree, packed_dimensions)
-        })?,
+        sv_parser::Primary::Cast(cast) => {
+            let expr = expr_from_expression_with_types(
+                &cast.nodes.2.nodes.1,
+                syntax_tree,
+                packed_dimensions,
+            )?;
+            if let Some(r#type) = cast_zero_type(cast, syntax_tree) {
+                Some(Expr::Resize {
+                    expr: Box::new(expr),
+                    width: r#type.width,
+                    signed: r#type.signed,
+                })
+            } else {
+                cast_target_is_named_type(&cast.nodes.0, syntax_tree).then_some(expr)
+            }
+        }
         sv_parser::Primary::MintypmaxExpression(expr) => match &expr.nodes.0.nodes.1 {
             sv_parser::MintypmaxExpression::Expression(expr) => {
                 expr_from_expression_with_types(expr, syntax_tree, packed_dimensions)
@@ -7779,6 +7981,7 @@ fn expr_select_from_select(
             expr: Box::new(base),
             msb,
             lsb,
+            signed: false,
         });
     }
 
@@ -7794,6 +7997,7 @@ fn expr_select_from_select(
                     expr: Box::new(base),
                     msb: add_expr(array_offset.clone(), msb),
                     lsb: add_expr(array_offset, lsb),
+                    signed: false,
                 });
             }
             if let Some(dimensions) = packed_dimensions.get(name)
@@ -7818,16 +8022,27 @@ fn expr_select_from_select(
                         },
                     ),
                     lsb: array_offset,
+                    signed: dimensions.signed,
                 });
             }
         }
     }
     if indices.len() == 1 {
+        let Expr::Ident(name) = &base else {
+            return None;
+        };
+        if packed_dimensions
+            .get(name)
+            .is_some_and(|dimensions| !dimensions.unpacked.is_empty())
+        {
+            return None;
+        }
         let bit = indices[0].clone();
         return Some(Expr::Select {
             expr: Box::new(base),
             msb: bit.clone(),
             lsb: bit,
+            signed: false,
         });
     }
 
@@ -7847,6 +8062,13 @@ fn flatten_variable_select(
 
     let mut offset = ConstExpr::Literal("0".to_string());
     for (index, value) in indices[..unpacked_count].iter().enumerate() {
+        if const_expr_is_out_of_range(
+            value,
+            &dimensions.unpacked[index].left,
+            &dimensions.unpacked[index].right,
+        ) {
+            return None;
+        }
         let mut stride_parts = dimensions.unpacked[index + 1..]
             .iter()
             .map(|dimension| dimension.width.clone())
@@ -8021,6 +8243,17 @@ fn unpacked_index_offset(dimension: &UnpackedDimension, index: ConstExpr) -> Con
             right: Box::new(dimension.left.clone()),
         }),
     }
+}
+
+fn const_expr_is_out_of_range(index: &ConstExpr, left: &ConstExpr, right: &ConstExpr) -> bool {
+    let (Some(index), Some(left), Some(right)) = (
+        eval_ast_const_expr(index, &HashMap::default()),
+        eval_ast_const_expr(left, &HashMap::default()),
+        eval_ast_const_expr(right, &HashMap::default()),
+    ) else {
+        return false;
+    };
+    index < left.min(right) || index > left.max(right)
 }
 
 fn product_expr(parts: &[ConstExpr]) -> ConstExpr {
@@ -8598,12 +8831,16 @@ fn const_expr_from_ref_node(node: RefNode<'_>, syntax_tree: &SyntaxTree) -> Opti
                 })
             }
             sv_parser::ConstantPrimary::ConstantCast(cast) => {
-                constant_cast_is_zero_literal(cast, syntax_tree).then(|| {
+                if let Some(r#type) = constant_cast_zero_type(cast, syntax_tree) {
+                    Some(ConstExpr::Literal(typed_zero_literal(r#type)))
+                } else if cast_target_is_named_type(&cast.nodes.0, syntax_tree) {
                     const_expr_from_ref_node(
                         RefNode::ConstantExpression(&cast.nodes.2.nodes.1),
                         syntax_tree,
                     )
-                })?
+                } else {
+                    None
+                }
             }
             sv_parser::ConstantPrimary::MintypmaxExpression(expr) => match &expr.nodes.0.nodes.1 {
                 sv_parser::ConstantMintypmaxExpression::Unary(expr) => {

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -1903,6 +1903,7 @@ pub enum LValue {
         name: String,
         msb: ConstExpr,
         lsb: ConstExpr,
+        signed: bool,
     },
 }
 
@@ -6142,10 +6143,16 @@ fn substitute_assignment_constants_with_parameter_literals(
 fn substitute_lvalue_constants(lvalue: LValue, const_env: &HashMap<String, i128>) -> LValue {
     match lvalue {
         LValue::Ident(name) => LValue::Ident(name),
-        LValue::Select { name, msb, lsb } => LValue::Select {
+        LValue::Select {
+            name,
+            msb,
+            lsb,
+            signed,
+        } => LValue::Select {
             name,
             msb: substitute_const_expr_constants(msb, const_env),
             lsb: substitute_const_expr_constants(lsb, const_env),
+            signed,
         },
     }
 }
@@ -7554,11 +7561,16 @@ fn assignment_op_expr(lhs: &LValue, op: &str, rhs: Expr) -> Option<Expr> {
 fn expr_from_lvalue(lhs: &LValue) -> Expr {
     match lhs {
         LValue::Ident(name) => Expr::Ident(name.clone()),
-        LValue::Select { name, msb, lsb } => Expr::Select {
+        LValue::Select {
+            name,
+            msb,
+            lsb,
+            signed,
+        } => Expr::Select {
             expr: Box::new(Expr::Ident(name.clone())),
             msb: msb.clone(),
             lsb: lsb.clone(),
-            signed: false,
+            signed: *signed,
         },
     }
 }
@@ -7623,7 +7635,12 @@ fn lvalue_from_select(
         let mut lsb =
             const_expr_from_ref_node(RefNode::ConstantExpression(&range.nodes.2), syntax_tree)?;
         (msb, lsb) = flatten_select_range(&name, &indices, msb, lsb, packed_dimensions)?;
-        return Some(LValue::Select { name, msb, lsb });
+        return Some(LValue::Select {
+            name,
+            msb,
+            lsb,
+            signed: false,
+        });
     }
 
     if let Some((array_offset, packed_indices)) =
@@ -7637,6 +7654,7 @@ fn lvalue_from_select(
                     name,
                     msb: add_expr(array_offset.clone(), msb),
                     lsb: add_expr(array_offset, lsb),
+                    signed: false,
                 });
             }
         } else if let Some(dimensions) = packed_dimensions.get(&name)
@@ -7661,6 +7679,7 @@ fn lvalue_from_select(
                     },
                 ),
                 lsb: array_offset,
+                signed: dimensions.signed,
             });
         }
     }
@@ -7677,6 +7696,7 @@ fn lvalue_from_select(
             name,
             msb: bit.clone(),
             lsb: bit,
+            signed: false,
         });
     }
 
@@ -7714,7 +7734,12 @@ fn lvalue_from_constant_select(
         let mut lsb =
             const_expr_from_ref_node(RefNode::ConstantExpression(&range.nodes.2), syntax_tree)?;
         (msb, lsb) = flatten_select_range(&name, &indices, msb, lsb, packed_dimensions)?;
-        return Some(LValue::Select { name, msb, lsb });
+        return Some(LValue::Select {
+            name,
+            msb,
+            lsb,
+            signed: false,
+        });
     }
 
     if let Some((array_offset, packed_indices)) =
@@ -7728,6 +7753,7 @@ fn lvalue_from_constant_select(
                     name,
                     msb: add_expr(array_offset.clone(), msb),
                     lsb: add_expr(array_offset, lsb),
+                    signed: false,
                 });
             }
         } else if let Some(dimensions) = packed_dimensions.get(&name)
@@ -7752,6 +7778,7 @@ fn lvalue_from_constant_select(
                     },
                 ),
                 lsb: array_offset,
+                signed: dimensions.signed,
             });
         }
     }
@@ -7768,6 +7795,7 @@ fn lvalue_from_constant_select(
             name,
             msb: bit.clone(),
             lsb: bit,
+            signed: false,
         });
     }
 

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -391,6 +391,114 @@ fn reject_unsupported_multidimensional_packed_bounds(
     }
 }
 
+fn static_for_loop_iterations(
+    loop_statement: &sv_parser::LoopStatement,
+    syntax_tree: &SyntaxTree,
+    const_env: &HashMap<String, i128>,
+) -> Option<(String, Vec<i128>)> {
+    let sv_parser::LoopStatement::For(loop_statement) = loop_statement else {
+        return None;
+    };
+    let (initialization, _, condition, _, step) = &loop_statement.nodes.1.nodes.1;
+    let (name, initial_value) = for_loop_initialization(initialization.as_ref()?, syntax_tree)
+        .and_then(|(name, value)| Some((name, eval_ast_const_expr(&value, const_env)?)))?;
+    let condition = const_expr_from_expr(condition.as_ref()?, syntax_tree)?;
+    let step = step.as_ref()?.nodes.0.contents().into_iter().next()?;
+
+    let mut values = Vec::new();
+    let mut value = initial_value;
+    for _ in 0..10_000 {
+        let mut loop_env = const_env.clone();
+        loop_env.insert(name.clone(), value);
+        if eval_ast_const_expr(&condition, &loop_env)? == 0 {
+            return Some((name, values));
+        }
+        values.push(value);
+        value = next_for_loop_value(step, &name, value, syntax_tree, &loop_env)?;
+    }
+
+    let mut loop_env = const_env.clone();
+    loop_env.insert(name.clone(), value);
+    (eval_ast_const_expr(&condition, &loop_env) == Some(0)).then_some((name, values))
+}
+
+fn for_loop_initialization(
+    initialization: &sv_parser::ForInitialization,
+    syntax_tree: &SyntaxTree,
+) -> Option<(String, ConstExpr)> {
+    match initialization {
+        sv_parser::ForInitialization::Declaration(declaration) => {
+            let declaration = declaration.nodes.0.contents().into_iter().next()?;
+            let assignment = declaration.nodes.2.contents().into_iter().next()?;
+            let name = identifier_text(RefNode::VariableIdentifier(&assignment.0), syntax_tree)?;
+            let value = const_expr_from_expr(&assignment.2, syntax_tree)?;
+            Some((name, value))
+        }
+        sv_parser::ForInitialization::ListOfVariableAssignments(assignments) => {
+            let assignment = assignments.nodes.0.contents().into_iter().next()?;
+            let name = for_loop_variable_lvalue_name(&assignment.nodes.0, syntax_tree)?;
+            let value = const_expr_from_expr(&assignment.nodes.2, syntax_tree)?;
+            Some((name, value))
+        }
+    }
+}
+
+fn for_loop_variable_lvalue_name(
+    lvalue: &sv_parser::VariableLvalue,
+    syntax_tree: &SyntaxTree,
+) -> Option<String> {
+    let sv_parser::VariableLvalue::Identifier(identifier) = lvalue else {
+        return None;
+    };
+    identifier_text(
+        RefNode::HierarchicalVariableIdentifier(&identifier.nodes.1),
+        syntax_tree,
+    )
+}
+
+fn next_for_loop_value(
+    step: &sv_parser::ForStepAssignment,
+    name: &str,
+    value: i128,
+    syntax_tree: &SyntaxTree,
+    const_env: &HashMap<String, i128>,
+) -> Option<i128> {
+    match step {
+        sv_parser::ForStepAssignment::OperatorAssignment(step) => {
+            if for_loop_variable_lvalue_name(&step.nodes.0, syntax_tree)? != name {
+                return None;
+            }
+            let operator = syntax_tree.get_str(&step.nodes.1.nodes.0)?;
+            let rhs = const_expr_from_expr(&step.nodes.2, syntax_tree)?;
+            let rhs = eval_ast_const_expr(&rhs, const_env)?;
+            match operator {
+                "=" => Some(rhs),
+                "+=" => value.checked_add(rhs),
+                "-=" => value.checked_sub(rhs),
+                "*=" => value.checked_mul(rhs),
+                "/=" => (rhs != 0).then(|| value / rhs),
+                "%=" => (rhs != 0).then(|| value % rhs),
+                _ => None,
+            }
+        }
+        sv_parser::ForStepAssignment::IncOrDecExpression(step) => {
+            let (lvalue, operator) = match &**step {
+                sv_parser::IncOrDecExpression::Prefix(step) => (&step.nodes.2, &step.nodes.0),
+                sv_parser::IncOrDecExpression::Suffix(step) => (&step.nodes.0, &step.nodes.2),
+            };
+            if for_loop_variable_lvalue_name(lvalue, syntax_tree)? != name {
+                return None;
+            }
+            match syntax_tree.get_str(&operator.nodes.0)? {
+                "++" => value.checked_add(1),
+                "--" => value.checked_sub(1),
+                _ => None,
+            }
+        }
+        sv_parser::ForStepAssignment::FunctionSubroutineCall(_) => None,
+    }
+}
+
 fn reject_silently_ignored_constructs(
     node: RefNode<'_>,
     syntax_tree: &SyntaxTree,
@@ -400,15 +508,6 @@ fn reject_silently_ignored_constructs(
     let has_leaking_conditional_generate_local =
         conditional_generate_has_leaking_local(node.clone(), syntax_tree);
     reject_duplicate_conditional_generate_locals(node.clone(), syntax_tree)?;
-    if node
-        .clone()
-        .into_iter()
-        .any(|child| matches!(child, RefNode::UnpackedDimension(_)))
-    {
-        return Err(AnalyzerError::Unsupported(
-            "unpacked array dimension".to_string(),
-        ));
-    }
     for child in node {
         if inactive_nodes.iter().any(|inactive| inactive == &child) {
             continue;
@@ -487,26 +586,28 @@ fn reject_silently_ignored_constructs(
                         "casez, casex, or pattern case inside always_ff".to_string(),
                     ));
                 }
-                if matches!(
-                    always.nodes.0,
-                    sv_parser::AlwaysKeyword::AlwaysFf(_)
-                        | sv_parser::AlwaysKeyword::AlwaysComb(_)
-                )
+                if matches!(always.nodes.0, sv_parser::AlwaysKeyword::AlwaysComb(_))
                     && body
                         .clone()
                         .into_iter()
                         .any(|node| matches!(node, RefNode::LoopStatement(_)))
                 {
-                    let kind = if matches!(
-                        always.nodes.0,
-                        sv_parser::AlwaysKeyword::AlwaysComb(_)
-                    ) {
-                        "always_comb"
-                    } else {
-                        "always_ff"
-                    };
                     return Err(AnalyzerError::Unsupported(
-                        format!("procedural loop inside {kind}"),
+                        "procedural loop inside always_comb".to_string(),
+                    ));
+                }
+                if matches!(always.nodes.0, sv_parser::AlwaysKeyword::AlwaysFf(_))
+                    && body.clone().into_iter().any(|node| {
+                        matches!(
+                            node,
+                            RefNode::LoopStatement(loop_statement)
+                                if static_for_loop_iterations(loop_statement, syntax_tree, const_env)
+                                    .is_none()
+                        )
+                    })
+                {
+                    return Err(AnalyzerError::Unsupported(
+                        "procedural loop inside always_ff".to_string(),
                     ));
                 }
                 if matches!(always.nodes.0, sv_parser::AlwaysKeyword::AlwaysComb(_))
@@ -584,11 +685,6 @@ fn reject_silently_ignored_constructs(
                         "always_ff inside loop-generate".to_string(),
                     ));
                 }
-            }
-            RefNode::UnpackedDimension(_) => {
-                return Err(AnalyzerError::Unsupported(
-                    "unpacked array dimension".to_string(),
-                ));
             }
             RefNode::InitialConstruct(_) => {
                 return Err(AnalyzerError::Unsupported("initial construct".to_string()));
@@ -669,9 +765,6 @@ fn reject_silently_ignored_constructs(
                 return Err(AnalyzerError::Unsupported(
                     "packed struct or union type".to_string(),
                 ));
-            }
-            RefNode::Cast(_) | RefNode::ConstantCast(_) => {
-                return Err(AnalyzerError::Unsupported("cast expression".to_string()));
             }
             RefNode::ConstantFunctionCall(call)
                 if matches!(
@@ -1462,6 +1555,7 @@ pub struct Type {
     kind: TypeKind,
     is_signed: bool,
     packed_ranges: Vec<PackedRange>,
+    unpacked_ranges: Vec<UnpackedRange>,
 }
 
 impl Type {
@@ -1470,6 +1564,7 @@ impl Type {
             kind: TypeKind::Implicit,
             is_signed: false,
             packed_ranges: Vec::new(),
+            unpacked_ranges: Vec::new(),
         }
     }
 
@@ -1478,6 +1573,7 @@ impl Type {
             kind,
             is_signed: false,
             packed_ranges: Vec::new(),
+            unpacked_ranges: Vec::new(),
         }
     }
 
@@ -1491,6 +1587,10 @@ impl Type {
 
     pub fn packed_ranges(&self) -> &[PackedRange] {
         &self.packed_ranges
+    }
+
+    pub fn unpacked_ranges(&self) -> &[UnpackedRange] {
+        &self.unpacked_ranges
     }
 }
 
@@ -1509,6 +1609,26 @@ pub struct PackedRange {
 }
 
 impl PackedRange {
+    fn new(left: ConstExpr, right: ConstExpr) -> Self {
+        Self { left, right }
+    }
+
+    pub fn left(&self) -> &ConstExpr {
+        &self.left
+    }
+
+    pub fn right(&self) -> &ConstExpr {
+        &self.right
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnpackedRange {
+    left: ConstExpr,
+    right: ConstExpr,
+}
+
+impl UnpackedRange {
     fn new(left: ConstExpr, right: ConstExpr) -> Self {
         Self { left, right }
     }
@@ -1843,9 +1963,14 @@ fn ports_from_module_node(
                     syntax_tree,
                     &type_aliases,
                 );
+                let inherited_type_base = r#type.clone();
+                let r#type = type_with_unpacked_ranges(
+                    r#type,
+                    unpacked_ranges_from_dimensions(&port.nodes.2, syntax_tree)?,
+                );
                 let name = port_name(RefNode::PortIdentifier(&port.nodes.1), syntax_tree)?;
                 inherited_direction = direction;
-                inherited_type = r#type.clone();
+                inherited_type = inherited_type_base;
                 ports.push(Port::new(name, direction, r#type, true));
             }
             RefNode::AnsiPortDeclarationVariable(port) => {
@@ -1868,9 +1993,14 @@ fn ports_from_module_node(
                     syntax_tree,
                     &type_aliases,
                 );
+                let inherited_type_base = r#type.clone();
+                let r#type = type_with_unpacked_ranges(
+                    r#type,
+                    unpacked_ranges_from_variable_dimensions(&port.nodes.2, syntax_tree)?,
+                );
                 let name = port_name(RefNode::PortIdentifier(&port.nodes.1), syntax_tree)?;
                 inherited_direction = direction;
-                inherited_type = r#type.clone();
+                inherited_type = inherited_type_base;
                 ports.push(Port::new(name, direction, r#type, false));
             }
             RefNode::AnsiPortDeclarationParen(port) => {
@@ -2134,6 +2264,10 @@ fn substitute_signal_local_constants(signals: &mut [Signal], const_env: &HashMap
             range.left = substitute_const_expr_constants(range.left.clone(), const_env);
             range.right = substitute_const_expr_constants(range.right.clone(), const_env);
         }
+        for range in &mut signal.r#type.unpacked_ranges {
+            range.left = substitute_const_expr_constants(range.left.clone(), const_env);
+            range.right = substitute_const_expr_constants(range.right.clone(), const_env);
+        }
     }
 }
 
@@ -2191,10 +2325,14 @@ fn signals_from_net_declaration(
             .ok_or_else(|| {
                 AnalyzerError::Unsupported("unsupported signal identifier".to_string())
             })?;
+        let signal_type = type_with_unpacked_ranges(
+            r#type.clone(),
+            unpacked_ranges_from_dimensions(&assignment.nodes.1, syntax_tree)?,
+        );
         signals.push(if is_net {
-            Signal::new_net(name, r#type.clone())
+            Signal::new_net(name, signal_type)
         } else {
-            Signal::new(name, r#type.clone())
+            Signal::new(name, signal_type)
         });
     }
     Ok(signals)
@@ -2426,7 +2564,11 @@ fn signals_from_data_declaration(
             syntax_tree,
         )
         .ok_or_else(|| AnalyzerError::Unsupported("unsupported signal identifier".to_string()))?;
-        signals.push(Signal::new(name, r#type.clone()));
+        let signal_type = type_with_unpacked_ranges(
+            r#type.clone(),
+            unpacked_ranges_from_variable_dimensions(&assignment.nodes.1, syntax_tree)?,
+        );
+        signals.push(Signal::new(name, signal_type));
     }
     Ok(signals)
 }
@@ -2999,7 +3141,20 @@ struct PackedDimension {
     normalize_single: bool,
 }
 
-type PackedDimensions = HashMap<String, Vec<PackedDimension>>;
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UnpackedDimension {
+    left: ConstExpr,
+    right: ConstExpr,
+    width: ConstExpr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VariableDimensions {
+    packed: Vec<PackedDimension>,
+    unpacked: Vec<UnpackedDimension>,
+}
+
+type PackedDimensions = HashMap<String, VariableDimensions>;
 
 fn packed_dimensions_from_ports_and_signals(
     ports: &[Port],
@@ -3009,13 +3164,19 @@ fn packed_dimensions_from_ports_and_signals(
     for port in ports {
         dimensions.insert(
             port.name().to_string(),
-            packed_dimension_widths(port.r#type().packed_ranges()),
+            VariableDimensions {
+                packed: packed_dimension_widths(port.r#type().packed_ranges()),
+                unpacked: unpacked_dimension_widths(port.r#type().unpacked_ranges()),
+            },
         );
     }
     for signal in signals {
         dimensions.insert(
             signal.name().to_string(),
-            packed_dimension_widths(signal.r#type().packed_ranges()),
+            VariableDimensions {
+                packed: packed_dimension_widths(signal.r#type().packed_ranges()),
+                unpacked: unpacked_dimension_widths(signal.r#type().unpacked_ranges()),
+            },
         );
     }
     dimensions
@@ -3050,6 +3211,38 @@ fn packed_dimension_widths(ranges: &[PackedRange]) -> Vec<PackedDimension> {
                 right,
                 width,
                 normalize_single: false,
+            }
+        })
+        .collect()
+}
+
+fn unpacked_dimension_widths(ranges: &[UnpackedRange]) -> Vec<UnpackedDimension> {
+    ranges
+        .iter()
+        .map(|range| {
+            let left = range.left().clone();
+            let right = range.right().clone();
+            let width = ConstExpr::Mux {
+                condition: Box::new(ConstExpr::Binary {
+                    left: Box::new(left.clone()),
+                    op: BinaryOp::Ge,
+                    right: Box::new(right.clone()),
+                }),
+                then_expr: Box::new(ConstExpr::Binary {
+                    left: Box::new(left.clone()),
+                    op: BinaryOp::Sub,
+                    right: Box::new(right.clone()),
+                }),
+                else_expr: Box::new(ConstExpr::Binary {
+                    left: Box::new(right.clone()),
+                    op: BinaryOp::Sub,
+                    right: Box::new(left.clone()),
+                }),
+            };
+            UnpackedDimension {
+                left,
+                right,
+                width: add_expr(width, ConstExpr::Literal("1".to_string())),
             }
         })
         .collect()
@@ -4007,11 +4200,15 @@ fn function_from_declaration(
                 type_aliases,
             )?;
             let mut function_packed_dimensions = packed_dimensions.clone();
-            function_packed_dimensions.extend(
-                params
-                    .iter()
-                    .map(|param| (param.name.clone(), param.packed_dimensions.clone())),
-            );
+            function_packed_dimensions.extend(params.iter().map(|param| {
+                (
+                    param.name.clone(),
+                    VariableDimensions {
+                        packed: param.packed_dimensions.clone(),
+                        unpacked: Vec::new(),
+                    },
+                )
+            }));
             function_packed_dimensions.extend(function_local_packed_dimensions_from_block_items(
                 &body.nodes.5,
                 syntax_tree,
@@ -4058,11 +4255,15 @@ fn function_from_declaration(
                 type_aliases,
             )?;
             let mut function_packed_dimensions = packed_dimensions.clone();
-            function_packed_dimensions.extend(
-                params
-                    .iter()
-                    .map(|param| (param.name.clone(), param.packed_dimensions.clone())),
-            );
+            function_packed_dimensions.extend(params.iter().map(|param| {
+                (
+                    param.name.clone(),
+                    VariableDimensions {
+                        packed: param.packed_dimensions.clone(),
+                        unpacked: Vec::new(),
+                    },
+                )
+            }));
             function_packed_dimensions.extend(
                 function_local_packed_dimensions_from_block_item_iter(
                     block_items.iter().copied(),
@@ -4145,7 +4346,10 @@ fn function_local_packed_dimensions_from_block_item_iter<'a>(
         dimensions.extend(signals.into_iter().map(|signal| {
             (
                 signal.name().to_string(),
-                function_packed_dimension_widths(signal.r#type().packed_ranges()),
+                VariableDimensions {
+                    packed: function_packed_dimension_widths(signal.r#type().packed_ranges()),
+                    unpacked: unpacked_dimension_widths(signal.r#type().unpacked_ranges()),
+                },
             )
         }));
     }
@@ -6721,6 +6925,40 @@ fn conditional_assignments_from_statement(
                 assignments,
             )?;
         }
+        sv_parser::StatementItem::LoopStatement(loop_statement) => {
+            let (name, values) = static_for_loop_iterations(loop_statement, syntax_tree, const_env)
+                .ok_or_else(|| {
+                    AnalyzerError::Unsupported("unsupported procedural for loop".to_string())
+                })?;
+            let body = match &**loop_statement {
+                sv_parser::LoopStatement::For(loop_statement) => &loop_statement.nodes.2,
+                _ => unreachable!(),
+            };
+            for value in values {
+                let mut loop_env = const_env.clone();
+                loop_env.insert(name.clone(), value);
+                let start = assignments.len();
+                conditional_assignments_from_statement_or_null(
+                    body,
+                    condition.clone(),
+                    syntax_tree,
+                    &loop_env,
+                    packed_dimensions,
+                    assignments,
+                )?;
+                for assignment in &mut assignments[start..] {
+                    assignment.condition = assignment.condition.take().map(|condition| {
+                        substitute_expr_constants_with_parameter_literals(
+                            condition,
+                            &loop_env,
+                            &HashMap::default(),
+                        )
+                    });
+                    assignment.assignment =
+                        substitute_assignment_constants(assignment.assignment.clone(), &loop_env);
+                }
+            }
+        }
         _ => {
             return Err(AnalyzerError::Unsupported(
                 "unsupported statement inside always_ff".to_string(),
@@ -7071,23 +7309,47 @@ fn lvalue_from_select(
             const_expr_from_ref_node(RefNode::ConstantExpression(&range.nodes.0), syntax_tree)?;
         let mut lsb =
             const_expr_from_ref_node(RefNode::ConstantExpression(&range.nodes.2), syntax_tree)?;
-        if indices.is_empty()
-            && let Some([dimension]) = packed_dimensions.get(&name).map(Vec::as_slice)
-            && dimension.normalize_single
-        {
-            msb = packed_index_offset(dimension, msb);
-            lsb = packed_index_offset(dimension, lsb);
-        }
-        if !indices.is_empty() {
-            let (_, prefix_offset) = flatten_packed_select(&name, &indices, packed_dimensions)?;
-            msb = add_expr(prefix_offset.clone(), msb);
-            lsb = add_expr(prefix_offset, lsb);
-        }
+        (msb, lsb) = flatten_select_range(&name, &indices, msb, lsb, packed_dimensions)?;
         return Some(LValue::Select { name, msb, lsb });
     }
 
-    if let Some((msb, lsb)) = flatten_packed_select(&name, &indices, packed_dimensions) {
-        return Some(LValue::Select { name, msb, lsb });
+    if let Some((array_offset, packed_indices)) =
+        flatten_variable_select(&name, &indices, packed_dimensions)
+    {
+        if !packed_indices.is_empty() {
+            if let Some((msb, lsb)) =
+                flatten_packed_select(&name, &packed_indices, packed_dimensions)
+            {
+                return Some(LValue::Select {
+                    name,
+                    msb: add_expr(array_offset.clone(), msb),
+                    lsb: add_expr(array_offset, lsb),
+                });
+            }
+        } else if let Some(dimensions) = packed_dimensions.get(&name)
+            && !dimensions.unpacked.is_empty()
+            && indices.len() == dimensions.unpacked.len()
+        {
+            let width = product_expr(
+                &dimensions
+                    .packed
+                    .iter()
+                    .map(|dimension| dimension.width.clone())
+                    .collect::<Vec<_>>(),
+            );
+            return Some(LValue::Select {
+                name,
+                msb: add_expr(
+                    array_offset.clone(),
+                    ConstExpr::Binary {
+                        left: Box::new(width),
+                        op: BinaryOp::Sub,
+                        right: Box::new(ConstExpr::Literal("1".to_string())),
+                    },
+                ),
+                lsb: array_offset,
+            });
+        }
     }
     if indices.len() == 1 {
         let bit = indices[0].clone();
@@ -7125,23 +7387,47 @@ fn lvalue_from_constant_select(
             const_expr_from_ref_node(RefNode::ConstantExpression(&range.nodes.0), syntax_tree)?;
         let mut lsb =
             const_expr_from_ref_node(RefNode::ConstantExpression(&range.nodes.2), syntax_tree)?;
-        if indices.is_empty()
-            && let Some([dimension]) = packed_dimensions.get(&name).map(Vec::as_slice)
-            && dimension.normalize_single
-        {
-            msb = packed_index_offset(dimension, msb);
-            lsb = packed_index_offset(dimension, lsb);
-        }
-        if !indices.is_empty() {
-            let (_, prefix_offset) = flatten_packed_select(&name, &indices, packed_dimensions)?;
-            msb = add_expr(prefix_offset.clone(), msb);
-            lsb = add_expr(prefix_offset, lsb);
-        }
+        (msb, lsb) = flatten_select_range(&name, &indices, msb, lsb, packed_dimensions)?;
         return Some(LValue::Select { name, msb, lsb });
     }
 
-    if let Some((msb, lsb)) = flatten_packed_select(&name, &indices, packed_dimensions) {
-        return Some(LValue::Select { name, msb, lsb });
+    if let Some((array_offset, packed_indices)) =
+        flatten_variable_select(&name, &indices, packed_dimensions)
+    {
+        if !packed_indices.is_empty() {
+            if let Some((msb, lsb)) =
+                flatten_packed_select(&name, &packed_indices, packed_dimensions)
+            {
+                return Some(LValue::Select {
+                    name,
+                    msb: add_expr(array_offset.clone(), msb),
+                    lsb: add_expr(array_offset, lsb),
+                });
+            }
+        } else if let Some(dimensions) = packed_dimensions.get(&name)
+            && !dimensions.unpacked.is_empty()
+            && indices.len() == dimensions.unpacked.len()
+        {
+            let width = product_expr(
+                &dimensions
+                    .packed
+                    .iter()
+                    .map(|dimension| dimension.width.clone())
+                    .collect::<Vec<_>>(),
+            );
+            return Some(LValue::Select {
+                name,
+                msb: add_expr(
+                    array_offset.clone(),
+                    ConstExpr::Binary {
+                        left: Box::new(width),
+                        op: BinaryOp::Sub,
+                        right: Box::new(ConstExpr::Literal("1".to_string())),
+                    },
+                ),
+                lsb: array_offset,
+            });
+        }
     }
     if indices.len() == 1 {
         let bit = indices[0].clone();
@@ -7334,6 +7620,9 @@ fn expr_from_primary_with_types(
         sv_parser::Primary::FunctionSubroutineCall(call) => {
             expr_from_function_subroutine_call(call, syntax_tree, packed_dimensions)
         }
+        sv_parser::Primary::Cast(cast) => {
+            expr_from_expression_with_types(&cast.nodes.2.nodes.1, syntax_tree, packed_dimensions)
+        }
         sv_parser::Primary::MintypmaxExpression(expr) => match &expr.nodes.0.nodes.1 {
             sv_parser::MintypmaxExpression::Expression(expr) => {
                 expr_from_expression_with_types(expr, syntax_tree, packed_dimensions)
@@ -7445,52 +7734,10 @@ fn expr_select_from_select(
             const_expr_from_ref_node(RefNode::ConstantExpression(&range.nodes.0), syntax_tree)?;
         let mut lsb =
             const_expr_from_ref_node(RefNode::ConstantExpression(&range.nodes.2), syntax_tree)?;
-        if indices.is_empty()
-            && let Expr::Ident(name) = &base
-            && let Some([dimension]) = packed_dimensions.get(name).map(Vec::as_slice)
-            && dimension.normalize_single
-        {
-            msb = packed_index_offset(dimension, msb);
-            lsb = packed_index_offset(dimension, lsb);
-        }
-        if !indices.is_empty() {
-            let Expr::Ident(name) = &base else {
-                return None;
-            };
-            let dimensions = packed_dimensions.get(name)?;
-            let dimension = dimensions.get(indices.len())?;
-            msb = packed_index_offset(dimension, msb);
-            lsb = packed_index_offset(dimension, lsb);
-
-            let stride = product_expr(
-                &dimensions[indices.len() + 1..]
-                    .iter()
-                    .map(|dimension| dimension.width.clone())
-                    .collect::<Vec<_>>(),
-            );
-            if !is_one(&stride) {
-                msb = add_expr(
-                    ConstExpr::Binary {
-                        left: Box::new(msb),
-                        op: BinaryOp::Mul,
-                        right: Box::new(stride.clone()),
-                    },
-                    ConstExpr::Binary {
-                        left: Box::new(stride.clone()),
-                        op: BinaryOp::Sub,
-                        right: Box::new(ConstExpr::Literal("1".to_string())),
-                    },
-                );
-                lsb = ConstExpr::Binary {
-                    left: Box::new(lsb),
-                    op: BinaryOp::Mul,
-                    right: Box::new(stride),
-                };
-            }
-            let (_, prefix_offset) = flatten_packed_select(name, &indices, packed_dimensions)?;
-            msb = add_expr(prefix_offset.clone(), msb);
-            lsb = add_expr(prefix_offset, lsb);
-        }
+        let Expr::Ident(name) = &base else {
+            return None;
+        };
+        (msb, lsb) = flatten_select_range(name, &indices, msb, lsb, packed_dimensions)?;
         return Some(Expr::Select {
             expr: Box::new(base),
             msb,
@@ -7499,12 +7746,43 @@ fn expr_select_from_select(
     }
 
     if let Expr::Ident(name) = &base {
-        if let Some((msb, lsb)) = flatten_packed_select(name, &indices, packed_dimensions) {
-            return Some(Expr::Select {
-                expr: Box::new(base),
-                msb,
-                lsb,
-            });
+        if let Some((array_offset, packed_indices)) =
+            flatten_variable_select(name, &indices, packed_dimensions)
+        {
+            if !packed_indices.is_empty()
+                && let Some((msb, lsb)) =
+                    flatten_packed_select(name, &packed_indices, packed_dimensions)
+            {
+                return Some(Expr::Select {
+                    expr: Box::new(base),
+                    msb: add_expr(array_offset.clone(), msb),
+                    lsb: add_expr(array_offset, lsb),
+                });
+            }
+            if let Some(dimensions) = packed_dimensions.get(name)
+                && !dimensions.unpacked.is_empty()
+                && indices.len() == dimensions.unpacked.len()
+            {
+                let width = product_expr(
+                    &dimensions
+                        .packed
+                        .iter()
+                        .map(|dimension| dimension.width.clone())
+                        .collect::<Vec<_>>(),
+                );
+                return Some(Expr::Select {
+                    expr: Box::new(base),
+                    msb: add_expr(
+                        array_offset.clone(),
+                        ConstExpr::Binary {
+                            left: Box::new(width),
+                            op: BinaryOp::Sub,
+                            right: Box::new(ConstExpr::Literal("1".to_string())),
+                        },
+                    ),
+                    lsb: array_offset,
+                });
+            }
         }
     }
     if indices.len() == 1 {
@@ -7519,15 +7797,108 @@ fn expr_select_from_select(
     None
 }
 
+fn flatten_variable_select(
+    name: &str,
+    indices: &[ConstExpr],
+    packed_dimensions: &PackedDimensions,
+) -> Option<(ConstExpr, Vec<ConstExpr>)> {
+    let dimensions = packed_dimensions.get(name)?;
+    let unpacked_count = dimensions.unpacked.len();
+    if indices.len() < unpacked_count {
+        return None;
+    }
+
+    let mut offset = ConstExpr::Literal("0".to_string());
+    for (index, value) in indices[..unpacked_count].iter().enumerate() {
+        let mut stride_parts = dimensions.unpacked[index + 1..]
+            .iter()
+            .map(|dimension| dimension.width.clone())
+            .collect::<Vec<_>>();
+        stride_parts.extend(
+            dimensions
+                .packed
+                .iter()
+                .map(|dimension| dimension.width.clone()),
+        );
+        let stride = product_expr(&stride_parts);
+        let index = unpacked_index_offset(&dimensions.unpacked[index], value.clone());
+        let term = if is_one(&stride) {
+            index
+        } else {
+            ConstExpr::Binary {
+                left: Box::new(index),
+                op: BinaryOp::Mul,
+                right: Box::new(stride),
+            }
+        };
+        offset = add_expr(offset, term);
+    }
+    Some((offset, indices[unpacked_count..].to_vec()))
+}
+
+fn flatten_select_range(
+    name: &str,
+    indices: &[ConstExpr],
+    mut msb: ConstExpr,
+    mut lsb: ConstExpr,
+    packed_dimensions: &PackedDimensions,
+) -> Option<(ConstExpr, ConstExpr)> {
+    let Some(dimensions) = packed_dimensions.get(name) else {
+        return indices.is_empty().then_some((msb, lsb));
+    };
+    let (array_offset, packed_indices) = flatten_variable_select(name, indices, packed_dimensions)?;
+    let dimension = dimensions.packed.get(packed_indices.len())?;
+    msb = packed_index_offset(dimension, msb);
+    lsb = packed_index_offset(dimension, lsb);
+
+    let stride = product_expr(
+        &dimensions.packed[packed_indices.len() + 1..]
+            .iter()
+            .map(|dimension| dimension.width.clone())
+            .collect::<Vec<_>>(),
+    );
+    if !is_one(&stride) {
+        msb = add_expr(
+            ConstExpr::Binary {
+                left: Box::new(msb),
+                op: BinaryOp::Mul,
+                right: Box::new(stride.clone()),
+            },
+            ConstExpr::Binary {
+                left: Box::new(stride.clone()),
+                op: BinaryOp::Sub,
+                right: Box::new(ConstExpr::Literal("1".to_string())),
+            },
+        );
+        lsb = ConstExpr::Binary {
+            left: Box::new(lsb),
+            op: BinaryOp::Mul,
+            right: Box::new(stride),
+        };
+    }
+
+    let prefix_offset = if packed_indices.is_empty() {
+        ConstExpr::Literal("0".to_string())
+    } else {
+        let (_, offset) = flatten_packed_select(name, &packed_indices, packed_dimensions)?;
+        offset
+    };
+    let offset = add_expr(array_offset, prefix_offset);
+    Some((add_expr(offset.clone(), msb), add_expr(offset, lsb)))
+}
+
 fn flatten_packed_select(
     name: &str,
     indices: &[ConstExpr],
     packed_dimensions: &PackedDimensions,
 ) -> Option<(ConstExpr, ConstExpr)> {
-    let dimensions = packed_dimensions.get(name)?;
+    let variable_dimensions = packed_dimensions.get(name)?;
+    let dimensions = &variable_dimensions.packed;
     if indices.is_empty()
         || indices.len() > dimensions.len()
-        || (dimensions.len() == 1 && !dimensions[0].normalize_single)
+        || (variable_dimensions.unpacked.is_empty()
+            && dimensions.len() == 1
+            && !dimensions[0].normalize_single)
     {
         return None;
     }
@@ -7591,6 +7962,26 @@ fn packed_index_offset(dimension: &PackedDimension, index: ConstExpr) -> ConstEx
             left: Box::new(dimension.right.clone()),
             op: BinaryOp::Sub,
             right: Box::new(index),
+        }),
+    }
+}
+
+fn unpacked_index_offset(dimension: &UnpackedDimension, index: ConstExpr) -> ConstExpr {
+    ConstExpr::Mux {
+        condition: Box::new(ConstExpr::Binary {
+            left: Box::new(dimension.left.clone()),
+            op: BinaryOp::Ge,
+            right: Box::new(dimension.right.clone()),
+        }),
+        then_expr: Box::new(ConstExpr::Binary {
+            left: Box::new(dimension.left.clone()),
+            op: BinaryOp::Sub,
+            right: Box::new(index.clone()),
+        }),
+        else_expr: Box::new(ConstExpr::Binary {
+            left: Box::new(index),
+            op: BinaryOp::Sub,
+            right: Box::new(dimension.left.clone()),
         }),
     }
 }
@@ -7978,6 +8369,11 @@ fn type_with_fallback_ranges(
     r#type
 }
 
+fn type_with_unpacked_ranges(mut r#type: Type, ranges: Vec<UnpackedRange>) -> Type {
+    r#type.unpacked_ranges.extend(ranges);
+    r#type
+}
+
 fn is_signed_from_ref_node(node: RefNode<'_>) -> Option<bool> {
     match unwrap_node!(node, Signing)? {
         RefNode::Signing(signing) => match signing {
@@ -8007,6 +8403,84 @@ fn packed_ranges_from_ref_node(node: RefNode<'_>, syntax_tree: &SyntaxTree) -> V
         }
     }
     ranges
+}
+
+fn unpacked_ranges_from_dimensions(
+    dimensions: &[sv_parser::UnpackedDimension],
+    syntax_tree: &SyntaxTree,
+) -> Result<Vec<UnpackedRange>, AnalyzerError> {
+    dimensions
+        .iter()
+        .map(|dimension| {
+            let (left, right) = match dimension {
+                sv_parser::UnpackedDimension::Range(range) => {
+                    let constant_range = &range.nodes.0.nodes.1;
+                    let left = const_expr_from_ref_node(
+                        RefNode::ConstantExpression(&constant_range.nodes.0),
+                        syntax_tree,
+                    );
+                    let right = const_expr_from_ref_node(
+                        RefNode::ConstantExpression(&constant_range.nodes.2),
+                        syntax_tree,
+                    );
+                    (left, right)
+                }
+                sv_parser::UnpackedDimension::Expression(expression) => {
+                    let size = const_expr_from_ref_node(
+                        RefNode::ConstantExpression(&expression.nodes.0.nodes.1),
+                        syntax_tree,
+                    );
+                    (
+                        Some(ConstExpr::Literal("0".to_string())),
+                        size.map(|size| ConstExpr::Binary {
+                            left: Box::new(size),
+                            op: BinaryOp::Sub,
+                            right: Box::new(ConstExpr::Literal("1".to_string())),
+                        }),
+                    )
+                }
+            };
+            match (left, right) {
+                (Some(left), Some(right)) => Ok(UnpackedRange::new(left, right)),
+                _ => Err(AnalyzerError::Unsupported(
+                    "unresolved unpacked array dimension".to_string(),
+                )),
+            }
+        })
+        .collect()
+}
+
+fn unpacked_ranges_from_variable_dimensions(
+    dimensions: &[sv_parser::VariableDimension],
+    syntax_tree: &SyntaxTree,
+) -> Result<Vec<UnpackedRange>, AnalyzerError> {
+    let mut ranges = Vec::new();
+    for dimension in dimensions {
+        match dimension {
+            sv_parser::VariableDimension::UnpackedDimension(dimension) => {
+                ranges.extend(unpacked_ranges_from_dimensions(
+                    std::slice::from_ref(&**dimension),
+                    syntax_tree,
+                )?);
+            }
+            sv_parser::VariableDimension::UnsizedDimension(_) => {
+                return Err(AnalyzerError::Unsupported(
+                    "unsized unpacked array dimension".to_string(),
+                ));
+            }
+            sv_parser::VariableDimension::AssociativeDimension(_) => {
+                return Err(AnalyzerError::Unsupported(
+                    "associative array dimension".to_string(),
+                ));
+            }
+            sv_parser::VariableDimension::QueueDimension(_) => {
+                return Err(AnalyzerError::Unsupported(
+                    "queue array dimension".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(ranges)
 }
 
 fn const_expr_from_ref_node(node: RefNode<'_>, syntax_tree: &SyntaxTree) -> Option<ConstExpr> {
@@ -8086,6 +8560,10 @@ fn const_expr_from_ref_node(node: RefNode<'_>, syntax_tree: &SyntaxTree) -> Opti
                         .map(ConstExpr::Ident)
                 })
             }
+            sv_parser::ConstantPrimary::ConstantCast(cast) => const_expr_from_ref_node(
+                RefNode::ConstantExpression(&cast.nodes.2.nodes.1),
+                syntax_tree,
+            ),
             sv_parser::ConstantPrimary::MintypmaxExpression(expr) => match &expr.nodes.0.nodes.1 {
                 sv_parser::ConstantMintypmaxExpression::Unary(expr) => {
                     const_expr_from_ref_node(RefNode::ConstantExpression(expr), syntax_tree)

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -452,11 +452,17 @@ fn for_loop_initialization(
 ) -> Option<(String, ConstExpr)> {
     match initialization {
         sv_parser::ForInitialization::Declaration(declaration) => {
-            let declaration = declaration.nodes.0.contents().into_iter().next()?;
+            let declarations = declaration.nodes.0.contents();
+            let [declaration] = declarations.as_slice() else {
+                return None;
+            };
             if !for_loop_index_type_is_supported(&declaration.nodes.1) {
                 return None;
             }
-            let assignment = declaration.nodes.2.contents().into_iter().next()?;
+            let assignments = declaration.nodes.2.contents();
+            let [assignment] = assignments.as_slice() else {
+                return None;
+            };
             let name = identifier_text(RefNode::VariableIdentifier(&assignment.0), syntax_tree)?;
             let value = const_expr_from_expr(&assignment.2, syntax_tree)?;
             Some((name, value))
@@ -8252,6 +8258,19 @@ fn flatten_select_range(
     }
     let (array_offset, packed_indices) = flatten_variable_select(name, indices, packed_dimensions)?;
     let dimension = dimensions.packed.get(packed_indices.len())?;
+    if const_expr_is_out_of_range(
+        &msb,
+        &dimension.left,
+        &dimension.right,
+        &packed_dimensions.const_env,
+    ) || const_expr_is_out_of_range(
+        &lsb,
+        &dimension.left,
+        &dimension.right,
+        &packed_dimensions.const_env,
+    ) {
+        return None;
+    }
     msb = packed_index_offset(dimension, msb);
     lsb = packed_index_offset(dimension, lsb);
 

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -412,7 +412,7 @@ fn static_for_loop_iterations(
     let (initialization, _, condition, _, step) = &loop_statement.nodes.1.nodes.1;
     let (name, initial_value) = for_loop_initialization(initialization.as_ref()?, syntax_tree)
         .and_then(|(name, value)| Some((name, eval_ast_const_expr(&value, const_env)?)))?;
-    i32::try_from(initial_value).ok()?;
+    let initial_value = coerce_for_loop_index_value(initial_value)?;
     let condition = const_expr_from_expr(condition.as_ref()?, syntax_tree)?;
     let steps = step.as_ref()?.nodes.0.contents();
     let [step] = steps.as_slice() else {
@@ -436,8 +436,13 @@ fn static_for_loop_iterations(
             return Some((name, values));
         }
         values.push(value);
-        value = next_for_loop_value(step, &name, value, syntax_tree, &loop_env)?;
-        i32::try_from(value).ok()?;
+        value = coerce_for_loop_index_value(next_for_loop_value(
+            step,
+            &name,
+            value,
+            syntax_tree,
+            &loop_env,
+        )?)?;
     }
 
     let mut loop_env = const_env.clone();
@@ -451,6 +456,17 @@ fn static_for_loop_iterations(
         },
     );
     (eval_ast_const_expr(&condition, &loop_env) == Some(0)).then_some((name, values))
+}
+
+fn coerce_for_loop_index_value(value: i128) -> Option<i128> {
+    const MODULUS: i128 = 1i128 << 32;
+    const SIGN_BIT: i128 = 1i128 << 31;
+    let value = value.rem_euclid(MODULUS);
+    Some(if value >= SIGN_BIT {
+        value - MODULUS
+    } else {
+        value
+    })
 }
 
 fn validate_static_for_loops_in_statement_or_null(

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -417,6 +417,14 @@ fn static_for_loop_iterations(
     for _ in 0..10_000 {
         let mut loop_env = const_env.clone();
         loop_env.insert(name.clone(), value);
+        insert_parameter_type_markers(
+            &mut loop_env,
+            &name,
+            ExprType {
+                width: 32,
+                signed: true,
+            },
+        );
         if eval_ast_const_expr(&condition, &loop_env)? == 0 {
             return Some((name, values));
         }
@@ -427,6 +435,14 @@ fn static_for_loop_iterations(
 
     let mut loop_env = const_env.clone();
     loop_env.insert(name.clone(), value);
+    insert_parameter_type_markers(
+        &mut loop_env,
+        &name,
+        ExprType {
+            width: 32,
+            signed: true,
+        },
+    );
     (eval_ast_const_expr(&condition, &loop_env) == Some(0)).then_some((name, values))
 }
 
@@ -7211,7 +7227,16 @@ fn conditional_assignments_from_statement(
                 let mut loop_env = const_env.clone();
                 loop_env.insert(name.clone(), value);
                 let mut loop_packed_dimensions = packed_dimensions.clone();
-                loop_packed_dimensions.const_env = loop_env.clone();
+                let mut loop_const_env = loop_env.clone();
+                insert_parameter_type_markers(
+                    &mut loop_const_env,
+                    &name,
+                    ExprType {
+                        width: 32,
+                        signed: true,
+                    },
+                );
+                loop_packed_dimensions.const_env = loop_const_env;
                 let start = assignments.len();
                 conditional_assignments_from_statement_or_null(
                     body,
@@ -8284,13 +8309,21 @@ fn flatten_packed_select(
 
     let mut offset = ConstExpr::Literal("0".to_string());
     for (idx, index) in indices.iter().enumerate() {
+        let dimension = &dimensions[idx];
+        if const_expr_is_out_of_range(
+            index,
+            &dimension.left,
+            &dimension.right,
+            &packed_dimensions.const_env,
+        ) {
+            return None;
+        }
         let stride = product_expr(
             &dimensions[idx + 1..]
                 .iter()
                 .map(|dimension| dimension.width.clone())
                 .collect::<Vec<_>>(),
         );
-        let dimension = &dimensions[idx];
         let index = packed_index_offset(dimension, index.clone());
         let term = if is_one(&stride) {
             index

--- a/crates/celox-sv-analyzer/src/ast.rs
+++ b/crates/celox-sv-analyzer/src/ast.rs
@@ -7565,6 +7565,12 @@ fn lvalue_from_select(
         .iter()
         .map(|bit_select| const_expr_from_expr(&bit_select.nodes.1, syntax_tree))
         .collect::<Option<Vec<_>>>()?;
+    if packed_dimensions
+        .get(&name)
+        .is_some_and(|dimensions| indices.len() < dimensions.unpacked.len())
+    {
+        return None;
+    }
     if let Some(range) = &select.nodes.2 {
         let sv_parser::PartSelectRange::ConstantRange(range) = &range.nodes.1 else {
             return None;
@@ -7643,6 +7649,12 @@ fn lvalue_from_constant_select(
             )
         })
         .collect::<Option<Vec<_>>>()?;
+    if packed_dimensions
+        .get(&name)
+        .is_some_and(|dimensions| indices.len() < dimensions.unpacked.len())
+    {
+        return None;
+    }
     if let Some(range) = &select.nodes.2 {
         let sv_parser::ConstantPartSelectRange::ConstantRange(range) = &range.nodes.1 else {
             return None;

--- a/crates/celox-sv-analyzer/src/ir.rs
+++ b/crates/celox-sv-analyzer/src/ir.rs
@@ -420,7 +420,8 @@ fn convert_type(
     let unpacked_width = unpacked_ranges.iter().try_fold(1usize, |acc, range| {
         let left = typecheck::eval_const_expr(range.left(), constants)?;
         let right = typecheck::eval_const_expr(range.right(), constants)?;
-        acc.checked_mul(left.abs_diff(right) as usize + 1)
+        let width = usize::try_from(left.abs_diff(right)).ok()?.checked_add(1)?;
+        acc.checked_mul(width)
     });
     let resolved_width = packed_width.and_then(|width| width.checked_mul(unpacked_width?));
     (packed_ranges, unpacked_ranges, resolved_width)

--- a/crates/celox-sv-analyzer/src/ir.rs
+++ b/crates/celox-sv-analyzer/src/ir.rs
@@ -821,7 +821,7 @@ impl From<ast::LValue> for LValue {
     fn from(value: ast::LValue) -> Self {
         match value {
             ast::LValue::Ident(name) => LValue::Ident(name),
-            ast::LValue::Select { name, msb, lsb } => LValue::Select {
+            ast::LValue::Select { name, msb, lsb, .. } => LValue::Select {
                 name,
                 msb: msb.into(),
                 lsb: lsb.into(),

--- a/crates/celox-sv-analyzer/src/ir.rs
+++ b/crates/celox-sv-analyzer/src/ir.rs
@@ -353,6 +353,7 @@ pub struct Type {
     kind: TypeKind,
     is_signed: bool,
     packed_ranges: Vec<PackedRange>,
+    unpacked_ranges: Vec<UnpackedRange>,
     resolved_width: Option<usize>,
 }
 
@@ -367,6 +368,10 @@ impl Type {
 
     pub fn packed_ranges(&self) -> &[PackedRange] {
         &self.packed_ranges
+    }
+
+    pub fn unpacked_ranges(&self) -> &[UnpackedRange] {
+        &self.unpacked_ranges
     }
 
     pub fn resolved_width(&self) -> Option<usize> {
@@ -386,11 +391,12 @@ impl Type {
     pub(crate) fn from_ast(r#type: ast::Type, constants: &fxhash::FxHashMap<String, i128>) -> Self {
         let kind = r#type.kind().into();
         let is_signed = r#type.is_signed();
-        let (packed_ranges, resolved_width) = convert_type(r#type, constants);
+        let (packed_ranges, unpacked_ranges, resolved_width) = convert_type(r#type, constants);
         Self {
             kind,
             is_signed,
             packed_ranges,
+            unpacked_ranges,
             resolved_width,
         }
     }
@@ -399,14 +405,25 @@ impl Type {
 fn convert_type(
     r#type: ast::Type,
     constants: &fxhash::FxHashMap<String, i128>,
-) -> (Vec<PackedRange>, Option<usize>) {
+) -> (Vec<PackedRange>, Vec<UnpackedRange>, Option<usize>) {
     let packed_ranges: Vec<_> = r#type
         .packed_ranges()
         .iter()
         .map(|range| PackedRange::new(range.left().clone().into(), range.right().clone().into()))
         .collect();
-    let resolved_width = typecheck::resolve_packed_width_with_env(&packed_ranges, constants);
-    (packed_ranges, resolved_width)
+    let unpacked_ranges: Vec<_> = r#type
+        .unpacked_ranges()
+        .iter()
+        .map(|range| UnpackedRange::new(range.left().clone().into(), range.right().clone().into()))
+        .collect();
+    let packed_width = typecheck::resolve_packed_width_with_env(&packed_ranges, constants);
+    let unpacked_width = unpacked_ranges.iter().try_fold(1usize, |acc, range| {
+        let left = typecheck::eval_const_expr(range.left(), constants)?;
+        let right = typecheck::eval_const_expr(range.right(), constants)?;
+        acc.checked_mul(left.abs_diff(right) as usize + 1)
+    });
+    let resolved_width = packed_width.and_then(|width| width.checked_mul(unpacked_width?));
+    (packed_ranges, unpacked_ranges, resolved_width)
 }
 
 impl From<ast::TypeKind> for TypeKind {
@@ -424,6 +441,26 @@ impl From<ast::TypeKind> for TypeKind {
 pub struct PackedRange {
     left: ConstExpr,
     right: ConstExpr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnpackedRange {
+    left: ConstExpr,
+    right: ConstExpr,
+}
+
+impl UnpackedRange {
+    pub(crate) fn new(left: ConstExpr, right: ConstExpr) -> Self {
+        Self { left, right }
+    }
+
+    pub fn left(&self) -> &ConstExpr {
+        &self.left
+    }
+
+    pub fn right(&self) -> &ConstExpr {
+        &self.right
+    }
 }
 
 impl PackedRange {

--- a/crates/celox-sv-analyzer/src/ir.rs
+++ b/crates/celox-sv-analyzer/src/ir.rs
@@ -706,6 +706,7 @@ pub enum Expr {
         expr: Box<Expr>,
         msb: ConstExpr,
         lsb: ConstExpr,
+        signed: bool,
     },
     Concat(Vec<Expr>),
     RepeatConcat {
@@ -896,10 +897,16 @@ impl From<ast::Expr> for Expr {
         match expr {
             ast::Expr::Ident(name) => Expr::Ident(name),
             ast::Expr::Literal(value) => Expr::Literal(value),
-            ast::Expr::Select { expr, msb, lsb } => Expr::Select {
+            ast::Expr::Select {
+                expr,
+                msb,
+                lsb,
+                signed,
+            } => Expr::Select {
                 expr: Box::new((*expr).into()),
                 msb: msb.into(),
                 lsb: lsb.into(),
+                signed,
             },
             ast::Expr::Concat(parts) => Expr::Concat(parts.into_iter().map(Into::into).collect()),
             ast::Expr::RepeatConcat { count, parts } => Expr::RepeatConcat {

--- a/crates/celox-sv-analyzer/src/ir.rs
+++ b/crates/celox-sv-analyzer/src/ir.rs
@@ -576,6 +576,8 @@ pub enum LValue {
         name: String,
         msb: ConstExpr,
         lsb: ConstExpr,
+        array_slice_width: Option<ConstExpr>,
+        array_slice_reversed: bool,
     },
 }
 
@@ -821,10 +823,19 @@ impl From<ast::LValue> for LValue {
     fn from(value: ast::LValue) -> Self {
         match value {
             ast::LValue::Ident(name) => LValue::Ident(name),
-            ast::LValue::Select { name, msb, lsb, .. } => LValue::Select {
+            ast::LValue::Select {
+                name,
+                msb,
+                lsb,
+                array_slice_width,
+                array_slice_reversed,
+                ..
+            } => LValue::Select {
                 name,
                 msb: msb.into(),
                 lsb: lsb.into(),
+                array_slice_width: array_slice_width.map(Into::into),
+                array_slice_reversed,
             },
         }
     }

--- a/crates/celox-sv-analyzer/src/lib.rs
+++ b/crates/celox-sv-analyzer/src/lib.rs
@@ -958,6 +958,52 @@ mod tests {
     }
 
     #[test]
+    fn flattens_unpacked_array_range_selections() {
+        let ir = analyze_source(
+            r#"
+                module Top(
+                    input logic [7:0] source[4],
+                    output logic [7:0] target[4]
+                );
+                    assign target[1:0] = source[1:0];
+                endmodule
+            "#,
+            Path::new("unpacked_array_range_selection.sv"),
+        )
+        .expect("unpacked array ranges should be analyzed");
+        let assignment = &ir.modules()[0].comb_processes()[0].assignments()[0];
+        let ir::LValue::Select { msb, lsb, .. } = assignment.lhs_value() else {
+            panic!("expected a flattened unpacked range lvalue");
+        };
+        assert_eq!(eval_test_const_expr(msb), Some(15));
+        assert_eq!(eval_test_const_expr(lsb), Some(0));
+        let ir::Expr::Select { msb, lsb, .. } = assignment.rhs() else {
+            panic!("expected a flattened unpacked range expression");
+        };
+        assert_eq!(eval_test_const_expr(msb), Some(15));
+        assert_eq!(eval_test_const_expr(lsb), Some(0));
+    }
+
+    #[test]
+    fn preserves_implicit_packed_bit_selects_on_scalar_arrays() {
+        let ir = analyze_source(
+            r#"
+                module Top(input logic values[2], output logic y);
+                    assign y = values[0][0];
+                endmodule
+            "#,
+            Path::new("scalar_array_bit_selection.sv"),
+        )
+        .expect("scalar array bit-selects should be analyzed");
+        let expression = ir.modules()[0].comb_processes()[0].assignments()[0].rhs();
+        let ir::Expr::Select { msb, lsb, .. } = expression else {
+            panic!("expected a scalar array bit-select, got {expression:?}");
+        };
+        assert_eq!(eval_test_const_expr(msb), Some(0));
+        assert_eq!(eval_test_const_expr(lsb), Some(0));
+    }
+
+    #[test]
     fn rejects_duplicate_parameters() {
         let err = analyze_source(
             r#"

--- a/crates/celox-sv-analyzer/src/lib.rs
+++ b/crates/celox-sv-analyzer/src/lib.rs
@@ -175,6 +175,40 @@ mod tests {
     }
 
     #[test]
+    fn preserves_signedness_for_compound_unpacked_array_lvalues() {
+        let ir = analyze_source(
+            r#"
+                module Top(input logic signed [7:0] input_value);
+                    logic signed [7:0] values[2];
+                    always_comb begin
+                        values[0] = input_value;
+                        values[0] >>>= 1;
+                    end
+                endmodule
+            "#,
+            Path::new("compound_array.sv"),
+        )
+        .expect("SV analysis should succeed");
+        let compound = ir.modules()[0]
+            .comb_processes()
+            .iter()
+            .flat_map(|process| process.assignments())
+            .find_map(|assignment| match assignment.rhs() {
+                ir::Expr::Binary {
+                    op: ir::BinaryOp::Sar,
+                    left,
+                    ..
+                } => Some(left),
+                _ => None,
+            })
+            .expect("compound assignment should lower to an arithmetic shift");
+        assert!(matches!(
+            compound.as_ref(),
+            ir::Expr::Select { signed: true, .. }
+        ));
+    }
+
+    #[test]
     fn tracks_default_nettype_state_for_each_module() {
         let source = r#"
             `default_nettype none

--- a/crates/celox-sv-analyzer/src/lib.rs
+++ b/crates/celox-sv-analyzer/src/lib.rs
@@ -767,6 +767,45 @@ mod tests {
     }
 
     #[test]
+    fn rejects_nonpositive_implicit_unpacked_array_dimensions() {
+        for size in ["0", "-1", "SIZE"] {
+            let source = format!(
+                r#"
+                    module Top #(parameter SIZE = 0) ();
+                        logic [7:0] values[{size}];
+                    endmodule
+                "#
+            );
+            let error = analyze_source(&source, Path::new("invalid_array_size.sv"))
+                .expect_err("nonpositive implicit array dimensions should be rejected");
+            assert!(
+                matches!(error, AnalyzerError::Unsupported(message) if message == "nonpositive unpacked array dimension")
+            );
+        }
+    }
+
+    #[test]
+    fn analyzes_nested_static_loops_with_outer_index_environment() {
+        let ir = analyze_source(
+            r#"
+                module Top(input logic clk, input logic d);
+                    logic q[2][2];
+                    always_ff @(posedge clk) begin
+                        for (int i = 0; i < 2; i++) begin
+                            for (int j = 0; j < i; j++) begin
+                                q[i][j] <= d;
+                            end
+                        end
+                    end
+                endmodule
+            "#,
+            Path::new("nested_static_loops.sv"),
+        )
+        .expect("nested static loops should use the outer loop environment");
+        assert_eq!(ir.modules()[0].ff_processes()[0].assignments().len(), 1);
+    }
+
+    #[test]
     fn rejects_duplicate_parameters() {
         let err = analyze_source(
             r#"

--- a/crates/celox-sv-analyzer/src/lib.rs
+++ b/crates/celox-sv-analyzer/src/lib.rs
@@ -123,6 +123,38 @@ pub fn analyze_source_module_with_parameter_expr_overrides(
 mod tests {
     use super::*;
 
+    fn eval_test_const_expr(expr: &ir::ConstExpr) -> Option<i128> {
+        match expr {
+            ir::ConstExpr::Literal(value) => value.parse().ok(),
+            ir::ConstExpr::Binary { left, op, right } => {
+                let left = eval_test_const_expr(left)?;
+                let right = eval_test_const_expr(right)?;
+                Some(match op {
+                    ir::BinaryOp::Add => left + right,
+                    ir::BinaryOp::Sub => left - right,
+                    ir::BinaryOp::Mul => left * right,
+                    ir::BinaryOp::Ge => (left >= right) as i128,
+                    ir::BinaryOp::Le => (left <= right) as i128,
+                    ir::BinaryOp::LogicAnd => ((left != 0) && (right != 0)) as i128,
+                    ir::BinaryOp::LogicOr => ((left != 0) || (right != 0)) as i128,
+                    _ => return None,
+                })
+            }
+            ir::ConstExpr::Mux {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                if eval_test_const_expr(condition)? != 0 {
+                    eval_test_const_expr(then_expr)
+                } else {
+                    eval_test_const_expr(else_expr)
+                }
+            }
+            _ => None,
+        }
+    }
+
     #[test]
     fn analyzes_basic_sv_module_name() {
         let ir = analyze_source(
@@ -205,6 +237,36 @@ mod tests {
         assert!(matches!(
             compound.as_ref(),
             ir::Expr::Select { signed: true, .. }
+        ));
+    }
+
+    #[test]
+    fn preserves_operand_signedness_for_size_casts() {
+        let ir = analyze_source(
+            r#"
+                module Top(output logic y);
+                    assign y = (8'(0) < -1);
+                endmodule
+            "#,
+            Path::new("size_cast_signedness.sv"),
+        )
+        .expect("size casts should preserve operand signedness");
+        let expression = ir.modules()[0].comb_processes()[0].assignments()[0].rhs();
+        let ir::Expr::Binary {
+            op: ir::BinaryOp::Lt,
+            left,
+            ..
+        } = expression
+        else {
+            panic!("expected a signed less-than comparison, got {expression:?}");
+        };
+        assert!(matches!(
+            left.as_ref(),
+            ir::Expr::Resize {
+                width: 8,
+                signed: true,
+                ..
+            }
         ));
     }
 
@@ -803,6 +865,70 @@ mod tests {
         )
         .expect("nested static loops should use the outer loop environment");
         assert_eq!(ir.modules()[0].ff_processes()[0].assignments().len(), 1);
+    }
+
+    #[test]
+    fn carries_outer_loop_types_into_nested_loop_preflight() {
+        let ir = analyze_source(
+            r#"
+                module Top(input logic clk, input logic d);
+                    logic q;
+                    always_ff @(posedge clk) begin
+                        for (int i = -1; i < 0; i++) begin
+                            for (int j = 0; i < 32'd1; j++) begin
+                                q <= d;
+                            end
+                        end
+                    end
+                endmodule
+            "#,
+            Path::new("nested_loop_preflight_types.sv"),
+        )
+        .expect("nested loop preflight should use outer loop types");
+        assert!(ir.modules()[0].ff_processes().is_empty());
+    }
+
+    #[test]
+    fn applies_expression_types_to_compound_loop_steps() {
+        let ir = analyze_source(
+            r#"
+                module Top(input logic clk, output logic q);
+                    always_ff @(posedge clk) begin
+                        for (int i = -2; i < 0; i /= 32'd2) begin
+                            q <= 1'b1;
+                        end
+                        for (int i = -3; i < 0; i %= 32'd2) begin
+                            q <= 1'b0;
+                        end
+                    end
+                endmodule
+            "#,
+            Path::new("typed_compound_loop_steps.sv"),
+        )
+        .expect("compound loop steps should use expression types");
+        assert_eq!(ir.modules()[0].ff_processes()[0].assignments().len(), 2);
+    }
+
+    #[test]
+    fn flattens_partial_unpacked_array_selections() {
+        let ir = analyze_source(
+            r#"
+                module Top(
+                    input logic [7:0] values[2][3],
+                    output logic [7:0] row[3]
+                );
+                    assign row = values[0];
+                endmodule
+            "#,
+            Path::new("partial_unpacked_selection.sv"),
+        )
+        .expect("partial unpacked selections should be analyzed");
+        let expression = ir.modules()[0].comb_processes()[0].assignments()[0].rhs();
+        let ir::Expr::Select { msb, lsb, .. } = expression else {
+            panic!("expected a flattened partial selection, got {expression:?}");
+        };
+        assert_eq!(eval_test_const_expr(msb), Some(23));
+        assert_eq!(eval_test_const_expr(lsb), Some(0));
     }
 
     #[test]

--- a/crates/celox-sv-analyzer/src/lib.rs
+++ b/crates/celox-sv-analyzer/src/lib.rs
@@ -527,7 +527,7 @@ mod tests {
         assert_eq!(assignments.len(), 1);
         assert!(matches!(
             assignments[0].rhs(),
-            ir::Expr::Select { expr, msb, lsb }
+            ir::Expr::Select { expr, msb, lsb, .. }
                 if matches!(&**expr, ir::Expr::Ident(name) if name == "o_val")
                     && typecheck::eval_const_expr(msb, &HashMap::default())
                         == Some(0)

--- a/crates/celox-sv-analyzer/src/lib.rs
+++ b/crates/celox-sv-analyzer/src/lib.rs
@@ -556,7 +556,7 @@ mod tests {
 
         assert!(lfsr.assignments().iter().any(|assignment| matches!(
             assignment.lhs_value(),
-            ir::LValue::Select { name, msb, lsb }
+            ir::LValue::Select { name, msb, lsb, .. }
                 if name == "val_next"
                     && typecheck::eval_const_expr(
                         msb,
@@ -592,7 +592,7 @@ mod tests {
             .filter(|assignment| {
                 matches!(
                     assignment.lhs_value(),
-                    ir::LValue::Select { name, msb, lsb }
+                    ir::LValue::Select { name, msb, lsb, .. }
                         if name == "val_next"
                             && typecheck::eval_const_expr(
                                 msb,
@@ -613,7 +613,7 @@ mod tests {
             .filter(|assignment| {
                 matches!(
                     assignment.lhs_value(),
-                    ir::LValue::Select { name, msb, lsb }
+                    ir::LValue::Select { name, msb, lsb, .. }
                         if name == "val_next"
                             && typecheck::eval_const_expr(msb, &constants) == Some(0)
                             && typecheck::eval_const_expr(lsb, &constants) == Some(0)
@@ -972,11 +972,23 @@ mod tests {
         )
         .expect("unpacked array ranges should be analyzed");
         let assignment = &ir.modules()[0].comb_processes()[0].assignments()[0];
-        let ir::LValue::Select { msb, lsb, .. } = assignment.lhs_value() else {
+        let ir::LValue::Select {
+            msb,
+            lsb,
+            array_slice_width,
+            array_slice_reversed,
+            ..
+        } = assignment.lhs_value()
+        else {
             panic!("expected a flattened unpacked range lvalue");
         };
         assert_eq!(eval_test_const_expr(msb), Some(15));
         assert_eq!(eval_test_const_expr(lsb), Some(0));
+        assert_eq!(
+            array_slice_width.as_ref().map(eval_test_const_expr),
+            Some(Some(8))
+        );
+        assert!(*array_slice_reversed);
         let ir::Expr::Concat(parts) = assignment.rhs() else {
             panic!("expected an element-ordered unpacked range expression");
         };

--- a/crates/celox-sv-analyzer/src/lib.rs
+++ b/crates/celox-sv-analyzer/src/lib.rs
@@ -932,6 +932,32 @@ mod tests {
     }
 
     #[test]
+    fn flattens_partial_unpacked_array_lvalue_selections() {
+        let ir = analyze_source(
+            r#"
+                module Top(
+                    input logic [7:0] row[3],
+                    output logic [7:0] values[2][3]
+                );
+                    assign values[0] = row;
+                endmodule
+            "#,
+            Path::new("partial_unpacked_lvalue_selection.sv"),
+        )
+        .expect("partial unpacked lvalues should be analyzed");
+        let assignment = &ir.modules()[0].comb_processes()[0].assignments()[0];
+        let ir::LValue::Select { name, msb, lsb, .. } = assignment.lhs_value() else {
+            panic!(
+                "expected a flattened partial lvalue selection, got {:?}",
+                assignment.lhs_value()
+            );
+        };
+        assert_eq!(name, "values");
+        assert_eq!(eval_test_const_expr(msb), Some(23));
+        assert_eq!(eval_test_const_expr(lsb), Some(0));
+    }
+
+    #[test]
     fn rejects_duplicate_parameters() {
         let err = analyze_source(
             r#"

--- a/crates/celox-sv-analyzer/src/lib.rs
+++ b/crates/celox-sv-analyzer/src/lib.rs
@@ -704,6 +704,35 @@ mod tests {
     }
 
     #[test]
+    fn analyzes_fixed_unpacked_array_dimensions() {
+        let ir = analyze_source(
+            r#"
+                module Top #(parameter N = 2) (
+                    input logic [7:0] data,
+                    output logic [7:0] out
+                );
+                    logic [7:0] values [N];
+                    assign values[0] = data;
+                    assign values[1] = data;
+                    assign out = values[1];
+                endmodule
+            "#,
+            Path::new("fixed_array.sv"),
+        )
+        .expect("fixed unpacked arrays should be analyzed");
+
+        let top = &ir.modules()[0];
+        let values = top
+            .signals()
+            .iter()
+            .find(|signal| signal.name() == "values")
+            .expect("array signal should be present");
+        assert_eq!(values.r#type().unpacked_ranges().len(), 1);
+        assert_eq!(values.r#type().resolved_width(), Some(16));
+        assert_eq!(top.ports()[1].r#type().resolved_width(), Some(8));
+    }
+
+    #[test]
     fn rejects_duplicate_parameters() {
         let err = analyze_source(
             r#"
@@ -966,10 +995,7 @@ mod tests {
         ] {
             let error = analyze_source(source, Path::new(name))
                 .expect_err("unlowered constructs must not be silently ignored");
-            assert!(matches!(
-                error,
-                AnalyzerError::Unsupported(detail) if detail == "unpacked array dimension"
-            ));
+            assert!(matches!(error, AnalyzerError::Unsupported(_)));
         }
 
         let error = analyze_source(

--- a/crates/celox-sv-analyzer/src/lib.rs
+++ b/crates/celox-sv-analyzer/src/lib.rs
@@ -977,11 +977,20 @@ mod tests {
         };
         assert_eq!(eval_test_const_expr(msb), Some(15));
         assert_eq!(eval_test_const_expr(lsb), Some(0));
-        let ir::Expr::Select { msb, lsb, .. } = assignment.rhs() else {
-            panic!("expected a flattened unpacked range expression");
+        let ir::Expr::Concat(parts) = assignment.rhs() else {
+            panic!("expected an element-ordered unpacked range expression");
+        };
+        assert_eq!(parts.len(), 2);
+        let ir::Expr::Select { msb, lsb, .. } = &parts[0] else {
+            panic!("expected the first unpacked range element selection");
+        };
+        assert_eq!(eval_test_const_expr(msb), Some(7));
+        assert_eq!(eval_test_const_expr(lsb), Some(0));
+        let ir::Expr::Select { msb, lsb, .. } = &parts[1] else {
+            panic!("expected the second unpacked range element selection");
         };
         assert_eq!(eval_test_const_expr(msb), Some(15));
-        assert_eq!(eval_test_const_expr(lsb), Some(0));
+        assert_eq!(eval_test_const_expr(lsb), Some(8));
     }
 
     #[test]

--- a/crates/celox-sv-analyzer/src/typecheck.rs
+++ b/crates/celox-sv-analyzer/src/typecheck.rs
@@ -29,7 +29,7 @@ pub fn resolve_packed_width_with_env(
     ranges.iter().try_fold(1usize, |acc, range| {
         let left = eval_const_expr(range.left(), constants)?;
         let right = eval_const_expr(range.right(), constants)?;
-        let width = left.abs_diff(right) as usize + 1;
+        let width = usize::try_from(left.abs_diff(right)).ok()?.checked_add(1)?;
         acc.checked_mul(width)
     })
 }

--- a/crates/celox/tests/frontends/systemverilog/hierarchy.rs
+++ b/crates/celox/tests/frontends/systemverilog/hierarchy.rs
@@ -442,7 +442,7 @@ fn rejects_veryl_generated_sv_that_uses_unlowered_constructs() {
         (
             "Fifo.sv",
             include_str!("../../../testdata/verilator/Fifo.sv"),
-            "cast expression",
+            "non-integer module parameter override `TYPE`",
         ),
         (
             "LinearSec.sv",

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -921,6 +921,40 @@ fn connects_child_outputs_to_unpacked_array_elements() {
 }
 
 #[test]
+fn connects_runtime_selected_unpacked_array_elements_to_child_inputs() {
+    let source = r#"
+        module Child(
+            input logic [7:0] input_value,
+            output logic [7:0] output_value
+        );
+            assign output_value = input_value;
+        endmodule
+        module Top(
+            input logic [1:0] sel,
+            input logic [7:0] values[4],
+            output logic [7:0] value
+        );
+            Child child(.input_value(values[sel]), .output_value(value));
+        endmodule
+        "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("array_input_dynamic_connection.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let sel = sim.signal("sel");
+    let values = sim.signal("values");
+    let value = sim.signal("value");
+    sim.modify(|io| {
+        io.set(sel, 2u8);
+        io.set(values, 0x44332211u32);
+    })
+    .unwrap();
+    assert_eq!(sim.get(value), 0x33u8.into());
+}
+
+#[test]
 fn reads_unpacked_array_elements_at_runtime_indices() {
     let source = r#"
         module Top(
@@ -978,6 +1012,94 @@ fn writes_unpacked_array_elements_at_runtime_indices() {
     })
     .unwrap();
     assert_eq!(sim.get(value), 0x5au8.into());
+}
+
+#[test]
+fn composes_dynamic_array_writes_after_whole_array_assignments() {
+    let source = r#"
+        module Top(
+            input logic [1:0] sel,
+            input logic [7:0] data,
+            output logic [7:0] selected,
+            output logic [7:0] cleared
+        );
+            logic [7:0] values[4];
+            always_comb begin
+                values = '0;
+                values[sel] = data;
+            end
+            assign selected = values[sel];
+            assign cleared = values[0];
+        endmodule
+        "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("dynamic_array_write_after_default.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let sel = sim.signal("sel");
+    let data = sim.signal("data");
+    let selected = sim.signal("selected");
+    let cleared = sim.signal("cleared");
+    sim.modify(|io| {
+        io.set(sel, 0u8);
+        io.set(data, 0xa5u8);
+    })
+    .unwrap();
+    assert_eq!(sim.get(selected), 0xa5u8.into());
+    sim.modify(|io| {
+        io.set(sel, 2u8);
+        io.set(data, 0x5au8);
+    })
+    .unwrap();
+    assert_eq!(sim.get(selected), 0x5au8.into());
+    assert_eq!(sim.get(cleared), 0u8.into());
+}
+
+#[test]
+fn rejects_dynamic_array_writes_after_partial_array_assignments() {
+    let error = cranelift_build_error(
+        r#"
+        module Top(
+            input logic [1:0] sel,
+            input logic [7:0] data,
+            output logic [7:0] value
+        );
+            logic [7:0] values[4];
+            always_comb begin
+                values[0] = 8'h00;
+                values[sel] = data;
+            end
+            assign value = values[sel];
+        endmodule
+        "#,
+    );
+    assert!(
+        error.contains("dynamic unpacked-array assignment after an earlier partial assignment"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn rejects_dynamic_array_writes_in_continuous_assignments() {
+    let error = cranelift_build_error(
+        r#"
+        module Top(
+            input logic [1:0] sel,
+            input logic [7:0] data,
+            output logic [7:0] value
+        );
+            wire [7:0] values[4];
+            assign values[sel] = data;
+            assign value = values[sel];
+        endmodule
+        "#,
+    );
+    assert!(
+        error.contains("combinational assignment target `values`"),
+        "unexpected error: {error}"
+    );
 }
 
 #[test]

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -921,6 +921,98 @@ fn connects_child_outputs_to_unpacked_array_elements() {
 }
 
 #[test]
+fn reads_unpacked_array_elements_at_runtime_indices() {
+    let source = r#"
+        module Top(
+            input logic clk,
+            input logic [1:0] sel,
+            input logic [7:0] values[4],
+            output logic [7:0] combinational,
+            output logic [7:0] registered
+        );
+            assign combinational = values[sel];
+            always_ff @(posedge clk) registered <= values[sel];
+        endmodule
+        "#;
+    let mut sim =
+        Simulator::from_sv_sources(vec![(source, Path::new("dynamic_array_index.sv"))], "Top")
+            .build_cranelift()
+            .unwrap();
+    let sel = sim.signal("sel");
+    let values = sim.signal("values");
+    let combinational = sim.signal("combinational");
+    let registered = sim.signal("registered");
+    sim.modify(|io| {
+        io.set(sel, 2u8);
+        io.set(values, 0x44332211u32);
+    })
+    .unwrap();
+    assert_eq!(sim.get(combinational), 0x33u8.into());
+    sim.tick(sim.event("clk")).unwrap();
+    assert_eq!(sim.get(registered), 0x33u8.into());
+}
+
+#[test]
+fn writes_unpacked_array_elements_at_runtime_indices() {
+    let source = r#"
+        module Top(
+            input logic [1:0] sel,
+            input logic [7:0] data,
+            output logic [7:0] value
+        );
+            logic [7:0] values[4];
+            always_comb values[sel] = data;
+            assign value = values[sel];
+        endmodule
+        "#;
+    let mut sim =
+        Simulator::from_sv_sources(vec![(source, Path::new("dynamic_array_write.sv"))], "Top")
+            .build_cranelift()
+            .unwrap();
+    let sel = sim.signal("sel");
+    let data = sim.signal("data");
+    let value = sim.signal("value");
+    sim.modify(|io| {
+        io.set(sel, 2u8);
+        io.set(data, 0x5au8);
+    })
+    .unwrap();
+    assert_eq!(sim.get(value), 0x5au8.into());
+}
+
+#[test]
+fn writes_unpacked_array_elements_at_runtime_indices_in_always_ff() {
+    let source = r#"
+        module Top(
+            input logic clk,
+            input logic [1:0] sel,
+            input logic [7:0] data,
+            output logic [7:0] value
+        );
+            logic [7:0] values[4];
+            always_ff @(posedge clk) values[sel] <= data;
+            assign value = values[sel];
+        endmodule
+        "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("dynamic_array_ff_write.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let sel = sim.signal("sel");
+    let data = sim.signal("data");
+    let value = sim.signal("value");
+    sim.modify(|io| {
+        io.set(sel, 2u8);
+        io.set(data, 0x5au8);
+    })
+    .unwrap();
+    sim.tick(sim.event("clk")).unwrap();
+    assert_eq!(sim.get(value), 0x5au8.into());
+}
+
+#[test]
 fn uses_the_first_always_ff_event_as_a_negedge_clock() {
     let source = r#"
         module Top(input logic clk, input logic rst, input logic d, output logic q);

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -991,6 +991,29 @@ fn connects_child_outputs_to_unpacked_array_elements() {
 }
 
 #[test]
+fn connects_child_outputs_to_unpacked_array_ranges() {
+    let source = r#"
+        module Child(output logic [15:0] output_value);
+            assign output_value = 16'h1234;
+        endmodule
+        module Top(
+            output logic [7:0] values[4],
+            output logic [15:0] value
+        );
+            Child child(.output_value(values[1:0]));
+            assign value = values[1:0];
+        endmodule
+        "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("array_output_range_connection.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    assert_eq!(sim.get(sim.signal("value")), 0x1234u16.into());
+}
+
+#[test]
 fn connects_runtime_selected_unpacked_array_elements_to_child_inputs() {
     let source = r#"
         module Child(
@@ -2768,6 +2791,52 @@ fn applies_generate_localparams_inside_always_ff() {
 }
 
 #[test]
+fn rejects_nonpositive_generate_localparam_array_sizes() {
+    let error = cranelift_build_error(
+        r#"
+        module Top();
+            if (1) begin : active
+                localparam N = 0;
+                logic [7:0] values[N];
+            end
+        endmodule
+        "#,
+    );
+    assert!(
+        error.contains("nonpositive unpacked array dimension"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn preserves_bit_selects_on_computed_expressions() {
+    let source = r#"
+        module Top(
+            input logic [7:0] a,
+            input logic [7:0] b,
+            output logic y
+        );
+            assign y = {a + b}[0];
+        endmodule
+        "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("computed_expression_bit_select.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let a = sim.signal("a");
+    let b = sim.signal("b");
+    let y = sim.signal("y");
+    sim.modify(|io| {
+        io.set(a, 1u8);
+        io.set(b, 0u8);
+    })
+    .unwrap();
+    assert_eq!(sim.get(y), 1u8.into());
+}
+
+#[test]
 fn reads_partial_unpacked_array_selections() {
     let source = r#"
         module Top(output logic [23:0] row);
@@ -2838,6 +2907,68 @@ fn reads_runtime_partial_unpacked_array_selections() {
     })
     .unwrap();
     assert_eq!(sim.get(row), 0x060504u32.into());
+}
+
+#[test]
+fn writes_runtime_partial_unpacked_array_selections_in_always_ff() {
+    let source = r#"
+        module Top(
+            input logic clk,
+            input logic sel,
+            input logic [23:0] row,
+            output logic [23:0] selected
+        );
+            logic [7:0] values[2][3];
+            always_ff @(posedge clk) values[sel] <= row;
+            assign selected = values[sel];
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("dynamic_partial_unpacked_lvalue.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let sel = sim.signal("sel");
+    let row = sim.signal("row");
+    let selected = sim.signal("selected");
+    sim.modify(|io| {
+        io.set(sel, 1u8);
+        io.set_wide(row, BigUint::from(0x060504u32));
+    })
+    .unwrap();
+    sim.tick(sim.event("clk")).unwrap();
+    assert_eq!(sim.get(selected), 0x060504u32.into());
+}
+
+#[test]
+fn writes_runtime_partial_unpacked_array_selections_in_always_comb() {
+    let source = r#"
+        module Top(
+            input logic sel,
+            input logic [23:0] row,
+            output logic [23:0] selected
+        );
+            logic [7:0] values[2][3];
+            always_comb values[sel] = row;
+            assign selected = values[sel];
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("dynamic_partial_unpacked_comb_lvalue.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let sel = sim.signal("sel");
+    let row = sim.signal("row");
+    let selected = sim.signal("selected");
+    sim.modify(|io| {
+        io.set(sel, 1u8);
+        io.set_wide(row, BigUint::from(0x060504u32));
+    })
+    .unwrap();
+    assert_eq!(sim.get(selected), 0x060504u32.into());
 }
 
 #[test]

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -873,6 +873,28 @@ fn coerces_sized_loop_initializers_to_signed_int() {
 }
 
 #[test]
+fn preserves_outer_loop_index_types_during_nested_unrolling() {
+    let source = r#"
+        module Top(input logic clk, output logic [1:0] q);
+            always_ff @(posedge clk) begin
+                q <= 2'b00;
+                for (int i = -1; i < 0; i++) begin
+                    for (int j = 0; j < (i < 32'd1); j++) q[j] <= 1'b1;
+                end
+            end
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("nested_signed_loop_index.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    sim.tick(sim.event("clk")).unwrap();
+    assert_eq!(sim.get(sim.signal("q")), 0u8.into());
+}
+
+#[test]
 fn rejects_out_of_range_packed_array_element_indices() {
     let error = cranelift_build_error(
         r#"
@@ -1121,6 +1143,38 @@ fn returns_unknown_for_invalid_runtime_array_read_indices() {
 }
 
 #[test]
+fn returns_unknown_for_invalid_inner_runtime_array_indices() {
+    let source = r#"
+        module Top(
+            input logic [1:0] sel,
+            input logic [7:0] values[2][3],
+            output logic [7:0] selected
+        );
+            assign selected = values[0][sel];
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("dynamic_multidimensional_array_read.sv"))],
+        "Top",
+    )
+    .four_state(true)
+    .build_cranelift()
+    .unwrap();
+    let sel = sim.signal("sel");
+    let values = sim.signal("values");
+    let selected = sim.signal("selected");
+    sim.modify(|io| {
+        io.set(sel, 3u8);
+        io.set_wide(values, BigUint::from(0x6655_4433_2211u64));
+    })
+    .unwrap();
+    assert_eq!(
+        sim.get_four_state(selected),
+        (BigUint::default(), BigUint::from(0xffu16))
+    );
+}
+
+#[test]
 fn reads_packed_subselects_of_runtime_unpacked_array_elements() {
     let source = r#"
         module Top(
@@ -1335,6 +1389,53 @@ fn writes_unpacked_array_elements_at_runtime_indices_in_always_ff() {
     .unwrap();
     sim.tick(sim.event("clk")).unwrap();
     assert_eq!(sim.get(value), 0x5au8.into());
+}
+
+#[test]
+fn ignores_invalid_dynamic_array_indices_in_always_ff() {
+    let source = r#"
+        module Top(
+            input bit clk,
+            input logic [2:0] sel,
+            input logic [7:0] data,
+            output logic [7:0] value0
+        );
+            logic [7:0] values[2];
+            always_ff @(posedge clk) values[sel] <= data;
+            assign value0 = values[0];
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("dynamic_array_ff_invalid_write.sv"))],
+        "Top",
+    )
+    .four_state(true)
+    .build_cranelift()
+    .unwrap();
+    let sel = sim.signal("sel");
+    let data = sim.signal("data");
+    let value0 = sim.signal("value0");
+    sim.modify(|io| {
+        io.set(sel, 0u8);
+        io.set(data, 0x11u8);
+    })
+    .unwrap();
+    sim.tick(sim.event("clk")).unwrap();
+    assert_eq!(sim.get(value0), 0x11u8.into());
+    sim.modify(|io| {
+        io.set(sel, 5u8);
+        io.set(data, 0x22u8);
+    })
+    .unwrap();
+    sim.tick(sim.event("clk")).unwrap();
+    assert_eq!(sim.get(value0), 0x11u8.into());
+    sim.modify(|io| {
+        io.set_four_state(sel, BigUint::default(), BigUint::from(0b111u8));
+        io.set(data, 0x33u8);
+    })
+    .unwrap();
+    sim.tick(sim.event("clk")).unwrap();
+    assert_eq!(sim.get(value0), 0x11u8.into());
 }
 
 #[test]

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -2120,14 +2120,6 @@ fn rejects_constructs_that_are_not_yet_lowered() {
         "#,
         ),
         (
-            "unpacked array dimension",
-            r#"
-            module Top(input logic [7:0] mem [0:1], output logic [7:0] y);
-                assign y = mem[0];
-            endmodule
-        "#,
-        ),
-        (
             "local data declaration inside loop-generate",
             r#"
             module Top(input logic [1:0] a, output logic [1:0] y);
@@ -2277,14 +2269,6 @@ fn rejects_constructs_that_are_not_yet_lowered() {
             module Top(output logic [7:0] y);
                 struct packed { logic [3:0] a; logic [3:0] b; } value;
                 assign y = value;
-            endmodule
-        "#,
-        ),
-        (
-            "cast expression",
-            r#"
-            module Top(input logic a, b, output logic [1:0] y);
-                assign y = {logic'(a), b};
             endmodule
         "#,
         ),

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -807,6 +807,24 @@ fn preserves_named_zero_cast_width() {
 }
 
 #[test]
+fn rejects_loop_substituted_out_of_range_array_indices() {
+    let error = cranelift_build_error(
+        r#"
+        module Top(input logic clk);
+            logic [7:0] a[0:1][0:2];
+            always_ff @(posedge clk) begin
+                for (int i = 3; i < 4; i++) a[0][i] <= 8'hff;
+            end
+        endmodule
+        "#,
+    );
+    assert!(
+        error.contains("always_ff assignment lowering"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
 fn uses_the_first_always_ff_event_as_a_negedge_clock() {
     let source = r#"
         module Top(input logic clk, input logic rst, input logic d, output logic q);

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -2009,6 +2009,16 @@ fn rejects_constructs_that_are_not_yet_lowered() {
         "#,
         ),
         (
+            "continuous assignment",
+            r#"
+            module Top(output logic y);
+                localparam J = 3;
+                logic [7:0] values [0:1][0:2];
+                assign y = values[0][J];
+            endmodule
+        "#,
+        ),
+        (
             "control flow inside always_comb",
             r#"
             module Top(input logic s, a, b, output logic y);

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -2334,6 +2334,16 @@ fn rejects_constructs_that_are_not_yet_lowered() {
         "#,
         ),
         (
+            "procedural loop inside always_ff",
+            r#"
+            module Top(input logic clk, d, output logic q);
+                always_ff @(posedge clk) begin
+                    for (int i = 0; i < 4; i++, i++) q <= d;
+                end
+            endmodule
+        "#,
+        ),
+        (
             "delayed continuous assignment",
             r#"
             module Top(input logic a, output wire y); assign #5 y = a; endmodule
@@ -2388,6 +2398,30 @@ fn rejects_constructs_that_are_not_yet_lowered() {
                     return values[1];
                 endfunction
                 assign y = pick('{default: value});
+            endmodule
+        "#,
+        ),
+        (
+            "unsupported function local data type",
+            r#"
+            module Top(input logic [7:0] value, output logic [7:0] y);
+                function automatic logic [7:0] pick(input logic [7:0] value);
+                    logic [7:0] tmp [2];
+                    return value;
+                endfunction
+                assign y = pick(value);
+            endmodule
+        "#,
+        ),
+        (
+            "unpacked dimension",
+            r#"
+            module Top(input logic [7:0] value, output logic [7:0] y);
+                typedef logic [7:0] pair_t [2];
+                function automatic pair_t make_pair();
+                    return value;
+                endfunction
+                assign y = value;
             endmodule
         "#,
         ),
@@ -3786,6 +3820,45 @@ fn remaps_trailing_part_select_bounds_in_ascending_packed_dimensions() {
 }
 
 #[test]
+fn preserves_declared_coordinates_for_non_array_packed_part_selects() {
+    let source = r#"
+        module Top(input logic [15:8] a, output logic [3:0] y);
+            assign y = a[15:12];
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("non_array_packed_part_select.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let a = sim.signal("a");
+    sim.modify(|io| io.set(a, 0xabu8)).unwrap();
+    assert_eq!(sim.get(sim.signal("y")), 0xau8.into());
+}
+
+#[test]
+fn preserves_part_selects_on_concatenation_expressions() {
+    let source = r#"
+        module Top(input logic [7:0] value, output logic [3:0] y);
+            function automatic logic [7:0] get_word(input logic [7:0] value);
+                return value;
+            endfunction
+            assign y = {4'h0, get_word(value)}[3:0];
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("concatenation_part_select.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let value = sim.signal("value");
+    sim.modify(|io| io.set(value, 0xabu8)).unwrap();
+    assert_eq!(sim.get(sim.signal("y")), 0xbu8.into());
+}
+
+#[test]
 fn appends_use_site_packed_dimensions_to_typedefs() {
     let source = r#"
         module Top(input logic [7:0] value, output logic [7:0] y);
@@ -3804,6 +3877,38 @@ fn appends_use_site_packed_dimensions_to_typedefs() {
     let value = sim.signal("value");
     sim.modify(|io| io.set(value, 0xabu8)).unwrap();
     assert_eq!(sim.get(sim.signal("y")), 0xabu8.into());
+}
+
+#[test]
+fn prepends_declarator_dimensions_to_typedef_dimensions() {
+    let source = r#"
+        module Top(
+            input logic [7:0] value,
+            output logic [47:0] all
+        );
+            typedef logic [7:0] row_t [0:2];
+            row_t matrix [0:1];
+
+            always_comb begin
+                matrix[0][0] = value;
+                matrix[0][1] = value + 1;
+                matrix[0][2] = value + 2;
+                matrix[1][0] = value + 3;
+                matrix[1][1] = value + 4;
+                matrix[1][2] = value + 5;
+            end
+            assign all = matrix;
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("typedef_dimension_order.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let value = sim.signal("value");
+    sim.modify(|io| io.set(value, 0x10u8)).unwrap();
+    assert_eq!(sim.get(sim.signal("all")), 0x151413121110u64.into());
 }
 
 #[test]

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -955,6 +955,33 @@ fn connects_runtime_selected_unpacked_array_elements_to_child_inputs() {
 }
 
 #[test]
+fn connects_runtime_selected_unpacked_array_elements_to_child_outputs() {
+    let source = r#"
+        module Child(output logic [7:0] output_value);
+            assign output_value = 8'h5a;
+        endmodule
+        module Top(
+            input logic [1:0] sel,
+            output logic [7:0] values[4],
+            output logic [7:0] value
+        );
+            Child child(.output_value(values[sel]));
+            assign value = values[sel];
+        endmodule
+        "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("array_output_dynamic_connection.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let sel = sim.signal("sel");
+    let value = sim.signal("value");
+    sim.modify(|io| io.set(sel, 2u8)).unwrap();
+    assert_eq!(sim.get(value), 0x5au8.into());
+}
+
+#[test]
 fn reads_unpacked_array_elements_at_runtime_indices() {
     let source = r#"
         module Top(
@@ -984,6 +1011,38 @@ fn reads_unpacked_array_elements_at_runtime_indices() {
     assert_eq!(sim.get(combinational), 0x33u8.into());
     sim.tick(sim.event("clk")).unwrap();
     assert_eq!(sim.get(registered), 0x33u8.into());
+}
+
+#[test]
+fn reads_packed_subselects_of_runtime_unpacked_array_elements() {
+    let source = r#"
+        module Top(
+            input logic [1:0] sel,
+            input logic [7:0] values[4],
+            output logic selected_bit,
+            output logic [3:0] selected_part
+        );
+            assign selected_bit = values[sel][4];
+            assign selected_part = values[sel][7:4];
+        endmodule
+        "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("dynamic_array_packed_subselect.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let sel = sim.signal("sel");
+    let values = sim.signal("values");
+    let selected_bit = sim.signal("selected_bit");
+    let selected_part = sim.signal("selected_part");
+    sim.modify(|io| {
+        io.set(sel, 2u8);
+        io.set(values, 0x44332211u32);
+    })
+    .unwrap();
+    assert_eq!(sim.get(selected_bit), 1u8.into());
+    assert_eq!(sim.get(selected_part), 3u8.into());
 }
 
 #[test]
@@ -1055,6 +1114,43 @@ fn composes_dynamic_array_writes_after_whole_array_assignments() {
     .unwrap();
     assert_eq!(sim.get(selected), 0x5au8.into());
     assert_eq!(sim.get(cleared), 0u8.into());
+}
+
+#[test]
+fn ignores_unknown_dynamic_array_write_indices() {
+    let source = r#"
+        module Top(
+            input logic [1:0] sel,
+            input logic [7:0] data,
+            output logic [7:0] value
+        );
+            logic [7:0] values[4];
+            always_comb begin
+                values = '0;
+                values[sel] = data;
+            end
+            assign value = values[0];
+        endmodule
+        "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("dynamic_array_write_unknown_index.sv"))],
+        "Top",
+    )
+    .four_state(true)
+    .build_cranelift()
+    .unwrap();
+    let sel = sim.signal("sel");
+    let data = sim.signal("data");
+    let value = sim.signal("value");
+    sim.modify(|io| {
+        io.set_four_state(sel, BigUint::default(), BigUint::from(0b11u8));
+        io.set(data, 0xffu8);
+    })
+    .unwrap();
+    assert_eq!(
+        sim.get_four_state(value),
+        (BigUint::default(), BigUint::default())
+    );
 }
 
 #[test]

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -840,6 +840,21 @@ fn rejects_out_of_range_packed_array_element_indices() {
 }
 
 #[test]
+fn rejects_out_of_range_packed_array_part_select_bounds() {
+    let error = cranelift_build_error(
+        r#"
+        module Top(input logic [7:0] a[0:1], output logic [1:0] y);
+            assign y = a[0][9:8];
+        endmodule
+        "#,
+    );
+    assert!(
+        error.contains("continuous assignment expression"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
 fn preserves_signedness_in_loop_conditions() {
     let source = r#"
         module Top(input logic clk, output logic q, output logic [1:0] result);
@@ -855,6 +870,19 @@ fn preserves_signedness_in_loop_conditions() {
             .unwrap();
     sim.tick(sim.event("clk")).unwrap();
     assert_eq!(sim.get(sim.signal("result")), 0u8.into());
+}
+
+#[test]
+fn rejects_extra_loop_index_declarations() {
+    cranelift_build_error(
+        r#"
+        module Top #(parameter J = 1) (input logic clk, output logic [1:0] q);
+            always_ff @(posedge clk) begin
+                for (int i = 0, J = 0; i < 1; i++) q[J] <= 1'b1;
+            end
+        endmodule
+        "#,
+    );
 }
 
 #[test]

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -1984,6 +1984,13 @@ fn rejects_constructs_that_are_not_yet_lowered() {
         "#,
         ),
         (
+            "module instance array",
+            r#"
+            module Child(); endmodule
+            module Top(); Child child[1:0](); endmodule
+        "#,
+        ),
+        (
             "control flow inside always_comb",
             r#"
             module Top(input logic s, a, b, output logic y);
@@ -2288,6 +2295,17 @@ fn rejects_constructs_that_are_not_yet_lowered() {
         "#,
         ),
         (
+            "procedural loop inside always_ff",
+            r#"
+            module Top(input logic clk, d, output logic q);
+                integer i;
+                always_ff @(posedge clk) begin
+                    for (i = 0; i < 2; i = i + 1) q <= d;
+                end
+            endmodule
+        "#,
+        ),
+        (
             "delayed continuous assignment",
             r#"
             module Top(input logic a, output wire y); assign #5 y = a; endmodule
@@ -2315,6 +2333,22 @@ fn rejects_constructs_that_are_not_yet_lowered() {
             r#"
             module Top(input logic [7:0] a, output logic [7:0] y);
                 assign y = {<<{a}};
+            endmodule
+        "#,
+        ),
+        (
+            "cast expression",
+            r#"
+            module Top(output logic [7:0] y);
+                assign y = 8'(16'h1234);
+            endmodule
+        "#,
+        ),
+        (
+            "cast expression",
+            r#"
+            module Top(input logic [7:0] value, output logic [7:0] y);
+                assign y = signed'(value);
             endmodule
         "#,
         ),
@@ -2668,6 +2702,15 @@ fn rejects_constructs_that_are_not_yet_lowered() {
             module Top #(parameter W = 2 ** 3)
                       (input logic [W-1:0] a, output logic [W-1:0] y);
                 assign y = a;
+            endmodule
+        "#,
+        ),
+        (
+            "signal width overflow",
+            r#"
+            module Top(output logic y);
+                logic [7:0] values [0:9223372036854775807][0:1];
+                assign y = values[0][0];
             endmodule
         "#,
         ),

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -1991,6 +1991,24 @@ fn rejects_constructs_that_are_not_yet_lowered() {
         "#,
         ),
         (
+            "continuous assignment",
+            r#"
+            module Top(output logic [23:0] row);
+                logic [7:0] values [0:1][0:2];
+                assign row = values[1];
+            endmodule
+        "#,
+        ),
+        (
+            "continuous assignment",
+            r#"
+            module Top(output logic y);
+                logic [7:0] values [0:1][0:2];
+                assign y = values[0][3];
+            endmodule
+        "#,
+        ),
+        (
             "control flow inside always_comb",
             r#"
             module Top(input logic s, a, b, output logic y);
@@ -2306,6 +2324,16 @@ fn rejects_constructs_that_are_not_yet_lowered() {
         "#,
         ),
         (
+            "procedural loop inside always_ff",
+            r#"
+            module Top(input logic clk, d, output logic q);
+                always_ff @(posedge clk) begin
+                    for (logic signed [1:0] i = 2; i < 0; i++) q <= d;
+                end
+            endmodule
+        "#,
+        ),
+        (
             "delayed continuous assignment",
             r#"
             module Top(input logic a, output wire y); assign #5 y = a; endmodule
@@ -2349,6 +2377,17 @@ fn rejects_constructs_that_are_not_yet_lowered() {
             r#"
             module Top(input logic [7:0] value, output logic [7:0] y);
                 assign y = signed'(value);
+            endmodule
+        "#,
+        ),
+        (
+            "unpacked dimension",
+            r#"
+            module Top(input logic [7:0] value, output logic [7:0] y);
+                function automatic logic [7:0] pick(input logic [7:0] values [2]);
+                    return values[1];
+                endfunction
+                assign y = pick('{default: value});
             endmodule
         "#,
         ),
@@ -2711,6 +2750,15 @@ fn rejects_constructs_that_are_not_yet_lowered() {
             module Top(output logic y);
                 logic [7:0] values [0:9223372036854775807][0:1];
                 assign y = values[0][0];
+            endmodule
+        "#,
+        ),
+        (
+            "continuous assignment",
+            r#"
+            module Top(output logic y);
+                logic [7:0] values [0:1][0:2];
+                assign y = values[1][3];
             endmodule
         "#,
         ),

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -2864,6 +2864,29 @@ fn reads_unpacked_array_ranges() {
 }
 
 #[test]
+fn writes_reversed_unpacked_array_lvalue_ranges() {
+    let source = r#"
+        module Top(
+            input logic [7:0] source[4],
+            output logic [7:0] target[2]
+        );
+            assign target[1:0] = source[0:1];
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("reversed_unpacked_array_lvalue.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let source = sim.signal("source");
+    let target = sim.signal("target");
+    sim.modify(|io| io.set_wide(source, BigUint::from(0x04030201u64)))
+        .unwrap();
+    assert_eq!(sim.get(target), 0x0102u16.into());
+}
+
+#[test]
 fn reads_bit_selects_of_scalar_array_elements() {
     let source = r#"
         module Top(

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -792,6 +792,35 @@ fn builds_whole_unpacked_array_always_ff_assignment() {
 }
 
 #[test]
+fn connects_whole_unpacked_array_ports() {
+    let source = r#"
+        module Child(
+            input logic [7:0] input_values[2],
+            output logic [7:0] output_values[2]
+        );
+            assign output_values = input_values;
+        endmodule
+        module Top(
+            input logic [7:0] values[2],
+            output logic [7:0] result[2]
+        );
+            Child child(
+                .input_values(values),
+                .output_values(result)
+            );
+        endmodule
+    "#;
+    let mut sim =
+        Simulator::from_sv_sources(vec![(source, Path::new("whole_array_ports.sv"))], "Top")
+            .build_cranelift()
+            .unwrap();
+    let values = sim.signal("values");
+    let result = sim.signal("result");
+    sim.modify(|io| io.set(values, 0x3412u16)).unwrap();
+    assert_eq!(sim.get(result), 0x3412u16.into());
+}
+
+#[test]
 fn preserves_named_zero_cast_width() {
     let source = r#"
         module Top(output logic [8:0] y);
@@ -822,6 +851,25 @@ fn rejects_loop_substituted_out_of_range_array_indices() {
         error.contains("always_ff assignment lowering"),
         "unexpected error: {error}"
     );
+}
+
+#[test]
+fn coerces_sized_loop_initializers_to_signed_int() {
+    let source = r#"
+        module Top(input logic clk, output logic q);
+            always_ff @(posedge clk) begin
+                for (int i = 32'hffff_ffff; i < 0; i++) q <= 1'b1;
+            end
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("signed_loop_initializer.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    sim.tick(sim.event("clk")).unwrap();
+    assert_eq!(sim.get(sim.signal("q")), 1u8.into());
 }
 
 #[test]
@@ -962,7 +1010,7 @@ fn connects_runtime_selected_unpacked_array_elements_to_child_outputs() {
         endmodule
         module Top(
             input logic [1:0] sel,
-            output logic [7:0] values[4],
+            output var logic [7:0] values[4],
             output logic [7:0] value
         );
             Child child(.output_value(values[sel]));
@@ -979,6 +1027,27 @@ fn connects_runtime_selected_unpacked_array_elements_to_child_outputs() {
     let value = sim.signal("value");
     sim.modify(|io| io.set(sel, 2u8)).unwrap();
     assert_eq!(sim.get(value), 0x5au8.into());
+}
+
+#[test]
+fn rejects_runtime_selected_child_outputs_to_nets() {
+    let error = cranelift_build_error(
+        r#"
+        module Child(output logic [7:0] output_value);
+            assign output_value = 8'h5a;
+        endmodule
+        module Top(input logic [1:0] sel, output logic [7:0] value);
+            wire [7:0] values[4];
+            Child child(.output_value(values[sel]));
+            assign value = values[0];
+        endmodule
+        "#,
+    );
+    assert!(
+        error.contains("undriven net declaration `values`")
+            || error.contains("dynamic child output connection to a net"),
+        "unexpected error: {error}"
+    );
 }
 
 #[test]
@@ -1011,6 +1080,44 @@ fn reads_unpacked_array_elements_at_runtime_indices() {
     assert_eq!(sim.get(combinational), 0x33u8.into());
     sim.tick(sim.event("clk")).unwrap();
     assert_eq!(sim.get(registered), 0x33u8.into());
+}
+
+#[test]
+fn returns_unknown_for_invalid_runtime_array_read_indices() {
+    let source = r#"
+        module Top(
+            input bit clk,
+            input logic [2:0] sel,
+            input logic [7:0] values[4],
+            output logic [7:0] combinational,
+            output logic [7:0] registered
+        );
+            assign combinational = values[sel];
+            always_ff @(posedge clk) registered <= values[sel];
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("dynamic_array_invalid_read.sv"))],
+        "Top",
+    )
+    .four_state(true)
+    .build_cranelift()
+    .unwrap();
+    let sel = sim.signal("sel");
+    let values = sim.signal("values");
+    let combinational = sim.signal("combinational");
+    let registered = sim.signal("registered");
+    sim.modify(|io| {
+        io.set(values, 0x44332211u32);
+        io.set_four_state(sel, BigUint::default(), BigUint::from(0b111u8));
+    })
+    .unwrap();
+    let all_x = (BigUint::default(), BigUint::from(0xffu16));
+    assert_eq!(sim.get_four_state(combinational), all_x);
+    sim.tick(sim.event("clk")).unwrap();
+    assert_eq!(sim.get_four_state(registered), all_x);
+    sim.modify(|io| io.set(sel, 5u8)).unwrap();
+    assert_eq!(sim.get_four_state(combinational), all_x);
 }
 
 #[test]

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -2860,7 +2860,7 @@ fn reads_unpacked_array_ranges() {
     let selected = sim.signal("selected");
     sim.modify(|io| io.set_wide(source, BigUint::from(0x04030201u64)))
         .unwrap();
-    assert_eq!(sim.get(selected), 0x0201u16.into());
+    assert_eq!(sim.get(selected), 0x0102u16.into());
 }
 
 #[test]

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -1392,6 +1392,75 @@ fn writes_unpacked_array_elements_at_runtime_indices_in_always_ff() {
 }
 
 #[test]
+fn writes_packed_subselects_of_runtime_array_elements_in_always_ff() {
+    let source = r#"
+        module Top(
+            input logic clk,
+            input logic [1:0] sel,
+            input logic [3:0] data,
+            output logic [7:0] value
+        );
+            logic [7:0] values[2];
+            always_ff @(posedge clk) begin
+                values[sel][7:4] <= 4'ha;
+                values[sel][3:0] <= data;
+            end
+            assign value = values[1];
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("dynamic_array_ff_packed_write.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let sel = sim.signal("sel");
+    let data = sim.signal("data");
+    let value = sim.signal("value");
+    sim.modify(|io| {
+        io.set(sel, 1u8);
+        io.set(data, 0x5u8);
+    })
+    .unwrap();
+    sim.tick(sim.event("clk")).unwrap();
+    assert_eq!(sim.get(value), 0xa5u8.into());
+}
+
+#[test]
+fn writes_packed_subselects_of_runtime_array_elements_in_always_comb() {
+    let source = r#"
+        module Top(
+            input logic [1:0] sel,
+            input logic [3:0] data,
+            output logic [7:0] value
+        );
+            logic [7:0] values[2];
+            always_comb begin
+                values = '0;
+                values[sel][7:4] = 4'ha;
+                values[sel][3:0] = data;
+            end
+            assign value = values[1];
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("dynamic_array_comb_packed_write.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let sel = sim.signal("sel");
+    let data = sim.signal("data");
+    let value = sim.signal("value");
+    sim.modify(|io| {
+        io.set(sel, 1u8);
+        io.set(data, 0x5u8);
+    })
+    .unwrap();
+    assert_eq!(sim.get(value), 0xa5u8.into());
+}
+
+#[test]
 fn ignores_invalid_dynamic_array_indices_in_always_ff() {
     let source = r#"
         module Top(

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -886,6 +886,41 @@ fn rejects_extra_loop_index_declarations() {
 }
 
 #[test]
+fn connects_child_outputs_to_unpacked_array_elements() {
+    let source = r#"
+        module Child(
+            input logic [7:0] input_value,
+            output logic [7:0] output_value
+        );
+            assign output_value = input_value;
+        endmodule
+        module Top(
+            input logic [7:0] a,
+            input logic [7:0] b,
+            output logic [7:0] values[2]
+        );
+            Child first(.input_value(a), .output_value(values[0]));
+            Child second(.input_value(b), .output_value(values[1]));
+        endmodule
+        "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("array_output_connection.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let a = sim.signal("a");
+    let b = sim.signal("b");
+    let values = sim.signal("values");
+    sim.modify(|io| {
+        io.set(a, 0x12u8);
+        io.set(b, 0x34u8);
+    })
+    .unwrap();
+    assert_eq!(sim.get(values), 0x3412u16.into());
+}
+
+#[test]
 fn uses_the_first_always_ff_event_as_a_negedge_clock() {
     let source = r#"
         module Top(input logic clk, input logic rst, input logic d, output logic q);

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -773,6 +773,40 @@ fn merges_always_ff_processes_with_the_same_trigger() {
 }
 
 #[test]
+fn builds_whole_unpacked_array_always_ff_assignment() {
+    let source = r#"
+        module Top(
+            input logic clk,
+            input logic [7:0] d [2],
+            output logic [7:0] q [2]
+        );
+            always_ff @(posedge clk) q <= d;
+        endmodule
+    "#;
+    Simulator::from_sv_sources(
+        vec![(source, Path::new("whole_array_ff_assignment.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+}
+
+#[test]
+fn preserves_named_zero_cast_width() {
+    let source = r#"
+        module Top(output logic [8:0] y);
+            typedef logic [7:0] byte_t;
+            assign y = {1'b1, byte_t'(0)};
+        endmodule
+    "#;
+    let mut sim =
+        Simulator::from_sv_sources(vec![(source, Path::new("named_zero_cast.sv"))], "Top")
+            .build_cranelift()
+            .unwrap();
+    assert_eq!(sim.get(sim.signal("y")), 0x100u16.into());
+}
+
+#[test]
 fn uses_the_first_always_ff_event_as_a_negedge_clock() {
     let source = r#"
         module Top(input logic clk, input logic rst, input logic d, output logic q);

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -825,6 +825,39 @@ fn rejects_loop_substituted_out_of_range_array_indices() {
 }
 
 #[test]
+fn rejects_out_of_range_packed_array_element_indices() {
+    let error = cranelift_build_error(
+        r#"
+        module Top(input logic [7:0] a[0:1], output logic y);
+            assign y = a[0][8];
+        endmodule
+        "#,
+    );
+    assert!(
+        error.contains("continuous assignment expression"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn preserves_signedness_in_loop_conditions() {
+    let source = r#"
+        module Top(input logic clk, output logic q, output logic [1:0] result);
+            always_ff @(posedge clk) begin
+                q <= 1'b0;
+                for (int i = -1; i < 32'd1; i++) result[i + 1] <= 1'b1;
+            end
+        endmodule
+        "#;
+    let mut sim =
+        Simulator::from_sv_sources(vec![(source, Path::new("signed_loop_condition.sv"))], "Top")
+            .build_cranelift()
+            .unwrap();
+    sim.tick(sim.event("clk")).unwrap();
+    assert_eq!(sim.get(sim.signal("result")), 0u8.into());
+}
+
+#[test]
 fn uses_the_first_always_ff_event_as_a_negedge_clock() {
     let source = r#"
         module Top(input logic clk, input logic rst, input logic d, output logic q);

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -2768,6 +2768,26 @@ fn applies_generate_localparams_inside_always_ff() {
 }
 
 #[test]
+fn reads_partial_unpacked_array_selections() {
+    let source = r#"
+        module Top(output logic [23:0] row);
+            logic [7:0] values [0:1][0:2];
+            assign row = values[1];
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("partial_unpacked_selection.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let values = sim.signal("values");
+    sim.modify(|io| io.set_wide(values, BigUint::from(0x060504030201u64)))
+        .unwrap();
+    assert_eq!(sim.get(sim.signal("row")), 0x060504u32.into());
+}
+
+#[test]
 fn rejects_constructs_that_are_not_yet_lowered() {
     let cases = [
         (
@@ -2803,15 +2823,6 @@ fn rejects_constructs_that_are_not_yet_lowered() {
             r#"
             module Child(); endmodule
             module Top(); Child child[1:0](); endmodule
-        "#,
-        ),
-        (
-            "continuous assignment",
-            r#"
-            module Top(output logic [23:0] row);
-                logic [7:0] values [0:1][0:2];
-                assign row = values[1];
-            endmodule
         "#,
         ),
         (

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -2019,6 +2019,15 @@ fn rejects_constructs_that_are_not_yet_lowered() {
         "#,
         ),
         (
+            "continuous assignment lvalue",
+            r#"
+            module Top(input logic [23:0] row);
+                logic [7:0] values [2][3];
+                assign values[1] = row;
+            endmodule
+        "#,
+        ),
+        (
             "control flow inside always_comb",
             r#"
             module Top(input logic s, a, b, output logic y);

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -2788,6 +2788,59 @@ fn reads_partial_unpacked_array_selections() {
 }
 
 #[test]
+fn writes_partial_unpacked_array_selections() {
+    let source = r#"
+        module Top(
+            input logic [23:0] row,
+            output logic [7:0] selected[3]
+        );
+            wire [7:0] values[2][3];
+            assign values[0] = row;
+            assign selected = values[0];
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("partial_unpacked_lvalue_selection.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let row = sim.signal("row");
+    let selected = sim.signal("selected");
+    sim.modify(|io| io.set_wide(row, BigUint::from(0x060504u32)))
+        .unwrap();
+    assert_eq!(sim.get(selected), 0x060504u32.into());
+}
+
+#[test]
+fn reads_runtime_partial_unpacked_array_selections() {
+    let source = r#"
+        module Top(
+            input logic sel,
+            input logic [7:0] values[2][3],
+            output logic [23:0] row
+        );
+            assign row = values[sel];
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("dynamic_partial_unpacked_selection.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let sel = sim.signal("sel");
+    let values = sim.signal("values");
+    let row = sim.signal("row");
+    sim.modify(|io| {
+        io.set(sel, 1u8);
+        io.set_wide(values, BigUint::from(0x060504030201u64));
+    })
+    .unwrap();
+    assert_eq!(sim.get(row), 0x060504u32.into());
+}
+
+#[test]
 fn rejects_constructs_that_are_not_yet_lowered() {
     let cases = [
         (
@@ -2841,15 +2894,6 @@ fn rejects_constructs_that_are_not_yet_lowered() {
                 localparam J = 3;
                 logic [7:0] values [0:1][0:2];
                 assign y = values[0][J];
-            endmodule
-        "#,
-        ),
-        (
-            "continuous assignment lvalue",
-            r#"
-            module Top(input logic [23:0] row);
-                logic [7:0] values [2][3];
-                assign values[1] = row;
             endmodule
         "#,
         ),

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -1052,6 +1052,45 @@ fn connects_runtime_selected_unpacked_array_elements_to_child_outputs() {
 }
 
 #[test]
+fn connects_runtime_selected_packed_subselects_to_child_outputs() {
+    let source = r#"
+        module Child(
+            input logic [3:0] input_value,
+            output logic [3:0] output_value
+        );
+            assign output_value = input_value;
+        endmodule
+        module Top(
+            input logic [1:0] sel,
+            input logic [3:0] input_value,
+            output var logic [7:0] values[4],
+            output logic [3:0] value
+        );
+            Child child(.input_value(input_value), .output_value(values[sel][3:0]));
+            assign value = values[sel][3:0];
+        endmodule
+        "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(
+            source,
+            Path::new("array_output_dynamic_packed_subselect.sv"),
+        )],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let sel = sim.signal("sel");
+    let input_value = sim.signal("input_value");
+    let value = sim.signal("value");
+    sim.modify(|io| {
+        io.set(sel, 2u8);
+        io.set(input_value, 0xau8);
+    })
+    .unwrap();
+    assert_eq!(sim.get(value), 0xau8.into());
+}
+
+#[test]
 fn rejects_runtime_selected_child_outputs_to_nets() {
     let error = cranelift_build_error(
         r#"
@@ -1140,6 +1179,47 @@ fn returns_unknown_for_invalid_runtime_array_read_indices() {
     assert_eq!(sim.get_four_state(registered), all_x);
     sim.modify(|io| io.set(sel, 5u8)).unwrap();
     assert_eq!(sim.get_four_state(combinational), all_x);
+}
+
+#[test]
+fn returns_zero_for_invalid_runtime_two_state_array_read_indices() {
+    let source = r#"
+        module Top(
+            input bit clk,
+            input logic [2:0] sel,
+            input bit [7:0] values[2],
+            output logic [7:0] combinational,
+            output logic [7:0] registered
+        );
+            assign combinational = values[sel];
+            always_ff @(posedge clk) registered <= values[sel];
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("dynamic_array_invalid_two_state_read.sv"))],
+        "Top",
+    )
+    .four_state(true)
+    .build_cranelift()
+    .unwrap();
+    let sel = sim.signal("sel");
+    let values = sim.signal("values");
+    let combinational = sim.signal("combinational");
+    let registered = sim.signal("registered");
+    sim.modify(|io| {
+        io.set(values, 0x2211u16);
+        io.set(sel, 5u8);
+    })
+    .unwrap();
+    let zero = (BigUint::default(), BigUint::default());
+    assert_eq!(sim.get_four_state(combinational), zero);
+    sim.tick(sim.event("clk")).unwrap();
+    assert_eq!(sim.get_four_state(registered), zero);
+    sim.modify(|io| io.set_four_state(sel, BigUint::default(), BigUint::from(0b111u8)))
+        .unwrap();
+    assert_eq!(sim.get_four_state(combinational), zero);
+    sim.tick(sim.event("clk")).unwrap();
+    assert_eq!(sim.get_four_state(registered), zero);
 }
 
 #[test]

--- a/crates/celox/tests/frontends/systemverilog/review_regressions.rs
+++ b/crates/celox/tests/frontends/systemverilog/review_regressions.rs
@@ -2841,6 +2841,51 @@ fn reads_runtime_partial_unpacked_array_selections() {
 }
 
 #[test]
+fn reads_unpacked_array_ranges() {
+    let source = r#"
+        module Top(
+            input logic [7:0] source[4],
+            output logic [7:0] selected[2]
+        );
+            assign selected = source[1:0];
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("unpacked_array_range_selection.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let source = sim.signal("source");
+    let selected = sim.signal("selected");
+    sim.modify(|io| io.set_wide(source, BigUint::from(0x04030201u64)))
+        .unwrap();
+    assert_eq!(sim.get(selected), 0x0201u16.into());
+}
+
+#[test]
+fn reads_bit_selects_of_scalar_array_elements() {
+    let source = r#"
+        module Top(
+            input logic values[2],
+            output logic selected
+        );
+            assign selected = values[0][0];
+        endmodule
+    "#;
+    let mut sim = Simulator::from_sv_sources(
+        vec![(source, Path::new("scalar_array_bit_selection.sv"))],
+        "Top",
+    )
+    .build_cranelift()
+    .unwrap();
+    let values = sim.signal("values");
+    let selected = sim.signal("selected");
+    sim.modify(|io| io.set(values, 1u8)).unwrap();
+    assert_eq!(sim.get(selected), 1u8.into());
+}
+
+#[test]
 fn rejects_constructs_that_are_not_yet_lowered() {
     let cases = [
         (

--- a/crates/celox/tests/std_delay.rs
+++ b/crates/celox/tests/std_delay.rs
@@ -8,7 +8,6 @@ all_backends! {
 
     // DELAY=0: passthrough (no delay)
     fn test_delay_zero(sim) {
-        @ignore_on(sv);
         @setup { let top = r#"
 module Top (
 clk: input  clock,
@@ -40,7 +39,6 @@ let code = format!("{}\n{top}", test_utils::veryl_std::source(&["delay", "delay.
 
     // DELAY=1: one cycle delay
     fn test_delay_one(sim) {
-        @ignore_on(sv);
         @setup { let top = r#"
 module Top (
 clk: input  clock,
@@ -89,7 +87,6 @@ let code = format!("{}\n{top}", test_utils::veryl_std::source(&["delay", "delay.
 
     // DELAY=3: three cycle pipeline
     fn test_delay_three(sim) {
-        @ignore_on(sv);
         @setup { let top = r#"
 module Top (
 clk: input  clock,

--- a/crates/celox/tests/sv_unpacked_array.rs
+++ b/crates/celox/tests/sv_unpacked_array.rs
@@ -95,3 +95,41 @@ fn supports_fixed_multidimensional_unpacked_array_selects() {
     assert_eq!(simulator.get(output), 0x13u8.into());
     assert_eq!(simulator.get(all), 0x1300_0000_0012u64.into());
 }
+
+#[cfg(feature = "systemverilog")]
+#[test]
+fn preserves_typedef_owned_unpacked_array_dimensions() {
+    let source = r#"
+        module Top (
+            input  logic [7:0] i,
+            output logic [7:0] o,
+            output logic [15:0] all
+        );
+            typedef logic [7:0] word_t [0:1];
+            word_t values;
+
+            always_comb begin
+                values[0] = i;
+                values[1] = i + 1;
+            end
+
+            assign o = values[1];
+            assign all = values;
+        endmodule
+    "#;
+    let mut simulator = celox::Simulator::from_sv_sources(
+        vec![(source, std::path::Path::new("typedef_array.sv"))],
+        "Top",
+    )
+    .build()
+    .expect("typedef-owned unpacked arrays should build");
+    let input = simulator.signal("i");
+    let output = simulator.signal("o");
+    let all = simulator.signal("all");
+
+    simulator
+        .modify(|io| io.set(input, 0x12u8))
+        .expect("input update should succeed");
+    assert_eq!(simulator.get(output), 0x13u8.into());
+    assert_eq!(simulator.get(all), 0x1312u16.into());
+}

--- a/crates/celox/tests/sv_unpacked_array.rs
+++ b/crates/celox/tests/sv_unpacked_array.rs
@@ -1,0 +1,97 @@
+#[cfg(feature = "systemverilog")]
+#[test]
+fn supports_fixed_unpacked_array_selects() {
+    let source = r#"
+        module Top (
+            input  logic [7:0] i,
+            output logic [7:0] o,
+            output logic [15:0] all
+        );
+            logic [7:0] values [2];
+
+            always_comb begin
+                values[0] = i;
+                values[1] = i + 1;
+            end
+
+            assign o = values[1];
+            assign all = values;
+        endmodule
+    "#;
+    let mut simulator = celox::Simulator::from_sv_sources(
+        vec![(source, std::path::Path::new("fixed_array.sv"))],
+        "Top",
+    )
+    .build()
+    .expect("fixed unpacked array SV should build");
+    let input = simulator.signal("i");
+    let output = simulator.signal("o");
+    let all = simulator.signal("all");
+
+    simulator
+        .modify(|io| io.set(input, 0x12u8))
+        .expect("input update should succeed");
+    assert_eq!(simulator.get(output), 0x13u8.into());
+    assert_eq!(simulator.get(all), 0x1312u16.into());
+}
+
+#[cfg(feature = "systemverilog")]
+#[test]
+fn supports_fixed_unpacked_array_ports() {
+    let source = r#"
+        module Top (
+            input logic [7:0] values [0:1],
+            output logic [7:0] o
+        );
+            assign o = values[1];
+        endmodule
+    "#;
+    let mut simulator = celox::Simulator::from_sv_sources(
+        vec![(source, std::path::Path::new("fixed_array_port.sv"))],
+        "Top",
+    )
+    .build()
+    .expect("fixed unpacked array ports should build");
+    let values = simulator.signal("values");
+    let output = simulator.signal("o");
+
+    simulator
+        .modify(|io| io.set(values, 0x3412u16))
+        .expect("array input update should succeed");
+    assert_eq!(simulator.get(output), 0x34u8.into());
+}
+
+#[cfg(feature = "systemverilog")]
+#[test]
+fn supports_fixed_multidimensional_unpacked_array_selects() {
+    let source = r#"
+        module Top (
+            input logic [7:0] i,
+            output logic [7:0] o,
+            output logic [47:0] all
+        );
+            logic [7:0] values [0:1][0:2];
+            always_comb begin
+                values[0][0] = i;
+                values[1][2] = i + 1;
+            end
+            assign o = values[1][2];
+            assign all = values;
+        endmodule
+    "#;
+    let mut simulator = celox::Simulator::from_sv_sources(
+        vec![(source, std::path::Path::new("fixed_multidim_array.sv"))],
+        "Top",
+    )
+    .build()
+    .expect("fixed multidimensional unpacked arrays should build");
+    let input = simulator.signal("i");
+    let output = simulator.signal("o");
+    let all = simulator.signal("all");
+
+    simulator
+        .modify(|io| io.set(input, 0x12u8))
+        .expect("input update should succeed");
+    assert_eq!(simulator.get(output), 0x13u8.into());
+    assert_eq!(simulator.get(all), 0x1300_0000_0012u64.into());
+}

--- a/crates/celox/tests/sv_unpacked_array.rs
+++ b/crates/celox/tests/sv_unpacked_array.rs
@@ -133,3 +133,87 @@ fn preserves_typedef_owned_unpacked_array_dimensions() {
     assert_eq!(simulator.get(output), 0x13u8.into());
     assert_eq!(simulator.get(all), 0x1312u16.into());
 }
+
+#[cfg(feature = "systemverilog")]
+#[test]
+fn preserves_typedef_declarator_unpacked_array_dimensions() {
+    let source = r#"
+        module Top (
+            input  logic [7:0] i,
+            output logic [7:0] o,
+            output logic [15:0] all
+        );
+            typedef logic [7:0] word_t;
+            word_t values [0:1];
+
+            always_comb begin
+                values[0] = i;
+                values[1] = i + 1;
+            end
+
+            assign o = values[1];
+            assign all = values;
+        endmodule
+    "#;
+    let mut simulator = celox::Simulator::from_sv_sources(
+        vec![(source, std::path::Path::new("typedef_declarator_array.sv"))],
+        "Top",
+    )
+    .build()
+    .expect("typedef declarator unpacked arrays should build");
+    let input = simulator.signal("i");
+    let output = simulator.signal("o");
+    let all = simulator.signal("all");
+
+    simulator
+        .modify(|io| io.set(input, 0x12u8))
+        .expect("input update should succeed");
+    assert_eq!(simulator.get(output), 0x13u8.into());
+    assert_eq!(simulator.get(all), 0x1312u16.into());
+}
+
+#[cfg(feature = "systemverilog")]
+#[test]
+fn preserves_signedness_of_unpacked_array_elements() {
+    let source = r#"
+        module Top (
+            input  logic signed [7:0] i,
+            output logic lt
+        );
+            logic signed [7:0] values [0:1];
+            assign values[0] = i;
+            assign values[1] = 0;
+            assign lt = values[0] < 0;
+        endmodule
+    "#;
+    let mut simulator = celox::Simulator::from_sv_sources(
+        vec![(source, std::path::Path::new("signed_array.sv"))],
+        "Top",
+    )
+    .build()
+    .expect("signed unpacked arrays should build");
+    let input = simulator.signal("i");
+    let output = simulator.signal("lt");
+
+    simulator
+        .modify(|io| io.set(input, 0xffu8))
+        .expect("input update should succeed");
+    assert_eq!(simulator.get(output), 1u8.into());
+}
+
+#[cfg(feature = "systemverilog")]
+#[test]
+fn preserves_width_of_zero_literal_casts() {
+    let source = r#"
+        module Top(output logic [8:0] y);
+            assign y = {1'b1, 8'(0)};
+        endmodule
+    "#;
+    let mut simulator = celox::Simulator::from_sv_sources(
+        vec![(source, std::path::Path::new("zero_cast.sv"))],
+        "Top",
+    )
+    .build()
+    .expect("zero literal casts should build");
+    assert_eq!(simulator.get(simulator.signal("y")), 0x100u16.into());
+}


### PR DESCRIPTION
## Summary

- add fixed-size unpacked array dimensions to the SystemVerilog analyzer and frontend
- lower single-dimensional, multidimensional, and port array selections
- support static `always_ff` loop unrolling and the simple identity casts emitted by the Veryl frontend
- enable the three SystemVerilog `std_delay` cases and add unpacked-array regression coverage

## Why

The SystemVerilog frontend rejected fixed unpacked dimensions before lowering, which left related integration tests ignored. The analyzer also did not preserve array shape or account for flattened storage offsets.

## Validation

- `cargo test --locked -j 2 -p celox --features systemverilog --tests`
- SV integration tests: 351 passed
- `cargo test --locked -p celox-sv-analyzer`
- `cargo check --locked -p celox-frontend-sv -p celox-sv-analyzer`
- `cargo clippy --locked -j 2 -p celox-sv-analyzer -p celox-frontend-sv --all-targets -- -D warnings`
- `cargo fmt --all -- --check`