### PR TITLE
perf(arm64): improve native code generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,7 @@ version = "0.0.0"
 dependencies = [
  "num-bigint",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,7 @@ dependencies = [
  "fxhash",
  "miette",
  "num-bigint",
+ "serde",
  "thiserror 2.0.20",
  "tracing",
 ]

--- a/crates/celox-backend-arm64/src/regalloc.rs
+++ b/crates/celox-backend-arm64/src/regalloc.rs
@@ -405,7 +405,34 @@ fn select_spill_batch(
             (value, length)
         })
         .collect::<BTreeMap<_, _>>();
+    let mut use_counts = BTreeMap::<VReg, u64>::new();
+    for block in &function.blocks {
+        for phi in &block.phis {
+            *use_counts.entry(phi.dst).or_default() += 1;
+            for &(_, source) in &phi.sources {
+                *use_counts.entry(source).or_default() += 1;
+            }
+        }
+        for instruction in &block.insts {
+            if !matches!(instruction, MInst::KeepAlive { .. }) {
+                for value in instruction.uses() {
+                    *use_counts.entry(value).or_default() += 1;
+                }
+            }
+            if let Some(value) = instruction.def() {
+                *use_counts.entry(value).or_default() += 1;
+            }
+        }
+    }
     let live_length = |value: VReg| live_lengths.get(&value).copied().unwrap_or(0);
+    let spill_priority = |value: VReg| {
+        let cost = use_counts.get(&value).copied().unwrap_or(1);
+        (
+            live_length(value) / cost,
+            live_length(value),
+            Reverse(value),
+        )
+    };
     // The widest target instruction has five uses and one definition. Keep
     // that many registers free so a spilled row's local reload/definition
     // temporaries do not immediately create a second pressure wave.
@@ -437,7 +464,7 @@ fn select_spill_batch(
                 let Some(spilled) = active
                     .iter()
                     .filter(|(_, value)| candidates.contains(value))
-                    .max_by_key(|(_, value)| (live_length(*value), Reverse(*value)))
+                    .max_by_key(|(_, value)| spill_priority(*value))
                     .map(|&(_, value)| value)
                 else {
                     break;
@@ -456,7 +483,7 @@ fn select_spill_batch(
     }
     peak.into_iter()
         .filter(|value| candidates.contains(value))
-        .max_by_key(|value| (live_length(*value), Reverse(*value)))
+        .max_by_key(|value| spill_priority(*value))
         .into_iter()
         .collect()
 }
@@ -1158,6 +1185,55 @@ mod tests {
             allocate_without_spills(function),
             Err(TargetRegallocError::RegisterPressure { .. })
         ));
+    }
+
+    #[test]
+    fn prefers_long_lived_values_with_fewer_uses_for_spilling() {
+        let mut instructions = (0..19_u32)
+            .map(|value| MInst::LoadImm {
+                dst: VReg(value),
+                value: u64::from(value),
+            })
+            .collect::<Vec<_>>();
+        instructions.extend((0..100).map(|index| MInst::Store {
+            base: BaseReg::SimState,
+            offset: index * 8,
+            src: VReg(1),
+            size: OpSize::S64,
+        }));
+        instructions.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 800,
+            src: VReg(0),
+            size: OpSize::S64,
+        });
+        instructions.extend((2..19_u32).map(|value| MInst::Store {
+            base: BaseReg::SimState,
+            offset: 800 + (value as i32) * 8,
+            src: VReg(value),
+            size: OpSize::S64,
+        }));
+        instructions.push(MInst::Return);
+        let function = MFunction::new(
+            vec![MBlock {
+                id: BlockId(0),
+                phis: Vec::new(),
+                insts: instructions,
+            }],
+            Vec::new(),
+        );
+        let facts = build_facts(&function).unwrap();
+        let intervals = analyze_live_intervals(&facts).unwrap();
+        let candidates = facts.blocks[0]
+            .instructions
+            .iter()
+            .flat_map(|instruction| instruction.defs.iter().copied())
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(
+            select_spill_batch(&function, &intervals, &candidates, false),
+            vec![VReg(0)]
+        );
     }
 
     #[test]

--- a/crates/celox-backend-arm64/src/regalloc.rs
+++ b/crates/celox-backend-arm64/src/regalloc.rs
@@ -213,7 +213,7 @@ pub(crate) fn verify_allocated(function: &AllocatedFunction) -> Result<(), Targe
                         value,
                     });
                 };
