### PR TITLE
feat(frontend): add external frontend SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "celox-backend-x86",
  "celox-design",
  "celox-frontend-core",
+ "celox-frontend-sdk",
  "celox-frontend-sv",
  "celox-frontend-veryl",
  "celox-macros",
@@ -585,6 +586,7 @@ name = "celox-frontend-core"
 version = "0.0.0"
 dependencies = [
  "celox-design",
+ "celox-frontend-sdk",
  "celox-sir",
  "celox-slt",
  "fxhash",
@@ -592,6 +594,17 @@ dependencies = [
  "num-bigint",
  "thiserror 2.0.20",
  "tracing",
+]
+
+[[package]]
+name = "celox-frontend-sdk"
+version = "0.1.0"
+dependencies = [
+ "fxhash",
+ "num-bigint",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,6 +664,7 @@ name = "celox-napi"
 version = "0.0.0"
 dependencies = [
  "celox",
+ "celox-design",
  "celox-ts-gen",
  "fxhash",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/celox-bench",
     "crates/celox-design",
     "crates/celox-frontend-core",
+    "crates/celox-frontend-sdk",
     "crates/celox-frontend-sv",
     "crates/celox-frontend-veryl",
     "crates/celox-sir",

--- a/crates/celox-frontend-core/Cargo.toml
+++ b/crates/celox-frontend-core/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 
 [dependencies]
 celox-design = { path = "../celox-design" }
+celox-frontend-sdk = { path = "../celox-frontend-sdk" }
 celox-sir = { path = "../celox-sir" }
 celox-slt = { path = "../celox-slt" }
 fxhash = { workspace = true }

--- a/crates/celox-frontend-core/src/lib.rs
+++ b/crates/celox-frontend-core/src/lib.rs
@@ -1,11 +1,13 @@
 //! Source-language-independent symbolic lowering and scheduling.
 
 mod error;
+mod sdk;
 pub mod shared;
 pub mod symbolic;
 mod trace;
 
 pub use error::{LoweringPhase, ParserError, SourceLocation};
+pub use sdk::{FrontendArtifactError, LoweredFrontendArtifact, lower_frontend_artifact};
 pub use shared::{
     FrontendLookup, FusedSirOptimizationHints, InstancePath, ScheduledRtl, ScheduledRtlOutput,
     SourceAddr, SourceVarId, VariableInfo, VariableKind,

--- a/crates/celox-frontend-core/src/sdk.rs
+++ b/crates/celox-frontend-core/src/sdk.rs
@@ -791,23 +791,27 @@ fn lower_control(
         SIROffset::Static(0),
         1,
     ));
-    let two_state = if signal_info.value_type().is_four_state() {
-        let result = builder.alloc_bit(1, false);
-        builder.emit(SIRInstruction::Unary(result, UnaryOp::ToTwoState, loaded));
-        result
+    let polarized = if active == ActiveLevel::Low {
+        let inverted = alloc_register(
+            builder,
+            ValueType::new(1, false, signal_info.value_type().is_four_state())?,
+        );
+        builder.emit(SIRInstruction::Unary(inverted, UnaryOp::LogicNot, loaded));
+        inverted
     } else {
         loaded
     };
-    if active == ActiveLevel::High {
-        return Ok(two_state);
+    if signal_info.value_type().is_four_state() {
+        let result = builder.alloc_bit(1, false);
+        builder.emit(SIRInstruction::Unary(
+            result,
+            UnaryOp::ToTwoState,
+            polarized,
+        ));
+        Ok(result)
+    } else {
+        Ok(polarized)
     }
-    let inverted = builder.alloc_bit(1, false);
-    builder.emit(SIRInstruction::Unary(
-        inverted,
-        UnaryOp::LogicNot,
-        two_state,
-    ));
-    Ok(inverted)
 }
 
 fn seal_builder(mut builder: SIRBuilder<RegionedSourceAddr>) -> ExecutionUnit<RegionedSourceAddr> {

--- a/crates/celox-frontend-core/src/sdk.rs
+++ b/crates/celox-frontend-core/src/sdk.rs
@@ -1,0 +1,669 @@
+//! Projection from the stable frontend SDK into Celox symbolic internals.
+
+use celox_design::{
+    BinaryOp, BitAccess, DomainKind, InitialStateData, InitialStateValue, ModuleId, PortTypeKind,
+    RegionedVarAddrBase, STABLE_REGION, TriggerSet, UnaryOp, VarAtomBase, VariableMetadata,
+    WORKING_REGION,
+};
+use celox_frontend_sdk::{
+    ActiveLevel, Direction, Edge, ExprId, ExprNode, FrontendArtifact, SignalId, SignalSlice,
+};
+use celox_sir::{
+    BlockId, ExecutionUnit, RegisterId, SIRBuilder, SIRInstruction, SIROffset, SIRTerminator,
+    SIRValue, merge_sir_eus,
+};
+use celox_slt::{LogicPath, LogicPathTarget, NodeId, SLTNode, SLTNodeArena};
+use thiserror::Error;
+
+use crate::symbolic::artifact::{
+    ExternalHierarchy, ExternalModule, SimModule, SymbolicRtl, SymbolicVariable,
+};
+use crate::{HashMap, HashSet, SourceVarId, VariableKind};
+
+type RegionedSourceAddr = RegionedVarAddrBase<SourceVarId>;
+
+/// Internal artifacts derived from one stable SDK value.
+///
+/// `symbolic` compiles the artifact as a standalone design. `external` lets a
+/// Veryl native testbench instantiate the same module without teaching the SDK
+/// about Veryl syntax.
+pub struct LoweredFrontendArtifact {
+    pub symbolic: SymbolicRtl,
+    pub external: ExternalHierarchy,
+}
+
+#[derive(Debug, Error)]
+pub enum FrontendArtifactError {
+    #[error("invalid frontend artifact: {0}")]
+    Validation(#[from] celox_frontend_sdk::BuildError),
+    #[error("frontend artifact references unknown signal {0}")]
+    UnknownSignal(u32),
+    #[error("frontend artifact references unknown expression {0}")]
+    UnknownExpression(u32),
+    #[error("unsupported frontend SDK expression or operation")]
+    UnsupportedOperation,
+    #[error("signal `{signal}` is used with conflicting clock/reset roles")]
+    ConflictingSignalRole { signal: String },
+    #[error("frontend SDK expression is invalid: {0}")]
+    InvalidExpression(#[from] celox_slt::SLTNodeFactsError),
+}
+
+fn source_id(id: SignalId) -> SourceVarId {
+    SourceVarId(id.index())
+}
+
+fn signal_atom(slice: SignalSlice) -> VarAtomBase<SourceVarId> {
+    VarAtomBase::new(
+        source_id(slice.signal()),
+        slice.lsb(),
+        slice.lsb() + slice.width() - 1,
+    )
+}
+
+fn binary_op(op: celox_frontend_sdk::BinaryOp) -> Result<BinaryOp, FrontendArtifactError> {
+    Ok(match op {
+        celox_frontend_sdk::BinaryOp::Add => BinaryOp::Add,
+        celox_frontend_sdk::BinaryOp::Sub => BinaryOp::Sub,
+        celox_frontend_sdk::BinaryOp::Mul => BinaryOp::Mul,
+        celox_frontend_sdk::BinaryOp::DivUnsigned => BinaryOp::DivU,
+        celox_frontend_sdk::BinaryOp::DivSigned => BinaryOp::DivS,
+        celox_frontend_sdk::BinaryOp::RemUnsigned => BinaryOp::RemU,
+        celox_frontend_sdk::BinaryOp::RemSigned => BinaryOp::RemS,
+        celox_frontend_sdk::BinaryOp::And => BinaryOp::And,
+        celox_frontend_sdk::BinaryOp::Or => BinaryOp::Or,
+        celox_frontend_sdk::BinaryOp::Xor => BinaryOp::Xor,
+        celox_frontend_sdk::BinaryOp::ShiftLeft => BinaryOp::Shl,
+        celox_frontend_sdk::BinaryOp::ShiftRight => BinaryOp::Shr,
+        celox_frontend_sdk::BinaryOp::ArithmeticShiftRight => BinaryOp::Sar,
+        celox_frontend_sdk::BinaryOp::Equal => BinaryOp::Eq,
+        celox_frontend_sdk::BinaryOp::NotEqual => BinaryOp::Ne,
+        celox_frontend_sdk::BinaryOp::CaseEqual => BinaryOp::EqCase,
+        celox_frontend_sdk::BinaryOp::CaseNotEqual => BinaryOp::NeCase,
+        celox_frontend_sdk::BinaryOp::LessUnsigned => BinaryOp::LtU,
+        celox_frontend_sdk::BinaryOp::LessSigned => BinaryOp::LtS,
+        celox_frontend_sdk::BinaryOp::LessEqualUnsigned => BinaryOp::LeU,
+        celox_frontend_sdk::BinaryOp::LessEqualSigned => BinaryOp::LeS,
+        celox_frontend_sdk::BinaryOp::GreaterUnsigned => BinaryOp::GtU,
+        celox_frontend_sdk::BinaryOp::GreaterSigned => BinaryOp::GtS,
+        celox_frontend_sdk::BinaryOp::GreaterEqualUnsigned => BinaryOp::GeU,
+        celox_frontend_sdk::BinaryOp::GreaterEqualSigned => BinaryOp::GeS,
+        celox_frontend_sdk::BinaryOp::LogicAnd => BinaryOp::LogicAnd,
+        celox_frontend_sdk::BinaryOp::LogicOr => BinaryOp::LogicOr,
+        _ => return Err(FrontendArtifactError::UnsupportedOperation),
+    })
+}
+
+fn unary_op(op: celox_frontend_sdk::UnaryOp) -> Result<UnaryOp, FrontendArtifactError> {
+    Ok(match op {
+        celox_frontend_sdk::UnaryOp::ToTwoState => UnaryOp::ToTwoState,
+        celox_frontend_sdk::UnaryOp::Negate => UnaryOp::Minus,
+        celox_frontend_sdk::UnaryOp::BitNot => UnaryOp::BitNot,
+        celox_frontend_sdk::UnaryOp::LogicNot => UnaryOp::LogicNot,
+        celox_frontend_sdk::UnaryOp::ReduceAnd => UnaryOp::And,
+        celox_frontend_sdk::UnaryOp::ReduceOr => UnaryOp::Or,
+        celox_frontend_sdk::UnaryOp::ReduceXor => UnaryOp::Xor,
+        celox_frontend_sdk::UnaryOp::PopCount => UnaryOp::PopCount,
+        celox_frontend_sdk::UnaryOp::CountLeadingZeros => UnaryOp::CountLeadingZeros,
+        celox_frontend_sdk::UnaryOp::CountTrailingZeros => UnaryOp::CountTrailingZeros,
+        _ => return Err(FrontendArtifactError::UnsupportedOperation),
+    })
+}
+
+fn expression_sources(
+    artifact: &FrontendArtifact,
+    id: ExprId,
+    sources: &mut HashSet<VarAtomBase<SourceVarId>>,
+) -> Result<(), FrontendArtifactError> {
+    let expression = artifact
+        .expression(id)
+        .ok_or(FrontendArtifactError::UnknownExpression(id.index()))?;
+    match expression.node() {
+        ExprNode::Signal(slice) => {
+            sources.insert(signal_atom(*slice));
+        }
+        ExprNode::Constant(_) => {}
+        ExprNode::Binary { lhs, rhs, .. } => {
+            expression_sources(artifact, *lhs, sources)?;
+            expression_sources(artifact, *rhs, sources)?;
+        }
+        ExprNode::Unary { input, .. } | ExprNode::Slice { input, .. } => {
+            expression_sources(artifact, *input, sources)?;
+        }
+        ExprNode::Mux {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            expression_sources(artifact, *condition, sources)?;
+            expression_sources(artifact, *then_expr, sources)?;
+            expression_sources(artifact, *else_expr, sources)?;
+        }
+        ExprNode::Concat(parts) => {
+            for part in parts {
+                expression_sources(artifact, *part, sources)?;
+            }
+        }
+        _ => return Err(FrontendArtifactError::UnsupportedOperation),
+    }
+    Ok(())
+}
+
+fn lower_slt_expression(
+    artifact: &FrontendArtifact,
+    id: ExprId,
+    arena: &mut SLTNodeArena<SourceVarId>,
+    cache: &mut HashMap<ExprId, NodeId>,
+) -> Result<NodeId, FrontendArtifactError> {
+    if let Some(node) = cache.get(&id) {
+        return Ok(*node);
+    }
+    let expression = artifact
+        .expression(id)
+        .ok_or(FrontendArtifactError::UnknownExpression(id.index()))?;
+    let node = match expression.node() {
+        ExprNode::Signal(slice) => SLTNode::Input {
+            variable: source_id(slice.signal()),
+            signed: artifact
+                .signal(slice.signal())
+                .ok_or(FrontendArtifactError::UnknownSignal(slice.signal().index()))?
+                .value_type()
+                .is_signed(),
+            index: Vec::new(),
+            access: BitAccess::new(slice.lsb(), slice.lsb() + slice.width() - 1),
+        },
+        ExprNode::Constant(value) => SLTNode::Constant(
+            value.payload().clone(),
+            value.mask().clone(),
+            value.value_type().width(),
+            value.value_type().is_signed(),
+        ),
+        ExprNode::Binary { op, lhs, rhs } => SLTNode::Binary(
+            lower_slt_expression(artifact, *lhs, arena, cache)?,
+            binary_op(*op)?,
+            lower_slt_expression(artifact, *rhs, arena, cache)?,
+        ),
+        ExprNode::Unary { op, input } => SLTNode::Unary(
+            unary_op(*op)?,
+            lower_slt_expression(artifact, *input, arena, cache)?,
+        ),
+        ExprNode::Mux {
+            condition,
+            then_expr,
+            else_expr,
+        } => SLTNode::Mux {
+            cond: lower_slt_expression(artifact, *condition, arena, cache)?,
+            then_expr: lower_slt_expression(artifact, *then_expr, arena, cache)?,
+            else_expr: lower_slt_expression(artifact, *else_expr, arena, cache)?,
+        },
+        ExprNode::Concat(parts) => SLTNode::Concat(
+            parts
+                .iter()
+                .map(|part| {
+                    let expression = artifact
+                        .expression(*part)
+                        .ok_or(FrontendArtifactError::UnknownExpression(part.index()))?;
+                    Ok((
+                        lower_slt_expression(artifact, *part, arena, cache)?,
+                        expression.value_type().width(),
+                    ))
+                })
+                .collect::<Result<Vec<_>, FrontendArtifactError>>()?,
+        ),
+        ExprNode::Slice { input, lsb } => SLTNode::Slice {
+            expr: lower_slt_expression(artifact, *input, arena, cache)?,
+            access: BitAccess::new(*lsb, *lsb + expression.value_type().width() - 1),
+        },
+        _ => return Err(FrontendArtifactError::UnsupportedOperation),
+    };
+    let node = arena.alloc(node)?;
+    cache.insert(id, node);
+    Ok(node)
+}
+
+fn alloc_register(
+    builder: &mut SIRBuilder<RegionedSourceAddr>,
+    ty: celox_frontend_sdk::ValueType,
+) -> RegisterId {
+    if ty.is_four_state() {
+        builder.alloc_logic(ty.width())
+    } else {
+        builder.alloc_bit(ty.width(), ty.is_signed())
+    }
+}
+
+fn lower_sir_expression(
+    artifact: &FrontendArtifact,
+    id: ExprId,
+    builder: &mut SIRBuilder<RegionedSourceAddr>,
+    cache: &mut HashMap<ExprId, RegisterId>,
+) -> Result<RegisterId, FrontendArtifactError> {
+    if let Some(register) = cache.get(&id) {
+        return Ok(*register);
+    }
+    let expression = artifact
+        .expression(id)
+        .ok_or(FrontendArtifactError::UnknownExpression(id.index()))?;
+    let result = alloc_register(builder, expression.value_type());
+    match expression.node() {
+        ExprNode::Signal(slice) => builder.emit(SIRInstruction::Load(
+            result,
+            RegionedSourceAddr {
+                region: STABLE_REGION,
+                var_id: source_id(slice.signal()),
+            },
+            SIROffset::Static(slice.lsb()),
+            slice.width(),
+        )),
+        ExprNode::Constant(value) => builder.emit(SIRInstruction::Imm(
+            result,
+            SIRValue::new_four_state(value.payload().clone(), value.mask().clone()),
+        )),
+        ExprNode::Binary { op, lhs, rhs } => {
+            let lhs = lower_sir_expression(artifact, *lhs, builder, cache)?;
+            let rhs = lower_sir_expression(artifact, *rhs, builder, cache)?;
+            builder.emit(SIRInstruction::Binary(result, lhs, binary_op(*op)?, rhs));
+        }
+        ExprNode::Unary { op, input } => {
+            let input = lower_sir_expression(artifact, *input, builder, cache)?;
+            builder.emit(SIRInstruction::Unary(result, unary_op(*op)?, input));
+        }
+        ExprNode::Mux {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            let condition = lower_sir_expression(artifact, *condition, builder, cache)?;
+            let then_expr = lower_sir_expression(artifact, *then_expr, builder, cache)?;
+            let else_expr = lower_sir_expression(artifact, *else_expr, builder, cache)?;
+            builder.emit(SIRInstruction::Mux(result, condition, then_expr, else_expr));
+        }
+        ExprNode::Concat(parts) => {
+            let parts = parts
+                .iter()
+                .map(|part| lower_sir_expression(artifact, *part, builder, cache))
+                .collect::<Result<Vec<_>, _>>()?;
+            builder.emit(SIRInstruction::Concat(result, parts));
+        }
+        ExprNode::Slice { input, lsb } => {
+            let input = lower_sir_expression(artifact, *input, builder, cache)?;
+            builder.emit(SIRInstruction::Slice(
+                result,
+                input,
+                *lsb,
+                expression.value_type().width(),
+            ));
+        }
+        _ => return Err(FrontendArtifactError::UnsupportedOperation),
+    }
+    cache.insert(id, result);
+    Ok(result)
+}
+
+fn lower_control(
+    artifact: &FrontendArtifact,
+    signal: SignalId,
+    active: ActiveLevel,
+    builder: &mut SIRBuilder<RegionedSourceAddr>,
+) -> Result<RegisterId, FrontendArtifactError> {
+    let signal_info = artifact
+        .signal(signal)
+        .ok_or(FrontendArtifactError::UnknownSignal(signal.index()))?;
+    let loaded = alloc_register(builder, signal_info.value_type());
+    builder.emit(SIRInstruction::Load(
+        loaded,
+        RegionedSourceAddr {
+            region: STABLE_REGION,
+            var_id: source_id(signal),
+        },
+        SIROffset::Static(0),
+        1,
+    ));
+    let two_state = if signal_info.value_type().is_four_state() {
+        let result = builder.alloc_bit(1, false);
+        builder.emit(SIRInstruction::Unary(result, UnaryOp::ToTwoState, loaded));
+        result
+    } else {
+        loaded
+    };
+    if active == ActiveLevel::High {
+        return Ok(two_state);
+    }
+    let inverted = builder.alloc_bit(1, false);
+    builder.emit(SIRInstruction::Unary(
+        inverted,
+        UnaryOp::LogicNot,
+        two_state,
+    ));
+    Ok(inverted)
+}
+
+fn seal_builder(mut builder: SIRBuilder<RegionedSourceAddr>) -> ExecutionUnit<RegionedSourceAddr> {
+    builder.seal_block(SIRTerminator::Return);
+    let (blocks, register_map, _) = builder.drain();
+    ExecutionUnit {
+        entry_block_id: BlockId(0),
+        blocks,
+        register_map,
+    }
+}
+
+fn insert_or_merge(
+    blocks: &mut HashMap<TriggerSet<SourceVarId>, ExecutionUnit<RegionedSourceAddr>>,
+    trigger: TriggerSet<SourceVarId>,
+    unit: ExecutionUnit<RegionedSourceAddr>,
+) {
+    if let Some(existing) = blocks.remove(&trigger) {
+        blocks.insert(trigger, merge_sir_eus(&[existing, unit]).0);
+    } else {
+        blocks.insert(trigger, unit);
+    }
+}
+
+fn lower_registers(
+    artifact: &FrontendArtifact,
+    eval_only: &mut HashMap<TriggerSet<SourceVarId>, ExecutionUnit<RegionedSourceAddr>>,
+    apply: &mut HashMap<TriggerSet<SourceVarId>, ExecutionUnit<RegionedSourceAddr>>,
+    eval_apply: &mut HashMap<TriggerSet<SourceVarId>, ExecutionUnit<RegionedSourceAddr>>,
+    reset_clock_map: &mut HashMap<SourceVarId, SourceVarId>,
+) -> Result<(), FrontendArtifactError> {
+    for register in artifact.registers() {
+        let target = register.target();
+        let target_id = source_id(target.signal());
+        let trigger = TriggerSet {
+            clock: source_id(register.clock()),
+            resets: register
+                .async_reset()
+                .into_iter()
+                .map(|reset| source_id(reset.signal()))
+                .collect(),
+        };
+        if let Some(reset) = register.async_reset() {
+            reset_clock_map.insert(source_id(reset.signal()), source_id(register.clock()));
+        }
+
+        let build_eval =
+            |commit: bool| -> Result<ExecutionUnit<RegionedSourceAddr>, FrontendArtifactError> {
+                let mut builder = SIRBuilder::new();
+                builder.emit(SIRInstruction::Commit(
+                    RegionedSourceAddr {
+                        region: STABLE_REGION,
+                        var_id: target_id,
+                    },
+                    RegionedSourceAddr {
+                        region: WORKING_REGION,
+                        var_id: target_id,
+                    },
+                    SIROffset::Static(0),
+                    target.width(),
+                    Vec::new(),
+                ));
+                let mut cache = HashMap::default();
+                let mut next =
+                    lower_sir_expression(artifact, register.next(), &mut builder, &mut cache)?;
+                if let Some(enable) = register.enable() {
+                    let condition =
+                        lower_control(artifact, enable.signal(), enable.active(), &mut builder)?;
+                    let target_info = artifact.signal(target.signal()).ok_or(
+                        FrontendArtifactError::UnknownSignal(target.signal().index()),
+                    )?;
+                    let current = alloc_register(&mut builder, target_info.value_type());
+                    builder.emit(SIRInstruction::Load(
+                        current,
+                        RegionedSourceAddr {
+                            region: STABLE_REGION,
+                            var_id: target_id,
+                        },
+                        SIROffset::Static(0),
+                        target.width(),
+                    ));
+                    let selected = alloc_register(&mut builder, target_info.value_type());
+                    builder.emit(SIRInstruction::Mux(selected, condition, next, current));
+                    next = selected;
+                }
+                if let Some(reset) = register.async_reset() {
+                    let condition =
+                        lower_control(artifact, reset.signal(), reset.active(), &mut builder)?;
+                    let reset_value =
+                        lower_sir_expression(artifact, reset.value(), &mut builder, &mut cache)?;
+                    let target_info = artifact.signal(target.signal()).ok_or(
+                        FrontendArtifactError::UnknownSignal(target.signal().index()),
+                    )?;
+                    let selected = alloc_register(&mut builder, target_info.value_type());
+                    builder.emit(SIRInstruction::Mux(selected, condition, reset_value, next));
+                    next = selected;
+                }
+                builder.emit(SIRInstruction::Store(
+                    RegionedSourceAddr {
+                        region: WORKING_REGION,
+                        var_id: target_id,
+                    },
+                    SIROffset::Static(0),
+                    target.width(),
+                    next,
+                    Vec::new(),
+                    Vec::new(),
+                ));
+                if commit {
+                    builder.emit(SIRInstruction::Commit(
+                        RegionedSourceAddr {
+                            region: WORKING_REGION,
+                            var_id: target_id,
+                        },
+                        RegionedSourceAddr {
+                            region: STABLE_REGION,
+                            var_id: target_id,
+                        },
+                        SIROffset::Static(0),
+                        target.width(),
+                        Vec::new(),
+                    ));
+                }
+                Ok(seal_builder(builder))
+            };
+
+        let mut apply_builder = SIRBuilder::new();
+        apply_builder.emit(SIRInstruction::Commit(
+            RegionedSourceAddr {
+                region: WORKING_REGION,
+                var_id: target_id,
+            },
+            RegionedSourceAddr {
+                region: STABLE_REGION,
+                var_id: target_id,
+            },
+            SIROffset::Static(0),
+            target.width(),
+            Vec::new(),
+        ));
+        insert_or_merge(eval_only, trigger.clone(), build_eval(false)?);
+        insert_or_merge(apply, trigger.clone(), seal_builder(apply_builder));
+        insert_or_merge(eval_apply, trigger, build_eval(true)?);
+    }
+    Ok(())
+}
+
+fn set_role(
+    roles: &mut HashMap<SignalId, (DomainKind, PortTypeKind)>,
+    artifact: &FrontendArtifact,
+    signal: SignalId,
+    role: (DomainKind, PortTypeKind),
+) -> Result<(), FrontendArtifactError> {
+    if let Some(existing) = roles.get(&signal) {
+        if *existing != role {
+            let signal = artifact
+                .signal(signal)
+                .ok_or(FrontendArtifactError::UnknownSignal(signal.index()))?;
+            return Err(FrontendArtifactError::ConflictingSignalRole {
+                signal: signal.name().to_string(),
+            });
+        }
+    } else {
+        roles.insert(signal, role);
+    }
+    Ok(())
+}
+
+/// Validate and project a stable SDK artifact into Celox symbolic structures.
+pub fn lower_frontend_artifact(
+    artifact: &FrontendArtifact,
+) -> Result<LoweredFrontendArtifact, FrontendArtifactError> {
+    artifact.validate()?;
+    let mut roles = HashMap::default();
+    for register in artifact.registers() {
+        set_role(
+            &mut roles,
+            artifact,
+            register.clock(),
+            match register.edge() {
+                Edge::Posedge => (DomainKind::ClockPosedge, PortTypeKind::Clock),
+                Edge::Negedge => (DomainKind::ClockNegedge, PortTypeKind::Clock),
+            },
+        )?;
+        if let Some(reset) = register.async_reset() {
+            set_role(
+                &mut roles,
+                artifact,
+                reset.signal(),
+                match reset.active() {
+                    ActiveLevel::High => (DomainKind::ResetAsyncHigh, PortTypeKind::ResetAsyncHigh),
+                    ActiveLevel::Low => (DomainKind::ResetAsyncLow, PortTypeKind::ResetAsyncLow),
+                },
+            )?;
+        }
+    }
+
+    let variables = artifact
+        .signals()
+        .iter()
+        .map(|signal| {
+            let (kind, type_kind) = roles.get(&signal.id()).copied().unwrap_or((
+                DomainKind::Other,
+                if signal.value_type().is_four_state() {
+                    PortTypeKind::Logic
+                } else {
+                    PortTypeKind::Bit
+                },
+            ));
+            let variable_kind = match signal.direction() {
+                Direction::Input => VariableKind::Input,
+                Direction::Output => VariableKind::Output,
+                Direction::Inout => VariableKind::Inout,
+                Direction::Internal => VariableKind::Variable,
+                _ => VariableKind::Variable,
+            };
+            (
+                source_id(signal.id()),
+                SymbolicVariable {
+                    path: vec![signal.name().to_string()],
+                    kind: variable_kind,
+                    signed: signal.value_type().is_signed(),
+                    metadata: VariableMetadata {
+                        width: signal.value_type().width(),
+                        is_4state: signal.value_type().is_four_state(),
+                        kind,
+                        type_kind,
+                        array_dims: Vec::new(),
+                    },
+                    packed_dims: vec![signal.value_type().width()],
+                    source: None,
+                    module_affiliated: true,
+                },
+            )
+        })
+        .collect();
+
+    let mut arena = SLTNodeArena::new();
+    let mut node_cache = HashMap::default();
+    let mut comb_blocks = Vec::new();
+    for assignment in artifact.assignments() {
+        let mut sources = HashSet::default();
+        expression_sources(artifact, assignment.value(), &mut sources)?;
+        comb_blocks.push(LogicPath {
+            target: LogicPathTarget::Var(signal_atom(assignment.target())),
+            sources,
+            previous_sources: HashSet::default(),
+            address_sources: HashSet::default(),
+            local_inputs: Vec::new(),
+            order_before: HashSet::default(),
+            comb_capture_enable_sites: Vec::new(),
+            comb_capture_enable_always: false,
+            pre_lower_nodes: Vec::new(),
+            expr: lower_slt_expression(artifact, assignment.value(), &mut arena, &mut node_cache)?,
+        });
+    }
+
+    let mut eval_only_ff_blocks = HashMap::default();
+    let mut apply_ff_blocks = HashMap::default();
+    let mut eval_apply_ff_blocks = HashMap::default();
+    let mut reset_clock_map = HashMap::default();
+    lower_registers(
+        artifact,
+        &mut eval_only_ff_blocks,
+        &mut apply_ff_blocks,
+        &mut eval_apply_ff_blocks,
+        &mut reset_clock_map,
+    )?;
+
+    let initial_memory_values = artifact
+        .signals()
+        .iter()
+        .filter_map(|signal| {
+            signal.initial().map(|initial| InitialStateValue {
+                address: source_id(signal.id()),
+                data: InitialStateData::Packed {
+                    value: initial.payload().clone(),
+                    mask: initial.mask().clone(),
+                    written_mask: (num_bigint::BigUint::from(1u8) << signal.value_type().width())
+                        - num_bigint::BigUint::from(1u8),
+                },
+            })
+        })
+        .collect();
+
+    let module_id = ModuleId(0);
+    let sim_module = SimModule {
+        name: artifact.module_name().to_string(),
+        variables,
+        ff_access_summaries: HashMap::default(),
+        eval_only_ff_blocks,
+        apply_ff_blocks,
+        eval_apply_ff_blocks,
+        glue_blocks: HashMap::default(),
+        indexed_instance_names: HashSet::default(),
+        comb_blocks,
+        comb_observers: Vec::new(),
+        runtime_errors: HashMap::default(),
+        runtime_event_sites: Vec::new(),
+        initial_memory_values,
+        comb_boundaries: HashMap::default(),
+        arena,
+        reset_clock_map,
+    };
+    let symbolic = SymbolicRtl {
+        modules: [(module_id, sim_module.clone())].into_iter().collect(),
+        module_names: [(module_id, artifact.module_name().to_string())]
+            .into_iter()
+            .collect(),
+        root_id: module_id,
+    };
+    let external = ExternalHierarchy {
+        modules: [(
+            module_id,
+            ExternalModule {
+                sim_module,
+                port_order: artifact
+                    .port_order()
+                    .iter()
+                    .map(|signal| source_id(*signal))
+                    .collect(),
+                unresolved_instances: Vec::new(),
+            },
+        )]
+        .into_iter()
+        .collect(),
+        roots: [(artifact.module_name().to_string(), module_id)]
+            .into_iter()
+            .collect(),
+    };
+    Ok(LoweredFrontendArtifact { symbolic, external })
+}

--- a/crates/celox-frontend-core/src/sdk.rs
+++ b/crates/celox-frontend-core/src/sdk.rs
@@ -7,6 +7,7 @@ use celox_design::{
 };
 use celox_frontend_sdk::{
     ActiveLevel, Direction, Edge, ExprId, ExprNode, FrontendArtifact, SignalId, SignalSlice,
+    ValueType,
 };
 use celox_sir::{
     BlockId, ExecutionUnit, RegisterId, SIRBuilder, SIRInstruction, SIROffset, SIRTerminator,
@@ -18,6 +19,7 @@ use thiserror::Error;
 use crate::symbolic::artifact::{
     ExternalHierarchy, ExternalModule, SimModule, SymbolicRtl, SymbolicVariable,
 };
+use crate::symbolic::width::coerce_node_width;
 use crate::{HashMap, HashSet, SourceVarId, VariableKind};
 
 type RegionedSourceAddr = RegionedVarAddrBase<SourceVarId>;
@@ -44,6 +46,14 @@ pub enum FrontendArtifactError {
     UnsupportedOperation,
     #[error("signal `{signal}` is used with conflicting clock/reset roles")]
     ConflictingSignalRole { signal: String },
+    #[error(
+        "async reset `{reset}` is shared by distinct clock domains `{first_clock}` and `{second_clock}`"
+    )]
+    SharedResetAcrossClocks {
+        reset: String,
+        first_clock: String,
+        second_clock: String,
+    },
     #[error("frontend SDK expression is invalid: {0}")]
     InvalidExpression(#[from] celox_slt::SLTNodeFactsError),
 }
@@ -113,7 +123,11 @@ fn expression_sources(
     artifact: &FrontendArtifact,
     id: ExprId,
     sources: &mut HashSet<VarAtomBase<SourceVarId>>,
+    visited: &mut HashSet<ExprId>,
 ) -> Result<(), FrontendArtifactError> {
+    if !visited.insert(id) {
+        return Ok(());
+    }
     let expression = artifact
         .expression(id)
         .ok_or(FrontendArtifactError::UnknownExpression(id.index()))?;
@@ -123,29 +137,67 @@ fn expression_sources(
         }
         ExprNode::Constant(_) => {}
         ExprNode::Binary { lhs, rhs, .. } => {
-            expression_sources(artifact, *lhs, sources)?;
-            expression_sources(artifact, *rhs, sources)?;
+            expression_sources(artifact, *lhs, sources, visited)?;
+            expression_sources(artifact, *rhs, sources, visited)?;
         }
         ExprNode::Unary { input, .. } | ExprNode::Slice { input, .. } => {
-            expression_sources(artifact, *input, sources)?;
+            expression_sources(artifact, *input, sources, visited)?;
         }
         ExprNode::Mux {
             condition,
             then_expr,
             else_expr,
         } => {
-            expression_sources(artifact, *condition, sources)?;
-            expression_sources(artifact, *then_expr, sources)?;
-            expression_sources(artifact, *else_expr, sources)?;
+            expression_sources(artifact, *condition, sources, visited)?;
+            expression_sources(artifact, *then_expr, sources, visited)?;
+            expression_sources(artifact, *else_expr, sources, visited)?;
         }
         ExprNode::Concat(parts) => {
             for part in parts {
-                expression_sources(artifact, *part, sources)?;
+                expression_sources(artifact, *part, sources, visited)?;
             }
         }
         _ => return Err(FrontendArtifactError::UnsupportedOperation),
     }
     Ok(())
+}
+
+fn coerce_slt_expression(
+    artifact: &FrontendArtifact,
+    id: ExprId,
+    target_width: usize,
+    arena: &mut SLTNodeArena<SourceVarId>,
+    cache: &mut HashMap<ExprId, NodeId>,
+) -> Result<NodeId, FrontendArtifactError> {
+    let value_type = artifact
+        .expression(id)
+        .ok_or(FrontendArtifactError::UnknownExpression(id.index()))?
+        .value_type();
+    let node = lower_slt_expression(artifact, id, arena, cache)?;
+    Ok(coerce_node_width(
+        arena,
+        node,
+        Some(target_width),
+        value_type.is_signed(),
+    )?)
+}
+
+fn finish_slt_expression(
+    arena: &mut SLTNodeArena<SourceVarId>,
+    node: NodeId,
+    value_type: ValueType,
+) -> Result<NodeId, FrontendArtifactError> {
+    let node = coerce_node_width(
+        arena,
+        node,
+        Some(value_type.width()),
+        value_type.is_signed(),
+    )?;
+    if value_type.is_four_state() {
+        Ok(node)
+    } else {
+        Ok(arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, node))?)
+    }
 }
 
 fn lower_slt_expression(
@@ -163,11 +215,7 @@ fn lower_slt_expression(
     let node = match expression.node() {
         ExprNode::Signal(slice) => SLTNode::Input {
             variable: source_id(slice.signal()),
-            signed: artifact
-                .signal(slice.signal())
-                .ok_or(FrontendArtifactError::UnknownSignal(slice.signal().index()))?
-                .value_type()
-                .is_signed(),
+            signed: expression.value_type().is_signed(),
             index: Vec::new(),
             access: BitAccess::new(slice.lsb(), slice.lsb() + slice.width() - 1),
         },
@@ -177,23 +225,106 @@ fn lower_slt_expression(
             value.value_type().width(),
             value.value_type().is_signed(),
         ),
-        ExprNode::Binary { op, lhs, rhs } => SLTNode::Binary(
-            lower_slt_expression(artifact, *lhs, arena, cache)?,
-            binary_op(*op)?,
-            lower_slt_expression(artifact, *rhs, arena, cache)?,
-        ),
-        ExprNode::Unary { op, input } => SLTNode::Unary(
-            unary_op(*op)?,
-            lower_slt_expression(artifact, *input, arena, cache)?,
-        ),
+        ExprNode::Binary { op, lhs, rhs } => {
+            use celox_frontend_sdk::BinaryOp as SdkBinaryOp;
+
+            let lhs_type = artifact
+                .expression(*lhs)
+                .ok_or(FrontendArtifactError::UnknownExpression(lhs.index()))?
+                .value_type();
+            let rhs_type = artifact
+                .expression(*rhs)
+                .ok_or(FrontendArtifactError::UnknownExpression(rhs.index()))?
+                .value_type();
+            let (lhs, rhs) = match op {
+                SdkBinaryOp::ShiftLeft
+                | SdkBinaryOp::ShiftRight
+                | SdkBinaryOp::ArithmeticShiftRight => (
+                    coerce_slt_expression(
+                        artifact,
+                        *lhs,
+                        expression.value_type().width(),
+                        arena,
+                        cache,
+                    )?,
+                    lower_slt_expression(artifact, *rhs, arena, cache)?,
+                ),
+                SdkBinaryOp::Equal
+                | SdkBinaryOp::NotEqual
+                | SdkBinaryOp::CaseEqual
+                | SdkBinaryOp::CaseNotEqual
+                | SdkBinaryOp::LessUnsigned
+                | SdkBinaryOp::LessSigned
+                | SdkBinaryOp::LessEqualUnsigned
+                | SdkBinaryOp::LessEqualSigned
+                | SdkBinaryOp::GreaterUnsigned
+                | SdkBinaryOp::GreaterSigned
+                | SdkBinaryOp::GreaterEqualUnsigned
+                | SdkBinaryOp::GreaterEqualSigned => {
+                    let operand_width = lhs_type.width().max(rhs_type.width());
+                    (
+                        coerce_slt_expression(artifact, *lhs, operand_width, arena, cache)?,
+                        coerce_slt_expression(artifact, *rhs, operand_width, arena, cache)?,
+                    )
+                }
+                SdkBinaryOp::LogicAnd | SdkBinaryOp::LogicOr => (
+                    lower_slt_expression(artifact, *lhs, arena, cache)?,
+                    lower_slt_expression(artifact, *rhs, arena, cache)?,
+                ),
+                _ => (
+                    coerce_slt_expression(
+                        artifact,
+                        *lhs,
+                        expression.value_type().width(),
+                        arena,
+                        cache,
+                    )?,
+                    coerce_slt_expression(
+                        artifact,
+                        *rhs,
+                        expression.value_type().width(),
+                        arena,
+                        cache,
+                    )?,
+                ),
+            };
+            SLTNode::Binary(lhs, binary_op(*op)?, rhs)
+        }
+        ExprNode::Unary { op, input } => {
+            let input = match op {
+                celox_frontend_sdk::UnaryOp::Negate | celox_frontend_sdk::UnaryOp::BitNot => {
+                    coerce_slt_expression(
+                        artifact,
+                        *input,
+                        expression.value_type().width(),
+                        arena,
+                        cache,
+                    )?
+                }
+                _ => lower_slt_expression(artifact, *input, arena, cache)?,
+            };
+            SLTNode::Unary(unary_op(*op)?, input)
+        }
         ExprNode::Mux {
             condition,
             then_expr,
             else_expr,
         } => SLTNode::Mux {
             cond: lower_slt_expression(artifact, *condition, arena, cache)?,
-            then_expr: lower_slt_expression(artifact, *then_expr, arena, cache)?,
-            else_expr: lower_slt_expression(artifact, *else_expr, arena, cache)?,
+            then_expr: coerce_slt_expression(
+                artifact,
+                *then_expr,
+                expression.value_type().width(),
+                arena,
+                cache,
+            )?,
+            else_expr: coerce_slt_expression(
+                artifact,
+                *else_expr,
+                expression.value_type().width(),
+                arena,
+                cache,
+            )?,
         },
         ExprNode::Concat(parts) => SLTNode::Concat(
             parts
@@ -216,6 +347,7 @@ fn lower_slt_expression(
         _ => return Err(FrontendArtifactError::UnsupportedOperation),
     };
     let node = arena.alloc(node)?;
+    let node = finish_slt_expression(arena, node, expression.value_type())?;
     cache.insert(id, node);
     Ok(node)
 }
@@ -378,7 +510,28 @@ fn lower_registers(
                 .collect(),
         };
         if let Some(reset) = register.async_reset() {
-            reset_clock_map.insert(source_id(reset.signal()), source_id(register.clock()));
+            let reset_id = source_id(reset.signal());
+            let clock_id = source_id(register.clock());
+            if let Some(first_clock_id) = reset_clock_map.get(&reset_id)
+                && *first_clock_id != clock_id
+            {
+                let signal_name = |id: SignalId| {
+                    artifact
+                        .signal(id)
+                        .map(|signal| signal.name().to_string())
+                        .ok_or(FrontendArtifactError::UnknownSignal(id.index()))
+                };
+                let first_clock = artifact
+                    .signals()
+                    .get(first_clock_id.0 as usize)
+                    .ok_or(FrontendArtifactError::UnknownSignal(first_clock_id.0))?;
+                return Err(FrontendArtifactError::SharedResetAcrossClocks {
+                    reset: signal_name(reset.signal())?,
+                    first_clock: first_clock.name().to_string(),
+                    second_clock: signal_name(register.clock())?,
+                });
+            }
+            reset_clock_map.insert(reset_id, clock_id);
         }
 
         let build_eval =
@@ -577,7 +730,8 @@ pub fn lower_frontend_artifact(
     let mut comb_blocks = Vec::new();
     for assignment in artifact.assignments() {
         let mut sources = HashSet::default();
-        expression_sources(artifact, assignment.value(), &mut sources)?;
+        let mut visited = HashSet::default();
+        expression_sources(artifact, assignment.value(), &mut sources, &mut visited)?;
         comb_blocks.push(LogicPath {
             target: LogicPathTarget::Var(signal_atom(assignment.target())),
             sources,

--- a/crates/celox-frontend-core/src/sdk.rs
+++ b/crates/celox-frontend-core/src/sdk.rs
@@ -878,6 +878,10 @@ fn lower_registers(
         let build_eval =
             |commit: bool| -> Result<ExecutionUnit<RegionedSourceAddr>, FrontendArtifactError> {
                 let mut builder = SIRBuilder::new();
+                let target_info = artifact.signal(target.signal()).ok_or(
+                    FrontendArtifactError::UnknownSignal(target.signal().index()),
+                )?;
+                let target_type = target_info.value_type();
                 builder.emit(SIRInstruction::Commit(
                     RegionedSourceAddr {
                         region: STABLE_REGION,
@@ -892,15 +896,17 @@ fn lower_registers(
                     Vec::new(),
                 ));
                 let mut cache = HashMap::default();
-                let mut next =
-                    lower_sir_expression(artifact, register.next(), &mut builder, &mut cache)?;
+                let mut next = coerce_sir_expression(
+                    artifact,
+                    register.next(),
+                    target_type,
+                    &mut builder,
+                    &mut cache,
+                )?;
                 if let Some(enable) = register.enable() {
                     let condition =
                         lower_control(artifact, enable.signal(), enable.active(), &mut builder)?;
-                    let target_info = artifact.signal(target.signal()).ok_or(
-                        FrontendArtifactError::UnknownSignal(target.signal().index()),
-                    )?;
-                    let current = alloc_register(&mut builder, target_info.value_type());
+                    let current = alloc_register(&mut builder, target_type);
                     builder.emit(SIRInstruction::Load(
                         current,
                         RegionedSourceAddr {
@@ -910,19 +916,21 @@ fn lower_registers(
                         SIROffset::Static(0),
                         target.width(),
                     ));
-                    let selected = alloc_register(&mut builder, target_info.value_type());
+                    let selected = alloc_register(&mut builder, target_type);
                     builder.emit(SIRInstruction::Mux(selected, condition, next, current));
                     next = selected;
                 }
                 if let Some(reset) = register.async_reset() {
                     let condition =
                         lower_control(artifact, reset.signal(), reset.active(), &mut builder)?;
-                    let reset_value =
-                        lower_sir_expression(artifact, reset.value(), &mut builder, &mut cache)?;
-                    let target_info = artifact.signal(target.signal()).ok_or(
-                        FrontendArtifactError::UnknownSignal(target.signal().index()),
+                    let reset_value = coerce_sir_expression(
+                        artifact,
+                        reset.value(),
+                        target_type,
+                        &mut builder,
+                        &mut cache,
                     )?;
-                    let selected = alloc_register(&mut builder, target_info.value_type());
+                    let selected = alloc_register(&mut builder, target_type);
                     builder.emit(SIRInstruction::Mux(selected, condition, reset_value, next));
                     next = selected;
                 }

--- a/crates/celox-frontend-core/src/sdk.rs
+++ b/crates/celox-frontend-core/src/sdk.rs
@@ -363,6 +363,97 @@ fn alloc_register(
     }
 }
 
+fn coerce_sir_register(
+    builder: &mut SIRBuilder<RegionedSourceAddr>,
+    input: RegisterId,
+    input_type: ValueType,
+    target_type: ValueType,
+) -> Result<RegisterId, FrontendArtifactError> {
+    let mut current = input;
+    let mut current_type = input_type;
+
+    if current_type.width() > target_type.width() {
+        let narrowed_type = ValueType::new(
+            target_type.width(),
+            current_type.is_signed(),
+            current_type.is_four_state(),
+        )?;
+        let narrowed = alloc_register(builder, narrowed_type);
+        builder.emit(SIRInstruction::Slice(
+            narrowed,
+            current,
+            0,
+            target_type.width(),
+        ));
+        current = narrowed;
+        current_type = narrowed_type;
+    } else if current_type.width() < target_type.width() {
+        let extension_width = target_type.width() - current_type.width();
+        let extension_type = ValueType::new(extension_width, false, current_type.is_four_state())?;
+        let extension = alloc_register(builder, extension_type);
+        if current_type.is_signed() {
+            let sign_type = ValueType::new(1, false, current_type.is_four_state())?;
+            let sign = alloc_register(builder, sign_type);
+            builder.emit(SIRInstruction::Slice(
+                sign,
+                current,
+                current_type.width() - 1,
+                1,
+            ));
+            builder.emit(SIRInstruction::Concat(
+                extension,
+                vec![sign; extension_width],
+            ));
+        } else {
+            builder.emit(SIRInstruction::Imm(extension, SIRValue::new(0u8)));
+        }
+        let widened_type = ValueType::new(
+            target_type.width(),
+            current_type.is_signed(),
+            current_type.is_four_state(),
+        )?;
+        let widened = alloc_register(builder, widened_type);
+        builder.emit(SIRInstruction::Concat(widened, vec![extension, current]));
+        current = widened;
+        current_type = widened_type;
+    }
+
+    if current_type.is_four_state() && !target_type.is_four_state() {
+        let converted = alloc_register(builder, target_type);
+        builder.emit(SIRInstruction::Unary(
+            converted,
+            UnaryOp::ToTwoState,
+            current,
+        ));
+        return Ok(converted);
+    }
+
+    if current_type.is_four_state() != target_type.is_four_state()
+        || (!target_type.is_four_state() && current_type.is_signed() != target_type.is_signed())
+    {
+        let converted = alloc_register(builder, target_type);
+        builder.emit(SIRInstruction::Unary(converted, UnaryOp::Ident, current));
+        return Ok(converted);
+    }
+
+    Ok(current)
+}
+
+fn coerce_sir_expression(
+    artifact: &FrontendArtifact,
+    id: ExprId,
+    target_type: ValueType,
+    builder: &mut SIRBuilder<RegionedSourceAddr>,
+    cache: &mut HashMap<ExprId, RegisterId>,
+) -> Result<RegisterId, FrontendArtifactError> {
+    let input_type = artifact
+        .expression(id)
+        .ok_or(FrontendArtifactError::UnknownExpression(id.index()))?
+        .value_type();
+    let input = lower_sir_expression(artifact, id, builder, cache)?;
+    coerce_sir_register(builder, input, input_type, target_type)
+}
+
 fn lower_sir_expression(
     artifact: &FrontendArtifact,
     id: ExprId,
@@ -375,58 +466,308 @@ fn lower_sir_expression(
     let expression = artifact
         .expression(id)
         .ok_or(FrontendArtifactError::UnknownExpression(id.index()))?;
-    let result = alloc_register(builder, expression.value_type());
-    match expression.node() {
-        ExprNode::Signal(slice) => builder.emit(SIRInstruction::Load(
-            result,
-            RegionedSourceAddr {
-                region: STABLE_REGION,
-                var_id: source_id(slice.signal()),
-            },
-            SIROffset::Static(slice.lsb()),
-            slice.width(),
-        )),
-        ExprNode::Constant(value) => builder.emit(SIRInstruction::Imm(
-            result,
-            SIRValue::new_four_state(value.payload().clone(), value.mask().clone()),
-        )),
+    let result = match expression.node() {
+        ExprNode::Signal(slice) => {
+            let result = alloc_register(builder, expression.value_type());
+            builder.emit(SIRInstruction::Load(
+                result,
+                RegionedSourceAddr {
+                    region: STABLE_REGION,
+                    var_id: source_id(slice.signal()),
+                },
+                SIROffset::Static(slice.lsb()),
+                slice.width(),
+            ));
+            result
+        }
+        ExprNode::Constant(value) => {
+            let result = alloc_register(builder, expression.value_type());
+            builder.emit(SIRInstruction::Imm(
+                result,
+                SIRValue::new_four_state(value.payload().clone(), value.mask().clone()),
+            ));
+            result
+        }
         ExprNode::Binary { op, lhs, rhs } => {
-            let lhs = lower_sir_expression(artifact, *lhs, builder, cache)?;
-            let rhs = lower_sir_expression(artifact, *rhs, builder, cache)?;
-            builder.emit(SIRInstruction::Binary(result, lhs, binary_op(*op)?, rhs));
+            use celox_frontend_sdk::BinaryOp as SdkBinaryOp;
+
+            let lhs_type = artifact
+                .expression(*lhs)
+                .ok_or(FrontendArtifactError::UnknownExpression(lhs.index()))?
+                .value_type();
+            let rhs_type = artifact
+                .expression(*rhs)
+                .ok_or(FrontendArtifactError::UnknownExpression(rhs.index()))?
+                .value_type();
+            let (lhs, rhs) = match op {
+                SdkBinaryOp::ShiftLeft
+                | SdkBinaryOp::ShiftRight
+                | SdkBinaryOp::ArithmeticShiftRight => (
+                    coerce_sir_expression(
+                        artifact,
+                        *lhs,
+                        ValueType::new(
+                            expression.value_type().width(),
+                            lhs_type.is_signed(),
+                            lhs_type.is_four_state(),
+                        )?,
+                        builder,
+                        cache,
+                    )?,
+                    lower_sir_expression(artifact, *rhs, builder, cache)?,
+                ),
+                SdkBinaryOp::Equal
+                | SdkBinaryOp::NotEqual
+                | SdkBinaryOp::CaseEqual
+                | SdkBinaryOp::CaseNotEqual
+                | SdkBinaryOp::LessUnsigned
+                | SdkBinaryOp::LessSigned
+                | SdkBinaryOp::LessEqualUnsigned
+                | SdkBinaryOp::LessEqualSigned
+                | SdkBinaryOp::GreaterUnsigned
+                | SdkBinaryOp::GreaterSigned
+                | SdkBinaryOp::GreaterEqualUnsigned
+                | SdkBinaryOp::GreaterEqualSigned => {
+                    let width = lhs_type.width().max(rhs_type.width());
+                    (
+                        coerce_sir_expression(
+                            artifact,
+                            *lhs,
+                            ValueType::new(width, lhs_type.is_signed(), lhs_type.is_four_state())?,
+                            builder,
+                            cache,
+                        )?,
+                        coerce_sir_expression(
+                            artifact,
+                            *rhs,
+                            ValueType::new(width, rhs_type.is_signed(), rhs_type.is_four_state())?,
+                            builder,
+                            cache,
+                        )?,
+                    )
+                }
+                SdkBinaryOp::LogicAnd | SdkBinaryOp::LogicOr => (
+                    lower_sir_expression(artifact, *lhs, builder, cache)?,
+                    lower_sir_expression(artifact, *rhs, builder, cache)?,
+                ),
+                _ => (
+                    coerce_sir_expression(
+                        artifact,
+                        *lhs,
+                        ValueType::new(
+                            expression.value_type().width(),
+                            lhs_type.is_signed(),
+                            lhs_type.is_four_state(),
+                        )?,
+                        builder,
+                        cache,
+                    )?,
+                    coerce_sir_expression(
+                        artifact,
+                        *rhs,
+                        ValueType::new(
+                            expression.value_type().width(),
+                            rhs_type.is_signed(),
+                            rhs_type.is_four_state(),
+                        )?,
+                        builder,
+                        cache,
+                    )?,
+                ),
+            };
+            let is_boolean = matches!(
+                op,
+                SdkBinaryOp::Equal
+                    | SdkBinaryOp::NotEqual
+                    | SdkBinaryOp::CaseEqual
+                    | SdkBinaryOp::CaseNotEqual
+                    | SdkBinaryOp::LessUnsigned
+                    | SdkBinaryOp::LessSigned
+                    | SdkBinaryOp::LessEqualUnsigned
+                    | SdkBinaryOp::LessEqualSigned
+                    | SdkBinaryOp::GreaterUnsigned
+                    | SdkBinaryOp::GreaterSigned
+                    | SdkBinaryOp::GreaterEqualUnsigned
+                    | SdkBinaryOp::GreaterEqualSigned
+                    | SdkBinaryOp::LogicAnd
+                    | SdkBinaryOp::LogicOr
+            );
+            let case_equality = matches!(op, SdkBinaryOp::CaseEqual | SdkBinaryOp::CaseNotEqual);
+            let operation_four_state = expression.value_type().is_four_state()
+                || (!case_equality && (lhs_type.is_four_state() || rhs_type.is_four_state()));
+            let operation_type = ValueType::new(
+                if is_boolean {
+                    1
+                } else {
+                    expression.value_type().width()
+                },
+                !is_boolean && expression.value_type().is_signed(),
+                operation_four_state,
+            )?;
+            let operation_result = alloc_register(builder, operation_type);
+            builder.emit(SIRInstruction::Binary(
+                operation_result,
+                lhs,
+                binary_op(*op)?,
+                rhs,
+            ));
+            coerce_sir_register(
+                builder,
+                operation_result,
+                operation_type,
+                expression.value_type(),
+            )?
         }
         ExprNode::Unary { op, input } => {
-            let input = lower_sir_expression(artifact, *input, builder, cache)?;
-            builder.emit(SIRInstruction::Unary(result, unary_op(*op)?, input));
+            use celox_frontend_sdk::UnaryOp as SdkUnaryOp;
+
+            let input_type = artifact
+                .expression(*input)
+                .ok_or(FrontendArtifactError::UnknownExpression(input.index()))?
+                .value_type();
+            let (input, operation_type) = match op {
+                SdkUnaryOp::Negate | SdkUnaryOp::BitNot => (
+                    coerce_sir_expression(
+                        artifact,
+                        *input,
+                        ValueType::new(
+                            expression.value_type().width(),
+                            input_type.is_signed(),
+                            input_type.is_four_state(),
+                        )?,
+                        builder,
+                        cache,
+                    )?,
+                    ValueType::new(
+                        expression.value_type().width(),
+                        expression.value_type().is_signed(),
+                        expression.value_type().is_four_state() || input_type.is_four_state(),
+                    )?,
+                ),
+                SdkUnaryOp::LogicNot
+                | SdkUnaryOp::ReduceAnd
+                | SdkUnaryOp::ReduceOr
+                | SdkUnaryOp::ReduceXor => (
+                    lower_sir_expression(artifact, *input, builder, cache)?,
+                    ValueType::new(
+                        1,
+                        false,
+                        expression.value_type().is_four_state() || input_type.is_four_state(),
+                    )?,
+                ),
+                SdkUnaryOp::ToTwoState => (
+                    lower_sir_expression(artifact, *input, builder, cache)?,
+                    ValueType::new(input_type.width(), input_type.is_signed(), false)?,
+                ),
+                SdkUnaryOp::PopCount
+                | SdkUnaryOp::CountLeadingZeros
+                | SdkUnaryOp::CountTrailingZeros => (
+                    lower_sir_expression(artifact, *input, builder, cache)?,
+                    ValueType::new(
+                        unary_op(*op)?.result_width(input_type.width()),
+                        false,
+                        expression.value_type().is_four_state() || input_type.is_four_state(),
+                    )?,
+                ),
+                _ => return Err(FrontendArtifactError::UnsupportedOperation),
+            };
+            let operation_result = alloc_register(builder, operation_type);
+            builder.emit(SIRInstruction::Unary(
+                operation_result,
+                unary_op(*op)?,
+                input,
+            ));
+            coerce_sir_register(
+                builder,
+                operation_result,
+                operation_type,
+                expression.value_type(),
+            )?
         }
         ExprNode::Mux {
             condition,
             then_expr,
             else_expr,
         } => {
+            let condition_type = artifact
+                .expression(*condition)
+                .ok_or(FrontendArtifactError::UnknownExpression(condition.index()))?
+                .value_type();
             let condition = lower_sir_expression(artifact, *condition, builder, cache)?;
-            let then_expr = lower_sir_expression(artifact, *then_expr, builder, cache)?;
-            let else_expr = lower_sir_expression(artifact, *else_expr, builder, cache)?;
-            builder.emit(SIRInstruction::Mux(result, condition, then_expr, else_expr));
+            let then_type = artifact
+                .expression(*then_expr)
+                .ok_or(FrontendArtifactError::UnknownExpression(then_expr.index()))?
+                .value_type();
+            let else_type = artifact
+                .expression(*else_expr)
+                .ok_or(FrontendArtifactError::UnknownExpression(else_expr.index()))?
+                .value_type();
+            let then_expr = coerce_sir_expression(
+                artifact,
+                *then_expr,
+                ValueType::new(
+                    expression.value_type().width(),
+                    then_type.is_signed(),
+                    then_type.is_four_state(),
+                )?,
+                builder,
+                cache,
+            )?;
+            let else_expr = coerce_sir_expression(
+                artifact,
+                *else_expr,
+                ValueType::new(
+                    expression.value_type().width(),
+                    else_type.is_signed(),
+                    else_type.is_four_state(),
+                )?,
+                builder,
+                cache,
+            )?;
+            let operation_type = ValueType::new(
+                expression.value_type().width(),
+                expression.value_type().is_signed(),
+                expression.value_type().is_four_state()
+                    || condition_type.is_four_state()
+                    || then_type.is_four_state()
+                    || else_type.is_four_state(),
+            )?;
+            let operation_result = alloc_register(builder, operation_type);
+            builder.emit(SIRInstruction::Mux(
+                operation_result,
+                condition,
+                then_expr,
+                else_expr,
+            ));
+            coerce_sir_register(
+                builder,
+                operation_result,
+                operation_type,
+                expression.value_type(),
+            )?
         }
         ExprNode::Concat(parts) => {
             let parts = parts
                 .iter()
                 .map(|part| lower_sir_expression(artifact, *part, builder, cache))
                 .collect::<Result<Vec<_>, _>>()?;
+            let result = alloc_register(builder, expression.value_type());
             builder.emit(SIRInstruction::Concat(result, parts));
+            result
         }
         ExprNode::Slice { input, lsb } => {
             let input = lower_sir_expression(artifact, *input, builder, cache)?;
+            let result = alloc_register(builder, expression.value_type());
             builder.emit(SIRInstruction::Slice(
                 result,
                 input,
                 *lsb,
                 expression.value_type().width(),
             ));
+            result
         }
         _ => return Err(FrontendArtifactError::UnsupportedOperation),
-    }
+    };
     cache.insert(id, result);
     Ok(result)
 }

--- a/crates/celox-frontend-core/src/sdk.rs
+++ b/crates/celox-frontend-core/src/sdk.rs
@@ -70,6 +70,21 @@ fn signal_atom(slice: SignalSlice) -> VarAtomBase<SourceVarId> {
     )
 }
 
+fn signal_slice_type(
+    artifact: &FrontendArtifact,
+    slice: SignalSlice,
+) -> Result<ValueType, FrontendArtifactError> {
+    let signal_type = artifact
+        .signal(slice.signal())
+        .ok_or(FrontendArtifactError::UnknownSignal(slice.signal().index()))?
+        .value_type();
+    Ok(ValueType::new(
+        slice.width(),
+        signal_type.is_signed() && slice.width() == signal_type.width(),
+        signal_type.is_four_state(),
+    )?)
+}
+
 fn binary_op(op: celox_frontend_sdk::BinaryOp) -> Result<BinaryOp, FrontendArtifactError> {
     Ok(match op {
         celox_frontend_sdk::BinaryOp::Add => BinaryOp::Add,
@@ -180,6 +195,25 @@ fn coerce_slt_expression(
         Some(target_width),
         value_type.is_signed(),
     )?)
+}
+
+fn coerce_slt_expression_to_type(
+    artifact: &FrontendArtifact,
+    id: ExprId,
+    target_type: ValueType,
+    arena: &mut SLTNodeArena<SourceVarId>,
+    cache: &mut HashMap<ExprId, NodeId>,
+) -> Result<NodeId, FrontendArtifactError> {
+    let value_type = artifact
+        .expression(id)
+        .ok_or(FrontendArtifactError::UnknownExpression(id.index()))?
+        .value_type();
+    let node = lower_slt_expression(artifact, id, arena, cache)?;
+    if value_type == target_type {
+        Ok(node)
+    } else {
+        finish_slt_expression(arena, node, target_type)
+    }
 }
 
 fn finish_slt_expression(
@@ -1082,6 +1116,7 @@ pub fn lower_frontend_artifact(
     let mut node_cache = HashMap::default();
     let mut comb_blocks = Vec::new();
     for assignment in artifact.assignments() {
+        let target_type = signal_slice_type(artifact, assignment.target())?;
         let mut sources = HashSet::default();
         let mut visited = HashSet::default();
         expression_sources(artifact, assignment.value(), &mut sources, &mut visited)?;
@@ -1095,7 +1130,13 @@ pub fn lower_frontend_artifact(
             comb_capture_enable_sites: Vec::new(),
             comb_capture_enable_always: false,
             pre_lower_nodes: Vec::new(),
-            expr: lower_slt_expression(artifact, assignment.value(), &mut arena, &mut node_cache)?,
+            expr: coerce_slt_expression_to_type(
+                artifact,
+                assignment.value(),
+                target_type,
+                &mut arena,
+                &mut node_cache,
+            )?,
         });
     }
 

--- a/crates/celox-frontend-sdk/Cargo.toml
+++ b/crates/celox-frontend-sdk/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "celox-frontend-sdk"
+version = "0.1.0"
+authors.workspace = true
+repository.workspace = true
+license.workspace = true
+description = "Stable authoring SDK for external Celox netlist frontends"
+readme = "README.md"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+fxhash = { workspace = true }
+num-bigint = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/celox-frontend-sdk/README.md
+++ b/crates/celox-frontend-sdk/README.md
@@ -34,3 +34,7 @@ equivalent is `runTestWithFrontendArtifact`.
 The versioned JSON representation is checked at decode time. Consumers should
 produce it through `to_json` instead of relying on its field spelling as a
 hand-authored format.
+
+Artifact format version 1 models one flattened module and does not support
+bidirectional (`inout`) signals. External frontends must lower them to separate
+input, output, and output-enable signals before building the artifact.

--- a/crates/celox-frontend-sdk/README.md
+++ b/crates/celox-frontend-sdk/README.md
@@ -1,0 +1,36 @@
+# celox-frontend-sdk
+
+`celox-frontend-sdk` is the stable authoring boundary for external Celox
+frontends. It models one flattened, elaborated netlist without depending on
+Celox scheduling, SIR, optimization, or backend crates.
+
+```rust
+use celox_frontend_sdk::{BinaryOp, ModuleBuilder, ValueType};
+
+let byte = ValueType::bits(8)?;
+let mut module = ModuleBuilder::new("Adder")?;
+let a = module.input("a", byte)?;
+let b = module.input("b", byte)?;
+let y = module.output("y", byte)?;
+let a = module.read(a)?;
+let b = module.read(b)?;
+let sum = module.binary(BinaryOp::Add, a, b, byte)?;
+let y = module.whole(y)?;
+module.assign(y, sum)?;
+let artifact = module.finish();
+# Ok::<(), celox_frontend_sdk::BuildError>(())
+```
+
+In Rust, pass the result to `celox::Simulator::from_frontend`. For TypeScript
+testbenches, serialize it with `FrontendArtifact::to_json` and call
+`Simulator.fromFrontendArtifact` or `Simulation.fromFrontendArtifact` from
+`@celox-sim/celox`.
+
+A Veryl native testbench can instantiate the artifact module using its existing
+`$sv::ModuleName` external-module syntax. Pass the artifact and testbench
+sources to `celox::Simulator::from_frontend_with_testbench`; the TypeScript
+equivalent is `runTestWithFrontendArtifact`.
+
+The versioned JSON representation is checked at decode time. Consumers should
+produce it through `to_json` instead of relying on its field spelling as a
+hand-authored format.

--- a/crates/celox-frontend-sdk/examples/adder_json.rs
+++ b/crates/celox-frontend-sdk/examples/adder_json.rs
@@ -1,0 +1,16 @@
+use celox_frontend_sdk::{BinaryOp, ModuleBuilder, ValueType};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let byte = ValueType::bits(8)?;
+    let mut module = ModuleBuilder::new("NetAdder")?;
+    let a = module.input("a", byte)?;
+    let b = module.input("b", byte)?;
+    let y = module.output("y", byte)?;
+    let a = module.read(a)?;
+    let b = module.read(b)?;
+    let sum = module.binary(BinaryOp::Add, a, b, byte)?;
+    let y = module.whole(y)?;
+    module.assign(y, sum)?;
+    println!("{}", module.finish().to_json()?);
+    Ok(())
+}

--- a/crates/celox-frontend-sdk/src/lib.rs
+++ b/crates/celox-frontend-sdk/src/lib.rs
@@ -673,7 +673,9 @@ impl FrontendArtifact {
                     let expected_type = ValueType {
                         width: then_type.width(),
                         signed: then_type.is_signed() && else_type.is_signed(),
-                        four_state: then_type.is_four_state() || else_type.is_four_state(),
+                        four_state: condition_type.is_four_state()
+                            || then_type.is_four_state()
+                            || else_type.is_four_state(),
                     };
                     if expression.value_type() != expected_type {
                         return Err(BuildError::TypeMismatch {
@@ -1134,7 +1136,9 @@ impl ModuleBuilder {
         let result_type = ValueType::new(
             then_type.width(),
             then_type.is_signed() && else_type.is_signed(),
-            then_type.is_four_state() || else_type.is_four_state(),
+            condition_type.is_four_state()
+                || then_type.is_four_state()
+                || else_type.is_four_state(),
         )?;
         Ok(self.push_expr(
             ExprNode::Mux {
@@ -1513,10 +1517,10 @@ mod tests {
 
     #[test]
     fn revalidates_mux_types_from_json() {
-        let bit = ValueType::bits(1).unwrap();
+        let logic = ValueType::logic(1).unwrap();
         let byte = ValueType::bits(8).unwrap();
         let mut module = ModuleBuilder::new("MuxJson").unwrap();
-        let condition = module.input("condition", bit).unwrap();
+        let condition = module.input("condition", logic).unwrap();
         let a = module.input("a", byte).unwrap();
         let b = module.input("b", byte).unwrap();
         let condition = module.read(condition).unwrap();
@@ -1524,6 +1528,7 @@ mod tests {
         let b = module.read(b).unwrap();
         module.mux(condition, a, b).unwrap();
         let artifact = module.finish();
+        assert!(artifact.expressions()[3].value_type().is_four_state());
 
         let mut wide_condition = serde_json::to_value(&artifact).unwrap();
         wide_condition["expressions"][3]["node"]["Mux"]["condition"] = 1.into();
@@ -1539,6 +1544,14 @@ mod tests {
         let mut wrong_result = serde_json::to_value(&artifact).unwrap();
         wrong_result["expressions"][3]["value_type"]["width"] = 4.into();
         let error = FrontendArtifact::from_json(&wrong_result.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::TypeMismatch { .. })
+        ));
+
+        let mut wrong_state = serde_json::to_value(&artifact).unwrap();
+        wrong_state["expressions"][3]["value_type"]["four_state"] = false.into();
+        let error = FrontendArtifact::from_json(&wrong_state.to_string()).unwrap_err();
         assert!(matches!(
             error,
             ArtifactJsonError::InvalidArtifact(BuildError::TypeMismatch { .. })

--- a/crates/celox-frontend-sdk/src/lib.rs
+++ b/crates/celox-frontend-sdk/src/lib.rs
@@ -40,6 +40,7 @@ impl ExprId {
 pub enum Direction {
     Input,
     Output,
+    /// Reserved for a future artifact version; version 1 validation rejects it.
     Inout,
     Internal,
 }
@@ -450,6 +451,11 @@ impl FrontendArtifact {
             if signal.name.is_empty() {
                 return Err(BuildError::EmptySignalName);
             }
+            if matches!(signal.direction, Direction::Inout) {
+                return Err(BuildError::UnsupportedInout {
+                    name: signal.name.clone(),
+                });
+            }
             if names.insert(signal.name.clone(), signal.id).is_some() {
                 return Err(BuildError::DuplicateSignal(signal.name.clone()));
             }
@@ -507,8 +513,30 @@ impl FrontendArtifact {
                     }
                 }
                 ExprNode::Binary { lhs, rhs, .. } => references.extend([*lhs, *rhs]),
-                ExprNode::Unary { input, .. } | ExprNode::Slice { input, .. } => {
+                ExprNode::Unary { input, .. } => {
                     references.push(*input);
+                }
+                ExprNode::Slice { input, lsb } => {
+                    if input.index() as usize >= index {
+                        return Err(BuildError::ForwardExpressionReference {
+                            expression: expression.id.index(),
+                            referenced: input.index(),
+                        });
+                    }
+                    let input_type = self
+                        .expression(*input)
+                        .ok_or(BuildError::UnknownExpression(input.index()))?
+                        .value_type();
+                    if lsb
+                        .checked_add(expression.value_type().width())
+                        .is_none_or(|end| end > input_type.width())
+                    {
+                        return Err(BuildError::InvalidSlice {
+                            lsb: *lsb,
+                            width: expression.value_type().width(),
+                            signal_width: input_type.width(),
+                        });
+                    }
                 }
                 ExprNode::Mux {
                     condition,
@@ -664,6 +692,8 @@ pub enum BuildError {
     ForwardExpressionReference { expression: u32, referenced: u32 },
     #[error("internal signal `{name}` appears in the module port order")]
     InternalSignalInPortOrder { name: String },
+    #[error("inout signal `{name}` is not supported by frontend artifact format version 1")]
+    UnsupportedInout { name: String },
 }
 
 /// JSON interchange failures for frontend artifacts.
@@ -714,6 +744,9 @@ impl ModuleBuilder {
         let name = name.into();
         if name.is_empty() {
             return Err(BuildError::EmptySignalName);
+        }
+        if matches!(direction, Direction::Inout) {
+            return Err(BuildError::UnsupportedInout { name });
         }
         if self.signal_names.contains_key(&name) {
             return Err(BuildError::DuplicateSignal(name));
@@ -1100,5 +1133,44 @@ mod tests {
             .register(partial, q_expr, clock, Edge::Posedge, None, None)
             .unwrap_err();
         assert!(matches!(error, BuildError::PartialRegisterTarget { .. }));
+    }
+
+    #[test]
+    fn rejects_inout_in_builder_and_json_artifacts() {
+        let bit = ValueType::bits(1).unwrap();
+        let mut module = ModuleBuilder::new("InoutBuilder").unwrap();
+        let error = module.signal("bus", Direction::Inout, bit).unwrap_err();
+        assert!(matches!(error, BuildError::UnsupportedInout { .. }));
+
+        let mut module = ModuleBuilder::new("InoutJson").unwrap();
+        module.input("bus", bit).unwrap();
+        let json = module.finish().to_json().unwrap().replace("Input", "Inout");
+        let error = FrontendArtifact::from_json(&json).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::UnsupportedInout { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_out_of_bounds_expression_slice_from_json() {
+        let byte = ValueType::bits(8).unwrap();
+        let mut module = ModuleBuilder::new("InvalidSlice").unwrap();
+        let input = module.input("input", byte).unwrap();
+        let input = module.read(input).unwrap();
+        module.expr_slice(input, 0, 4).unwrap();
+        let artifact = module.finish();
+        let mut json = serde_json::to_value(&artifact).unwrap();
+        json["expressions"][1]["node"]["Slice"]["lsb"] = 7.into();
+
+        let error = FrontendArtifact::from_json(&json.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::InvalidSlice {
+                lsb: 7,
+                width: 4,
+                signal_width: 8,
+            })
+        ));
     }
 }

--- a/crates/celox-frontend-sdk/src/lib.rs
+++ b/crates/celox-frontend-sdk/src/lib.rs
@@ -563,13 +563,30 @@ impl FrontendArtifact {
             }
             let mut references = Vec::new();
             match &expression.node {
-                ExprNode::Signal(slice) => validate_slice(*slice)?,
+                ExprNode::Signal(slice) => {
+                    validate_slice(*slice)?;
+                    let signal_type = self
+                        .signal(slice.signal)
+                        .ok_or(BuildError::UnknownSignal(slice.signal.index()))?
+                        .value_type();
+                    let expected_type = ValueType::new(
+                        slice.width,
+                        signal_type.is_signed() && slice.width == signal_type.width(),
+                        signal_type.is_four_state(),
+                    )?;
+                    if expression.value_type() != expected_type {
+                        return Err(BuildError::TypeMismatch {
+                            expected: expected_type,
+                            actual: expression.value_type(),
+                        });
+                    }
+                }
                 ExprNode::Constant(value) => {
                     validate_constant_state(value)?;
-                    if value.value_type().width() != expression.value_type.width() {
-                        return Err(BuildError::WidthMismatch {
-                            expected: expression.value_type.width(),
-                            actual: value.value_type().width(),
+                    if value.value_type() != expression.value_type() {
+                        return Err(BuildError::TypeMismatch {
+                            expected: value.value_type(),
+                            actual: expression.value_type(),
                         });
                     }
                 }
@@ -648,7 +665,36 @@ impl FrontendArtifact {
                         });
                     }
                 }
-                ExprNode::Concat(parts) => references.extend(parts),
+                ExprNode::Concat(parts) => {
+                    if parts.is_empty() {
+                        return Err(BuildError::ZeroWidth);
+                    }
+                    let mut width = 0usize;
+                    let mut four_state = false;
+                    for part in parts {
+                        if part.index() as usize >= index {
+                            return Err(BuildError::ForwardExpressionReference {
+                                expression: expression.id.index(),
+                                referenced: part.index(),
+                            });
+                        }
+                        let part_type = self
+                            .expression(*part)
+                            .ok_or(BuildError::UnknownExpression(part.index()))?
+                            .value_type();
+                        width = width
+                            .checked_add(part_type.width())
+                            .ok_or(BuildError::ZeroWidth)?;
+                        four_state |= part_type.is_four_state();
+                    }
+                    let expected_type = ValueType::new(width, false, four_state)?;
+                    if expression.value_type() != expected_type {
+                        return Err(BuildError::TypeMismatch {
+                            expected: expected_type,
+                            actual: expression.value_type(),
+                        });
+                    }
+                }
             }
             for reference in references {
                 if reference.index() as usize >= index {
@@ -674,6 +720,7 @@ impl FrontendArtifact {
             let signal = self
                 .signal(assignment.target.signal)
                 .ok_or(BuildError::UnknownSignal(assignment.target.signal.index()))?;
+            validate_driver_target(signal)?;
             insert_driver_target(&mut driver_ranges, assignment.target, &signal.name)?;
         }
         for register in &self.registers {
@@ -681,6 +728,7 @@ impl FrontendArtifact {
             let target = self
                 .signal(register.target.signal)
                 .ok_or(BuildError::UnknownSignal(register.target.signal.index()))?;
+            validate_driver_target(target)?;
             if register.target.lsb != 0 || register.target.width != target.value_type.width() {
                 return Err(BuildError::PartialRegisterTarget {
                     name: target.name.clone(),
@@ -829,6 +877,8 @@ pub enum BuildError {
     MissingPortOrder { name: String },
     #[error("signal `{name}` has overlapping continuous or register drivers")]
     OverlappingDrivers { name: String },
+    #[error("input signal `{name}` cannot be driven by artifact logic")]
+    InvalidDriverTarget { name: String },
     #[error("two-state constants cannot contain X/Z mask bits")]
     TwoStateConstantMask,
     #[error("signal names `{first}` and `{second}` collide in the DUT namespace")]
@@ -1117,6 +1167,7 @@ impl ModuleBuilder {
 
     pub fn assign(&mut self, target: SignalSlice, value: ExprId) -> Result<(), BuildError> {
         self.validate_slice(target)?;
+        validate_driver_target(self.signal_info(target.signal)?)?;
         let value_width = self.expr_info(value)?.value_type.width();
         if target.width != value_width {
             return Err(BuildError::WidthMismatch {
@@ -1140,6 +1191,7 @@ impl ModuleBuilder {
     ) -> Result<(), BuildError> {
         self.validate_slice(target)?;
         let target_signal = self.signal_info(target.signal)?;
+        validate_driver_target(target_signal)?;
         if target.lsb != 0 || target.width != target_signal.value_type.width() {
             return Err(BuildError::PartialRegisterTarget {
                 name: target_signal.name.clone(),
@@ -1264,6 +1316,16 @@ impl ModuleBuilder {
             value_type,
         });
         id
+    }
+}
+
+fn validate_driver_target(signal: &Signal) -> Result<(), BuildError> {
+    if matches!(signal.direction, Direction::Output | Direction::Internal) {
+        Ok(())
+    } else {
+        Err(BuildError::InvalidDriverTarget {
+            name: signal.name.clone(),
+        })
     }
 }
 
@@ -1479,6 +1541,107 @@ mod tests {
         assert!(matches!(
             error,
             ArtifactJsonError::InvalidArtifact(BuildError::SignalNamespaceCollision { .. })
+        ));
+    }
+
+    #[test]
+    fn revalidates_leaf_expression_types_from_json() {
+        let byte = ValueType::bits(8).unwrap();
+        let mut module = ModuleBuilder::new("LeafTypes").unwrap();
+        let input = module.input("input", byte).unwrap();
+        module.read(input).unwrap();
+        module.constant(Constant::two_state(0xa5u8, 8).unwrap());
+        let artifact = module.finish();
+
+        let mut signal = serde_json::to_value(&artifact).unwrap();
+        signal["expressions"][0]["value_type"]["width"] = 4.into();
+        let error = FrontendArtifact::from_json(&signal.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::TypeMismatch { .. })
+        ));
+
+        let mut constant = serde_json::to_value(&artifact).unwrap();
+        constant["expressions"][1]["value_type"]["four_state"] = true.into();
+        let error = FrontendArtifact::from_json(&constant.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::TypeMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn revalidates_concat_types_from_json() {
+        let bit = ValueType::bits(1).unwrap();
+        let logic = ValueType::logic(1).unwrap();
+        let mut module = ModuleBuilder::new("ConcatTypes").unwrap();
+        let a = module.input("a", bit).unwrap();
+        let b = module.input("b", logic).unwrap();
+        let a = module.read(a).unwrap();
+        let b = module.read(b).unwrap();
+        module.concat(vec![a, b]).unwrap();
+        let artifact = module.finish();
+
+        let mut wrong_type = serde_json::to_value(&artifact).unwrap();
+        wrong_type["expressions"][2]["value_type"]["four_state"] = false.into();
+        let error = FrontendArtifact::from_json(&wrong_type.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::TypeMismatch { .. })
+        ));
+
+        let mut empty = serde_json::to_value(&artifact).unwrap();
+        empty["expressions"][2]["node"]["Concat"] = serde_json::json!([]);
+        let error = FrontendArtifact::from_json(&empty.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::ZeroWidth)
+        ));
+    }
+
+    #[test]
+    fn rejects_input_driver_targets_in_builder_and_json() {
+        let bit = ValueType::bits(1).unwrap();
+        let mut module = ModuleBuilder::new("InputDriver").unwrap();
+        let clock = module.input("clock", bit).unwrap();
+        let input = module.input("input", bit).unwrap();
+        let value = module.constant(Constant::two_state(1u8, 1).unwrap());
+        let target = module.whole(input).unwrap();
+        let error = module.assign(target, value).unwrap_err();
+        assert!(matches!(error, BuildError::InvalidDriverTarget { .. }));
+        let error = module
+            .register(target, value, clock, Edge::Posedge, None, None)
+            .unwrap_err();
+        assert!(matches!(error, BuildError::InvalidDriverTarget { .. }));
+
+        let mut valid = ModuleBuilder::new("InputDriverJson").unwrap();
+        let input = valid.input("input", bit).unwrap();
+        let output = valid.output("output", bit).unwrap();
+        let value = valid.read(input).unwrap();
+        valid.assign(valid.whole(output).unwrap(), value).unwrap();
+        let mut json = serde_json::to_value(valid.finish()).unwrap();
+        json["assignments"][0]["target"]["signal"] = input.index().into();
+        let error = FrontendArtifact::from_json(&json.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::InvalidDriverTarget { .. })
+        ));
+
+        let mut valid = ModuleBuilder::new("InputRegisterJson").unwrap();
+        let clock = valid.input("clock", bit).unwrap();
+        let input = valid.input("input", bit).unwrap();
+        let output = valid.output("output", bit).unwrap();
+        let value = valid.read(input).unwrap();
+        let output_target = valid.whole(output).unwrap();
+        valid
+            .register(output_target, value, clock, Edge::Posedge, None, None)
+            .unwrap();
+        let mut json = serde_json::to_value(valid.finish()).unwrap();
+        json["registers"][0]["target"]["signal"] = input.index().into();
+        let error = FrontendArtifact::from_json(&json.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::InvalidDriverTarget { .. })
         ));
     }
 }

--- a/crates/celox-frontend-sdk/src/lib.rs
+++ b/crates/celox-frontend-sdk/src/lib.rs
@@ -1,0 +1,1104 @@
+//! Stable, source-language-independent authoring API for Celox frontends.
+//!
+//! This crate deliberately does not depend on Celox compiler internals. A
+//! frontend parses and elaborates its input, constructs a [`FrontendArtifact`],
+//! and hands that artifact to the public `celox` compiler API.
+
+use fxhash::FxHashMap;
+use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Current JSON interchange version of [`FrontendArtifact`].
+pub const ARTIFACT_FORMAT_VERSION: u32 = 1;
+
+/// Identity of one signal in the elaborated module.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct SignalId(u32);
+
+impl SignalId {
+    /// Return the stable module-local numeric identity.
+    pub const fn index(self) -> u32 {
+        self.0
+    }
+}
+
+/// Identity of one expression in the elaborated module.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ExprId(u32);
+
+impl ExprId {
+    /// Return the stable module-local numeric identity.
+    pub const fn index(self) -> u32 {
+        self.0
+    }
+}
+
+/// Public direction of a signal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum Direction {
+    Input,
+    Output,
+    Inout,
+    Internal,
+}
+
+/// Edge polarity used by clocked storage.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Edge {
+    Posedge,
+    Negedge,
+}
+
+/// Active level of a reset or enable signal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ActiveLevel {
+    High,
+    Low,
+}
+
+/// Source-independent bit-vector type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValueType {
+    width: usize,
+    signed: bool,
+    four_state: bool,
+}
+
+impl ValueType {
+    pub fn bits(width: usize) -> Result<Self, BuildError> {
+        Self::new(width, false, false)
+    }
+
+    pub fn logic(width: usize) -> Result<Self, BuildError> {
+        Self::new(width, false, true)
+    }
+
+    pub fn new(width: usize, signed: bool, four_state: bool) -> Result<Self, BuildError> {
+        if width == 0 {
+            return Err(BuildError::ZeroWidth);
+        }
+        Ok(Self {
+            width,
+            signed,
+            four_state,
+        })
+    }
+
+    pub const fn width(self) -> usize {
+        self.width
+    }
+
+    pub const fn is_signed(self) -> bool {
+        self.signed
+    }
+
+    pub const fn is_four_state(self) -> bool {
+        self.four_state
+    }
+}
+
+/// One declared signal retained for runtime reflection and TypeScript access.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Signal {
+    id: SignalId,
+    name: String,
+    direction: Direction,
+    value_type: ValueType,
+    initial: Option<Constant>,
+}
+
+impl Signal {
+    pub const fn id(&self) -> SignalId {
+        self.id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub const fn direction(&self) -> Direction {
+        self.direction
+    }
+
+    pub const fn value_type(&self) -> ValueType {
+        self.value_type
+    }
+
+    pub fn initial(&self) -> Option<&Constant> {
+        self.initial.as_ref()
+    }
+}
+
+/// A fixed bit range of a signal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SignalSlice {
+    signal: SignalId,
+    lsb: usize,
+    width: usize,
+}
+
+impl SignalSlice {
+    pub const fn signal(self) -> SignalId {
+        self.signal
+    }
+
+    pub const fn lsb(self) -> usize {
+        self.lsb
+    }
+
+    pub const fn width(self) -> usize {
+        self.width
+    }
+}
+
+/// Constant payload and four-state mask. Set mask bits represent X/Z.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Constant {
+    payload: BigUint,
+    mask: BigUint,
+    value_type: ValueType,
+}
+
+impl Constant {
+    pub fn new(payload: BigUint, mask: BigUint, value_type: ValueType) -> Self {
+        let bit_mask = (BigUint::from(1u8) << value_type.width()) - BigUint::from(1u8);
+        Self {
+            payload: payload & &bit_mask,
+            mask: mask & bit_mask,
+            value_type,
+        }
+    }
+
+    pub fn two_state(payload: impl Into<BigUint>, width: usize) -> Result<Self, BuildError> {
+        Ok(Self::new(
+            payload.into(),
+            BigUint::default(),
+            ValueType::bits(width)?,
+        ))
+    }
+
+    pub fn four_state(
+        payload: impl Into<BigUint>,
+        mask: impl Into<BigUint>,
+        width: usize,
+    ) -> Result<Self, BuildError> {
+        Ok(Self::new(
+            payload.into(),
+            mask.into(),
+            ValueType::logic(width)?,
+        ))
+    }
+
+    pub fn payload(&self) -> &BigUint {
+        &self.payload
+    }
+
+    pub fn mask(&self) -> &BigUint {
+        &self.mask
+    }
+
+    pub const fn value_type(&self) -> ValueType {
+        self.value_type
+    }
+}
+
+/// Binary operation in the frontend expression vocabulary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum BinaryOp {
+    Add,
+    Sub,
+    Mul,
+    DivUnsigned,
+    DivSigned,
+    RemUnsigned,
+    RemSigned,
+    And,
+    Or,
+    Xor,
+    ShiftLeft,
+    ShiftRight,
+    ArithmeticShiftRight,
+    Equal,
+    NotEqual,
+    CaseEqual,
+    CaseNotEqual,
+    LessUnsigned,
+    LessSigned,
+    LessEqualUnsigned,
+    LessEqualSigned,
+    GreaterUnsigned,
+    GreaterSigned,
+    GreaterEqualUnsigned,
+    GreaterEqualSigned,
+    LogicAnd,
+    LogicOr,
+}
+
+/// Unary operation in the frontend expression vocabulary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum UnaryOp {
+    ToTwoState,
+    Negate,
+    BitNot,
+    LogicNot,
+    ReduceAnd,
+    ReduceOr,
+    ReduceXor,
+    PopCount,
+    CountLeadingZeros,
+    CountTrailingZeros,
+}
+
+/// One expression node. Node result types are explicit so a netlist frontend
+/// does not inherit source-language width inference rules from Celox.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum ExprNode {
+    Signal(SignalSlice),
+    Constant(Constant),
+    Binary {
+        op: BinaryOp,
+        lhs: ExprId,
+        rhs: ExprId,
+    },
+    Unary {
+        op: UnaryOp,
+        input: ExprId,
+    },
+    Mux {
+        condition: ExprId,
+        then_expr: ExprId,
+        else_expr: ExprId,
+    },
+    Concat(Vec<ExprId>),
+    Slice {
+        input: ExprId,
+        lsb: usize,
+    },
+}
+
+/// Typed expression entry.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Expression {
+    id: ExprId,
+    node: ExprNode,
+    value_type: ValueType,
+}
+
+impl Expression {
+    pub const fn id(&self) -> ExprId {
+        self.id
+    }
+
+    pub fn node(&self) -> &ExprNode {
+        &self.node
+    }
+
+    pub const fn value_type(&self) -> ValueType {
+        self.value_type
+    }
+}
+
+/// One continuous/combinational assignment.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct Assignment {
+    target: SignalSlice,
+    value: ExprId,
+}
+
+impl Assignment {
+    pub const fn target(self) -> SignalSlice {
+        self.target
+    }
+
+    pub const fn value(self) -> ExprId {
+        self.value
+    }
+}
+
+/// Optional asynchronous reset configuration for a storage element.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct AsyncReset {
+    signal: SignalId,
+    active: ActiveLevel,
+    value: ExprId,
+}
+
+impl AsyncReset {
+    pub const fn signal(self) -> SignalId {
+        self.signal
+    }
+
+    pub const fn active(self) -> ActiveLevel {
+        self.active
+    }
+
+    pub const fn value(self) -> ExprId {
+        self.value
+    }
+}
+
+/// Optional synchronous enable configuration for a storage element.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct Enable {
+    signal: SignalId,
+    active: ActiveLevel,
+}
+
+impl Enable {
+    pub const fn signal(self) -> SignalId {
+        self.signal
+    }
+
+    pub const fn active(self) -> ActiveLevel {
+        self.active
+    }
+}
+
+/// One edge-triggered storage element in an elaborated netlist.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct Register {
+    target: SignalSlice,
+    next: ExprId,
+    clock: SignalId,
+    edge: Edge,
+    async_reset: Option<AsyncReset>,
+    enable: Option<Enable>,
+}
+
+impl Register {
+    pub const fn target(self) -> SignalSlice {
+        self.target
+    }
+
+    pub const fn next(self) -> ExprId {
+        self.next
+    }
+
+    pub const fn clock(self) -> SignalId {
+        self.clock
+    }
+
+    pub const fn edge(self) -> Edge {
+        self.edge
+    }
+
+    pub const fn async_reset(self) -> Option<AsyncReset> {
+        self.async_reset
+    }
+
+    pub const fn enable(self) -> Option<Enable> {
+        self.enable
+    }
+}
+
+/// Fully elaborated frontend result. The first SDK version intentionally
+/// models one flattened module; hierarchical netlists can be flattened by the
+/// producing frontend without affecting runtime signal names.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FrontendArtifact {
+    format_version: u32,
+    module_name: String,
+    signals: Vec<Signal>,
+    expressions: Vec<Expression>,
+    assignments: Vec<Assignment>,
+    registers: Vec<Register>,
+    port_order: Vec<SignalId>,
+}
+
+impl FrontendArtifact {
+    pub const fn format_version(&self) -> u32 {
+        self.format_version
+    }
+
+    /// Serialize the artifact for transport to the Celox N-API runtime.
+    pub fn to_json(&self) -> Result<String, ArtifactJsonError> {
+        Ok(serde_json::to_string(self)?)
+    }
+
+    /// Decode and version-check an artifact produced by an external frontend.
+    pub fn from_json(json: &str) -> Result<Self, ArtifactJsonError> {
+        let artifact: Self = serde_json::from_str(json)?;
+        if artifact.format_version != ARTIFACT_FORMAT_VERSION {
+            return Err(ArtifactJsonError::UnsupportedVersion {
+                expected: ARTIFACT_FORMAT_VERSION,
+                actual: artifact.format_version,
+            });
+        }
+        artifact.validate()?;
+        Ok(artifact)
+    }
+
+    /// Recheck all identities, ranges, widths, and expression ordering at a
+    /// trust boundary. Compiler consumers call this even for in-process values.
+    pub fn validate(&self) -> Result<(), BuildError> {
+        if self.module_name.is_empty() {
+            return Err(BuildError::EmptyModuleName);
+        }
+        let mut names = FxHashMap::default();
+        for (index, signal) in self.signals.iter().enumerate() {
+            if signal.id.index() as usize != index {
+                return Err(BuildError::InvalidSignalIdentity {
+                    expected: index as u32,
+                    actual: signal.id.index(),
+                });
+            }
+            if signal.name.is_empty() {
+                return Err(BuildError::EmptySignalName);
+            }
+            if names.insert(signal.name.clone(), signal.id).is_some() {
+                return Err(BuildError::DuplicateSignal(signal.name.clone()));
+            }
+            if signal.value_type.width() == 0 {
+                return Err(BuildError::ZeroWidth);
+            }
+            if let Some(initial) = &signal.initial
+                && initial.value_type().width() != signal.value_type.width()
+            {
+                return Err(BuildError::WidthMismatch {
+                    expected: signal.value_type.width(),
+                    actual: initial.value_type().width(),
+                });
+            }
+        }
+        let validate_slice = |slice: SignalSlice| -> Result<(), BuildError> {
+            let signal = self
+                .signal(slice.signal)
+                .ok_or(BuildError::UnknownSignal(slice.signal.index()))?;
+            if slice.width == 0 {
+                return Err(BuildError::ZeroWidth);
+            }
+            if slice
+                .lsb
+                .checked_add(slice.width)
+                .is_none_or(|end| end > signal.value_type.width())
+            {
+                return Err(BuildError::InvalidSlice {
+                    lsb: slice.lsb,
+                    width: slice.width,
+                    signal_width: signal.value_type.width(),
+                });
+            }
+            Ok(())
+        };
+        for (index, expression) in self.expressions.iter().enumerate() {
+            if expression.id.index() as usize != index {
+                return Err(BuildError::InvalidExpressionIdentity {
+                    expected: index as u32,
+                    actual: expression.id.index(),
+                });
+            }
+            if expression.value_type.width() == 0 {
+                return Err(BuildError::ZeroWidth);
+            }
+            let mut references = Vec::new();
+            match &expression.node {
+                ExprNode::Signal(slice) => validate_slice(*slice)?,
+                ExprNode::Constant(value) => {
+                    if value.value_type().width() != expression.value_type.width() {
+                        return Err(BuildError::WidthMismatch {
+                            expected: expression.value_type.width(),
+                            actual: value.value_type().width(),
+                        });
+                    }
+                }
+                ExprNode::Binary { lhs, rhs, .. } => references.extend([*lhs, *rhs]),
+                ExprNode::Unary { input, .. } | ExprNode::Slice { input, .. } => {
+                    references.push(*input);
+                }
+                ExprNode::Mux {
+                    condition,
+                    then_expr,
+                    else_expr,
+                } => references.extend([*condition, *then_expr, *else_expr]),
+                ExprNode::Concat(parts) => references.extend(parts),
+            }
+            for reference in references {
+                if reference.index() as usize >= index {
+                    return Err(BuildError::ForwardExpressionReference {
+                        expression: expression.id.index(),
+                        referenced: reference.index(),
+                    });
+                }
+            }
+        }
+        for assignment in &self.assignments {
+            validate_slice(assignment.target)?;
+            let expression = self
+                .expression(assignment.value)
+                .ok_or(BuildError::UnknownExpression(assignment.value.index()))?;
+            if assignment.target.width != expression.value_type.width() {
+                return Err(BuildError::WidthMismatch {
+                    expected: assignment.target.width,
+                    actual: expression.value_type.width(),
+                });
+            }
+        }
+        for register in &self.registers {
+            validate_slice(register.target)?;
+            let target = self
+                .signal(register.target.signal)
+                .ok_or(BuildError::UnknownSignal(register.target.signal.index()))?;
+            if register.target.lsb != 0 || register.target.width != target.value_type.width() {
+                return Err(BuildError::PartialRegisterTarget {
+                    name: target.name.clone(),
+                });
+            }
+            let next = self
+                .expression(register.next)
+                .ok_or(BuildError::UnknownExpression(register.next.index()))?;
+            if next.value_type.width() != register.target.width {
+                return Err(BuildError::WidthMismatch {
+                    expected: register.target.width,
+                    actual: next.value_type.width(),
+                });
+            }
+            for control in std::iter::once(register.clock)
+                .chain(register.async_reset.map(|reset| reset.signal))
+                .chain(register.enable.map(|enable| enable.signal))
+            {
+                let signal = self
+                    .signal(control)
+                    .ok_or(BuildError::UnknownSignal(control.index()))?;
+                if signal.value_type.width() != 1 {
+                    return Err(BuildError::InvalidControlWidth {
+                        name: signal.name.clone(),
+                    });
+                }
+            }
+            if let Some(reset) = register.async_reset {
+                let value = self
+                    .expression(reset.value)
+                    .ok_or(BuildError::UnknownExpression(reset.value.index()))?;
+                if value.value_type.width() != register.target.width {
+                    return Err(BuildError::WidthMismatch {
+                        expected: register.target.width,
+                        actual: value.value_type.width(),
+                    });
+                }
+            }
+        }
+        for signal in &self.port_order {
+            let signal = self
+                .signal(*signal)
+                .ok_or(BuildError::UnknownSignal(signal.index()))?;
+            if matches!(signal.direction, Direction::Internal) {
+                return Err(BuildError::InternalSignalInPortOrder {
+                    name: signal.name.clone(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub fn module_name(&self) -> &str {
+        &self.module_name
+    }
+
+    pub fn signals(&self) -> &[Signal] {
+        &self.signals
+    }
+
+    pub fn expressions(&self) -> &[Expression] {
+        &self.expressions
+    }
+
+    pub fn assignments(&self) -> &[Assignment] {
+        &self.assignments
+    }
+
+    pub fn registers(&self) -> &[Register] {
+        &self.registers
+    }
+
+    pub fn port_order(&self) -> &[SignalId] {
+        &self.port_order
+    }
+
+    pub fn signal(&self, id: SignalId) -> Option<&Signal> {
+        self.signals.get(id.index() as usize)
+    }
+
+    pub fn expression(&self, id: ExprId) -> Option<&Expression> {
+        self.expressions.get(id.index() as usize)
+    }
+}
+
+/// Errors detected while constructing a frontend artifact.
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BuildError {
+    #[error("signal and expression widths must be non-zero")]
+    ZeroWidth,
+    #[error("duplicate signal name `{0}`")]
+    DuplicateSignal(String),
+    #[error("unknown signal id {0}")]
+    UnknownSignal(u32),
+    #[error("unknown expression id {0}")]
+    UnknownExpression(u32),
+    #[error("bit range {lsb} +: {width} exceeds signal width {signal_width}")]
+    InvalidSlice {
+        lsb: usize,
+        width: usize,
+        signal_width: usize,
+    },
+    #[error("width mismatch: expected {expected}, got {actual}")]
+    WidthMismatch { expected: usize, actual: usize },
+    #[error("control signal `{name}` must be one bit wide")]
+    InvalidControlWidth { name: String },
+    #[error("register target `{name}` must cover the complete signal")]
+    PartialRegisterTarget { name: String },
+    #[error("module name must not be empty")]
+    EmptyModuleName,
+    #[error("signal name must not be empty")]
+    EmptySignalName,
+    #[error("signal identity mismatch: expected {expected}, got {actual}")]
+    InvalidSignalIdentity { expected: u32, actual: u32 },
+    #[error("expression identity mismatch: expected {expected}, got {actual}")]
+    InvalidExpressionIdentity { expected: u32, actual: u32 },
+    #[error("expression {expression} references non-prior expression {referenced}")]
+    ForwardExpressionReference { expression: u32, referenced: u32 },
+    #[error("internal signal `{name}` appears in the module port order")]
+    InternalSignalInPortOrder { name: String },
+}
+
+/// JSON interchange failures for frontend artifacts.
+#[derive(Debug, Error)]
+pub enum ArtifactJsonError {
+    #[error("invalid frontend artifact JSON: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("unsupported frontend artifact version {actual}; expected {expected}")]
+    UnsupportedVersion { expected: u32, actual: u32 },
+    #[error("invalid frontend artifact: {0}")]
+    InvalidArtifact(#[from] BuildError),
+}
+
+/// Builder for one flattened, elaborated netlist module.
+pub struct ModuleBuilder {
+    name: String,
+    signals: Vec<Signal>,
+    signal_names: FxHashMap<String, SignalId>,
+    expressions: Vec<Expression>,
+    assignments: Vec<Assignment>,
+    registers: Vec<Register>,
+    port_order: Vec<SignalId>,
+}
+
+impl ModuleBuilder {
+    pub fn new(name: impl Into<String>) -> Result<Self, BuildError> {
+        let name = name.into();
+        if name.is_empty() {
+            return Err(BuildError::EmptyModuleName);
+        }
+        Ok(Self {
+            name,
+            signals: Vec::new(),
+            signal_names: FxHashMap::default(),
+            expressions: Vec::new(),
+            assignments: Vec::new(),
+            registers: Vec::new(),
+            port_order: Vec::new(),
+        })
+    }
+
+    pub fn signal(
+        &mut self,
+        name: impl Into<String>,
+        direction: Direction,
+        value_type: ValueType,
+    ) -> Result<SignalId, BuildError> {
+        let name = name.into();
+        if name.is_empty() {
+            return Err(BuildError::EmptySignalName);
+        }
+        if self.signal_names.contains_key(&name) {
+            return Err(BuildError::DuplicateSignal(name));
+        }
+        let id = SignalId(self.signals.len() as u32);
+        self.signal_names.insert(name.clone(), id);
+        self.signals.push(Signal {
+            id,
+            name,
+            direction,
+            value_type,
+            initial: None,
+        });
+        if !matches!(direction, Direction::Internal) {
+            self.port_order.push(id);
+        }
+        Ok(id)
+    }
+
+    pub fn input(
+        &mut self,
+        name: impl Into<String>,
+        value_type: ValueType,
+    ) -> Result<SignalId, BuildError> {
+        self.signal(name, Direction::Input, value_type)
+    }
+
+    pub fn output(
+        &mut self,
+        name: impl Into<String>,
+        value_type: ValueType,
+    ) -> Result<SignalId, BuildError> {
+        self.signal(name, Direction::Output, value_type)
+    }
+
+    pub fn internal(
+        &mut self,
+        name: impl Into<String>,
+        value_type: ValueType,
+    ) -> Result<SignalId, BuildError> {
+        self.signal(name, Direction::Internal, value_type)
+    }
+
+    pub fn set_initial(&mut self, signal: SignalId, value: Constant) -> Result<(), BuildError> {
+        let signal_info = self.signal_info(signal)?;
+        if signal_info.value_type.width() != value.value_type().width() {
+            return Err(BuildError::WidthMismatch {
+                expected: signal_info.value_type.width(),
+                actual: value.value_type().width(),
+            });
+        }
+        self.signals[signal.index() as usize].initial = Some(value);
+        Ok(())
+    }
+
+    pub fn whole(&self, signal: SignalId) -> Result<SignalSlice, BuildError> {
+        let info = self.signal_info(signal)?;
+        Ok(SignalSlice {
+            signal,
+            lsb: 0,
+            width: info.value_type.width(),
+        })
+    }
+
+    pub fn slice(
+        &self,
+        signal: SignalId,
+        lsb: usize,
+        width: usize,
+    ) -> Result<SignalSlice, BuildError> {
+        let info = self.signal_info(signal)?;
+        if width == 0 {
+            return Err(BuildError::ZeroWidth);
+        }
+        if lsb
+            .checked_add(width)
+            .is_none_or(|end| end > info.value_type.width())
+        {
+            return Err(BuildError::InvalidSlice {
+                lsb,
+                width,
+                signal_width: info.value_type.width(),
+            });
+        }
+        Ok(SignalSlice { signal, lsb, width })
+    }
+
+    pub fn read(&mut self, signal: SignalId) -> Result<ExprId, BuildError> {
+        let slice = self.whole(signal)?;
+        self.read_slice(slice)
+    }
+
+    pub fn read_slice(&mut self, slice: SignalSlice) -> Result<ExprId, BuildError> {
+        let info = self.signal_info(slice.signal)?;
+        self.validate_slice(slice)?;
+        let value_type = ValueType::new(
+            slice.width,
+            info.value_type.is_signed() && slice.width == info.value_type.width(),
+            info.value_type.is_four_state(),
+        )?;
+        Ok(self.push_expr(ExprNode::Signal(slice), value_type))
+    }
+
+    pub fn constant(&mut self, value: Constant) -> ExprId {
+        let value_type = value.value_type();
+        self.push_expr(ExprNode::Constant(value), value_type)
+    }
+
+    pub fn binary(
+        &mut self,
+        op: BinaryOp,
+        lhs: ExprId,
+        rhs: ExprId,
+        result_type: ValueType,
+    ) -> Result<ExprId, BuildError> {
+        self.expr_info(lhs)?;
+        self.expr_info(rhs)?;
+        Ok(self.push_expr(ExprNode::Binary { op, lhs, rhs }, result_type))
+    }
+
+    pub fn unary(
+        &mut self,
+        op: UnaryOp,
+        input: ExprId,
+        result_type: ValueType,
+    ) -> Result<ExprId, BuildError> {
+        self.expr_info(input)?;
+        Ok(self.push_expr(ExprNode::Unary { op, input }, result_type))
+    }
+
+    pub fn mux(
+        &mut self,
+        condition: ExprId,
+        then_expr: ExprId,
+        else_expr: ExprId,
+    ) -> Result<ExprId, BuildError> {
+        let condition_type = self.expr_info(condition)?.value_type;
+        if condition_type.width() != 1 {
+            return Err(BuildError::WidthMismatch {
+                expected: 1,
+                actual: condition_type.width(),
+            });
+        }
+        let then_type = self.expr_info(then_expr)?.value_type;
+        let else_type = self.expr_info(else_expr)?.value_type;
+        if then_type.width() != else_type.width() {
+            return Err(BuildError::WidthMismatch {
+                expected: then_type.width(),
+                actual: else_type.width(),
+            });
+        }
+        let result_type = ValueType::new(
+            then_type.width(),
+            then_type.is_signed() && else_type.is_signed(),
+            then_type.is_four_state() || else_type.is_four_state(),
+        )?;
+        Ok(self.push_expr(
+            ExprNode::Mux {
+                condition,
+                then_expr,
+                else_expr,
+            },
+            result_type,
+        ))
+    }
+
+    pub fn concat(&mut self, parts: Vec<ExprId>) -> Result<ExprId, BuildError> {
+        let mut width = 0usize;
+        let mut four_state = false;
+        for part in &parts {
+            let value_type = self.expr_info(*part)?.value_type;
+            width = width
+                .checked_add(value_type.width())
+                .ok_or(BuildError::ZeroWidth)?;
+            four_state |= value_type.is_four_state();
+        }
+        let result_type = ValueType::new(width, false, four_state)?;
+        Ok(self.push_expr(ExprNode::Concat(parts), result_type))
+    }
+
+    pub fn expr_slice(
+        &mut self,
+        input: ExprId,
+        lsb: usize,
+        width: usize,
+    ) -> Result<ExprId, BuildError> {
+        let input_type = self.expr_info(input)?.value_type;
+        if width == 0 {
+            return Err(BuildError::ZeroWidth);
+        }
+        if lsb
+            .checked_add(width)
+            .is_none_or(|end| end > input_type.width())
+        {
+            return Err(BuildError::InvalidSlice {
+                lsb,
+                width,
+                signal_width: input_type.width(),
+            });
+        }
+        let result_type = ValueType::new(width, false, input_type.is_four_state())?;
+        Ok(self.push_expr(ExprNode::Slice { input, lsb }, result_type))
+    }
+
+    pub fn assign(&mut self, target: SignalSlice, value: ExprId) -> Result<(), BuildError> {
+        self.validate_slice(target)?;
+        let value_width = self.expr_info(value)?.value_type.width();
+        if target.width != value_width {
+            return Err(BuildError::WidthMismatch {
+                expected: target.width,
+                actual: value_width,
+            });
+        }
+        self.assignments.push(Assignment { target, value });
+        Ok(())
+    }
+
+    pub fn register(
+        &mut self,
+        target: SignalSlice,
+        next: ExprId,
+        clock: SignalId,
+        edge: Edge,
+        async_reset: Option<AsyncReset>,
+        enable: Option<Enable>,
+    ) -> Result<(), BuildError> {
+        self.validate_slice(target)?;
+        let target_signal = self.signal_info(target.signal)?;
+        if target.lsb != 0 || target.width != target_signal.value_type.width() {
+            return Err(BuildError::PartialRegisterTarget {
+                name: target_signal.name.clone(),
+            });
+        }
+        let next_width = self.expr_info(next)?.value_type.width();
+        if next_width != target.width {
+            return Err(BuildError::WidthMismatch {
+                expected: target.width,
+                actual: next_width,
+            });
+        }
+        self.validate_control(clock)?;
+        if let Some(reset) = async_reset {
+            self.validate_control(reset.signal)?;
+            let reset_width = self.expr_info(reset.value)?.value_type.width();
+            if reset_width != target.width {
+                return Err(BuildError::WidthMismatch {
+                    expected: target.width,
+                    actual: reset_width,
+                });
+            }
+        }
+        if let Some(enable) = enable {
+            self.validate_control(enable.signal)?;
+        }
+        self.registers.push(Register {
+            target,
+            next,
+            clock,
+            edge,
+            async_reset,
+            enable,
+        });
+        Ok(())
+    }
+
+    pub fn async_reset(
+        &self,
+        signal: SignalId,
+        active: ActiveLevel,
+        value: ExprId,
+    ) -> Result<AsyncReset, BuildError> {
+        self.validate_control(signal)?;
+        self.expr_info(value)?;
+        Ok(AsyncReset {
+            signal,
+            active,
+            value,
+        })
+    }
+
+    pub fn enable(&self, signal: SignalId, active: ActiveLevel) -> Result<Enable, BuildError> {
+        self.validate_control(signal)?;
+        Ok(Enable { signal, active })
+    }
+
+    pub fn finish(self) -> FrontendArtifact {
+        FrontendArtifact {
+            format_version: ARTIFACT_FORMAT_VERSION,
+            module_name: self.name,
+            signals: self.signals,
+            expressions: self.expressions,
+            assignments: self.assignments,
+            registers: self.registers,
+            port_order: self.port_order,
+        }
+    }
+
+    fn signal_info(&self, signal: SignalId) -> Result<&Signal, BuildError> {
+        self.signals
+            .get(signal.index() as usize)
+            .ok_or(BuildError::UnknownSignal(signal.index()))
+    }
+
+    fn expr_info(&self, expression: ExprId) -> Result<&Expression, BuildError> {
+        self.expressions
+            .get(expression.index() as usize)
+            .ok_or(BuildError::UnknownExpression(expression.index()))
+    }
+
+    fn validate_slice(&self, slice: SignalSlice) -> Result<(), BuildError> {
+        let signal = self.signal_info(slice.signal)?;
+        if slice.width == 0 {
+            return Err(BuildError::ZeroWidth);
+        }
+        if slice
+            .lsb
+            .checked_add(slice.width)
+            .is_none_or(|end| end > signal.value_type.width())
+        {
+            return Err(BuildError::InvalidSlice {
+                lsb: slice.lsb,
+                width: slice.width,
+                signal_width: signal.value_type.width(),
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_control(&self, signal: SignalId) -> Result<(), BuildError> {
+        let signal = self.signal_info(signal)?;
+        if signal.value_type.width() != 1 {
+            return Err(BuildError::InvalidControlWidth {
+                name: signal.name.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    fn push_expr(&mut self, node: ExprNode, value_type: ValueType) -> ExprId {
+        let id = ExprId(self.expressions.len() as u32);
+        self.expressions.push(Expression {
+            id,
+            node,
+            value_type,
+        });
+        id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_flat_combinational_artifact() {
+        let mut module = ModuleBuilder::new("Adder").unwrap();
+        let ty = ValueType::bits(8).unwrap();
+        let a = module.input("a", ty).unwrap();
+        let b = module.input("b", ty).unwrap();
+        let y = module.output("y", ty).unwrap();
+        let a = module.read(a).unwrap();
+        let b = module.read(b).unwrap();
+        let sum = module.binary(BinaryOp::Add, a, b, ty).unwrap();
+        let y = module.whole(y).unwrap();
+        module.assign(y, sum).unwrap();
+
+        let artifact = module.finish();
+        assert_eq!(artifact.module_name(), "Adder");
+        assert_eq!(artifact.signals().len(), 3);
+        assert_eq!(artifact.assignments().len(), 1);
+        assert_eq!(artifact.port_order().len(), 3);
+    }
+
+    #[test]
+    fn rejects_partial_register_target() {
+        let mut module = ModuleBuilder::new("Counter").unwrap();
+        let bit = ValueType::bits(1).unwrap();
+        let byte = ValueType::bits(8).unwrap();
+        let clock = module.input("clock", bit).unwrap();
+        let q = module.output("q", byte).unwrap();
+        let q_expr = module.read(q).unwrap();
+        let partial = module.slice(q, 0, 4).unwrap();
+        let error = module
+            .register(partial, q_expr, clock, Edge::Posedge, None, None)
+            .unwrap_err();
+        assert!(matches!(error, BuildError::PartialRegisterTarget { .. }));
+    }
+}

--- a/crates/celox-frontend-sdk/src/lib.rs
+++ b/crates/celox-frontend-sdk/src/lib.rs
@@ -4,6 +4,8 @@
 //! frontend parses and elaborates its input, constructs a [`FrontendArtifact`],
 //! and hands that artifact to the public `celox` compiler API.
 
+use std::collections::BTreeMap;
+
 use fxhash::FxHashMap;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
@@ -165,9 +167,14 @@ pub struct Constant {
 impl Constant {
     pub fn new(payload: BigUint, mask: BigUint, value_type: ValueType) -> Self {
         let bit_mask = (BigUint::from(1u8) << value_type.width()) - BigUint::from(1u8);
+        let mask = if value_type.is_four_state() {
+            mask & &bit_mask
+        } else {
+            BigUint::default()
+        };
         Self {
             payload: payload & &bit_mask,
-            mask: mask & bit_mask,
+            mask,
             value_type,
         }
     }
@@ -203,6 +210,37 @@ impl Constant {
     pub const fn value_type(&self) -> ValueType {
         self.value_type
     }
+}
+
+fn signal_name_prefixes(name: &str) -> impl Iterator<Item = &str> {
+    name.match_indices('.').map(|(index, _)| &name[..index])
+}
+
+fn insert_driver_target(
+    driver_ranges: &mut FxHashMap<SignalId, BTreeMap<usize, usize>>,
+    target: SignalSlice,
+    signal_name: &str,
+) -> Result<(), BuildError> {
+    let end = target.lsb + target.width;
+    let ranges = driver_ranges.entry(target.signal).or_default();
+    if ranges
+        .range(..end)
+        .next_back()
+        .is_some_and(|(_, existing_end)| *existing_end > target.lsb)
+    {
+        return Err(BuildError::OverlappingDrivers {
+            name: signal_name.to_string(),
+        });
+    }
+    ranges.insert(target.lsb, end);
+    Ok(())
+}
+
+fn validate_constant_state(value: &Constant) -> Result<(), BuildError> {
+    if !value.value_type().is_four_state() && value.mask() != &BigUint::default() {
+        return Err(BuildError::TwoStateConstantMask);
+    }
+    Ok(())
 }
 
 /// Binary operation in the frontend expression vocabulary.
@@ -440,7 +478,8 @@ impl FrontendArtifact {
         if self.module_name.is_empty() {
             return Err(BuildError::EmptyModuleName);
         }
-        let mut names = FxHashMap::default();
+        let mut names: FxHashMap<String, SignalId> = FxHashMap::default();
+        let mut namespace_prefixes: FxHashMap<String, String> = FxHashMap::default();
         for (index, signal) in self.signals.iter().enumerate() {
             if signal.id.index() as usize != index {
                 return Err(BuildError::InvalidSignalIdentity {
@@ -456,19 +495,40 @@ impl FrontendArtifact {
                     name: signal.name.clone(),
                 });
             }
-            if names.insert(signal.name.clone(), signal.id).is_some() {
+            if names.contains_key(&signal.name) {
                 return Err(BuildError::DuplicateSignal(signal.name.clone()));
+            }
+            if let Some(existing) = namespace_prefixes.get(&signal.name) {
+                return Err(BuildError::SignalNamespaceCollision {
+                    first: existing.clone(),
+                    second: signal.name.clone(),
+                });
+            }
+            if let Some(existing) =
+                signal_name_prefixes(&signal.name).find(|prefix| names.contains_key(*prefix))
+            {
+                return Err(BuildError::SignalNamespaceCollision {
+                    first: existing.to_string(),
+                    second: signal.name.clone(),
+                });
+            }
+            names.insert(signal.name.clone(), signal.id);
+            for prefix in signal_name_prefixes(&signal.name) {
+                namespace_prefixes
+                    .entry(prefix.to_string())
+                    .or_insert_with(|| signal.name.clone());
             }
             if signal.value_type.width() == 0 {
                 return Err(BuildError::ZeroWidth);
             }
-            if let Some(initial) = &signal.initial
-                && initial.value_type().width() != signal.value_type.width()
-            {
-                return Err(BuildError::WidthMismatch {
-                    expected: signal.value_type.width(),
-                    actual: initial.value_type().width(),
-                });
+            if let Some(initial) = &signal.initial {
+                validate_constant_state(initial)?;
+                if initial.value_type().width() != signal.value_type.width() {
+                    return Err(BuildError::WidthMismatch {
+                        expected: signal.value_type.width(),
+                        actual: initial.value_type().width(),
+                    });
+                }
             }
         }
         let validate_slice = |slice: SignalSlice| -> Result<(), BuildError> {
@@ -505,6 +565,7 @@ impl FrontendArtifact {
             match &expression.node {
                 ExprNode::Signal(slice) => validate_slice(*slice)?,
                 ExprNode::Constant(value) => {
+                    validate_constant_state(value)?;
                     if value.value_type().width() != expression.value_type.width() {
                         return Err(BuildError::WidthMismatch {
                             expected: expression.value_type.width(),
@@ -542,7 +603,51 @@ impl FrontendArtifact {
                     condition,
                     then_expr,
                     else_expr,
-                } => references.extend([*condition, *then_expr, *else_expr]),
+                } => {
+                    for reference in [*condition, *then_expr, *else_expr] {
+                        if reference.index() as usize >= index {
+                            return Err(BuildError::ForwardExpressionReference {
+                                expression: expression.id.index(),
+                                referenced: reference.index(),
+                            });
+                        }
+                    }
+                    let condition_type = self
+                        .expression(*condition)
+                        .ok_or(BuildError::UnknownExpression(condition.index()))?
+                        .value_type();
+                    if condition_type.width() != 1 {
+                        return Err(BuildError::WidthMismatch {
+                            expected: 1,
+                            actual: condition_type.width(),
+                        });
+                    }
+                    let then_type = self
+                        .expression(*then_expr)
+                        .ok_or(BuildError::UnknownExpression(then_expr.index()))?
+                        .value_type();
+                    let else_type = self
+                        .expression(*else_expr)
+                        .ok_or(BuildError::UnknownExpression(else_expr.index()))?
+                        .value_type();
+                    if then_type.width() != else_type.width() {
+                        return Err(BuildError::WidthMismatch {
+                            expected: then_type.width(),
+                            actual: else_type.width(),
+                        });
+                    }
+                    let expected_type = ValueType {
+                        width: then_type.width(),
+                        signed: then_type.is_signed() && else_type.is_signed(),
+                        four_state: then_type.is_four_state() || else_type.is_four_state(),
+                    };
+                    if expression.value_type() != expected_type {
+                        return Err(BuildError::TypeMismatch {
+                            expected: expected_type,
+                            actual: expression.value_type(),
+                        });
+                    }
+                }
                 ExprNode::Concat(parts) => references.extend(parts),
             }
             for reference in references {
@@ -554,6 +659,7 @@ impl FrontendArtifact {
                 }
             }
         }
+        let mut driver_ranges = FxHashMap::default();
         for assignment in &self.assignments {
             validate_slice(assignment.target)?;
             let expression = self
@@ -565,6 +671,10 @@ impl FrontendArtifact {
                     actual: expression.value_type.width(),
                 });
             }
+            let signal = self
+                .signal(assignment.target.signal)
+                .ok_or(BuildError::UnknownSignal(assignment.target.signal.index()))?;
+            insert_driver_target(&mut driver_ranges, assignment.target, &signal.name)?;
         }
         for register in &self.registers {
             validate_slice(register.target)?;
@@ -609,13 +719,29 @@ impl FrontendArtifact {
                     });
                 }
             }
+            insert_driver_target(&mut driver_ranges, register.target, &target.name)?;
         }
+        let mut ordered_ports = FxHashMap::default();
         for signal in &self.port_order {
             let signal = self
                 .signal(*signal)
                 .ok_or(BuildError::UnknownSignal(signal.index()))?;
             if matches!(signal.direction, Direction::Internal) {
                 return Err(BuildError::InternalSignalInPortOrder {
+                    name: signal.name.clone(),
+                });
+            }
+            if ordered_ports.insert(signal.id, ()).is_some() {
+                return Err(BuildError::DuplicatePortOrder {
+                    name: signal.name.clone(),
+                });
+            }
+        }
+        for signal in &self.signals {
+            if !matches!(signal.direction, Direction::Internal)
+                && !ordered_ports.contains_key(&signal.id)
+            {
+                return Err(BuildError::MissingPortOrder {
                     name: signal.name.clone(),
                 });
             }
@@ -676,6 +802,11 @@ pub enum BuildError {
     },
     #[error("width mismatch: expected {expected}, got {actual}")]
     WidthMismatch { expected: usize, actual: usize },
+    #[error("type mismatch: expected {expected:?}, got {actual:?}")]
+    TypeMismatch {
+        expected: ValueType,
+        actual: ValueType,
+    },
     #[error("control signal `{name}` must be one bit wide")]
     InvalidControlWidth { name: String },
     #[error("register target `{name}` must cover the complete signal")]
@@ -692,6 +823,16 @@ pub enum BuildError {
     ForwardExpressionReference { expression: u32, referenced: u32 },
     #[error("internal signal `{name}` appears in the module port order")]
     InternalSignalInPortOrder { name: String },
+    #[error("signal `{name}` appears more than once in the module port order")]
+    DuplicatePortOrder { name: String },
+    #[error("public signal `{name}` is missing from the module port order")]
+    MissingPortOrder { name: String },
+    #[error("signal `{name}` has overlapping continuous or register drivers")]
+    OverlappingDrivers { name: String },
+    #[error("two-state constants cannot contain X/Z mask bits")]
+    TwoStateConstantMask,
+    #[error("signal names `{first}` and `{second}` collide in the DUT namespace")]
+    SignalNamespaceCollision { first: String, second: String },
     #[error("inout signal `{name}` is not supported by frontend artifact format version 1")]
     UnsupportedInout { name: String },
 }
@@ -712,9 +853,11 @@ pub struct ModuleBuilder {
     name: String,
     signals: Vec<Signal>,
     signal_names: FxHashMap<String, SignalId>,
+    signal_namespace_prefixes: FxHashMap<String, String>,
     expressions: Vec<Expression>,
     assignments: Vec<Assignment>,
     registers: Vec<Register>,
+    driver_ranges: FxHashMap<SignalId, BTreeMap<usize, usize>>,
     port_order: Vec<SignalId>,
 }
 
@@ -728,9 +871,11 @@ impl ModuleBuilder {
             name,
             signals: Vec::new(),
             signal_names: FxHashMap::default(),
+            signal_namespace_prefixes: FxHashMap::default(),
             expressions: Vec::new(),
             assignments: Vec::new(),
             registers: Vec::new(),
+            driver_ranges: FxHashMap::default(),
             port_order: Vec::new(),
         })
     }
@@ -751,8 +896,27 @@ impl ModuleBuilder {
         if self.signal_names.contains_key(&name) {
             return Err(BuildError::DuplicateSignal(name));
         }
+        if let Some(existing) = self.signal_namespace_prefixes.get(&name) {
+            return Err(BuildError::SignalNamespaceCollision {
+                first: existing.clone(),
+                second: name,
+            });
+        }
+        if let Some(existing) =
+            signal_name_prefixes(&name).find(|prefix| self.signal_names.contains_key(*prefix))
+        {
+            return Err(BuildError::SignalNamespaceCollision {
+                first: existing.to_string(),
+                second: name.clone(),
+            });
+        }
         let id = SignalId(self.signals.len() as u32);
         self.signal_names.insert(name.clone(), id);
+        for prefix in signal_name_prefixes(&name) {
+            self.signal_namespace_prefixes
+                .entry(prefix.to_string())
+                .or_insert_with(|| name.clone());
+        }
         self.signals.push(Signal {
             id,
             name,
@@ -960,6 +1124,7 @@ impl ModuleBuilder {
                 actual: value_width,
             });
         }
+        self.record_driver_target(target)?;
         self.assignments.push(Assignment { target, value });
         Ok(())
     }
@@ -1001,6 +1166,7 @@ impl ModuleBuilder {
         if let Some(enable) = enable {
             self.validate_control(enable.signal)?;
         }
+        self.record_driver_target(target)?;
         self.registers.push(Register {
             target,
             next,
@@ -1083,6 +1249,11 @@ impl ModuleBuilder {
             });
         }
         Ok(())
+    }
+
+    fn record_driver_target(&mut self, target: SignalSlice) -> Result<(), BuildError> {
+        let signal_name = self.signal_info(target.signal)?.name.clone();
+        insert_driver_target(&mut self.driver_ranges, target, &signal_name)
     }
 
     fn push_expr(&mut self, node: ExprNode, value_type: ValueType) -> ExprId {
@@ -1171,6 +1342,143 @@ mod tests {
                 width: 4,
                 signal_width: 8,
             })
+        ));
+    }
+
+    #[test]
+    fn rejects_overlapping_register_and_assignment_drivers() {
+        let bit = ValueType::bits(1).unwrap();
+        let mut module = ModuleBuilder::new("DriverConflict").unwrap();
+        let clock = module.input("clock", bit).unwrap();
+        let d = module.input("d", bit).unwrap();
+        let q = module.output("q", bit).unwrap();
+        let d_expr = module.read(d).unwrap();
+        let q_target = module.whole(q).unwrap();
+        module.assign(q_target, d_expr).unwrap();
+        let error = module
+            .register(q_target, d_expr, clock, Edge::Posedge, None, None)
+            .unwrap_err();
+        assert!(matches!(error, BuildError::OverlappingDrivers { .. }));
+
+        let mut module = ModuleBuilder::new("DuplicateRegisterJson").unwrap();
+        let clock = module.input("clock", bit).unwrap();
+        let d = module.input("d", bit).unwrap();
+        let q = module.output("q", bit).unwrap();
+        let d_expr = module.read(d).unwrap();
+        let q_target = module.whole(q).unwrap();
+        module
+            .register(q_target, d_expr, clock, Edge::Posedge, None, None)
+            .unwrap();
+        let mut json = serde_json::to_value(module.finish()).unwrap();
+        let duplicate = json["registers"][0].clone();
+        json["registers"].as_array_mut().unwrap().push(duplicate);
+        let error = FrontendArtifact::from_json(&json.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::OverlappingDrivers { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_incomplete_or_duplicate_json_port_order() {
+        let bit = ValueType::bits(1).unwrap();
+        let mut module = ModuleBuilder::new("PortOrder").unwrap();
+        module.input("a", bit).unwrap();
+        module.output("b", bit).unwrap();
+        let artifact = module.finish();
+
+        let mut duplicate = serde_json::to_value(&artifact).unwrap();
+        duplicate["port_order"] = serde_json::json!([0, 0]);
+        let error = FrontendArtifact::from_json(&duplicate.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::DuplicatePortOrder { .. })
+        ));
+
+        let mut missing = serde_json::to_value(&artifact).unwrap();
+        missing["port_order"] = serde_json::json!([0]);
+        let error = FrontendArtifact::from_json(&missing.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::MissingPortOrder { .. })
+        ));
+    }
+
+    #[test]
+    fn revalidates_mux_types_from_json() {
+        let bit = ValueType::bits(1).unwrap();
+        let byte = ValueType::bits(8).unwrap();
+        let mut module = ModuleBuilder::new("MuxJson").unwrap();
+        let condition = module.input("condition", bit).unwrap();
+        let a = module.input("a", byte).unwrap();
+        let b = module.input("b", byte).unwrap();
+        let condition = module.read(condition).unwrap();
+        let a = module.read(a).unwrap();
+        let b = module.read(b).unwrap();
+        module.mux(condition, a, b).unwrap();
+        let artifact = module.finish();
+
+        let mut wide_condition = serde_json::to_value(&artifact).unwrap();
+        wide_condition["expressions"][3]["node"]["Mux"]["condition"] = 1.into();
+        let error = FrontendArtifact::from_json(&wide_condition.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::WidthMismatch {
+                expected: 1,
+                actual: 8,
+            })
+        ));
+
+        let mut wrong_result = serde_json::to_value(&artifact).unwrap();
+        wrong_result["expressions"][3]["value_type"]["width"] = 4.into();
+        let error = FrontendArtifact::from_json(&wrong_result.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::TypeMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn normalizes_two_state_constant_masks_and_rejects_them_in_json() {
+        let byte = ValueType::bits(8).unwrap();
+        let value = Constant::new(BigUint::from(0xa5u8), BigUint::from(0xffu8), byte);
+        assert_eq!(value.mask(), &BigUint::default());
+
+        let mut module = ModuleBuilder::new("ConstantMaskJson").unwrap();
+        module.constant(value);
+        let mut json = serde_json::to_value(module.finish()).unwrap();
+        json["expressions"][0]["node"]["Constant"]["mask"] =
+            serde_json::to_value(BigUint::from(1u8)).unwrap();
+        let error = FrontendArtifact::from_json(&json.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::TwoStateConstantMask)
+        ));
+    }
+
+    #[test]
+    fn rejects_signal_namespace_prefix_collisions() {
+        let bit = ValueType::bits(1).unwrap();
+        let mut module = ModuleBuilder::new("NamespaceBuilder").unwrap();
+        module.input("bus", bit).unwrap();
+        let error = module.input("bus.member", bit).unwrap_err();
+        assert!(matches!(error, BuildError::SignalNamespaceCollision { .. }));
+
+        let mut reverse = ModuleBuilder::new("ReverseNamespaceBuilder").unwrap();
+        reverse.input("bus.member", bit).unwrap();
+        let error = reverse.input("bus", bit).unwrap_err();
+        assert!(matches!(error, BuildError::SignalNamespaceCollision { .. }));
+
+        let mut module = ModuleBuilder::new("NamespaceJson").unwrap();
+        module.input("first", bit).unwrap();
+        module.input("second", bit).unwrap();
+        let mut json = serde_json::to_value(module.finish()).unwrap();
+        json["signals"][0]["name"] = "bus".into();
+        json["signals"][1]["name"] = "bus.member".into();
+        let error = FrontendArtifact::from_json(&json.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::SignalNamespaceCollision { .. })
         ));
     }
 }

--- a/crates/celox-frontend-sdk/src/lib.rs
+++ b/crates/celox-frontend-sdk/src/lib.rs
@@ -237,6 +237,12 @@ fn insert_driver_target(
 }
 
 fn validate_constant_state(value: &Constant) -> Result<(), BuildError> {
+    let width = value.value_type().width() as u64;
+    if value.payload().bits() > width || value.mask().bits() > width {
+        return Err(BuildError::ConstantOutOfRange {
+            width: value.value_type().width(),
+        });
+    }
     if !value.value_type().is_four_state() && value.mask() != &BigUint::default() {
         return Err(BuildError::TwoStateConstantMask);
     }
@@ -615,6 +621,17 @@ impl FrontendArtifact {
                             signal_width: input_type.width(),
                         });
                     }
+                    let expected_type = ValueType::new(
+                        expression.value_type().width(),
+                        false,
+                        input_type.is_four_state(),
+                    )?;
+                    if expression.value_type() != expected_type {
+                        return Err(BuildError::TypeMismatch {
+                            expected: expected_type,
+                            actual: expression.value_type(),
+                        });
+                    }
                 }
                 ExprNode::Mux {
                     condition,
@@ -881,6 +898,8 @@ pub enum BuildError {
     InvalidDriverTarget { name: String },
     #[error("two-state constants cannot contain X/Z mask bits")]
     TwoStateConstantMask,
+    #[error("constant payload or mask does not fit its declared width {width}")]
+    ConstantOutOfRange { width: usize },
     #[error("signal names `{first}` and `{second}` collide in the DUT namespace")]
     SignalNamespaceCollision { first: String, second: String },
     #[error("inout signal `{name}` is not supported by frontend artifact format version 1")]
@@ -1408,6 +1427,32 @@ mod tests {
     }
 
     #[test]
+    fn revalidates_expression_slice_type_from_json() {
+        let logic = ValueType::logic(8).unwrap();
+        let mut module = ModuleBuilder::new("SliceType").unwrap();
+        let input = module.input("input", logic).unwrap();
+        let input = module.read(input).unwrap();
+        module.expr_slice(input, 0, 4).unwrap();
+        let artifact = module.finish();
+
+        let mut signed = serde_json::to_value(&artifact).unwrap();
+        signed["expressions"][1]["value_type"]["signed"] = true.into();
+        let error = FrontendArtifact::from_json(&signed.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::TypeMismatch { .. })
+        ));
+
+        let mut two_state = serde_json::to_value(&artifact).unwrap();
+        two_state["expressions"][1]["value_type"]["four_state"] = false.into();
+        let error = FrontendArtifact::from_json(&two_state.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::TypeMismatch { .. })
+        ));
+    }
+
+    #[test]
     fn rejects_overlapping_register_and_assignment_drivers() {
         let bit = ValueType::bits(1).unwrap();
         let mut module = ModuleBuilder::new("DriverConflict").unwrap();
@@ -1515,6 +1560,32 @@ mod tests {
         assert!(matches!(
             error,
             ArtifactJsonError::InvalidArtifact(BuildError::TwoStateConstantMask)
+        ));
+    }
+
+    #[test]
+    fn rejects_out_of_range_constant_bits_from_json() {
+        let value = Constant::four_state(0xa5u8, 0u8, 8).unwrap();
+        let mut module = ModuleBuilder::new("ConstantRange").unwrap();
+        module.constant(value);
+        let artifact = module.finish();
+
+        let mut payload = serde_json::to_value(&artifact).unwrap();
+        payload["expressions"][0]["node"]["Constant"]["payload"] =
+            serde_json::to_value(BigUint::from(0x100u16)).unwrap();
+        let error = FrontendArtifact::from_json(&payload.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::ConstantOutOfRange { width: 8 })
+        ));
+
+        let mut mask = serde_json::to_value(&artifact).unwrap();
+        mask["expressions"][0]["node"]["Constant"]["mask"] =
+            serde_json::to_value(BigUint::from(0x100u16)).unwrap();
+        let error = FrontendArtifact::from_json(&mask.to_string()).unwrap_err();
+        assert!(matches!(
+            error,
+            ArtifactJsonError::InvalidArtifact(BuildError::ConstantOutOfRange { width: 8 })
         ));
     }
 

--- a/crates/celox-napi/Cargo.toml
+++ b/crates/celox-napi/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib"]
 napi              = { version = "=3.12.1", features = ["napi8", "serde-json"] }
 napi-derive       = "=3.6.3"
 celox-ts-gen      = { path = "../celox-ts-gen" }
+celox-design      = { path = "../celox-design" }
 veryl-analyzer    = { workspace = true }
 veryl-metadata    = { workspace = true }
 veryl-parser      = { workspace = true }

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1694,6 +1694,12 @@ impl NativeSimulatorHandle {
         )
     }
 
+    /// Return a complete initialized memory image for the TypeScript WASM bridge.
+    #[napi]
+    pub fn initial_memory_bytes(&self) -> Vec<u8> {
+        Self::build_initial_memory_bytes(&self.program, self.program.layout(), self.four_state)
+    }
+
     /// Returns the instance hierarchy as a JSON string.
     #[napi(getter)]
     pub fn hierarchy_json(&self) -> String {
@@ -1768,6 +1774,119 @@ impl NativeSimulatorHandle {
 
 #[cfg(target_arch = "wasm32")]
 impl NativeSimulatorHandle {
+    fn write_memory_bit(memory: &mut [u8], byte: usize, bit: usize, value: bool) {
+        let mask = 1u8 << bit;
+        if value {
+            memory[byte] |= mask;
+        } else {
+            memory[byte] &= !mask;
+        }
+    }
+
+    fn byte_bit(bytes: &[u8], bit: usize) -> bool {
+        bytes
+            .get(bit / 8)
+            .is_some_and(|byte| byte & (1u8 << (bit % 8)) != 0)
+    }
+
+    fn build_initial_memory_bytes(
+        program: &celox::LaidOutProgram,
+        layout: &celox::MemoryLayout,
+        four_state: bool,
+    ) -> Vec<u8> {
+        let mut memory = vec![0u8; layout.merged_total_size];
+
+        if four_state {
+            for (address, &offset) in &layout.offsets {
+                if layout.is_4states.get(address).copied().unwrap_or(false) {
+                    let plane_size = layout.plane_size(address);
+                    memory[offset..offset + plane_size * 2].fill(0xff);
+                }
+            }
+            for (address, &relative_offset) in &layout.working_offsets {
+                if layout.is_4states.get(address).copied().unwrap_or(false) {
+                    let offset = layout.working_base_offset + relative_offset;
+                    let plane_size = layout.plane_size(address);
+                    memory[offset..offset + plane_size * 2].fill(0xff);
+                }
+            }
+        }
+
+        for initial in &program.design.initial_state {
+            let Some(&offset) = layout.offsets.get(&initial.address) else {
+                continue;
+            };
+            let width = layout.widths[&initial.address];
+            let plane_size = layout.plane_size(&initial.address);
+            let write_mask = four_state
+                && layout
+                    .is_4states
+                    .get(&initial.address)
+                    .copied()
+                    .unwrap_or(false);
+
+            match &initial.data {
+                celox_design::InitialStateData::Packed {
+                    value,
+                    mask,
+                    written_mask,
+                } => {
+                    let value = value.to_bytes_le();
+                    let mask = mask.to_bytes_le();
+                    let written_mask = written_mask.to_bytes_le();
+                    for bit in 0..width {
+                        if !Self::byte_bit(&written_mask, bit) {
+                            continue;
+                        }
+                        let (byte, intra) = layout.map_static_bit_offset(&initial.address, bit);
+                        let is_unknown = Self::byte_bit(&mask, bit);
+                        Self::write_memory_bit(
+                            &mut memory,
+                            offset + byte,
+                            intra,
+                            Self::byte_bit(&value, bit) && (write_mask || !is_unknown),
+                        );
+                        if write_mask {
+                            Self::write_memory_bit(
+                                &mut memory,
+                                offset + plane_size + byte,
+                                intra,
+                                is_unknown,
+                            );
+                        }
+                    }
+                }
+                celox_design::InitialStateData::Writes(runs) => {
+                    for run in runs {
+                        for relative_bit in 0..run.bit_width {
+                            let bit = run.bit_offset + relative_bit;
+                            if bit >= width {
+                                break;
+                            }
+                            let (byte, intra) = layout.map_static_bit_offset(&initial.address, bit);
+                            Self::write_memory_bit(
+                                &mut memory,
+                                offset + byte,
+                                intra,
+                                Self::byte_bit(&run.value_bytes, relative_bit),
+                            );
+                            if write_mask {
+                                Self::write_memory_bit(
+                                    &mut memory,
+                                    offset + plane_size + byte,
+                                    intra,
+                                    Self::byte_bit(&run.mask_bytes, relative_bit),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        memory
+    }
+
     fn build_four_state_init_regions_json(
         program: &celox::LaidOutProgram,
         layout: &celox::MemoryLayout,
@@ -1863,12 +1982,10 @@ impl NativeSimulatorHandle {
         use std::collections::BTreeMap;
 
         let mut events: BTreeMap<String, usize> = BTreeMap::new();
-        let mut next_id = 0usize;
 
-        for addr in program.sir.eval_apply_ffs.keys() {
+        for (next_id, addr) in program.sir.eval_apply_ffs.keys().enumerate() {
             let name = program.get_path(addr);
             events.insert(name, next_id);
-            next_id += 1;
         }
 
         serde_json::to_string(&events).unwrap_or_else(|_| "{}".to_string())

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1568,6 +1568,47 @@ impl NativeSimulatorHandle {
         })
     }
 
+    /// Create a WASM-oriented handle from a versioned external-frontend artifact.
+    #[napi(factory)]
+    pub fn from_frontend_artifact(
+        artifact_json: String,
+        options: Option<NapiOptions>,
+    ) -> Result<Self> {
+        let opts = parse_options_common(&options)?;
+        let artifact = celox::FrontendArtifact::from_json(&artifact_json)
+            .map_err(|error| Error::from_reason(error.to_string()))?;
+        let trace_opts = celox::TraceOptions::default();
+        let (program, warnings) = celox::compile_frontend_to_sir(
+            &artifact,
+            &opts.false_loops,
+            &opts.true_loops,
+            opts.four_state,
+            &trace_opts,
+            None,
+            &opts.optimize_options,
+        )
+        .map_err(|error| Error::from_reason(error.to_string()))?;
+
+        let laid_out = program.into_laid_out(opts.four_state);
+        let layout = laid_out.layout();
+        let layout_json = Self::build_layout_json(&laid_out, layout, opts.four_state);
+        let events_json = Self::build_events_json(&laid_out);
+        let warnings_json = format_warnings_json(&warnings);
+        let stable_size = layout.total_size as u32;
+        let total_size = layout.merged_total_size as u32;
+
+        Ok(Self {
+            program: laid_out,
+            four_state: opts.four_state,
+            layout_json,
+            events_json,
+            hierarchy_json: "{}".to_string(),
+            warnings_json,
+            stable_size,
+            total_size,
+        })
+    }
+
     /// Create a new simulator from a Veryl project directory.
     #[napi(factory)]
     pub fn from_project(

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -972,6 +972,22 @@ impl NativeSimulatorHandle {
         Self::build_and_cache(sim, opts.four_state, opts.vcd.as_deref(), Some(cache_key))
     }
 
+    /// Create a simulator from a versioned external-frontend artifact.
+    #[napi(factory)]
+    pub fn from_frontend_artifact(
+        artifact_json: String,
+        options: Option<NapiOptions>,
+    ) -> Result<Self> {
+        let opts = parse_options(&options)?;
+        let artifact = celox::FrontendArtifact::from_json(&artifact_json)
+            .map_err(|error| Error::from_reason(error.to_string()))?;
+        let builder = apply_options(celox::Simulator::from_frontend(artifact), &opts);
+        let sim = builder
+            .build()
+            .map_err(|error| Error::from_reason(error.to_string()))?;
+        Self::build_and_cache(sim, opts.four_state, opts.vcd.as_deref(), None)
+    }
+
     /// Create a new simulator from a Veryl project directory.
     ///
     /// Searches upward from `project_path` for `Veryl.toml`, gathers all
@@ -1196,6 +1212,52 @@ impl NativeSimulationHandle {
             .map_err(|e| Error::from_reason(format!("Failed to serialize events: {}", e)))?;
         let hierarchy_json = serde_json::to_string(&hierarchy_node)
             .map_err(|e| Error::from_reason(format!("Failed to serialize hierarchy: {}", e)))?;
+
+        Ok(Self {
+            sim: Some(sim),
+            layout_json,
+            events_json,
+            hierarchy_json,
+            warnings_json,
+            stable_size: stable_size as u32,
+            total_size: total_size as u32,
+            default_max_steps: None,
+        })
+    }
+
+    /// Create a timed simulation from a versioned external-frontend artifact.
+    #[napi(factory)]
+    pub fn from_frontend_artifact(
+        artifact_json: String,
+        options: Option<NapiOptions>,
+    ) -> Result<Self> {
+        let opts = parse_options(&options)?;
+        let artifact = celox::FrontendArtifact::from_json(&artifact_json)
+            .map_err(|error| Error::from_reason(error.to_string()))?;
+        let mut builder = apply_options(celox::Simulation::from_frontend(artifact), &opts);
+        if let Some(path) = &opts.vcd {
+            builder = builder.vcd(path);
+        }
+        let sim = builder
+            .build()
+            .map_err(|error| Error::from_reason(error.to_string()))?;
+
+        let warnings_json = format_warnings_json(sim.warnings());
+        let signals = sim.named_signals();
+        let events = sim.named_events();
+        let hierarchy = sim.named_hierarchy();
+        let (_, total_size) = sim.memory_as_ptr();
+        let stable_size = sim.stable_region_size();
+        let layout_map = build_signal_layout(&signals, opts.four_state);
+        let event_map = build_event_map(&events);
+        let hierarchy_node = build_hierarchy_node(&hierarchy, opts.four_state);
+        let layout_json = serde_json::to_string(&layout_map)
+            .map_err(|error| Error::from_reason(format!("Failed to serialize layout: {error}")))?;
+        let events_json = serde_json::to_string(&event_map)
+            .map_err(|error| Error::from_reason(format!("Failed to serialize events: {error}")))?;
+        let hierarchy_json = serde_json::to_string(&hierarchy_node).map_err(|error| {
+            Error::from_reason(format!("Failed to serialize hierarchy: {error}"))
+        })?;
 
         Ok(Self {
             sim: Some(sim),
@@ -2227,6 +2289,40 @@ pub fn run_test(
     let result = builder
         .run_test_detailed()
         .map_err(|e| Error::from_reason(format!("{e}")))?;
+    Ok(convert_test_result(result))
+}
+
+/// Run a Veryl native testbench against an external frontend artifact.
+#[cfg(not(target_arch = "wasm32"))]
+#[napi]
+pub fn run_test_with_frontend_artifact(
+    env: Env,
+    artifact_json: String,
+    sources: Vec<NapiSourceFile>,
+    top: String,
+    options: Option<NapiOptions>,
+    components: Option<Vec<NapiInjectedComponent>>,
+) -> Result<NapiTestResult> {
+    let opts = parse_options(&options)?;
+    let artifact = celox::FrontendArtifact::from_json(&artifact_json)
+        .map_err(|error| Error::from_reason(error.to_string()))?;
+    let mut src_pairs: Vec<(String, std::path::PathBuf)> = sources
+        .into_iter()
+        .map(|source| (source.content, std::path::PathBuf::from(source.path)))
+        .collect();
+    append_extra_source(&mut src_pairs, &opts.extra_source);
+    let source_refs: Vec<(&str, &std::path::Path)> = src_pairs
+        .iter()
+        .map(|(source, path)| (source.as_str(), path.as_path()))
+        .collect();
+    let builder = apply_options(
+        celox::Simulator::from_frontend_with_testbench(artifact, source_refs, &top),
+        &opts,
+    )
+    .with_injected_components(injected_components(env, components)?);
+    let result = builder
+        .run_test_detailed()
+        .map_err(|error| Error::from_reason(error.to_string()))?;
     Ok(convert_test_result(result))
 }
 

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -35,6 +35,7 @@ celox-analysis        = { path = "../celox-analysis" }
 celox-backend-wasm    = { path = "../celox-backend-wasm" }
 celox-design          = { path = "../celox-design" }
 celox-frontend-core   = { path = "../celox-frontend-core" }
+celox-frontend-sdk    = { path = "../celox-frontend-sdk" }
 celox-frontend-sv     = { path = "../celox-frontend-sv", optional = true }
 celox-frontend-veryl  = { path = "../celox-frontend-veryl" }
 celox-sir             = { path = "../celox-sir" }

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -25,6 +25,9 @@ pub use backend::{
     EventHandle, LayoutRequirements, MemoryLayout, MemoryLayoutMode, SimBackend, get_byte_size,
 };
 pub use celox_design::{DomainKind, ElaboratedDesign, EventTopology, RuntimeSchema};
+pub use celox_frontend_core::FrontendArtifactError;
+pub use celox_frontend_sdk as frontend_sdk;
+pub use celox_frontend_sdk::FrontendArtifact;
 pub use celox_frontend_veryl::{FrontendDiagnostic, LoweringPhase, ParserError};
 pub use celox_runtime::{
     DesignReflection, ReflectionScope, ReflectionScopeId, ReflectionSignal, ReflectionSignalId,
@@ -148,7 +151,7 @@ pub use host_api::*;
 pub use backend::wasm_codegen;
 
 // Public compilation API (available on all targets)
-pub use simulator::compile_to_sir;
+pub use simulator::{compile_frontend_to_sir, compile_to_sir};
 #[cfg(feature = "systemverilog")]
 pub use simulator::{compile_mixed_to_sir, compile_sv_to_sir};
 

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -591,7 +591,7 @@ pub fn parse_mixed(
     )],
     four_state: bool,
     trace_opts: &crate::debug::TraceOptions,
-    mut trace: Option<&mut crate::debug::CompilationTrace>,
+    trace: Option<&mut crate::debug::CompilationTrace>,
     optimize_options: &crate::optimizer::OptimizeOptions,
     diagnostics: &crate::RuntimeDiagnostics,
     preserve_element_storage_layout: bool,

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -285,7 +285,7 @@ fn verify_region_contract(
     Ok(())
 }
 
-fn finalize_scheduled_rtl(
+pub(crate) fn finalize_scheduled_rtl(
     mut scheduled: celox_frontend_core::ScheduledRtlOutput,
     mut testbench_source: Option<celox_frontend_veryl::VerylTestbenchSource>,
     four_state: bool,
@@ -622,10 +622,62 @@ pub fn parse_mixed(
                     None,
                 ),
             })?;
-    let symbolic = celox_frontend_veryl::parse_ir_with_external_hierarchy(
+    parse_with_external_hierarchy(
+        top,
         ir,
         loop_provenance,
         &external,
+        config,
+        ignored_loops,
+        true_loops,
+        four_state,
+        trace_opts,
+        trace,
+        optimize_options,
+        diagnostics,
+        preserve_element_storage_layout,
+        testbench_random_seed,
+        component_libraries,
+        component_file_base,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn parse_with_external_hierarchy(
+    top: &StrId,
+    ir: &veryl_analyzer::ir::Ir,
+    loop_provenance: &loop_provenance::LoopProvenance,
+    external: &celox_frontend_core::symbolic::artifact::ExternalHierarchy,
+    config: &BuildConfig,
+    ignored_loops: &[(
+        (Vec<(String, usize)>, Vec<String>),
+        (Vec<(String, usize)>, Vec<String>),
+    )],
+    true_loops: &[(
+        (Vec<(String, usize)>, Vec<String>),
+        (Vec<(String, usize)>, Vec<String>),
+        usize,
+    )],
+    four_state: bool,
+    trace_opts: &crate::debug::TraceOptions,
+    mut trace: Option<&mut crate::debug::CompilationTrace>,
+    optimize_options: &crate::optimizer::OptimizeOptions,
+    diagnostics: &crate::RuntimeDiagnostics,
+    preserve_element_storage_layout: bool,
+    testbench_random_seed: Option<u64>,
+    component_libraries: Vec<celox_testbench::ComponentLibrary>,
+    component_file_base: Option<std::path::PathBuf>,
+) -> Result<
+    (
+        crate::ir::OptimizedSir,
+        Vec<celox_frontend_veryl::FrontendDiagnostic>,
+    ),
+    ParserError,
+> {
+    let symbolic = celox_frontend_veryl::parse_ir_with_external_hierarchy(
+        ir,
+        loop_provenance,
+        external,
         config,
         top,
     )?;

--- a/crates/celox/src/simulation.rs
+++ b/crates/celox/src/simulation.rs
@@ -98,6 +98,13 @@ impl Simulation {
     ) -> crate::SimulatorBuilder<'a, Simulation> {
         crate::SimulatorBuilder::<Simulation>::from_sources(sources, top)
     }
+
+    /// Build a timed simulation from an elaborated external frontend artifact.
+    pub fn from_frontend(
+        artifact: celox_frontend_sdk::FrontendArtifact,
+    ) -> crate::SimulatorBuilder<'static, Simulation> {
+        crate::SimulatorBuilder::<Simulation>::from_frontend(artifact)
+    }
 }
 
 // ── Generic methods available for any backend ───────────────────────

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -9,9 +9,9 @@ mod error;
     )
 ))]
 pub use builder::NativeCompilation;
-pub use builder::compile_to_sir;
 #[cfg(feature = "host-runtime")]
 pub use builder::{DeadStorePolicy, SimulatorBuilder, SimulatorOptions};
+pub use builder::{compile_frontend_to_sir, compile_to_sir};
 #[cfg(feature = "systemverilog")]
 pub use builder::{compile_mixed_to_sir, compile_sv_to_sir};
 pub use error::render_diagnostic;
@@ -1470,6 +1470,22 @@ mod host {
             top: &'a str,
         ) -> SimulatorBuilder<'a, Simulator> {
             SimulatorBuilder::<Simulator>::from_sources(sources, top)
+        }
+
+        /// Build a simulator from an elaborated external frontend artifact.
+        pub fn from_frontend(
+            artifact: celox_frontend_sdk::FrontendArtifact,
+        ) -> SimulatorBuilder<'static, Simulator> {
+            SimulatorBuilder::<Simulator>::from_frontend(artifact)
+        }
+
+        /// Build a Veryl native testbench around an external frontend module.
+        pub fn from_frontend_with_testbench<'a>(
+            artifact: celox_frontend_sdk::FrontendArtifact,
+            sources: Vec<(&'a str, &'a std::path::Path)>,
+            top: &'a str,
+        ) -> SimulatorBuilder<'a, Simulator> {
+            SimulatorBuilder::<Simulator>::from_frontend_with_testbench(artifact, sources, top)
         }
 
         /// Build a simulator directly from SystemVerilog sources.

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -180,6 +180,7 @@ fn elaborate_parameterized_top(
 fn analyze(
     sources: &[(&str, &Path)],
     sv_sources: Option<&[(&str, &Path)]>,
+    external_frontend: Option<&celox_frontend_core::symbolic::artifact::ExternalHierarchy>,
     top: &str,
     ignored_loops: &[(
         (Vec<(String, usize)>, Vec<String>),
@@ -316,13 +317,12 @@ fn analyze(
     if let Some(rt) = reset_type {
         build_config.reset_type = rt;
     }
-    #[cfg(feature = "systemverilog")]
-    let sir = if let Some(sv_sources) = sv_sources {
-        parser::parse_mixed(
+    let sir = if let Some(external) = external_frontend {
+        parser::parse_with_external_hierarchy(
             &top,
             &ir,
             &loop_provenance,
-            sv_sources,
+            external,
             &build_config,
             ignored_loops,
             true_loops,
@@ -337,44 +337,68 @@ fn analyze(
             component_file_base,
         )
     } else {
-        parser::parse(
-            &top,
-            &ir,
-            &loop_provenance,
-            &build_config,
-            ignored_loops,
-            true_loops,
-            four_state,
-            trace_opts,
-            trace_out,
-            optimize_options,
-            diagnostics,
-            preserve_element_storage_layout,
-            testbench_random_seed,
-            component_libraries,
-            component_file_base,
-        )
-    };
-    #[cfg(not(feature = "systemverilog"))]
-    let sir = {
-        debug_assert!(sv_sources.is_none());
-        parser::parse(
-            &top,
-            &ir,
-            &loop_provenance,
-            &build_config,
-            ignored_loops,
-            true_loops,
-            four_state,
-            trace_opts,
-            trace_out,
-            optimize_options,
-            diagnostics,
-            preserve_element_storage_layout,
-            testbench_random_seed,
-            component_libraries,
-            component_file_base,
-        )
+        #[cfg(feature = "systemverilog")]
+        {
+            if let Some(sv_sources) = sv_sources {
+                parser::parse_mixed(
+                    &top,
+                    &ir,
+                    &loop_provenance,
+                    sv_sources,
+                    &build_config,
+                    ignored_loops,
+                    true_loops,
+                    four_state,
+                    trace_opts,
+                    trace_out,
+                    optimize_options,
+                    diagnostics,
+                    preserve_element_storage_layout,
+                    testbench_random_seed,
+                    component_libraries,
+                    component_file_base,
+                )
+            } else {
+                parser::parse(
+                    &top,
+                    &ir,
+                    &loop_provenance,
+                    &build_config,
+                    ignored_loops,
+                    true_loops,
+                    four_state,
+                    trace_opts,
+                    trace_out,
+                    optimize_options,
+                    diagnostics,
+                    preserve_element_storage_layout,
+                    testbench_random_seed,
+                    component_libraries,
+                    component_file_base,
+                )
+            }
+        }
+        #[cfg(not(feature = "systemverilog"))]
+        {
+            debug_assert!(sv_sources.is_none());
+            parser::parse(
+                &top,
+                &ir,
+                &loop_provenance,
+                &build_config,
+                ignored_loops,
+                true_loops,
+                four_state,
+                trace_opts,
+                trace_out,
+                optimize_options,
+                diagnostics,
+                preserve_element_storage_layout,
+                testbench_random_seed,
+                component_libraries,
+                component_file_base,
+            )
+        }
     };
     let sir = sir.map(|(sir, mut elaborated_diagnostics)| {
         frontend_diagnostics.append(&mut elaborated_diagnostics);
@@ -428,6 +452,168 @@ pub fn compile_to_sir(
     )
 }
 
+/// Compile an elaborated external-frontend artifact to optimized SIR.
+///
+/// The artifact carries source-independent signal reflection, so the resulting
+/// program can be used by the same Rust and TypeScript testbench APIs as a
+/// Veryl- or SystemVerilog-produced program.
+pub fn compile_frontend_to_sir(
+    artifact: &celox_frontend_sdk::FrontendArtifact,
+    ignored_loops: &[(
+        (Vec<(String, usize)>, Vec<String>),
+        (Vec<(String, usize)>, Vec<String>),
+    )],
+    true_loops: &[(
+        (Vec<(String, usize)>, Vec<String>),
+        (Vec<(String, usize)>, Vec<String>),
+        usize,
+    )],
+    four_state: bool,
+    trace_opts: &crate::debug::TraceOptions,
+    trace_out: Option<&mut crate::debug::CompilationTrace>,
+    optimize_options: &crate::optimizer::OptimizeOptions,
+) -> Result<(OptimizedSir, Vec<CompilationWarning>), SimulatorError> {
+    compile_frontend_to_sir_with_layout_mode(
+        artifact,
+        ignored_loops,
+        true_loops,
+        four_state,
+        trace_opts,
+        trace_out,
+        optimize_options,
+        &crate::RuntimeDiagnostics::default(),
+        crate::backend::memory_layout::MemoryLayoutMode::Packed,
+    )
+}
+
+fn compile_frontend_to_sir_with_layout_mode(
+    artifact: &celox_frontend_sdk::FrontendArtifact,
+    ignored_loops: &[(
+        (Vec<(String, usize)>, Vec<String>),
+        (Vec<(String, usize)>, Vec<String>),
+    )],
+    true_loops: &[(
+        (Vec<(String, usize)>, Vec<String>),
+        (Vec<(String, usize)>, Vec<String>),
+        usize,
+    )],
+    four_state: bool,
+    trace_opts: &crate::debug::TraceOptions,
+    mut trace_out: Option<&mut crate::debug::CompilationTrace>,
+    optimize_options: &crate::optimizer::OptimizeOptions,
+    diagnostics: &crate::RuntimeDiagnostics,
+    layout_mode: crate::backend::memory_layout::MemoryLayoutMode,
+) -> Result<(OptimizedSir, Vec<CompilationWarning>), SimulatorError> {
+    let lowered = celox_frontend_core::lower_frontend_artifact(artifact)?;
+    let frontend_trace_options = trace_opts.frontend(diagnostics);
+    let mut frontend_trace = celox_frontend_core::FrontendTrace::default();
+    let scheduled = celox_frontend_core::symbolic::assembly::schedule_symbolic_rtl(
+        lowered.symbolic,
+        None,
+        ignored_loops,
+        true_loops,
+        four_state,
+        &frontend_trace_options,
+        trace_out.is_some().then_some(&mut frontend_trace),
+    )
+    .map_err(celox_frontend_veryl::ParserError::from)?;
+    if let Some(trace) = trace_out.as_deref_mut() {
+        trace.absorb_frontend(frontend_trace);
+    }
+    let program = parser::finalize_scheduled_rtl(
+        scheduled,
+        None,
+        four_state,
+        trace_opts,
+        trace_out,
+        optimize_options,
+        diagnostics,
+        layout_mode == crate::backend::memory_layout::MemoryLayoutMode::ElementStrided,
+        None,
+        Vec::new(),
+        None,
+    )?;
+    Ok((program, Vec::new()))
+}
+
+#[cfg(feature = "host-runtime")]
+fn compile_frontend_testbench_to_sir_with_layout_mode(
+    artifact: &celox_frontend_sdk::FrontendArtifact,
+    sources: &[(&str, &Path)],
+    top: &str,
+    ignored_loops: &[(
+        (Vec<(String, usize)>, Vec<String>),
+        (Vec<(String, usize)>, Vec<String>),
+    )],
+    true_loops: &[(
+        (Vec<(String, usize)>, Vec<String>),
+        (Vec<(String, usize)>, Vec<String>),
+        usize,
+    )],
+    four_state: bool,
+    trace_opts: &crate::debug::TraceOptions,
+    trace_out: Option<&mut crate::debug::CompilationTrace>,
+    metadata: Option<Metadata>,
+    clock_type: Option<ClockType>,
+    reset_type: Option<ResetType>,
+    optimize_options: &crate::optimizer::OptimizeOptions,
+    diagnostics: &crate::RuntimeDiagnostics,
+    injected_manifests: &[(String, veryl_metadata::ComponentManifest)],
+    layout_mode: crate::backend::memory_layout::MemoryLayoutMode,
+    recover_comb_loops: bool,
+) -> Result<(OptimizedSir, Vec<CompilationWarning>), SimulatorError> {
+    let lowered = celox_frontend_core::lower_frontend_artifact(artifact)?;
+    let (sir, errors, frontend_diagnostics) = analyze(
+        sources,
+        None,
+        Some(&lowered.external),
+        top,
+        ignored_loops,
+        true_loops,
+        four_state,
+        trace_opts,
+        trace_out,
+        metadata,
+        clock_type,
+        reset_type,
+        &[],
+        optimize_options,
+        diagnostics,
+        injected_manifests,
+        layout_mode == crate::backend::memory_layout::MemoryLayoutMode::ElementStrided,
+        recover_comb_loops,
+    );
+    let (real_errors, analyzer_warnings): (Vec<_>, Vec<_>) =
+        errors.into_iter().partition(AnalyzerError::is_error);
+    let (frontend_errors, frontend_warnings): (Vec<_>, Vec<_>) = frontend_diagnostics
+        .into_iter()
+        .partition(FrontendDiagnostic::is_error);
+    let warnings = analyzer_warnings
+        .into_iter()
+        .map(CompilationWarning::Analyzer)
+        .chain(
+            frontend_warnings
+                .into_iter()
+                .map(CompilationWarning::Frontend),
+        )
+        .collect::<Vec<_>>();
+    if !real_errors.is_empty() {
+        return Err(
+            SimulatorError::new(SimulatorErrorKind::Analyzer(real_errors)).with_warnings(warnings),
+        );
+    }
+    if !frontend_errors.is_empty() {
+        return Err(
+            SimulatorError::new(SimulatorErrorKind::Frontend(frontend_errors))
+                .with_warnings(warnings),
+        );
+    }
+    match sir {
+        Ok(program) => Ok((program, warnings)),
+        Err(error) => Err(SimulatorError::from(error).with_warnings(warnings)),
+    }
+}
+
 fn compile_to_sir_with_layout_mode(
     sources: &[(&str, &Path)],
     top: &str,
@@ -455,6 +641,7 @@ fn compile_to_sir_with_layout_mode(
 ) -> Result<(OptimizedSir, Vec<CompilationWarning>), SimulatorError> {
     let (sir, errors, frontend_diagnostics) = analyze(
         sources,
+        None,
         None,
         top,
         ignored_loops,
@@ -676,6 +863,7 @@ fn compile_mixed_to_sir_with_layout_mode(
     let (sir, errors, frontend_diagnostics) = analyze(
         sources,
         Some(sv_sources),
+        None,
         top,
         ignored_loops,
         true_loops,
@@ -754,7 +942,7 @@ fn compile_hdl_to_sir_with_layout_mode(
     #[cfg(not(feature = "systemverilog"))]
     {
         debug_assert!(sv_sources.is_empty());
-        return compile_to_sir_with_layout_mode(
+        compile_to_sir_with_layout_mode(
             sources,
             top,
             ignored_loops,
@@ -771,7 +959,7 @@ fn compile_hdl_to_sir_with_layout_mode(
             injected_manifests,
             layout_mode,
             recover_comb_loops,
-        );
+        )
     }
     #[cfg(feature = "systemverilog")]
     match (sources.is_empty(), sv_sources.is_empty()) {
@@ -993,6 +1181,7 @@ mod host {
         param_overrides: Vec<(String, u64)>,
         live_signals: Vec<(Vec<(String, usize)>, Vec<String>)>,
         injected_components: crate::InjectedComponents,
+        frontend_artifact: Option<celox_frontend_sdk::FrontendArtifact>,
         _marker: std::marker::PhantomData<Target>,
     }
 
@@ -1017,8 +1206,14 @@ mod host {
         }
 
         /// Returns the top module name.
-        pub fn top(&self) -> &'a str {
-            self.top
+        pub fn top(&self) -> &str {
+            if !self.sources.is_empty() {
+                self.top
+            } else {
+                self.frontend_artifact
+                    .as_ref()
+                    .map_or(self.top, celox_frontend_sdk::FrontendArtifact::module_name)
+            }
         }
 
         /// Returns whether four-state simulation is enabled for this builder.
@@ -1351,6 +1546,7 @@ mod host {
                 param_overrides: Vec::new(),
                 live_signals: Vec::new(),
                 injected_components: Default::default(),
+                frontend_artifact: None,
                 _marker: std::marker::PhantomData,
             }
         }
@@ -1370,6 +1566,7 @@ mod host {
                 param_overrides: Vec::new(),
                 live_signals: Vec::new(),
                 injected_components: Default::default(),
+                frontend_artifact: None,
                 _marker: std::marker::PhantomData,
             }
         }
@@ -1390,6 +1587,7 @@ mod host {
                 param_overrides: Vec::new(),
                 live_signals: Vec::new(),
                 injected_components: Default::default(),
+                frontend_artifact: None,
                 _marker: std::marker::PhantomData,
             }
         }
@@ -1414,6 +1612,56 @@ mod host {
                 param_overrides: Vec::new(),
                 live_signals: Vec::new(),
                 injected_components: Default::default(),
+                frontend_artifact: None,
+                _marker: std::marker::PhantomData,
+            }
+        }
+
+        /// Build a simulator from a source-independent external frontend artifact.
+        pub fn from_frontend(
+            artifact: celox_frontend_sdk::FrontendArtifact,
+        ) -> SimulatorBuilder<'static, Simulator> {
+            SimulatorBuilder {
+                sources: Vec::new(),
+                sv_sources: Vec::new(),
+                top: "",
+                ignored_loops: Vec::new(),
+                true_loops: Vec::new(),
+                options: SimulatorOptions::default(),
+                vcd_path: None,
+                metadata: None,
+                clock_type: None,
+                reset_type: None,
+                param_overrides: Vec::new(),
+                live_signals: Vec::new(),
+                injected_components: Default::default(),
+                frontend_artifact: Some(artifact),
+                _marker: std::marker::PhantomData,
+            }
+        }
+
+        /// Build a Veryl native testbench whose `$sv::Module` instances are
+        /// resolved from an external frontend artifact.
+        pub fn from_frontend_with_testbench(
+            artifact: celox_frontend_sdk::FrontendArtifact,
+            sources: Vec<(&'a str, &'a Path)>,
+            top: &'a str,
+        ) -> Self {
+            Self {
+                sources,
+                sv_sources: Vec::new(),
+                top,
+                ignored_loops: Vec::new(),
+                true_loops: Vec::new(),
+                options: SimulatorOptions::default(),
+                vcd_path: None,
+                metadata: None,
+                clock_type: None,
+                reset_type: None,
+                param_overrides: Vec::new(),
+                live_signals: Vec::new(),
+                injected_components: Default::default(),
+                frontend_artifact: Some(artifact),
                 _marker: std::marker::PhantomData,
             }
         }
@@ -1438,25 +1686,60 @@ mod host {
             let phase_timing = self.options.diagnostics.phase_timing;
             let compile_start = phase_timing.then(crate::timing::now);
             let injected_manifests = self.injected_components.manifests();
-            let (program, warnings) = compile_hdl_to_sir_with_layout_mode(
-                &self.sources,
-                &self.sv_sources,
-                self.top,
-                &self.ignored_loops,
-                &self.true_loops,
-                self.options.four_state,
-                &self.options.trace,
-                None,
-                self.metadata,
-                self.clock_type,
-                self.reset_type,
-                &self.param_overrides,
-                &self.options.optimize_options,
-                &self.options.diagnostics,
-                &injected_manifests,
-                layout_mode,
-                !self.options.native_force_support,
-            )?;
+            let (program, warnings) = if let Some(artifact) = &self.frontend_artifact {
+                if self.sources.is_empty() {
+                    compile_frontend_to_sir_with_layout_mode(
+                        artifact,
+                        &self.ignored_loops,
+                        &self.true_loops,
+                        self.options.four_state,
+                        &self.options.trace,
+                        None,
+                        &self.options.optimize_options,
+                        &self.options.diagnostics,
+                        layout_mode,
+                    )?
+                } else {
+                    compile_frontend_testbench_to_sir_with_layout_mode(
+                        artifact,
+                        &self.sources,
+                        self.top,
+                        &self.ignored_loops,
+                        &self.true_loops,
+                        self.options.four_state,
+                        &self.options.trace,
+                        None,
+                        self.metadata,
+                        self.clock_type,
+                        self.reset_type,
+                        &self.options.optimize_options,
+                        &self.options.diagnostics,
+                        &injected_manifests,
+                        layout_mode,
+                        !self.options.native_force_support,
+                    )?
+                }
+            } else {
+                compile_hdl_to_sir_with_layout_mode(
+                    &self.sources,
+                    &self.sv_sources,
+                    self.top,
+                    &self.ignored_loops,
+                    &self.true_loops,
+                    self.options.four_state,
+                    &self.options.trace,
+                    None,
+                    self.metadata,
+                    self.clock_type,
+                    self.reset_type,
+                    &self.param_overrides,
+                    &self.options.optimize_options,
+                    &self.options.diagnostics,
+                    &injected_manifests,
+                    layout_mode,
+                    !self.options.native_force_support,
+                )?
+            };
             if let Some(start) = compile_start {
                 tracing::debug!("[phase-timing] compile_to_sir: {:?}", start.elapsed());
             }
@@ -1779,6 +2062,7 @@ mod host {
                 param_overrides: Vec::new(),
                 live_signals: Vec::new(),
                 injected_components: Default::default(),
+                frontend_artifact: None,
                 _marker: std::marker::PhantomData,
             }
         }
@@ -1798,6 +2082,29 @@ mod host {
                 param_overrides: Vec::new(),
                 live_signals: Vec::new(),
                 injected_components: Default::default(),
+                frontend_artifact: None,
+                _marker: std::marker::PhantomData,
+            }
+        }
+
+        pub(crate) fn from_frontend(
+            artifact: celox_frontend_sdk::FrontendArtifact,
+        ) -> SimulatorBuilder<'static, crate::Simulation> {
+            SimulatorBuilder {
+                sources: Vec::new(),
+                sv_sources: Vec::new(),
+                top: "",
+                ignored_loops: Vec::new(),
+                true_loops: Vec::new(),
+                options: SimulatorOptions::default(),
+                vcd_path: None,
+                metadata: None,
+                clock_type: None,
+                reset_type: None,
+                param_overrides: Vec::new(),
+                live_signals: Vec::new(),
+                injected_components: Default::default(),
+                frontend_artifact: Some(artifact),
                 _marker: std::marker::PhantomData,
             }
         }
@@ -1816,25 +2123,39 @@ mod host {
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             )))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::Packed;
-            let (program, warnings) = compile_hdl_to_sir_with_layout_mode(
-                &self.sources,
-                &self.sv_sources,
-                self.top,
-                &self.ignored_loops,
-                &self.true_loops,
-                self.options.four_state,
-                &self.options.trace,
-                None,
-                self.metadata,
-                self.clock_type,
-                self.reset_type,
-                &self.param_overrides,
-                &self.options.optimize_options,
-                &self.options.diagnostics,
-                &self.injected_components.manifests(),
-                layout_mode,
-                !self.options.native_force_support,
-            )?;
+            let (program, warnings) = if let Some(artifact) = &self.frontend_artifact {
+                compile_frontend_to_sir_with_layout_mode(
+                    artifact,
+                    &self.ignored_loops,
+                    &self.true_loops,
+                    self.options.four_state,
+                    &self.options.trace,
+                    None,
+                    &self.options.optimize_options,
+                    &self.options.diagnostics,
+                    layout_mode,
+                )?
+            } else {
+                compile_hdl_to_sir_with_layout_mode(
+                    &self.sources,
+                    &self.sv_sources,
+                    self.top,
+                    &self.ignored_loops,
+                    &self.true_loops,
+                    self.options.four_state,
+                    &self.options.trace,
+                    None,
+                    self.metadata,
+                    self.clock_type,
+                    self.reset_type,
+                    &self.param_overrides,
+                    &self.options.optimize_options,
+                    &self.options.diagnostics,
+                    &self.injected_components.manifests(),
+                    layout_mode,
+                    !self.options.native_force_support,
+                )?
+            };
             let mut laid_out =
                 program.into_laid_out_with_mode(self.options.four_state, layout_mode);
 

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -1954,25 +1954,61 @@ mod host {
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             )))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::Packed;
-            let program_res = compile_hdl_to_sir_with_layout_mode(
-                &self.sources,
-                &self.sv_sources,
-                self.top,
-                &self.ignored_loops,
-                &self.true_loops,
-                self.options.four_state,
-                &self.options.trace,
-                Some(&mut trace),
-                self.metadata,
-                self.clock_type,
-                self.reset_type,
-                &self.param_overrides,
-                &self.options.optimize_options,
-                &self.options.diagnostics,
-                &self.injected_components.manifests(),
-                layout_mode,
-                !self.options.native_force_support,
-            );
+            let injected_manifests = self.injected_components.manifests();
+            let program_res = if let Some(artifact) = &self.frontend_artifact {
+                if self.sources.is_empty() {
+                    compile_frontend_to_sir_with_layout_mode(
+                        artifact,
+                        &self.ignored_loops,
+                        &self.true_loops,
+                        self.options.four_state,
+                        &self.options.trace,
+                        Some(&mut trace),
+                        &self.options.optimize_options,
+                        &self.options.diagnostics,
+                        layout_mode,
+                    )
+                } else {
+                    compile_frontend_testbench_to_sir_with_layout_mode(
+                        artifact,
+                        &self.sources,
+                        self.top,
+                        &self.ignored_loops,
+                        &self.true_loops,
+                        self.options.four_state,
+                        &self.options.trace,
+                        Some(&mut trace),
+                        self.metadata,
+                        self.clock_type,
+                        self.reset_type,
+                        &self.options.optimize_options,
+                        &self.options.diagnostics,
+                        &injected_manifests,
+                        layout_mode,
+                        !self.options.native_force_support,
+                    )
+                }
+            } else {
+                compile_hdl_to_sir_with_layout_mode(
+                    &self.sources,
+                    &self.sv_sources,
+                    self.top,
+                    &self.ignored_loops,
+                    &self.true_loops,
+                    self.options.four_state,
+                    &self.options.trace,
+                    Some(&mut trace),
+                    self.metadata,
+                    self.clock_type,
+                    self.reset_type,
+                    &self.param_overrides,
+                    &self.options.optimize_options,
+                    &self.options.diagnostics,
+                    &injected_manifests,
+                    layout_mode,
+                    !self.options.native_force_support,
+                )
+            };
 
             let sim_res = program_res.and_then(|(program, warnings)| {
                 let mut laid_out =

--- a/crates/celox/src/simulator/error.rs
+++ b/crates/celox/src/simulator/error.rs
@@ -102,6 +102,7 @@ impl miette::Diagnostic for CompilationWarning {
 /// The specific kind of simulator error.
 #[derive(Debug)]
 pub enum SimulatorErrorKind {
+    FrontendArtifact(crate::FrontendArtifactError),
     SIRParser(crate::ParserError),
     Analyzer(Vec<veryl_analyzer::AnalyzerError>),
     Frontend(Vec<celox_frontend_veryl::FrontendDiagnostic>),
@@ -232,6 +233,7 @@ impl SimulatorError {
 impl fmt::Display for SimulatorError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind.as_ref() {
+            SimulatorErrorKind::FrontendArtifact(error) => write!(f, "{error}")?,
             SimulatorErrorKind::SIRParser(e) => f.write_str(&render_diagnostic(e))?,
             SimulatorErrorKind::Analyzer(errors) => {
                 for (i, e) in errors.iter().enumerate() {
@@ -268,11 +270,18 @@ impl fmt::Display for SimulatorError {
 impl std::error::Error for SimulatorError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self.kind.as_ref() {
+            SimulatorErrorKind::FrontendArtifact(error) => Some(error),
             SimulatorErrorKind::SIRParser(e) => Some(e),
             SimulatorErrorKind::Runtime(e) => Some(e),
             SimulatorErrorKind::Codegen(error) => Some(error),
             _ => None,
         }
+    }
+}
+
+impl From<crate::FrontendArtifactError> for SimulatorError {
+    fn from(error: crate::FrontendArtifactError) -> Self {
+        SimulatorError::new(SimulatorErrorKind::FrontendArtifact(error))
     }
 }
 

--- a/crates/celox/tests/frontend_sdk.rs
+++ b/crates/celox/tests/frontend_sdk.rs
@@ -123,3 +123,107 @@ fn frontend_builder_accepts_internal_signals_without_exposing_them_as_ports() {
     assert_eq!(signal.index(), 0);
     assert!(module.finish().port_order().is_empty());
 }
+
+#[test]
+fn frontend_expression_result_width_is_preserved() {
+    let byte = ValueType::bits(8).unwrap();
+    let word = ValueType::bits(16).unwrap();
+    let signed_byte = ValueType::new(8, true, false).unwrap();
+    let signed_word = ValueType::new(16, true, false).unwrap();
+    let mut module = ModuleBuilder::new("WideMultiply").unwrap();
+    let a = module.input("a", byte).unwrap();
+    let b = module.input("b", byte).unwrap();
+    let signed_a = module.input("signed_a", signed_byte).unwrap();
+    let signed_b = module.input("signed_b", signed_byte).unwrap();
+    let y = module.output("y", word).unwrap();
+    let signed_y = module.output("signed_y", signed_word).unwrap();
+
+    let a_expr = module.read(a).unwrap();
+    let b_expr = module.read(b).unwrap();
+    let product = module.binary(BinaryOp::Mul, a_expr, b_expr, word).unwrap();
+    let y = module.whole(y).unwrap();
+    module.assign(y, product).unwrap();
+
+    let signed_a_expr = module.read(signed_a).unwrap();
+    let signed_b_expr = module.read(signed_b).unwrap();
+    let signed_product = module
+        .binary(BinaryOp::Mul, signed_a_expr, signed_b_expr, signed_word)
+        .unwrap();
+    let signed_y = module.whole(signed_y).unwrap();
+    module.assign(signed_y, signed_product).unwrap();
+
+    let mut sim = Simulator::from_frontend(module.finish())
+        .build_cranelift()
+        .unwrap();
+    let a = sim.signal("a");
+    let b = sim.signal("b");
+    let signed_a = sim.signal("signed_a");
+    let signed_b = sim.signal("signed_b");
+    let y = sim.signal("y");
+    let signed_y = sim.signal("signed_y");
+    sim.modify(|io| {
+        io.set(a, 0xffu8);
+        io.set(b, 0xffu8);
+        io.set(signed_a, 0xffu8);
+        io.set(signed_b, 2u8);
+    })
+    .unwrap();
+    assert_eq!(sim.get(y), 65_025u16.into());
+    assert_eq!(sim.get(signed_y), 0xfffeu16.into());
+}
+
+#[test]
+fn frontend_shared_expression_dag_is_lowered_once_per_assignment() {
+    let byte = ValueType::bits(8).unwrap();
+    let mut module = ModuleBuilder::new("SharedDag").unwrap();
+    let input = module.input("input", byte).unwrap();
+    let output = module.output("output", byte).unwrap();
+    let mut expression = module.read(input).unwrap();
+    for _ in 0..64 {
+        expression = module
+            .binary(BinaryOp::Xor, expression, expression, byte)
+            .unwrap();
+    }
+    let output = module.whole(output).unwrap();
+    module.assign(output, expression).unwrap();
+
+    Simulator::from_frontend(module.finish())
+        .build_cranelift()
+        .unwrap();
+}
+
+#[test]
+fn frontend_rejects_one_async_reset_shared_across_clock_domains() {
+    let bit = ValueType::bits(1).unwrap();
+    let mut module = ModuleBuilder::new("SharedReset").unwrap();
+    let clock_a = module.input("clock_a", bit).unwrap();
+    let clock_b = module.input("clock_b", bit).unwrap();
+    let reset = module.input("reset", bit).unwrap();
+    let d_a = module.input("d_a", bit).unwrap();
+    let d_b = module.input("d_b", bit).unwrap();
+    let q_a = module.output("q_a", bit).unwrap();
+    let q_b = module.output("q_b", bit).unwrap();
+    let reset_value = module.constant(Constant::two_state(0u8, 1).unwrap());
+    let reset = module
+        .async_reset(reset, ActiveLevel::High, reset_value)
+        .unwrap();
+    let d_a = module.read(d_a).unwrap();
+    let d_b = module.read(d_b).unwrap();
+    let q_a = module.whole(q_a).unwrap();
+    let q_b = module.whole(q_b).unwrap();
+    module
+        .register(q_a, d_a, clock_a, Edge::Posedge, Some(reset), None)
+        .unwrap();
+    module
+        .register(q_b, d_b, clock_b, Edge::Posedge, Some(reset), None)
+        .unwrap();
+
+    let error = match Simulator::from_frontend(module.finish()).build_cranelift() {
+        Ok(_) => panic!("shared async reset across clock domains was accepted"),
+        Err(error) => error,
+    };
+    let message = error.to_string();
+    assert!(message.contains("reset"));
+    assert!(message.contains("clock_a"));
+    assert!(message.contains("clock_b"));
+}

--- a/crates/celox/tests/frontend_sdk.rs
+++ b/crates/celox/tests/frontend_sdk.rs
@@ -286,6 +286,85 @@ fn frontend_register_inputs_are_coerced_to_target_state_kind() {
 }
 
 #[test]
+fn frontend_mux_infers_four_state_from_its_condition() {
+    let logic = ValueType::logic(1).unwrap();
+    let mut module = ModuleBuilder::new("MuxConditionState").unwrap();
+    let condition = module.input("condition", logic).unwrap();
+    let y = module.output("y", logic).unwrap();
+    let condition = module.read(condition).unwrap();
+    let one = module.constant(Constant::two_state(1u8, 1).unwrap());
+    let zero = module.constant(Constant::two_state(0u8, 1).unwrap());
+    let selected = module.mux(condition, one, zero).unwrap();
+    let y_target = module.whole(y).unwrap();
+    module.assign(y_target, selected).unwrap();
+    let artifact = module.finish();
+    assert_eq!(
+        artifact.expressions()[selected.index() as usize].value_type(),
+        logic
+    );
+
+    let mut sim = Simulator::from_frontend(artifact)
+        .four_state(true)
+        .build_cranelift()
+        .unwrap();
+    let condition = sim.signal("condition");
+    let y = sim.signal("y");
+    sim.modify(|io| io.set_four_state(condition, 1u8.into(), 1u8.into()))
+        .unwrap();
+    let (_, mask) = sim.get_four_state(y);
+    assert_eq!(mask, 1u8.into());
+}
+
+#[test]
+fn frontend_active_low_unknown_controls_remain_inactive() {
+    let bit = ValueType::bits(1).unwrap();
+    let logic = ValueType::logic(1).unwrap();
+    let mut module = ModuleBuilder::new("ActiveLowUnknown").unwrap();
+    let clock = module.input("clock", bit).unwrap();
+    let reset_n = module.input("reset_n", logic).unwrap();
+    let enable_n = module.input("enable_n", logic).unwrap();
+    let q_reset = module.output("q_reset", bit).unwrap();
+    let q_enable = module.output("q_enable", bit).unwrap();
+    let one = module.constant(Constant::two_state(1u8, 1).unwrap());
+    let zero = module.constant(Constant::two_state(0u8, 1).unwrap());
+    let reset = module.async_reset(reset_n, ActiveLevel::Low, zero).unwrap();
+    let enable = module.enable(enable_n, ActiveLevel::Low).unwrap();
+    let q_reset_target = module.whole(q_reset).unwrap();
+    let q_enable_target = module.whole(q_enable).unwrap();
+    module
+        .register(q_reset_target, one, clock, Edge::Posedge, Some(reset), None)
+        .unwrap();
+    module
+        .register(
+            q_enable_target,
+            one,
+            clock,
+            Edge::Posedge,
+            None,
+            Some(enable),
+        )
+        .unwrap();
+
+    let mut sim = Simulator::from_frontend(module.finish())
+        .four_state(true)
+        .build_cranelift()
+        .unwrap();
+    let clock = sim.event("clock");
+    let reset_n = sim.signal("reset_n");
+    let enable_n = sim.signal("enable_n");
+    let q_reset = sim.signal("q_reset");
+    let q_enable = sim.signal("q_enable");
+    sim.modify(|io| {
+        io.set_four_state(reset_n, 1u8.into(), 1u8.into());
+        io.set_four_state(enable_n, 1u8.into(), 1u8.into());
+    })
+    .unwrap();
+    sim.tick(clock).unwrap();
+    assert_eq!(sim.get(q_reset), 1u8.into());
+    assert_eq!(sim.get(q_enable), 0u8.into());
+}
+
+#[test]
 fn frontend_artifacts_build_with_compilation_trace() {
     Simulator::from_frontend(adder_artifact())
         .build_with_trace()

--- a/crates/celox/tests/frontend_sdk.rs
+++ b/crates/celox/tests/frontend_sdk.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use celox::Simulator;
 use celox::frontend_sdk::{
-    ActiveLevel, BinaryOp, Constant, Direction, Edge, ModuleBuilder, ValueType,
+    ActiveLevel, BinaryOp, Constant, Direction, Edge, ModuleBuilder, UnaryOp, ValueType,
 };
 
 fn adder_artifact() -> celox::FrontendArtifact {
@@ -170,6 +170,75 @@ fn frontend_expression_result_width_is_preserved() {
     .unwrap();
     assert_eq!(sim.get(y), 65_025u16.into());
     assert_eq!(sim.get(signed_y), 0xfffeu16.into());
+}
+
+#[test]
+fn frontend_sequential_expressions_honor_declared_types() {
+    let bit = ValueType::bits(1).unwrap();
+    let byte = ValueType::bits(8).unwrap();
+    let word = ValueType::bits(16).unwrap();
+    let mut module = ModuleBuilder::new("SequentialTypes").unwrap();
+    let clock = module.input("clock", bit).unwrap();
+    let input = module.input("input", byte).unwrap();
+    let divisor = module.input("divisor", byte).unwrap();
+    let negated = module.output("negated", word).unwrap();
+    let quotient = module.output("quotient", word).unwrap();
+    let equal = module.output("equal", word).unwrap();
+
+    let input_expr = module.read(input).unwrap();
+    let divisor_expr = module.read(divisor).unwrap();
+    let negate_expr = module.unary(UnaryOp::Negate, input_expr, word).unwrap();
+    let quotient_expr = module
+        .binary(BinaryOp::DivUnsigned, input_expr, divisor_expr, word)
+        .unwrap();
+    let equal_expr = module
+        .binary(BinaryOp::Equal, input_expr, divisor_expr, word)
+        .unwrap();
+    let negated_target = module.whole(negated).unwrap();
+    let quotient_target = module.whole(quotient).unwrap();
+    let equal_target = module.whole(equal).unwrap();
+    module
+        .register(
+            negated_target,
+            negate_expr,
+            clock,
+            Edge::Posedge,
+            None,
+            None,
+        )
+        .unwrap();
+    module
+        .register(
+            quotient_target,
+            quotient_expr,
+            clock,
+            Edge::Posedge,
+            None,
+            None,
+        )
+        .unwrap();
+    module
+        .register(equal_target, equal_expr, clock, Edge::Posedge, None, None)
+        .unwrap();
+
+    let mut sim = Simulator::from_frontend(module.finish())
+        .build_cranelift()
+        .unwrap();
+    let clock = sim.event("clock");
+    let input = sim.signal("input");
+    let divisor = sim.signal("divisor");
+    let negated = sim.signal("negated");
+    let quotient = sim.signal("quotient");
+    let equal = sim.signal("equal");
+    sim.modify(|io| {
+        io.set(input, 0xf0u8);
+        io.set(divisor, 0x0fu8);
+    })
+    .unwrap();
+    sim.tick(clock).unwrap();
+    assert_eq!(sim.get(negated), 0xff10u16.into());
+    assert_eq!(sim.get(quotient), 16u16.into());
+    assert_eq!(sim.get(equal), 0u16.into());
 }
 
 #[test]

--- a/crates/celox/tests/frontend_sdk.rs
+++ b/crates/celox/tests/frontend_sdk.rs
@@ -242,6 +242,74 @@ fn frontend_sequential_expressions_honor_declared_types() {
 }
 
 #[test]
+fn frontend_register_inputs_are_coerced_to_target_state_kind() {
+    let bit = ValueType::bits(1).unwrap();
+    let logic = ValueType::logic(1).unwrap();
+    let mut module = ModuleBuilder::new("RegisterStateCoercion").unwrap();
+    let clock = module.input("clock", bit).unwrap();
+    let reset = module.input("reset", bit).unwrap();
+    let d = module.input("d", logic).unwrap();
+    let q = module.output("q", bit).unwrap();
+    let d_expr = module.read(d).unwrap();
+    let reset_value = module.constant(Constant::four_state(1u8, 1u8, 1).unwrap());
+    let reset = module
+        .async_reset(reset, ActiveLevel::High, reset_value)
+        .unwrap();
+    let q_target = module.whole(q).unwrap();
+    module
+        .register(q_target, d_expr, clock, Edge::Posedge, Some(reset), None)
+        .unwrap();
+
+    let mut sim = Simulator::from_frontend(module.finish())
+        .four_state(true)
+        .build_cranelift()
+        .unwrap();
+    let clock = sim.event("clock");
+    let reset = sim.signal("reset");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    sim.modify(|io| {
+        io.set(reset, 0u8);
+        io.set_four_state(d, 1u8.into(), 1u8.into());
+    })
+    .unwrap();
+    sim.tick(clock).unwrap();
+    assert_eq!(sim.get(q), 0u8.into());
+
+    sim.modify(|io| {
+        io.set(reset, 1u8);
+        io.set_four_state(d, 1u8.into(), 0u8.into());
+    })
+    .unwrap();
+    sim.tick(clock).unwrap();
+    assert_eq!(sim.get(q), 0u8.into());
+}
+
+#[test]
+fn frontend_artifacts_build_with_compilation_trace() {
+    Simulator::from_frontend(adder_artifact())
+        .build_with_trace()
+        .unwrap();
+
+    let source = r#"
+        #[test(t)]
+        module NetlistTraceTb {
+            var a: logic<8>;
+            var b: logic<8>;
+            var y: logic<8>;
+            inst dut: $sv::NetAdder (a, b, y);
+        }
+    "#;
+    Simulator::from_frontend_with_testbench(
+        adder_artifact(),
+        vec![(source, Path::new("netlist_trace_tb.veryl"))],
+        "NetlistTraceTb",
+    )
+    .build_with_trace()
+    .unwrap();
+}
+
+#[test]
 fn frontend_shared_expression_dag_is_lowered_once_per_assignment() {
     let byte = ValueType::bits(8).unwrap();
     let mut module = ModuleBuilder::new("SharedDag").unwrap();

--- a/crates/celox/tests/frontend_sdk.rs
+++ b/crates/celox/tests/frontend_sdk.rs
@@ -1,0 +1,125 @@
+use std::path::Path;
+
+use celox::Simulator;
+use celox::frontend_sdk::{
+    ActiveLevel, BinaryOp, Constant, Direction, Edge, ModuleBuilder, ValueType,
+};
+
+fn adder_artifact() -> celox::FrontendArtifact {
+    let byte = ValueType::bits(8).unwrap();
+    let mut module = ModuleBuilder::new("NetAdder").unwrap();
+    let a = module.input("a", byte).unwrap();
+    let b = module.input("b", byte).unwrap();
+    let y = module.output("y", byte).unwrap();
+    let a_expr = module.read(a).unwrap();
+    let b_expr = module.read(b).unwrap();
+    let sum = module.binary(BinaryOp::Add, a_expr, b_expr, byte).unwrap();
+    let y = module.whole(y).unwrap();
+    module.assign(y, sum).unwrap();
+    module.finish()
+}
+
+#[test]
+fn frontend_artifact_preserves_signal_reflection_for_host_testbenches() {
+    let json = adder_artifact().to_json().unwrap();
+    let artifact = celox::FrontendArtifact::from_json(&json).unwrap();
+    let mut sim = Simulator::from_frontend(artifact)
+        .build_cranelift()
+        .unwrap();
+
+    let hierarchy = sim.named_hierarchy();
+    assert_eq!(hierarchy.module_name, "NetAdder");
+    assert_eq!(hierarchy.signals.len(), 3);
+    assert!(hierarchy.signals.iter().any(|signal| {
+        signal.name == "a"
+            && signal.info.var_kind == celox::VariableKind::Input
+            && signal.info.width == 8
+    }));
+
+    let a = sim.signal("a");
+    let b = sim.signal("b");
+    let y = sim.signal("y");
+    sim.modify(|io| {
+        io.set(a, 10u8);
+        io.set(b, 23u8);
+    })
+    .unwrap();
+    assert_eq!(sim.get(y), 33u8.into());
+}
+
+#[test]
+fn frontend_artifact_runs_edge_triggered_storage() {
+    let bit = ValueType::bits(1).unwrap();
+    let byte = ValueType::bits(8).unwrap();
+    let mut module = ModuleBuilder::new("NetRegister").unwrap();
+    let clock = module.input("clock", bit).unwrap();
+    let reset_n = module.input("reset_n", bit).unwrap();
+    let d = module.input("d", byte).unwrap();
+    let q = module.output("q", byte).unwrap();
+    module
+        .set_initial(q, Constant::two_state(0u8, 8).unwrap())
+        .unwrap();
+    let d_expr = module.read(d).unwrap();
+    let zero = module.constant(Constant::two_state(0u8, 8).unwrap());
+    let reset = module.async_reset(reset_n, ActiveLevel::Low, zero).unwrap();
+    let q_target = module.whole(q).unwrap();
+    module
+        .register(q_target, d_expr, clock, Edge::Posedge, Some(reset), None)
+        .unwrap();
+
+    let mut sim = Simulator::from_frontend(module.finish())
+        .build_cranelift()
+        .unwrap();
+    let clock = sim.event("clock");
+    let reset_n = sim.signal("reset_n");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    sim.modify(|io| {
+        io.set(reset_n, 0u8);
+        io.set(d, 42u8);
+    })
+    .unwrap();
+    sim.tick(clock).unwrap();
+    assert_eq!(sim.get(q), 0u8.into());
+    sim.modify(|io| io.set(reset_n, 1u8)).unwrap();
+    sim.tick(clock).unwrap();
+    assert_eq!(sim.get(q), 42u8.into());
+}
+
+#[test]
+fn veryl_native_testbench_can_instantiate_frontend_artifact() {
+    let source = r#"
+        #[test(t)]
+        module NetlistTb {
+            var a: logic<8>;
+            var b: logic<8>;
+            var y: logic<8>;
+            inst dut: $sv::NetAdder (a, b, y);
+
+            initial {
+                a = 8'd10;
+                b = 8'd23;
+                $assert(y == 8'd33, "external frontend artifact");
+                $finish();
+            }
+        }
+    "#;
+    let result = Simulator::from_frontend_with_testbench(
+        adder_artifact(),
+        vec![(source, Path::new("netlist_tb.veryl"))],
+        "NetlistTb",
+    )
+    .run_test_cranelift()
+    .unwrap();
+    assert_eq!(result, celox::TestResult::Pass);
+}
+
+#[test]
+fn frontend_builder_accepts_internal_signals_without_exposing_them_as_ports() {
+    let mut module = ModuleBuilder::new("InternalSignal").unwrap();
+    let signal = module
+        .signal("tmp", Direction::Internal, ValueType::bits(1).unwrap())
+        .unwrap();
+    assert_eq!(signal.index(), 0);
+    assert!(module.finish().port_order().is_empty());
+}

--- a/crates/celox/tests/frontend_sdk.rs
+++ b/crates/celox/tests/frontend_sdk.rs
@@ -286,6 +286,28 @@ fn frontend_register_inputs_are_coerced_to_target_state_kind() {
 }
 
 #[test]
+fn frontend_assignments_are_coerced_to_target_state_kind() {
+    let bit = ValueType::bits(1).unwrap();
+    let logic = ValueType::logic(1).unwrap();
+    let mut module = ModuleBuilder::new("AssignmentStateCoercion").unwrap();
+    let d = module.input("d", logic).unwrap();
+    let q = module.output("q", bit).unwrap();
+    let d_expr = module.read(d).unwrap();
+    let q_target = module.whole(q).unwrap();
+    module.assign(q_target, d_expr).unwrap();
+
+    let mut sim = Simulator::from_frontend(module.finish())
+        .four_state(true)
+        .build_cranelift()
+        .unwrap();
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    sim.modify(|io| io.set_four_state(d, 1u8.into(), 1u8.into()))
+        .unwrap();
+    assert_eq!(sim.get(q), 0u8.into());
+}
+
+#[test]
 fn frontend_mux_infers_four_state_from_its_condition() {
     let logic = ValueType::logic(1).unwrap();
     let mut module = ModuleBuilder::new("MuxConditionState").unwrap();

--- a/docs/guide/external-frontends.md
+++ b/docs/guide/external-frontends.md
@@ -1,0 +1,92 @@
+# External Frontends
+
+An external frontend can target Celox without depending on compiler-internal
+crates. Build a validated module with the published `celox-frontend-sdk` crate,
+serialize its versioned `FrontendArtifact`, and pass that JSON to a Celox host.
+
+```rust
+use celox_frontend_sdk::{BinaryOp, ModuleBuilder, ValueType};
+
+let byte = ValueType::bits(8)?;
+let mut module = ModuleBuilder::new("NetAdder")?;
+let a = module.input("a", byte)?;
+let b = module.input("b", byte)?;
+let y = module.output("y", byte)?;
+let a_expr = module.read(a)?;
+let b_expr = module.read(b)?;
+let sum = module.binary(BinaryOp::Add, a_expr, b_expr, byte)?;
+let y_target = module.whole(y)?;
+module.assign(y_target, sum)?;
+
+let artifact_json = module.finish().to_json()?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+The first SDK release represents one flattened module. It supports typed signals,
+constants, combinational expressions and assignments, edge-triggered registers,
+asynchronous reset, synchronous enable, and initial values. Hierarchical netlists,
+memories, latches, and custom primitives should be flattened or lowered by the
+external frontend before emitting an artifact.
+
+## TypeScript testbenches
+
+The artifact retains port and signal metadata, so the regular typed DUT API works:
+
+```ts
+import { Simulator } from "@celox-sim/celox";
+
+interface NetAdderPorts {
+  a: bigint;
+  b: bigint;
+  readonly y: bigint;
+}
+
+const sim = Simulator.fromFrontendArtifact<NetAdderPorts>(artifactJson);
+sim.dut.a = 10n;
+sim.dut.b = 23n;
+console.assert(sim.dut.y === 33n);
+sim.dispose();
+```
+
+Use `Simulation.fromFrontendArtifact` when the testbench needs timed clocks and
+scheduled events.
+
+## Veryl native testbenches
+
+`runTestWithFrontendArtifact` compiles a Veryl test module and makes the artifact
+module available through the existing external-module namespace:
+
+```veryl
+#[test(t)]
+module NetlistTb {
+    var a: logic<8>;
+    var b: logic<8>;
+    var y: logic<8>;
+    inst dut: $sv::NetAdder (a, b, y);
+
+    initial {
+        a = 8'd10;
+        b = 8'd23;
+        $assert(y == 8'd33);
+        $finish();
+    }
+}
+```
+
+```ts
+import { runTestWithFrontendArtifact } from "@celox-sim/celox";
+
+const result = runTestWithFrontendArtifact(
+  artifactJson,
+  [{ path: "netlist_tb.veryl", content: testbenchSource }],
+  "NetlistTb",
+);
+```
+
+Here `$sv` denotes Celox's existing external-module link namespace; the design
+itself still comes from exactly one external frontend artifact. This compatibility
+path does not turn the netlist frontend into a mixed Veryl/SystemVerilog frontend.
+
+Artifacts are validated again when Celox compiles them. Treat the
+`format_version` field as the wire-format compatibility boundary and use the SDK
+builder instead of constructing JSON by hand.

--- a/docs/guide/external-frontends.md
+++ b/docs/guide/external-frontends.md
@@ -26,7 +26,9 @@ The first SDK release represents one flattened module. It supports typed signals
 constants, combinational expressions and assignments, edge-triggered registers,
 asynchronous reset, synchronous enable, and initial values. Hierarchical netlists,
 memories, latches, and custom primitives should be flattened or lowered by the
-external frontend before emitting an artifact.
+external frontend before emitting an artifact. Bidirectional (`inout`) signals
+are also unsupported in artifact format version 1; lower them to separate input,
+output, and output-enable signals.
 
 ## TypeScript testbenches
 

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -8,15 +8,15 @@ refactors.
 ## Pipeline
 
 ```text
-Veryl source ─────────────► celox-frontend-veryl ──┐
-                                                   ├─► celox-frontend-core
-SystemVerilog source ─► celox-sv-analyzer          │          │
-                               │                   │          ▼
-                               └► celox-frontend-sv ┘     SymbolicRtl
-                                                              │
-                                                         celox-slt
-                                                              ▼
-                                                         ScheduledRtl
+Veryl source ----------> celox-frontend-veryl --------------------\
+SystemVerilog source --> celox-sv-analyzer --> celox-frontend-sv --+--> celox-frontend-core
+External frontend -----> celox-frontend-sdk artifact -------------/             |
+                                                                                 v
+                                                                            SymbolicRtl
+                                                                                 |
+                                                                            celox-slt
+                                                                                 v
+                                                                            ScheduledRtl
                                                               │
                                                         UnoptimizedSir
                                                               │
@@ -44,8 +44,11 @@ not depend on the facade. `celox-backend-x86` and `celox-backend-arm64` depend o
 `celox-backend-common` for allocation machinery; that crate is a compile-time
 library, not another pipeline artifact.
 
-The frontend boundary is split into one source-independent crate and one adapter
-crate per source language. `celox-frontend-core` owns the symbolic assembly,
+The frontend boundary is split into a published authoring contract, one
+source-independent adapter crate, and parser-backed adapters for bundled source
+languages. `celox-frontend-sdk` owns a versioned, serializable artifact that an
+external frontend can construct without depending on Celox compiler internals.
+`celox-frontend-core` owns the symbolic assembly,
 flattening, source lookup, tracing, and scheduled output contracts shared by all
 adapters. It must not depend on a parser, analyzer, or language adapter.
 
@@ -111,6 +114,7 @@ for.
 | `celox-analysis` | Reusable graph and data-flow algorithms | Veryl or backend-specific types |
 | `celox-design` | Source-independent design identities, hierarchy, events, and runtime schema | Parser nodes or physical addresses |
 | `celox-sv-analyzer` | Reusable SystemVerilog syntax and semantic analysis | Celox scheduling or Veryl dependencies |
+| `celox-frontend-sdk` | Published, versioned frontend artifact schema and validated module builder | Parser types, Celox compiler internals, or backend policy |
 | `celox-frontend-core` | Source lookup, shared symbolic assembly, flattening, tracing, and scheduled frontend contracts | Parser, analyzer, or language-adapter dependencies |
 | `celox-frontend-sv` | SystemVerilog hierarchy preparation and lowering into frontend-core contracts | Veryl dependencies, optimization, or target code generation |
 | `celox-frontend-veryl` | Veryl analysis, lowering, diagnostics, and testbench source sidecars | SystemVerilog dependencies, optimization, or target code generation |
@@ -175,16 +179,19 @@ The following rules define the intended architecture:
 1. Source-language types stop at the frontend boundary. One language adapter
    must not depend on another language frontend; shared assembly belongs in
    `celox-frontend-core`.
-2. Semantic state identities remain distinct from physical memory offsets until
+2. External frontends depend only on `celox-frontend-sdk` and exchange a
+   versioned artifact; internal symbolic and scheduled types are not a public
+   compatibility surface.
+3. Semantic state identities remain distinct from physical memory offsets until
    layout finalization.
-3. SIR optimizations are independent of any concrete backend.
-4. Target MIR, allocation policy, ABI handling, and emission remain private to
+4. SIR optimizations are independent of any concrete backend.
+5. Target MIR, allocation policy, ABI handling, and emission remain private to
    their backend; target-independent allocation mechanisms belong in
    `celox-backend-common`.
-5. Runtime code depends on backend contracts, not concrete compiler pipelines.
-6. Testbench execution uses source-independent bytecode; only the frontend parses
+6. Runtime code depends on backend contracts, not concrete compiler pipelines.
+7. Testbench execution uses source-independent bytecode; only the frontend parses
    Veryl testbench syntax.
-7. The facade coordinates phases but does not become a second owner of their
+8. The facade coordinates phases but does not become a second owner of their
    algorithms or data structures.
 
 These rules are enforced primarily by Cargo dependencies and artifact types. A
@@ -200,6 +207,9 @@ is therefore an architectural change, not a convenient shortcut.
   `celox-frontend-sv`.
 - Source-independent frontend lookup, symbolic assembly, flattening, and tracing
   belong in `celox-frontend-core`.
+- Stable external-frontend construction and serialization belong in
+  `celox-frontend-sdk`; a netlist parser or other source-specific analysis stays
+  in the independently developed frontend.
 - A symbolic scheduling rule belongs in `celox-slt`.
 - A backend-independent instruction or CFG rule belongs in `celox-sir`.
 - A backend-independent transformation belongs in `celox-sir-opt`.

--- a/packages/celox/src/e2e.test.ts
+++ b/packages/celox/src/e2e.test.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 import { readFourState } from "./dut.js";
 import {
+	buildPortsFromLayout,
 	createSimulatorBridge,
 	loadNativeAddon,
 	type NapiTestResult,
@@ -2209,6 +2210,30 @@ module Top (
     assign out = sig.data;
 }
 `;
+
+test("port layout maps preserve prototype-key signal names", () => {
+	const signal = {
+		offset: 0,
+		width: 1,
+		byteSize: 1,
+		is4state: false,
+		direction: "input" as const,
+		typeKind: "bit",
+	};
+	const signals = Object.fromEntries([
+		["__proto__", signal],
+		["bus.__proto__", { ...signal, offset: 1 }],
+	]);
+	const ports = buildPortsFromLayout(signals, {});
+
+	expect(Object.getPrototypeOf(ports)).toBeNull();
+	expect(Object.hasOwn(ports, "__proto__")).toBe(true);
+	expect(Reflect.get(ports, "__proto__")).toEqual(
+		expect.objectContaining({ type: "bit" }),
+	);
+	expect(Object.getPrototypeOf(ports.bus.interface)).toBeNull();
+	expect(Object.hasOwn(ports.bus.interface!, "__proto__")).toBe(true);
+});
 
 // A module that uses two instances connected via an interface so we can verify
 // that the hierarchy DUT also exposes nested accessors correctly.

--- a/packages/celox/src/e2e.test.ts
+++ b/packages/celox/src/e2e.test.ts
@@ -22,7 +22,12 @@ import {
 } from "./napi-helpers.js";
 import { Simulation } from "./simulation.js";
 import { Simulator } from "./simulator.js";
-import { defineTbComponent, runTest, runTestFromProject } from "./testbench.js";
+import {
+	defineTbComponent,
+	runTest,
+	runTestFromProject,
+	runTestWithFrontendArtifact,
+} from "./testbench.js";
 import {
 	FourState,
 	type FourStateSignalValue,
@@ -77,6 +82,79 @@ module Counter (
 
     always_comb {
         count = count_r;
+    }
+}
+`;
+
+// JSON emitted by crates/celox-frontend-sdk/examples/adder_json.rs. Keeping the
+// serialized boundary in this test verifies what an independently published
+// frontend actually sends to the TypeScript runtime.
+const FRONTEND_ADDER_ARTIFACT = JSON.stringify({
+	format_version: 1,
+	module_name: "NetAdder",
+	signals: [
+		{
+			id: 0,
+			name: "a",
+			direction: "Input",
+			value_type: { width: 8, signed: false, four_state: false },
+			initial: null,
+		},
+		{
+			id: 1,
+			name: "b",
+			direction: "Input",
+			value_type: { width: 8, signed: false, four_state: false },
+			initial: null,
+		},
+		{
+			id: 2,
+			name: "y",
+			direction: "Output",
+			value_type: { width: 8, signed: false, four_state: false },
+			initial: null,
+		},
+	],
+	expressions: [
+		{
+			id: 0,
+			node: { Signal: { signal: 0, lsb: 0, width: 8 } },
+			value_type: { width: 8, signed: false, four_state: false },
+		},
+		{
+			id: 1,
+			node: { Signal: { signal: 1, lsb: 0, width: 8 } },
+			value_type: { width: 8, signed: false, four_state: false },
+		},
+		{
+			id: 2,
+			node: { Binary: { op: "Add", lhs: 0, rhs: 1 } },
+			value_type: { width: 8, signed: false, four_state: false },
+		},
+	],
+	assignments: [
+		{
+			target: { signal: 2, lsb: 0, width: 8 },
+			value: 2,
+		},
+	],
+	registers: [],
+	port_order: [0, 1, 2],
+});
+
+const FRONTEND_ADDER_TB = `
+#[test(t)]
+module NetlistTb {
+    var a: logic<8>;
+    var b: logic<8>;
+    var y: logic<8>;
+    inst dut: $sv::NetAdder (a, b, y);
+
+    initial {
+        a = 8'd10;
+        b = 8'd23;
+        $assert(y == 8'd33, "external frontend artifact");
+        $finish();
     }
 }
 `;
@@ -186,6 +264,35 @@ module MuxX (
 // ---------------------------------------------------------------------------
 // Simulator (event-based) e2e tests — fromSource API
 // ---------------------------------------------------------------------------
+
+describe("E2E: external frontend artifact", () => {
+	test("drives a frontend SDK design from a TypeScript testbench", () => {
+		interface AdderPorts {
+			a: bigint;
+			b: bigint;
+			readonly y: bigint;
+		}
+
+		const sim = Simulator.fromFrontendArtifact<AdderPorts>(
+			FRONTEND_ADDER_ARTIFACT,
+		);
+		sim.dut.a = 10n;
+		sim.dut.b = 23n;
+		expect(sim.dut.y).toBe(33n);
+		sim.dispose();
+	});
+
+	test("runs a Veryl native testbench against a frontend SDK design", () => {
+		const result = runTestWithFrontendArtifact(
+			FRONTEND_ADDER_ARTIFACT,
+			[{ content: FRONTEND_ADDER_TB, path: "netlist_tb.veryl" }],
+			"NetlistTb",
+		);
+		expect(result.passed).toBe(true);
+		expect(result.assertions).toHaveLength(1);
+		expect(result.assertions[0]?.passed).toBe(true);
+	});
+});
 
 describe("E2E: Simulator.fromSource (event-based)", () => {
 	test("combinational adder: a + b = sum", () => {

--- a/packages/celox/src/index.ts
+++ b/packages/celox/src/index.ts
@@ -55,6 +55,7 @@ export {
 	defineTbComponent,
 	runTest,
 	runTestFromProject,
+	runTestWithFrontendArtifact,
 } from "./testbench.js";
 // Core types
 /** @internal */

--- a/packages/celox/src/napi-helpers.ts
+++ b/packages/celox/src/napi-helpers.ts
@@ -206,6 +206,10 @@ export interface RawNapiAddon {
 			top: string,
 			options?: NapiOptions,
 		): RawNapiSimulatorHandle;
+		fromFrontendArtifact(
+			artifactJson: string,
+			options?: NapiOptions,
+		): RawNapiSimulatorHandle;
 	};
 	NativeSimulationHandle: {
 		new (
@@ -218,10 +222,21 @@ export interface RawNapiAddon {
 			top: string,
 			options?: NapiOptions,
 		): RawNapiSimulationHandle;
+		fromFrontendArtifact(
+			artifactJson: string,
+			options?: NapiOptions,
+		): RawNapiSimulationHandle;
 	};
 	genTs(projectPath: string, components?: NapiInjectedManifest[]): string;
 	clearJitCache(): void;
 	runTest(
+		sources: NapiSourceFile[],
+		top: string,
+		options?: NapiOptions,
+		components?: NapiInjectedComponent[],
+	): NapiTestResult;
+	runTestWithFrontendArtifact(
+		artifactJson: string,
 		sources: NapiSourceFile[],
 		top: string,
 		options?: NapiOptions,

--- a/packages/celox/src/napi-helpers.ts
+++ b/packages/celox/src/napi-helpers.ts
@@ -595,7 +595,7 @@ export function buildPortsFromLayout(
 	_events: Record<string, number>,
 ): Record<string, PortInfo> {
 	// Step 1: Build flat PortInfo for every signal name
-	const flat: Record<string, PortInfo> = {};
+	const flat = Object.create(null) as Record<string, PortInfo>;
 
 	for (const [name, sig] of Object.entries(signals)) {
 		const typeKind = sig.typeKind;
@@ -626,7 +626,7 @@ export function buildPortsFromLayout(
 	// Veryl interface ports are exactly one level deep, so "bus.data" → parent "bus",
 	// member "data". The parent entry receives an `interface` map of its members;
 	// the flat layout keys are kept as-is so createNestedDut can look them up.
-	const ports: Record<string, PortInfo> = {};
+	const ports = Object.create(null) as Record<string, PortInfo>;
 	const ifMaps = new Map<string, Record<string, PortInfo>>();
 
 	for (const [name, port] of Object.entries(flat)) {
@@ -639,7 +639,7 @@ export function buildPortsFromLayout(
 		const parentName = name.slice(0, dotIdx);
 		const memberName = name.slice(dotIdx + 1);
 		if (!ifMaps.has(parentName)) {
-			const ifMap: Record<string, PortInfo> = {};
+			const ifMap = Object.create(null) as Record<string, PortInfo>;
 			ifMaps.set(parentName, ifMap);
 			ports[parentName] = {
 				direction: "inout",

--- a/packages/celox/src/simulation.ts
+++ b/packages/celox/src/simulation.ts
@@ -252,6 +252,53 @@ export class Simulation<P = Record<string, unknown>> {
 		);
 	}
 
+	/** Create a timed Simulation from an external frontend artifact. */
+	static fromFrontendArtifact<P = Record<string, unknown>>(
+		artifactJson: string,
+		options?: SimulatorOptions & { nativeAddonPath?: string },
+	): Simulation<P> {
+		const addon = loadNativeAddon(options?.nativeAddonPath);
+		const factory = addon.NativeSimulationHandle?.fromFrontendArtifact;
+		if (!factory) {
+			throw new Error(
+				"The loaded Celox native addon does not support timed frontend artifacts.",
+			);
+		}
+		const raw = factory.call(
+			addon.NativeSimulationHandle,
+			artifactJson,
+			buildNapiOpts(options),
+		);
+		const layout = parseNapiLayout(raw.layoutJson);
+		const events: Record<string, number> = JSON.parse(raw.eventsJson);
+		const hierarchy = filterHierarchyForDse(
+			parseHierarchyLayout(raw.hierarchyJson, events),
+			options?.deadStorePolicy,
+		);
+		const ports = buildPortsFromLayout(hierarchy.signals, events);
+		const buffer = raw.sharedMemory().buffer;
+		const handle = wrapDirectSimulationHandle(raw);
+		const state: DirtyState = { dirty: false };
+		const dut = createDut<P>(
+			buffer,
+			layout.forDut,
+			ports,
+			handle,
+			state,
+			hierarchy,
+		);
+		const warnings: string[] = JSON.parse(raw.warningsJson ?? "[]");
+		return new Simulation<P>(
+			handle,
+			dut,
+			events,
+			state,
+			buffer,
+			layout.signals,
+			warnings,
+		);
+	}
+
 	/**
 	 * Create a Simulation from a Veryl project directory.
 	 *

--- a/packages/celox/src/simulator.ts
+++ b/packages/celox/src/simulator.ts
@@ -295,7 +295,7 @@ export class Simulator<P = Record<string, unknown>> {
 			buffer = raw.sharedMemory!().buffer;
 			handle = wrapDirectSimulatorHandle(raw);
 		}
-		const state: DirtyState = { dirty: false };
+		const state: DirtyState = { dirty: isWasm };
 		const dut = createDut<P>(
 			buffer,
 			layout.forDut,

--- a/packages/celox/src/simulator.ts
+++ b/packages/celox/src/simulator.ts
@@ -271,15 +271,31 @@ export class Simulator<P = Record<string, unknown>> {
 			artifactJson,
 			buildNapiOpts(options),
 		);
-		const layout = parseNapiLayout(raw.layoutJson);
+		const isWasm = isWasmHandle(raw);
+		const layout =
+			isWasm && options?.fourState
+				? recoverWasmFourStateLayout(parseNapiLayout(raw.layoutJson))
+				: parseNapiLayout(raw.layoutJson);
 		const events: Record<string, number> = JSON.parse(raw.eventsJson);
 		const hierarchy = filterHierarchyForDse(
 			parseHierarchyLayout(raw.hierarchyJson, events),
 			options?.deadStorePolicy,
 		);
-		const ports = buildPortsFromLayout(hierarchy.signals, events);
-		const buffer = raw.sharedMemory!().buffer;
-		const handle = wrapDirectSimulatorHandle(raw);
+		const hasHierarchySignals = Object.keys(hierarchy.signals).length > 0;
+		const ports = hasHierarchySignals
+			? buildPortsFromLayout(hierarchy.signals, events)
+			: buildPortsFromLayout(layout.signals, events);
+
+		let buffer: ArrayBuffer | SharedArrayBuffer;
+		let handle: NativeSimulatorHandle;
+		if (isWasm) {
+			const bridge = createWasmSimulatorBridge(raw);
+			buffer = bridge.sharedMemory.buffer;
+			handle = bridge.handle;
+		} else {
+			buffer = raw.sharedMemory!().buffer;
+			handle = wrapDirectSimulatorHandle(raw);
+		}
 		const state: DirtyState = { dirty: false };
 		const dut = createDut<P>(
 			buffer,
@@ -287,7 +303,7 @@ export class Simulator<P = Record<string, unknown>> {
 			ports,
 			handle,
 			state,
-			hierarchy,
+			hasHierarchySignals ? hierarchy : undefined,
 		);
 		const warnings: string[] = JSON.parse(raw.warningsJson ?? "[]");
 		return new Simulator<P>(

--- a/packages/celox/src/simulator.ts
+++ b/packages/celox/src/simulator.ts
@@ -252,6 +252,56 @@ export class Simulator<P = Record<string, unknown>> {
 	}
 
 	/**
+	 * Create a Simulator from a versioned artifact emitted by an external
+	 * frontend built with `celox-frontend-sdk`.
+	 */
+	static fromFrontendArtifact<P = Record<string, unknown>>(
+		artifactJson: string,
+		options?: SimulatorOptions & { nativeAddonPath?: string },
+	): Simulator<P> {
+		const addon = loadNativeAddon(options?.nativeAddonPath);
+		const factory = addon.NativeSimulatorHandle.fromFrontendArtifact;
+		if (!factory) {
+			throw new Error(
+				"The loaded Celox native addon does not support frontend artifacts.",
+			);
+		}
+		const raw = factory.call(
+			addon.NativeSimulatorHandle,
+			artifactJson,
+			buildNapiOpts(options),
+		);
+		const layout = parseNapiLayout(raw.layoutJson);
+		const events: Record<string, number> = JSON.parse(raw.eventsJson);
+		const hierarchy = filterHierarchyForDse(
+			parseHierarchyLayout(raw.hierarchyJson, events),
+			options?.deadStorePolicy,
+		);
+		const ports = buildPortsFromLayout(hierarchy.signals, events);
+		const buffer = raw.sharedMemory!().buffer;
+		const handle = wrapDirectSimulatorHandle(raw);
+		const state: DirtyState = { dirty: false };
+		const dut = createDut<P>(
+			buffer,
+			layout.forDut,
+			ports,
+			handle,
+			state,
+			hierarchy,
+		);
+		const warnings: string[] = JSON.parse(raw.warningsJson ?? "[]");
+		return new Simulator<P>(
+			handle,
+			dut,
+			events,
+			state,
+			buffer,
+			layout.forDut,
+			warnings,
+		);
+	}
+
+	/**
 	 * Create a Simulator from a Veryl project directory.
 	 *
 	 * Searches upward from `projectPath` for `Veryl.toml`, gathers all

--- a/packages/celox/src/simulator.ts
+++ b/packages/celox/src/simulator.ts
@@ -272,10 +272,9 @@ export class Simulator<P = Record<string, unknown>> {
 			buildNapiOpts(options),
 		);
 		const isWasm = isWasmHandle(raw);
-		const layout =
-			isWasm && options?.fourState
-				? recoverWasmFourStateLayout(parseNapiLayout(raw.layoutJson))
-				: parseNapiLayout(raw.layoutJson);
+		// Frontend artifacts carry an exact state kind for every signal, including
+		// clock/reset ports. Do not apply the legacy WASM type-kind inference here.
+		const layout = parseNapiLayout(raw.layoutJson);
 		const events: Record<string, number> = JSON.parse(raw.eventsJson);
 		const hierarchy = filterHierarchyForDse(
 			parseHierarchyLayout(raw.hierarchyJson, events),

--- a/packages/celox/src/testbench.ts
+++ b/packages/celox/src/testbench.ts
@@ -259,6 +259,26 @@ export function runTest(
 	);
 }
 
+/** Run a Veryl native testbench against an external frontend artifact. */
+export function runTestWithFrontendArtifact(
+	artifactJson: string,
+	sources: ReadonlyArray<SourceFile>,
+	top: string,
+	options: RunTestOptions = {},
+): NapiTestResult {
+	const { components, ...nativeOptions } = options;
+	const injected: NapiInjectedComponent[] = Object.entries(
+		components ?? {},
+	).map(([name, component]) => ({ name, ...component }));
+	return loadNativeAddon().runTestWithFrontendArtifact(
+		artifactJson,
+		sources.map(({ content, path }) => ({ content, path })),
+		top,
+		buildNapiOpts(nativeOptions),
+		injected,
+	);
+}
+
 /** Run a Veryl project testbench with optional TS components. */
 export function runTestFromProject(
 	projectPath: string,

--- a/packages/celox/src/wasm-bridge.ts
+++ b/packages/celox/src/wasm-bridge.ts
@@ -56,6 +56,7 @@ export interface RawWasmSimulatorHandle {
 	readonly warningsJson: string;
 	readonly stableSize: number;
 	readonly totalSize: number;
+	initialMemoryBytes(): Uint8Array | number[];
 	combWasmBytes(): Uint8Array | number[];
 	eventWasmBytes(name: string): Uint8Array | number[];
 	dispose(): void;
@@ -114,6 +115,9 @@ export function createWasmSimulatorBridge(
 	// Create shared WebAssembly.Memory
 	const pages = Math.max(1, Math.ceil(totalSize / 65536));
 	const memory = new WebAssembly.Memory({ initial: pages });
+	new Uint8Array(memory.buffer, 0, totalSize).set(
+		new Uint8Array(raw.initialMemoryBytes()),
+	);
 
 	// Compile and instantiate comb WASM module (synchronous)
 	const combBytes = new Uint8Array(raw.combWasmBytes());
@@ -177,6 +181,9 @@ export async function createWasmSimulatorBridgeAsync(
 
 	const pages = Math.max(1, Math.ceil(totalSize / 65536));
 	const memory = new WebAssembly.Memory({ initial: pages });
+	new Uint8Array(memory.buffer, 0, totalSize).set(
+		new Uint8Array(raw.initialMemoryBytes()),
+	);
 
 	// Compile comb module
 	const combBytes = new Uint8Array(raw.combWasmBytes());

--- a/packages/playground/src/celox-wasm-loader.d.ts
+++ b/packages/playground/src/celox-wasm-loader.d.ts
@@ -12,6 +12,7 @@ export class NativeSimulatorHandle {
 	readonly eventsJson: string;
 	readonly fourStateInitRegionsJson: string;
 	readonly totalSize: number;
+	initialMemoryBytes(): Uint8Array;
 	combWasmBytes(): Uint8Array;
 	eventWasmBytes(name: string): Uint8Array;
 	dispose(): void;

--- a/packages/playground/test/frontend-artifact-wasm.test.ts
+++ b/packages/playground/test/frontend-artifact-wasm.test.ts
@@ -55,6 +55,28 @@ const FRONTEND_ADDER_ARTIFACT = JSON.stringify({
   port_order: [0, 1, 2],
 });
 
+const INITIALIZED_ARTIFACT = JSON.stringify({
+  format_version: 1,
+  module_name: "Initialized",
+  signals: [
+    {
+      id: 0,
+      name: "q",
+      direction: "Output",
+      value_type: { width: 8, signed: false, four_state: false },
+      initial: {
+        payload: [0xa5],
+        mask: [],
+        value_type: { width: 8, signed: false, four_state: false },
+      },
+    },
+  ],
+  expressions: [],
+  assignments: [],
+  registers: [],
+  port_order: [0],
+});
+
 const isWasm =
   !!process.env.NAPI_RS_WASI_FLAVOR ||
   process.env.NAPI_RS_FORCE_WASI === "true" ||
@@ -71,6 +93,15 @@ describe.skipIf(!isWasm)("External frontend artifact (WASM bridge)", () => {
     sim.dut.a = 10n;
     sim.dut.b = 23n;
     expect(sim.dut.y).toBe(33n);
+    sim.dispose();
+  });
+
+  test("applies artifact initial values to WASM memory", () => {
+    const sim = Simulator.fromFrontendArtifact<{ readonly q: bigint }>(
+      INITIALIZED_ARTIFACT,
+    );
+
+    expect(sim.dut.q).toBe(0xa5n);
     sim.dispose();
   });
 });

--- a/packages/playground/test/frontend-artifact-wasm.test.ts
+++ b/packages/playground/test/frontend-artifact-wasm.test.ts
@@ -77,6 +77,41 @@ const INITIALIZED_ARTIFACT = JSON.stringify({
   port_order: [0],
 });
 
+const CONSTANT_OUTPUT_ARTIFACT = JSON.stringify({
+  format_version: 1,
+  module_name: "ConstantOutput",
+  signals: [
+    {
+      id: 0,
+      name: "y",
+      direction: "Output",
+      value_type: { width: 8, signed: false, four_state: false },
+      initial: null,
+    },
+  ],
+  expressions: [
+    {
+      id: 0,
+      node: {
+        Constant: {
+          payload: [0x2a],
+          mask: [],
+          value_type: { width: 8, signed: false, four_state: false },
+        },
+      },
+      value_type: { width: 8, signed: false, four_state: false },
+    },
+  ],
+  assignments: [
+    {
+      target: { signal: 0, lsb: 0, width: 8 },
+      value: 0,
+    },
+  ],
+  registers: [],
+  port_order: [0],
+});
+
 const TWO_STATE_RESET_ARTIFACT = JSON.stringify({
   format_version: 1,
   module_name: "TwoStateReset",
@@ -170,6 +205,15 @@ describe.skipIf(!isWasm)("External frontend artifact (WASM bridge)", () => {
     );
 
     expect(sim.dut.q).toBe(0xa5n);
+    sim.dispose();
+  });
+
+  test("evaluates combinational outputs before the first WASM read", () => {
+    const sim = Simulator.fromFrontendArtifact<{ readonly y: bigint }>(
+      CONSTANT_OUTPUT_ARTIFACT,
+    );
+
+    expect(sim.dut.y).toBe(0x2an);
     sim.dispose();
   });
 

--- a/packages/playground/test/frontend-artifact-wasm.test.ts
+++ b/packages/playground/test/frontend-artifact-wasm.test.ts
@@ -1,0 +1,76 @@
+/** End-to-end coverage for external frontend artifacts in the WASM addon. */
+import { Simulator } from "@celox-sim/celox";
+import { describe, expect, test } from "vitest";
+
+const FRONTEND_ADDER_ARTIFACT = JSON.stringify({
+  format_version: 1,
+  module_name: "NetAdder",
+  signals: [
+    {
+      id: 0,
+      name: "a",
+      direction: "Input",
+      value_type: { width: 8, signed: false, four_state: false },
+      initial: null,
+    },
+    {
+      id: 1,
+      name: "b",
+      direction: "Input",
+      value_type: { width: 8, signed: false, four_state: false },
+      initial: null,
+    },
+    {
+      id: 2,
+      name: "y",
+      direction: "Output",
+      value_type: { width: 8, signed: false, four_state: false },
+      initial: null,
+    },
+  ],
+  expressions: [
+    {
+      id: 0,
+      node: { Signal: { signal: 0, lsb: 0, width: 8 } },
+      value_type: { width: 8, signed: false, four_state: false },
+    },
+    {
+      id: 1,
+      node: { Signal: { signal: 1, lsb: 0, width: 8 } },
+      value_type: { width: 8, signed: false, four_state: false },
+    },
+    {
+      id: 2,
+      node: { Binary: { op: "Add", lhs: 0, rhs: 1 } },
+      value_type: { width: 8, signed: false, four_state: false },
+    },
+  ],
+  assignments: [
+    {
+      target: { signal: 2, lsb: 0, width: 8 },
+      value: 2,
+    },
+  ],
+  registers: [],
+  port_order: [0, 1, 2],
+});
+
+const isWasm =
+  !!process.env.NAPI_RS_WASI_FLAVOR ||
+  process.env.NAPI_RS_FORCE_WASI === "true" ||
+  process.env.NAPI_RS_FORCE_WASI === "error";
+
+describe.skipIf(!isWasm)("External frontend artifact (WASM bridge)", () => {
+  test("constructs and executes an SDK artifact", () => {
+    const sim = Simulator.fromFrontendArtifact<{
+      a: bigint;
+      b: bigint;
+      readonly y: bigint;
+    }>(FRONTEND_ADDER_ARTIFACT);
+
+    sim.dut.a = 10n;
+    sim.dut.b = 23n;
+    expect(sim.dut.y).toBe(33n);
+    sim.dispose();
+  });
+});

--- a/packages/playground/test/frontend-artifact-wasm.test.ts
+++ b/packages/playground/test/frontend-artifact-wasm.test.ts
@@ -77,6 +77,74 @@ const INITIALIZED_ARTIFACT = JSON.stringify({
   port_order: [0],
 });
 
+const TWO_STATE_RESET_ARTIFACT = JSON.stringify({
+  format_version: 1,
+  module_name: "TwoStateReset",
+  signals: [
+    {
+      id: 0,
+      name: "reset",
+      direction: "Input",
+      value_type: { width: 1, signed: false, four_state: false },
+      initial: null,
+    },
+    {
+      id: 1,
+      name: "q",
+      direction: "Output",
+      value_type: { width: 1, signed: false, four_state: false },
+      initial: {
+        payload: [1],
+        mask: [],
+        value_type: { width: 1, signed: false, four_state: false },
+      },
+    },
+    {
+      id: 2,
+      name: "clock",
+      direction: "Input",
+      value_type: { width: 1, signed: false, four_state: false },
+      initial: null,
+    },
+  ],
+  expressions: [
+    {
+      id: 0,
+      node: {
+        Constant: {
+          payload: [],
+          mask: [],
+          value_type: { width: 1, signed: false, four_state: false },
+        },
+      },
+      value_type: { width: 1, signed: false, four_state: false },
+    },
+    {
+      id: 1,
+      node: {
+        Constant: {
+          payload: [1],
+          mask: [],
+          value_type: { width: 1, signed: false, four_state: false },
+        },
+      },
+      value_type: { width: 1, signed: false, four_state: false },
+    },
+  ],
+  assignments: [],
+  registers: [
+    {
+      target: { signal: 1, lsb: 0, width: 1 },
+      next: 1,
+      clock: 2,
+      edge: "Posedge",
+      async_reset: { signal: 0, active: "High", value: 0 },
+      enable: null,
+    },
+  ],
+  port_order: [0, 1, 2],
+});
+
 const isWasm =
   !!process.env.NAPI_RS_WASI_FLAVOR ||
   process.env.NAPI_RS_FORCE_WASI === "true" ||
@@ -102,6 +170,19 @@ describe.skipIf(!isWasm)("External frontend artifact (WASM bridge)", () => {
     );
 
     expect(sim.dut.q).toBe(0xa5n);
+    sim.dispose();
+  });
+
+  test("preserves two-state reset layout in four-state WASM mode", () => {
+    const sim = Simulator.fromFrontendArtifact<{
+      reset: bigint;
+      readonly q: bigint;
+      clock: bigint;
+    }>(TWO_STATE_RESET_ARTIFACT, { fourState: true });
+
+    expect(sim.dut.q).toBe(1n);
+    sim.dut.reset = 1n;
+    expect(sim.dut.q).toBe(1n);
     sim.dispose();
   });
 });


### PR DESCRIPTION
## Summary

- add a publishable `celox-frontend-sdk` crate with a versioned, validated frontend artifact and flattened-module builder
- lower SDK artifacts into Celox symbolic/SIR internals while keeping compiler implementation types private
- allow Rust callers to execute in-memory artifacts directly through `Simulator::from_frontend` and `Simulation::from_frontend`
- expose JSON transport through N-API and TypeScript for `Simulator.fromFrontendArtifact` and `Simulation.fromFrontendArtifact`
- support Veryl native testbenches through `runTestWithFrontendArtifact` and the existing external-module namespace
- document the frontend boundary and current flattened netlist scope

## Motivation

Veryl and SystemVerilog remain Celox's bundled source frontends, but independently developed frontends such as a netlist frontend need a stable target that does not expose `celox-frontend-core`, SLT, SIR, or parser-specific identities as compatibility APIs.

The SDK artifact is the external contract. Rust frontends can pass it directly in memory; JSON is only the transport boundary for N-API/TypeScript and cross-process use.

## User impact

External frontend authors can depend on the standalone SDK and emit combinational logic, edge-triggered registers, asynchronous reset, synchronous enable, initial values, and signal reflection. TypeScript testbenches use the normal typed DUT API, and Veryl native testbenches can instantiate the artifact module.

Artifact format v1 intentionally represents one flattened module. Hierarchy, memories, latches, and custom primitives remain frontend-side lowering responsibilities.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p celox-frontend-sdk -p celox-frontend-core -p celox -p celox-napi --all-targets -- -D warnings`
- `cargo clippy -p celox --no-default-features -- -D warnings`
- `cargo test -p celox-frontend-sdk -p celox-frontend-core`
- `cargo test -p celox --test frontend_sdk`
- `cargo package -p celox-frontend-sdk --allow-dirty --offline`
- `pnpm --filter @celox-sim/celox build`
- `pnpm run build:napi`
- `pnpm --filter @celox-sim/celox exec vitest run src/e2e.test.ts -t "external frontend artifact"`
- pre-push hooks: submodule check, Cargo formatting/check, Biome, clean tree