-                if !(1..=15).contains(&register.number()) && !(19..=28).contains(&register.number())
+                if !(1..=15).contains(&register.number()) && !(19..=27).contains(&register.number())
                 {
                     return Err(TargetRegallocError::ReservedAssignment {
                         block: block.id,
@@ -228,7 +228,7 @@ pub(crate) fn verify_allocated(function: &AllocatedFunction) -> Result<(), Targe
     verify_interval_registers(function, &intervals)
 }
 
-const ALLOCATABLE_REGISTERS: [Arm64Reg; 25] = [
+const ALLOCATABLE_REGISTERS: [Arm64Reg; 24] = [
     Arm64Reg::new(1),
     Arm64Reg::new(2),
     Arm64Reg::new(3),
@@ -253,7 +253,6 @@ const ALLOCATABLE_REGISTERS: [Arm64Reg; 25] = [
     Arm64Reg::new(25),
     Arm64Reg::new(26),
     Arm64Reg::new(27),
-    Arm64Reg::new(28),
 ];
 
 pub(crate) struct TargetAllocation {
@@ -1085,7 +1084,7 @@ mod tests {
         for value in [VReg(0), VReg(1), VReg(2), VReg(3)] {
             let register = allocated.assignment.get(&value).unwrap();
             assert!(
-                (1..=15).contains(&register.number()) || (19..=28).contains(&register.number())
+                (1..=15).contains(&register.number()) || (19..=27).contains(&register.number())
             );
         }
         verify_allocated(&allocated).unwrap();
@@ -1408,7 +1407,7 @@ mod tests {
             allocated
                 .assignment
                 .iter()
-                .any(|(_, register)| (19..=28).contains(&register.number()))
+                .any(|(_, register)| (19..=27).contains(&register.number()))
         );
     }
 }

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -1473,31 +1473,82 @@ fn emit_packed_byte_affine_compare(
     rhs: u8,
     kind: CmpKind,
 ) {
-    dynasm!(ops ; .arch aarch64 ; mov x30, xzr);
-    for lane in 0..16_u32 {
-        if lane == 0 {
-            dynasm!(ops ; .arch aarch64 ; mov x16, X(base));
-        } else if !emit_add_sub_immediate(ops, SCRATCH0, base, i64::from(lane)) {
-            emit_load_imm(ops, SCRATCH1, u64::from(lane));
-            dynasm!(ops ; .arch aarch64 ; add x16, X(base), x17);
+    // This pseudo always compares exactly sixteen byte lanes.  Keep the
+    // affine sequence in NEON registers, then turn each 0xff/0x00 predicate
+    // into one bit with a byte-weighted horizontal sum.  The scalar fallback
+    // used to materialize and compare every lane independently.
+    emit_load_imm(ops, 30, 0x0706_0504_0302_0100);
+    dynasm!(ops ; .arch aarch64 ; fmov d2, x30);
+    emit_load_imm(ops, 30, 0x0f0e_0d0c_0b0a_0908);
+    dynasm!(ops
+        ; .arch aarch64
+        ; fmov d3, x30
+        ; ins v2.d[1], v3.d[0]
+        ; dup v4.b16, W(base)
+        ; dup v1.b16, W(rhs)
+        ; add v0.b16, v2.b16, v4.b16
+        ; movi v5.b16, #0
+    );
+    match kind {
+        CmpKind::Eq => {
+            dynasm!(ops ; .arch aarch64 ; cmeq v0.b16, v0.b16, v1.b16);
         }
-        dynasm!(ops ; .arch aarch64 ; mov x17, X(rhs));
-        emit_logical_immediate(ops, SCRATCH0, SCRATCH0, 0xff, 64, true);
-        emit_logical_immediate(ops, SCRATCH1, SCRATCH1, 0xff, 64, true);
-        if matches!(
-            kind,
-            CmpKind::LtS | CmpKind::LeS | CmpKind::GtS | CmpKind::GeS
-        ) {
-            dynasm!(ops ; .arch aarch64 ; sxtb x16, w16 ; sxtb x17, w17);
+        CmpKind::Ne => {
+            dynasm!(ops
+                ; .arch aarch64
+                ; cmeq v0.b16, v0.b16, v1.b16
+                ; mvn v0.b16, v0.b16
+            );
         }
-        dynasm!(ops ; .arch aarch64 ; cmp x16, x17);
-        emit_cset(ops, SCRATCH0, kind);
-        if lane != 0 {
-            dynasm!(ops ; .arch aarch64 ; lsl x16, x16, lane);
+        CmpKind::LtU | CmpKind::GeU => {
+            dynasm!(ops
+                ; .arch aarch64
+                ; uqsub v2.b16, v1.b16, v0.b16
+                ; cmeq v0.b16, v2.b16, v5.b16
+            );
+            if matches!(kind, CmpKind::LtU) {
+                dynasm!(ops ; .arch aarch64 ; mvn v0.b16, v0.b16);
+            }
         }
-        dynasm!(ops ; .arch aarch64 ; orr x30, x30, x16);
+        CmpKind::GtU | CmpKind::LeU => {
+            dynasm!(ops
+                ; .arch aarch64
+                ; uqsub v2.b16, v0.b16, v1.b16
+                ; cmeq v0.b16, v2.b16, v5.b16
+            );
+            if matches!(kind, CmpKind::GtU) {
+                dynasm!(ops ; .arch aarch64 ; mvn v0.b16, v0.b16);
+            }
+        }
+        CmpKind::LtS | CmpKind::GeS => {
+            dynasm!(ops ; .arch aarch64 ; cmgt v0.b16, v1.b16, v0.b16);
+            if matches!(kind, CmpKind::GeS) {
+                dynasm!(ops ; .arch aarch64 ; mvn v0.b16, v0.b16);
+            }
+        }
+        CmpKind::GtS | CmpKind::LeS => {
+            dynasm!(ops ; .arch aarch64 ; cmgt v0.b16, v0.b16, v1.b16);
+            if matches!(kind, CmpKind::LeS) {
+                dynasm!(ops ; .arch aarch64 ; mvn v0.b16, v0.b16);
+            }
+        }
     }
-    dynasm!(ops ; .arch aarch64 ; mov X(destination), x30);
+    emit_load_imm(ops, 30, 0x8040_2010_0804_0201);
+    dynasm!(ops
+        ; .arch aarch64
+        ; ushr v0.b16, v0.b16, #7
+        ; fmov d6, x30
+        ; dup v6.d2, v6.d[0]
+        ; mul v0.b16, v0.b16, v6.b16
+        ; addv b5, v0.b8
+        ; umov W(SCRATCH0), v5.b[0]
+        ; ext v7.b16, v0.b16, v0.b16, #8
+        ; addv b5, v7.b8
+        ; umov W(SCRATCH1), v5.b[0]
+        ; lsl x17, x17, #8
+        ; orr x30, x16, x17
+        ; mov X(destination), x30
+    );
 }
 
 fn emit_sparse_commit_worklist(
@@ -3053,8 +3104,26 @@ mod tests {
         let lanes = vregs.alloc();
         let base = vregs.alloc();
         let affine_rhs = vregs.alloc();
-        let affine = vregs.alloc();
-        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 5]);
+        let affine_kinds = [
+            CmpKind::Eq,
+            CmpKind::Ne,
+            CmpKind::LtU,
+            CmpKind::LeU,
+            CmpKind::GtU,
+            CmpKind::GeU,
+            CmpKind::LtS,
+            CmpKind::LeS,
+            CmpKind::GtS,
+            CmpKind::GeS,
+        ];
+        let affine_outputs = affine_kinds
+            .iter()
+            .map(|_| vregs.alloc())
+            .collect::<Vec<_>>();
+        let mut function = MFunction::new(
+            vregs,
+            vec![SpillDesc::transient(); 4 + affine_outputs.len()],
+        );
         let mut block = MBlock::new(BlockId(0));
         block.push(MInst::LoadImm { dst: rhs, value: 5 });
         block.push(MInst::PackedLaneCompare {
@@ -3082,18 +3151,20 @@ mod tests {
             dst: affine_rhs,
             value: 2,
         });
-        block.push(MInst::PackedByteAffineCompare {
-            dst: affine,
-            base,
-            rhs: affine_rhs,
-            kind: CmpKind::Eq,
-        });
-        block.push(MInst::Store {
-            base: BaseReg::SimState,
-            offset: 32,
-            src: affine,
-            size: OpSize::S64,
-        });
+        for (index, (&kind, &output)) in affine_kinds.iter().zip(&affine_outputs).enumerate() {
+            block.push(MInst::PackedByteAffineCompare {
+                dst: output,
+                base,
+                rhs: affine_rhs,
+                kind,
+            });
+            block.push(MInst::Store {
+                base: BaseReg::SimState,
+                offset: 32 + (index as i32 * 8),
+                src: output,
+                size: OpSize::S64,
+            });
+        }
         block.push(MInst::Return);
         function.push_block(block);
         let mut assignment = AssignmentMap::default();
@@ -3102,23 +3173,54 @@ mod tests {
             (lanes, PhysReg::RDX),
             (base, PhysReg::RSI),
             (affine_rhs, PhysReg::RDI),
-            (affine, PhysReg::R8),
         ] {
+            assignment.set(value, register);
+        }
+        for (value, register) in affine_outputs.into_iter().zip([
+            PhysReg::R8,
+            PhysReg::R9,
+            PhysReg::R10,
+            PhysReg::R11,
+            PhysReg::R12,
+            PhysReg::R13,
+            PhysReg::R14,
+            PhysReg::R15,
+            PhysReg::RBX,
+            PhysReg::RBP,
+        ]) {
             assignment.set(value, register);
         }
         let emitted = emit(&function, &assignment, 0).unwrap();
         let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
-        let mut state = vec![0_u8; 40];
+        let mut state = vec![0_u8; 112];
         state[..16].copy_from_slice(&[5, 1, 5, 2, 3, 5, 4, 5, 6, 7, 8, 9, 5, 5, 0, 5]);
         assert_eq!(unsafe { code.call(&mut state) }, 0);
         assert_eq!(
             u64::from_le_bytes(state[24..32].try_into().unwrap()),
             0b1011_0000_1010_0101
         );
-        assert_eq!(
-            u64::from_le_bytes(state[32..40].try_into().unwrap()),
-            1 << 8
-        );
+        for (index, expected) in [
+            1 << 8,
+            0xfeff,
+            0x00c0,
+            0x01c0,
+            0xfe3f,
+            0xff3f,
+            0x00ff,
+            0x01ff,
+            0xfe00,
+            0xff00,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let offset = 32 + index * 8;
+            assert_eq!(
+                u64::from_le_bytes(state[offset..offset + 8].try_into().unwrap()),
+                expected,
+                "packed affine kind index {index}"
+            );
+        }
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -1233,38 +1233,123 @@ fn emit_parallel_bits(
     mask: u8,
     deposit: bool,
 ) {
+    if destination != source && destination != mask {
+        emit_parallel_bits_loop(ops, destination, source, mask, deposit);
+        return;
+    }
+
+    emit_parallel_bits_saved_loop(ops, destination, source, mask, deposit);
+}
+
+fn emit_parallel_bits_loop(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: u8,
+    source: u8,
+    mask: u8,
+    deposit: bool,
+) {
+    let loop_label = ops.new_dynamic_label();
+    let done = ops.new_dynamic_label();
+    dynasm!(ops
+        ; .arch aarch64
+        ; mov X(destination), xzr
+        ; mov x16, X(mask)
+        ; mov x17, xzr
+        ; =>loop_label
+        ; cbz x16, =>done
+        ; rbit x30, x16
+        ; clz x30, x30
+        ; fmov d4, x30
+        ; sub x30, x16, #1
+        ; and x16, x16, x30
+    );
+    if deposit {
+        // x17 counts source bits while d4 retains the destination bit
+        // selected by the lowest set mask bit. d5 protects the working mask
+        // while x16 is reused as the variable shift amount.
+        dynasm!(ops
+            ; .arch aarch64
+            ; fmov d5, x16
+            ; lsrv x30, X(source), x17
+            ; and x30, x30, #1
+            ; fmov x16, d4
+            ; lslv x30, x30, x16
+            ; orr X(destination), X(destination), x30
+            ; fmov x16, d5
+            ; add x17, x17, #1
+            ; b =>loop_label
+            ; =>done
+        );
+    } else {
+        dynasm!(ops
+            ; .arch aarch64
+            ; fmov x30, d4
+            ; lsrv x30, X(source), x30
+            ; and x30, x30, #1
+            ; lslv x30, x30, x17
+            ; orr X(destination), X(destination), x30
+            ; add x17, x17, #1
+            ; b =>loop_label
+            ; =>done
+        );
+    }
+}
+
+fn emit_parallel_bits_saved_loop(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: u8,
+    source: u8,
+    mask: u8,
+    deposit: bool,
+) {
     // Save both inputs before defining the result: allocation may coalesce a
-    // dying input with the destination. The fixed unroll avoids a hidden GPR
-    // clobber while matching BMI2 semantics on baseline ARMv8-A.
+    // dying input with the destination. The result can then reuse the
+    // destination register, while d4-d7 hold the transient scalar values.
+    let loop_label = ops.new_dynamic_label();
+    let done = ops.new_dynamic_label();
     dynasm!(ops
         ; .arch aarch64
         ; fmov d6, X(source)
         ; fmov d7, X(mask)
+        ; mov X(destination), xzr
         ; mov x17, xzr
-        ; mov x30, xzr
+        ; =>loop_label
+        ; fmov x16, d7
+        ; cbz x16, =>done
+        ; rbit x30, x16
+        ; clz x30, x30
+        ; fmov d4, x30
+        ; sub x30, x16, #1
+        ; and x16, x16, x30
+        ; fmov d7, x16
     );
-    for bit in 0..64_u32 {
-        let skip = ops.new_dynamic_label();
-        dynasm!(ops ; .arch aarch64 ; fmov x16, d7 ; tbz x16, bit, =>skip ; fmov x16, d6);
-        if deposit {
-            dynasm!(ops ; .arch aarch64 ; lsr x16, x16, x17 ; and x16, x16, #1);
-            if bit != 0 {
-                dynasm!(ops ; .arch aarch64 ; lsl x16, x16, bit);
-            }
-        } else {
-            if bit != 0 {
-                dynasm!(ops ; .arch aarch64 ; lsr x16, x16, bit);
-            }
-            dynasm!(ops ; .arch aarch64 ; and x16, x16, #1 ; lsl x16, x16, x17);
-        }
+    if deposit {
         dynasm!(ops
             ; .arch aarch64
-            ; orr x30, x30, x16
+            ; fmov x16, d6
+            ; lsrv x30, x16, x17
+            ; and x30, x30, #1
+            ; fmov x16, d4
+            ; lslv x30, x30, x16
+            ; orr X(destination), X(destination), x30
             ; add x17, x17, #1
-            ; =>skip
+            ; b =>loop_label
+            ; =>done
+        );
+    } else {
+        dynasm!(ops
+            ; .arch aarch64
+            ; fmov x16, d6
+            ; fmov x30, d4
+            ; lsrv x30, x16, x30
+            ; and x30, x30, #1
+            ; lslv x30, x30, x17
+            ; orr X(destination), X(destination), x30
+            ; add x17, x17, #1
+            ; b =>loop_label
+            ; =>done
         );
     }
-    dynasm!(ops ; .arch aarch64 ; mov X(destination), x30);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2835,6 +2920,89 @@ mod tests {
         assert_eq!(unsafe { code.call(&mut state) }, 0);
         assert_eq!(u64::from_le_bytes(state[..8].try_into().unwrap()), 0b100);
         assert_eq!(u64::from_le_bytes(state[8..].try_into().unwrap()), 0b100010);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn executes_parallel_bit_extract_and_deposit_with_aliased_destination() {
+        let source = arm_mir::VReg(0);
+        let mask = arm_mir::VReg(1);
+        let deposited_source = arm_mir::VReg(2);
+        let function = arm_mir::MFunction::new(
+            vec![arm_mir::MBlock {
+                id: arm_mir::BlockId(0),
+                phis: Vec::new(),
+                insts: vec![
+                    arm_mir::MInst::Load {
+                        dst: source,
+                        base: arm_mir::BaseReg::SimState,
+                        offset: 0,
+                        size: arm_mir::OpSize::S64,
+                    },
+                    arm_mir::MInst::Load {
+                        dst: mask,
+                        base: arm_mir::BaseReg::SimState,
+                        offset: 8,
+                        size: arm_mir::OpSize::S64,
+                    },
+                    arm_mir::MInst::Pext {
+                        dst: source,
+                        src: source,
+                        mask,
+                    },
+                    arm_mir::MInst::Load {
+                        dst: deposited_source,
+                        base: arm_mir::BaseReg::SimState,
+                        offset: 24,
+                        size: arm_mir::OpSize::S64,
+                    },
+                    arm_mir::MInst::Pdep {
+                        dst: deposited_source,
+                        src: deposited_source,
+                        mask,
+                    },
+                    arm_mir::MInst::Store {
+                        base: arm_mir::BaseReg::SimState,
+                        offset: 16,
+                        src: source,
+                        size: arm_mir::OpSize::S64,
+                    },
+                    arm_mir::MInst::Store {
+                        base: arm_mir::BaseReg::SimState,
+                        offset: 32,
+                        src: deposited_source,
+                        size: arm_mir::OpSize::S64,
+                    },
+                    arm_mir::MInst::Return,
+                ],
+            }],
+            Vec::new(),
+        );
+        let mut assignment = Assignment::default();
+        assignment.set(source, Arm64Reg::new(9));
+        assignment.set(mask, Arm64Reg::new(10));
+        assignment.set(deposited_source, Arm64Reg::new(11));
+        let emitted = emit_function(
+            &function,
+            &assignment,
+            0,
+            40,
+            &EdgeCopyPlan::default(),
+            false,
+            false,
+        )
+        .unwrap();
+        let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
+        let mut state = vec![0_u8; 40];
+        state[..8].copy_from_slice(&0b110101_u64.to_le_bytes());
+        state[8..16].copy_from_slice(&0b101010_u64.to_le_bytes());
+        state[24..32].copy_from_slice(&0b101_u64.to_le_bytes());
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        assert_eq!(u64::from_le_bytes(state[16..24].try_into().unwrap()), 0b100);
+        assert_eq!(
+            u64::from_le_bytes(state[32..40].try_into().unwrap()),
+            0b100010
+        );
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -261,6 +261,12 @@ fn emit_function(
         .map(|(_, register)| register.number())
         .filter(|register| (19..=28).contains(register))
         .collect::<Vec<_>>();
+    if tick_loop {
+        // x29 is not allocated to MIR values and carries the native-loop
+        // counter across repeated body entries. Saving it once in the
+        // prologue avoids two FP/GPR transfers on every loop iteration.
+        callee_saved.push(29);
+    }
     callee_saved.sort_unstable();
     callee_saved.dedup();
 
@@ -282,7 +288,7 @@ fn emit_function(
     }
     if tick_loop {
         // d29 retains the simulator-state pointer across success/error return
-        // values. d31 carries the remaining tick count between body entries.
+        // values. x29 carries the remaining tick count between body entries.
         dynasm!(ops ; .arch aarch64 ; fmov d29, x0);
         emit_address(
             &mut ops,
@@ -296,7 +302,7 @@ fn emit_function(
             ; cbnz x16, =>count_ready
             ; mov x16, #1
             ; =>count_ready
-            ; fmov d31, x16
+            ; mov x29, x16
         );
         if check_runtime_events {
             emit_address(
@@ -352,7 +358,7 @@ fn emit_function(
     if tick_loop {
         dynasm!(ops
             ; .arch aarch64
-            ; fmov x16, d31
+            ; mov x16, x29
             ; fmov x17, d29
         );
         emit_load_imm(
@@ -710,17 +716,22 @@ fn emit_instruction(
         }
         MInst::AndImm { dst, src, imm } | MInst::OrImm { dst, src, imm } => {
             let (dst, src) = (resolve(assignment, *dst)?, resolve(assignment, *src)?);
-            emit_load_imm(ops, SCRATCH0, *imm);
-            if matches!(instruction, MInst::AndImm { .. }) {
-                dynasm!(ops ; .arch aarch64 ; and X(dst), X(src), x16);
-            } else {
-                dynasm!(ops ; .arch aarch64 ; orr X(dst), X(src), x16);
+            let is_and = matches!(instruction, MInst::AndImm { .. });
+            if !emit_logical_immediate(ops, dst, src, *imm, 64, is_and) {
+                emit_load_imm(ops, SCRATCH0, *imm);
+                if is_and {
+                    dynasm!(ops ; .arch aarch64 ; and X(dst), X(src), x16);
+                } else {
+                    dynasm!(ops ; .arch aarch64 ; orr X(dst), X(src), x16);
+                }
             }
         }
         MInst::AndImm32 { dst, src, imm } => {
             let (dst, src) = (resolve(assignment, *dst)?, resolve(assignment, *src)?);
-            emit_load_imm(ops, SCRATCH0, u64::from(*imm));
-            dynasm!(ops ; .arch aarch64 ; and W(dst), W(src), w16);
+            if !emit_logical_immediate(ops, dst, src, u64::from(*imm), 32, true) {
+                emit_load_imm(ops, SCRATCH0, u64::from(*imm));
+                dynasm!(ops ; .arch aarch64 ; and W(dst), W(src), w16);
+            }
         }
         MInst::ShrImm { dst, src, imm }
         | MInst::ShlImm { dst, src, imm }
@@ -774,8 +785,10 @@ fn emit_instruction(
             kind,
         } => {
             let (dst, lhs) = (resolve(assignment, *dst)?, resolve(assignment, *lhs)?);
-            emit_load_imm(ops, SCRATCH0, *imm as i64 as u64);
-            dynasm!(ops ; .arch aarch64 ; cmp X(lhs), x16);
+            if !emit_cmp_immediate(ops, lhs, *imm) {
+                emit_load_imm(ops, SCRATCH0, *imm as i64 as u64);
+                dynasm!(ops ; .arch aarch64 ; cmp X(lhs), x16);
+            }
             emit_cset(ops, dst, *kind);
         }
         MInst::UDiv { dst, lhs, rhs }
@@ -882,8 +895,10 @@ fn emit_instruction(
                 resolve(assignment, *true_val)?,
                 resolve(assignment, *false_val)?,
             );
-            emit_load_imm(ops, SCRATCH0, *imm as i64 as u64);
-            dynasm!(ops ; .arch aarch64 ; cmp X(lhs), x16);
+            if !emit_cmp_immediate(ops, lhs, *imm) {
+                emit_load_imm(ops, SCRATCH0, *imm as i64 as u64);
+                dynasm!(ops ; .arch aarch64 ; cmp X(lhs), x16);
+            }
             emit_csel(ops, dst, true_val, false_val, *kind);
         }
         MInst::JumpTable { index, targets, .. } => {
@@ -955,9 +970,7 @@ fn emit_instruction(
             if let (Some(entry), Some(success)) = (tick_entry, tick_success) {
                 dynasm!(ops
                     ; .arch aarch64
-                    ; fmov x16, d31
-                    ; subs x16, x16, #1
-                    ; fmov d31, x16
+                    ; subs x29, x29, #1
                     ; b.eq =>success
                 );
                 if check_runtime_events {
@@ -986,9 +999,7 @@ fn emit_instruction(
             if tick_entry.is_some() {
                 dynasm!(ops
                     ; .arch aarch64
-                    ; fmov x16, d31
-                    ; sub x16, x16, #1
-                    ; fmov d31, x16
+                    ; sub x29, x29, #1
                 );
             }
             emit_load_imm(ops, STATE_REG, *code as u64);
@@ -1371,10 +1382,10 @@ fn emit_packed_lane_compare(
         4 => OpSize::S32,
         _ => return Err(EmitError::Range("packed lane stride must be 1, 2, or 4")),
     };
-    if let PackedLaneCompareRhs::Scalar(value) = rhs {
-        let register = resolve(assignment, value)?;
-        dynasm!(ops ; .arch aarch64 ; fmov d6, X(register));
-    }
+    let scalar_rhs = match rhs {
+        PackedLaneCompareRhs::Scalar(value) => Some(resolve(assignment, value)?),
+        PackedLaneCompareRhs::Memory { .. } => None,
+    };
     dynasm!(ops ; .arch aarch64 ; mov x30, xzr);
     let field_mask = if field_width == 64 {
         u64::MAX
@@ -1390,7 +1401,7 @@ fn emit_packed_lane_compare(
         emit_load(ops, SCRATCH0, SCRATCH0, size);
         match rhs {
             PackedLaneCompareRhs::Scalar(_) => {
-                dynasm!(ops ; .arch aarch64 ; fmov x17, d6);
+                dynasm!(ops ; .arch aarch64 ; mov x17, X(scalar_rhs.unwrap()));
             }
             PackedLaneCompareRhs::Memory { offset, .. } => {
                 dynasm!(ops ; .arch aarch64 ; fmov d7, x16);
@@ -1413,14 +1424,19 @@ fn emit_packed_lane_compare(
         }
         let storage_width = element_stride * 8;
         if field_width != storage_width {
-            dynasm!(ops ; .arch aarch64 ; fmov d5, x30);
-            emit_load_imm(ops, 30, field_mask);
-            dynasm!(ops
-                ; .arch aarch64
-                ; and x16, x16, x30
-                ; and x17, x17, x30
-                ; fmov x30, d5
-            );
+            if logical_immediate_encoding(field_mask, 64, SCRATCH0, SCRATCH0, true).is_some() {
+                emit_logical_immediate(ops, SCRATCH0, SCRATCH0, field_mask, 64, true);
+                emit_logical_immediate(ops, SCRATCH1, SCRATCH1, field_mask, 64, true);
+            } else {
+                dynasm!(ops ; .arch aarch64 ; fmov d5, x30);
+                emit_load_imm(ops, 30, field_mask);
+                dynasm!(ops
+                    ; .arch aarch64
+                    ; and x16, x16, x30
+                    ; and x17, x17, x30
+                    ; fmov x30, d5
+                );
+            }
         }
         if matches!(
             kind,
@@ -1452,26 +1468,17 @@ fn emit_packed_byte_affine_compare(
     rhs: u8,
     kind: CmpKind,
 ) {
-    dynasm!(ops
-        ; .arch aarch64
-        ; fmov d6, X(base)
-        ; fmov d7, X(rhs)
-        ; mov x30, xzr
-    );
+    dynasm!(ops ; .arch aarch64 ; mov x30, xzr);
     for lane in 0..16_u32 {
-        dynasm!(ops ; .arch aarch64 ; fmov x16, d6);
-        if lane != 0 {
+        if lane == 0 {
+            dynasm!(ops ; .arch aarch64 ; mov x16, X(base));
+        } else if !emit_add_sub_immediate(ops, SCRATCH0, base, i64::from(lane)) {
             emit_load_imm(ops, SCRATCH1, u64::from(lane));
-            dynasm!(ops ; .arch aarch64 ; add x16, x16, x17);
+            dynasm!(ops ; .arch aarch64 ; add x16, X(base), x17);
         }
-        dynasm!(ops ; .arch aarch64 ; fmov x17, d7 ; fmov d5, x30);
-        emit_load_imm(ops, 30, 0xff);
-        dynasm!(ops
-            ; .arch aarch64
-            ; and x16, x16, x30
-            ; and x17, x17, x30
-            ; fmov x30, d5
-        );
+        dynasm!(ops ; .arch aarch64 ; mov x17, X(rhs));
+        emit_logical_immediate(ops, SCRATCH0, SCRATCH0, 0xff, 64, true);
+        emit_logical_immediate(ops, SCRATCH1, SCRATCH1, 0xff, 64, true);
         if matches!(
             kind,
             CmpKind::LtS | CmpKind::LeS | CmpKind::GtS | CmpKind::GeS
@@ -1860,26 +1867,149 @@ fn add_sub_immediate(offset: i64) -> Option<(bool, u32, bool)> {
     None
 }
 
-fn emit_add_sub_immediate(
-    ops: &mut VecAssembler<Aarch64Relocation>,
+fn add_sub_immediate_encoding(
     destination: u8,
     base: u8,
     offset: i64,
-) -> bool {
-    let Some((subtract, immediate, shifted)) = add_sub_immediate(offset) else {
-        return false;
-    };
-    // ADD/SUB (immediate): sf=1, op selects SUB, sh selects <<12, and the
-    // 12-bit immediate is encoded between Rn and Rd.  Encoding this one
-    // instruction directly keeps both registers dynamic without forcing a
-    // large dynasm register match table.
-    let instruction = 0x9100_0000
+    set_flags: bool,
+) -> Option<u32> {
+    let (subtract, immediate, shifted) = add_sub_immediate(offset)?;
+    // ADD/SUB (immediate): sf=1, op selects SUB, S selects flag-setting,
+    // and sh selects an optional <<12 immediate.  Using the same encoder for
+    // arithmetic and CMP keeps the immediate selection identical.
+    let opcode = if set_flags { 0xb100_0000 } else { 0x9100_0000 };
+    let instruction = opcode
         | (u32::from(subtract) << 30)
         | (u32::from(shifted) << 22)
         | (immediate << 10)
         | (u32::from(base) << 5)
         | u32::from(destination);
     debug_assert!(immediate <= 0xfff);
+    Some(instruction)
+}
+
+fn emit_add_sub_immediate(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: u8,
+    base: u8,
+    offset: i64,
+) -> bool {
+    let Some(instruction) = add_sub_immediate_encoding(destination, base, offset, false) else {
+        return false;
+    };
+    ops.push_u32(instruction);
+    true
+}
+
+fn emit_cmp_immediate(ops: &mut VecAssembler<Aarch64Relocation>, lhs: u8, immediate: i32) -> bool {
+    // CMP lhs, #imm is SUBS lhs, #imm.  A negative immediate is therefore
+    // represented by ADDS with its positive magnitude.  The immediate is
+    // sign-extended to 64 bits by the MIR contract.
+    let Some(instruction) = add_sub_immediate_encoding(31, lhs, -i64::from(immediate), true) else {
+        return false;
+    };
+    ops.push_u32(instruction);
+    true
+}
+
+fn logical_immediate_encoding(
+    value: u64,
+    width: u32,
+    destination: u8,
+    source: u8,
+    is_and: bool,
+) -> Option<u32> {
+    debug_assert!(matches!(width, 32 | 64));
+    let width_mask = if width == 32 {
+        u64::from(u32::MAX)
+    } else {
+        u64::MAX
+    };
+    let value = value & width_mask;
+    let opcode = match (width, is_and) {
+        (32, true) => 0x1200_0000,
+        (32, false) => 0x3200_0000,
+        (64, true) => 0x9200_0000,
+        (64, false) => 0xb200_0000,
+        _ => unreachable!(),
+    };
+
+    // AArch64 represents a logical immediate as a rotated run of ones in a
+    // power-of-two element, replicated to the operand width.  Try the
+    // smallest element first; this also selects N=0 for repeated masks and
+    // N=1 only for a full 64-bit element.
+    for element_size in [2_u32, 4, 8, 16, 32, 64] {
+        if element_size > width {
+            continue;
+        }
+        let element_mask = if element_size == 64 {
+            u64::MAX
+        } else {
+            (1_u64 << element_size) - 1
+        };
+        let pattern = value & element_mask;
+        if pattern == 0 || pattern == element_mask {
+            continue;
+        }
+        let mut repeated = 0_u64;
+        let mut offset = 0_u32;
+        while offset < width {
+            repeated |= pattern << offset;
+            offset += element_size;
+        }
+        if repeated != value {
+            continue;
+        }
+
+        let ones = pattern.count_ones();
+        let length = element_size.trailing_zeros();
+        let imms_prefix = (!((1_u32 << (length + 1)) - 1)) & 0x3f;
+        let imms = imms_prefix | (ones - 1);
+        let run = (1_u64 << ones) - 1;
+        for rotation in 0..element_size {
+            if rotate_right(run, rotation, element_size) != pattern {
+                continue;
+            }
+            let n = u32::from(width == 64 && element_size == 64);
+            return Some(
+                opcode
+                    | (n << 22)
+                    | (rotation << 16)
+                    | (imms << 10)
+                    | (u32::from(source) << 5)
+                    | u32::from(destination),
+            );
+        }
+    }
+    None
+}
+
+fn rotate_right(value: u64, amount: u32, width: u32) -> u64 {
+    let amount = amount % width;
+    let mask = if width == 64 {
+        u64::MAX
+    } else {
+        (1_u64 << width) - 1
+    };
+    if amount == 0 {
+        value & mask
+    } else {
+        ((value >> amount) | (value << (width - amount))) & mask
+    }
+}
+
+fn emit_logical_immediate(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: u8,
+    source: u8,
+    value: u64,
+    width: u32,
+    is_and: bool,
+) -> bool {
+    let Some(instruction) = logical_immediate_encoding(value, width, destination, source, is_and)
+    else {
+        return false;
+    };
     ops.push_u32(instruction);
     true
 }
@@ -2072,8 +2202,10 @@ fn emit_branch_predicate(
         }
         BranchPredicate::CompareImm { lhs, imm, .. } => {
             let lhs = resolve(assignment, lhs)?;
-            emit_load_imm(ops, SCRATCH0, imm as i64 as u64);
-            dynasm!(ops ; .arch aarch64 ; cmp X(lhs), x16);
+            if !emit_cmp_immediate(ops, lhs, imm) {
+                emit_load_imm(ops, SCRATCH0, imm as i64 as u64);
+                dynasm!(ops ; .arch aarch64 ; cmp X(lhs), x16);
+            }
         }
         BranchPredicate::MemoryNonZero { base, offset, size } => {
             let base_register = base_register(base);
@@ -2382,6 +2514,40 @@ mod tests {
         assert_eq!(add_sub_immediate(4096), Some((false, 1, true)));
         assert_eq!(add_sub_immediate(-4096), Some((true, 1, true)));
         assert_eq!(add_sub_immediate(4097), None);
+        assert_eq!(
+            add_sub_immediate_encoding(31, 1, -4095, true),
+            Some(0xf13f_fc3f)
+        );
+        assert_eq!(
+            add_sub_immediate_encoding(31, 1, 4095, true),
+            Some(0xb13f_fc3f)
+        );
+        assert_eq!(
+            add_sub_immediate_encoding(31, 1, -4096, true),
+            Some(0xf140_043f)
+        );
+    }
+
+    #[test]
+    fn selects_aarch64_logical_immediates() {
+        assert_eq!(
+            logical_immediate_encoding(0xff, 64, 0, 1, true),
+            Some(0x9240_1c20)
+        );
+        assert_eq!(
+            logical_immediate_encoding(0x5555_5555_5555_5555, 64, 0, 1, true),
+            Some(0x9200_f020)
+        );
+        assert_eq!(
+            logical_immediate_encoding(0xff00_ff00_ff00_ff00, 64, 0, 1, false),
+            Some(0xb208_9c20)
+        );
+        assert_eq!(
+            logical_immediate_encoding(0xff, 32, 0, 1, true),
+            Some(0x1200_1c20)
+        );
+        assert_eq!(logical_immediate_encoding(0, 64, 0, 1, true), None);
+        assert_eq!(logical_immediate_encoding(u64::MAX, 64, 0, 1, true), None);
     }
 
     #[test]
@@ -2423,6 +2589,99 @@ mod tests {
         state[..8].copy_from_slice(&37_u64.to_le_bytes());
         assert_eq!(unsafe { code.call(&mut state) }, 0);
         assert_eq!(u64::from_le_bytes(state[8..].try_into().unwrap()), 42);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn executes_logical_and_compare_immediates() {
+        let mut vregs = VRegAllocator::new();
+        let input = vregs.alloc();
+        let anded = vregs.alloc();
+        let ored = vregs.alloc();
+        let unsigned = vregs.alloc();
+        let signed = vregs.alloc();
+        let fallback = vregs.alloc();
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 6]);
+        let mut block = MBlock::new(BlockId(0));
+        block.push(MInst::Load {
+            dst: input,
+            base: BaseReg::SimState,
+            offset: 0,
+            size: OpSize::S64,
+        });
+        block.push(MInst::AndImm {
+            dst: anded,
+            src: input,
+            imm: 0xff,
+        });
+        block.push(MInst::OrImm {
+            dst: ored,
+            src: input,
+            imm: 0xff00_ff00_ff00_ff00,
+        });
+        block.push(MInst::CmpImm {
+            dst: unsigned,
+            lhs: input,
+            imm: 4095,
+            kind: CmpKind::LtU,
+        });
+        block.push(MInst::CmpImm {
+            dst: signed,
+            lhs: input,
+            imm: -4095,
+            kind: CmpKind::GtS,
+        });
+        block.push(MInst::CmpImm {
+            dst: fallback,
+            lhs: input,
+            imm: 0x12345,
+            kind: CmpKind::Eq,
+        });
+        for (offset, source) in [
+            (8, anded),
+            (16, ored),
+            (24, unsigned),
+            (32, signed),
+            (40, fallback),
+        ] {
+            block.push(MInst::Store {
+                base: BaseReg::SimState,
+                offset,
+                src: source,
+                size: OpSize::S64,
+            });
+        }
+        block.push(MInst::Return);
+        function.push_block(block);
+        let mut assignment = AssignmentMap::default();
+        for (value, register) in [
+            (input, PhysReg::RAX),
+            (anded, PhysReg::RDX),
+            (ored, PhysReg::RSI),
+            (unsigned, PhysReg::RDI),
+            (signed, PhysReg::R8),
+            (fallback, PhysReg::R9),
+        ] {
+            assignment.set(value, register);
+        }
+
+        let emitted = emit(&function, &assignment, 0).unwrap();
+        let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
+        let mut state = vec![0_u8; 48];
+        let input_value = 0x1234_5678_9abc_def0_u64;
+        state[..8].copy_from_slice(&input_value.to_le_bytes());
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        assert_eq!(
+            u64::from_le_bytes(state[8..16].try_into().unwrap()),
+            input_value & 0xff
+        );
+        assert_eq!(
+            u64::from_le_bytes(state[16..24].try_into().unwrap()),
+            input_value | 0xff00_ff00_ff00_ff00
+        );
+        assert_eq!(u64::from_le_bytes(state[24..32].try_into().unwrap()), 0);
+        assert_eq!(u64::from_le_bytes(state[32..40].try_into().unwrap()), 1);
+        assert_eq!(u64::from_le_bytes(state[40..48].try_into().unwrap()), 0);
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -264,12 +264,21 @@ fn emit_function(
     callee_saved.sort_unstable();
     callee_saved.dedup();
 
-    dynasm!(ops
-        ; .arch aarch64
-        ; str x30, [sp, #-16]!
-    );
-    for &register in &callee_saved {
-        dynasm!(ops ; .arch aarch64 ; str X(register), [sp, #-16]!);
+    if let Some(&first) = callee_saved.first() {
+        dynasm!(ops ; .arch aarch64 ; stp x30, X(first), [sp, #-16]!);
+        let mut index = 1;
+        while index + 1 < callee_saved.len() {
+            dynasm!(ops
+                ; .arch aarch64
+                ; stp X(callee_saved[index]), X(callee_saved[index + 1]), [sp, #-16]!
+            );
+            index += 2;
+        }
+        if index < callee_saved.len() {
+            dynasm!(ops ; .arch aarch64 ; str X(callee_saved[index]), [sp, #-16]!);
+        }
+    } else {
+        dynasm!(ops ; .arch aarch64 ; str x30, [sp, #-16]!);
     }
     if tick_loop {
         // d29 retains the simulator-state pointer across success/error return
@@ -353,10 +362,24 @@ fn emit_function(
         );
         dynasm!(ops ; .arch aarch64 ; add x17, x17, x30 ; str x16, [x17]);
     }
-    for &register in callee_saved.iter().rev() {
-        dynasm!(ops ; .arch aarch64 ; ldr X(register), [sp], #16);
+    if callee_saved.is_empty() {
+        dynasm!(ops ; .arch aarch64 ; ldr x30, [sp], #16);
+    } else {
+        let mut index = callee_saved.len();
+        if index > 1 && (index - 1) % 2 == 1 {
+            index -= 1;
+            dynasm!(ops ; .arch aarch64 ; ldr X(callee_saved[index]), [sp], #16);
+        }
+        while index > 1 {
+            index -= 2;
+            dynasm!(ops
+                ; .arch aarch64
+                ; ldp X(callee_saved[index]), X(callee_saved[index + 1]), [sp], #16
+            );
+        }
+        dynasm!(ops ; .arch aarch64 ; ldp x30, X(callee_saved[0]), [sp], #16);
     }
-    dynasm!(ops ; .arch aarch64 ; ldr x30, [sp], #16 ; ret);
+    dynasm!(ops ; .arch aarch64 ; ret);
     let text_size = ops.offset().0;
     for (index, table) in function.constant_tables().iter().enumerate() {
         let label = table_labels[index];
@@ -423,8 +446,15 @@ fn emit_instruction(
             offset,
             size,
         } => {
-            emit_base_address(ops, *base, *offset, spill_base)?;
-            emit_load(ops, resolve(assignment, *dst)?, SCRATCH0, *size);
+            let base_register = base_register(*base);
+            let offset = base_offset(*base, *offset, spill_base)?;
+            emit_load_at(
+                ops,
+                resolve(assignment, *dst)?,
+                base_register,
+                offset,
+                *size,
+            );
         }
         MInst::Store {
             base,
@@ -432,8 +462,15 @@ fn emit_instruction(
             src,
             size,
         } => {
-            emit_base_address(ops, *base, *offset, spill_base)?;
-            emit_store(ops, resolve(assignment, *src)?, SCRATCH0, *size);
+            let base_register = base_register(*base);
+            let offset = base_offset(*base, *offset, spill_base)?;
+            emit_store_at(
+                ops,
+                resolve(assignment, *src)?,
+                base_register,
+                offset,
+                *size,
+            );
         }
         MInst::LoadPtr {
             dst,
@@ -441,8 +478,13 @@ fn emit_instruction(
             offset,
             size,
         } => {
-            emit_address(ops, resolve(assignment, *ptr)?, i64::from(*offset));
-            emit_load(ops, resolve(assignment, *dst)?, SCRATCH0, *size);
+            emit_load_at(
+                ops,
+                resolve(assignment, *dst)?,
+                resolve(assignment, *ptr)?,
+                i64::from(*offset),
+                *size,
+            );
         }
         MInst::StorePtr {
             ptr,
@@ -450,8 +492,13 @@ fn emit_instruction(
             src,
             size,
         } => {
-            emit_address(ops, resolve(assignment, *ptr)?, i64::from(*offset));
-            emit_store(ops, resolve(assignment, *src)?, SCRATCH0, *size);
+            emit_store_at(
+                ops,
+                resolve(assignment, *src)?,
+                resolve(assignment, *ptr)?,
+                i64::from(*offset),
+                *size,
+            );
         }
         MInst::ReleaseStorePtr {
             ptr,
@@ -475,8 +522,13 @@ fn emit_instruction(
             let index = resolve(assignment, *index)?;
             let shift = scale.trailing_zeros();
             dynasm!(ops ; .arch aarch64 ; add x16, X(base), X(index), LSL #shift);
-            emit_add_offset(ops, i64::from(*offset));
-            emit_load(ops, resolve(assignment, *dst)?, SCRATCH0, *size);
+            emit_load_at(
+                ops,
+                resolve(assignment, *dst)?,
+                SCRATCH0,
+                i64::from(*offset),
+                *size,
+            );
         }
         MInst::StoreIndexed {
             base,
@@ -497,14 +549,28 @@ fn emit_instruction(
             let base = base_register(*base);
             let index = resolve(assignment, *index)?;
             dynasm!(ops ; .arch aarch64 ; add x16, X(base), X(index));
-            emit_add_offset(ops, i64::from(*offset));
             if matches!(instruction, MInst::OrStoreIndexed { .. }) {
-                emit_load(ops, SCRATCH1, SCRATCH0, *size);
                 let src = resolve(assignment, *src)?;
-                dynasm!(ops ; .arch aarch64 ; orr x17, x17, X(src));
-                emit_store(ops, SCRATCH1, SCRATCH0, *size);
+                if memory_access_encoding(SCRATCH1, SCRATCH0, i64::from(*offset), *size, false)
+                    .is_some()
+                {
+                    emit_load_at(ops, SCRATCH1, SCRATCH0, i64::from(*offset), *size);
+                    dynasm!(ops ; .arch aarch64 ; orr x17, x17, X(src));
+                    emit_store_at(ops, SCRATCH1, SCRATCH0, i64::from(*offset), *size);
+                } else {
+                    emit_add_offset(ops, i64::from(*offset));
+                    emit_load(ops, SCRATCH1, SCRATCH0, *size);
+                    dynasm!(ops ; .arch aarch64 ; orr x17, x17, X(src));
+                    emit_store(ops, SCRATCH1, SCRATCH0, *size);
+                }
             } else {
-                emit_store(ops, resolve(assignment, *src)?, SCRATCH0, *size);
+                emit_store_at(
+                    ops,
+                    resolve(assignment, *src)?,
+                    SCRATCH0,
+                    i64::from(*offset),
+                    *size,
+                );
             }
         }
         MInst::LoadPtrIndexed {
@@ -516,8 +582,13 @@ fn emit_instruction(
         } => {
             let (ptr, index) = (resolve(assignment, *ptr)?, resolve(assignment, *index)?);
             dynasm!(ops ; .arch aarch64 ; add x16, X(ptr), X(index));
-            emit_add_offset(ops, i64::from(*offset));
-            emit_load(ops, resolve(assignment, *dst)?, SCRATCH0, *size);
+            emit_load_at(
+                ops,
+                resolve(assignment, *dst)?,
+                SCRATCH0,
+                i64::from(*offset),
+                *size,
+            );
         }
         MInst::StorePtrIndexed {
             ptr,
@@ -535,12 +606,12 @@ fn emit_instruction(
         } => {
             let (ptr, index) = (resolve(assignment, *ptr)?, resolve(assignment, *index)?);
             dynasm!(ops ; .arch aarch64 ; add x16, X(ptr), X(index));
-            emit_add_offset(ops, i64::from(*offset));
             let src = resolve(assignment, *src)?;
             if matches!(instruction, MInst::ReleaseStorePtrIndexed { .. }) {
+                emit_add_offset(ops, i64::from(*offset));
                 emit_release_store(ops, src, SCRATCH0, *size);
             } else {
-                emit_store(ops, src, SCRATCH0, *size);
+                emit_store_at(ops, src, SCRATCH0, i64::from(*offset), *size);
             }
         }
         MInst::AndStoreImm {
@@ -555,16 +626,31 @@ fn emit_instruction(
             size,
             imm,
         } => {
-            emit_base_address(ops, *base, *offset, spill_base)?;
-            emit_load(ops, SCRATCH1, SCRATCH0, *size);
-            emit_load_imm(ops, SCRATCH0, *imm);
-            if matches!(instruction, MInst::AndStoreImm { .. }) {
-                dynasm!(ops ; .arch aarch64 ; and x30, x17, x16);
+            let base_register = base_register(*base);
+            let address_offset = base_offset(*base, *offset, spill_base)?;
+            if memory_access_encoding(SCRATCH1, base_register, address_offset, *size, false)
+                .is_some()
+            {
+                emit_load_at(ops, SCRATCH1, base_register, address_offset, *size);
+                emit_load_imm(ops, SCRATCH0, *imm);
+                if matches!(instruction, MInst::AndStoreImm { .. }) {
+                    dynasm!(ops ; .arch aarch64 ; and x30, x17, x16);
+                } else {
+                    dynasm!(ops ; .arch aarch64 ; orr x30, x17, x16);
+                }
+                emit_store_at(ops, 30, base_register, address_offset, *size);
             } else {
-                dynasm!(ops ; .arch aarch64 ; orr x30, x17, x16);
+                emit_base_address(ops, *base, *offset, spill_base)?;
+                emit_load(ops, SCRATCH1, SCRATCH0, *size);
+                emit_load_imm(ops, SCRATCH0, *imm);
+                if matches!(instruction, MInst::AndStoreImm { .. }) {
+                    dynasm!(ops ; .arch aarch64 ; and x30, x17, x16);
+                } else {
+                    dynasm!(ops ; .arch aarch64 ; orr x30, x17, x16);
+                }
+                emit_base_address(ops, *base, *offset, spill_base)?;
+                emit_store(ops, 30, SCRATCH0, *size);
             }
-            emit_base_address(ops, *base, *offset, spill_base)?;
-            emit_store(ops, 30, SCRATCH0, *size);
         }
         MInst::Add { dst, lhs, rhs }
         | MInst::Sub { dst, lhs, rhs }
@@ -1575,15 +1661,19 @@ fn emit_base_address(
     offset: i32,
     spill_base: usize,
 ) -> Result<(), EmitError> {
-    let offset = match base {
-        BaseReg::SimState => i64::from(offset),
+    let offset = base_offset(base, offset, spill_base)?;
+    emit_address(ops, STATE_REG, offset);
+    Ok(())
+}
+
+fn base_offset(base: BaseReg, offset: i32, spill_base: usize) -> Result<i64, EmitError> {
+    match base {
+        BaseReg::SimState => Ok(i64::from(offset)),
         BaseReg::StackFrame => i64::try_from(spill_base)
             .ok()
             .and_then(|base| base.checked_add(i64::from(offset)))
-            .ok_or(EmitError::Range("stack-frame address overflow"))?,
-    };
-    emit_address(ops, STATE_REG, offset);
-    Ok(())
+            .ok_or(EmitError::Range("stack-frame address overflow")),
+    }
 }
 
 fn emit_address(ops: &mut VecAssembler<Aarch64Relocation>, base: u8, offset: i64) {
@@ -1594,6 +1684,70 @@ fn emit_address(ops: &mut VecAssembler<Aarch64Relocation>, base: u8, offset: i64
         dynasm!(ops ; .arch aarch64 ; add x16, X(base), x17);
     } else {
         // The address was formed directly by ADD/SUB immediate.
+    }
+}
+
+fn memory_access_encoding(
+    register: u8,
+    base: u8,
+    offset: i64,
+    size: OpSize,
+    store: bool,
+) -> Option<u32> {
+    let (bytes, scaled_opcode, unscaled_opcode) = match (size, store) {
+        (OpSize::S8, false) => (1, 0x3940_0000, 0x3840_0000),
+        (OpSize::S8, true) => (1, 0x3900_0000, 0x3800_0000),
+        (OpSize::S16, false) => (2, 0x7940_0000, 0x7840_0000),
+        (OpSize::S16, true) => (2, 0x7900_0000, 0x7800_0000),
+        (OpSize::S32, false) => (4, 0xb940_0000, 0xb840_0000),
+        (OpSize::S32, true) => (4, 0xb900_0000, 0xb800_0000),
+        (OpSize::S64, false) => (8, 0xf940_0000, 0xf840_0000),
+        (OpSize::S64, true) => (8, 0xf900_0000, 0xf800_0000),
+    };
+    let register = u32::from(register);
+    let base = u32::from(base);
+    let registers = (base << 5) | register;
+
+    if offset >= 0 && offset % bytes == 0 {
+        let scaled = offset / bytes;
+        if scaled <= 0xfff {
+            return Some(scaled_opcode | ((scaled as u32) << 10) | registers);
+        }
+    }
+    if (-256..=255).contains(&offset) {
+        let immediate = ((offset as i32) & 0x1ff) as u32;
+        return Some(unscaled_opcode | (immediate << 12) | registers);
+    }
+    None
+}
+
+fn emit_load_at(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: u8,
+    base: u8,
+    offset: i64,
+    size: OpSize,
+) {
+    if let Some(instruction) = memory_access_encoding(destination, base, offset, size, false) {
+        ops.push_u32(instruction);
+    } else {
+        emit_address(ops, base, offset);
+        emit_load(ops, destination, SCRATCH0, size);
+    }
+}
+
+fn emit_store_at(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    source: u8,
+    base: u8,
+    offset: i64,
+    size: OpSize,
+) {
+    if let Some(instruction) = memory_access_encoding(source, base, offset, size, true) {
+        ops.push_u32(instruction);
+    } else {
+        emit_address(ops, base, offset);
+        emit_store(ops, source, SCRATCH0, size);
     }
 }
 
@@ -1837,8 +1991,9 @@ fn emit_branch_predicate(
             dynasm!(ops ; .arch aarch64 ; cmp X(lhs), x16);
         }
         BranchPredicate::MemoryNonZero { base, offset, size } => {
-            emit_base_address(ops, base, offset, spill_base)?;
-            emit_load(ops, SCRATCH0, SCRATCH0, size);
+            let base_register = base_register(base);
+            let offset = base_offset(base, offset, spill_base)?;
+            emit_load_at(ops, SCRATCH0, base_register, offset, size);
             dynasm!(ops ; .arch aarch64 ; cmp x16, #0);
         }
     }
@@ -2142,6 +2297,27 @@ mod tests {
         assert_eq!(add_sub_immediate(4096), Some((false, 1, true)));
         assert_eq!(add_sub_immediate(-4096), Some((true, 1, true)));
         assert_eq!(add_sub_immediate(4097), None);
+    }
+
+    #[test]
+    fn selects_scaled_and_unscaled_memory_immediates() {
+        assert_eq!(
+            memory_access_encoding(5, 0, 16, crate::mir::OpSize::S64, false),
+            Some(0xf940_0805)
+        );
+        assert_eq!(
+            memory_access_encoding(5, 0, -8, crate::mir::OpSize::S64, false),
+            Some(0xf85f_8005)
+        );
+        assert_eq!(
+            memory_access_encoding(7, 3, 4092, crate::mir::OpSize::S32, true),
+            Some(0xb90f_fc67)
+        );
+        assert_eq!(
+            memory_access_encoding(2, 4, -1, crate::mir::OpSize::S8, true),
+            Some(0x381f_f082)
+        );
+        assert!(memory_access_encoding(5, 0, 4096, crate::mir::OpSize::S8, false).is_none());
     }
 
     #[test]

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -1674,14 +1674,6 @@ fn emit_packed_lane_compare_vector(
         (1_u64 << field_width) - 1
     };
 
-    if let Some(rhs) = scalar_rhs {
-        match element_stride {
-            1 => dynasm!(ops ; .arch aarch64 ; dup v1.b16, W(rhs)),
-            2 => dynasm!(ops ; .arch aarch64 ; dup v1.h8, W(rhs)),
-            4 => dynasm!(ops ; .arch aarch64 ; dup v1.s4, W(rhs)),
-            _ => unreachable!(),
-        }
-    }
     if needs_mask {
         emit_load_imm(ops, SCRATCH1, field_mask);
         match element_stride {
@@ -1710,6 +1702,13 @@ fn emit_packed_lane_compare_vector(
             let (rhs_base, rhs_offset) =
                 select_vector_memory_base(BaseReg::SimState, i64::from(rhs_offset), state_pages);
             emit_vector_load(ops, 1, rhs_base, rhs_offset);
+        } else if let Some(rhs) = scalar_rhs {
+            match element_stride {
+                1 => dynasm!(ops ; .arch aarch64 ; dup v1.b16, W(rhs)),
+                2 => dynasm!(ops ; .arch aarch64 ; dup v1.h8, W(rhs)),
+                4 => dynasm!(ops ; .arch aarch64 ; dup v1.s4, W(rhs)),
+                _ => unreachable!(),
+            }
         }
 
         if bit_offset != 0 {
@@ -1727,8 +1726,7 @@ fn emit_packed_lane_compare_vector(
                     4 => dynasm!(ops ; .arch aarch64 ; ushr v1.s4, v1.s4, #shift),
                     _ => unreachable!(),
                 }
-            } else if let Some(rhs) = scalar_rhs {
-                let _ = rhs;
+            } else if scalar_rhs.is_some() {
                 match element_stride {
                     1 => dynasm!(ops ; .arch aarch64 ; ushr v1.b16, v1.b16, #shift),
                     2 => dynasm!(ops ; .arch aarch64 ; ushr v1.h8, v1.h8, #shift),
@@ -4712,6 +4710,52 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn executes_vector_packed_lane_compare_scalar_rhs_per_chunk() {
+        let mut vregs = VRegAllocator::new();
+        let result = vregs.alloc();
+        let rhs = vregs.alloc();
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 2]);
+        let mut block = MBlock::new(BlockId(0));
+        block.push(MInst::LoadImm {
+            dst: rhs,
+            value: 0x0a,
+        });
+        block.push(MInst::PackedLaneCompare {
+            dst: result,
+            rhs: PackedLaneCompareRhs::Scalar(rhs),
+            kind: CmpKind::Eq,
+            offset: 0,
+            lane_count: 32,
+            element_stride: 1,
+            bit_offset: 1,
+            field_width: 8,
+            alias_range: None,
+        });
+        block.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 64,
+            src: result,
+            size: OpSize::S64,
+        });
+        block.push(MInst::Return);
+        function.push_block(block);
+
+        let mut assignment = AssignmentMap::default();
+        assignment.set(result, PhysReg::RDX);
+        assignment.set(rhs, PhysReg::RAX);
+        let emitted = emit(&function, &assignment, 0).unwrap();
+        let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
+        let mut state = vec![0_u8; 72];
+        state[..32].fill(0x0a);
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        assert_eq!(
+            u64::from_le_bytes(state[64..72].try_into().unwrap()),
+            u64::from(u32::MAX)
+        );
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -31,7 +31,14 @@ const SCRATCH1: u8 = 17;
 const SPILL_REG: u8 = 28;
 const STATE_PAGE_REG: u8 = 29;
 const STATE_PAGE_BYTES: i64 = 4096;
+const MAX_SECONDARY_STATE_PAGES: usize = 4;
 const TEMPORARY_BYTES: usize = 16;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct StatePageBases {
+    primary: Option<i64>,
+    secondary: [Option<(u8, i64)>; MAX_SECONDARY_STATE_PAGES],
+}
 
 /// Result of scalar AArch64 emission.
 pub struct EmitResult {
@@ -256,11 +263,18 @@ fn emit_function(
         .collect::<HashMap<_, _>>();
     // Use x29 for the most frequently accessed state page so large state
     // offsets can use ordinary AArch64 memory immediates without reducing the
-    // allocator's general-purpose register file.  The tick loop normally uses
-    // x29 for its counter; when a page base is profitable, keep that counter
-    // in an otherwise-unused SIMD scalar register instead.
-    let state_base_page = select_state_base_page(function);
-    let tick_counter_in_fp = tick_loop && state_base_page.is_some();
+    // allocator's general-purpose register file.  If a preserved register is
+    // unused by this function, cache a second hot page there as well.  The
+    // tick loop normally uses x29 for its counter; when a page base is
+    // profitable, keep that counter in an otherwise-unused SIMD scalar
+    // register instead.
+    let secondary_page_registers = (19..=27).rev().filter(|register| {
+        !assignment
+            .iter()
+            .any(|(_, value)| value.number() == *register)
+    });
+    let state_pages = select_state_base_pages(function, secondary_page_registers);
+    let tick_counter_in_fp = tick_loop && state_pages.primary.is_some();
     let table_labels = function
         .constant_tables()
         .iter()
@@ -275,10 +289,13 @@ fn emit_function(
         .map(|(_, register)| register.number())
         .filter(|register| (19..=27).contains(register))
         .collect::<Vec<_>>();
-    if tick_loop || state_base_page.is_some() {
+    if tick_loop || state_pages.primary.is_some() {
         // x29 is reserved for either the native-loop counter or the cached
         // state-page base, so preserve the host value across the JIT call.
         callee_saved.push(STATE_PAGE_REG);
+    }
+    for &(register, _) in state_pages.secondary.iter().flatten() {
+        callee_saved.push(register);
     }
     // x28 is the fixed base for the spill/cycle-break arena, including the
     // temporary slot used by parallel-copy resolution even when no value was
@@ -350,8 +367,11 @@ fn emit_function(
         }
     }
     emit_address_to(&mut ops, SPILL_REG, STATE_REG, spill_base as i64);
-    if let Some(page) = state_base_page {
+    if let Some(page) = state_pages.primary {
         emit_address_to(&mut ops, STATE_PAGE_REG, STATE_REG, page);
+    }
+    for &(register, page) in state_pages.secondary.iter().flatten() {
+        emit_address_to(&mut ops, register, STATE_REG, page);
     }
     for block in &function.blocks {
         let label = block_labels[&block.id];
@@ -376,7 +396,7 @@ fn emit_function(
                 tick_entry,
                 tick_success,
                 check_runtime_events,
-                state_base_page,
+                state_pages,
                 tick_counter_in_fp,
             )?;
         }
@@ -461,7 +481,7 @@ fn emit_instruction(
     tick_entry: Option<DynamicLabel>,
     tick_success: Option<DynamicLabel>,
     check_runtime_events: bool,
-    state_base_page: Option<i64>,
+    state_pages: StatePageBases,
     tick_counter_in_fp: bool,
 ) -> Result<(), EmitError> {
     match instruction {
@@ -491,7 +511,7 @@ fn emit_instruction(
             let offset = base_offset(*base, *offset);
             let destination = resolve(assignment, *dst)?;
             let (base_register, offset) =
-                select_memory_base(*base, offset, destination, *size, false, state_base_page);
+                select_memory_base(*base, offset, destination, *size, false, state_pages);
             emit_load_at(ops, destination, base_register, offset, *size);
         }
         MInst::Store {
@@ -503,7 +523,7 @@ fn emit_instruction(
             let offset = base_offset(*base, *offset);
             let source = resolve(assignment, *src)?;
             let (base_register, offset) =
-                select_memory_base(*base, offset, source, *size, true, state_base_page);
+                select_memory_base(*base, offset, source, *size, true, state_pages);
             emit_store_at(ops, source, base_register, offset, *size);
         }
         MInst::LoadPtr {
@@ -552,17 +572,17 @@ fn emit_instruction(
             size,
             ..
         } => {
-            let base = base_register(*base);
             let index = resolve(assignment, *index)?;
-            let shift = scale.trailing_zeros();
-            dynasm!(ops ; .arch aarch64 ; add x16, X(base), X(index), LSL #shift);
-            emit_load_at(
-                ops,
-                resolve(assignment, *dst)?,
-                SCRATCH0,
+            let destination = resolve(assignment, *dst)?;
+            let (base, offset) = select_indexed_memory_base(
+                *base,
                 i64::from(*offset),
+                destination,
                 *size,
+                false,
+                state_pages,
             );
+            emit_load_indexed_at(ops, destination, base, index, offset, *scale, *size);
         }
         MInst::StoreIndexed {
             base,
@@ -580,31 +600,39 @@ fn emit_instruction(
             size,
             ..
         } => {
-            let base = base_register(*base);
             let index = resolve(assignment, *index)?;
-            dynasm!(ops ; .arch aarch64 ; add x16, X(base), X(index));
             if matches!(instruction, MInst::OrStoreIndexed { .. }) {
                 let src = resolve(assignment, *src)?;
-                if memory_access_encoding(SCRATCH1, SCRATCH0, i64::from(*offset), *size, false)
-                    .is_some()
-                {
-                    emit_load_at(ops, SCRATCH1, SCRATCH0, i64::from(*offset), *size);
+                let (base, offset) = select_indexed_memory_base(
+                    *base,
+                    i64::from(*offset),
+                    SCRATCH1,
+                    *size,
+                    false,
+                    state_pages,
+                );
+                if offset == 0 {
+                    emit_load_indexed_at(ops, SCRATCH1, base, index, 0, 1, *size);
                     dynasm!(ops ; .arch aarch64 ; orr x17, x17, X(src));
-                    emit_store_at(ops, SCRATCH1, SCRATCH0, i64::from(*offset), *size);
+                    emit_store_indexed_at(ops, SCRATCH1, base, index, 0, 1, *size);
                 } else {
-                    emit_add_offset(ops, i64::from(*offset));
+                    dynasm!(ops ; .arch aarch64 ; add x16, X(base), X(index));
+                    emit_add_offset(ops, offset);
                     emit_load(ops, SCRATCH1, SCRATCH0, *size);
                     dynasm!(ops ; .arch aarch64 ; orr x17, x17, X(src));
                     emit_store(ops, SCRATCH1, SCRATCH0, *size);
                 }
             } else {
-                emit_store_at(
-                    ops,
-                    resolve(assignment, *src)?,
-                    SCRATCH0,
+                let src = resolve(assignment, *src)?;
+                let (base, offset) = select_indexed_memory_base(
+                    *base,
                     i64::from(*offset),
+                    src,
                     *size,
+                    true,
+                    state_pages,
                 );
+                emit_store_indexed_at(ops, src, base, index, offset, 1, *size);
             }
         }
         MInst::LoadPtrIndexed {
@@ -615,12 +643,13 @@ fn emit_instruction(
             size,
         } => {
             let (ptr, index) = (resolve(assignment, *ptr)?, resolve(assignment, *index)?);
-            dynasm!(ops ; .arch aarch64 ; add x16, X(ptr), X(index));
-            emit_load_at(
+            emit_load_indexed_at(
                 ops,
                 resolve(assignment, *dst)?,
-                SCRATCH0,
+                ptr,
+                index,
                 i64::from(*offset),
+                1,
                 *size,
             );
         }
@@ -639,13 +668,13 @@ fn emit_instruction(
             size,
         } => {
             let (ptr, index) = (resolve(assignment, *ptr)?, resolve(assignment, *index)?);
-            dynasm!(ops ; .arch aarch64 ; add x16, X(ptr), X(index));
             let src = resolve(assignment, *src)?;
             if matches!(instruction, MInst::ReleaseStorePtrIndexed { .. }) {
+                dynasm!(ops ; .arch aarch64 ; add x16, X(ptr), X(index));
                 emit_add_offset(ops, i64::from(*offset));
                 emit_release_store(ops, src, SCRATCH0, *size);
             } else {
-                emit_store_at(ops, src, SCRATCH0, i64::from(*offset), *size);
+                emit_store_indexed_at(ops, src, ptr, index, i64::from(*offset), 1, *size);
             }
         }
         MInst::AndStoreImm {
@@ -661,14 +690,8 @@ fn emit_instruction(
             imm,
         } => {
             let address_offset = base_offset(*base, *offset);
-            let (base_register, address_offset) = select_memory_base(
-                *base,
-                address_offset,
-                SCRATCH1,
-                *size,
-                false,
-                state_base_page,
-            );
+            let (base_register, address_offset) =
+                select_memory_base(*base, address_offset, SCRATCH1, *size, false, state_pages);
             if memory_access_encoding(SCRATCH1, base_register, address_offset, *size, false)
                 .is_some()
             {
@@ -986,7 +1009,7 @@ fn emit_instruction(
             true_bb,
             false_bb,
         } => {
-            emit_branch_predicate(ops, *predicate, assignment, state_base_page)?;
+            emit_branch_predicate(ops, *predicate, assignment, state_pages)?;
             let true_path = ops.new_dynamic_label();
             emit_conditional_branch(ops, true_path, predicate_kind(*predicate));
             emit_edge_copies(ops, plan, block, *false_bb, spill_base, temporary_offset)?;
@@ -1080,6 +1103,7 @@ fn emit_instruction(
             *bit_offset,
             *field_width,
             assignment,
+            state_pages,
         )?,
         MInst::PackedByteAffineCompare {
             dst,
@@ -1097,12 +1121,12 @@ fn emit_instruction(
             src_offset,
             dst_offset,
             byte_len,
-        } => emit_mem_copy(ops, *src_offset, *dst_offset, *byte_len),
+        } => emit_mem_copy(ops, *src_offset, *dst_offset, *byte_len, state_pages),
         MInst::MemFill {
             dst_offset,
             byte_len,
             value,
-        } => emit_mem_fill(ops, *dst_offset, *byte_len, *value),
+        } => emit_mem_fill(ops, *dst_offset, *byte_len, *value, state_pages),
         MInst::SparseCommit {
             src_offset,
             dst_offset,
@@ -1140,7 +1164,7 @@ fn emit_instruction(
                 SCRATCH1,
                 OpSize::S64,
                 false,
-                state_base_page,
+                state_pages,
             );
             emit_load_at(ops, SCRATCH1, base, offset, OpSize::S64);
             emit_load_imm(ops, SCRATCH0, 1_u64 << (*active_index % 64));
@@ -1151,7 +1175,7 @@ fn emit_instruction(
                 30,
                 OpSize::S64,
                 true,
-                state_base_page,
+                state_pages,
             );
             emit_store_at(ops, 30, base, offset, OpSize::S64);
         }
@@ -1214,6 +1238,7 @@ fn emit_mem_copy(
     src_offset: i32,
     dst_offset: i32,
     byte_len: usize,
+    state_pages: StatePageBases,
 ) {
     if byte_len == 0 || src_offset == dst_offset {
         return;
@@ -1223,6 +1248,10 @@ fn emit_mem_copy(
     let copy_backward = src_end > i64::from(dst_offset)
         && dst_end > i64::from(src_offset)
         && dst_offset > src_offset;
+    if !copy_backward && (16..=256).contains(&byte_len) {
+        emit_mem_copy_forward_vectors(ops, src_offset, dst_offset, byte_len, state_pages);
+        return;
+    }
     let qwords = byte_len / 8;
     let remainder = byte_len % 8;
 
@@ -1296,6 +1325,43 @@ fn emit_mem_copy(
         );
     }
     if remainder >= 4 {
+        dynasm!(ops ; .arch aarch64 ; ldr w30, [x16], #4 ; str w30, [x17], #4);
+    }
+    if remainder % 4 >= 2 {
+        dynasm!(ops ; .arch aarch64 ; ldrh w30, [x16], #2 ; strh w30, [x17], #2);
+    }
+    if remainder % 2 == 1 {
+        dynasm!(ops ; .arch aarch64 ; ldrb w30, [x16] ; strb w30, [x17]);
+    }
+}
+
+fn emit_mem_copy_forward_vectors(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    src_offset: i32,
+    dst_offset: i32,
+    byte_len: usize,
+    state_pages: StatePageBases,
+) {
+    let (src_base, src_relative) =
+        select_vector_memory_base(BaseReg::SimState, i64::from(src_offset), state_pages);
+    emit_address_to(ops, SCRATCH0, src_base, src_relative);
+    let (dst_base, dst_relative) =
+        select_vector_memory_base(BaseReg::SimState, i64::from(dst_offset), state_pages);
+    emit_address_to(ops, SCRATCH1, dst_base, dst_relative);
+
+    let vector_chunks = byte_len / 16;
+    for _ in 0..vector_chunks {
+        dynasm!(ops
+            ; .arch aarch64
+            ; ldr q0, [x16], #16
+            ; str q0, [x17], #16
+        );
+    }
+    let remainder = byte_len % 16;
+    if remainder >= 8 {
+        dynasm!(ops ; .arch aarch64 ; ldr x30, [x16], #8 ; str x30, [x17], #8);
+    }
+    if remainder % 8 >= 4 {
         dynasm!(ops ; .arch aarch64 ; ldr w30, [x16], #4 ; str w30, [x17], #4);
     }
     if remainder % 4 >= 2 {
@@ -1444,6 +1510,7 @@ fn emit_packed_lane_compare(
     bit_offset: u8,
     field_width: u8,
     assignment: &Assignment<VReg>,
+    state_pages: StatePageBases,
 ) -> Result<(), EmitError> {
     let size = match element_stride {
         1 => OpSize::S8,
@@ -1451,6 +1518,22 @@ fn emit_packed_lane_compare(
         4 => OpSize::S32,
         _ => return Err(EmitError::Range("packed lane stride must be 1, 2, or 4")),
     };
+    if usize::from(lane_count) * usize::from(element_stride) % 16 == 0 {
+        emit_packed_lane_compare_vector(
+            ops,
+            destination,
+            rhs,
+            kind,
+            offset,
+            lane_count,
+            element_stride,
+            bit_offset,
+            field_width,
+            assignment,
+            state_pages,
+        )?;
+        return Ok(());
+    }
     let scalar_rhs = match rhs {
         PackedLaneCompareRhs::Scalar(value) => Some(resolve(assignment, value)?),
         PackedLaneCompareRhs::Memory { .. } => None,
@@ -1466,7 +1549,15 @@ fn emit_packed_lane_compare(
             .checked_mul(i32::from(element_stride))
             .and_then(|delta| offset.checked_add(delta))
             .ok_or(EmitError::Range("packed lane offset overflow"))?;
-        emit_load_at(ops, SCRATCH0, STATE_REG, i64::from(lane_delta), size);
+        let (base, offset) = select_memory_base(
+            BaseReg::SimState,
+            i64::from(lane_delta),
+            SCRATCH0,
+            size,
+            false,
+            state_pages,
+        );
+        emit_load_at(ops, SCRATCH0, base, offset, size);
         match rhs {
             PackedLaneCompareRhs::Scalar(_) => {
                 dynasm!(ops ; .arch aarch64 ; mov x17, X(scalar_rhs.unwrap()));
@@ -1476,13 +1567,19 @@ fn emit_packed_lane_compare(
                     .checked_mul(i32::from(element_stride))
                     .and_then(|delta| offset.checked_add(delta))
                     .ok_or(EmitError::Range("packed lane RHS offset overflow"))?;
-                let direct =
-                    memory_access_encoding(SCRATCH1, STATE_REG, i64::from(rhs_offset), size, false)
-                        .is_some();
+                let (base, offset) = select_memory_base(
+                    BaseReg::SimState,
+                    i64::from(rhs_offset),
+                    SCRATCH1,
+                    size,
+                    false,
+                    state_pages,
+                );
+                let direct = memory_access_encoding(SCRATCH1, base, offset, size, false).is_some();
                 if !direct {
                     dynasm!(ops ; .arch aarch64 ; fmov d7, x16);
                 }
-                emit_load_at(ops, SCRATCH1, STATE_REG, i64::from(rhs_offset), size);
+                emit_load_at(ops, SCRATCH1, base, offset, size);
                 if !direct {
                     dynasm!(ops ; .arch aarch64 ; fmov x16, d7);
                 }
@@ -1533,6 +1630,303 @@ fn emit_packed_lane_compare(
     }
     dynasm!(ops ; .arch aarch64 ; mov X(destination), x30);
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_packed_lane_compare_vector(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: u8,
+    rhs: PackedLaneCompareRhs,
+    kind: CmpKind,
+    offset: i32,
+    lane_count: u8,
+    element_stride: u8,
+    bit_offset: u8,
+    field_width: u8,
+    assignment: &Assignment<VReg>,
+    state_pages: StatePageBases,
+) -> Result<(), EmitError> {
+    let lanes_per_vector = 16 / usize::from(element_stride);
+    let storage_width = element_stride * 8;
+    let scalar_rhs = match rhs {
+        PackedLaneCompareRhs::Scalar(value) => Some(resolve(assignment, value)?),
+        PackedLaneCompareRhs::Memory { .. } => None,
+    };
+    let needs_mask = field_width != storage_width;
+    let field_mask = if field_width == 64 {
+        u64::MAX
+    } else {
+        (1_u64 << field_width) - 1
+    };
+
+    if let Some(rhs) = scalar_rhs {
+        match element_stride {
+            1 => dynasm!(ops ; .arch aarch64 ; dup v1.b16, W(rhs)),
+            2 => dynasm!(ops ; .arch aarch64 ; dup v1.h8, W(rhs)),
+            4 => dynasm!(ops ; .arch aarch64 ; dup v1.s4, W(rhs)),
+            _ => unreachable!(),
+        }
+    }
+    if needs_mask {
+        emit_load_imm(ops, SCRATCH1, field_mask);
+        match element_stride {
+            1 => dynasm!(ops ; .arch aarch64 ; dup v4.b16, W(SCRATCH1)),
+            2 => dynasm!(ops ; .arch aarch64 ; dup v4.h8, W(SCRATCH1)),
+            4 => dynasm!(ops ; .arch aarch64 ; dup v4.s4, W(SCRATCH1)),
+            _ => unreachable!(),
+        }
+    }
+    dynasm!(ops ; .arch aarch64 ; mov x30, xzr);
+
+    for lane_base in (0..usize::from(lane_count)).step_by(lanes_per_vector) {
+        let chunk_delta = i32::try_from(lane_base * usize::from(element_stride))
+            .map_err(|_| EmitError::Range("packed lane offset overflow"))?;
+        let lhs_offset = offset
+            .checked_add(chunk_delta)
+            .ok_or(EmitError::Range("packed lane offset overflow"))?;
+        let (lhs_base, lhs_offset) =
+            select_vector_memory_base(BaseReg::SimState, i64::from(lhs_offset), state_pages);
+        emit_vector_load(ops, 0, lhs_base, lhs_offset);
+
+        if let PackedLaneCompareRhs::Memory { offset: rhs_offset } = rhs {
+            let rhs_offset = rhs_offset
+                .checked_add(chunk_delta)
+                .ok_or(EmitError::Range("packed lane RHS offset overflow"))?;
+            let (rhs_base, rhs_offset) =
+                select_vector_memory_base(BaseReg::SimState, i64::from(rhs_offset), state_pages);
+            emit_vector_load(ops, 1, rhs_base, rhs_offset);
+        }
+
+        if bit_offset != 0 {
+            let shift = u32::from(bit_offset);
+            match element_stride {
+                1 => dynasm!(ops ; .arch aarch64 ; ushr v0.b16, v0.b16, #shift),
+                2 => dynasm!(ops ; .arch aarch64 ; ushr v0.h8, v0.h8, #shift),
+                4 => dynasm!(ops ; .arch aarch64 ; ushr v0.s4, v0.s4, #shift),
+                _ => unreachable!(),
+            }
+            if matches!(rhs, PackedLaneCompareRhs::Memory { .. }) {
+                match element_stride {
+                    1 => dynasm!(ops ; .arch aarch64 ; ushr v1.b16, v1.b16, #shift),
+                    2 => dynasm!(ops ; .arch aarch64 ; ushr v1.h8, v1.h8, #shift),
+                    4 => dynasm!(ops ; .arch aarch64 ; ushr v1.s4, v1.s4, #shift),
+                    _ => unreachable!(),
+                }
+            } else if let Some(rhs) = scalar_rhs {
+                let _ = rhs;
+                match element_stride {
+                    1 => dynasm!(ops ; .arch aarch64 ; ushr v1.b16, v1.b16, #shift),
+                    2 => dynasm!(ops ; .arch aarch64 ; ushr v1.h8, v1.h8, #shift),
+                    4 => dynasm!(ops ; .arch aarch64 ; ushr v1.s4, v1.s4, #shift),
+                    _ => unreachable!(),
+                }
+            }
+        }
+        if needs_mask {
+            match element_stride {
+                1 => dynasm!(ops
+                    ; .arch aarch64
+                    ; and v0.b16, v0.b16, v4.b16
+                    ; and v1.b16, v1.b16, v4.b16
+                ),
+                2 => dynasm!(ops
+                    ; .arch aarch64
+                    ; and v0.b16, v0.b16, v4.b16
+                    ; and v1.b16, v1.b16, v4.b16
+                ),
+                4 => dynasm!(ops
+                    ; .arch aarch64
+                    ; and v0.b16, v0.b16, v4.b16
+                    ; and v1.b16, v1.b16, v4.b16
+                ),
+                _ => unreachable!(),
+            }
+        }
+
+        emit_packed_vector_compare(ops, element_stride, kind);
+        emit_packed_vector_mask(ops, element_stride);
+        if lane_base != 0 {
+            let shift = u32::try_from(lane_base)
+                .map_err(|_| EmitError::Range("packed lane result shift overflow"))?;
+            dynasm!(ops ; .arch aarch64 ; lsl x16, x16, #shift);
+        }
+        dynasm!(ops ; .arch aarch64 ; orr x30, x30, x16);
+    }
+    dynasm!(ops ; .arch aarch64 ; mov X(destination), x30);
+    Ok(())
+}
+
+fn emit_vector_load(ops: &mut VecAssembler<Aarch64Relocation>, vector: u8, base: u8, offset: i64) {
+    emit_address_to(ops, SCRATCH0, base, offset);
+    match vector {
+        0 => dynasm!(ops ; .arch aarch64 ; ldr q0, [x16]),
+        1 => dynasm!(ops ; .arch aarch64 ; ldr q1, [x16]),
+        _ => unreachable!(),
+    }
+}
+
+fn emit_packed_vector_compare(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    element_stride: u8,
+    kind: CmpKind,
+) {
+    macro_rules! compare {
+        ($instruction:ident, $shape:ident) => {
+            dynasm!(ops ; .arch aarch64 ; $instruction v0.$shape, v0.$shape, v1.$shape)
+        };
+    }
+    macro_rules! compare_swapped {
+        ($instruction:ident, $shape:ident) => {
+            dynasm!(ops ; .arch aarch64 ; $instruction v0.$shape, v1.$shape, v0.$shape)
+        };
+    }
+    macro_rules! invert {
+        ($shape:ident) => {
+            dynasm!(ops ; .arch aarch64 ; mvn v0.b16, v0.b16)
+        };
+    }
+
+    match (element_stride, kind) {
+        (1, CmpKind::Eq) => compare!(cmeq, b16),
+        (2, CmpKind::Eq) => compare!(cmeq, h8),
+        (4, CmpKind::Eq) => compare!(cmeq, s4),
+        (1, CmpKind::Ne) => {
+            compare!(cmeq, b16);
+            invert!(b16);
+        }
+        (2, CmpKind::Ne) => {
+            compare!(cmeq, h8);
+            invert!(h8);
+        }
+        (4, CmpKind::Ne) => {
+            compare!(cmeq, s4);
+            invert!(s4);
+        }
+        (1, CmpKind::LtU | CmpKind::GeU) => {
+            compare_swapped!(cmhi, b16);
+            if matches!(kind, CmpKind::GeU) {
+                invert!(b16);
+            }
+        }
+        (2, CmpKind::LtU | CmpKind::GeU) => {
+            compare_swapped!(cmhi, h8);
+            if matches!(kind, CmpKind::GeU) {
+                invert!(h8);
+            }
+        }
+        (4, CmpKind::LtU | CmpKind::GeU) => {
+            compare_swapped!(cmhi, s4);
+            if matches!(kind, CmpKind::GeU) {
+                invert!(s4);
+            }
+        }
+        (1, CmpKind::GtU | CmpKind::LeU) => {
+            compare!(cmhi, b16);
+            if matches!(kind, CmpKind::LeU) {
+                invert!(b16);
+            }
+        }
+        (2, CmpKind::GtU | CmpKind::LeU) => {
+            compare!(cmhi, h8);
+            if matches!(kind, CmpKind::LeU) {
+                invert!(h8);
+            }
+        }
+        (4, CmpKind::GtU | CmpKind::LeU) => {
+            compare!(cmhi, s4);
+            if matches!(kind, CmpKind::LeU) {
+                invert!(s4);
+            }
+        }
+        (1, CmpKind::LtS | CmpKind::GeS) => {
+            compare_swapped!(cmgt, b16);
+            if matches!(kind, CmpKind::GeS) {
+                invert!(b16);
+            }
+        }
+        (2, CmpKind::LtS | CmpKind::GeS) => {
+            compare_swapped!(cmgt, h8);
+            if matches!(kind, CmpKind::GeS) {
+                invert!(h8);
+            }
+        }
+        (4, CmpKind::LtS | CmpKind::GeS) => {
+            compare_swapped!(cmgt, s4);
+            if matches!(kind, CmpKind::GeS) {
+                invert!(s4);
+            }
+        }
+        (1, CmpKind::GtS | CmpKind::LeS) => {
+            compare!(cmgt, b16);
+            if matches!(kind, CmpKind::LeS) {
+                invert!(b16);
+            }
+        }
+        (2, CmpKind::GtS | CmpKind::LeS) => {
+            compare!(cmgt, h8);
+            if matches!(kind, CmpKind::LeS) {
+                invert!(h8);
+            }
+        }
+        (4, CmpKind::GtS | CmpKind::LeS) => {
+            compare!(cmgt, s4);
+            if matches!(kind, CmpKind::LeS) {
+                invert!(s4);
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn emit_packed_vector_mask(ops: &mut VecAssembler<Aarch64Relocation>, element_stride: u8) {
+    match element_stride {
+        1 => {
+            emit_load_imm(ops, SCRATCH1, 0x8040_2010_0804_0201);
+            dynasm!(ops
+                ; .arch aarch64
+                ; ushr v0.b16, v0.b16, #7
+                ; fmov d6, x17
+                ; dup v6.d2, v6.d[0]
+                ; mul v0.b16, v0.b16, v6.b16
+                ; addv b5, v0.b8
+                ; umov W(SCRATCH0), v5.b[0]
+                ; ext v7.b16, v0.b16, v0.b16, #8
+                ; addv b5, v7.b8
+                ; umov W(SCRATCH1), v5.b[0]
+                ; lsl x17, x17, #8
+                ; orr x16, x16, x17
+            );
+        }
+        2 => {
+            emit_load_imm(ops, SCRATCH1, 0x0008_0004_0002_0001);
+            dynasm!(ops ; .arch aarch64 ; fmov d6, x17);
+            emit_load_imm(ops, SCRATCH1, 0x0080_0040_0020_0010);
+            dynasm!(ops
+                ; .arch aarch64
+                ; fmov d7, x17
+                ; ins v6.d[1], v7.d[0]
+                ; ushr v0.h8, v0.h8, #15
+                ; mul v0.h8, v0.h8, v6.h8
+                ; addv h5, v0.h8
+                ; umov W(SCRATCH0), v5.h[0]
+            );
+        }
+        4 => {
+            emit_load_imm(ops, SCRATCH1, 0x0000_0002_0000_0001);
+            dynasm!(ops ; .arch aarch64 ; fmov d6, x17);
+            emit_load_imm(ops, SCRATCH1, 0x0000_0008_0000_0004);
+            dynasm!(ops
+                ; .arch aarch64
+                ; fmov d7, x17
+                ; ins v6.d[1], v7.d[0]
+                ; ushr v0.s4, v0.s4, #31
+                ; mul v0.s4, v0.s4, v6.s4
+                ; addv s5, v0.s4
+                ; umov W(SCRATCH0), v5.s[0]
+            );
+        }
+        _ => unreachable!(),
+    }
 }
 
 fn emit_packed_byte_affine_compare(
@@ -1825,36 +2219,47 @@ fn emit_mem_fill(
     dst_offset: i32,
     byte_len: usize,
     value: u8,
+    state_pages: StatePageBases,
 ) {
     if byte_len == 0 {
         return;
     }
-    let qwords = byte_len / 8;
-    let remainder = byte_len % 8;
     let pattern = u64::from(value) * 0x0101_0101_0101_0101;
-    emit_load_imm(ops, SCRATCH0, dst_offset as i64 as u64);
-    dynasm!(ops ; .arch aarch64 ; add x16, x0, x16);
+    let (base, offset) =
+        select_vector_memory_base(BaseReg::SimState, i64::from(dst_offset), state_pages);
+    emit_address_to(ops, SCRATCH0, base, offset);
     emit_load_imm(ops, 30, pattern);
-    if qwords != 0 {
-        let loop_label = ops.new_dynamic_label();
-        let done = ops.new_dynamic_label();
-        emit_load_imm(
-            ops,
-            SCRATCH1,
-            (i64::from(dst_offset) + (qwords * 8) as i64) as u64,
-        );
+    let vector_chunks = byte_len / 16;
+    if vector_chunks != 0 {
         dynasm!(ops
             ; .arch aarch64
-            ; add x17, x0, x17
-            ; =>loop_label
-            ; cmp x16, x17
-            ; b.hs =>done
-            ; str x30, [x16], #8
-            ; b =>loop_label
-            ; =>done
+            ; fmov d0, x30
+            ; dup v0.d2, v0.d[0]
         );
+        if vector_chunks <= 32 {
+            for _ in 0..vector_chunks {
+                dynasm!(ops ; .arch aarch64 ; str q0, [x16], #16);
+            }
+        } else {
+            let loop_label = ops.new_dynamic_label();
+            let done = ops.new_dynamic_label();
+            emit_load_imm(ops, SCRATCH1, vector_chunks as u64);
+            dynasm!(ops
+                ; .arch aarch64
+                ; =>loop_label
+                ; cbz x17, =>done
+                ; str q0, [x16], #16
+                ; sub x17, x17, #1
+                ; b =>loop_label
+                ; =>done
+            );
+        }
     }
-    if remainder >= 4 {
+    let remainder = byte_len % 16;
+    if remainder >= 8 {
+        dynasm!(ops ; .arch aarch64 ; str x30, [x16], #8);
+    }
+    if remainder % 8 >= 4 {
         dynasm!(ops ; .arch aarch64 ; str w30, [x16], #4);
     }
     if remainder % 4 >= 2 {
@@ -1865,11 +2270,14 @@ fn emit_mem_fill(
     }
 }
 
-fn select_state_base_page(function: &MFunction) -> Option<i64> {
+fn select_state_base_pages(
+    function: &MFunction,
+    secondary_registers: impl IntoIterator<Item = u8>,
+) -> StatePageBases {
     let mut page_counts = BTreeMap::<i64, usize>::new();
     for block in &function.blocks {
         for instruction in &block.insts {
-            let Some(offset) = (match instruction {
+            match instruction {
                 MInst::Load {
                     base: BaseReg::SimState,
                     offset,
@@ -1889,7 +2297,33 @@ fn select_state_base_page(function: &MFunction) -> Option<i64> {
                     base: BaseReg::SimState,
                     offset,
                     ..
-                } => Some(i64::from(*offset)),
+                } => count_state_page_access(&mut page_counts, i64::from(*offset)),
+                MInst::LoadIndexed {
+                    base: BaseReg::SimState,
+                    offset,
+                    ..
+                }
+                | MInst::StoreIndexed {
+                    base: BaseReg::SimState,
+                    offset,
+                    ..
+                }
+                | MInst::OrStoreIndexed {
+                    base: BaseReg::SimState,
+                    offset,
+                    ..
+                } => count_state_page_access(&mut page_counts, i64::from(*offset)),
+                MInst::MemCopy {
+                    src_offset,
+                    dst_offset,
+                    ..
+                } => {
+                    count_state_page_access(&mut page_counts, i64::from(*src_offset));
+                    count_state_page_access(&mut page_counts, i64::from(*dst_offset));
+                }
+                MInst::MemFill { dst_offset, .. } => {
+                    count_state_page_access(&mut page_counts, i64::from(*dst_offset));
+                }
                 MInst::BranchPred {
                     predicate:
                         BranchPredicate::MemoryNonZero {
@@ -1898,25 +2332,68 @@ fn select_state_base_page(function: &MFunction) -> Option<i64> {
                             ..
                         },
                     ..
-                } => Some(i64::from(*offset)),
+                } => count_state_page_access(&mut page_counts, i64::from(*offset)),
                 MInst::SparseMarkActive {
                     active_index,
                     active_bits_offset,
                     ..
-                } => Some(i64::from(*active_bits_offset) + i64::from(*active_index / 64) * 8),
-                _ => None,
-            }) else {
-                continue;
-            };
-            let page = offset.div_euclid(STATE_PAGE_BYTES) * STATE_PAGE_BYTES;
-            *page_counts.entry(page).or_default() += 1;
+                } => count_state_page_access(
+                    &mut page_counts,
+                    i64::from(*active_bits_offset) + i64::from(*active_index / 64) * 8,
+                ),
+                MInst::PackedLaneCompare {
+                    offset,
+                    lane_count,
+                    element_stride,
+                    rhs,
+                    ..
+                } => {
+                    for lane in 0..*lane_count {
+                        let delta = i64::from(lane) * i64::from(*element_stride);
+                        count_state_page_access(&mut page_counts, i64::from(*offset) + delta);
+                        if let PackedLaneCompareRhs::Memory {
+                            offset: rhs_offset, ..
+                        } = rhs
+                        {
+                            count_state_page_access(
+                                &mut page_counts,
+                                i64::from(*rhs_offset) + delta,
+                            );
+                        }
+                    }
+                }
+                _ => {}
+            }
         }
     }
-    page_counts
+    let mut pages = page_counts
         .into_iter()
         .filter(|(_, count)| *count >= 8)
-        .max_by_key(|(page, count)| (*count, -*page))
-        .map(|(page, _)| page)
+        .collect::<Vec<_>>();
+    pages.sort_unstable_by(|(left_page, left_count), (right_page, right_count)| {
+        right_count
+            .cmp(left_count)
+            .then_with(|| left_page.cmp(right_page))
+    });
+    let secondary = secondary_registers
+        .into_iter()
+        .zip(pages.iter().skip(1))
+        .take(MAX_SECONDARY_STATE_PAGES)
+        .map(|(register, (page, _))| Some((register, *page)))
+        .chain(std::iter::repeat(None))
+        .take(MAX_SECONDARY_STATE_PAGES)
+        .collect::<Vec<_>>()
+        .try_into()
+        .expect("secondary state page count is fixed");
+    StatePageBases {
+        primary: pages.first().map(|(page, _)| *page),
+        secondary,
+    }
+}
+
+fn count_state_page_access(page_counts: &mut BTreeMap<i64, usize>, offset: i64) {
+    let page = offset.div_euclid(STATE_PAGE_BYTES) * STATE_PAGE_BYTES;
+    *page_counts.entry(page).or_default() += 1;
 }
 
 fn select_memory_base(
@@ -1925,20 +2402,89 @@ fn select_memory_base(
     register: u8,
     size: OpSize,
     store: bool,
-    state_base_page: Option<i64>,
+    state_pages: StatePageBases,
 ) -> (u8, i64) {
     let normal = (base_register(base), offset);
     if base != BaseReg::SimState {
         return normal;
     }
-    let Some(page) = state_base_page else {
+    if let Some(page) = state_pages.primary {
+        let relative = offset - page;
+        if memory_access_encoding(register, STATE_PAGE_REG, relative, size, store).is_some() {
+            return (STATE_PAGE_REG, relative);
+        }
+    }
+    for &(page_register, page) in state_pages.secondary.iter().flatten() {
+        let relative = offset - page;
+        if memory_access_encoding(register, page_register, relative, size, store).is_some() {
+            return (page_register, relative);
+        }
+    }
+    normal
+}
+
+fn select_indexed_memory_base(
+    base: BaseReg,
+    offset: i64,
+    register: u8,
+    size: OpSize,
+    store: bool,
+    state_pages: StatePageBases,
+) -> (u8, i64) {
+    let normal = (base_register(base), offset);
+    if base != BaseReg::SimState {
         return normal;
-    };
-    let relative = offset - page;
-    if memory_access_encoding(register, STATE_PAGE_REG, relative, size, store).is_some() {
-        (STATE_PAGE_REG, relative)
+    }
+    if let Some(page) = state_pages.primary {
+        let relative = offset - page;
+        if indexed_offset_encoding(relative, register, size, store) {
+            return (STATE_PAGE_REG, relative);
+        }
+    }
+    for &(page_register, page) in state_pages.secondary.iter().flatten() {
+        let relative = offset - page;
+        if indexed_offset_encoding(relative, register, size, store) {
+            return (page_register, relative);
+        }
+    }
+    normal
+}
+
+fn indexed_offset_encoding(offset: i64, register: u8, size: OpSize, store: bool) -> bool {
+    add_sub_immediate(offset).is_some()
+        || memory_access_encoding(register, STATE_PAGE_REG, offset, size, store).is_some()
+}
+
+fn select_vector_memory_base(base: BaseReg, offset: i64, state_pages: StatePageBases) -> (u8, i64) {
+    let normal = (base_register(base), offset);
+    if base != BaseReg::SimState {
+        return normal;
+    }
+    let candidates = state_pages
+        .primary
+        .into_iter()
+        .map(|page| (STATE_PAGE_REG, page))
+        .chain(state_pages.secondary.iter().flatten().copied());
+    candidates
+        .map(|(page_register, page)| {
+            let relative = offset - page;
+            (
+                address_materialization_cost(relative),
+                (page_register, relative),
+            )
+        })
+        .min_by_key(|(cost, _)| *cost)
+        .map(|(_, base)| base)
+        .unwrap_or(normal)
+}
+
+fn address_materialization_cost(offset: i64) -> usize {
+    if offset == 0 {
+        0
+    } else if add_sub_immediate(offset).is_some() {
+        1
     } else {
-        normal
+        move_wide_plan(offset as u64).instruction_count + 1
     }
 }
 
@@ -2032,6 +2578,39 @@ fn emit_load_at(
     }
 }
 
+fn emit_load_indexed_at(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: u8,
+    base: u8,
+    index: u8,
+    offset: i64,
+    scale: u8,
+    size: OpSize,
+) {
+    if offset == 0
+        && let Some(shift) = indexed_address_shift(scale, size)
+    {
+        match size {
+            OpSize::S8 => {
+                dynasm!(ops ; .arch aarch64 ; ldrb W(destination), [X(base), X(index), LSL #shift])
+            }
+            OpSize::S16 => {
+                dynasm!(ops ; .arch aarch64 ; ldrh W(destination), [X(base), X(index), LSL #shift])
+            }
+            OpSize::S32 => {
+                dynasm!(ops ; .arch aarch64 ; ldr W(destination), [X(base), X(index), LSL #shift])
+            }
+            OpSize::S64 => {
+                dynasm!(ops ; .arch aarch64 ; ldr X(destination), [X(base), X(index), LSL #shift])
+            }
+        }
+    } else {
+        let shift = scale.trailing_zeros();
+        dynasm!(ops ; .arch aarch64 ; add x16, X(base), X(index), LSL #shift);
+        emit_load_at(ops, destination, SCRATCH0, offset, size);
+    }
+}
+
 fn emit_store_at(
     ops: &mut VecAssembler<Aarch64Relocation>,
     source: u8,
@@ -2044,6 +2623,55 @@ fn emit_store_at(
     } else {
         emit_address(ops, base, offset);
         emit_store(ops, source, SCRATCH0, size);
+    }
+}
+
+fn emit_store_indexed_at(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    source: u8,
+    base: u8,
+    index: u8,
+    offset: i64,
+    scale: u8,
+    size: OpSize,
+) {
+    if offset == 0
+        && let Some(shift) = indexed_address_shift(scale, size)
+    {
+        match size {
+            OpSize::S8 => {
+                dynasm!(ops ; .arch aarch64 ; strb W(source), [X(base), X(index), LSL #shift])
+            }
+            OpSize::S16 => {
+                dynasm!(ops ; .arch aarch64 ; strh W(source), [X(base), X(index), LSL #shift])
+            }
+            OpSize::S32 => {
+                dynasm!(ops ; .arch aarch64 ; str W(source), [X(base), X(index), LSL #shift])
+            }
+            OpSize::S64 => {
+                dynasm!(ops ; .arch aarch64 ; str X(source), [X(base), X(index), LSL #shift])
+            }
+        }
+    } else {
+        let shift = scale.trailing_zeros();
+        dynasm!(ops ; .arch aarch64 ; add x16, X(base), X(index), LSL #shift);
+        emit_store_at(ops, source, SCRATCH0, offset, size);
+    }
+}
+
+fn indexed_address_shift(scale: u8, size: OpSize) -> Option<u32> {
+    let natural_scale = match size {
+        OpSize::S8 => 1,
+        OpSize::S16 => 2,
+        OpSize::S32 => 4,
+        OpSize::S64 => 8,
+    };
+    if scale == 1 {
+        Some(0)
+    } else if scale == natural_scale {
+        Some(scale.trailing_zeros())
+    } else {
+        None
     }
 }
 
@@ -2397,7 +3025,7 @@ fn emit_branch_predicate(
     ops: &mut VecAssembler<Aarch64Relocation>,
     predicate: BranchPredicate,
     assignment: &Assignment<VReg>,
-    state_base_page: Option<i64>,
+    state_pages: StatePageBases,
 ) -> Result<(), EmitError> {
     match predicate {
         BranchPredicate::Compare { lhs, rhs, .. } => {
@@ -2414,7 +3042,7 @@ fn emit_branch_predicate(
         BranchPredicate::MemoryNonZero { base, offset, size } => {
             let offset = base_offset(base, offset);
             let (base_register, offset) =
-                select_memory_base(base, offset, SCRATCH0, size, false, state_base_page);
+                select_memory_base(base, offset, SCRATCH0, size, false, state_pages);
             emit_load_at(ops, SCRATCH0, base_register, offset, size);
             dynasm!(ops ; .arch aarch64 ; cmp x16, #0);
         }
@@ -2660,7 +3288,10 @@ mod tests {
             Vec::new(),
         );
 
-        assert_eq!(select_state_base_page(&function), Some(4096));
+        assert_eq!(
+            select_state_base_pages(&function, std::iter::empty::<u8>()).primary,
+            Some(4096)
+        );
         assert_eq!(
             select_memory_base(
                 crate::mir::BaseReg::SimState,
@@ -2668,9 +3299,73 @@ mod tests {
                 SCRATCH0,
                 crate::mir::OpSize::S64,
                 false,
-                Some(4096),
+                StatePageBases {
+                    primary: Some(4096),
+                    ..StatePageBases::default()
+                },
             ),
             (STATE_PAGE_REG, 16)
+        );
+
+        let multi_page = crate::mir::MFunction::new(
+            vec![crate::mir::MBlock {
+                id: crate::mir::BlockId(0),
+                phis: Vec::new(),
+                insts: (0..16)
+                    .map(|index| crate::mir::MInst::Load {
+                        dst: crate::mir::VReg(index),
+                        base: crate::mir::BaseReg::SimState,
+                        offset: 4096 + (index % 8) as i32 * 8 + (index / 8) as i32 * 36864,
+                        size: crate::mir::OpSize::S64,
+                    })
+                    .chain(std::iter::once(crate::mir::MInst::Return))
+                    .collect(),
+            }],
+            Vec::new(),
+        );
+        let multi_page_bases = select_state_base_pages(&multi_page, [27, 26, 25, 24]);
+        assert_eq!(multi_page_bases.primary, Some(4096));
+        assert_eq!(multi_page_bases.secondary[0], Some((27, 40960)));
+        assert_eq!(multi_page_bases.secondary[1], None);
+        assert_eq!(
+            select_memory_base(
+                crate::mir::BaseReg::SimState,
+                40976,
+                SCRATCH0,
+                crate::mir::OpSize::S64,
+                false,
+                multi_page_bases,
+            ),
+            (27, 16)
+        );
+        assert_eq!(
+            select_vector_memory_base(crate::mir::BaseReg::SimState, 40960, multi_page_bases),
+            (27, 0)
+        );
+
+        let packed = crate::mir::MFunction::new(
+            vec![crate::mir::MBlock {
+                id: crate::mir::BlockId(0),
+                phis: Vec::new(),
+                insts: vec![
+                    crate::mir::MInst::PackedLaneCompare {
+                        dst: crate::mir::VReg(0),
+                        rhs: crate::mir::PackedLaneCompareRhs::Memory { offset: 4160 },
+                        kind: crate::mir::CmpKind::Eq,
+                        offset: 4096,
+                        lane_count: 8,
+                        element_stride: 1,
+                        bit_offset: 0,
+                        field_width: 8,
+                    },
+                    crate::mir::MInst::Return,
+                ],
+            }],
+            Vec::new(),
+        );
+        assert_eq!(
+            select_state_base_pages(&packed, std::iter::empty::<u8>()).primary,
+            Some(4096)
         );
     }
 
@@ -2746,6 +3441,16 @@ mod tests {
             byte_len: 13,
             value: 0xa5,
         });
+        block.push(MInst::MemCopy {
+            src_offset: 64,
+            dst_offset: 96,
+            byte_len: 32,
+        });
+        block.push(MInst::MemFill {
+            dst_offset: 128,
+            byte_len: 32,
+            value: 0x3c,
+        });
         block.push(MInst::Return);
         function.push_block(block);
         (function, AssignmentMap::default())
@@ -2779,6 +3484,14 @@ mod tests {
             add_sub_immediate_encoding(31, 1, -4096, true),
             Some(0xf140_043f)
         );
+    }
+
+    #[test]
+    fn selects_only_architecturally_encodable_index_scales() {
+        assert_eq!(indexed_address_shift(1, crate::mir::OpSize::S64), Some(0));
+        assert_eq!(indexed_address_shift(8, crate::mir::OpSize::S64), Some(3));
+        assert_eq!(indexed_address_shift(2, crate::mir::OpSize::S16), Some(1));
+        assert_eq!(indexed_address_shift(8, crate::mir::OpSize::S16), None);
     }
 
     #[test]
@@ -2987,6 +3700,83 @@ mod tests {
 
     #[cfg(target_arch = "aarch64")]
     #[test]
+    fn executes_indexed_memory_operands() {
+        let function = arm_mir::MFunction::new(
+            vec![arm_mir::MBlock {
+                id: arm_mir::BlockId(0),
+                phis: Vec::new(),
+                insts: vec![
+                    arm_mir::MInst::Load {
+                        dst: arm_mir::VReg(0),
+                        base: arm_mir::BaseReg::SimState,
+                        offset: 0,
+                        size: arm_mir::OpSize::S64,
+                    },
+                    arm_mir::MInst::LoadIndexed {
+                        dst: arm_mir::VReg(1),
+                        base: arm_mir::BaseReg::SimState,
+                        offset: 0,
+                        index: arm_mir::VReg(0),
+                        scale: 8,
+                        size: arm_mir::OpSize::S64,
+                    },
+                    arm_mir::MInst::LoadImm {
+                        dst: arm_mir::VReg(2),
+                        value: 24,
+                    },
+                    arm_mir::MInst::StoreIndexed {
+                        base: arm_mir::BaseReg::SimState,
+                        offset: 8,
+                        index: arm_mir::VReg(2),
+                        src: arm_mir::VReg(1),
+                        size: arm_mir::OpSize::S64,
+                    },
+                    arm_mir::MInst::OrStoreIndexed {
+                        base: arm_mir::BaseReg::SimState,
+                        offset: 100_000,
+                        index: arm_mir::VReg(2),
+                        src: arm_mir::VReg(1),
+                        size: arm_mir::OpSize::S64,
+                    },
+                    arm_mir::MInst::Return,
+                ],
+            }],
+            Vec::new(),
+        );
+        let mut assignment = Assignment::default();
+        assignment.set(arm_mir::VReg(0), Arm64Reg::new(9));
+        assignment.set(arm_mir::VReg(1), Arm64Reg::new(10));
+        assignment.set(arm_mir::VReg(2), Arm64Reg::new(11));
+        let emitted = emit_function(
+            &function,
+            &assignment,
+            0,
+            64,
+            &EdgeCopyPlan::default(),
+            false,
+            false,
+        )
+        .unwrap();
+        let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
+        let mut state = vec![0_u8; 100_064];
+        state[..8].copy_from_slice(&3_u64.to_le_bytes());
+        let payload = 0x1234_5678_9abc_def0_u64;
+        state[24..32].copy_from_slice(&payload.to_le_bytes());
+        state[100_024..100_032].copy_from_slice(&0x0f_u64.to_le_bytes());
+
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        assert_eq!(
+            u64::from_le_bytes(state[32..40].try_into().unwrap()),
+            payload
+        );
+        assert_eq!(
+            u64::from_le_bytes(state[100_024..100_032].try_into().unwrap()),
+            payload | 0x0f
+        );
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
     fn executes_guarded_compare_select() {
         let (function, assignment) = guarded_select();
         let result = emit(&function, &assignment, 0).unwrap();
@@ -3009,13 +3799,18 @@ mod tests {
         let (function, assignment) = bulk_memory_ops();
         let result = emit(&function, &assignment, 0).unwrap();
         let code = crate::jit_mem::JitCode::new(&result.code).unwrap();
-        let mut state = vec![0_u8; 40];
+        let mut state = vec![0_u8; 200];
         for (index, byte) in state[..16].iter_mut().enumerate() {
             *byte = index as u8;
+        }
+        for (index, byte) in state[64..96].iter_mut().enumerate() {
+            *byte = (index as u8).wrapping_mul(3);
         }
         assert_eq!(unsafe { code.call(&mut state) }, 0);
         assert_eq!(&state[4..16], &(0_u8..12).collect::<Vec<_>>());
         assert_eq!(&state[20..33], &[0xa5; 13]);
+        assert_eq!(&state[96..128], &state[64..96]);
+        assert_eq!(&state[128..160], &[0x3c; 32]);
     }
 
     #[cfg(target_arch = "aarch64")]
@@ -3417,6 +4212,144 @@ mod tests {
                 expected,
                 "packed affine kind index {index}"
             );
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn executes_vector_packed_lane_comparisons() {
+        let kinds = [
+            CmpKind::Eq,
+            CmpKind::Ne,
+            CmpKind::LtU,
+            CmpKind::LeU,
+            CmpKind::GtU,
+            CmpKind::GeU,
+            CmpKind::LtS,
+            CmpKind::LeS,
+            CmpKind::GtS,
+            CmpKind::GeS,
+        ];
+        let cases = [
+            (
+                1_usize,
+                vec![
+                    0, 1, 5, 6, 7, 8, 0x7f, 0x80, 0xfe, 0xff, 3, 5, 128, 1, 42, 200,
+                ],
+                vec![
+                    0, 1, 6, 5, 7, 9, 0x7f, 0x81, 0xfd, 0xff, 4, 5, 127, 2, 40, 201,
+                ],
+            ),
+            (
+                2,
+                vec![0, 1, 5, 6, 7, 0x7fff, 0x8000, 0xffff],
+                vec![0, 2, 6, 5, 7, 0x7ffe, 0x8001, 0xfffe],
+            ),
+            (
+                4,
+                vec![0, 1, 5, 0x8000_0000],
+                vec![1, 5, 0x8000_0000, 0x7fff_ffff],
+            ),
+        ];
+        let write_lanes = |state: &mut [u8], offset: usize, stride: usize, values: &[u64]| {
+            for (index, value) in values.iter().copied().enumerate() {
+                let start = offset + index * stride;
+                state[start..start + stride].copy_from_slice(&value.to_le_bytes()[..stride]);
+            }
+        };
+        let matches = |kind: CmpKind, lhs: u64, rhs: u64, bits: usize| {
+            let mask = (1_u64 << bits) - 1;
+            let lhs = lhs & mask;
+            let rhs = rhs & mask;
+            let signed = |value: u64| {
+                if value & (1_u64 << (bits - 1)) != 0 {
+                    (value | !mask) as i64
+                } else {
+                    value as i64
+                }
+            };
+            match kind {
+                CmpKind::Eq => lhs == rhs,
+                CmpKind::Ne => lhs != rhs,
+                CmpKind::LtU => lhs < rhs,
+                CmpKind::LeU => lhs <= rhs,
+                CmpKind::GtU => lhs > rhs,
+                CmpKind::GeU => lhs >= rhs,
+                CmpKind::LtS => signed(lhs) < signed(rhs),
+                CmpKind::LeS => signed(lhs) <= signed(rhs),
+                CmpKind::GtS => signed(lhs) > signed(rhs),
+                CmpKind::GeS => signed(lhs) >= signed(rhs),
+            }
+        };
+
+        for (stride, lhs_values, rhs_values) in cases {
+            for use_memory_rhs in [false, true] {
+                for kind in kinds {
+                    let mut vregs = VRegAllocator::new();
+                    let result = vregs.alloc();
+                    let scalar_rhs = (!use_memory_rhs).then(|| vregs.alloc());
+                    let mut function = MFunction::new(
+                        vregs,
+                        vec![SpillDesc::transient(); usize::from(!use_memory_rhs)],
+                    );
+                    let mut block = MBlock::new(BlockId(0));
+                    if let Some(rhs) = scalar_rhs {
+                        block.push(MInst::LoadImm { dst: rhs, value: 5 });
+                    }
+                    block.push(MInst::PackedLaneCompare {
+                        dst: result,
+                        rhs: if let Some(rhs) = scalar_rhs {
+                            PackedLaneCompareRhs::Scalar(rhs)
+                        } else {
+                            PackedLaneCompareRhs::Memory {
+                                offset: 128,
+                                alias_range: None,
+                            }
+                        },
+                        kind,
+                        offset: 0,
+                        lane_count: u8::try_from(lhs_values.len()).unwrap(),
+                        element_stride: u8::try_from(stride).unwrap(),
+                        bit_offset: 0,
+                        field_width: u8::try_from(stride * 8).unwrap(),
+                        alias_range: None,
+                    });
+                    block.push(MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 256,
+                        src: result,
+                        size: OpSize::S64,
+                    });
+                    block.push(MInst::Return);
+                    function.push_block(block);
+                    let mut assignment = AssignmentMap::default();
+                    assignment.set(result, PhysReg::RDX);
+                    if let Some(rhs) = scalar_rhs {
+                        assignment.set(rhs, PhysReg::RAX);
+                    }
+                    let emitted = emit(&function, &assignment, 0).unwrap();
+                    let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
+                    let mut state = vec![0_u8; 272];
+                    write_lanes(&mut state, 0, stride, &lhs_values);
+                    if use_memory_rhs {
+                        write_lanes(&mut state, 128, stride, &rhs_values);
+                    }
+                    assert_eq!(unsafe { code.call(&mut state) }, 0);
+                    let actual = u64::from_le_bytes(state[256..264].try_into().unwrap());
+                    let expected =
+                        lhs_values
+                            .iter()
+                            .enumerate()
+                            .fold(0_u64, |mask, (index, &lhs)| {
+                                let rhs = if use_memory_rhs { rhs_values[index] } else { 5 };
+                                mask | u64::from(matches(kind, lhs, rhs, stride * 8)) << index
+                            });
+                    assert_eq!(
+                        actual, expected,
+                        "stride={stride} memory_rhs={use_memory_rhs} kind={kind:?}"
+                    );
+                }
+            }
         }
     }
 

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -1397,21 +1397,26 @@ fn emit_packed_lane_compare(
             .checked_mul(i32::from(element_stride))
             .and_then(|delta| offset.checked_add(delta))
             .ok_or(EmitError::Range("packed lane offset overflow"))?;
-        emit_address(ops, STATE_REG, i64::from(lane_delta));
-        emit_load(ops, SCRATCH0, SCRATCH0, size);
+        emit_load_at(ops, SCRATCH0, STATE_REG, i64::from(lane_delta), size);
         match rhs {
             PackedLaneCompareRhs::Scalar(_) => {
                 dynasm!(ops ; .arch aarch64 ; mov x17, X(scalar_rhs.unwrap()));
             }
             PackedLaneCompareRhs::Memory { offset, .. } => {
-                dynasm!(ops ; .arch aarch64 ; fmov d7, x16);
                 let rhs_offset = i32::from(lane)
                     .checked_mul(i32::from(element_stride))
                     .and_then(|delta| offset.checked_add(delta))
                     .ok_or(EmitError::Range("packed lane RHS offset overflow"))?;
-                emit_address(ops, STATE_REG, i64::from(rhs_offset));
-                emit_load(ops, SCRATCH1, SCRATCH0, size);
-                dynasm!(ops ; .arch aarch64 ; fmov x16, d7);
+                let direct =
+                    memory_access_encoding(SCRATCH1, STATE_REG, i64::from(rhs_offset), size, false)
+                        .is_some();
+                if !direct {
+                    dynasm!(ops ; .arch aarch64 ; fmov d7, x16);
+                }
+                emit_load_at(ops, SCRATCH1, STATE_REG, i64::from(rhs_offset), size);
+                if !direct {
+                    dynasm!(ops ; .arch aarch64 ; fmov x16, d7);
+                }
             }
         }
         if bit_offset != 0 {

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -2623,6 +2623,8 @@ fn indexed_offset_cost(offset: i64, size: OpSize, store: bool) -> Option<usize> 
         Some(0)
     } else if add_sub_immediate(offset).is_some() {
         Some(1)
+    } else if add_sub_immediate_pair(offset).is_some() {
+        Some(2)
     } else {
         None
     }
@@ -2714,6 +2716,8 @@ fn address_materialization_cost(offset: i64) -> usize {
         0
     } else if add_sub_immediate(offset).is_some() {
         1
+    } else if add_sub_immediate_pair(offset).is_some() {
+        2
     } else {
         move_wide_plan(offset as u64).instruction_count + 1
     }
@@ -2755,8 +2759,13 @@ fn emit_address_to(
     if offset == 0 {
         dynasm!(ops ; .arch aarch64 ; mov X(destination), X(base));
     } else if !emit_add_sub_immediate(ops, destination, base, offset) {
-        emit_load_imm(ops, SCRATCH1, offset as u64);
-        dynasm!(ops ; .arch aarch64 ; add X(destination), X(base), x17);
+        if let Some((high, low)) = add_sub_immediate_pair(offset) {
+            let _ = emit_add_sub_immediate(ops, destination, base, high);
+            let _ = emit_add_sub_immediate(ops, destination, destination, low);
+        } else {
+            emit_load_imm(ops, SCRATCH1, offset as u64);
+            dynasm!(ops ; .arch aarch64 ; add X(destination), X(base), x17);
+        }
     }
 }
 
@@ -2909,8 +2918,13 @@ fn indexed_address_shift(scale: u8, size: OpSize) -> Option<u32> {
 fn emit_add_offset(ops: &mut VecAssembler<Aarch64Relocation>, offset: i64) {
     if offset != 0 {
         if !emit_add_sub_immediate(ops, SCRATCH0, SCRATCH0, offset) {
-            emit_load_imm(ops, SCRATCH1, offset as u64);
-            dynasm!(ops ; .arch aarch64 ; add x16, x16, x17);
+            if let Some((high, low)) = add_sub_immediate_pair(offset) {
+                let _ = emit_add_sub_immediate(ops, SCRATCH0, SCRATCH0, high);
+                let _ = emit_add_sub_immediate(ops, SCRATCH0, SCRATCH0, low);
+            } else {
+                emit_load_imm(ops, SCRATCH1, offset as u64);
+                dynasm!(ops ; .arch aarch64 ; add x16, x16, x17);
+            }
         }
     }
 }
@@ -2928,6 +2942,19 @@ fn add_sub_immediate(offset: i64) -> Option<(bool, u32, bool)> {
         return Some((subtract, (magnitude / 0x1000) as u32, true));
     }
     None
+}
+
+fn add_sub_immediate_pair(offset: i64) -> Option<(i64, i64)> {
+    let magnitude = offset.unsigned_abs();
+    let high = magnitude & !0xfff;
+    let low = magnitude & 0xfff;
+    if high == 0 || low == 0 {
+        return None;
+    }
+    let sign = if offset < 0 { -1_i64 } else { 1_i64 };
+    let high = i64::try_from(high).ok()?.checked_mul(sign)?;
+    let low = i64::try_from(low).ok()?.checked_mul(sign)?;
+    (add_sub_immediate(high).is_some() && add_sub_immediate(low).is_some()).then_some((high, low))
 }
 
 fn add_sub_immediate_encoding(
@@ -3555,13 +3582,13 @@ mod tests {
             Vec::new(),
         );
         let multi_page_bases = select_state_base_pages(&multi_page, [27, 26, 25, 24]);
-        assert_eq!(multi_page_bases.primary, Some(69632));
-        assert_eq!(multi_page_bases.secondary[0], Some((27, 32768)));
+        assert_eq!(multi_page_bases.primary, Some(32768));
+        assert_eq!(multi_page_bases.secondary[0], Some((27, 69632)));
         assert_eq!(multi_page_bases.secondary[1], None);
         assert_eq!(
             select_memory_base(
                 crate::mir::BaseReg::SimState,
-                32784,
+                69648,
                 SCRATCH0,
                 crate::mir::OpSize::S64,
                 false,
@@ -3571,7 +3598,7 @@ mod tests {
         );
         assert_eq!(
             select_vector_memory_base(crate::mir::BaseReg::SimState, 69632, multi_page_bases),
-            (STATE_PAGE_REG, 0)
+            (27, 0)
         );
 
         let adjacent_pages = crate::mir::MFunction::new(
@@ -3745,6 +3772,9 @@ mod tests {
         assert_eq!(add_sub_immediate(4096), Some((false, 1, true)));
         assert_eq!(add_sub_immediate(-4096), Some((true, 1, true)));
         assert_eq!(add_sub_immediate(4097), None);
+        assert_eq!(add_sub_immediate_pair(0x123456), Some((0x123000, 0x456)));
+        assert_eq!(add_sub_immediate_pair(-0x123456), Some((-0x123000, -0x456)));
+        assert_eq!(address_materialization_cost(0x123456), 2);
         assert_eq!(
             add_sub_immediate_encoding(31, 1, -4095, true),
             Some(0xf13f_fc3f)

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -1719,20 +1719,11 @@ fn emit_packed_lane_compare_vector(
                 4 => dynasm!(ops ; .arch aarch64 ; ushr v0.s4, v0.s4, #shift),
                 _ => unreachable!(),
             }
-            if matches!(rhs, PackedLaneCompareRhs::Memory { .. }) {
-                match element_stride {
-                    1 => dynasm!(ops ; .arch aarch64 ; ushr v1.b16, v1.b16, #shift),
-                    2 => dynasm!(ops ; .arch aarch64 ; ushr v1.h8, v1.h8, #shift),
-                    4 => dynasm!(ops ; .arch aarch64 ; ushr v1.s4, v1.s4, #shift),
-                    _ => unreachable!(),
-                }
-            } else if scalar_rhs.is_some() {
-                match element_stride {
-                    1 => dynasm!(ops ; .arch aarch64 ; ushr v1.b16, v1.b16, #shift),
-                    2 => dynasm!(ops ; .arch aarch64 ; ushr v1.h8, v1.h8, #shift),
-                    4 => dynasm!(ops ; .arch aarch64 ; ushr v1.s4, v1.s4, #shift),
-                    _ => unreachable!(),
-                }
+            match element_stride {
+                1 => dynasm!(ops ; .arch aarch64 ; ushr v1.b16, v1.b16, #shift),
+                2 => dynasm!(ops ; .arch aarch64 ; ushr v1.h8, v1.h8, #shift),
+                4 => dynasm!(ops ; .arch aarch64 ; ushr v1.s4, v1.s4, #shift),
+                _ => unreachable!(),
             }
         }
         if needs_mask {

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -1,6 +1,6 @@
 //! AArch64 emission for the transitional scalar MIR pipeline.
 
-use std::{collections::BTreeMap, fmt};
+use std::{collections::BTreeSet, fmt};
 
 use celox_backend_x86::native::mir::MFunction as LegacyFunction;
 use celox_backend_x86::native::regalloc::AssignmentMap as LegacyAssignment;
@@ -32,12 +32,40 @@ const SPILL_REG: u8 = 28;
 const STATE_PAGE_REG: u8 = 29;
 const STATE_PAGE_BYTES: i64 = 4096;
 const MAX_SECONDARY_STATE_PAGES: usize = 4;
+const MIN_STATE_PAGE_BENEFIT: usize = 8;
 const TEMPORARY_BYTES: usize = 16;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct StatePageBases {
     primary: Option<i64>,
     secondary: [Option<(u8, i64)>; MAX_SECONDARY_STATE_PAGES],
+}
+
+#[derive(Clone, Copy, Debug)]
+enum StatePageAccess {
+    Direct {
+        offset: i64,
+        size: OpSize,
+        store: bool,
+    },
+    Indexed {
+        offset: i64,
+        size: OpSize,
+        store: bool,
+    },
+    Vector {
+        offset: i64,
+    },
+}
+
+impl StatePageAccess {
+    fn offset(self) -> i64 {
+        match self {
+            Self::Direct { offset, .. }
+            | Self::Indexed { offset, .. }
+            | Self::Vector { offset } => offset,
+        }
+    }
 }
 
 /// Result of scalar AArch64 emission.
@@ -574,14 +602,8 @@ fn emit_instruction(
         } => {
             let index = resolve(assignment, *index)?;
             let destination = resolve(assignment, *dst)?;
-            let (base, offset) = select_indexed_memory_base(
-                *base,
-                i64::from(*offset),
-                destination,
-                *size,
-                false,
-                state_pages,
-            );
+            let (base, offset) =
+                select_indexed_memory_base(*base, i64::from(*offset), *size, false, state_pages);
             emit_load_indexed_at(ops, destination, base, index, offset, *scale, *size);
         }
         MInst::StoreIndexed {
@@ -606,7 +628,6 @@ fn emit_instruction(
                 let (base, offset) = select_indexed_memory_base(
                     *base,
                     i64::from(*offset),
-                    SCRATCH1,
                     *size,
                     false,
                     state_pages,
@@ -624,14 +645,8 @@ fn emit_instruction(
                 }
             } else {
                 let src = resolve(assignment, *src)?;
-                let (base, offset) = select_indexed_memory_base(
-                    *base,
-                    i64::from(*offset),
-                    src,
-                    *size,
-                    true,
-                    state_pages,
-                );
+                let (base, offset) =
+                    select_indexed_memory_base(*base, i64::from(*offset), *size, true, state_pages);
                 emit_store_indexed_at(ops, src, base, index, offset, 1, *size);
             }
         }
@@ -1243,15 +1258,15 @@ fn emit_mem_copy(
     if byte_len == 0 || src_offset == dst_offset {
         return;
     }
+    if mem_copy_uses_forward_vectors(src_offset, dst_offset, byte_len) {
+        emit_mem_copy_forward_vectors(ops, src_offset, dst_offset, byte_len, state_pages);
+        return;
+    }
     let src_end = i64::from(src_offset) + byte_len as i64;
     let dst_end = i64::from(dst_offset) + byte_len as i64;
     let copy_backward = src_end > i64::from(dst_offset)
         && dst_end > i64::from(src_offset)
         && dst_offset > src_offset;
-    if !copy_backward && (16..=256).contains(&byte_len) {
-        emit_mem_copy_forward_vectors(ops, src_offset, dst_offset, byte_len, state_pages);
-        return;
-    }
     let qwords = byte_len / 8;
     let remainder = byte_len % 8;
 
@@ -2274,126 +2289,343 @@ fn select_state_base_pages(
     function: &MFunction,
     secondary_registers: impl IntoIterator<Item = u8>,
 ) -> StatePageBases {
-    let mut page_counts = BTreeMap::<i64, usize>::new();
-    for block in &function.blocks {
-        for instruction in &block.insts {
-            match instruction {
-                MInst::Load {
-                    base: BaseReg::SimState,
-                    offset,
-                    ..
-                }
-                | MInst::Store {
-                    base: BaseReg::SimState,
-                    offset,
-                    ..
-                }
-                | MInst::AndStoreImm {
-                    base: BaseReg::SimState,
-                    offset,
-                    ..
-                }
-                | MInst::OrStoreImm {
-                    base: BaseReg::SimState,
-                    offset,
-                    ..
-                } => count_state_page_access(&mut page_counts, i64::from(*offset)),
-                MInst::LoadIndexed {
-                    base: BaseReg::SimState,
-                    offset,
-                    ..
-                }
-                | MInst::StoreIndexed {
-                    base: BaseReg::SimState,
-                    offset,
-                    ..
-                }
-                | MInst::OrStoreIndexed {
-                    base: BaseReg::SimState,
-                    offset,
-                    ..
-                } => count_state_page_access(&mut page_counts, i64::from(*offset)),
-                MInst::MemCopy {
-                    src_offset,
-                    dst_offset,
-                    ..
-                } => {
-                    count_state_page_access(&mut page_counts, i64::from(*src_offset));
-                    count_state_page_access(&mut page_counts, i64::from(*dst_offset));
-                }
-                MInst::MemFill { dst_offset, .. } => {
-                    count_state_page_access(&mut page_counts, i64::from(*dst_offset));
-                }
-                MInst::BranchPred {
-                    predicate:
-                        BranchPredicate::MemoryNonZero {
-                            base: BaseReg::SimState,
-                            offset,
-                            ..
-                        },
-                    ..
-                } => count_state_page_access(&mut page_counts, i64::from(*offset)),
-                MInst::SparseMarkActive {
-                    active_index,
-                    active_bits_offset,
-                    ..
-                } => count_state_page_access(
-                    &mut page_counts,
-                    i64::from(*active_bits_offset) + i64::from(*active_index / 64) * 8,
-                ),
-                MInst::PackedLaneCompare {
-                    offset,
-                    lane_count,
-                    element_stride,
-                    rhs,
-                    ..
-                } => {
-                    for lane in 0..*lane_count {
-                        let delta = i64::from(lane) * i64::from(*element_stride);
-                        count_state_page_access(&mut page_counts, i64::from(*offset) + delta);
-                        if let PackedLaneCompareRhs::Memory {
-                            offset: rhs_offset, ..
-                        } = rhs
-                        {
-                            count_state_page_access(
-                                &mut page_counts,
-                                i64::from(*rhs_offset) + delta,
-                            );
-                        }
-                    }
-                }
-                _ => {}
+    let accesses = collect_state_page_accesses(function);
+    let candidates = accesses
+        .iter()
+        .map(|access| access.offset().div_euclid(STATE_PAGE_BYTES) * STATE_PAGE_BYTES)
+        .collect::<BTreeSet<_>>();
+    let mut selected = Vec::new();
+    let mut current_costs = accesses
+        .iter()
+        .copied()
+        .map(state_page_baseline_cost)
+        .collect::<Vec<_>>();
+
+    // Greedily choose pages by the actual number of address-materialization
+    // instructions they remove.  A page base can cover several adjacent
+    // pages for wider accesses, so counting exact pages independently can
+    // waste preserved registers on redundant bases.
+    for _ in 0..=MAX_SECONDARY_STATE_PAGES {
+        let mut best = None;
+        for &candidate in &candidates {
+            if selected.contains(&candidate) {
+                continue;
+            }
+            let benefit = accesses
+                .iter()
+                .copied()
+                .zip(current_costs.iter().copied())
+                .map(|(access, current_cost)| {
+                    state_page_cost(access, candidate)
+                        .map_or(0, |cost| current_cost.saturating_sub(cost))
+                })
+                .sum::<usize>();
+            if best
+                .map(|(best_benefit, best_page)| {
+                    benefit > best_benefit || (benefit == best_benefit && candidate < best_page)
+                })
+                .unwrap_or(true)
+            {
+                best = Some((benefit, candidate));
+            }
+        }
+        let Some((benefit, page)) = best else {
+            break;
+        };
+        if benefit < MIN_STATE_PAGE_BENEFIT {
+            break;
+        }
+        selected.push(page);
+        for (access, current_cost) in accesses.iter().copied().zip(&mut current_costs) {
+            if let Some(cost) = state_page_cost(access, page) {
+                *current_cost = (*current_cost).min(cost);
             }
         }
     }
-    let mut pages = page_counts
-        .into_iter()
-        .filter(|(_, count)| *count >= 8)
-        .collect::<Vec<_>>();
-    pages.sort_unstable_by(|(left_page, left_count), (right_page, right_count)| {
-        right_count
-            .cmp(left_count)
-            .then_with(|| left_page.cmp(right_page))
-    });
+
     let secondary = secondary_registers
         .into_iter()
-        .zip(pages.iter().skip(1))
+        .zip(selected.iter().skip(1))
         .take(MAX_SECONDARY_STATE_PAGES)
-        .map(|(register, (page, _))| Some((register, *page)))
+        .map(|(register, page)| Some((register, *page)))
         .chain(std::iter::repeat(None))
         .take(MAX_SECONDARY_STATE_PAGES)
         .collect::<Vec<_>>()
         .try_into()
         .expect("secondary state page count is fixed");
     StatePageBases {
-        primary: pages.first().map(|(page, _)| *page),
+        primary: selected.first().copied(),
         secondary,
     }
 }
 
-fn count_state_page_access(page_counts: &mut BTreeMap<i64, usize>, offset: i64) {
-    let page = offset.div_euclid(STATE_PAGE_BYTES) * STATE_PAGE_BYTES;
-    *page_counts.entry(page).or_default() += 1;
+fn collect_state_page_accesses(function: &MFunction) -> Vec<StatePageAccess> {
+    let mut accesses = Vec::new();
+    for block in &function.blocks {
+        for instruction in &block.insts {
+            match instruction {
+                MInst::Load {
+                    base: BaseReg::SimState,
+                    offset,
+                    size,
+                    ..
+                } => accesses.push(StatePageAccess::Direct {
+                    offset: i64::from(*offset),
+                    size: *size,
+                    store: false,
+                }),
+                MInst::Store {
+                    base: BaseReg::SimState,
+                    offset,
+                    size,
+                    ..
+                } => accesses.push(StatePageAccess::Direct {
+                    offset: i64::from(*offset),
+                    size: *size,
+                    store: true,
+                }),
+                MInst::AndStoreImm {
+                    base: BaseReg::SimState,
+                    offset,
+                    size,
+                    ..
+                }
+                | MInst::OrStoreImm {
+                    base: BaseReg::SimState,
+                    offset,
+                    size,
+                    ..
+                } => {
+                    let offset = i64::from(*offset);
+                    accesses.push(StatePageAccess::Direct {
+                        offset,
+                        size: *size,
+                        store: false,
+                    });
+                    accesses.push(StatePageAccess::Direct {
+                        offset,
+                        size: *size,
+                        store: true,
+                    });
+                }
+                MInst::LoadIndexed {
+                    base: BaseReg::SimState,
+                    offset,
+                    size,
+                    ..
+                } => accesses.push(StatePageAccess::Indexed {
+                    offset: i64::from(*offset),
+                    size: *size,
+                    store: false,
+                }),
+                MInst::StoreIndexed {
+                    base: BaseReg::SimState,
+                    offset,
+                    size,
+                    ..
+                } => accesses.push(StatePageAccess::Indexed {
+                    offset: i64::from(*offset),
+                    size: *size,
+                    store: true,
+                }),
+                MInst::OrStoreIndexed {
+                    base: BaseReg::SimState,
+                    offset,
+                    size,
+                    ..
+                } => {
+                    let offset = i64::from(*offset);
+                    accesses.push(StatePageAccess::Indexed {
+                        offset,
+                        size: *size,
+                        store: false,
+                    });
+                    accesses.push(StatePageAccess::Indexed {
+                        offset,
+                        size: *size,
+                        store: true,
+                    });
+                }
+                MInst::MemCopy {
+                    src_offset,
+                    dst_offset,
+                    byte_len,
+                } if mem_copy_uses_forward_vectors(*src_offset, *dst_offset, *byte_len) => {
+                    accesses.push(StatePageAccess::Vector {
+                        offset: i64::from(*src_offset),
+                    });
+                    accesses.push(StatePageAccess::Vector {
+                        offset: i64::from(*dst_offset),
+                    });
+                }
+                MInst::MemFill { dst_offset, .. } => {
+                    accesses.push(StatePageAccess::Vector {
+                        offset: i64::from(*dst_offset),
+                    });
+                }
+                MInst::BranchPred {
+                    predicate:
+                        BranchPredicate::MemoryNonZero {
+                            base: BaseReg::SimState,
+                            offset,
+                            size,
+                        },
+                    ..
+                } => accesses.push(StatePageAccess::Direct {
+                    offset: i64::from(*offset),
+                    size: *size,
+                    store: false,
+                }),
+                MInst::SparseMarkActive {
+                    active_index,
+                    active_bits_offset,
+                    ..
+                } => {
+                    let offset = i64::from(*active_bits_offset) + i64::from(*active_index / 64) * 8;
+                    accesses.push(StatePageAccess::Direct {
+                        offset,
+                        size: OpSize::S64,
+                        store: false,
+                    });
+                    accesses.push(StatePageAccess::Direct {
+                        offset,
+                        size: OpSize::S64,
+                        store: true,
+                    });
+                }
+                MInst::PackedLaneCompare {
+                    offset,
+                    lane_count,
+                    element_stride,
+                    rhs,
+                    ..
+                } => collect_packed_lane_accesses(
+                    &mut accesses,
+                    *offset,
+                    *lane_count,
+                    *element_stride,
+                    *rhs,
+                ),
+                _ => {}
+            }
+        }
+    }
+    accesses
+}
+
+fn collect_packed_lane_accesses(
+    accesses: &mut Vec<StatePageAccess>,
+    offset: i32,
+    lane_count: u8,
+    element_stride: u8,
+    rhs: PackedLaneCompareRhs,
+) {
+    let Some(size) = packed_lane_size(element_stride) else {
+        return;
+    };
+    let lane_count = usize::from(lane_count);
+    let element_stride = usize::from(element_stride);
+    if lane_count * element_stride % 16 == 0 {
+        let lanes_per_vector = 16 / element_stride;
+        for lane_base in (0..lane_count).step_by(lanes_per_vector) {
+            let delta =
+                i64::try_from(lane_base * element_stride).expect("packed lane offset fits in i64");
+            accesses.push(StatePageAccess::Vector {
+                offset: i64::from(offset) + delta,
+            });
+            if let PackedLaneCompareRhs::Memory { offset: rhs_offset } = rhs {
+                accesses.push(StatePageAccess::Vector {
+                    offset: i64::from(rhs_offset) + delta,
+                });
+            }
+        }
+    } else {
+        for lane in 0..lane_count {
+            let delta =
+                i64::try_from(lane * element_stride).expect("packed lane offset fits in i64");
+            accesses.push(StatePageAccess::Direct {
+                offset: i64::from(offset) + delta,
+                size,
+                store: false,
+            });
+            if let PackedLaneCompareRhs::Memory { offset: rhs_offset } = rhs {
+                accesses.push(StatePageAccess::Direct {
+                    offset: i64::from(rhs_offset) + delta,
+                    size,
+                    store: false,
+                });
+            }
+        }
+    }
+}
+
+fn packed_lane_size(element_stride: u8) -> Option<OpSize> {
+    match element_stride {
+        1 => Some(OpSize::S8),
+        2 => Some(OpSize::S16),
+        4 => Some(OpSize::S32),
+        _ => None,
+    }
+}
+
+fn mem_copy_uses_forward_vectors(src_offset: i32, dst_offset: i32, byte_len: usize) -> bool {
+    if byte_len == 0 || src_offset == dst_offset {
+        return false;
+    }
+    let byte_len = byte_len as i64;
+    let src_end = i64::from(src_offset) + byte_len;
+    let dst_end = i64::from(dst_offset) + byte_len;
+    let copy_backward = src_end > i64::from(dst_offset)
+        && dst_end > i64::from(src_offset)
+        && dst_offset > src_offset;
+    !copy_backward && (16..=256).contains(&byte_len)
+}
+
+fn state_page_baseline_cost(access: StatePageAccess) -> usize {
+    match access {
+        StatePageAccess::Direct {
+            offset,
+            size,
+            store,
+        } => {
+            if memory_access_encoding(SCRATCH0, STATE_REG, offset, size, store).is_some() {
+                0
+            } else {
+                address_materialization_cost(offset)
+            }
+        }
+        StatePageAccess::Indexed {
+            offset,
+            size,
+            store,
+        } => indexed_access_cost(offset, size, store),
+        StatePageAccess::Vector { offset } => address_materialization_cost(offset),
+    }
+}
+
+fn state_page_cost(access: StatePageAccess, page: i64) -> Option<usize> {
+    let offset = access.offset() - page;
+    match access {
+        StatePageAccess::Direct { size, store, .. } => {
+            memory_access_encoding(SCRATCH0, STATE_PAGE_REG, offset, size, store).map(|_| 0)
+        }
+        StatePageAccess::Indexed { size, store, .. } => indexed_offset_cost(offset, size, store),
+        StatePageAccess::Vector { .. } => Some(address_materialization_cost(offset)),
+    }
+}
+
+fn indexed_access_cost(offset: i64, size: OpSize, store: bool) -> usize {
+    indexed_offset_cost(offset, size, store).unwrap_or_else(|| address_materialization_cost(offset))
+}
+
+fn indexed_offset_cost(offset: i64, size: OpSize, store: bool) -> Option<usize> {
+    if memory_access_encoding(SCRATCH0, SCRATCH0, offset, size, store).is_some() {
+        Some(0)
+    } else if add_sub_immediate(offset).is_some() {
+        Some(1)
+    } else {
+        None
+    }
 }
 
 fn select_memory_base(
@@ -2426,7 +2658,6 @@ fn select_memory_base(
 fn select_indexed_memory_base(
     base: BaseReg,
     offset: i64,
-    register: u8,
     size: OpSize,
     store: bool,
     state_pages: StatePageBases,
@@ -2435,24 +2666,22 @@ fn select_indexed_memory_base(
     if base != BaseReg::SimState {
         return normal;
     }
-    if let Some(page) = state_pages.primary {
-        let relative = offset - page;
-        if indexed_offset_encoding(relative, register, size, store) {
-            return (STATE_PAGE_REG, relative);
-        }
-    }
-    for &(page_register, page) in state_pages.secondary.iter().flatten() {
-        let relative = offset - page;
-        if indexed_offset_encoding(relative, register, size, store) {
-            return (page_register, relative);
-        }
-    }
-    normal
-}
-
-fn indexed_offset_encoding(offset: i64, register: u8, size: OpSize, store: bool) -> bool {
-    add_sub_immediate(offset).is_some()
-        || memory_access_encoding(register, STATE_PAGE_REG, offset, size, store).is_some()
+    let candidates = std::iter::once((indexed_access_cost(offset, size, store), normal)).chain(
+        state_pages
+            .primary
+            .into_iter()
+            .map(|page| (STATE_PAGE_REG, page))
+            .chain(state_pages.secondary.iter().flatten().copied())
+            .filter_map(|(page_register, page)| {
+                let relative = offset - page;
+                indexed_offset_cost(relative, size, store)
+                    .map(|cost| (cost, (page_register, relative)))
+            }),
+    );
+    candidates
+        .min_by_key(|(cost, _)| *cost)
+        .map(|(_, base)| base)
+        .unwrap_or(normal)
 }
 
 fn select_vector_memory_base(base: BaseReg, offset: i64, state_pages: StatePageBases) -> (u8, i64) {
@@ -2460,19 +2689,21 @@ fn select_vector_memory_base(base: BaseReg, offset: i64, state_pages: StatePageB
     if base != BaseReg::SimState {
         return normal;
     }
-    let candidates = state_pages
-        .primary
-        .into_iter()
-        .map(|page| (STATE_PAGE_REG, page))
-        .chain(state_pages.secondary.iter().flatten().copied());
+    let candidates = std::iter::once((address_materialization_cost(offset), normal)).chain(
+        state_pages
+            .primary
+            .into_iter()
+            .map(|page| (STATE_PAGE_REG, page))
+            .chain(state_pages.secondary.iter().flatten().copied())
+            .map(|(page_register, page)| {
+                let relative = offset - page;
+                (
+                    address_materialization_cost(relative),
+                    (page_register, relative),
+                )
+            }),
+    );
     candidates
-        .map(|(page_register, page)| {
-            let relative = offset - page;
-            (
-                address_materialization_cost(relative),
-                (page_register, relative),
-            )
-        })
         .min_by_key(|(cost, _)| *cost)
         .map(|(_, base)| base)
         .unwrap_or(normal)
@@ -3274,7 +3505,7 @@ mod tests {
             insts.push(crate::mir::MInst::Load {
                 dst,
                 base: crate::mir::BaseReg::SimState,
-                offset: 4096 + (index as i32) * 8,
+                offset: 32768 + (index as i32) * 8,
                 size: crate::mir::OpSize::S64,
             });
         }
@@ -3290,17 +3521,17 @@ mod tests {
 
         assert_eq!(
             select_state_base_pages(&function, std::iter::empty::<u8>()).primary,
-            Some(4096)
+            Some(32768)
         );
         assert_eq!(
             select_memory_base(
                 crate::mir::BaseReg::SimState,
-                4112,
+                32784,
                 SCRATCH0,
                 crate::mir::OpSize::S64,
                 false,
                 StatePageBases {
-                    primary: Some(4096),
+                    primary: Some(32768),
                     ..StatePageBases::default()
                 },
             ),
@@ -3315,7 +3546,7 @@ mod tests {
                     .map(|index| crate::mir::MInst::Load {
                         dst: crate::mir::VReg(index),
                         base: crate::mir::BaseReg::SimState,
-                        offset: 4096 + (index % 8) as i32 * 8 + (index / 8) as i32 * 36864,
+                        offset: 32768 + (index % 8) as i32 * 8 + (index / 8) as i32 * 36864,
                         size: crate::mir::OpSize::S64,
                     })
                     .chain(std::iter::once(crate::mir::MInst::Return))
@@ -3324,13 +3555,13 @@ mod tests {
             Vec::new(),
         );
         let multi_page_bases = select_state_base_pages(&multi_page, [27, 26, 25, 24]);
-        assert_eq!(multi_page_bases.primary, Some(4096));
-        assert_eq!(multi_page_bases.secondary[0], Some((27, 40960)));
+        assert_eq!(multi_page_bases.primary, Some(69632));
+        assert_eq!(multi_page_bases.secondary[0], Some((27, 32768)));
         assert_eq!(multi_page_bases.secondary[1], None);
         assert_eq!(
             select_memory_base(
                 crate::mir::BaseReg::SimState,
-                40976,
+                32784,
                 SCRATCH0,
                 crate::mir::OpSize::S64,
                 false,
@@ -3339,8 +3570,50 @@ mod tests {
             (27, 16)
         );
         assert_eq!(
-            select_vector_memory_base(crate::mir::BaseReg::SimState, 40960, multi_page_bases),
-            (27, 0)
+            select_vector_memory_base(crate::mir::BaseReg::SimState, 69632, multi_page_bases),
+            (STATE_PAGE_REG, 0)
+        );
+
+        let adjacent_pages = crate::mir::MFunction::new(
+            vec![crate::mir::MBlock {
+                id: crate::mir::BlockId(0),
+                phis: Vec::new(),
+                insts: (0..16)
+                    .map(|index| crate::mir::MInst::Load {
+                        dst: crate::mir::VReg(index),
+                        base: crate::mir::BaseReg::SimState,
+                        offset: 32768 + (index % 8) as i32 * 8 + (index / 8) as i32 * 4096,
+                        size: crate::mir::OpSize::S64,
+                    })
+                    .chain(std::iter::once(crate::mir::MInst::Return))
+                    .collect(),
+            }],
+            Vec::new(),
+        );
+        let adjacent_page_bases = select_state_base_pages(&adjacent_pages, [27, 26, 25, 24]);
+        assert_eq!(adjacent_page_bases.primary, Some(32768));
+        assert_eq!(adjacent_page_bases.secondary[0], None);
+        assert_eq!(
+            select_memory_base(
+                crate::mir::BaseReg::SimState,
+                36880,
+                SCRATCH0,
+                crate::mir::OpSize::S64,
+                false,
+                adjacent_page_bases,
+            ),
+            (STATE_PAGE_REG, 4112)
+        );
+        assert_eq!(
+            select_vector_memory_base(
+                crate::mir::BaseReg::SimState,
+                0,
+                StatePageBases {
+                    primary: Some(4096),
+                    ..StatePageBases::default()
+                },
+            ),
+            (STATE_REG, 0)
         );
 
         let packed = crate::mir::MFunction::new(

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -653,12 +653,18 @@ fn emit_instruction(
         }
         MInst::AddImm { dst, src, imm } | MInst::SubImm { dst, src, imm } => {
             let (dst, src) = (resolve(assignment, *dst)?, resolve(assignment, *src)?);
-            emit_load_imm(ops, SCRATCH0, i64::from(*imm).unsigned_abs());
-            let subtract = matches!(instruction, MInst::SubImm { .. }) ^ (*imm < 0);
-            if subtract {
-                dynasm!(ops ; .arch aarch64 ; sub X(dst), X(src), x16);
+            let offset = if matches!(instruction, MInst::SubImm { .. }) {
+                -i64::from(*imm)
             } else {
-                dynasm!(ops ; .arch aarch64 ; add X(dst), X(src), x16);
+                i64::from(*imm)
+            };
+            if !emit_add_sub_immediate(ops, dst, src, offset) {
+                emit_load_imm(ops, SCRATCH0, offset.unsigned_abs());
+                if offset < 0 {
+                    dynasm!(ops ; .arch aarch64 ; sub X(dst), X(src), x16);
+                } else {
+                    dynasm!(ops ; .arch aarch64 ; add X(dst), X(src), x16);
+                }
             }
         }
         MInst::Cmp {
@@ -1583,16 +1589,100 @@ fn emit_base_address(
 fn emit_address(ops: &mut VecAssembler<Aarch64Relocation>, base: u8, offset: i64) {
     if offset == 0 {
         dynasm!(ops ; .arch aarch64 ; mov x16, X(base));
-    } else {
+    } else if !emit_add_sub_immediate(ops, SCRATCH0, base, offset) {
         emit_load_imm(ops, SCRATCH1, offset as u64);
         dynasm!(ops ; .arch aarch64 ; add x16, X(base), x17);
+    } else {
+        // The address was formed directly by ADD/SUB immediate.
     }
 }
 
 fn emit_add_offset(ops: &mut VecAssembler<Aarch64Relocation>, offset: i64) {
     if offset != 0 {
-        emit_load_imm(ops, SCRATCH1, offset as u64);
-        dynasm!(ops ; .arch aarch64 ; add x16, x16, x17);
+        if !emit_add_sub_immediate(ops, SCRATCH0, SCRATCH0, offset) {
+            emit_load_imm(ops, SCRATCH1, offset as u64);
+            dynasm!(ops ; .arch aarch64 ; add x16, x16, x17);
+        }
+    }
+}
+
+fn add_sub_immediate(offset: i64) -> Option<(bool, u32, bool)> {
+    let (subtract, magnitude) = if offset < 0 {
+        (true, offset.unsigned_abs())
+    } else {
+        (false, offset as u64)
+    };
+    if magnitude <= 0xfff {
+        return Some((subtract, magnitude as u32, false));
+    }
+    if magnitude.is_multiple_of(0x1000) && magnitude / 0x1000 <= 0xfff {
+        return Some((subtract, (magnitude / 0x1000) as u32, true));
+    }
+    None
+}
+
+fn emit_add_sub_immediate(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: u8,
+    base: u8,
+    offset: i64,
+) -> bool {
+    let Some((subtract, immediate, shifted)) = add_sub_immediate(offset) else {
+        return false;
+    };
+    // ADD/SUB (immediate): sf=1, op selects SUB, sh selects <<12, and the
+    // 12-bit immediate is encoded between Rn and Rd.  Encoding this one
+    // instruction directly keeps both registers dynamic without forcing a
+    // large dynasm register match table.
+    let instruction = 0x9100_0000
+        | (u32::from(subtract) << 30)
+        | (u32::from(shifted) << 22)
+        | (immediate << 10)
+        | (u32::from(base) << 5)
+        | u32::from(destination);
+    debug_assert!(immediate <= 0xfff);
+    ops.push_u32(instruction);
+    true
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct MoveWidePlan {
+    inverted: bool,
+    first: usize,
+    instruction_count: usize,
+}
+
+fn move_wide_plan(value: u64) -> MoveWidePlan {
+    let halves = [
+        value as u16,
+        (value >> 16) as u16,
+        (value >> 32) as u16,
+        (value >> 48) as u16,
+    ];
+    let movz_candidates = halves
+        .iter()
+        .enumerate()
+        .filter_map(|(index, &half)| (half != 0).then_some(index))
+        .collect::<Vec<_>>();
+    let movn_candidates = halves
+        .iter()
+        .enumerate()
+        .filter_map(|(index, &half)| (half != u16::MAX).then_some(index))
+        .collect::<Vec<_>>();
+    let movz = MoveWidePlan {
+        inverted: false,
+        first: movz_candidates.first().copied().unwrap_or(0),
+        instruction_count: movz_candidates.len().max(1),
+    };
+    let movn = MoveWidePlan {
+        inverted: true,
+        first: movn_candidates.first().copied().unwrap_or(0),
+        instruction_count: movn_candidates.len().max(1),
+    };
+    if movn.instruction_count < movz.instruction_count {
+        movn
+    } else {
+        movz
     }
 }
 
@@ -1603,17 +1693,27 @@ fn emit_load_imm(ops: &mut VecAssembler<Aarch64Relocation>, register: u8, value:
         (value >> 32) as u16,
         (value >> 48) as u16,
     ];
-    let first = halves.iter().position(|half| *half != 0).unwrap_or(0);
-    let half = u32::from(halves[first]);
-    match first {
-        0 => dynasm!(ops ; .arch aarch64 ; movz X(register), half),
-        1 => dynasm!(ops ; .arch aarch64 ; movz X(register), half, LSL #16),
-        2 => dynasm!(ops ; .arch aarch64 ; movz X(register), half, LSL #32),
-        3 => dynasm!(ops ; .arch aarch64 ; movz X(register), half, LSL #48),
+    let plan = move_wide_plan(value);
+    let first = plan.first;
+    let fill = if plan.inverted { u16::MAX } else { 0 };
+    let half = if plan.inverted {
+        u32::from(!halves[first])
+    } else {
+        u32::from(halves[first])
+    };
+    match (plan.inverted, first) {
+        (false, 0) => dynasm!(ops ; .arch aarch64 ; movz X(register), half),
+        (false, 1) => dynasm!(ops ; .arch aarch64 ; movz X(register), half, LSL #16),
+        (false, 2) => dynasm!(ops ; .arch aarch64 ; movz X(register), half, LSL #32),
+        (false, 3) => dynasm!(ops ; .arch aarch64 ; movz X(register), half, LSL #48),
+        (true, 0) => dynasm!(ops ; .arch aarch64 ; movn X(register), half),
+        (true, 1) => dynasm!(ops ; .arch aarch64 ; movn X(register), half, LSL #16),
+        (true, 2) => dynasm!(ops ; .arch aarch64 ; movn X(register), half, LSL #32),
+        (true, 3) => dynasm!(ops ; .arch aarch64 ; movn X(register), half, LSL #48),
         _ => unreachable!(),
     }
     for (index, half) in halves.into_iter().enumerate() {
-        if index == first || half == 0 {
+        if index == first || half == fill {
             continue;
         }
         let half = u32::from(half);
@@ -2033,6 +2133,23 @@ mod tests {
         assert!(!result.code.is_empty());
         assert!(result.text_size <= result.code.len());
         assert_eq!(result.block_offsets, vec![(crate::mir::BlockId(0), 4)]);
+    }
+
+    #[test]
+    fn selects_short_aarch64_immediates() {
+        assert_eq!(add_sub_immediate(4095), Some((false, 4095, false)));
+        assert_eq!(add_sub_immediate(-4095), Some((true, 4095, false)));
+        assert_eq!(add_sub_immediate(4096), Some((false, 1, true)));
+        assert_eq!(add_sub_immediate(-4096), Some((true, 1, true)));
+        assert_eq!(add_sub_immediate(4097), None);
+    }
+
+    #[test]
+    fn uses_movn_for_constants_close_to_all_ones() {
+        assert_eq!(move_wide_plan(0).instruction_count, 1);
+        assert!(move_wide_plan(u64::MAX).inverted);
+        assert_eq!(move_wide_plan(u64::MAX).instruction_count, 1);
+        assert_eq!(move_wide_plan(0xffff_ffff_ffff_0000).instruction_count, 1);
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -24,6 +24,11 @@ use crate::{Arm64Reg, HashMap};
 const STATE_REG: u8 = 0;
 const SCRATCH0: u8 = 16;
 const SCRATCH1: u8 = 17;
+// x28 is reserved as the base of the target-owned spill frame.  Keeping the
+// frame base live avoids materializing `state + spill_base` for every reload
+// and spill store when the simulator state is larger than AArch64's immediate
+// addressing range.
+const SPILL_REG: u8 = 28;
 const TEMPORARY_BYTES: usize = 16;
 
 /// Result of scalar AArch64 emission.
@@ -259,7 +264,7 @@ fn emit_function(
     let mut callee_saved = assignment
         .iter()
         .map(|(_, register)| register.number())
-        .filter(|register| (19..=28).contains(register))
+        .filter(|register| (19..=27).contains(register))
         .collect::<Vec<_>>();
     if tick_loop {
         // x29 is not allocated to MIR values and carries the native-loop
@@ -267,6 +272,10 @@ fn emit_function(
         // prologue avoids two FP/GPR transfers on every loop iteration.
         callee_saved.push(29);
     }
+    // x28 is the fixed base for the spill/cycle-break arena, including the
+    // temporary slot used by parallel-copy resolution even when no value was
+    // spilled.
+    callee_saved.push(SPILL_REG);
     callee_saved.sort_unstable();
     callee_saved.dedup();
 
@@ -321,6 +330,7 @@ fn emit_function(
             emit_store(&mut ops, 30, SCRATCH0, OpSize::S64);
         }
     }
+    emit_address_to(&mut ops, SPILL_REG, STATE_REG, spill_base as i64);
     for block in &function.blocks {
         let label = block_labels[&block.id];
         block_offsets.push((block.id, ops.offset().0 as u64));
@@ -453,7 +463,7 @@ fn emit_instruction(
             size,
         } => {
             let base_register = base_register(*base);
-            let offset = base_offset(*base, *offset, spill_base)?;
+            let offset = base_offset(*base, *offset);
             emit_load_at(
                 ops,
                 resolve(assignment, *dst)?,
@@ -469,7 +479,7 @@ fn emit_instruction(
             size,
         } => {
             let base_register = base_register(*base);
-            let offset = base_offset(*base, *offset, spill_base)?;
+            let offset = base_offset(*base, *offset);
             emit_store_at(
                 ops,
                 resolve(assignment, *src)?,
@@ -633,7 +643,7 @@ fn emit_instruction(
             imm,
         } => {
             let base_register = base_register(*base);
-            let address_offset = base_offset(*base, *offset, spill_base)?;
+            let address_offset = base_offset(*base, *offset);
             if memory_access_encoding(SCRATCH1, base_register, address_offset, *size, false)
                 .is_some()
             {
@@ -646,7 +656,7 @@ fn emit_instruction(
                 }
                 emit_store_at(ops, 30, base_register, address_offset, *size);
             } else {
-                emit_base_address(ops, *base, *offset, spill_base)?;
+                emit_base_address(ops, *base, *offset)?;
                 emit_load(ops, SCRATCH1, SCRATCH0, *size);
                 emit_load_imm(ops, SCRATCH0, *imm);
                 if matches!(instruction, MInst::AndStoreImm { .. }) {
@@ -654,7 +664,7 @@ fn emit_instruction(
                 } else {
                     dynasm!(ops ; .arch aarch64 ; orr x30, x17, x16);
                 }
-                emit_base_address(ops, *base, *offset, spill_base)?;
+                emit_base_address(ops, *base, *offset)?;
                 emit_store(ops, 30, SCRATCH0, *size);
             }
         }
@@ -951,7 +961,7 @@ fn emit_instruction(
             true_bb,
             false_bb,
         } => {
-            emit_branch_predicate(ops, *predicate, assignment, spill_base)?;
+            emit_branch_predicate(ops, *predicate, assignment)?;
             let true_path = ops.new_dynamic_label();
             emit_conditional_branch(ops, true_path, predicate_kind(*predicate));
             emit_edge_copies(ops, plan, block, *false_bb, spill_base, temporary_offset)?;
@@ -1079,11 +1089,11 @@ fn emit_instruction(
             let offset = active_bits_offset
                 .checked_add(word_offset)
                 .ok_or(EmitError::Range("sparse active bitmap offset overflow"))?;
-            emit_base_address(ops, BaseReg::SimState, offset, spill_base)?;
+            emit_base_address(ops, BaseReg::SimState, offset)?;
             emit_load(ops, SCRATCH1, SCRATCH0, OpSize::S64);
             emit_load_imm(ops, SCRATCH0, 1_u64 << (*active_index % 64));
             dynasm!(ops ; .arch aarch64 ; orr x30, x17, x16);
-            emit_base_address(ops, BaseReg::SimState, offset, spill_base)?;
+            emit_base_address(ops, BaseReg::SimState, offset)?;
             emit_store(ops, 30, SCRATCH0, OpSize::S64);
         }
         MInst::SparseCommitWorklist {
@@ -1799,7 +1809,7 @@ fn emit_mem_fill(
 fn base_register(base: BaseReg) -> u8 {
     match base {
         BaseReg::SimState => STATE_REG,
-        BaseReg::StackFrame => STATE_REG,
+        BaseReg::StackFrame => SPILL_REG,
     }
 }
 
@@ -1807,31 +1817,33 @@ fn emit_base_address(
     ops: &mut VecAssembler<Aarch64Relocation>,
     base: BaseReg,
     offset: i32,
-    spill_base: usize,
 ) -> Result<(), EmitError> {
-    let offset = base_offset(base, offset, spill_base)?;
-    emit_address(ops, STATE_REG, offset);
+    let offset = base_offset(base, offset);
+    emit_address(ops, base_register(base), offset);
     Ok(())
 }
 
-fn base_offset(base: BaseReg, offset: i32, spill_base: usize) -> Result<i64, EmitError> {
+fn base_offset(base: BaseReg, offset: i32) -> i64 {
     match base {
-        BaseReg::SimState => Ok(i64::from(offset)),
-        BaseReg::StackFrame => i64::try_from(spill_base)
-            .ok()
-            .and_then(|base| base.checked_add(i64::from(offset)))
-            .ok_or(EmitError::Range("stack-frame address overflow")),
+        BaseReg::SimState | BaseReg::StackFrame => i64::from(offset),
     }
 }
 
 fn emit_address(ops: &mut VecAssembler<Aarch64Relocation>, base: u8, offset: i64) {
+    emit_address_to(ops, SCRATCH0, base, offset);
+}
+
+fn emit_address_to(
+    ops: &mut VecAssembler<Aarch64Relocation>,
+    destination: u8,
+    base: u8,
+    offset: i64,
+) {
     if offset == 0 {
-        dynasm!(ops ; .arch aarch64 ; mov x16, X(base));
-    } else if !emit_add_sub_immediate(ops, SCRATCH0, base, offset) {
+        dynasm!(ops ; .arch aarch64 ; mov X(destination), X(base));
+    } else if !emit_add_sub_immediate(ops, destination, base, offset) {
         emit_load_imm(ops, SCRATCH1, offset as u64);
-        dynasm!(ops ; .arch aarch64 ; add x16, X(base), x17);
-    } else {
-        // The address was formed directly by ADD/SUB immediate.
+        dynasm!(ops ; .arch aarch64 ; add X(destination), X(base), x17);
     }
 }
 
@@ -2249,7 +2261,6 @@ fn emit_branch_predicate(
     ops: &mut VecAssembler<Aarch64Relocation>,
     predicate: BranchPredicate,
     assignment: &Assignment<VReg>,
-    spill_base: usize,
 ) -> Result<(), EmitError> {
     match predicate {
         BranchPredicate::Compare { lhs, rhs, .. } => {
@@ -2265,7 +2276,7 @@ fn emit_branch_predicate(
         }
         BranchPredicate::MemoryNonZero { base, offset, size } => {
             let base_register = base_register(base);
-            let offset = base_offset(base, offset, spill_base)?;
+            let offset = base_offset(base, offset);
             emit_load_at(ops, SCRATCH0, base_register, offset, size);
             dynasm!(ops ; .arch aarch64 ; cmp x16, #0);
         }
@@ -2315,7 +2326,7 @@ fn emit_edge_copies(
             CopyOperation::Move {
                 destination,
                 source,
-            } => emit_copy(ops, destination, source, spill_base)?,
+            } => emit_copy(ops, destination, source)?,
             CopyOperation::SwapRegisters { left, right } => {
                 let (left, right) = (left.number(), right.number());
                 dynasm!(ops
@@ -2326,17 +2337,35 @@ fn emit_edge_copies(
                 );
             }
             CopyOperation::SaveTemporary(destination) => {
-                read_copy_destination(ops, destination, spill_base, SCRATCH1)?;
+                read_copy_destination(ops, destination, SCRATCH1)?;
                 // Address materialization uses x17 for the offset. Preserve
                 // the value being saved before computing the temporary slot.
                 dynasm!(ops ; .arch aarch64 ; mov x30, x17);
-                emit_address(ops, STATE_REG, temporary_offset as i64);
-                emit_store(ops, 30, SCRATCH0, OpSize::S64);
+                let temporary = temporary_offset
+                    .checked_sub(spill_base)
+                    .ok_or(EmitError::Range("temporary spill offset underflow"))?;
+                emit_store_at(
+                    ops,
+                    30,
+                    SPILL_REG,
+                    i64::try_from(temporary)
+                        .map_err(|_| EmitError::Range("temporary spill offset overflow"))?,
+                    OpSize::S64,
+                );
             }
             CopyOperation::RestoreTemporary(destination) => {
-                emit_address(ops, STATE_REG, temporary_offset as i64);
-                emit_load(ops, SCRATCH1, SCRATCH0, OpSize::S64);
-                write_copy_destination(ops, destination, spill_base, SCRATCH1)?;
+                let temporary = temporary_offset
+                    .checked_sub(spill_base)
+                    .ok_or(EmitError::Range("temporary spill offset underflow"))?;
+                emit_load_at(
+                    ops,
+                    SCRATCH1,
+                    SPILL_REG,
+                    i64::try_from(temporary)
+                        .map_err(|_| EmitError::Range("temporary spill offset overflow"))?,
+                    OpSize::S64,
+                );
+                write_copy_destination(ops, destination, SCRATCH1)?;
             }
         }
     }
@@ -2347,20 +2376,18 @@ fn emit_copy(
     ops: &mut VecAssembler<Aarch64Relocation>,
     destination: CopyDestination,
     source: CopySource,
-    spill_base: usize,
 ) -> Result<(), EmitError> {
     match source {
         CopySource::Register(register) => {
-            write_copy_destination(ops, destination, spill_base, register.number())
+            write_copy_destination(ops, destination, register.number())
         }
         CopySource::Stack(offset) => {
-            emit_address(ops, STATE_REG, spill_base as i64 + i64::from(offset));
-            emit_load(ops, SCRATCH1, SCRATCH0, OpSize::S64);
-            write_copy_destination(ops, destination, spill_base, SCRATCH1)
+            emit_load_at(ops, SCRATCH1, SPILL_REG, i64::from(offset), OpSize::S64);
+            write_copy_destination(ops, destination, SCRATCH1)
         }
         CopySource::Immediate(value) => {
             emit_load_imm(ops, SCRATCH1, value);
-            write_copy_destination(ops, destination, spill_base, SCRATCH1)
+            write_copy_destination(ops, destination, SCRATCH1)
         }
     }
 }
@@ -2368,7 +2395,6 @@ fn emit_copy(
 fn read_copy_destination(
     ops: &mut VecAssembler<Aarch64Relocation>,
     destination: CopyDestination,
-    spill_base: usize,
     output: u8,
 ) -> Result<(), EmitError> {
     match destination {
@@ -2377,8 +2403,7 @@ fn read_copy_destination(
             dynasm!(ops ; .arch aarch64 ; mov X(output), X(register));
         }
         CopyDestination::Stack(offset) => {
-            emit_address(ops, STATE_REG, spill_base as i64 + i64::from(offset));
-            emit_load(ops, output, SCRATCH0, OpSize::S64);
+            emit_load_at(ops, output, SPILL_REG, i64::from(offset), OpSize::S64);
         }
     }
     Ok(())
@@ -2387,7 +2412,6 @@ fn read_copy_destination(
 fn write_copy_destination(
     ops: &mut VecAssembler<Aarch64Relocation>,
     destination: CopyDestination,
-    spill_base: usize,
     source: u8,
 ) -> Result<(), EmitError> {
     match destination {
@@ -2405,8 +2429,7 @@ fn write_copy_destination(
             } else {
                 source
             };
-            emit_address(ops, STATE_REG, spill_base as i64 + i64::from(offset));
-            emit_store(ops, source, SCRATCH0, OpSize::S64);
+            emit_store_at(ops, source, SPILL_REG, i64::from(offset), OpSize::S64);
         }
     }
     Ok(())
@@ -2560,7 +2583,7 @@ mod tests {
         let result = emit(&function, &assignment, 0).unwrap();
         assert!(!result.code.is_empty());
         assert!(result.text_size <= result.code.len());
-        assert_eq!(result.block_offsets, vec![(crate::mir::BlockId(0), 4)]);
+        assert_eq!(result.block_offsets, vec![(crate::mir::BlockId(0), 8)]);
     }
 
     #[test]

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -1,6 +1,6 @@
 //! AArch64 emission for the transitional scalar MIR pipeline.
 
-use std::fmt;
+use std::{collections::BTreeMap, fmt};
 
 use celox_backend_x86::native::mir::MFunction as LegacyFunction;
 use celox_backend_x86::native::regalloc::AssignmentMap as LegacyAssignment;
@@ -29,6 +29,8 @@ const SCRATCH1: u8 = 17;
 // and spill store when the simulator state is larger than AArch64's immediate
 // addressing range.
 const SPILL_REG: u8 = 28;
+const STATE_PAGE_REG: u8 = 29;
+const STATE_PAGE_BYTES: i64 = 4096;
 const TEMPORARY_BYTES: usize = 16;
 
 /// Result of scalar AArch64 emission.
@@ -252,6 +254,13 @@ fn emit_function(
         .iter()
         .map(|block| (block.id, ops.new_dynamic_label()))
         .collect::<HashMap<_, _>>();
+    // Use x29 for the most frequently accessed state page so large state
+    // offsets can use ordinary AArch64 memory immediates without reducing the
+    // allocator's general-purpose register file.  The tick loop normally uses
+    // x29 for its counter; when a page base is profitable, keep that counter
+    // in an otherwise-unused SIMD scalar register instead.
+    let state_base_page = select_state_base_page(function);
+    let tick_counter_in_fp = tick_loop && state_base_page.is_some();
     let table_labels = function
         .constant_tables()
         .iter()
@@ -266,11 +275,10 @@ fn emit_function(
         .map(|(_, register)| register.number())
         .filter(|register| (19..=27).contains(register))
         .collect::<Vec<_>>();
-    if tick_loop {
-        // x29 is not allocated to MIR values and carries the native-loop
-        // counter across repeated body entries. Saving it once in the
-        // prologue avoids two FP/GPR transfers on every loop iteration.
-        callee_saved.push(29);
+    if tick_loop || state_base_page.is_some() {
+        // x29 is reserved for either the native-loop counter or the cached
+        // state-page base, so preserve the host value across the JIT call.
+        callee_saved.push(STATE_PAGE_REG);
     }
     // x28 is the fixed base for the spill/cycle-break arena, including the
     // temporary slot used by parallel-copy resolution even when no value was
@@ -297,7 +305,8 @@ fn emit_function(
     }
     if tick_loop {
         // d29 retains the simulator-state pointer across success/error return
-        // values. x29 carries the remaining tick count between body entries.
+        // values. Keep the remaining tick count in x29 unless x29 is needed
+        // for the cached state-page base.
         dynasm!(ops ; .arch aarch64 ; fmov d29, x0);
         emit_address(
             &mut ops,
@@ -306,13 +315,23 @@ fn emit_function(
         );
         emit_load(&mut ops, SCRATCH0, SCRATCH0, OpSize::S64);
         let count_ready = ops.new_dynamic_label();
-        dynasm!(ops
-            ; .arch aarch64
-            ; cbnz x16, =>count_ready
-            ; mov x16, #1
-            ; =>count_ready
-            ; mov x29, x16
-        );
+        if tick_counter_in_fp {
+            dynasm!(ops
+                ; .arch aarch64
+                ; cbnz x16, =>count_ready
+                ; mov x16, #1
+                ; =>count_ready
+                ; fmov d31, x16
+            );
+        } else {
+            dynasm!(ops
+                ; .arch aarch64
+                ; cbnz x16, =>count_ready
+                ; mov x16, #1
+                ; =>count_ready
+                ; mov x29, x16
+            );
+        }
         if check_runtime_events {
             emit_address(
                 &mut ops,
@@ -331,6 +350,9 @@ fn emit_function(
         }
     }
     emit_address_to(&mut ops, SPILL_REG, STATE_REG, spill_base as i64);
+    if let Some(page) = state_base_page {
+        emit_address_to(&mut ops, STATE_PAGE_REG, STATE_REG, page);
+    }
     for block in &function.blocks {
         let label = block_labels[&block.id];
         block_offsets.push((block.id, ops.offset().0 as u64));
@@ -354,6 +376,8 @@ fn emit_function(
                 tick_entry,
                 tick_success,
                 check_runtime_events,
+                state_base_page,
+                tick_counter_in_fp,
             )?;
         }
     }
@@ -366,11 +390,11 @@ fn emit_function(
         ; =>epilogue
     );
     if tick_loop {
-        dynasm!(ops
-            ; .arch aarch64
-            ; mov x16, x29
-            ; fmov x17, d29
-        );
+        if tick_counter_in_fp {
+            dynasm!(ops ; .arch aarch64 ; fmov x16, d31 ; fmov x17, d29);
+        } else {
+            dynasm!(ops ; .arch aarch64 ; mov x16, x29 ; fmov x17, d29);
+        }
         emit_load_imm(
             &mut ops,
             30,
@@ -437,6 +461,8 @@ fn emit_instruction(
     tick_entry: Option<DynamicLabel>,
     tick_success: Option<DynamicLabel>,
     check_runtime_events: bool,
+    state_base_page: Option<i64>,
+    tick_counter_in_fp: bool,
 ) -> Result<(), EmitError> {
     match instruction {
         MInst::Mov { dst, src } => {
@@ -462,15 +488,11 @@ fn emit_instruction(
             offset,
             size,
         } => {
-            let base_register = base_register(*base);
             let offset = base_offset(*base, *offset);
-            emit_load_at(
-                ops,
-                resolve(assignment, *dst)?,
-                base_register,
-                offset,
-                *size,
-            );
+            let destination = resolve(assignment, *dst)?;
+            let (base_register, offset) =
+                select_memory_base(*base, offset, destination, *size, false, state_base_page);
+            emit_load_at(ops, destination, base_register, offset, *size);
         }
         MInst::Store {
             base,
@@ -478,15 +500,11 @@ fn emit_instruction(
             src,
             size,
         } => {
-            let base_register = base_register(*base);
             let offset = base_offset(*base, *offset);
-            emit_store_at(
-                ops,
-                resolve(assignment, *src)?,
-                base_register,
-                offset,
-                *size,
-            );
+            let source = resolve(assignment, *src)?;
+            let (base_register, offset) =
+                select_memory_base(*base, offset, source, *size, true, state_base_page);
+            emit_store_at(ops, source, base_register, offset, *size);
         }
         MInst::LoadPtr {
             dst,
@@ -642,8 +660,15 @@ fn emit_instruction(
             size,
             imm,
         } => {
-            let base_register = base_register(*base);
             let address_offset = base_offset(*base, *offset);
+            let (base_register, address_offset) = select_memory_base(
+                *base,
+                address_offset,
+                SCRATCH1,
+                *size,
+                false,
+                state_base_page,
+            );
             if memory_access_encoding(SCRATCH1, base_register, address_offset, *size, false)
                 .is_some()
             {
@@ -961,7 +986,7 @@ fn emit_instruction(
             true_bb,
             false_bb,
         } => {
-            emit_branch_predicate(ops, *predicate, assignment)?;
+            emit_branch_predicate(ops, *predicate, assignment, state_base_page)?;
             let true_path = ops.new_dynamic_label();
             emit_conditional_branch(ops, true_path, predicate_kind(*predicate));
             emit_edge_copies(ops, plan, block, *false_bb, spill_base, temporary_offset)?;
@@ -978,11 +1003,21 @@ fn emit_instruction(
         }
         MInst::Return => {
             if let (Some(entry), Some(success)) = (tick_entry, tick_success) {
-                dynasm!(ops
-                    ; .arch aarch64
-                    ; subs x29, x29, #1
-                    ; b.eq =>success
-                );
+                if tick_counter_in_fp {
+                    dynasm!(ops
+                        ; .arch aarch64
+                        ; fmov x16, d31
+                        ; subs x16, x16, #1
+                        ; fmov d31, x16
+                        ; b.eq =>success
+                    );
+                } else {
+                    dynasm!(ops
+                        ; .arch aarch64
+                        ; subs x29, x29, #1
+                        ; b.eq =>success
+                    );
+                }
                 if check_runtime_events {
                     emit_address(
                         ops,
@@ -1007,10 +1042,19 @@ fn emit_instruction(
         }
         MInst::ReturnError { code } => {
             if tick_entry.is_some() {
-                dynasm!(ops
-                    ; .arch aarch64
-                    ; sub x29, x29, #1
-                );
+                if tick_counter_in_fp {
+                    dynasm!(ops
+                        ; .arch aarch64
+                        ; fmov x16, d31
+                        ; sub x16, x16, #1
+                        ; fmov d31, x16
+                    );
+                } else {
+                    dynasm!(ops
+                        ; .arch aarch64
+                        ; sub x29, x29, #1
+                    );
+                }
             }
             emit_load_imm(ops, STATE_REG, *code as u64);
             dynasm!(ops ; .arch aarch64 ; b =>epilogue);
@@ -1089,12 +1133,27 @@ fn emit_instruction(
             let offset = active_bits_offset
                 .checked_add(word_offset)
                 .ok_or(EmitError::Range("sparse active bitmap offset overflow"))?;
-            emit_base_address(ops, BaseReg::SimState, offset)?;
-            emit_load(ops, SCRATCH1, SCRATCH0, OpSize::S64);
+            let offset = i64::from(offset);
+            let (base, offset) = select_memory_base(
+                BaseReg::SimState,
+                offset,
+                SCRATCH1,
+                OpSize::S64,
+                false,
+                state_base_page,
+            );
+            emit_load_at(ops, SCRATCH1, base, offset, OpSize::S64);
             emit_load_imm(ops, SCRATCH0, 1_u64 << (*active_index % 64));
             dynasm!(ops ; .arch aarch64 ; orr x30, x17, x16);
-            emit_base_address(ops, BaseReg::SimState, offset)?;
-            emit_store(ops, 30, SCRATCH0, OpSize::S64);
+            let (base, offset) = select_memory_base(
+                BaseReg::SimState,
+                i64::from(*active_bits_offset) + i64::from(word_offset),
+                30,
+                OpSize::S64,
+                true,
+                state_base_page,
+            );
+            emit_store_at(ops, 30, base, offset, OpSize::S64);
         }
         MInst::SparseCommitWorklist {
             descriptor_table,
@@ -1806,6 +1865,83 @@ fn emit_mem_fill(
     }
 }
 
+fn select_state_base_page(function: &MFunction) -> Option<i64> {
+    let mut page_counts = BTreeMap::<i64, usize>::new();
+    for block in &function.blocks {
+        for instruction in &block.insts {
+            let Some(offset) = (match instruction {
+                MInst::Load {
+                    base: BaseReg::SimState,
+                    offset,
+                    ..
+                }
+                | MInst::Store {
+                    base: BaseReg::SimState,
+                    offset,
+                    ..
+                }
+                | MInst::AndStoreImm {
+                    base: BaseReg::SimState,
+                    offset,
+                    ..
+                }
+                | MInst::OrStoreImm {
+                    base: BaseReg::SimState,
+                    offset,
+                    ..
+                } => Some(i64::from(*offset)),
+                MInst::BranchPred {
+                    predicate:
+                        BranchPredicate::MemoryNonZero {
+                            base: BaseReg::SimState,
+                            offset,
+                            ..
+                        },
+                    ..
+                } => Some(i64::from(*offset)),
+                MInst::SparseMarkActive {
+                    active_index,
+                    active_bits_offset,
+                    ..
+                } => Some(i64::from(*active_bits_offset) + i64::from(*active_index / 64) * 8),
+                _ => None,
+            }) else {
+                continue;
+            };
+            let page = offset.div_euclid(STATE_PAGE_BYTES) * STATE_PAGE_BYTES;
+            *page_counts.entry(page).or_default() += 1;
+        }
+    }
+    page_counts
+        .into_iter()
+        .filter(|(_, count)| *count >= 8)
+        .max_by_key(|(page, count)| (*count, -*page))
+        .map(|(page, _)| page)
+}
+
+fn select_memory_base(
+    base: BaseReg,
+    offset: i64,
+    register: u8,
+    size: OpSize,
+    store: bool,
+    state_base_page: Option<i64>,
+) -> (u8, i64) {
+    let normal = (base_register(base), offset);
+    if base != BaseReg::SimState {
+        return normal;
+    }
+    let Some(page) = state_base_page else {
+        return normal;
+    };
+    let relative = offset - page;
+    if memory_access_encoding(register, STATE_PAGE_REG, relative, size, store).is_some() {
+        (STATE_PAGE_REG, relative)
+    } else {
+        normal
+    }
+}
+
 fn base_register(base: BaseReg) -> u8 {
     match base {
         BaseReg::SimState => STATE_REG,
@@ -2261,6 +2397,7 @@ fn emit_branch_predicate(
     ops: &mut VecAssembler<Aarch64Relocation>,
     predicate: BranchPredicate,
     assignment: &Assignment<VReg>,
+    state_base_page: Option<i64>,
 ) -> Result<(), EmitError> {
     match predicate {
         BranchPredicate::Compare { lhs, rhs, .. } => {
@@ -2275,8 +2412,9 @@ fn emit_branch_predicate(
             }
         }
         BranchPredicate::MemoryNonZero { base, offset, size } => {
-            let base_register = base_register(base);
             let offset = base_offset(base, offset);
+            let (base_register, offset) =
+                select_memory_base(base, offset, SCRATCH0, size, false, state_base_page);
             emit_load_at(ops, SCRATCH0, base_register, offset, size);
             dynasm!(ops ; .arch aarch64 ; cmp x16, #0);
         }
@@ -2498,6 +2636,42 @@ mod tests {
         assignment.set(increment, PhysReg::RDX);
         assignment.set(result, PhysReg::RSI);
         (function, assignment)
+    }
+
+    #[test]
+    fn selects_a_state_page_base_for_repeated_accesses() {
+        let destinations = (0..8).map(crate::mir::VReg).collect::<Vec<_>>();
+        let mut insts = Vec::new();
+        for (index, dst) in destinations.into_iter().enumerate() {
+            insts.push(crate::mir::MInst::Load {
+                dst,
+                base: crate::mir::BaseReg::SimState,
+                offset: 4096 + (index as i32) * 8,
+                size: crate::mir::OpSize::S64,
+            });
+        }
+        insts.push(crate::mir::MInst::Return);
+        let function = crate::mir::MFunction::new(
+            vec![crate::mir::MBlock {
+                id: crate::mir::BlockId(0),
+                phis: Vec::new(),
+                insts,
+            }],
+            Vec::new(),
+        );
+
+        assert_eq!(select_state_base_page(&function), Some(4096));
+        assert_eq!(
+            select_memory_base(
+                crate::mir::BaseReg::SimState,
+                4112,
+                SCRATCH0,
+                crate::mir::OpSize::S64,
+                false,
+                Some(4096),
+            ),
+            (STATE_PAGE_REG, 16)
+        );
     }
 
     #[cfg(target_arch = "aarch64")]

--- a/crates/celox-backend-arm64/src/scalar.rs
+++ b/crates/celox-backend-arm64/src/scalar.rs
@@ -4080,6 +4080,64 @@ mod tests {
 
     #[cfg(target_arch = "aarch64")]
     #[test]
+    fn executes_split_address_immediates() {
+        let function = arm_mir::MFunction::new(
+            vec![arm_mir::MBlock {
+                id: arm_mir::BlockId(0),
+                phis: Vec::new(),
+                insts: vec![
+                    arm_mir::MInst::LoadImm {
+                        dst: arm_mir::VReg(0),
+                        value: 0x1234_5678_9abc_def0,
+                    },
+                    arm_mir::MInst::Store {
+                        base: arm_mir::BaseReg::SimState,
+                        offset: 0x123456,
+                        src: arm_mir::VReg(0),
+                        size: arm_mir::OpSize::S64,
+                    },
+                    arm_mir::MInst::Load {
+                        dst: arm_mir::VReg(1),
+                        base: arm_mir::BaseReg::SimState,
+                        offset: 0x123456,
+                        size: arm_mir::OpSize::S64,
+                    },
+                    arm_mir::MInst::Store {
+                        base: arm_mir::BaseReg::SimState,
+                        offset: 0x123460,
+                        src: arm_mir::VReg(1),
+                        size: arm_mir::OpSize::S64,
+                    },
+                    arm_mir::MInst::Return,
+                ],
+            }],
+            Vec::new(),
+        );
+        let mut assignment = Assignment::default();
+        assignment.set(arm_mir::VReg(0), Arm64Reg::new(9));
+        assignment.set(arm_mir::VReg(1), Arm64Reg::new(10));
+        let emitted = emit_function(
+            &function,
+            &assignment,
+            0,
+            0,
+            &EdgeCopyPlan::default(),
+            false,
+            false,
+        )
+        .unwrap();
+        let code = crate::jit_mem::JitCode::new(&emitted.code).unwrap();
+        let mut state = vec![0_u8; 0x123500];
+
+        assert_eq!(unsafe { code.call(&mut state) }, 0);
+        assert_eq!(
+            u64::from_le_bytes(state[0x123460..0x123468].try_into().unwrap()),
+            0x1234_5678_9abc_def0
+        );
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[test]
     fn executes_guarded_compare_select() {
         let (function, assignment) = guarded_select();
         let result = emit(&function, &assignment, 0).unwrap();

--- a/crates/celox-bench/Cargo.toml
+++ b/crates/celox-bench/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace     = true
 [features]
 default = []
 experimental-arm64-backend = ["celox/experimental-arm64-backend"]
+arm64-codegen = ["celox/arm64-codegen"]
 
 [dependencies]
 celox           = { path = "../celox" }

--- a/crates/celox-bench/src/bin/celox-heliodor.rs
+++ b/crates/celox-bench/src/bin/celox-heliodor.rs
@@ -30,6 +30,12 @@ struct Cli {
     four_state: bool,
     #[arg(long)]
     compile_only: bool,
+    /// Write a pointer-free native image during compile-only mode.
+    #[arg(long, value_name = "PATH")]
+    native_image_output: Option<PathBuf>,
+    /// Load a pointer-free native image instead of generating machine code.
+    #[arg(long, value_name = "PATH")]
+    native_image_input: Option<PathBuf>,
     #[arg(long, value_parser = parse_positive_u64)]
     tick_limit: Option<u64>,
     #[arg(long)]
@@ -54,6 +60,8 @@ struct Options {
     backend: Backend,
     four_state: bool,
     compile_only: bool,
+    native_image_output: Option<PathBuf>,
+    native_image_input: Option<PathBuf>,
     tick_limit: Option<u64>,
     dump_ir_dir: Option<PathBuf>,
     dump_ir_and_run: bool,
@@ -75,6 +83,8 @@ enum CeloxHeliodorError {
         #[source]
         source: celox::SimulatorError,
     },
+    #[error("native image container failed: {0}")]
+    NativeImage(#[from] celox::NativeImageContainerError),
     #[error("{message}")]
     InvalidConfiguration { message: &'static str },
     #[error("{artifact} trace was not captured")]
@@ -140,13 +150,15 @@ fn run() -> Result<(), CeloxHeliodorError> {
         backend: cli.backend,
         four_state: cli.four_state,
         compile_only: cli.compile_only,
+        native_image_output: cli.native_image_output,
+        native_image_input: cli.native_image_input,
         tick_limit: cli.tick_limit,
         dump_ir_dir: cli.dump_ir_dir,
         dump_ir_and_run: cli.dump_ir_and_run,
         native_profile_blocks: cli.native_profile_blocks,
         pass_overrides: cli.pass_overrides,
         native_memory_width: cli.native_memory_width.unwrap_or({
-            if cfg!(target_arch = "x86_64") {
+            if cfg!(all(target_arch = "x86_64", not(feature = "arm64-codegen"))) {
                 128
             } else {
                 64
@@ -155,8 +167,38 @@ fn run() -> Result<(), CeloxHeliodorError> {
         x86_slp: cli
             .x86_slp
             .map(|value| matches!(value, OnOff::On))
-            .unwrap_or(cfg!(target_arch = "x86_64")),
+            .unwrap_or(cfg!(all(
+                target_arch = "x86_64",
+                not(feature = "arm64-codegen")
+            ))),
     };
+    if opts.native_image_output.is_some() && !opts.compile_only {
+        return Err(CeloxHeliodorError::InvalidConfiguration {
+            message: "--native-image-output requires --compile-only",
+        });
+    }
+    if opts.native_image_input.is_some() && opts.compile_only {
+        return Err(CeloxHeliodorError::InvalidConfiguration {
+            message: "--native-image-input cannot be used with --compile-only",
+        });
+    }
+    if opts.native_image_input.is_some() && opts.native_image_output.is_some() {
+        return Err(CeloxHeliodorError::InvalidConfiguration {
+            message: "--native-image-input and --native-image-output are mutually exclusive",
+        });
+    }
+    if (opts.native_image_input.is_some() || opts.native_image_output.is_some())
+        && matches!(opts.backend, Backend::Cranelift)
+    {
+        return Err(CeloxHeliodorError::InvalidConfiguration {
+            message: "native image options require --backend native",
+        });
+    }
+    if opts.native_image_input.is_some() && opts.dump_ir_dir.is_some() {
+        return Err(CeloxHeliodorError::InvalidConfiguration {
+            message: "--native-image-input cannot be combined with --dump-ir-dir",
+        });
+    }
     if !opts.native_profile_blocks.is_empty() && opts.dump_ir_dir.is_none() {
         return Err(CeloxHeliodorError::InvalidConfiguration {
             message: "--native-profile-block requires --dump-ir-dir",
@@ -169,6 +211,7 @@ fn run() -> Result<(), CeloxHeliodorError> {
     }
     #[cfg(not(any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     )))]
     if matches!(opts.backend, Backend::Native) {
@@ -176,7 +219,23 @@ fn run() -> Result<(), CeloxHeliodorError> {
             message: "the custom native backend is unavailable; enable experimental-arm64-backend on AArch64",
         });
     }
-    let (sources, metadata) = load_sources(&opts.project, &opts.source_files)?;
+    let mut native_image = match &opts.native_image_input {
+        Some(path) => Some(celox::NativeProgramImage::from_container_bytes(&fs::read(
+            path,
+        )?)?),
+        None => None,
+    };
+    let (sources, metadata): (Vec<(String, PathBuf)>, Option<Metadata>) = if native_image.is_some()
+    {
+        // The image contains the target-specific machine code and all
+        // source-independent runtime/testbench metadata needed to execute
+        // it. The execution side therefore does not need the project
+        // sources at all.
+        (Vec::new(), None)
+    } else {
+        let (sources, metadata) = load_sources(&opts.project, &opts.source_files)?;
+        (sources, Some(metadata))
+    };
     let source_refs: Vec<(&str, &Path)> = sources
         .iter()
         .map(|(source, path)| (source.as_str(), path.as_path()))
@@ -193,8 +252,11 @@ fn run() -> Result<(), CeloxHeliodorError> {
     let total_start = Instant::now();
     let optimize_options =
         OptimizeOptions::new(opts.opt_level).with_max_native_memory_width(opts.native_memory_width);
-    let mut builder = Simulator::from_sources(source_refs, &opts.test)
-        .with_metadata(metadata)
+    let mut builder = Simulator::from_sources(source_refs, &opts.test);
+    if let Some(metadata) = metadata {
+        builder = builder.with_metadata(metadata);
+    }
+    let mut builder = builder
         .opt_level(opts.opt_level)
         .optimize_options(optimize_options)
         .x86_slp(opts.x86_slp)
@@ -321,6 +383,7 @@ fn run() -> Result<(), CeloxHeliodorError> {
                 compile_initial_testbench(&sim).ok_or(CeloxHeliodorError::MissingInitialBlock)?;
             #[cfg(any(
                 target_arch = "x86_64",
+                feature = "arm64-codegen",
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             ))]
             sim.start_native_execution_timing();
@@ -334,6 +397,7 @@ fn run() -> Result<(), CeloxHeliodorError> {
             };
             #[cfg(any(
                 target_arch = "x86_64",
+                feature = "arm64-codegen",
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             ))]
             let jit_execute_elapsed = sim
@@ -342,6 +406,7 @@ fn run() -> Result<(), CeloxHeliodorError> {
                 .elapsed();
             #[cfg(not(any(
                 target_arch = "x86_64",
+                feature = "arm64-codegen",
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             )))]
             let jit_execute_elapsed = Duration::ZERO;
@@ -402,13 +467,29 @@ fn run() -> Result<(), CeloxHeliodorError> {
         match opts.backend {
             #[cfg(any(
                 target_arch = "x86_64",
+                feature = "arm64-codegen",
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             ))]
             Backend::Native => {
-                let _compiled = builder.compile_native()?;
+                let compiled = builder.compile_native()?;
+                if let Some(output_path) = &opts.native_image_output {
+                    if let Some(parent) = output_path
+                        .parent()
+                        .filter(|path| !path.as_os_str().is_empty())
+                    {
+                        fs::create_dir_all(parent)?;
+                    }
+                    compiled.write_image(output_path)?;
+                    println!(
+                        "CELOX_NATIVE_IMAGE test={} mode=generated path={}",
+                        opts.test,
+                        output_path.display()
+                    );
+                }
             }
             #[cfg(not(any(
                 target_arch = "x86_64",
+                feature = "arm64-codegen",
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             )))]
             Backend::Native => unreachable!("native backend availability checked above"),
@@ -445,10 +526,23 @@ fn run() -> Result<(), CeloxHeliodorError> {
     ) = match opts.backend {
         #[cfg(any(
             target_arch = "x86_64",
+            feature = "arm64-codegen",
             all(target_arch = "aarch64", feature = "experimental-arm64-backend")
         ))]
         Backend::Native => {
-            let mut sim = builder.build_native()?;
+            let mut sim = if let Some(image_path) = &opts.native_image_input {
+                let image = native_image
+                    .take()
+                    .expect("native image was loaded before builder construction");
+                println!(
+                    "CELOX_NATIVE_IMAGE test={} mode=loaded path={}",
+                    opts.test,
+                    image_path.display()
+                );
+                builder.build_native_from_image(image)?
+            } else {
+                builder.build_native()?
+            };
             let testbench =
                 compile_initial_testbench(&sim).ok_or(CeloxHeliodorError::MissingInitialBlock)?;
             let compile_elapsed = compile_start.elapsed();
@@ -479,6 +573,7 @@ fn run() -> Result<(), CeloxHeliodorError> {
         }
         #[cfg(not(any(
             target_arch = "x86_64",
+            feature = "arm64-codegen",
             all(target_arch = "aarch64", feature = "experimental-arm64-backend")
         )))]
         Backend::Native => unreachable!("native backend availability checked above"),

--- a/crates/celox-bench/src/bin/celox-heliodor.rs
+++ b/crates/celox-bench/src/bin/celox-heliodor.rs
@@ -214,6 +214,12 @@ fn run() -> Result<(), CeloxHeliodorError> {
             message: "--dump-ir-and-run requires --dump-ir-dir",
         });
     }
+    #[cfg(all(target_arch = "x86_64", feature = "arm64-codegen"))]
+    if opts.dump_ir_dir.is_some() {
+        return Err(CeloxHeliodorError::InvalidConfiguration {
+            message: "--dump-ir-dir is unavailable when generating AArch64 code on x86-64",
+        });
+    }
     #[cfg(not(any(
         target_arch = "x86_64",
         feature = "arm64-codegen",
@@ -398,9 +404,8 @@ fn run() -> Result<(), CeloxHeliodorError> {
             let testbench =
                 compile_initial_testbench(&sim).ok_or(CeloxHeliodorError::MissingInitialBlock)?;
             #[cfg(any(
-                target_arch = "x86_64",
-                feature = "arm64-codegen",
-                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", feature = "arm64-codegen")
             ))]
             sim.start_native_execution_timing();
             let execute_cpu_start = process_cpu_time();
@@ -412,18 +417,16 @@ fn run() -> Result<(), CeloxHeliodorError> {
                 (run_compiled_testbench(&mut sim, &testbench), 0, false)
             };
             #[cfg(any(
-                target_arch = "x86_64",
-                feature = "arm64-codegen",
-                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", feature = "arm64-codegen")
             ))]
             let jit_execute_elapsed = sim
                 .finish_native_execution_timing()
                 .expect("native execution timing was started")
                 .elapsed();
             #[cfg(not(any(
-                target_arch = "x86_64",
-                feature = "arm64-codegen",
-                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", feature = "arm64-codegen")
             )))]
             let jit_execute_elapsed = Duration::ZERO;
             let execute_elapsed = execute_start.elapsed();

--- a/crates/celox-bench/src/bin/celox-heliodor.rs
+++ b/crates/celox-bench/src/bin/celox-heliodor.rs
@@ -83,6 +83,11 @@ enum CeloxHeliodorError {
         #[source]
         source: celox::SimulatorError,
     },
+    #[cfg(any(
+        target_arch = "x86_64",
+        feature = "arm64-codegen",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    ))]
     #[error("native image container failed: {0}")]
     NativeImage(#[from] celox::NativeImageContainerError),
     #[error("{message}")]
@@ -219,12 +224,23 @@ fn run() -> Result<(), CeloxHeliodorError> {
             message: "the custom native backend is unavailable; enable experimental-arm64-backend on AArch64",
         });
     }
+    #[cfg(any(
+        target_arch = "x86_64",
+        feature = "arm64-codegen",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    ))]
     let mut native_image = match &opts.native_image_input {
         Some(path) => Some(celox::NativeProgramImage::from_container_bytes(&fs::read(
             path,
         )?)?),
         None => None,
     };
+    #[cfg(not(any(
+        target_arch = "x86_64",
+        feature = "arm64-codegen",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    )))]
+    let native_image: Option<()> = None;
     let (sources, metadata): (Vec<(String, PathBuf)>, Option<Metadata>) = if native_image.is_some()
     {
         // The image contains the target-specific machine code and all

--- a/crates/celox-design/src/lib.rs
+++ b/crates/celox-design/src/lib.rs
@@ -36,7 +36,7 @@ pub enum PortTypeKind {
 ///
 /// Source IDs, source paths, and declaration syntax belong to the frontend and
 /// deliberately are not part of this type.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VariableMetadata {
     pub width: usize,
     pub is_4state: bool,

--- a/crates/celox-frontend-core/Cargo.toml
+++ b/crates/celox-frontend-core/Cargo.toml
@@ -14,6 +14,7 @@ celox-slt = { path = "../celox-slt" }
 fxhash = { workspace = true }
 miette = { workspace = true }
 num-bigint = { workspace = true }
+serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/celox-frontend-core/src/shared/lookup.rs
+++ b/crates/celox-frontend-core/src/shared/lookup.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use celox_design::{AbsoluteAddrBase, InstanceId, ModuleId, StateAddr, VariableMetadata};
+use serde::{Deserialize, Serialize};
 
 use crate::{HashMap, HashSet};
 
@@ -11,7 +12,9 @@ pub type SourceAddr = AbsoluteAddrBase<SourceVarId>;
 /// This is deliberately distinct from every parser or analyzer's variable ID.
 /// A frontend projects its native IDs into this namespace before constructing
 /// source lookup metadata retained by the runtime.
-#[derive(Debug, Clone, Copy, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, Default, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
 pub struct SourceVarId(pub u32);
 
 impl fmt::Display for SourceVarId {
@@ -21,7 +24,7 @@ impl fmt::Display for SourceVarId {
 }
 
 /// Source-language-independent role of a frontend variable.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum VariableKind {
     Parameter,
     Constant,
@@ -50,7 +53,7 @@ impl VariableKind {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct VariableInfo {
     pub id: SourceVarId,
     pub path: Vec<String>,
@@ -86,13 +89,13 @@ impl fmt::Debug for VariableInfo {
     }
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InstancePath(pub Vec<(String, usize)>);
 
 /// Source-language-independent lookup retained for diagnostics and public paths.
 /// Parser-native IDs are projected into [`SourceVarId`] before this artifact is
 /// built and do not cross into runtime metadata.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub struct FrontendLookup {
     pub instance_ids: HashMap<InstancePath, InstanceId>,
     pub instance_module: HashMap<InstanceId, ModuleId>,

--- a/crates/celox-testbench/Cargo.toml
+++ b/crates/celox-testbench/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace     = true
 [dependencies]
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
+serde = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/celox-testbench/src/lib.rs
+++ b/crates/celox-testbench/src/lib.rs
@@ -5,6 +5,7 @@
 //! part of the bytecode representation.
 
 use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 mod format;
@@ -12,13 +13,13 @@ mod vm;
 pub use format::{DisplayFormatArg, format_display_arg};
 pub use vm::{CompiledExpr, TestbenchValue};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StateLocation<A> {
     pub address: A,
     pub byte_offset: usize,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TestbenchOperator {
     Add,
     Sub,
@@ -50,14 +51,14 @@ pub enum TestbenchOperator {
     BitNot,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SourceLocation {
     pub file: String,
     pub line: u32,
     pub column: u32,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AssertMessage<Argument> {
     Formatted {
         template: String,
@@ -66,13 +67,13 @@ pub enum AssertMessage<Argument> {
     DynamicArgs(Vec<Argument>),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ClockCount<Expression> {
     Static(u64),
     Dynamic(Expression),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LoopBound<Expression> {
     Static(usize),
     Dynamic {
@@ -82,13 +83,13 @@ pub enum LoopBound<Expression> {
     },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ComponentParameterValue {
     Bits { words: Vec<u64>, width: u32 },
     String(String),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ComponentConnection {
     pub port: String,
     pub group: Option<String>,
@@ -100,7 +101,7 @@ pub struct ComponentConnection {
     pub width: u32,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TestbenchComponent {
     pub instance: String,
     pub component: String,
@@ -110,14 +111,14 @@ pub struct TestbenchComponent {
     pub source: Option<SourceLocation>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ComponentLibrary {
     pub export: String,
     pub type_name: String,
     pub path: PathBuf,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ComponentConnectionBinding<Event, Signal, Expression> {
     pub port: String,
     pub input: Option<Expression>,
@@ -130,7 +131,7 @@ pub struct ComponentConnectionBinding<Event, Signal, Expression> {
     pub event: Option<Event>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ComponentBinding<Event, Signal, Expression> {
     pub instance: String,
     pub connections: Vec<ComponentConnectionBinding<Event, Signal, Expression>>,
@@ -141,7 +142,7 @@ pub struct ComponentBinding<Event, Signal, Expression> {
 /// Frontends instantiate this with semantic state/event identities and
 /// unbound expressions. Runtime binding instantiates the same contract with
 /// backend event/signal handles and executable expressions.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TestbenchStatement<Event, Signal, Expression, Argument, Target = Signal> {
     ClockNext {
         clock_event: Event,
@@ -220,26 +221,26 @@ pub enum TestbenchStatement<Event, Signal, Expression, Argument, Target = Signal
     Finish,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SemanticSignal<A> {
     pub address: A,
     pub width: usize,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TestbenchSelection<Expression> {
     pub offset: Expression,
     pub width: usize,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TestbenchTarget<Signal, Expression> {
     pub signal: Signal,
     pub selection: Option<TestbenchSelection<Expression>>,
     pub width: usize,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SemanticArgument<A> {
     pub expr: ExprBytecode<StateLocation<A>>,
     pub width: usize,
@@ -257,7 +258,7 @@ pub type SemanticStatement<A> = TestbenchStatement<
 pub type SemanticComponentBinding<A> =
     ComponentBinding<A, SemanticSignal<A>, ExprBytecode<StateLocation<A>>>;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TestbenchProgram<A> {
     statements: Vec<SemanticStatement<A>>,
     random_seed: Option<u64>,
@@ -356,7 +357,7 @@ impl<A> TestbenchProgram<A> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ExprOpcode<L = usize> {
     ConstU64(u64),
     ConstWide(BigUint),
@@ -414,7 +415,7 @@ pub enum ExprOpcode<L = usize> {
     },
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExprBytecode<L = usize> {
     ops: Vec<ExprOpcode<L>>,
 }

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -21,7 +21,8 @@ host-runtime = [
     "celox-sir-opt/timing",
 ]
 systemverilog = ["dep:celox-frontend-sv"]
-experimental-arm64-backend = ["host-runtime", "dep:celox-backend-arm64"]
+arm64-codegen = ["host-runtime", "dep:celox-backend-arm64"]
+experimental-arm64-backend = ["arm64-codegen"]
 
 [dependencies]
 toml                  = { workspace = true }
@@ -59,6 +60,7 @@ itertools             = { workspace = true }
 tracing               = { workspace = true }
 celox-macros          = { path = "../celox-macros", optional = true }
 celox-backend-cranelift = { path = "../celox-backend-cranelift", optional = true }
+celox-backend-arm64 = { path = "../celox-backend-arm64", optional = true }
 wasmtime              = { version = "47", optional = true }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
@@ -66,9 +68,6 @@ celox-backend-x86     = { path = "../celox-backend-x86", optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 celox-sir-opt         = { path = "../celox-sir-opt", default-features = false, features = ["wide-native-memory"] }
-
-[target.'cfg(target_arch = "aarch64")'.dependencies]
-celox-backend-arm64   = { path = "../celox-backend-arm64", optional = true }
 
 [dev-dependencies]
 insta      = "1.46"

--- a/crates/celox/src/backend.rs
+++ b/crates/celox/src/backend.rs
@@ -3,6 +3,7 @@ pub(crate) mod memory_layout;
     feature = "host-runtime",
     any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     )
 ))]
@@ -29,6 +30,7 @@ mod host {
 
     #[cfg(any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     ))]
     pub use celox_backend_x86::{NativeDiagnostics, NativeDumpOptions, X86BackendOptions};

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -7,6 +7,7 @@ use crate::ir::{
     feature = "host-runtime",
     any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     )
 ))]

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -1924,14 +1924,27 @@ impl NativeBackend {
         Ok(image)
     }
 
+    /// Load a compiler-produced image into executable memory and create a
+    /// backend instance for it.
+    ///
+    /// # Safety
+    ///
+    /// The image's machine code must come from a trusted compiler or image
+    /// container. Structural validation does not authenticate code before it
+    /// is mapped executable and invoked.
+    pub unsafe fn from_image(image: NativeProgramImage) -> Result<Self, SimulatorError> {
+        // Safety: upheld by this constructor's caller.
+        let shared = Arc::new(unsafe { SharedNativeCode::from_image(image)? });
+        Ok(Self::from_shared(shared))
+    }
+
     pub fn new(
         laid_out: &LaidOutProgram,
         options: &SimulatorOptions,
     ) -> Result<Self, SimulatorError> {
         let image = Self::compile_image(laid_out, options)?;
         // Safety: `image` was produced in-process by the Celox compiler above.
-        let shared = Arc::new(unsafe { SharedNativeCode::from_image(image)? });
-        Ok(Self::from_shared(shared))
+        unsafe { Self::from_image(image) }
     }
 
     pub(crate) fn new_with_codegen_trace(

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -9,11 +9,12 @@ use std::time::{Duration, Instant};
 
 use bit_set::BitSet;
 use celox_design::{
-    InitialStateData, InitialStateValue, InitialStateWriteRun, RuntimeCombObserver,
-    RuntimeErrorInfo, RuntimeEventSite,
+    ElaboratedDesign, EventTopology, InitialStateData, InitialStateValue, InitialStateWriteRun,
+    RuntimeCombObserver, RuntimeErrorInfo, RuntimeEventSite, RuntimeSchema,
 };
 use celox_runtime::DesignReflection;
 use celox_runtime::backend::SimBackend;
+use celox_testbench::TestbenchProgram;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
@@ -40,11 +41,11 @@ const KNOWN_NATIVE_FEATURES: u8 = NATIVE_FEATURE_BMI2
     | NATIVE_FEATURE_POPCNT;
 
 fn current_native_feature_bits() -> u8 {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", not(feature = "arm64-codegen")))]
     {
         celox_backend_x86::native::features::detected_image_feature_bits()
     }
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(feature = "arm64-codegen", target_arch = "aarch64"))]
     {
         0
     }
@@ -75,9 +76,9 @@ fn format_native_feature_bits(bits: u8) -> String {
 // ────────────────────────────────────────────────────────────────
 
 /// JIT function type: `fn(state: *mut u8) -> i64`
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", not(feature = "arm64-codegen")))]
 pub type NativeSimFunc = unsafe extern "sysv64" fn(*mut u8) -> i64;
-#[cfg(all(target_arch = "aarch64", feature = "experimental-arm64-backend"))]
+#[cfg(any(feature = "arm64-codegen", target_arch = "aarch64"))]
 pub type NativeSimFunc = unsafe extern "C" fn(*mut u8) -> i64;
 
 /// Time spent inside generated native simulator functions.
@@ -314,11 +315,16 @@ pub(crate) struct NativeRuntimeSchema {
     pub(crate) runtime_errors: HashMap<i64, RuntimeErrorInfo<AbsoluteAddr>>,
     pub(crate) runtime_event_sites: Vec<RuntimeEventSite>,
     pub(crate) comb_observers: Vec<RuntimeCombObserver<AbsoluteAddr>>,
+    pub(crate) testbench_read_roots: HashSet<AbsoluteAddr>,
+    pub(crate) rtl_writes: HashSet<celox_design::VarAtomBase<AbsoluteAddr>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct NativeEventTopology {
     aliases: HashMap<AbsoluteAddr, AbsoluteAddr>,
+    ordered_events: Vec<AbsoluteAddr>,
+    cascaded_events: std::collections::BTreeSet<AbsoluteAddr>,
+    reset_clocks: HashMap<AbsoluteAddr, AbsoluteAddr>,
 }
 
 impl NativeEventTopology {
@@ -344,6 +350,7 @@ pub struct NativeProgramImage {
     id_to_event: Vec<NativeEventImageRef>,
     reflection: DesignReflection,
     initial_state: Vec<InitialStateValue<AbsoluteAddr>>,
+    testbench: Option<TestbenchProgram<AbsoluteAddr>>,
     runtime_schema: NativeRuntimeSchema,
     event_topology: NativeEventTopology,
     layout: MemoryLayout,
@@ -381,6 +388,33 @@ impl NativeProgramImage {
     /// Canonical event-domain topology used by the runtime scheduler.
     pub(crate) fn event_topology(&self) -> &NativeEventTopology {
         &self.event_topology
+    }
+
+    /// Reconstruct the source-independent runtime metadata retained by this
+    /// image. No frontend parsing or SIR/layout work is needed on the
+    /// execution side of a host-codegen workflow.
+    pub(crate) fn runtime_program(&self) -> crate::ir::RuntimeProgram {
+        crate::ir::RuntimeProgram {
+            design: ElaboratedDesign {
+                state_objects: HashMap::default(),
+                events: EventTopology {
+                    aliases: self.event_topology.aliases.clone(),
+                    ordered_events: self.event_topology.ordered_events.clone(),
+                    cascaded_events: self.event_topology.cascaded_events.clone(),
+                    reset_clocks: self.event_topology.reset_clocks.clone(),
+                },
+                initial_state: self.initial_state.clone(),
+            },
+            frontend: crate::ir::FrontendLookup::default(),
+            runtime_schema: RuntimeSchema {
+                runtime_errors: self.runtime_schema.runtime_errors.clone(),
+                runtime_event_sites: self.runtime_schema.runtime_event_sites.clone(),
+                comb_observers: self.runtime_schema.comb_observers.clone(),
+                testbench_read_roots: self.runtime_schema.testbench_read_roots.clone(),
+                rtl_writes: self.runtime_schema.rtl_writes.clone(),
+            },
+            testbench: self.testbench.clone(),
+        }
     }
 
     pub(super) fn validate(&self) -> Result<(), String> {
@@ -657,9 +691,9 @@ fn compile_unit_refs(
             symbols,
             trace,
             required_state_size: empty_result.required_state_size as usize,
-            #[cfg(target_arch = "x86_64")]
+            #[cfg(all(target_arch = "x86_64", not(feature = "arm64-codegen")))]
             required_native_features: empty_result.required_image_features,
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(any(feature = "arm64-codegen", target_arch = "aarch64"))]
             required_native_features: 0,
         });
     }
@@ -697,9 +731,9 @@ fn compile_unit_refs(
         symbols,
         trace,
         required_state_size,
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", not(feature = "arm64-codegen")))]
         required_native_features: emit_result.required_image_features,
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(feature = "arm64-codegen", target_arch = "aarch64"))]
         required_native_features: 0,
     })
 }
@@ -1791,13 +1825,19 @@ fn compile_program(
             id_to_event,
             reflection: sir.runtime().build_design_reflection(layout),
             initial_state: sir.runtime().design.initial_state.clone(),
+            testbench: sir.runtime().testbench.clone(),
             runtime_schema: NativeRuntimeSchema {
                 runtime_errors: sir.runtime().runtime_schema.runtime_errors.clone(),
                 runtime_event_sites: sir.runtime().runtime_schema.runtime_event_sites.clone(),
                 comb_observers: sir.runtime().runtime_schema.comb_observers.clone(),
+                testbench_read_roots: sir.runtime().runtime_schema.testbench_read_roots.clone(),
+                rtl_writes: sir.runtime().runtime_schema.rtl_writes.clone(),
             },
             event_topology: NativeEventTopology {
                 aliases: sir.runtime().design.events.aliases.clone(),
+                ordered_events: sir.runtime().design.events.ordered_events.clone(),
+                cascaded_events: sir.runtime().design.events.cascaded_events.clone(),
+                reset_clocks: sir.runtime().design.events.reset_clocks.clone(),
             },
             layout: layout.clone(),
             native_memory_size,

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -386,6 +386,11 @@ impl NativeProgramImage {
         &self.runtime_schema
     }
 
+    /// Whether the image's generated code and state layout use four-state data.
+    pub(crate) fn four_state(&self) -> bool {
+        self.options.four_state
+    }
+
     /// Canonical event-domain topology used by the runtime scheduler.
     pub(crate) fn event_topology(&self) -> &NativeEventTopology {
         &self.event_topology

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -349,6 +349,7 @@ pub struct NativeProgramImage {
     id_to_addr: Vec<AbsoluteAddr>,
     id_to_event: Vec<NativeEventImageRef>,
     reflection: DesignReflection,
+    frontend: crate::ir::FrontendLookup,
     initial_state: Vec<InitialStateValue<AbsoluteAddr>>,
     testbench: Option<TestbenchProgram<AbsoluteAddr>>,
     runtime_schema: NativeRuntimeSchema,
@@ -405,7 +406,7 @@ impl NativeProgramImage {
                 },
                 initial_state: self.initial_state.clone(),
             },
-            frontend: crate::ir::FrontendLookup::default(),
+            frontend: self.frontend.clone(),
             runtime_schema: RuntimeSchema {
                 runtime_errors: self.runtime_schema.runtime_errors.clone(),
                 runtime_event_sites: self.runtime_schema.runtime_event_sites.clone(),
@@ -527,6 +528,10 @@ struct CompiledNativeFunction {
     required_native_features: u8,
 }
 
+#[cfg_attr(
+    all(feature = "arm64-codegen", not(target_arch = "aarch64")),
+    allow(dead_code)
+)]
 pub(crate) struct NativeCodegenTrace {
     pub optimized_sir: String,
     pub mir: String,
@@ -1824,6 +1829,7 @@ fn compile_program(
             id_to_addr,
             id_to_event,
             reflection: sir.runtime().build_design_reflection(layout),
+            frontend: sir.runtime().frontend.clone(),
             initial_state: sir.runtime().design.initial_state.clone(),
             testbench: sir.runtime().testbench.clone(),
             runtime_schema: NativeRuntimeSchema {
@@ -1987,6 +1993,10 @@ impl NativeBackend {
         unsafe { Self::from_image(image) }
     }
 
+    #[cfg(any(
+        all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+        all(target_arch = "aarch64", feature = "arm64-codegen")
+    ))]
     pub(crate) fn new_with_codegen_trace(
         laid_out: &LaidOutProgram,
         options: &SimulatorOptions,

--- a/crates/celox/src/backend/native/image_file.rs
+++ b/crates/celox/src/backend/native/image_file.rs
@@ -6,7 +6,7 @@ use std::{fmt, path::Path};
 use super::backend::NativeProgramImage;
 
 const TRAILER_MAGIC: &[u8; 8] = b"CELOXNPI";
-const CONTAINER_VERSION: u16 = 1;
+const CONTAINER_VERSION: u16 = 2;
 const TRAILER_SIZE: usize = 32;
 const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
 const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
@@ -20,12 +20,12 @@ pub enum NativeImageArchitecture {
 }
 
 impl NativeImageArchitecture {
-    fn current() -> Self {
-        #[cfg(target_arch = "x86_64")]
+    pub fn current() -> Self {
+        #[cfg(all(target_arch = "x86_64", not(feature = "arm64-codegen")))]
         {
             Self::X86_64
         }
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(any(feature = "arm64-codegen", target_arch = "aarch64"))]
         {
             Self::Aarch64
         }

--- a/crates/celox/src/backend/native/image_file.rs
+++ b/crates/celox/src/backend/native/image_file.rs
@@ -95,6 +95,15 @@ impl NativeProgramImage {
         self.append_to_runtime(&[])
     }
 
+    /// Write this image as a standalone versioned binary container.
+    pub fn write_container(
+        &self,
+        output_path: impl AsRef<Path>,
+    ) -> Result<(), NativeImageContainerError> {
+        std::fs::write(output_path, self.to_container_bytes()?)?;
+        Ok(())
+    }
+
     /// Append this image to an existing precompiled runtime byte sequence.
     ///
     /// The runtime bytes are copied verbatim. A fixed-size trailer at EOF lets

--- a/crates/celox/src/backend/native/image_file.rs
+++ b/crates/celox/src/backend/native/image_file.rs
@@ -6,7 +6,7 @@ use std::{fmt, path::Path};
 use super::backend::NativeProgramImage;
 
 const TRAILER_MAGIC: &[u8; 8] = b"CELOXNPI";
-const CONTAINER_VERSION: u16 = 2;
+const CONTAINER_VERSION: u16 = 3;
 const TRAILER_SIZE: usize = 32;
 const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
 const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;

--- a/crates/celox/src/backend/native/mod.rs
+++ b/crates/celox/src/backend/native/mod.rs
@@ -4,7 +4,7 @@ mod runtime_image;
 pub use backend::{
     NativeBackend, NativeCodeEntry, NativeExecutionTiming, NativeProgramImage, SharedNativeCode,
 };
-#[cfg(all(target_arch = "aarch64", feature = "experimental-arm64-backend"))]
+#[cfg(feature = "arm64-codegen")]
 pub use celox_backend_arm64::{jit_mem, scalar as emit};
 pub use celox_backend_x86::native::*;
 pub use image_file::{AppendedNativeImage, NativeImageArchitecture, NativeImageContainerError};

--- a/crates/celox/src/diagnostics.rs
+++ b/crates/celox/src/diagnostics.rs
@@ -25,11 +25,13 @@ mod host {
         pub cranelift: crate::backend::CraneliftDiagnostics,
         #[cfg(any(
             target_arch = "x86_64",
+            feature = "arm64-codegen",
             all(target_arch = "aarch64", feature = "experimental-arm64-backend")
         ))]
         pub native: crate::backend::NativeDiagnostics,
         #[cfg(any(
             target_arch = "x86_64",
+            feature = "arm64-codegen",
             all(target_arch = "aarch64", feature = "experimental-arm64-backend")
         ))]
         pub native_tick_loop: Option<bool>,
@@ -99,6 +101,7 @@ mod host {
             let cranelift = crate::backend::CraneliftDiagnostics { pass_timing };
             #[cfg(any(
                 target_arch = "x86_64",
+                feature = "arm64-codegen",
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             ))]
             let (native, native_tick_loop) = {
@@ -147,11 +150,13 @@ mod host {
                 cranelift,
                 #[cfg(any(
                     target_arch = "x86_64",
+                    feature = "arm64-codegen",
                     all(target_arch = "aarch64", feature = "experimental-arm64-backend")
                 ))]
                 native,
                 #[cfg(any(
                     target_arch = "x86_64",
+                    feature = "arm64-codegen",
                     all(target_arch = "aarch64", feature = "experimental-arm64-backend")
                 ))]
                 native_tick_loop,
@@ -176,6 +181,7 @@ mod host {
             assert_eq!(options.runtime.tick_timing_every, Some(100));
             #[cfg(any(
                 target_arch = "x86_64",
+                feature = "arm64-codegen",
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             ))]
             assert!(options.native.verify_regalloc);

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -18,6 +18,7 @@ pub use celox_frontend_core::shared::{
     feature = "host-runtime",
     any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     )
 ))]
@@ -143,6 +144,7 @@ impl OptimizedSir {
         feature = "host-runtime",
         any(
             target_arch = "x86_64",
+            feature = "arm64-codegen",
             all(target_arch = "aarch64", feature = "experimental-arm64-backend")
         )
     ))]
@@ -334,6 +336,7 @@ impl RuntimeProgram {
         feature = "host-runtime",
         any(
             target_arch = "x86_64",
+            feature = "arm64-codegen",
             all(target_arch = "aarch64", feature = "experimental-arm64-backend")
         )
     ))]
@@ -749,6 +752,7 @@ pub use celox_frontend_core::TraceSimModule as SimModule;
     feature = "host-runtime",
     any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     )
 ))]

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -130,18 +130,16 @@ mod host_api {
     ))]
     pub use crate::backend::{NativeDiagnostics, NativeDumpOptions};
 
-    /// Default simulation backend: custom native on x86-64 and opt-in AArch64,
-    /// Cranelift elsewhere.
+    /// Default simulation backend: custom native on a matching host, and
+    /// Cranelift when `arm64-codegen` is used for cross-compilation.
     #[cfg(any(
-        target_arch = "x86_64",
-        feature = "arm64-codegen",
-        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+        all(target_arch = "aarch64", feature = "arm64-codegen")
     ))]
     pub type DefaultBackend = NativeBackend;
     #[cfg(not(any(
-        target_arch = "x86_64",
-        feature = "arm64-codegen",
-        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+        all(target_arch = "aarch64", feature = "arm64-codegen")
     )))]
     pub type DefaultBackend = JitBackend;
 

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -62,6 +62,7 @@ mod host_api {
     pub use crate::simulation::Simulation;
     #[cfg(any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     ))]
     pub use crate::simulator::NativeCompilation;
@@ -98,6 +99,7 @@ mod host_api {
 
     #[cfg(any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     ))]
     pub mod native_backend {
@@ -107,11 +109,13 @@ mod host_api {
 
     #[cfg(any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     ))]
     pub use crate::backend::native::backend::NativeEventRef;
     #[cfg(any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     ))]
     pub use crate::backend::native::{
@@ -121,6 +125,7 @@ mod host_api {
     };
     #[cfg(any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     ))]
     pub use crate::backend::{NativeDiagnostics, NativeDumpOptions};
@@ -129,11 +134,13 @@ mod host_api {
     /// Cranelift elsewhere.
     #[cfg(any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     ))]
     pub type DefaultBackend = NativeBackend;
     #[cfg(not(any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     )))]
     pub type DefaultBackend = JitBackend;

--- a/crates/celox/src/optimizer/sir.rs
+++ b/crates/celox/src/optimizer/sir.rs
@@ -2,6 +2,7 @@
     feature = "host-runtime",
     any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     )
 ))]
@@ -14,6 +15,7 @@ use crate::ir::{AbsoluteAddr, OptimizedSir};
     feature = "host-runtime",
     any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     )
 ))]
@@ -25,6 +27,7 @@ use crate::ir::{
     feature = "host-runtime",
     any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     )
 ))]
@@ -37,6 +40,7 @@ pub(crate) use celox_sir_opt::optimizer::{
     feature = "host-runtime",
     any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     )
 ))]
@@ -79,6 +83,7 @@ pub(crate) fn optimize_rooted_comb_memory(
     feature = "host-runtime",
     any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     )
 ))]
@@ -124,6 +129,7 @@ pub(crate) fn optimize_native_merged_chain(
     feature = "host-runtime",
     any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     )
 ))]

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -5,6 +5,7 @@ mod error;
     feature = "host-runtime",
     any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     )
 ))]
@@ -26,6 +27,7 @@ mod host {
     use crate::backend::RuntimeEventBuffer;
     #[cfg(any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     ))]
     use crate::backend::native::{NativeBackend, SharedNativeCode};
@@ -484,6 +486,7 @@ mod host {
 
     #[cfg(any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     ))]
     pub(crate) fn runtime_event_write_seq_for_backend<B: SimBackend>(backend: &B) -> u64 {
@@ -501,6 +504,7 @@ mod host {
 
     #[cfg(any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     ))]
     pub(crate) fn collect_runtime_events_for_backend<B: SimBackend>(
@@ -1514,6 +1518,7 @@ mod host {
 
     #[cfg(any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     ))]
     impl Simulator<NativeBackend> {

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -74,7 +74,8 @@ mod host {
     /// and an optional VCD writer. Provides low-level, event-driven control.
     ///
     /// The default type parameter `B = DefaultBackend` means that bare `Simulator`
-    /// uses the custom native backend on x86-64 and opt-in AArch64, and Cranelift elsewhere.
+    /// uses the custom native backend on a matching host and Cranelift for
+    /// cross-codegen builds or unsupported hosts.
     pub struct Simulator<B: SimBackend = crate::DefaultBackend> {
         pub(crate) backend: B,
         pub(crate) program: RuntimeProgram,

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -1577,20 +1577,19 @@ mod host {
         }
 
         /// Compiles the Veryl source and constructs the simulator.
-        /// Uses a custom native backend on x86-64 and opt-in AArch64, Cranelift elsewhere.
+        /// Uses a custom native backend when it matches the host, Cranelift
+        /// for cross-codegen builds.
         pub fn build(self) -> Result<Simulator<crate::DefaultBackend>, SimulatorError> {
             #[cfg(any(
-                target_arch = "x86_64",
-                feature = "arm64-codegen",
-                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", feature = "arm64-codegen")
             ))]
             {
                 self.build_native()
             }
             #[cfg(not(any(
-                target_arch = "x86_64",
-                feature = "arm64-codegen",
-                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", feature = "arm64-codegen")
             )))]
             {
                 self.build_cranelift()
@@ -1796,15 +1795,13 @@ mod host {
             self.enforce_native_force_optimizer();
             let mut trace = crate::debug::CompilationTrace::default();
             #[cfg(any(
-                target_arch = "x86_64",
-                feature = "arm64-codegen",
-                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", feature = "arm64-codegen")
             ))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::ElementStrided;
             #[cfg(not(any(
-                target_arch = "x86_64",
-                feature = "arm64-codegen",
-                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", feature = "arm64-codegen")
             )))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::Packed;
             let program_res = compile_hdl_to_sir_with_layout_mode(
@@ -1836,9 +1833,8 @@ mod host {
                 }
 
                 #[cfg(any(
-                    target_arch = "x86_64",
-                    feature = "arm64-codegen",
-                    all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                    all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                    all(target_arch = "aarch64", feature = "arm64-codegen")
                 ))]
                 let backend = if self.options.trace.mir
                     || !self.options.trace.native_profile_blocks.is_empty()
@@ -1857,9 +1853,8 @@ mod host {
                     crate::backend::native::NativeBackend::new(&laid_out, &self.options)?
                 };
                 #[cfg(not(any(
-                    target_arch = "x86_64",
-                    feature = "arm64-codegen",
-                    all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                    all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                    all(target_arch = "aarch64", feature = "arm64-codegen")
                 )))]
                 let backend = JitBackend::new(&laid_out, &self.options, None)?;
 
@@ -1945,15 +1940,13 @@ mod host {
             self.options.emit_triggers = true;
             self.enforce_native_force_optimizer();
             #[cfg(any(
-                target_arch = "x86_64",
-                feature = "arm64-codegen",
-                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", feature = "arm64-codegen")
             ))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::ElementStrided;
             #[cfg(not(any(
-                target_arch = "x86_64",
-                feature = "arm64-codegen",
-                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", feature = "arm64-codegen")
             )))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::Packed;
             let (program, warnings) = compile_hdl_to_sir_with_layout_mode(
@@ -1982,15 +1975,13 @@ mod host {
                 run_dead_store_elimination(&mut laid_out, &self.live_signals, &self.options);
             }
             #[cfg(any(
-                target_arch = "x86_64",
-                feature = "arm64-codegen",
-                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", feature = "arm64-codegen")
             ))]
             let backend = crate::backend::native::NativeBackend::new(&laid_out, &self.options)?;
             #[cfg(not(any(
-                target_arch = "x86_64",
-                feature = "arm64-codegen",
-                all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", feature = "arm64-codegen")
             )))]
             let backend = crate::backend::JitBackend::new(&laid_out, &self.options, None)?;
 

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -864,6 +864,7 @@ mod host {
         pub cranelift_options: crate::backend::CraneliftOptions,
         #[cfg(any(
             target_arch = "x86_64",
+            feature = "arm64-codegen",
             all(target_arch = "aarch64", feature = "experimental-arm64-backend")
         ))]
         pub x86_options: crate::backend::X86BackendOptions,
@@ -887,6 +888,7 @@ mod host {
     /// values or executing the first combinational settle.
     #[cfg(any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     ))]
     #[must_use]
@@ -901,6 +903,82 @@ mod host {
 
     #[cfg(any(
         target_arch = "x86_64",
+        feature = "arm64-codegen",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    ))]
+    fn initialize_native_backend(
+        backend: crate::backend::native::NativeBackend,
+        program: crate::ir::RuntimeProgram,
+        warnings: Vec<CompilationWarning>,
+        options: SimulatorOptions,
+        vcd_path: Option<std::path::PathBuf>,
+        injected_components: crate::InjectedComponents,
+    ) -> Result<Simulator<crate::backend::native::NativeBackend>, SimulatorError> {
+        let mut sim = Simulator::with_backend_and_program(backend, program, warnings);
+        sim.components.set_injected(injected_components);
+        sim.diagnostics = options.diagnostics.clone();
+        if let Some(path) = vcd_path {
+            let descs = sim.build_vcd_descs(options.four_state);
+            let vcd_writer = crate::VcdWriter::new(path, &descs)
+                .map_err(|_| SimulatorError::from(crate::RuntimeErrorCode::InternalError))?;
+            sim.vcd_writer = Some(vcd_writer);
+        }
+        let apply_initial_start = options.diagnostics.phase_timing.then(crate::timing::now);
+        sim.apply_initial_values();
+        if let Some(start) = apply_initial_start {
+            tracing::debug!("[phase-timing] apply_initial_values: {:?}", start.elapsed());
+        }
+        let settle_start = options.diagnostics.phase_timing.then(crate::timing::now);
+        sim.modify(|_| {}).map_err(SimulatorError::from)?;
+        if let Some(start) = settle_start {
+            tracing::debug!("[phase-timing] initial_settle: {:?}", start.elapsed());
+        }
+        Ok(sim)
+    }
+
+    #[cfg(any(
+        target_arch = "x86_64",
+        feature = "arm64-codegen",
+        all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+    ))]
+    #[allow(unreachable_code)]
+    fn initialize_native_image(
+        image: crate::backend::native::NativeProgramImage,
+        program: LaidOutProgram,
+        warnings: Vec<CompilationWarning>,
+        options: SimulatorOptions,
+        vcd_path: Option<std::path::PathBuf>,
+        injected_components: crate::InjectedComponents,
+    ) -> Result<Simulator<crate::backend::native::NativeBackend>, SimulatorError> {
+        #[cfg(all(feature = "arm64-codegen", not(target_arch = "aarch64")))]
+        {
+            let _ = (
+                image,
+                program,
+                warnings,
+                options,
+                vcd_path,
+                injected_components,
+            );
+            return Err(SimulatorError::from(crate::RuntimeErrorCode::InternalError));
+        }
+
+        // Safety: callers either produced the image in this process or loaded
+        // it from an explicitly trusted native-image artifact.
+        let backend = unsafe { crate::backend::native::NativeBackend::from_image(image)? };
+        initialize_native_backend(
+            backend,
+            program.into_runtime(),
+            warnings,
+            options,
+            vcd_path,
+            injected_components,
+        )
+    }
+
+    #[cfg(any(
+        target_arch = "x86_64",
+        feature = "arm64-codegen",
         all(target_arch = "aarch64", feature = "experimental-arm64-backend")
     ))]
     impl NativeCompilation {
@@ -939,30 +1017,14 @@ mod host {
                 vcd_path,
                 injected_components,
             } = self;
-            // Safety: the image was produced by `compile_native` in this
-            // process and has not crossed an untrusted input boundary.
-            let backend = unsafe { crate::backend::native::NativeBackend::from_image(image)? };
-            let mut sim =
-                Simulator::with_backend_and_program(backend, program.into_runtime(), warnings);
-            sim.components.set_injected(injected_components);
-            sim.diagnostics = options.diagnostics.clone();
-            if let Some(path) = vcd_path {
-                let descs = sim.build_vcd_descs(options.four_state);
-                let vcd_writer = crate::VcdWriter::new(path, &descs)
-                    .map_err(|_| SimulatorError::from(crate::RuntimeErrorCode::InternalError))?;
-                sim.vcd_writer = Some(vcd_writer);
-            }
-            let apply_initial_start = options.diagnostics.phase_timing.then(crate::timing::now);
-            sim.apply_initial_values();
-            if let Some(start) = apply_initial_start {
-                tracing::debug!("[phase-timing] apply_initial_values: {:?}", start.elapsed());
-            }
-            let settle_start = options.diagnostics.phase_timing.then(crate::timing::now);
-            sim.modify(|_| {}).map_err(SimulatorError::from)?;
-            if let Some(start) = settle_start {
-                tracing::debug!("[phase-timing] initial_settle: {:?}", start.elapsed());
-            }
-            Ok(sim)
+            initialize_native_image(
+                image,
+                program,
+                warnings,
+                options,
+                vcd_path,
+                injected_components,
+            )
         }
     }
 
@@ -975,6 +1037,7 @@ mod host {
                 cranelift_options: crate::backend::CraneliftOptions::default(),
                 #[cfg(any(
                     target_arch = "x86_64",
+                    feature = "arm64-codegen",
                     all(target_arch = "aarch64", feature = "experimental-arm64-backend")
                 ))]
                 x86_options: crate::backend::X86BackendOptions::default(),
@@ -1164,6 +1227,7 @@ mod host {
 
         #[cfg(any(
             target_arch = "x86_64",
+            feature = "arm64-codegen",
             all(target_arch = "aarch64", feature = "experimental-arm64-backend")
         ))]
         pub fn x86_slp(mut self, enable: bool) -> Self {
@@ -1173,6 +1237,7 @@ mod host {
 
         #[cfg(not(any(
             target_arch = "x86_64",
+            feature = "arm64-codegen",
             all(target_arch = "aarch64", feature = "experimental-arm64-backend")
         )))]
         pub fn x86_slp(self, enable: bool) -> Self {
@@ -1233,6 +1298,7 @@ mod host {
             self.options.cranelift_options.diagnostics = diagnostics.cranelift;
             #[cfg(any(
                 target_arch = "x86_64",
+                feature = "arm64-codegen",
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             ))]
             {
@@ -1515,6 +1581,7 @@ mod host {
         pub fn build(self) -> Result<Simulator<crate::DefaultBackend>, SimulatorError> {
             #[cfg(any(
                 target_arch = "x86_64",
+                feature = "arm64-codegen",
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             ))]
             {
@@ -1522,6 +1589,7 @@ mod host {
             }
             #[cfg(not(any(
                 target_arch = "x86_64",
+                feature = "arm64-codegen",
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             )))]
             {
@@ -1579,6 +1647,7 @@ mod host {
         /// Compiles using the custom native backend for this host architecture.
         #[cfg(any(
             target_arch = "x86_64",
+            feature = "arm64-codegen",
             all(target_arch = "aarch64", feature = "experimental-arm64-backend")
         ))]
         pub fn compile_native(self) -> Result<NativeCompilation, SimulatorError> {
@@ -1612,12 +1681,55 @@ mod host {
         /// Compiles using the custom native backend and initializes the simulator.
         #[cfg(any(
             target_arch = "x86_64",
+            feature = "arm64-codegen",
             all(target_arch = "aarch64", feature = "experimental-arm64-backend")
         ))]
         pub fn build_native(
             self,
         ) -> Result<Simulator<crate::backend::native::NativeBackend>, SimulatorError> {
             self.compile_native()?.initialize()
+        }
+
+        /// Load a previously generated native image without running source
+        /// parsing, SIR construction, layout, or native machine-code
+        /// generation here.
+        ///
+        /// This is the execution-side half of the host-codegen/QEMU workflow:
+        /// source-independent runtime metadata and the semantic testbench are
+        /// restored from `image`, while the target machine code is taken
+        /// entirely from it.
+        #[cfg(any(
+            target_arch = "x86_64",
+            feature = "arm64-codegen",
+            all(target_arch = "aarch64", feature = "experimental-arm64-backend")
+        ))]
+        #[allow(unreachable_code)]
+        pub fn build_native_from_image(
+            self,
+            image: crate::backend::native::NativeProgramImage,
+        ) -> Result<Simulator<crate::backend::native::NativeBackend>, SimulatorError> {
+            let options = self.options;
+            let vcd_path = self.vcd_path;
+            let injected_components = self.injected_components;
+
+            #[cfg(all(feature = "arm64-codegen", not(target_arch = "aarch64")))]
+            {
+                let _ = (image, options, vcd_path, injected_components);
+                return Err(SimulatorError::from(crate::RuntimeErrorCode::InternalError));
+            }
+
+            let program = image.runtime_program();
+            // Safety: the caller is explicitly loading a trusted native-image
+            // artifact, and `from_image` validates its structure first.
+            let backend = unsafe { crate::backend::native::NativeBackend::from_image(image)? };
+            initialize_native_backend(
+                backend,
+                program,
+                Vec::new(),
+                options,
+                vcd_path,
+                injected_components,
+            )
         }
 
         /// Compiles using the Wasmtime WASM backend.
@@ -1655,6 +1767,7 @@ mod host {
         /// Compiles and runs a testbench using the custom native backend.
         #[cfg(any(
             target_arch = "x86_64",
+            feature = "arm64-codegen",
             all(target_arch = "aarch64", feature = "experimental-arm64-backend")
         ))]
         pub fn run_test_native(self) -> Result<crate::testbench::TestResult, SimulatorError> {
@@ -1684,11 +1797,13 @@ mod host {
             let mut trace = crate::debug::CompilationTrace::default();
             #[cfg(any(
                 target_arch = "x86_64",
+                feature = "arm64-codegen",
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             ))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::ElementStrided;
             #[cfg(not(any(
                 target_arch = "x86_64",
+                feature = "arm64-codegen",
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             )))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::Packed;
@@ -1722,6 +1837,7 @@ mod host {
 
                 #[cfg(any(
                     target_arch = "x86_64",
+                    feature = "arm64-codegen",
                     all(target_arch = "aarch64", feature = "experimental-arm64-backend")
                 ))]
                 let backend = if self.options.trace.mir
@@ -1742,6 +1858,7 @@ mod host {
                 };
                 #[cfg(not(any(
                     target_arch = "x86_64",
+                    feature = "arm64-codegen",
                     all(target_arch = "aarch64", feature = "experimental-arm64-backend")
                 )))]
                 let backend = JitBackend::new(&laid_out, &self.options, None)?;
@@ -1829,11 +1946,13 @@ mod host {
             self.enforce_native_force_optimizer();
             #[cfg(any(
                 target_arch = "x86_64",
+                feature = "arm64-codegen",
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             ))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::ElementStrided;
             #[cfg(not(any(
                 target_arch = "x86_64",
+                feature = "arm64-codegen",
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             )))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::Packed;
@@ -1864,11 +1983,13 @@ mod host {
             }
             #[cfg(any(
                 target_arch = "x86_64",
+                feature = "arm64-codegen",
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             ))]
             let backend = crate::backend::native::NativeBackend::new(&laid_out, &self.options)?;
             #[cfg(not(any(
                 target_arch = "x86_64",
+                feature = "arm64-codegen",
                 all(target_arch = "aarch64", feature = "experimental-arm64-backend")
             )))]
             let backend = crate::backend::JitBackend::new(&laid_out, &self.options, None)?;

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -879,8 +879,8 @@ mod host {
         pub dead_store_policy: DeadStorePolicy,
     }
 
-    /// A fully code-generated native simulator that has not run any simulator
-    /// initialization yet.
+    /// A code-generated native program that has not been loaded into
+    /// executable memory or initialized as a simulator yet.
     ///
     /// Keeping compilation separate from initialization lets compiler-only
     /// clients stop after native code generation without applying initial
@@ -891,7 +891,7 @@ mod host {
     ))]
     #[must_use]
     pub struct NativeCompilation {
-        backend: crate::backend::native::NativeBackend,
+        image: crate::backend::native::NativeProgramImage,
         program: LaidOutProgram,
         warnings: Vec<CompilationWarning>,
         options: SimulatorOptions,
@@ -909,18 +909,39 @@ mod host {
             &self.warnings
         }
 
-        /// Allocate and initialize the runtime state for this compiled artifact.
+        /// Pointer-free native machine-code artifact produced by this build.
+        pub fn program_image(&self) -> &crate::backend::native::NativeProgramImage {
+            &self.image
+        }
+
+        /// Consume the compilation and return its pointer-free native image.
+        pub fn into_program_image(self) -> crate::backend::native::NativeProgramImage {
+            self.image
+        }
+
+        /// Write the generated native image as a standalone binary container.
+        pub fn write_image(
+            &self,
+            output_path: impl AsRef<std::path::Path>,
+        ) -> Result<(), crate::backend::native::NativeImageContainerError> {
+            self.image.write_container(output_path)
+        }
+
+        /// Load the image into executable memory and initialize runtime state.
         pub fn initialize(
             self,
         ) -> Result<Simulator<crate::backend::native::NativeBackend>, SimulatorError> {
             let Self {
-                backend,
+                image,
                 program,
                 warnings,
                 options,
                 vcd_path,
                 injected_components,
             } = self;
+            // Safety: the image was produced by `compile_native` in this
+            // process and has not crossed an untrusted input boundary.
+            let backend = unsafe { crate::backend::native::NativeBackend::from_image(image)? };
             let mut sim =
                 Simulator::with_backend_and_program(backend, program.into_runtime(), warnings);
             sim.components.set_injected(injected_components);
@@ -1574,12 +1595,12 @@ mod host {
                 );
             }
             let backend_start = phase_timing.then(crate::timing::now);
-            let backend = crate::backend::native::NativeBackend::new(&laid_out, &options)?;
+            let image = crate::backend::native::NativeBackend::compile_image(&laid_out, &options)?;
             if let Some(start) = backend_start {
-                tracing::debug!("[phase-timing] native_backend: {:?}", start.elapsed());
+                tracing::debug!("[phase-timing] native_codegen: {:?}", start.elapsed());
             }
             Ok(NativeCompilation {
-                backend,
+                image,
                 program: laid_out,
                 warnings,
                 options,

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -1707,7 +1707,8 @@ mod host {
             self,
             image: crate::backend::native::NativeProgramImage,
         ) -> Result<Simulator<crate::backend::native::NativeBackend>, SimulatorError> {
-            let options = self.options;
+            let mut options = self.options;
+            options.four_state = image.four_state();
             let vcd_path = self.vcd_path;
             let injected_components = self.injected_components;
 

--- a/crates/celox/src/simulator/error.rs
+++ b/crates/celox/src/simulator/error.rs
@@ -139,6 +139,7 @@ pub enum CodegenError {
         feature = "host-runtime",
         any(
             target_arch = "x86_64",
+            feature = "arm64-codegen",
             all(target_arch = "aarch64", feature = "experimental-arm64-backend")
         )
     ))]
@@ -152,6 +153,7 @@ pub enum CodegenError {
         feature = "host-runtime",
         any(
             target_arch = "x86_64",
+            feature = "arm64-codegen",
             all(target_arch = "aarch64", feature = "experimental-arm64-backend")
         )
     ))]
@@ -165,6 +167,7 @@ pub enum CodegenError {
         feature = "host-runtime",
         any(
             target_arch = "x86_64",
+            feature = "arm64-codegen",
             all(target_arch = "aarch64", feature = "experimental-arm64-backend")
         )
     ))]

--- a/crates/celox/tests/default_backend.rs
+++ b/crates/celox/tests/default_backend.rs
@@ -1,0 +1,17 @@
+//! The cross-codegen feature must not replace the host-executable default backend.
+#![cfg(all(target_arch = "x86_64", feature = "arm64-codegen"))]
+
+use celox::Simulator;
+
+#[test]
+fn arm64_codegen_keeps_default_simulator_executable_on_the_host() {
+    let code = r#"
+        module Top (o: output logic<8>) {
+            assign o = 8'h3c;
+        }
+    "#;
+
+    let mut sim = Simulator::builder(code, "Top").build().unwrap();
+    let output = sim.signal("o");
+    assert_eq!(sim.get(output), 0x3cu64.into());
+}

--- a/crates/celox/tests/native_exec.rs
+++ b/crates/celox/tests/native_exec.rs
@@ -30,6 +30,33 @@ fn native_compilation_can_be_initialized_later() {
     assert_eq!(sim.get(sim.signal("o")), 0x5au64.into());
 }
 
+#[cfg(target_arch = "aarch64")]
+#[test]
+fn native_image_restores_runtime_without_source_compilation() {
+    let code = r#"
+        module Top (o: output logic<8>) {
+            assign o = 8'ha5;
+        }
+    "#;
+
+    let image = Simulator::builder(code, "Top")
+        .compile_native()
+        .unwrap()
+        .into_program_image();
+    let output = image
+        .reflection()
+        .signals()
+        .iter()
+        .find(|signal| signal.full_name == "Top.o")
+        .expect("compiled image should retain output reflection")
+        .signal;
+
+    let mut sim = Simulator::from_sources(Vec::new(), "Top")
+        .build_native_from_image(image)
+        .unwrap();
+    assert_eq!(sim.get(output), 0xa5u64.into());
+}
+
 fn run_single_block_mir(insts: Vec<celox::native_backend::mir::MInst>, vreg_count: usize) -> u64 {
     use celox::native_backend::emit;
     use celox::native_backend::jit_mem;

--- a/crates/celox/tests/native_exec.rs
+++ b/crates/celox/tests/native_exec.rs
@@ -64,6 +64,36 @@ fn native_image_restores_runtime_metadata_without_source_compilation() {
     assert!(!sim.build_vcd_descs(false).is_empty());
 }
 
+#[test]
+fn native_image_restores_four_state_mode_for_vcd() {
+    let code = r#"
+        module Top (a: input logic<8>, o: output logic<8>) {
+            assign o = a;
+        }
+    "#;
+
+    let image = Simulator::builder(code, "Top")
+        .four_state(true)
+        .compile_native()
+        .unwrap()
+        .into_program_image();
+    let image =
+        celox::NativeProgramImage::from_container_bytes(&image.to_container_bytes().unwrap())
+            .unwrap();
+    let directory = tempfile::tempdir().unwrap();
+    let vcd_path = directory.path().join("top.vcd");
+    let mut sim = Simulator::from_sources(Vec::new(), "Top")
+        .four_state(false)
+        .vcd(&vcd_path)
+        .build_native_from_image(image)
+        .unwrap();
+
+    sim.set_four_state(sim.signal("a"), 0xffu8.into(), 0xffu8.into());
+    sim.dump(0);
+    let dump = std::fs::read_to_string(vcd_path).unwrap();
+    assert!(dump.contains("xxxxxxxx"), "{dump}");
+}
+
 fn run_single_block_mir(insts: Vec<celox::native_backend::mir::MInst>, vreg_count: usize) -> u64 {
     use celox::native_backend::emit;
     use celox::native_backend::jit_mem;

--- a/crates/celox/tests/native_exec.rs
+++ b/crates/celox/tests/native_exec.rs
@@ -16,6 +16,15 @@ fn native_compilation_can_be_initialized_later() {
 
     let compilation = Simulator::builder(code, "Top").compile_native().unwrap();
     assert!(compilation.warnings().is_empty());
+    assert!(!compilation.program_image().code_image().is_empty());
+
+    let directory = tempfile::tempdir().unwrap();
+    let image_path = directory.path().join("top.native-image");
+    compilation.write_image(&image_path).unwrap();
+    let image =
+        celox::NativeProgramImage::from_container_bytes(&std::fs::read(&image_path).unwrap())
+            .unwrap();
+    assert_eq!(image.code_image(), compilation.program_image().code_image());
 
     let mut sim = compilation.initialize().unwrap();
     assert_eq!(sim.get(sim.signal("o")), 0x5au64.into());

--- a/crates/celox/tests/native_exec.rs
+++ b/crates/celox/tests/native_exec.rs
@@ -1,6 +1,6 @@
 //! Integration tests: execute native backend output and verify correctness.
 #![cfg(any(
-    target_arch = "x86_64",
+    all(target_arch = "x86_64", not(feature = "arm64-codegen")),
     all(target_arch = "aarch64", feature = "experimental-arm64-backend")
 ))]
 
@@ -30,9 +30,8 @@ fn native_compilation_can_be_initialized_later() {
     assert_eq!(sim.get(sim.signal("o")), 0x5au64.into());
 }
 
-#[cfg(target_arch = "aarch64")]
 #[test]
-fn native_image_restores_runtime_without_source_compilation() {
+fn native_image_restores_runtime_metadata_without_source_compilation() {
     let code = r#"
         module Top (o: output logic<8>) {
             assign o = 8'ha5;
@@ -43,6 +42,9 @@ fn native_image_restores_runtime_without_source_compilation() {
         .compile_native()
         .unwrap()
         .into_program_image();
+    let image =
+        celox::NativeProgramImage::from_container_bytes(&image.to_container_bytes().unwrap())
+            .unwrap();
     let output = image
         .reflection()
         .signals()
@@ -55,6 +57,11 @@ fn native_image_restores_runtime_without_source_compilation() {
         .build_native_from_image(image)
         .unwrap();
     assert_eq!(sim.get(output), 0xa5u64.into());
+    assert!(sim.named_signals().iter().any(|signal| signal.name == "o"));
+    assert_eq!(sim.named_hierarchy().module_name, "Top");
+    let child_output = sim.child_signal(&[], "o");
+    assert_eq!(sim.get(child_output), 0xa5u64.into());
+    assert!(!sim.build_vcd_descs(false).is_empty());
 }
 
 fn run_single_block_mir(insts: Vec<celox::native_backend::mir::MInst>, vreg_count: usize) -> u64 {

--- a/crates/celox/tests/shared_jit_cache.rs
+++ b/crates/celox/tests/shared_jit_cache.rs
@@ -1,5 +1,5 @@
 #![cfg(any(
-    target_arch = "x86_64",
+    all(target_arch = "x86_64", not(feature = "arm64-codegen")),
     all(target_arch = "aarch64", feature = "experimental-arm64-backend")
 ))]
 

--- a/scripts/run-heliodor-bench.sh
+++ b/scripts/run-heliodor-bench.sh
@@ -27,6 +27,7 @@ HELIODOR_CELOX_CODEGEN_CARGO_FEATURES="${HELIODOR_CELOX_CODEGEN_CARGO_FEATURES:-
 HELIODOR_CELOX_EXECUTION_TARGET="${HELIODOR_CELOX_EXECUTION_TARGET:-}"
 HELIODOR_CELOX_EXECUTION_PREFIX="${HELIODOR_CELOX_EXECUTION_PREFIX:-}"
 if [[ "$HELIODOR_CELOX_NATIVE_IMAGE_MODE" == host-qemu ]]; then
+    HELIODOR_CELOX_EXECUTION_TARGET="${HELIODOR_CELOX_EXECUTION_TARGET:-aarch64-unknown-linux-gnu}"
     HELIODOR_CELOX_EXECUTION_CARGO_FEATURES="${HELIODOR_CELOX_EXECUTION_CARGO_FEATURES:-experimental-arm64-backend}"
 else
     HELIODOR_CELOX_EXECUTION_CARGO_FEATURES="${HELIODOR_CELOX_EXECUTION_CARGO_FEATURES:-$HELIODOR_CELOX_CARGO_FEATURES}"
@@ -127,6 +128,7 @@ Environment:
                        Cargo features for the execution runner
   HELIODOR_CELOX_EXECUTION_TARGET
                        target triple for the execution runner, e.g. aarch64-unknown-linux-gnu
+                       (defaults to aarch64-unknown-linux-gnu in host-qemu mode)
   HELIODOR_CELOX_EXECUTION_PREFIX
                        command prefix for execution, e.g. "qemu-aarch64 -L /usr/aarch64-linux-gnu"
   HELIODOR_BUILD_CELOX_RUNNER
@@ -1069,6 +1071,10 @@ validate_native_image_mode() {
             fi
             if [[ -z "$HELIODOR_CELOX_EXECUTION_PREFIX" ]]; then
                 echo "error: host-qemu native-image mode requires HELIODOR_CELOX_EXECUTION_PREFIX" >&2
+                return 2
+            fi
+            if [[ "$HELIODOR_CELOX_EXECUTION_TARGET" != aarch64-* ]]; then
+                echo "error: host-qemu native-image mode requires an AArch64 execution target" >&2
                 return 2
             fi
             ;;

--- a/scripts/run-heliodor-bench.sh
+++ b/scripts/run-heliodor-bench.sh
@@ -16,16 +16,46 @@ CELOX_OPT_LEVEL="${CELOX_OPT_LEVEL:-O2}"
 CELOX_SIR_PASS_OVERRIDES="${CELOX_SIR_PASS_OVERRIDES:-}"
 HELIODOR_CELOX_CARGO_PROFILE="${HELIODOR_CELOX_CARGO_PROFILE:-heliodor-dev}"
 HELIODOR_CELOX_CARGO_FEATURES="${HELIODOR_CELOX_CARGO_FEATURES:-}"
-CELOX_RUNNER_BIN="${CELOX_RUNNER_BIN:-$CELOX_ROOT/target/$HELIODOR_CELOX_CARGO_PROFILE/celox-heliodor}"
+CELOX_RUNNER_BIN="${CELOX_RUNNER_BIN:-}"
+CELOX_CODEGEN_RUNNER_BIN="${CELOX_CODEGEN_RUNNER_BIN:-}"
 VERYL_TIMED_RUNNER_BIN="${VERYL_TIMED_RUNNER_BIN:-$CELOX_ROOT/target/$HELIODOR_CELOX_CARGO_PROFILE/veryl-heliodor}"
 HELIODOR_BUILD_CELOX_RUNNER="${HELIODOR_BUILD_CELOX_RUNNER:-1}"
 HELIODOR_CELOX_TARGET_DIR="${HELIODOR_CELOX_TARGET_DIR:-}"
+HELIODOR_CELOX_NATIVE_IMAGE_MODE="${HELIODOR_CELOX_NATIVE_IMAGE_MODE:-off}"
+HELIODOR_CELOX_NATIVE_IMAGE_DIR="${HELIODOR_CELOX_NATIVE_IMAGE_DIR:-$HELIODOR_RESULTS_DIR/native-images}"
+HELIODOR_CELOX_CODEGEN_CARGO_FEATURES="${HELIODOR_CELOX_CODEGEN_CARGO_FEATURES:-arm64-codegen}"
+HELIODOR_CELOX_EXECUTION_TARGET="${HELIODOR_CELOX_EXECUTION_TARGET:-}"
+HELIODOR_CELOX_EXECUTION_PREFIX="${HELIODOR_CELOX_EXECUTION_PREFIX:-}"
+if [[ "$HELIODOR_CELOX_NATIVE_IMAGE_MODE" == host-qemu ]]; then
+    HELIODOR_CELOX_EXECUTION_CARGO_FEATURES="${HELIODOR_CELOX_EXECUTION_CARGO_FEATURES:-experimental-arm64-backend}"
+else
+    HELIODOR_CELOX_EXECUTION_CARGO_FEATURES="${HELIODOR_CELOX_EXECUTION_CARGO_FEATURES:-$HELIODOR_CELOX_CARGO_FEATURES}"
+fi
+CELOX_TARGET_ROOT="${HELIODOR_CELOX_TARGET_DIR:-$CELOX_ROOT/target}"
+if [[ -z "$CELOX_RUNNER_BIN" ]]; then
+    if [[ -n "$HELIODOR_CELOX_EXECUTION_TARGET" ]]; then
+        CELOX_RUNNER_BIN="$CELOX_TARGET_ROOT/$HELIODOR_CELOX_EXECUTION_TARGET/$HELIODOR_CELOX_CARGO_PROFILE/celox-heliodor"
+    else
+        CELOX_RUNNER_BIN="$CELOX_TARGET_ROOT/$HELIODOR_CELOX_CARGO_PROFILE/celox-heliodor"
+    fi
+fi
+if [[ -z "$CELOX_CODEGEN_RUNNER_BIN" ]]; then
+    CELOX_CODEGEN_RUNNER_BIN="$CELOX_TARGET_ROOT/$HELIODOR_CELOX_CARGO_PROFILE/celox-heliodor"
+fi
+if [[ -z "$VERYL_TIMED_RUNNER_BIN" ]]; then
+    VERYL_TIMED_RUNNER_BIN="$CELOX_TARGET_ROOT/$HELIODOR_CELOX_CARGO_PROFILE/veryl-heliodor"
+fi
 HELIODOR_COMPILE_ONLY="${HELIODOR_COMPILE_ONLY:-${HELIODOR_CELOX_COMPILE_ONLY:-0}}"
 HELIODOR_COMPILE_TIMEOUT_SEC="${HELIODOR_COMPILE_TIMEOUT_SEC:-${HELIODOR_CELOX_COMPILE_TIMEOUT_SEC:-}}"
 HELIODOR_CELOX_TIMEOUT_MULTIPLIER="${HELIODOR_CELOX_TIMEOUT_MULTIPLIER:-2}"
 HELIODOR_INSTALL_TOOLS="${HELIODOR_INSTALL_TOOLS:-1}"
 HELIODOR_VERYL_VERSION="${HELIODOR_VERYL_VERSION:-0.20.3}"
 VERYL_BIN="${VERYL_BIN:-}"
+
+declare -a CELOX_EXECUTION_PREFIX=()
+if [[ -n "$HELIODOR_CELOX_EXECUTION_PREFIX" ]]; then
+    read -r -a CELOX_EXECUTION_PREFIX <<<"$HELIODOR_CELOX_EXECUTION_PREFIX"
+fi
 
 readonly GATE_HELIODOR_REF=94e9c5821c24a8941c3ddc3b76daddc7124a855a
 readonly GATE_TEST=test_soc_linux_boot
@@ -79,12 +109,26 @@ Environment:
   CELOX_SIR_PASS_OVERRIDES
                        space-separated SIR pass overrides, e.g. "-vectorize_concat +gvn"
   CELOX_RUNNER_BIN     prebuilt Celox runner path
+  CELOX_CODEGEN_RUNNER_BIN
+                       host runner used by host-qemu native-image mode
   VERYL_TIMED_RUNNER_BIN
                        prebuilt synchronous Veryl-CC timing runner path
   HELIODOR_CELOX_CARGO_PROFILE
                        Cargo profile for the Celox runner (default: heliodor-dev)
   HELIODOR_CELOX_CARGO_FEATURES
                        optional Cargo features for the Celox runner
+  HELIODOR_CELOX_NATIVE_IMAGE_MODE
+                       off or host-qemu; generate ARM images on the host and run them through the execution prefix
+  HELIODOR_CELOX_NATIVE_IMAGE_DIR
+                       directory for host-generated native images
+  HELIODOR_CELOX_CODEGEN_CARGO_FEATURES
+                       Cargo features for the host codegen runner (default: arm64-codegen)
+  HELIODOR_CELOX_EXECUTION_CARGO_FEATURES
+                       Cargo features for the execution runner
+  HELIODOR_CELOX_EXECUTION_TARGET
+                       target triple for the execution runner, e.g. aarch64-unknown-linux-gnu
+  HELIODOR_CELOX_EXECUTION_PREFIX
+                       command prefix for execution, e.g. "qemu-aarch64 -L /usr/aarch64-linux-gnu"
   HELIODOR_BUILD_CELOX_RUNNER
                        build CELOX_RUNNER_BIN before Celox runs (default: 1)
   HELIODOR_CELOX_TARGET_DIR
@@ -1010,6 +1054,31 @@ runner_enabled() {
     return 1
 }
 
+validate_native_image_mode() {
+    case "$HELIODOR_CELOX_NATIVE_IMAGE_MODE" in
+        off)
+            ;;
+        host-qemu)
+            if ! runner_enabled celox; then
+                echo "error: host-qemu native-image mode requires the celox runner" >&2
+                return 2
+            fi
+            if [[ "$HELIODOR_COMPILE_ONLY" == 1 ]]; then
+                echo "error: host-qemu native-image mode is an execution benchmark and cannot use compile-only" >&2
+                return 2
+            fi
+            if [[ -z "$HELIODOR_CELOX_EXECUTION_PREFIX" ]]; then
+                echo "error: host-qemu native-image mode requires HELIODOR_CELOX_EXECUTION_PREFIX" >&2
+                return 2
+            fi
+            ;;
+        *)
+            echo "error: HELIODOR_CELOX_NATIVE_IMAGE_MODE must be off or host-qemu" >&2
+            return 2
+            ;;
+    esac
+}
+
 any_veryl_runner_enabled() {
     local runner
     for runner in $HELIODOR_RUNNERS; do
@@ -1025,6 +1094,7 @@ build_celox_runner() {
     local log="$HELIODOR_RESULTS_DIR/celox_runner_build.log"
     local -a feature_args=()
     local -a target_dir_args=()
+    local -a target_args=()
     if [[ "$HELIODOR_BUILD_CELOX_RUNNER" != 1 ]]; then
         if [[ ! -x "$CELOX_RUNNER_BIN" ]]; then
             echo "error: HELIODOR_BUILD_CELOX_RUNNER=0 but CELOX_RUNNER_BIN is not executable: $CELOX_RUNNER_BIN" >&2
@@ -1040,6 +1110,48 @@ build_celox_runner() {
     if [[ -n "$HELIODOR_CELOX_CARGO_FEATURES" ]]; then
         feature_args=(--features "$HELIODOR_CELOX_CARGO_FEATURES")
     fi
+    if [[ "$HELIODOR_CELOX_NATIVE_IMAGE_MODE" == host-qemu ]]; then
+        feature_args=()
+        target_args=()
+        if [[ -n "$HELIODOR_CELOX_EXECUTION_CARGO_FEATURES" ]]; then
+            feature_args=(--features "$HELIODOR_CELOX_EXECUTION_CARGO_FEATURES")
+        fi
+        if [[ -n "$HELIODOR_CELOX_EXECUTION_TARGET" ]]; then
+            target_args=(--target "$HELIODOR_CELOX_EXECUTION_TARGET")
+        fi
+    fi
+    if ! env -u CARGO_TARGET_DIR -u CARGO_BUILD_TARGET \
+        cargo build --manifest-path "$CELOX_ROOT/Cargo.toml" -p celox-bench \
+        --bin celox-heliodor --profile "$HELIODOR_CELOX_CARGO_PROFILE" --locked \
+        "${feature_args[@]}" "${target_args[@]}" "${target_dir_args[@]}" >"$log" 2>&1; then
+        tail -n 80 "$log" >&2 || true
+        return 1
+    fi
+    if [[ ! -f "$CELOX_RUNNER_BIN" || ! -x "$CELOX_RUNNER_BIN" ]]; then
+        echo "error: Celox build did not produce the selected runner: $CELOX_RUNNER_BIN" >&2
+        return 1
+    fi
+}
+
+build_celox_codegen_runner() {
+    local log="$HELIODOR_RESULTS_DIR/celox_codegen_runner_build.log"
+    local -a feature_args=()
+    local -a target_dir_args=()
+    if [[ "$HELIODOR_BUILD_CELOX_RUNNER" != 1 ]]; then
+        if [[ ! -x "$CELOX_CODEGEN_RUNNER_BIN" ]]; then
+            echo "error: HELIODOR_BUILD_CELOX_RUNNER=0 but CELOX_CODEGEN_RUNNER_BIN is not executable: $CELOX_CODEGEN_RUNNER_BIN" >&2
+            return 127
+        fi
+        echo "Using prebuilt Celox host codegen runner: $CELOX_CODEGEN_RUNNER_BIN"
+        return
+    fi
+    echo "Building Celox host codegen runner: $CELOX_CODEGEN_RUNNER_BIN"
+    if [[ -n "$HELIODOR_CELOX_TARGET_DIR" ]]; then
+        target_dir_args=(--target-dir "$HELIODOR_CELOX_TARGET_DIR")
+    fi
+    if [[ -n "$HELIODOR_CELOX_CODEGEN_CARGO_FEATURES" ]]; then
+        feature_args=(--features "$HELIODOR_CELOX_CODEGEN_CARGO_FEATURES")
+    fi
     if ! env -u CARGO_TARGET_DIR -u CARGO_BUILD_TARGET \
         cargo build --manifest-path "$CELOX_ROOT/Cargo.toml" -p celox-bench \
         --bin celox-heliodor --profile "$HELIODOR_CELOX_CARGO_PROFILE" --locked \
@@ -1047,8 +1159,8 @@ build_celox_runner() {
         tail -n 80 "$log" >&2 || true
         return 1
     fi
-    if [[ ! -f "$CELOX_RUNNER_BIN" || ! -x "$CELOX_RUNNER_BIN" ]]; then
-        echo "error: Celox build did not produce the selected runner: $CELOX_RUNNER_BIN" >&2
+    if [[ ! -f "$CELOX_CODEGEN_RUNNER_BIN" || ! -x "$CELOX_CODEGEN_RUNNER_BIN" ]]; then
+        echo "error: host codegen build did not produce the selected runner: $CELOX_CODEGEN_RUNNER_BIN" >&2
         return 1
     fi
 }
@@ -1226,6 +1338,7 @@ run_one() {
     local test="$2"
     local stamp log process_status start end process_elapsed timeout_sec
     local semantic_status reported_elapsed compile_elapsed execute_elapsed jit_execute_elapsed full_elapsed result_valid
+    local native_image_path="" native_codegen_log=""
     local veryl_aot_cache_dir=""
     local -a source_files celox_args timed_veryl_args
     collect_test_source_files "$test" source_files || return "$?"
@@ -1246,6 +1359,14 @@ run_one() {
     fi
     stamp="$(date -u +%Y%m%dT%H%M%SZ)"
     log="$HELIODOR_RESULTS_DIR/${stamp}_${runner}_${test}.log"
+    if [[ "$runner" == celox && "$HELIODOR_CELOX_NATIVE_IMAGE_MODE" == host-qemu ]]; then
+        if ! mkdir -p "$HELIODOR_CELOX_NATIVE_IMAGE_DIR"; then
+            echo "error: could not create native image directory: $HELIODOR_CELOX_NATIVE_IMAGE_DIR" >&2
+            return 1
+        fi
+        native_image_path="$(realpath -m "$HELIODOR_CELOX_NATIVE_IMAGE_DIR/${test}.native-image")"
+        native_codegen_log="${log}.host-codegen"
+    fi
     timeout_sec="$(timeout_sec_for "$runner" "$test")"
     if [[ ("$runner" == celox* || "$runner" == veryl-cc-sync) && "$HELIODOR_COMPILE_ONLY" == 1 ]]; then
         if [[ -n "$timeout_sec" && "$timeout_sec" != 0 ]]; then
@@ -1275,10 +1396,32 @@ run_one() {
     set +e
     case "$runner" in
         celox)
-            run_in_heliodor "$timeout_sec" "$log" \
-                "$CELOX_RUNNER_BIN" --project "$HELIODOR_DIR" --test "$test" \
-                "${celox_args[@]}" --backend native --opt-level "${CELOX_OPT_LEVEL,,}"
-            process_status="$?"
+            if [[ "$HELIODOR_CELOX_NATIVE_IMAGE_MODE" == host-qemu ]]; then
+                run_in_heliodor "$timeout_sec" "$native_codegen_log" \
+                    "$CELOX_CODEGEN_RUNNER_BIN" --project "$HELIODOR_DIR" --test "$test" \
+                    "${celox_args[@]}" --backend native --opt-level "${CELOX_OPT_LEVEL,,}" \
+                    --compile-only --native-image-output "$native_image_path"
+                process_status="$?"
+                if [[ "$process_status" == 0 ]]; then
+                    if ! start="$(monotonic_ns)" || ! is_uint "$start"; then
+                        echo "error: could not read a monotonic execution start timestamp" >&2
+                        return 1
+                    fi
+                    run_in_heliodor "$timeout_sec" "$log" \
+                        "${CELOX_EXECUTION_PREFIX[@]}" "$CELOX_RUNNER_BIN" \
+                        --project "$HELIODOR_DIR" --test "$test" \
+                        "${celox_args[@]}" --backend native --opt-level "${CELOX_OPT_LEVEL,,}" \
+                        --native-image-input "$native_image_path"
+                    process_status="$?"
+                else
+                    cp "$native_codegen_log" "$log"
+                fi
+            else
+                run_in_heliodor "$timeout_sec" "$log" \
+                    "$CELOX_RUNNER_BIN" --project "$HELIODOR_DIR" --test "$test" \
+                    "${celox_args[@]}" --backend native --opt-level "${CELOX_OPT_LEVEL,,}"
+                process_status="$?"
+            fi
             ;;
         celox-cranelift)
             run_in_heliodor "$timeout_sec" "$log" \
@@ -1399,11 +1542,15 @@ run_one() {
 }
 
 run_all() {
+    validate_native_image_mode || return "$?"
     prepare
     mkdir -p "$HELIODOR_RESULTS_DIR"
     ensure_results_schema "$HELIODOR_RESULTS_DIR/results.tsv" || return "$?"
     if runner_enabled celox || runner_enabled celox-cranelift; then
         build_celox_runner
+    fi
+    if [[ "$HELIODOR_CELOX_NATIVE_IMAGE_MODE" == host-qemu ]]; then
+        build_celox_codegen_runner
     fi
     if runner_enabled veryl-cc-sync; then
         build_timed_veryl_runner
@@ -1730,7 +1877,9 @@ run_gate() {
     HELIODOR_CELOX_CARGO_PROFILE=release
     HELIODOR_CELOX_CARGO_FEATURES=""
     HELIODOR_CELOX_TARGET_DIR=""
+    HELIODOR_CELOX_NATIVE_IMAGE_MODE=off
     CELOX_RUNNER_BIN=""
+    CELOX_CODEGEN_RUNNER_BIN=""
     VERYL_TIMED_RUNNER_BIN=""
 
     gate_record_celox_checkout || return "$?"


### PR DESCRIPTION
## Summary

- separate host-side ARM64 native image generation from target execution
- improve ARM64 state-page selection, spill selection, and native instruction emission
- split large address offsets into efficient ADD/SUB immediate pairs when possible
- keep the workflow independent of VPI
- add host and AArch64/QEMU regression coverage

## Motivation

Generating ARM64 binaries and executing them entirely through an emulator made the backend workflow unnecessarily slow. This change lets the host generate the native image and reserves QEMU for execution and benchmarking.

The backend is still behind GCC on ARM64, so this is an incremental code-generation quality pass rather than a claim of parity. Local QEMU runs showed noisy cumulative improvements of roughly 5–10% across the measured workload, while the generated image decreased from 29,318,308 to 28,856,837 bytes (~1.6%).

## Validation

- `cargo fmt --all`
- host `celox-backend-arm64` tests: 25 passed
- AArch64/`qemu-aarch64` `celox-backend-arm64` tests: 43 passed
- `cargo check --workspace --all-targets --locked`
- clippy for the changed backend, runtime, and benchmark targets
- host compile-only plus QEMU execution-only SoC run through 50,000 ticks