### PR TITLE
feat(rust): publish crates and add frontend adapters

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -53,8 +53,9 @@ release metadata, but tags are not deployment triggers.
 
 The same tagged stable release is published to crates.io. Nightly channels stay
 npm-only because crates.io has no mutable distribution tags. The release
-management workflow dispatches **Publish Rust Crates** after it verifies that the
-tag points at the current release commit and that the GitHub Release is public.
+management workflow dispatches **Publish Rust Crates** at that tag after it
+verifies that the tag points at the current release commit and that the GitHub
+Release is public.
 The Rust workflow repeats those checks, verifies every package archive, runs the
 external-frontend tests (including loading a separately built N-API addon), and
 then publishes in dependency order. A retry skips crate versions already present
@@ -67,13 +68,14 @@ rejects a release if any of those values differs from `VERSION`.
 Publication uses crates.io Trusted Publishing. The publish job has
 `id-token: write`, runs in the `crates-io` GitHub environment, and exchanges its
 GitHub OIDC identity for a temporary crates.io token. There is no persistent
-`CARGO_REGISTRY_TOKEN` Actions secret. The manual workflow requires an existing
-stable tag and published GitHub Release, so it is safe to use for a failed or
-partially completed publication retry.
+`CARGO_REGISTRY_TOKEN` Actions secret. A manual retry must select the existing
+stable tag as the workflow ref; the workflow has no free-form revision input.
+It also requires a published GitHub Release, so it is safe to use for a failed
+or partially completed publication retry.
 
 Create a GitHub environment named `crates-io` before the first release. Limit
-deployments to `master` and add required reviewers if publication should require
-a human approval.
+deployments to protected tags matching `v*` and add required reviewers if
+publication should require a human approval.
 
 ### First crates.io release
 

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -1,10 +1,11 @@
 # Release policy
 
-Celox is released as one lockstep npm distribution. `VERSION`,
-`.release-please-manifest.json`, `@celox-sim/celox`,
-`@celox-sim/celox-napi`, and `@celox-sim/vite-plugin` must always carry the same
-version. Rust workspace crates are internal implementation units, use version
-`0.0.0`, and are not published to crates.io.
+Celox is released as one lockstep distribution. `VERSION`,
+`.release-please-manifest.json`, the npm packages, and all Rust workspace crates
+must always carry the same version. The public Rust entry points are `celox`,
+`celox-frontend-sdk`, and the Rust adapter API in `celox-napi`; the remaining
+published `celox-*` crates satisfy their Cargo dependency graph and remain
+implementation details.
 
 ## Versioning before 1.0
 
@@ -47,6 +48,85 @@ Merging the release pull request changes `.release-please-manifest.json`; that
 push, rather than a tag push, starts the NAPI build and npm publication workflow.
 Release Please may still create an immutable version tag and GitHub Release as
 release metadata, but tags are not deployment triggers.
+
+## crates.io publication
+
+The same tagged stable release is published to crates.io. Nightly channels stay
+npm-only because crates.io has no mutable distribution tags. The release
+management workflow dispatches **Publish Rust Crates** after it verifies that the
+tag points at the current release commit and that the GitHub Release is public.
+The Rust workflow repeats those checks, verifies every package archive, runs the
+external-frontend tests (including loading a separately built N-API addon), and
+then publishes in dependency order. A retry skips crate versions already present
+on crates.io.
+
+Release Please updates the workspace version, exact internal dependency
+requirements, and all matching entries in `Cargo.lock`. `scripts/check-release-version.mjs`
+rejects a release if any of those values differs from `VERSION`.
+
+Publication uses crates.io Trusted Publishing. The publish job has
+`id-token: write`, runs in the `crates-io` GitHub environment, and exchanges its
+GitHub OIDC identity for a temporary crates.io token. There is no persistent
+`CARGO_REGISTRY_TOKEN` Actions secret. The manual workflow requires an existing
+stable tag and published GitHub Release, so it is safe to use for a failed or
+partially completed publication retry.
+
+Create a GitHub environment named `crates-io` before the first release. Limit
+deployments to `master` and add required reviewers if publication should require
+a human approval.
+
+### First crates.io release
+
+crates.io cannot configure a trusted publisher for a crate name that has never
+been published. Bootstrap the names locally before the first stable release;
+the bootstrap is deliberately not a GitHub Actions job:
+
+1. After this release setup is merged, validate the generated empty `0.0.0`
+   placeholder packages locally:
+
+   ```bash
+   ./scripts/bootstrap-crates-io.sh package
+   ```
+
+2. Create a short-expiry crates.io API token with the `publish-new` endpoint
+   scope and a crate scope covering `celox` and `celox-*`. Do not save it in
+   GitHub Actions.
+3. Pass the token without putting it in shell history, then publish the
+   placeholders. The confirmation is required because crates.io releases are
+   permanent:
+
+   ```bash
+   read -rsp 'crates.io bootstrap token: ' CARGO_REGISTRY_TOKEN
+   echo
+   export CARGO_REGISTRY_TOKEN
+   ./scripts/bootstrap-crates-io.sh publish BOOTSTRAP-CELOX-CRATES
+   unset CARGO_REGISTRY_TOKEN
+   ```
+
+4. On the **Trusted Publishers** settings page of every published Celox crate,
+   register this exact identity:
+
+   | Field | Value |
+   | --- | --- |
+   | GitHub owner | `celox-sim` |
+   | GitHub repository | `celox` |
+   | Workflow filename | `publish-crates.yml` |
+   | Environment | `crates-io` |
+
+   The crates to configure are the entries in the `crates` array in
+   `scripts/publish-crates.sh`.
+5. Revoke the bootstrap API token immediately. Add the intended crates.io team
+   or backup owners, because the account that performed the bootstrap is the
+   initial owner of every new crate.
+6. Run the first stable release normally. It publishes the real lockstep version
+   through OIDC; `0.0.0` remains only as the name bootstrap. After this succeeds,
+   optionally enable **Trusted Publishing Only** for each crate so ordinary API
+   tokens cannot publish future versions.
+
+Adding another public crate later requires the same bounded bootstrap only for
+that new name, followed by registering the same trusted publisher. The local
+script skips existing `0.0.0` placeholders; existing crates continue to publish
+through OIDC.
 
 ## Veryl dependency lanes
 
@@ -127,3 +207,8 @@ repository auto-merge so dependency rolls, lane synchronization, and weekly
 releases can queue checked pull requests. Allow the automation token to create
 `develop` on first use and force-update the disposable `integration/veryl-head`
 branch; never grant a force-push exception on `master` or `develop`.
+
+Do not create a `CARGO_REGISTRY_TOKEN` repository or environment secret. The
+only manually created crates.io credential in this process is the short-expiry
+bootstrap token, which must be revoked after the initial crate names are
+created.

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -185,15 +185,18 @@ distribution in every channel.
 ## Repository configuration
 
 Release automation uses the `celox-automation` GitHub App, installed for this
-repository with repository contents and pull request write access. Store its
-numeric App ID as the `RELEASE_APP_ID` Actions variable and its complete PEM
-private key as the `RELEASE_APP_PRIVATE_KEY` Actions secret. Each job mints a
-short-lived, repository-scoped installation token; never store an installation
-token itself because it expires. The weekly queue job uses this token so adding a
-pull request to the queue starts the required `merge_group` checks. The Veryl
-HEAD and vendored-metadata workflows use the same mechanism so generated branch
-pushes start normal CI. Using the default `GITHUB_TOKEN` for these events would
-prevent their follow-up workflows from running.
+repository with Actions, repository contents, pull request, and Workflows write
+access. Store its numeric App ID as the `RELEASE_APP_ID` Actions variable and
+its complete PEM private key as the `RELEASE_APP_PRIVATE_KEY` Actions secret.
+Each job mints a short-lived, repository-scoped installation token; never store
+an installation token itself because it expires. Actions write access lets the
+release workflow dispatch the crate publisher at the verified release tag;
+Workflows write access lets automation update workflow files. The weekly queue
+job uses this token so adding a pull request to the queue starts the required
+`merge_group` checks. The Veryl HEAD and vendored-metadata workflows use the
+same mechanism so generated branch pushes start normal CI. Using the default
+`GITHUB_TOKEN` for these events would prevent their follow-up workflows from
+running.
 
 The App has Issues write permission for Release Please's status labels. The
 weekly workflow still identifies the release pull request by the exact

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,124 @@
+name: Publish Rust Crates
+
+on:
+  repository_dispatch:
+    types: [crates-release]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing v-prefixed stable release tag
+        required: true
+        type: string
+
+concurrency:
+  group: crates-publish-${{ github.event.client_payload.tag || inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  RELEASE_TAG: ${{ github.event.client_payload.tag || inputs.tag }}
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate release
+    runs-on: ubuntu-latest
+    outputs:
+      build_sha: ${{ steps.revision.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+
+      - name: Resolve immutable release revision
+        id: revision
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Check release tag and version
+        shell: bash
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "A v-prefixed stable release tag is required." >&2
+            exit 1
+          fi
+          expected_tag="v$(tr -d '\r\n' < VERSION)"
+          if [[ "$RELEASE_TAG" != "$expected_tag" ]]; then
+            echo "Release tag $RELEASE_TAG does not match VERSION ($expected_tag)." >&2
+            exit 1
+          fi
+
+      - name: Check published GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          published_tag="$(
+            gh release view "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json tagName,isDraft,isPrerelease \
+              --jq 'select(.isDraft == false and .isPrerelease == false) | .tagName'
+          )"
+          if [[ "$published_tag" != "$RELEASE_TAG" ]]; then
+            echo "Published GitHub Release $RELEASE_TAG was not found." >&2
+            exit 1
+          fi
+
+      - name: Check synchronized release versions
+        run: node scripts/check-release-version.mjs
+
+  package:
+    name: Package and test
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.validate.outputs.build_sha }}
+
+      - uses: ./.github/actions/setup-rust
+
+      - name: Validate every public crate package
+        run: ./scripts/publish-crates.sh package
+
+      - name: Test the public frontend path
+        run: |
+          cargo test --locked -p celox-frontend-sdk
+          cargo test --locked -p celox --test frontend_sdk
+          cargo run --locked -p celox --example frontend_binary
+
+      - name: Build and load a frontend-owned N-API adapter
+        run: |
+          cargo build --locked -p celox-example-my-frontend-napi
+          cp target/debug/libcelox_example_my_frontend_napi.so "$RUNNER_TEMP/my-frontend.node"
+          node examples/my-frontend-napi/smoke.cjs "$RUNNER_TEMP/my-frontend.node"
+
+      - name: Build Rust API documentation
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --locked --workspace --no-deps
+
+  publish:
+    name: Publish to crates.io
+    needs: [validate, package]
+    runs-on: ubuntu-latest
+    environment: crates-io
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.validate.outputs.build_sha }}
+
+      - uses: ./.github/actions/setup-rust
+
+      - name: Authenticate to crates.io
+        id: crates_io_auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish crates in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates_io_auth.outputs.token }}
+        run: ./scripts/publish-crates.sh publish

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,21 +1,14 @@
 name: Publish Rust Crates
 
 on:
-  repository_dispatch:
-    types: [crates-release]
   workflow_dispatch:
-    inputs:
-      tag:
-        description: Existing v-prefixed stable release tag
-        required: true
-        type: string
 
 concurrency:
-  group: crates-publish-${{ github.event.client_payload.tag || inputs.tag }}
+  group: crates-publish-${{ github.ref }}
   cancel-in-progress: false
 
 env:
-  RELEASE_TAG: ${{ github.event.client_payload.tag || inputs.tag }}
+  RELEASE_TAG: ${{ github.ref_name }}
 
 permissions:
   contents: read
@@ -24,23 +17,17 @@ jobs:
   validate:
     name: Validate release
     runs-on: ubuntu-latest
-    outputs:
-      build_sha: ${{ steps.revision.outputs.sha }}
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
-
-      - name: Resolve immutable release revision
-        id: revision
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Check release tag and version
         shell: bash
         run: |
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "A v-prefixed stable release tag is required." >&2
+          if [[ "$GITHUB_REF_TYPE" != "tag" || ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Run this workflow from a v-prefixed stable release tag." >&2
             exit 1
           fi
           expected_tag="v$(tr -d '\r\n' < VERSION)"
@@ -75,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.validate.outputs.build_sha }}
+          ref: ${{ github.sha }}
 
       - uses: ./.github/actions/setup-rust
 
@@ -110,7 +97,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.validate.outputs.build_sha }}
+          ref: ${{ github.sha }}
 
       - uses: ./.github/actions/setup-rust
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-actions: write
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,13 +75,16 @@ jobs:
             exit 1
           fi
 
-          jq -n \
-            --arg tag "$release_tag" \
-            '{event_type: "napi-release", client_payload: {tag: $tag}}' \
-            | gh api \
-                --method POST \
-                "repos/$GITHUB_REPOSITORY/dispatches" \
-                --input -
+          for event_type in napi-release crates-release; do
+            jq -n \
+              --arg tag "$release_tag" \
+              --arg event_type "$event_type" \
+              '{event_type: $event_type, client_payload: {tag: $tag}}' \
+              | gh api \
+                  --method POST \
+                  "repos/$GITHUB_REPOSITORY/dispatches" \
+                  --input -
+          done
 
   queue-release:
     name: Queue weekly release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,16 +75,17 @@ jobs:
             exit 1
           fi
 
-          for event_type in napi-release crates-release; do
-            jq -n \
-              --arg tag "$release_tag" \
-              --arg event_type "$event_type" \
-              '{event_type: $event_type, client_payload: {tag: $tag}}' \
-              | gh api \
-                  --method POST \
-                  "repos/$GITHUB_REPOSITORY/dispatches" \
-                  --input -
-          done
+          jq -n \
+            --arg tag "$release_tag" \
+            '{event_type: "napi-release", client_payload: {tag: $tag}}' \
+            | gh api \
+                --method POST \
+                "repos/$GITHUB_REPOSITORY/dispatches" \
+                --input -
+
+          gh workflow run publish-crates.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$release_tag"
 
   queue-release:
     name: Queue weekly release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "celox"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "bit-set 0.11.1",
  "celox-analysis",
@@ -473,14 +473,14 @@ dependencies = [
 
 [[package]]
 name = "celox-analysis"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "fxhash",
 ]
 
 [[package]]
 name = "celox-backend-arm64"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "celox-backend-common",
  "celox-backend-x86",
@@ -492,14 +492,14 @@ dependencies = [
 
 [[package]]
 name = "celox-backend-common"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "fxhash",
 ]
 
 [[package]]
 name = "celox-backend-cranelift"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "celox-design",
  "celox-sir",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "celox-backend-wasm"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "celox-backend-cranelift",
  "celox-design",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "celox-backend-x86"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "celox-analysis",
  "celox-backend-common",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "celox-bench"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "celox",
  "clap",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "celox-bench-sv"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "veryl-analyzer",
  "veryl-emitter",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "celox-design"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "fxhash",
  "num-bigint",
@@ -582,8 +582,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "celox-example-my-frontend-napi"
+version = "0.3.0"
+dependencies = [
+ "celox-frontend-sdk",
+ "celox-napi",
+ "napi",
+ "napi-build",
+ "napi-derive",
+]
+
+[[package]]
 name = "celox-frontend-core"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "celox-design",
  "celox-frontend-sdk",
@@ -599,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "celox-frontend-sdk"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "fxhash",
  "num-bigint",
@@ -610,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "celox-frontend-sv"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "celox-design",
  "celox-frontend-core",
@@ -624,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "celox-frontend-veryl"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "bit-set 0.11.1",
  "celox-design",
@@ -646,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "celox-macros"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "fxhash",
  "insta",
@@ -662,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "celox-napi"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "celox",
  "celox-design",
@@ -685,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "celox-runtime"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "bit-set 0.11.1",
  "celox-design",
@@ -700,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "celox-sir"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "celox-analysis",
  "celox-design",
@@ -712,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "celox-sir-opt"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "bit-set 0.11.1",
  "celox-analysis",
@@ -729,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "celox-slt"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "celox-analysis",
  "celox-design",
@@ -745,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "celox-state-layout"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "celox-design",
  "fxhash",
@@ -754,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "celox-sv-analyzer"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "fxhash",
  "miette",
@@ -765,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "celox-testbench"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -774,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "celox-ts-gen"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "fxhash",
  "insta",
@@ -787,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "celox-vpi"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "celox",
  "clap",
@@ -799,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "celox-wasm"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "celox",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,14 @@ members = [
     "crates/celox-ts-gen",
     "crates/celox-wasm",
     "crates/celox-vpi",
+    "examples/my-frontend-napi",
 ]
 resolver = "2"
 
 [workspace.package]
-# Rust workspace crates are internal implementation units. The Celox distribution
-# version is tracked in VERSION and the published npm package manifests.
-version     = "0.0.0"
+# Keep the publishable Rust crates in lockstep with VERSION and the npm packages.
+# Release Please updates this annotated line as part of the shared release PR.
+version     = "0.3.0" # x-release-please-version
 authors     = ["tignear"]
 repository  = "https://github.com/celox-sim/celox"
 keywords    = ["hdl", "simulator", "veryl"]
@@ -44,6 +45,29 @@ description = "Celox HDL Simulator"
 rust-version = "1.97.1"
 
 [workspace.dependencies]
+celox                   = { version = "=0.3.0", path = "crates/celox", default-features = false } # x-release-please-version
+celox-analysis          = { version = "=0.3.0", path = "crates/celox-analysis" } # x-release-please-version
+celox-backend-arm64     = { version = "=0.3.0", path = "crates/celox-backend-arm64" } # x-release-please-version
+celox-backend-common    = { version = "=0.3.0", path = "crates/celox-backend-common" } # x-release-please-version
+celox-backend-cranelift = { version = "=0.3.0", path = "crates/celox-backend-cranelift" } # x-release-please-version
+celox-backend-wasm      = { version = "=0.3.0", path = "crates/celox-backend-wasm" } # x-release-please-version
+celox-backend-x86       = { version = "=0.3.0", path = "crates/celox-backend-x86" } # x-release-please-version
+celox-design            = { version = "=0.3.0", path = "crates/celox-design" } # x-release-please-version
+celox-frontend-core     = { version = "=0.3.0", path = "crates/celox-frontend-core" } # x-release-please-version
+celox-frontend-sdk      = { version = "=0.3.0", path = "crates/celox-frontend-sdk" } # x-release-please-version
+celox-frontend-sv       = { version = "=0.3.0", path = "crates/celox-frontend-sv" } # x-release-please-version
+celox-frontend-veryl    = { version = "=0.3.0", path = "crates/celox-frontend-veryl" } # x-release-please-version
+celox-macros            = { version = "=0.3.0", path = "crates/celox-macros" } # x-release-please-version
+celox-napi              = { version = "=0.3.0", path = "crates/celox-napi" } # x-release-please-version
+celox-runtime           = { version = "=0.3.0", path = "crates/celox-runtime" } # x-release-please-version
+celox-sir               = { version = "=0.3.0", path = "crates/celox-sir" } # x-release-please-version
+celox-sir-opt           = { version = "=0.3.0", path = "crates/celox-sir-opt", default-features = false } # x-release-please-version
+celox-slt               = { version = "=0.3.0", path = "crates/celox-slt" } # x-release-please-version
+celox-state-layout      = { version = "=0.3.0", path = "crates/celox-state-layout" } # x-release-please-version
+celox-sv-analyzer       = { version = "=0.3.0", path = "crates/celox-sv-analyzer" } # x-release-please-version
+celox-testbench         = { version = "=0.3.0", path = "crates/celox-testbench" } # x-release-please-version
+celox-ts-gen            = { version = "=0.3.0", path = "crates/celox-ts-gen" } # x-release-please-version
+
 veryl-analyzer = "0.20.3"
 veryl-emitter  = "0.20.3"
 veryl-metadata = "0.20.3"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Celox
 
 [![npm version](https://img.shields.io/npm/v/%40celox-sim%2Fcelox.svg)](https://www.npmjs.com/package/@celox-sim/celox)
+[![crates.io](https://img.shields.io/crates/v/celox.svg)](https://crates.io/crates/celox)
 
 **An experimental, compiler-based RTL simulator for [Veryl](https://veryl-lang.org/).**
 
@@ -44,6 +45,8 @@ compiler demo: the result can run real RTL tests, in Node.js or in a browser.
 - Override top-level parameters and include test-only Veryl sources.
 - Inspect child instances and emit VCD waveforms.
 - Compile a Veryl design into a native executable and run cocotb tests through VPI.
+- Build an external netlist frontend with the Rust SDK and ship its simulator as
+  a native application binary or a frontend-specific N-API/WASI addon.
 - Run through the custom x86-64 backend, the Cranelift fallback, or WebAssembly.
   A custom AArch64 backend is also available behind an experimental feature.
 
@@ -192,6 +195,7 @@ and API changes while the design is still evolving.
 - [Getting Started](https://celox-sim.github.io/celox/guide/getting-started)
 - [Writing Tests](https://celox-sim.github.io/celox/guide/writing-tests)
 - [Celox CLI and cocotb](https://celox-sim.github.io/celox/guide/cocotb)
+- [External Frontends and Rust Binaries](https://celox-sim.github.io/celox/guide/external-frontends)
 - [Four-State Simulation](https://celox-sim.github.io/celox/guide/four-state)
 - [VCD Waveforms](https://celox-sim.github.io/celox/guide/vcd)
 - [TypeScript API](https://celox-sim.github.io/celox/api/)

--- a/crates/celox-analysis/Cargo.toml
+++ b/crates/celox-analysis/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name                  = "celox-analysis"
 version.workspace     = true
-publish               = false
+publish               = ["crates-io"]
 authors.workspace     = true
 repository.workspace  = true
 license.workspace     = true
 description           = "IR-independent compiler analyses used by Celox"
 edition.workspace     = true
+rust-version.workspace = true
 
 [dependencies]
 fxhash.workspace = true

--- a/crates/celox-backend-arm64/Cargo.toml
+++ b/crates/celox-backend-arm64/Cargo.toml
@@ -1,16 +1,18 @@
 [package]
 name = "celox-backend-arm64"
 version.workspace = true
+publish = ["crates-io"]
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 description = "Celox AArch64 machine-code backend"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
-celox-backend-common = { path = "../celox-backend-common" }
-celox-backend-x86 = { path = "../celox-backend-x86" }
-celox-state-layout = { path = "../celox-state-layout" }
+celox-backend-common = { workspace = true }
+celox-backend-x86 = { workspace = true }
+celox-state-layout = { workspace = true }
 dynasmrt = "5.1.0"
 fxhash = { workspace = true }
 

--- a/crates/celox-backend-common/Cargo.toml
+++ b/crates/celox-backend-common/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "celox-backend-common"
 version.workspace = true
+publish = ["crates-io"]
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 description = "Target-independent machine-code backend primitives for Celox"
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/celox-backend-cranelift/Cargo.toml
+++ b/crates/celox-backend-cranelift/Cargo.toml
@@ -1,17 +1,19 @@
 [package]
 name = "celox-backend-cranelift"
 version.workspace = true
+publish = ["crates-io"]
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 description = "Celox Cranelift code-generation backend"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 tracing = { workspace = true }
-celox-design = { path = "../celox-design" }
-celox-sir = { path = "../celox-sir" }
-celox-state-layout = { path = "../celox-state-layout" }
+celox-design = { workspace = true }
+celox-sir = { workspace = true }
+celox-state-layout = { workspace = true }
 fxhash = { workspace = true }
 thiserror = { workspace = true }
 cranelift = "0.134.0"

--- a/crates/celox-backend-wasm/Cargo.toml
+++ b/crates/celox-backend-wasm/Cargo.toml
@@ -1,21 +1,23 @@
 [package]
 name = "celox-backend-wasm"
 version.workspace = true
+publish = ["crates-io"]
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 description = "Celox WebAssembly code-generation backend"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
-celox-design = { path = "../celox-design" }
-celox-sir = { path = "../celox-sir" }
-celox-state-layout = { path = "../celox-state-layout" }
+celox-design = { workspace = true }
+celox-sir = { workspace = true }
+celox-state-layout = { workspace = true }
 fxhash = { workspace = true }
 wasm-encoder = "0.256"
 
 [dev-dependencies]
-celox-backend-cranelift = { path = "../celox-backend-cranelift" }
+celox-backend-cranelift = { workspace = true }
 num-bigint = { workspace = true }
 wasmtime = "47"
 

--- a/crates/celox-backend-x86/Cargo.toml
+++ b/crates/celox-backend-x86/Cargo.toml
@@ -1,19 +1,21 @@
 [package]
 name = "celox-backend-x86"
 version.workspace = true
+publish = ["crates-io"]
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 description = "Celox x86-64 machine-code backend"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 tracing = { workspace = true }
-celox-analysis = { path = "../celox-analysis" }
-celox-backend-common = { path = "../celox-backend-common" }
-celox-design = { path = "../celox-design" }
-celox-sir = { path = "../celox-sir" }
-celox-state-layout = { path = "../celox-state-layout" }
+celox-analysis = { workspace = true }
+celox-backend-common = { workspace = true }
+celox-design = { workspace = true }
+celox-sir = { workspace = true }
+celox-state-layout = { workspace = true }
 fxhash = { workspace = true }
 libc = { workspace = true }
 memmap2 = "0.9"
@@ -21,7 +23,7 @@ num-bigint = { workspace = true }
 iced-x86 = { version = "1.21", default-features = false, features = ["std", "encoder", "block_encoder", "decoder", "nasm", "op_code_info", "code_asm"] }
 
 [dev-dependencies]
-celox-sir-opt = { path = "../celox-sir-opt" }
+celox-sir-opt = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/celox-backend-x86/src/backend/native/mir.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir.rs
@@ -701,7 +701,7 @@ pub enum MInst {
     // ── Data movement ──────────────────────────────────────────
     /// dst = src (full 64-bit word copy)
     Mov { dst: VReg, src: VReg },
-    /// dst = zero_extend(src[31:0])
+    /// `dst = zero_extend(src[31:0])`
     Mov32 { dst: VReg, src: VReg },
     /// dst = immediate
     LoadImm { dst: VReg, value: u64 },
@@ -911,29 +911,29 @@ pub enum MInst {
     // ── ALU (3-operand SSA) ────────────────────────────────────
     /// dst = lhs + rhs modulo 2^64
     Add { dst: VReg, lhs: VReg, rhs: VReg },
-    /// dst = zero_extend((lhs + rhs)[31:0])
+    /// `dst = zero_extend((lhs + rhs)[31:0])`
     Add32 { dst: VReg, lhs: VReg, rhs: VReg },
     /// dst = lhs - rhs modulo 2^64
     Sub { dst: VReg, lhs: VReg, rhs: VReg },
-    /// dst = zero_extend((lhs - rhs)[31:0])
+    /// `dst = zero_extend((lhs - rhs)[31:0])`
     Sub32 { dst: VReg, lhs: VReg, rhs: VReg },
     /// dst = lhs * rhs modulo 2^64
     Mul { dst: VReg, lhs: VReg, rhs: VReg },
-    /// dst = zero_extend((lhs * rhs)[31:0])
+    /// `dst = zero_extend((lhs * rhs)[31:0])`
     Mul32 { dst: VReg, lhs: VReg, rhs: VReg },
     /// dst = upper 64 bits of lhs * rhs (unsigned)
     UMulHi { dst: VReg, lhs: VReg, rhs: VReg },
     /// dst = lhs & rhs (full 64-bit word)
     And { dst: VReg, lhs: VReg, rhs: VReg },
-    /// dst = zero_extend((lhs & rhs)[31:0])
+    /// `dst = zero_extend((lhs & rhs)[31:0])`
     And32 { dst: VReg, lhs: VReg, rhs: VReg },
     /// dst = lhs | rhs (full 64-bit word)
     Or { dst: VReg, lhs: VReg, rhs: VReg },
-    /// dst = zero_extend((lhs | rhs)[31:0])
+    /// `dst = zero_extend((lhs | rhs)[31:0])`
     Or32 { dst: VReg, lhs: VReg, rhs: VReg },
     /// dst = lhs ^ rhs (full 64-bit word)
     Xor { dst: VReg, lhs: VReg, rhs: VReg },
-    /// dst = zero_extend((lhs ^ rhs)[31:0])
+    /// `dst = zero_extend((lhs ^ rhs)[31:0])`
     Xor32 { dst: VReg, lhs: VReg, rhs: VReg },
     /// dst = lhs >> rhs (logical)
     Shr { dst: VReg, lhs: VReg, rhs: VReg },
@@ -945,7 +945,7 @@ pub enum MInst {
     // ── ALU with immediate ─────────────────────────────────────
     /// dst = src & imm (full 64-bit word)
     AndImm { dst: VReg, src: VReg, imm: u64 },
-    /// dst = zero_extend((src & imm)[31:0])
+    /// `dst = zero_extend((src & imm)[31:0])`
     ///
     /// `imm` must fit in u32.
     AndImm32 { dst: VReg, src: VReg, imm: u32 },

--- a/crates/celox-design/Cargo.toml
+++ b/crates/celox-design/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name                  = "celox-design"
 version.workspace     = true
-publish               = false
+publish               = ["crates-io"]
 authors.workspace     = true
 repository.workspace  = true
 license.workspace     = true
 description           = "Source-independent elaborated design model for Celox"
 edition.workspace     = true
+rust-version.workspace = true
 
 [dependencies]
 fxhash = { workspace = true }

--- a/crates/celox-frontend-core/Cargo.toml
+++ b/crates/celox-frontend-core/Cargo.toml
@@ -1,17 +1,19 @@
 [package]
 name = "celox-frontend-core"
 version.workspace = true
+publish = ["crates-io"]
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 description = "Source-neutral symbolic frontend core for Celox"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
-celox-design = { path = "../celox-design" }
-celox-frontend-sdk = { path = "../celox-frontend-sdk" }
-celox-sir = { path = "../celox-sir" }
-celox-slt = { path = "../celox-slt" }
+celox-design = { workspace = true }
+celox-frontend-sdk = { workspace = true }
+celox-sir = { workspace = true }
+celox-slt = { workspace = true }
 fxhash = { workspace = true }
 miette = { workspace = true }
 num-bigint = { workspace = true }

--- a/crates/celox-frontend-sdk/Cargo.toml
+++ b/crates/celox-frontend-sdk/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "celox-frontend-sdk"
-version = "0.1.0"
+version.workspace = true
+publish = ["crates-io"]
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/celox-frontend-sdk/README.md
+++ b/crates/celox-frontend-sdk/README.md
@@ -21,20 +21,35 @@ let artifact = module.finish();
 # Ok::<(), celox_frontend_sdk::BuildError>(())
 ```
 
-In Rust, pass the result to `celox::Simulator::from_frontend`. For TypeScript
-testbenches, serialize it with `FrontendArtifact::to_json` and call
-`Simulator.fromFrontendArtifact` or `Simulation.fromFrontendArtifact` from
-`@celox-sim/celox`.
+`FrontendArtifact` is an adapter boundary, not the artifact type an application
+should consume. A frontend crate should keep the conversion internal and expose
+an API named for its own representation:
 
-A Veryl native testbench can instantiate the artifact module using its existing
-`$sv::ModuleName` external-module syntax. Pass the artifact and testbench
-sources to `celox::Simulator::from_frontend_with_testbench`; the TypeScript
-equivalent is `runTestWithFrontendArtifact`.
+```rust,ignore
+pub use celox::Simulator;
 
-The versioned JSON representation is checked at decode time. Consumers should
-produce it through `to_json` instead of relying on its field spelling as a
-hand-authored format.
+pub trait MyFrontendSimulatorExt: Sized {
+    fn from_my_artifact(artifact: MyArtifact) -> Result<Self, MyError>;
+}
+
+impl MyFrontendSimulatorExt for Simulator {
+    fn from_my_artifact(artifact: MyArtifact) -> Result<Self, MyError> {
+        let celox_artifact = lower_to_celox(&artifact)?;
+        Ok(Simulator::from_frontend(celox_artifact).build()?)
+    }
+}
+```
+
+After importing the extension trait, applications call
+`Simulator::from_my_artifact` and do not need to know that the adapter uses
+Celox's bridge type.
+
+Pass the resulting Rust value directly to Celox. The JSON representation is a
+separate transport format and is not required to build a Rust simulator binary.
 
 Artifact format version 1 models one flattened module and does not support
 bidirectional (`inout`) signals. External frontends must lower them to separate
 input, output, and output-enable signals before building the artifact.
+
+Frontend adapters that use both `celox-frontend-sdk` and `celox` must keep their
+versions aligned.

--- a/crates/celox-frontend-sv/Cargo.toml
+++ b/crates/celox-frontend-sv/Cargo.toml
@@ -1,18 +1,20 @@
 [package]
 name = "celox-frontend-sv"
 version.workspace = true
+publish = ["crates-io"]
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 description = "SystemVerilog frontend adapter for Celox"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
-celox-design = { path = "../celox-design" }
-celox-frontend-core = { path = "../celox-frontend-core" }
-celox-sir = { path = "../celox-sir" }
-celox-slt = { path = "../celox-slt" }
-celox-sv-analyzer = { path = "../celox-sv-analyzer" }
+celox-design = { workspace = true }
+celox-frontend-core = { workspace = true }
+celox-sir = { workspace = true }
+celox-slt = { workspace = true }
+celox-sv-analyzer = { workspace = true }
 fxhash = { workspace = true }
 num-bigint = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/celox-frontend-veryl/Cargo.toml
+++ b/crates/celox-frontend-veryl/Cargo.toml
@@ -1,20 +1,22 @@
 [package]
 name                  = "celox-frontend-veryl"
 version.workspace     = true
+publish               = ["crates-io"]
 authors.workspace     = true
 repository.workspace  = true
 license.workspace     = true
 description           = "Veryl frontend adapter for Celox"
 edition.workspace     = true
+rust-version.workspace = true
 
 [dependencies]
 tracing = { workspace = true }
 bit-set        = { workspace = true }
-celox-design   = { path = "../celox-design" }
-celox-frontend-core = { path = "../celox-frontend-core" }
-celox-sir      = { path = "../celox-sir" }
-celox-slt      = { path = "../celox-slt" }
-celox-testbench = { path = "../celox-testbench" }
+celox-design   = { workspace = true }
+celox-frontend-core = { workspace = true }
+celox-sir      = { workspace = true }
+celox-slt      = { workspace = true }
+celox-testbench = { workspace = true }
 fxhash         = { workspace = true }
 miette         = { workspace = true }
 num-bigint     = { workspace = true }

--- a/crates/celox-macros/Cargo.toml
+++ b/crates/celox-macros/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name                  = "celox-macros"
 version.workspace     = true
-publish               = false
+publish               = ["crates-io"]
 authors.workspace     = true
 repository.workspace  = true
 license.workspace     = true
 description.workspace = true
 edition.workspace     = true
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/celox-napi/Cargo.toml
+++ b/crates/celox-napi/Cargo.toml
@@ -1,21 +1,22 @@
 [package]
 name                  = "celox-napi"
 version.workspace     = true
-publish               = false
+publish               = ["crates-io"]
 authors.workspace     = true
 repository.workspace  = true
 license.workspace     = true
-description.workspace = true
+description           = "N-API/WASI simulator handles and frontend adapter API for Celox"
+readme                = "README.md"
 edition.workspace     = true
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 napi              = { version = "=3.12.1", features = ["napi8", "serde-json"] }
 napi-derive       = "=3.6.3"
-celox-ts-gen      = { path = "../celox-ts-gen" }
-celox-design      = { path = "../celox-design" }
+celox-ts-gen      = { workspace = true }
+celox-design      = { workspace = true }
 veryl-analyzer    = { workspace = true }
 veryl-metadata    = { workspace = true }
 veryl-parser      = { workspace = true }
@@ -28,10 +29,10 @@ globset           = "0.4"
 fxhash            = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-celox = { path = "../celox" }
+celox = { workspace = true, features = ["host-runtime"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-celox = { path = "../celox", default-features = false }
+celox = { workspace = true }
 
 [build-dependencies]
 napi-build = "=2.4.1"

--- a/crates/celox-napi/README.md
+++ b/crates/celox-napi/README.md
@@ -1,0 +1,48 @@
+# celox-napi
+
+Rust adapter API and N-API/WASI handles for Celox. This crate is useful to
+frontend authors that ship their own native addon and want to expose a
+frontend-specific constructor without serializing a Celox artifact as JSON.
+
+The frontend addon accepts its own artifact type, lowers it with
+`celox-frontend-sdk`, and returns the standard handle:
+
+```rust
+use celox_frontend_sdk::FrontendArtifact;
+use celox_napi::NativeSimulatorHandle;
+use napi::Result;
+use napi_derive::napi;
+
+#[napi(object)]
+pub struct MyArtifact {
+    // Fields owned by this frontend.
+    pub module_name: String,
+}
+
+fn lower_to_celox(artifact: MyArtifact) -> Result<FrontendArtifact> {
+    # todo!()
+}
+
+#[napi]
+pub fn from_my_artifact(artifact: MyArtifact) -> Result<NativeSimulatorHandle> {
+    NativeSimulatorHandle::from_frontend(lower_to_celox(artifact)?, None)
+}
+```
+
+The frontend's TypeScript package can expose the API its users expect:
+
+```ts
+import { Simulator, type FrontendSimulatorHandle } from "@celox-sim/celox";
+import { fromMyArtifact as nativeFromMyArtifact } from "./native.js";
+
+export function fromMyArtifact<P>(artifact: MyArtifact): Simulator<P> {
+  const handle: FrontendSimulatorHandle = nativeFromMyArtifact(artifact);
+  return Simulator.fromFrontendHandle<P>(handle);
+}
+```
+
+`MyArtifact` remains the frontend's public model. Its conversion happens inside
+Rust, directly into `FrontendArtifact`; the frontend artifact is not transported
+as JSON.
+
+See `examples/my-frontend-napi` in the Celox repository for a buildable addon.

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -837,6 +837,40 @@ pub struct NativeSimulatorHandle {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+impl NativeSimulatorHandle {
+    /// Wrap a simulator built by an external frontend in the standard Celox
+    /// N-API handle.
+    ///
+    /// This is a Rust-only adapter API. A frontend binding can accept its own
+    /// artifact type in a `#[napi]` function, lower it with
+    /// `celox-frontend-sdk`, build a [`celox::Simulator`], and pass the value
+    /// here without serializing an artifact to JSON.
+    pub fn from_simulator(
+        simulator: celox::Simulator,
+        four_state: bool,
+        vcd_path: Option<&str>,
+    ) -> Result<Self> {
+        Self::build_and_cache(simulator, four_state, vcd_path, None)
+    }
+
+    /// Build an N-API handle directly from an in-memory frontend artifact.
+    ///
+    /// Frontend bindings normally expose an artifact-specific function such
+    /// as `from_my_artifact` and use this as their final adapter step.
+    pub fn from_frontend(
+        artifact: celox::FrontendArtifact,
+        options: Option<NapiOptions>,
+    ) -> Result<Self> {
+        let opts = parse_options(&options)?;
+        let builder = apply_options(celox::Simulator::from_frontend(artifact), &opts);
+        let simulator = builder
+            .build()
+            .map_err(|error| Error::from_reason(error.to_string()))?;
+        Self::from_simulator(simulator, opts.four_state, opts.vcd.as_deref())
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 #[napi]
 impl NativeSimulatorHandle {
     /// Build a full simulator, extract metadata, cache the compiled code,
@@ -978,14 +1012,9 @@ impl NativeSimulatorHandle {
         artifact_json: String,
         options: Option<NapiOptions>,
     ) -> Result<Self> {
-        let opts = parse_options(&options)?;
         let artifact = celox::FrontendArtifact::from_json(&artifact_json)
             .map_err(|error| Error::from_reason(error.to_string()))?;
-        let builder = apply_options(celox::Simulator::from_frontend(artifact), &opts);
-        let sim = builder
-            .build()
-            .map_err(|error| Error::from_reason(error.to_string()))?;
-        Self::build_and_cache(sim, opts.four_state, opts.vcd.as_deref(), None)
+        Self::from_frontend(artifact, options)
     }
 
     /// Create a new simulator from a Veryl project directory.
@@ -1495,6 +1524,52 @@ pub struct NativeSimulatorHandle {
 }
 
 #[cfg(target_arch = "wasm32")]
+impl NativeSimulatorHandle {
+    /// Build an N-API/WASI handle directly from an in-memory frontend
+    /// artifact.
+    ///
+    /// Frontend bindings can accept their own artifact type, lower it with
+    /// `celox-frontend-sdk`, and call this Rust-only adapter API without a JSON
+    /// serialization boundary.
+    pub fn from_frontend(
+        artifact: celox::FrontendArtifact,
+        options: Option<NapiOptions>,
+    ) -> Result<Self> {
+        let opts = parse_options_common(&options)?;
+        let trace_opts = celox::TraceOptions::default();
+        let (program, warnings) = celox::compile_frontend_to_sir(
+            &artifact,
+            &opts.false_loops,
+            &opts.true_loops,
+            opts.four_state,
+            &trace_opts,
+            None,
+            &opts.optimize_options,
+        )
+        .map_err(|error| Error::from_reason(error.to_string()))?;
+
+        let laid_out = program.into_laid_out(opts.four_state);
+        let layout = laid_out.layout();
+        let layout_json = Self::build_layout_json(&laid_out, layout, opts.four_state);
+        let events_json = Self::build_events_json(&laid_out);
+        let warnings_json = format_warnings_json(&warnings);
+        let stable_size = layout.total_size as u32;
+        let total_size = layout.merged_total_size as u32;
+
+        Ok(Self {
+            program: laid_out,
+            four_state: opts.four_state,
+            layout_json,
+            events_json,
+            hierarchy_json: "{}".to_string(),
+            warnings_json,
+            stable_size,
+            total_size,
+        })
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
 #[napi]
 impl NativeSimulatorHandle {
     /// Compile Veryl source code and produce a WASM-oriented handle.
@@ -1574,39 +1649,9 @@ impl NativeSimulatorHandle {
         artifact_json: String,
         options: Option<NapiOptions>,
     ) -> Result<Self> {
-        let opts = parse_options_common(&options)?;
         let artifact = celox::FrontendArtifact::from_json(&artifact_json)
             .map_err(|error| Error::from_reason(error.to_string()))?;
-        let trace_opts = celox::TraceOptions::default();
-        let (program, warnings) = celox::compile_frontend_to_sir(
-            &artifact,
-            &opts.false_loops,
-            &opts.true_loops,
-            opts.four_state,
-            &trace_opts,
-            None,
-            &opts.optimize_options,
-        )
-        .map_err(|error| Error::from_reason(error.to_string()))?;
-
-        let laid_out = program.into_laid_out(opts.four_state);
-        let layout = laid_out.layout();
-        let layout_json = Self::build_layout_json(&laid_out, layout, opts.four_state);
-        let events_json = Self::build_events_json(&laid_out);
-        let warnings_json = format_warnings_json(&warnings);
-        let stable_size = layout.total_size as u32;
-        let total_size = layout.merged_total_size as u32;
-
-        Ok(Self {
-            program: laid_out,
-            four_state: opts.four_state,
-            layout_json,
-            events_json,
-            hierarchy_json: "{}".to_string(),
-            warnings_json,
-            stable_size,
-            total_size,
-        })
+        Self::from_frontend(artifact, options)
     }
 
     /// Create a new simulator from a Veryl project directory.

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -844,13 +844,10 @@ impl NativeSimulatorHandle {
     /// This is a Rust-only adapter API. A frontend binding can accept its own
     /// artifact type in a `#[napi]` function, lower it with
     /// `celox-frontend-sdk`, build a [`celox::Simulator`], and pass the value
-    /// here without serializing an artifact to JSON.
-    pub fn from_simulator(
-        simulator: celox::Simulator,
-        four_state: bool,
-        vcd_path: Option<&str>,
-    ) -> Result<Self> {
-        Self::build_and_cache(simulator, four_state, vcd_path, None)
+    /// here without serializing an artifact to JSON. Signal metadata is always
+    /// derived from the simulator's actual memory layout.
+    pub fn from_simulator(simulator: celox::Simulator, vcd_path: Option<&str>) -> Result<Self> {
+        Self::build_and_cache(simulator, vcd_path, None)
     }
 
     /// Build an N-API handle directly from an in-memory frontend artifact.
@@ -866,7 +863,7 @@ impl NativeSimulatorHandle {
         let simulator = builder
             .build()
             .map_err(|error| Error::from_reason(error.to_string()))?;
-        Self::from_simulator(simulator, opts.four_state, opts.vcd.as_deref())
+        Self::from_simulator(simulator, opts.vcd.as_deref())
     }
 }
 
@@ -877,10 +874,10 @@ impl NativeSimulatorHandle {
     /// and return the handle with a JitBackend (and optional VcdWriter).
     fn build_and_cache(
         sim: celox::Simulator,
-        four_state: bool,
         vcd_path: Option<&str>,
         cache_key: Option<CacheKey>,
     ) -> Result<Self> {
+        let four_state = sim.layout().four_state;
         let warnings_json = format_warnings_json(sim.warnings());
         let signals = sim.named_signals();
         let events = sim.named_events();
@@ -1003,7 +1000,7 @@ impl NativeSimulatorHandle {
             .build()
             .map_err(|e| Error::from_reason(format!("{}", e)))?;
 
-        Self::build_and_cache(sim, opts.four_state, opts.vcd.as_deref(), Some(cache_key))
+        Self::build_and_cache(sim, opts.vcd.as_deref(), Some(cache_key))
     }
 
     /// Create a simulator from a versioned external-frontend artifact.
@@ -1054,7 +1051,7 @@ impl NativeSimulatorHandle {
             .build()
             .map_err(|e| Error::from_reason(format!("{}", e)))?;
 
-        Self::build_and_cache(sim, opts.four_state, opts.vcd.as_deref(), Some(cache_key))
+        Self::build_and_cache(sim, opts.vcd.as_deref(), Some(cache_key))
     }
 
     /// Returns the signal layout as a JSON string.
@@ -2969,6 +2966,23 @@ mod tests {
             .iter()
             .map(|(content, path)| (content.to_string(), std::path::PathBuf::from(path)))
             .collect()
+    }
+
+    #[test]
+    fn simulator_handle_derives_four_state_metadata_from_layout() {
+        let source = "module Top (a: input logic<1>) {}";
+        let path = std::path::Path::new("top.veryl");
+
+        for four_state in [false, true] {
+            let simulator = celox::Simulator::from_sources(vec![(source, path)], "Top")
+                .four_state(four_state)
+                .build()
+                .unwrap();
+            let handle = NativeSimulatorHandle::from_simulator(simulator, None).unwrap();
+            let layout: serde_json::Value = serde_json::from_str(&handle.layout_json()).unwrap();
+
+            assert_eq!(layout["a"]["is_4state"].as_bool(), Some(four_state));
+        }
     }
 
     #[test]

--- a/crates/celox-runtime/Cargo.toml
+++ b/crates/celox-runtime/Cargo.toml
@@ -1,16 +1,18 @@
 [package]
 name = "celox-runtime"
 version.workspace = true
+publish = ["crates-io"]
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 description = "Backend-independent Celox simulation runtime contracts"
 edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
-celox-design = { path = "../celox-design" }
-celox-state-layout = { path = "../celox-state-layout" }
-celox-testbench = { path = "../celox-testbench" }
+celox-design = { workspace = true }
+celox-state-layout = { workspace = true }
+celox-testbench = { workspace = true }
 bit-set = { workspace = true }
 chrono = "0.4"
 fxhash.workspace = true

--- a/crates/celox-sir-opt/Cargo.toml
+++ b/crates/celox-sir-opt/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "celox-sir-opt"
 version.workspace = true
+publish = ["crates-io"]
 authors.workspace = true
 repository.workspace = true
 license.workspace = true
 description = "Backend-independent SIR optimization policy and passes for Celox"
 edition.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []
@@ -15,10 +17,10 @@ wide-native-memory = []
 [dependencies]
 tracing = { workspace = true }
 bit-set             = { workspace = true }
-celox-analysis      = { path = "../celox-analysis" }
-celox-design        = { path = "../celox-design" }
-celox-sir           = { path = "../celox-sir" }
-celox-state-layout  = { path = "../celox-state-layout" }
+celox-analysis      = { workspace = true }
+celox-design        = { workspace = true }
+celox-sir           = { workspace = true }
+celox-state-layout  = { workspace = true }
 fxhash              = { workspace = true }
 itertools           = { workspace = true }
 num-bigint          = "0.5"

--- a/crates/celox-sir/Cargo.toml
+++ b/crates/celox-sir/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
 name                  = "celox-sir"
 version.workspace     = true
-publish               = false
+publish               = ["crates-io"]
 authors.workspace     = true
 repository.workspace  = true
 license.workspace     = true
 description           = "Backend-independent Simulator IR for Celox"
 edition.workspace     = true
+rust-version.workspace = true
 
 [dependencies]
-celox-analysis = { path = "../celox-analysis" }
-celox-design   = { path = "../celox-design" }
+celox-analysis = { workspace = true }
+celox-design   = { workspace = true }
 fxhash         = { workspace = true }
 num-bigint     = { workspace = true }
 num-traits     = { workspace = true }

--- a/crates/celox-sir/src/transform.rs
+++ b/crates/celox-sir/src/transform.rs
@@ -8,7 +8,7 @@ use crate::{
 /// Merge multiple SIR ExecutionUnits into a single EU.
 /// Each EU's Return becomes a Jump to the next EU's entry block.
 /// RegisterIds and BlockIds are renumbered to avoid conflicts.
-/// Returns (merged_eu, eu_entry_block_ids) where eu_entry_block_ids[i] is the
+/// Returns (merged_eu, eu_entry_block_ids) where `eu_entry_block_ids[i]` is the
 /// BlockId of the i-th EU's entry block in the merged EU (for i > 0).
 pub fn merge_sir_eus<A: Clone>(units: &[ExecutionUnit<A>]) -> (ExecutionUnit<A>, Vec<BlockId>) {
     let units = units.iter().collect::<Vec<_>>();

--- a/crates/celox-slt/Cargo.toml
+++ b/crates/celox-slt/Cargo.toml
@@ -1,17 +1,19 @@
 [package]
 name                  = "celox-slt"
 version.workspace     = true
+publish               = ["crates-io"]
 authors.workspace     = true
 repository.workspace  = true
 license.workspace     = true
 description           = "Source-independent symbolic logic tree core for Celox"
 edition.workspace     = true
+rust-version.workspace = true
 
 [dependencies]
 tracing = { workspace = true }
-celox-analysis = { path = "../celox-analysis" }
-celox-design = { path = "../celox-design" }
-celox-sir    = { path = "../celox-sir" }
+celox-analysis = { workspace = true }
+celox-design = { workspace = true }
+celox-sir    = { workspace = true }
 fxhash       = { workspace = true }
 num-bigint   = { workspace = true }
 num-traits   = { workspace = true }

--- a/crates/celox-slt/src/node.rs
+++ b/crates/celox-slt/src/node.rs
@@ -1270,7 +1270,7 @@ impl<A: fmt::Debug + fmt::Display + Hash + Eq + Clone> SLTNode<A> {
 /// making it easy to visualize the expression structure. Each node type displays relevant
 /// information:
 ///
-/// - **Input**: Shows variable ID, dynamic indices (if any), and bit range [lsb:msb]
+/// - **Input**: Shows variable ID, dynamic indices (if any), and bit range `[lsb:msb]`
 /// - **Constant**: Displays the value in hexadecimal and width in bits
 /// - **Binary**: Shows the operation and recursively formats both operands with indentation
 /// - **Unary**: Shows the operation and recursively formats the inner expression

--- a/crates/celox-state-layout/Cargo.toml
+++ b/crates/celox-state-layout/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name                  = "celox-state-layout"
 version.workspace     = true
-publish               = false
+publish               = ["crates-io"]
 authors.workspace     = true
 repository.workspace  = true
 license.workspace     = true
 description           = "Physical simulation-state layout contracts for Celox"
 edition.workspace     = true
+rust-version.workspace = true
 
 [dependencies]
-celox-design = { path = "../celox-design" }
+celox-design = { workspace = true }
 fxhash       = { workspace = true }
 serde        = { workspace = true }
 

--- a/crates/celox-sv-analyzer/Cargo.toml
+++ b/crates/celox-sv-analyzer/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name                  = "celox-sv-analyzer"
 version.workspace     = true
+publish               = ["crates-io"]
 authors.workspace     = true
 repository.workspace  = true
 license.workspace     = true

--- a/crates/celox-sv-analyzer/src/lib.rs
+++ b/crates/celox-sv-analyzer/src/lib.rs
@@ -375,7 +375,7 @@ mod tests {
     #[test]
     fn inlines_veryl_generated_std_counter_functions() {
         let ir = analyze_source(
-            include_str!("../../../benches/verilator/StdCounter.sv"),
+            include_str!("../testdata/verilator/StdCounter.sv"),
             Path::new("StdCounter.sv"),
         )
         .expect("SV analysis should succeed");
@@ -434,7 +434,7 @@ mod tests {
     #[test]
     fn analyzes_veryl_generated_lfsr_tap_assignments() {
         let ir = analyze_source(
-            include_str!("../../../benches/verilator/Lfsr.sv"),
+            include_str!("../testdata/verilator/Lfsr.sv"),
             Path::new("Lfsr.sv"),
         )
         .expect("SV analysis should succeed");
@@ -476,7 +476,7 @@ mod tests {
     #[test]
     fn specializes_veryl_generated_lfsr_top_bit_assignment() {
         let ir = analyze_source_with_module_parameter_overrides(
-            include_str!("../../../benches/verilator/Lfsr.sv"),
+            include_str!("../testdata/verilator/Lfsr.sv"),
             Path::new("Lfsr.sv"),
             "lfsr_galois",
             &[("SIZE".to_string(), 32)].into_iter().collect(),
@@ -926,32 +926,26 @@ mod tests {
         let cases = [
             (
                 "Countones.sv",
-                include_str!("../../../benches/verilator/Countones.sv"),
+                include_str!("../testdata/verilator/Countones.sv"),
             ),
             (
                 "StdCounter.sv",
-                include_str!("../../../benches/verilator/StdCounter.sv"),
+                include_str!("../testdata/verilator/StdCounter.sv"),
             ),
             (
                 "GrayCounter.sv",
-                include_str!("../../../benches/verilator/GrayCounter.sv"),
+                include_str!("../testdata/verilator/GrayCounter.sv"),
             ),
             (
                 "GrayCodec.sv",
-                include_str!("../../../benches/verilator/GrayCodec.sv"),
+                include_str!("../testdata/verilator/GrayCodec.sv"),
             ),
             (
                 "EdgeDetector.sv",
-                include_str!("../../../benches/verilator/EdgeDetector.sv"),
+                include_str!("../testdata/verilator/EdgeDetector.sv"),
             ),
-            (
-                "Onehot.sv",
-                include_str!("../../../benches/verilator/Onehot.sv"),
-            ),
-            (
-                "Lfsr.sv",
-                include_str!("../../../benches/verilator/Lfsr.sv"),
-            ),
+            ("Onehot.sv", include_str!("../testdata/verilator/Onehot.sv")),
+            ("Lfsr.sv", include_str!("../testdata/verilator/Lfsr.sv")),
         ];
 
         for (name, code) in cases {
@@ -967,11 +961,8 @@ mod tests {
     #[test]
     fn rejects_unlowered_constructs_in_veryl_emitted_sources() {
         for (name, source) in [
-            ("Top.sv", include_str!("../../../benches/verilator/Top.sv")),
-            (
-                "Fifo.sv",
-                include_str!("../../../benches/verilator/Fifo.sv"),
-            ),
+            ("Top.sv", include_str!("../testdata/verilator/Top.sv")),
+            ("Fifo.sv", include_str!("../testdata/verilator/Fifo.sv")),
         ] {
             let error = analyze_source(source, Path::new(name))
                 .expect_err("unlowered constructs must not be silently ignored");
@@ -982,7 +973,7 @@ mod tests {
         }
 
         let error = analyze_source(
-            include_str!("../../../benches/verilator/LinearSec.sv"),
+            include_str!("../testdata/verilator/LinearSec.sv"),
             Path::new("LinearSec.sv"),
         )
         .expect_err("loop-local declarations must not be silently ignored");
@@ -996,7 +987,7 @@ mod tests {
     #[test]
     fn records_veryl_emitted_module_instantiations() {
         let ir = analyze_source(
-            include_str!("../../../benches/verilator/StdCounter.sv"),
+            include_str!("../testdata/verilator/StdCounter.sv"),
             Path::new("StdCounter.sv"),
         )
         .expect("SV analysis should succeed");

--- a/crates/celox-sv-analyzer/testdata/verilator/Countones.sv
+++ b/crates/celox-sv-analyzer/testdata/verilator/Countones.sv
@@ -1,0 +1,48 @@
+module countones #(
+    parameter  int unsigned W     = 16                                   ,
+    localparam int unsigned CLOGW = ((W > 1) ? ( $clog2(W) + 1 ) : ( 1 ))
+) (
+    input  var logic [W-1:0]     i_data,
+    output var logic [CLOGW-1:0] o_ones
+);
+    if ((W == 1)) begin :gen_base_case
+        always_comb o_ones = i_data;
+    end else begin :gen_rec_case
+        localparam int unsigned            WBOT     = W / 2;
+        localparam int unsigned            WTOP     = W - WBOT;
+        logic        [WBOT-1:0] data_bot; always_comb data_bot = i_data[WBOT - 1:0];
+        logic        [WTOP-1:0] data_top; always_comb data_top = i_data[W - 1:WBOT];
+
+        localparam int unsigned                CLOGWBOT = ((WBOT > 1) ? ( $clog2(WBOT) + 1 ) : ( 1 ));
+        localparam int unsigned                CLOGWTOP = ((WTOP > 1) ? ( $clog2(WTOP) + 1 ) : ( 1 ));
+        logic        [CLOGWBOT-1:0] ones_bot;
+        logic        [CLOGWTOP-1:0] ones_top;
+
+        countones #(
+            .W (WBOT)
+        ) u_bot (
+            .i_data (data_bot),
+            .o_ones (ones_bot)
+        );
+        countones #(
+            .W (WTOP)
+        ) u_top (
+            .i_data (data_top),
+            .o_ones (ones_top)
+        );
+        always_comb o_ones = {{(W - WTOP){1'b0}}, ones_top} + {{(W - WBOT){1'b0}}, ones_bot};
+
+    end
+endmodule
+
+module Top (
+    input  var logic [64-1:0] i_data,
+    output var logic [7-1:0]  o_ones
+);
+    countones #(
+        .W      (64    )
+    ) u (
+        .i_data (i_data),
+        .o_ones (o_ones)
+    );
+endmodule

--- a/crates/celox-sv-analyzer/testdata/verilator/EdgeDetector.sv
+++ b/crates/celox-sv-analyzer/testdata/verilator/EdgeDetector.sv
@@ -1,0 +1,59 @@
+
+module edge_detector #(
+
+    parameter int unsigned WIDTH = 1,
+
+    parameter bit [WIDTH-1:0] INITIAL_VALUE = '0
+) (
+
+    input var logic i_clk,
+
+    input var logic i_rst,
+
+    input var logic i_clear,
+
+    input var logic [WIDTH-1:0] i_data,
+
+    output var logic [WIDTH-1:0] o_edge,
+
+    output var logic [WIDTH-1:0] o_posedge,
+
+    output var logic [WIDTH-1:0] o_negedge
+);
+    logic [WIDTH-1:0] data;
+
+    always_comb o_edge    = (i_data) ^ (data) & (~i_clear);
+    always_comb o_posedge = (i_data) & (~data) & (~i_clear);
+    always_comb o_negedge = (~i_data) & (data) & (~i_clear);
+
+    always_ff @ (posedge i_clk, negedge i_rst) begin
+        if (!i_rst) begin
+            data <= INITIAL_VALUE;
+        end else if (i_clear) begin
+            data <= INITIAL_VALUE;
+        end else begin
+            data <= i_data;
+        end
+    end
+endmodule
+
+module Top (
+    input  var logic          clk      ,
+    input  var logic          rst      ,
+    input  var logic [32-1:0] i_data   ,
+    output var logic [32-1:0] o_edge   ,
+    output var logic [32-1:0] o_posedge,
+    output var logic [32-1:0] o_negedge
+);
+    edge_detector #(
+        .WIDTH     (32       )
+    ) u (
+        .i_clk     (clk      ),
+        .i_rst     (rst      ),
+        .i_clear   (1'b0     ),
+        .i_data    (i_data   ),
+        .o_edge    (o_edge   ),
+        .o_posedge (o_posedge),
+        .o_negedge (o_negedge)
+    );
+endmodule

--- a/crates/celox-sv-analyzer/testdata/verilator/Fifo.sv
+++ b/crates/celox-sv-analyzer/testdata/verilator/Fifo.sv
@@ -1,0 +1,551 @@
+module ram #(
+    parameter int unsigned WORD_SIZE     = 1                                                 ,
+    parameter int unsigned ADDRESS_WIDTH = ((WORD_SIZE >= 2) ? ( $clog2(WORD_SIZE) ) : ( 1 )),
+    parameter int unsigned DATA_WIDTH    = 8                                                 ,
+    parameter type         DATA_TYPE     = logic [DATA_WIDTH-1:0]                            ,
+    parameter bit          BUFFER_OUT    = 1'b0                                              ,
+    parameter bit          USE_RESET     = 1'b0                                              ,
+    parameter DATA_TYPE    INITIAL_VALUE = DATA_TYPE'(0                                     )
+) (
+    input  var logic                         i_clk ,
+    input  var logic                         i_rst ,
+    input  var logic                         i_clr ,
+    input  var logic                         i_mea ,
+    input  var logic                         i_wea ,
+    input  var logic     [ADDRESS_WIDTH-1:0] i_adra,
+    input  var DATA_TYPE                     i_da  ,
+    input  var logic                         i_meb ,
+    input  var logic     [ADDRESS_WIDTH-1:0] i_adrb,
+    output var DATA_TYPE                     o_qb
+);
+    logic [$bits(DATA_TYPE)-1:0] ram_data [WORD_SIZE];
+    logic [$bits(DATA_TYPE)-1:0] q                   ;
+
+    if (USE_RESET) begin :g_ram
+        always_ff @ (posedge i_clk, negedge i_rst) begin
+            if (!i_rst) begin
+                ram_data <= '{default: INITIAL_VALUE};
+            end else if (i_clr) begin
+                ram_data <= '{default: INITIAL_VALUE};
+            end else if (i_mea && i_wea) begin
+                ram_data[i_adra] <= i_da;
+            end
+        end
+    end else begin :g_ram
+        always_ff @ (posedge i_clk) begin
+            if (i_mea && i_wea) begin
+                ram_data[i_adra] <= i_da;
+            end
+        end
+    end
+
+    always_comb begin
+        o_qb = DATA_TYPE'(q);
+    end
+
+    if (!BUFFER_OUT) begin :g_out
+        always_comb begin
+            q = ram_data[i_adrb];
+        end
+    end else if (USE_RESET) begin :g_out
+        always_ff @ (posedge i_clk, negedge i_rst) begin
+            if (!i_rst) begin
+                q <= INITIAL_VALUE;
+            end else if (i_clr) begin
+                q <= INITIAL_VALUE;
+            end else if (i_meb) begin
+                q <= ram_data[i_adrb];
+            end
+        end
+    end else begin :g_out
+        always_ff @ (posedge i_clk) begin
+            if (i_meb) begin
+                q <= ram_data[i_adrb];
+            end
+        end
+    end
+endmodule
+
+module fifo_controller #(
+    parameter  type         TYPE              = logic                                             ,
+    parameter  int unsigned DEPTH             = 8                                                 ,
+    parameter  int unsigned THRESHOLD         = DEPTH                                             ,
+    parameter  bit          FLAG_FF_OUT       = 1'b1                                              ,
+    parameter  bit          DATA_FF_OUT       = 1'b1                                              ,
+    parameter  bit          PUSH_ON_CLEAR     = 1'b0                                              ,
+    parameter  int unsigned RAM_WORDS         = ((DATA_FF_OUT) ? ( DEPTH - 1 ) : ( DEPTH        )),
+    parameter  int unsigned RAM_POINTER_WIDTH = ((RAM_WORDS >= 2) ? ( $clog2(RAM_WORDS) ) : ( 1 )),
+    parameter  int unsigned MATCH_COUNT_WIDTH = 0                                                 ,
+    parameter  int unsigned POINTER_WIDTH     = ((DEPTH >= 2) ? ( $clog2(DEPTH) ) : ( 1         )),
+    localparam type         RAM_POINTER       = logic [RAM_POINTER_WIDTH-1:0]                     ,
+    localparam type         POINTER           = logic [POINTER_WIDTH-1:0]                         ,
+    localparam type         COUNTER           = logic [$clog2(DEPTH + 1)-1:0]
+) (
+    input  var logic       i_clk          ,
+    input  var logic       i_rst          ,
+    input  var logic       i_clear        ,
+    output var logic       o_empty        ,
+    output var logic       o_almost_full  ,
+    output var logic       o_full         ,
+    output var COUNTER     o_word_count   ,
+    input  var logic       i_push         ,
+    input  var TYPE        i_data         ,
+    input  var logic       i_pop          ,
+    output var RAM_POINTER o_write_pointer,
+    output var logic       o_write_to_ff  ,
+    output var logic       o_write_to_ram ,
+    output var RAM_POINTER o_read_pointer ,
+    output var logic       o_read_from_ram
+);
+    typedef struct packed {
+        logic empty      ;
+        logic almost_full;
+        logic full       ;
+    } s_status_flag;
+
+    logic                 push             ;
+    logic                 pop              ;
+    logic         [2-1:0] clear            ;
+    logic                 update_state     ;
+    COUNTER               word_counter     ;
+    COUNTER               word_counter_next;
+    logic                 word_counter_eq_1;
+    logic                 word_counter_eq_2;
+    logic                 word_counter_ge_2;
+    s_status_flag         status_flag      ;
+    logic                 write_to_ff      ;
+    logic                 write_to_ram     ;
+    RAM_POINTER           ram_write_pointer;
+    logic                 read_from_ram    ;
+    RAM_POINTER           ram_read_pointer ;
+    logic                 ram_empty_next   ;
+    logic                 match_data       ;
+    logic                 last_pop_data    ;
+
+    always_comb begin
+        push = i_push && ((PUSH_ON_CLEAR && i_clear) || ((!status_flag.full) && (!match_data)));
+        pop  = i_pop && (!status_flag.empty) && last_pop_data;
+    end
+
+    always_comb begin
+        clear[0] = i_clear && ((!PUSH_ON_CLEAR) || (!push));
+        clear[1] = i_clear && PUSH_ON_CLEAR && push;
+    end
+
+    always_comb begin
+        update_state = push || pop || i_clear;
+    end
+
+    function automatic COUNTER get_word_counter_next(
+        input var logic           push        ,
+        input var logic           pop         ,
+        input var logic   [2-1:0] clear       ,
+        input var COUNTER         word_counter
+    ) ;
+        logic up  ;
+        logic down;
+        up   = push && (!pop);
+        down = (!push) && pop;
+        case (1'b1)
+            clear[0]: return COUNTER'(0);
+            clear[1]: return COUNTER'(1);
+            up      : return word_counter + COUNTER'(1);
+            down    : return word_counter - COUNTER'(1);
+            default : return word_counter;
+        endcase
+    endfunction
+
+    always_comb begin
+        o_word_count = word_counter;
+    end
+
+    always_comb begin
+        word_counter_eq_1 = (DEPTH >= 1) && (word_counter == COUNTER'(1));
+        word_counter_eq_2 = (DEPTH >= 2) && (word_counter == COUNTER'(2));
+        word_counter_ge_2 = (DEPTH >= 2) && (word_counter >= COUNTER'(2));
+    end
+
+    always_comb begin
+        word_counter_next = get_word_counter_next(push, pop, clear, word_counter);
+    end
+
+    always_ff @ (posedge i_clk, negedge i_rst) begin
+        if (!i_rst) begin
+            word_counter <= '0;
+        end else if (update_state) begin
+            word_counter <= word_counter_next;
+        end
+    end
+
+    function automatic s_status_flag get_status_flag(
+        input var COUNTER word_count
+    ) ;
+        s_status_flag flag            ;
+        flag.empty       = word_count == 0;
+        flag.almost_full = word_count >= THRESHOLD;
+        flag.full        = word_count >= DEPTH;
+        return flag;
+    endfunction
+
+    always_comb begin
+        o_empty       = status_flag.empty;
+        o_almost_full = status_flag.almost_full;
+        o_full        = status_flag.full && (!match_data);
+    end
+
+    if (FLAG_FF_OUT) begin :g_flag_ff_out
+        always_ff @ (posedge i_clk, negedge i_rst) begin
+            if (!i_rst) begin
+                status_flag.empty       <= '1;
+                status_flag.almost_full <= '0;
+                status_flag.full        <= '0;
+            end else if (update_state) begin
+                status_flag <= get_status_flag(word_counter_next);
+            end
+        end
+    end else begin :g_flag_logic_out
+        always_comb begin
+            status_flag = get_status_flag(word_counter);
+        end
+    end
+
+    always_comb begin
+        o_write_pointer = ram_write_pointer;
+        o_write_to_ff   = write_to_ff;
+        o_write_to_ram  = write_to_ram;
+        o_read_pointer  = ram_read_pointer;
+        o_read_from_ram = read_from_ram;
+    end
+
+    if (DATA_FF_OUT) begin :g_data_ff_out
+        always_comb begin
+            if ((word_counter_eq_1 && pop) || status_flag.empty || clear[1]) begin
+                write_to_ff  = push;
+                write_to_ram = '0;
+            end else begin
+                write_to_ff  = '0;
+                write_to_ram = push;
+            end
+            read_from_ram  = pop && word_counter_ge_2;
+            ram_empty_next = read_from_ram && (!write_to_ram) && word_counter_eq_2;
+        end
+    end else begin :g_data_ram_out
+        always_comb begin
+            write_to_ff    = '0;
+            write_to_ram   = push;
+            read_from_ram  = pop;
+            ram_empty_next = read_from_ram && (!write_to_ram) && word_counter_eq_1;
+        end
+    end
+
+    if (RAM_WORDS >= 2) begin :g_multi_word_ram
+        always_ff @ (posedge i_clk, negedge i_rst) begin
+            if (!i_rst) begin
+                ram_write_pointer <= RAM_POINTER'(0);
+            end else if ((clear[0])) begin
+                ram_write_pointer <= RAM_POINTER'(0);
+            end else if ((clear[1])) begin
+                ram_write_pointer <= ((DATA_FF_OUT) ? ( RAM_POINTER'(0) ) : ( RAM_POINTER'(1) ));
+            end else if ((ram_empty_next)) begin
+                ram_write_pointer <= ram_read_pointer;
+            end else if ((write_to_ram)) begin
+                if ((ram_write_pointer == RAM_POINTER'((RAM_WORDS - 1)))) begin
+                    ram_write_pointer <= RAM_POINTER'(0);
+                end else begin
+                    ram_write_pointer <= ram_write_pointer + (RAM_POINTER'(1));
+                end
+            end
+        end
+
+        always_ff @ (posedge i_clk, negedge i_rst) begin
+            if (!i_rst) begin
+                ram_read_pointer <= RAM_POINTER'(0);
+            end else if ((i_clear)) begin
+                ram_read_pointer <= RAM_POINTER'(0);
+            end else if ((ram_empty_next)) begin
+                ram_read_pointer <= ram_read_pointer;
+            end else if ((read_from_ram)) begin
+                if ((ram_read_pointer == RAM_POINTER'((RAM_WORDS - 1)))) begin
+                    ram_read_pointer <= RAM_POINTER'(0);
+                end else begin
+                    ram_read_pointer <= ram_read_pointer + (RAM_POINTER'(1));
+                end
+            end
+        end
+    end else begin :g_single_word_ram
+        always_comb begin
+            ram_write_pointer = RAM_POINTER'(0);
+            ram_read_pointer  = RAM_POINTER'(0);
+        end
+    end
+
+    if (MATCH_COUNT_WIDTH > 0) begin :g_data_match
+        logic   [DEPTH-1:0][MATCH_COUNT_WIDTH-1:0] match_count     ;
+        logic   [DEPTH-1:0]                        match_count_full;
+        logic   [DEPTH-1:0]                        match_count_eq_1;
+        logic   [DEPTH-1:0]                        last_match_data ;
+        POINTER [2-1:0]                            write_pointer   ;
+        POINTER                                    read_pointer    ;
+        TYPE                                       data            ;
+
+        if (DEPTH == RAM_WORDS) begin :g_pointer
+            always_comb begin
+                write_pointer[0] = ram_write_pointer;
+                read_pointer     = ram_read_pointer;
+            end
+        end else begin :g_pointer
+            always_ff @ (posedge i_clk, negedge i_rst) begin
+                if (!i_rst) begin
+                    write_pointer[0] <= POINTER'(0);
+                end else if (clear[0]) begin
+                    write_pointer[0] <= POINTER'(0);
+                end else if (clear[1]) begin
+                    write_pointer[0] <= POINTER'(1);
+                end else if (push) begin
+                    if (write_pointer[0] == POINTER'((DEPTH - 1))) begin
+                        write_pointer[0] <= POINTER'(0);
+                    end else begin
+                        write_pointer[0] <= write_pointer[0] + (POINTER'(1));
+                    end
+                end
+            end
+
+            always_ff @ (posedge i_clk, negedge i_rst) begin
+                if (!i_rst) begin
+                    read_pointer <= POINTER'(0);
+                end else if (i_clear) begin
+                    read_pointer <= POINTER'(0);
+                end else if (pop) begin
+                    if (read_pointer == POINTER'((DEPTH - 1))) begin
+                        read_pointer <= POINTER'(0);
+                    end else begin
+                        read_pointer <= read_pointer + (POINTER'(1));
+                    end
+                end
+            end
+        end
+
+        always_comb begin
+            if (write_pointer[0] == POINTER'(0)) begin
+                write_pointer[1] = POINTER'((DEPTH - 1));
+            end else begin
+                write_pointer[1] = write_pointer[0] - POINTER'(1);
+            end
+        end
+
+        always_ff @ (posedge i_clk) begin
+            if (push) begin
+                data <= i_data;
+            end
+        end
+
+        always_comb begin
+            match_data    = (!status_flag.empty) && (i_data == data) && (!match_count_full[write_pointer[1]]);
+            last_pop_data = last_match_data[read_pointer];
+        end
+
+        for (genvar i = 0; i < DEPTH; i++) begin :g_match_count
+            logic [3-1:0] up_down;
+
+            always_comb begin
+                match_count_full[i] = match_count[i] == '1;
+                match_count_eq_1[i] = match_count[i] == MATCH_COUNT_WIDTH'(1);
+                last_match_data[i]  = match_count_eq_1[i] && (up_down[2:1] == '0);
+            end
+
+            always_comb begin
+                up_down[2] = (match_data == '0) && (write_pointer[0] == POINTER'(i)) && push;
+                up_down[1] = (match_data == '1) && (write_pointer[1] == POINTER'(i)) && i_push;
+                up_down[0] = (!status_flag.empty) && (read_pointer == POINTER'(i)) && i_pop;
+            end
+
+            always_ff @ (posedge i_clk, negedge i_rst) begin
+                if (!i_rst) begin
+                    match_count[i] <= MATCH_COUNT_WIDTH'(0);
+                end else if (clear[0] || (i_clear && (i >= 1))) begin
+                    match_count[i] <= MATCH_COUNT_WIDTH'(0);
+                end else if (clear[1] && (i == 0)) begin
+                    match_count[i] <= MATCH_COUNT_WIDTH'(1);
+                end else if (((up_down) inside {3'b1x0, 3'bx10})) begin
+                    match_count[i] <= match_count[i] + (MATCH_COUNT_WIDTH'(1));
+                end else if (up_down == 3'b001) begin
+                    match_count[i] <= match_count[i] - (MATCH_COUNT_WIDTH'(1));
+                end
+            end
+        end
+    end else begin :g
+        always_comb begin
+            match_data    = '0;
+            last_pop_data = '1;
+        end
+    end
+endmodule
+
+module fifo #(
+    parameter  int unsigned WIDTH             = 8                            ,
+    parameter  type         TYPE              = logic [WIDTH-1:0]            ,
+    parameter  int unsigned DEPTH             = 8                            ,
+    parameter  int unsigned THRESHOLD         = DEPTH                        ,
+    parameter  bit          FLAG_FF_OUT       = 1'b1                         ,
+    parameter  bit          DATA_FF_OUT       = 1'b1                         ,
+    parameter  bit          RESET_RAM         = 1'b0                         ,
+    parameter  bit          RESET_DATA_FF     = 1'b1                         ,
+    parameter  bit          CLEAR_DATA        = 1'b0                         ,
+    parameter  bit          PUSH_ON_CLEAR     = 1'b0                         ,
+    parameter  int unsigned MATCH_COUNT_WIDTH = 0                            ,
+    localparam type         COUNTER           = logic [$clog2(DEPTH + 1)-1:0]
+) (
+    input  var logic   i_clk        ,
+    input  var logic   i_rst        ,
+    input  var logic   i_clear      ,
+    output var logic   o_empty      ,
+    output var logic   o_almost_full,
+    output var logic   o_full       ,
+    output var COUNTER o_word_count ,
+    input  var logic   i_push       ,
+    input  var TYPE    i_data       ,
+    input  var logic   i_pop        ,
+    output var TYPE    o_data
+);
+    localparam int unsigned RAM_WORDS = ((DATA_FF_OUT) ? ( DEPTH - 1 ) : ( DEPTH ));
+
+    logic clear_data;
+
+    always_comb begin
+        clear_data = CLEAR_DATA && i_clear;
+    end
+
+    localparam int unsigned RAM_POINTER_WIDTH = ((RAM_WORDS >= 2) ? ( $clog2(RAM_WORDS) ) : ( 1 ));
+
+    logic [RAM_POINTER_WIDTH-1:0] write_pointer;
+    logic                         write_to_ff  ;
+    logic                         write_to_ram ;
+    logic [RAM_POINTER_WIDTH-1:0] read_pointer ;
+    logic                         read_from_ram;
+
+    fifo_controller #(
+        .TYPE              (TYPE             ),
+        .DEPTH             (DEPTH            ),
+        .THRESHOLD         (THRESHOLD        ),
+        .FLAG_FF_OUT       (FLAG_FF_OUT      ),
+        .DATA_FF_OUT       (DATA_FF_OUT      ),
+        .PUSH_ON_CLEAR     (PUSH_ON_CLEAR    ),
+        .RAM_WORDS         (RAM_WORDS        ),
+        .RAM_POINTER_WIDTH (RAM_POINTER_WIDTH),
+        .MATCH_COUNT_WIDTH (MATCH_COUNT_WIDTH)
+    ) u_controller (
+        .i_clk           (i_clk        ),
+        .i_rst           (i_rst        ),
+        .i_clear         (i_clear      ),
+        .o_empty         (o_empty      ),
+        .o_almost_full   (o_almost_full),
+        .o_full          (o_full       ),
+        .i_push          (i_push       ),
+        .i_data          (i_data       ),
+        .i_pop           (i_pop        ),
+        .o_word_count    (o_word_count ),
+        .o_write_pointer (write_pointer),
+        .o_write_to_ff   (write_to_ff  ),
+        .o_write_to_ram  (write_to_ram ),
+        .o_read_pointer  (read_pointer ),
+        .o_read_from_ram (read_from_ram)
+
+    );
+
+    TYPE ram_read_data;
+
+    if (RAM_WORDS >= 1) begin :g_ram
+        ram #(
+            .WORD_SIZE     (RAM_WORDS        ),
+            .ADDRESS_WIDTH (RAM_POINTER_WIDTH),
+            .DATA_TYPE     (TYPE             ),
+            .BUFFER_OUT    (0                ),
+            .USE_RESET     (RESET_RAM        )
+        ) u_ram (
+            .i_clk  (i_clk        ),
+            .i_rst  (i_rst        ),
+            .i_clr  (clear_data   ),
+            .i_mea  ('1           ),
+            .i_wea  (write_to_ram ),
+            .i_adra (write_pointer),
+            .i_da   (i_data       ),
+            .i_meb  ('1           ),
+            .i_adrb (read_pointer ),
+            .o_qb   (ram_read_data)
+        );
+    end else begin :g_no_ram
+        always_comb begin
+            ram_read_data = TYPE'(0);
+        end
+    end
+
+    if (DATA_FF_OUT) begin :g_data_out
+        TYPE data_out;
+
+        always_comb begin
+            o_data = data_out;
+        end
+
+        if (RESET_DATA_FF) begin :g
+            always_ff @ (posedge i_clk, negedge i_rst) begin
+                if (!i_rst) begin
+                    data_out <= TYPE'(0);
+                end else if (clear_data) begin
+                    data_out <= TYPE'(0);
+                end else if (write_to_ff) begin
+                    data_out <= i_data;
+                end else if (read_from_ram) begin
+                    data_out <= ram_read_data;
+                end
+            end
+        end else begin :g
+            always_ff @ (posedge i_clk) begin
+                if (clear_data) begin
+                    data_out <= TYPE'(0);
+                end else if (write_to_ff) begin
+                    data_out <= i_data;
+                end else if (read_from_ram) begin
+                    data_out <= ram_read_data;
+                end
+            end
+        end
+    end else begin :g
+        always_comb begin
+            o_data = ram_read_data;
+        end
+    end
+endmodule
+
+module Top (
+    input  var logic         clk         ,
+    input  var logic         rst         ,
+    input  var logic         i_push      ,
+    input  var logic [8-1:0] i_data      ,
+    input  var logic         i_pop       ,
+    output var logic [8-1:0] o_data      ,
+    output var logic         o_empty     ,
+    output var logic         o_full      ,
+    output var logic [5-1:0] o_word_count
+);
+    logic almost_full;
+    logic clear      ;
+    always_comb begin
+        clear       = '0;
+    end
+    fifo #(
+        .WIDTH (8 ),
+        .DEPTH (16)
+    ) u_fifo (
+        .i_clk         (clk         ),
+        .i_rst         (rst         ),
+        .i_clear       (clear       ),
+        .o_empty       (o_empty     ),
+        .o_almost_full (almost_full ),
+        .o_full        (o_full      ),
+        .o_word_count  (o_word_count),
+        .i_push        (i_push      ),
+        .i_data        (i_data      ),
+        .i_pop         (i_pop       ),
+        .o_data        (o_data      )
+    );
+endmodule

--- a/crates/celox-sv-analyzer/testdata/verilator/GrayCodec.sv
+++ b/crates/celox-sv-analyzer/testdata/verilator/GrayCodec.sv
@@ -1,0 +1,73 @@
+
+
+module gray_encoder #(
+
+    parameter int unsigned WIDTH = 32
+) (
+
+    input var logic [WIDTH-1:0] i_bin,
+
+    output var logic [WIDTH-1:0] o_gray
+);
+    always_comb o_gray = i_bin ^ (i_bin >> 1);
+endmodule
+
+module gray_decoder #(
+
+    parameter int unsigned WIDTH = 1
+) (
+
+    input var logic [WIDTH-1:0] i_gray,
+
+    output var logic [WIDTH-1:0] o_bin
+);
+    if (WIDTH == 1) begin :g_base
+        always_comb o_bin = i_gray;
+    end else begin :g_base
+        localparam int unsigned BWIDTH = WIDTH / 2;
+        localparam int unsigned TWIDTH = WIDTH - BWIDTH;
+
+        logic [TWIDTH-1:0] top_in ; always_comb top_in  = i_gray[WIDTH - 1:BWIDTH];
+        logic [TWIDTH-1:0] top_out;
+
+        gray_decoder #(
+            .WIDTH (TWIDTH)
+        ) u_top (
+            .i_gray (top_in ),
+            .o_bin  (top_out)
+        );
+
+        logic [BWIDTH-1:0] bot_in ; always_comb bot_in  = i_gray[BWIDTH - 1:0];
+        logic [BWIDTH-1:0] bot_out;
+
+        logic [BWIDTH-1:0] bot_red; always_comb bot_red = bot_out ^ {BWIDTH{top_out[0]}};
+
+        gray_decoder #(
+            .WIDTH (BWIDTH)
+        ) u_bot (
+            .i_gray (bot_in ),
+            .o_bin  (bot_out)
+        );
+
+        always_comb o_bin = {top_out, bot_red};
+    end
+endmodule
+
+module Top (
+    input  var logic [32-1:0] i_bin ,
+    output var logic [32-1:0] o_gray,
+    output var logic [32-1:0] o_bin
+);
+    gray_encoder #(
+        .WIDTH  (32    )
+    ) u_enc (
+        .i_bin  (i_bin ),
+        .o_gray (o_gray)
+    );
+    gray_decoder #(
+        .WIDTH  (32    )
+    ) u_dec (
+        .i_gray (o_gray),
+        .o_bin  (o_bin )
+    );
+endmodule

--- a/crates/celox-sv-analyzer/testdata/verilator/GrayCounter.sv
+++ b/crates/celox-sv-analyzer/testdata/verilator/GrayCounter.sv
@@ -1,0 +1,229 @@
+
+module counter #(
+
+    parameter int unsigned WIDTH = 2,
+
+    parameter bit [WIDTH-1:0] MAX_COUNT = '1,
+
+    parameter bit [WIDTH-1:0] MIN_COUNT = '0,
+
+    parameter bit [WIDTH-1:0] INITIAL_COUNT = MIN_COUNT,
+
+    parameter bit WRAP_AROUND = 1,
+
+    localparam type COUNT = logic [WIDTH-1:0]
+) (
+
+    input var logic i_clk,
+
+    input var logic i_rst,
+
+    input var logic i_clear,
+
+    input var logic i_set,
+
+    input var COUNT i_set_value,
+
+    input var logic i_up,
+
+    input var logic i_down,
+
+    output var COUNT o_count,
+
+    output var COUNT o_count_next,
+
+    output var logic o_wrap_around
+);
+    function automatic COUNT count_up(
+        input var COUNT current_count
+    ) ;
+        if (current_count == MAX_COUNT) begin
+            if (WRAP_AROUND) begin
+                return MIN_COUNT;
+            end else begin
+                return MAX_COUNT;
+            end
+        end else begin
+            return current_count + 1;
+        end
+    endfunction
+
+    function automatic COUNT count_down(
+        input var COUNT current_count
+    ) ;
+        if (current_count == MIN_COUNT) begin
+            if (WRAP_AROUND) begin
+                return MAX_COUNT;
+            end else begin
+                return MIN_COUNT;
+            end
+        end else begin
+            return current_count - 1;
+        end
+    endfunction
+
+    function automatic logic get_wrap_around_flag(
+        input var logic clear        ,
+        input var logic set          ,
+        input var logic up           ,
+        input var logic down         ,
+        input var COUNT current_count
+    ) ;
+        logic [2-1:0] up_down;
+        up_down = {up, down};
+        if (clear || set) begin
+            return '0;
+        end else if ((current_count == MAX_COUNT) && (up_down == 2'b10)) begin
+            return '1;
+        end else if ((current_count == MIN_COUNT) && (up_down == 2'b01)) begin
+            return '1;
+        end else begin
+            return '0;
+        end
+    endfunction
+
+    function automatic COUNT get_count_next(
+        input var logic clear        ,
+        input var logic set          ,
+        input var COUNT set_value    ,
+        input var logic up           ,
+        input var logic down         ,
+        input var COUNT current_count
+    ) ;
+        case (1'b1)
+            clear          : return INITIAL_COUNT;
+            set            : return set_value;
+            (up && (!down)): return count_up(current_count);
+            (down && (!up)): return count_down(current_count);
+            default        : return current_count;
+        endcase
+    endfunction
+
+    COUNT count     ;
+    COUNT count_next;
+
+    always_comb o_count      = count;
+    always_comb o_count_next = count_next;
+
+    always_comb count_next = get_count_next(i_clear, i_set, i_set_value, i_up, i_down, count);
+    always_ff @ (posedge i_clk, negedge i_rst) begin
+        if (!i_rst) begin
+            count <= INITIAL_COUNT;
+        end else begin
+            count <= count_next;
+        end
+    end
+
+    if ((WRAP_AROUND)) begin :g
+        always_comb o_wrap_around = get_wrap_around_flag(i_clear, i_set, i_up, i_down, count);
+    end else begin :g
+        always_comb o_wrap_around = '0;
+    end
+endmodule
+
+module gray_encoder #(
+
+    parameter int unsigned WIDTH = 32
+) (
+
+    input var logic [WIDTH-1:0] i_bin,
+
+    output var logic [WIDTH-1:0] o_gray
+);
+    always_comb o_gray = i_bin ^ (i_bin >> 1);
+endmodule
+
+module gray_counter #(
+
+    parameter int unsigned WIDTH = 2,
+
+    parameter bit [WIDTH-1:0] MAX_COUNT = '1,
+
+    parameter bit [WIDTH-1:0] MIN_COUNT = '0,
+
+    parameter bit [WIDTH-1:0] INITIAL_COUNT = MIN_COUNT,
+
+    parameter bit WRAP_AROUND = 1,
+
+    localparam type COUNT = logic [WIDTH-1:0]
+) (
+
+    input var logic i_clk,
+
+    input var logic i_rst,
+
+    input var logic i_clear,
+
+    input var logic i_set,
+
+    input var COUNT i_set_value,
+
+    input var logic i_up,
+
+    input var logic i_down,
+
+    output var COUNT o_count,
+
+    output var COUNT o_count_next,
+
+    output var logic o_wrap_around
+);
+
+    COUNT bin_count     ;
+    COUNT bin_count_next;
+
+    counter #(
+        .WIDTH         (WIDTH        ),
+        .MAX_COUNT     (MAX_COUNT    ),
+        .MIN_COUNT     (MIN_COUNT    ),
+        .INITIAL_COUNT (INITIAL_COUNT),
+        .WRAP_AROUND   (WRAP_AROUND  )
+    ) u_bin_counter (
+        .i_clk         (i_clk         ),
+        .i_rst         (i_rst         ),
+        .i_clear       (i_clear       ),
+        .i_set         (i_set         ),
+        .i_set_value   (i_set_value   ),
+        .i_up          (i_up          ),
+        .i_down        (i_down        ),
+        .o_count       (bin_count     ),
+        .o_count_next  (bin_count_next),
+        .o_wrap_around (o_wrap_around )
+    );
+
+    gray_encoder #(
+        .WIDTH (WIDTH)
+    ) u_gray_cur (
+        .i_bin  (bin_count),
+        .o_gray (o_count  )
+    );
+    gray_encoder #(
+        .WIDTH (WIDTH)
+    ) u_gray_next (
+        .i_bin  (bin_count_next),
+        .o_gray (o_count_next  )
+    );
+
+endmodule
+
+module Top (
+    input  var logic          clk    ,
+    input  var logic          rst    ,
+    input  var logic          i_up   ,
+    output var logic [32-1:0] o_count
+);
+    gray_counter #(
+        .WIDTH         (32     )
+    ) u (
+        .i_clk         (clk    ),
+        .i_rst         (rst    ),
+        .i_clear       (1'b0   ),
+        .i_set         (1'b0   ),
+        .i_set_value   (32'b0  ),
+        .i_up          (i_up   ),
+        .i_down        (1'b0   ),
+        .o_count       (o_count),
+        .o_count_next  (       ),
+        .o_wrap_around (       )
+    );
+endmodule

--- a/crates/celox-sv-analyzer/testdata/verilator/Lfsr.sv
+++ b/crates/celox-sv-analyzer/testdata/verilator/Lfsr.sv
@@ -1,0 +1,185 @@
+module lfsr_galois #(
+
+    parameter  int unsigned SIZE     = 64              ,
+    localparam type         TAPVEC_T = logic [SIZE-1:0],
+
+    parameter TAPVEC_T TAPVEC = (((SIZE) ==? (2)) ? (
+        2'h3
+    ) : ((SIZE) ==? (3)) ? (
+        3'h5
+    ) : ((SIZE) ==? (4)) ? (
+        4'h9
+    ) : ((SIZE) ==? (5)) ? (
+        5'h12
+    ) : ((SIZE) ==? (6)) ? (
+        6'h21
+    ) : ((SIZE) ==? (7)) ? (
+        7'h41
+    ) : ((SIZE) ==? (8)) ? (
+        8'h8e
+    ) : ((SIZE) ==? (9)) ? (
+        9'h108
+    ) : ((SIZE) ==? (10)) ? (
+        10'h204
+    ) : ((SIZE) ==? (11)) ? (
+        11'h402
+    ) : ((SIZE) ==? (12)) ? (
+        12'h829
+    ) : ((SIZE) ==? (13)) ? (
+        13'h100d
+    ) : ((SIZE) ==? (14)) ? (
+        14'h2015
+    ) : ((SIZE) ==? (15)) ? (
+        15'h4001
+    ) : ((SIZE) ==? (16)) ? (
+        16'h8016
+    ) : ((SIZE) ==? (17)) ? (
+        17'h10004
+    ) : ((SIZE) ==? (18)) ? (
+        18'h20013
+    ) : ((SIZE) ==? (19)) ? (
+        19'h40013
+    ) : ((SIZE) ==? (20)) ? (
+        20'h80004
+    ) : ((SIZE) ==? (21)) ? (
+        21'h100002
+    ) : ((SIZE) ==? (22)) ? (
+        22'h200001
+    ) : ((SIZE) ==? (23)) ? (
+        23'h400010
+    ) : ((SIZE) ==? (24)) ? (
+        24'h80000d
+    ) : ((SIZE) ==? (25)) ? (
+        25'h1000004
+    ) : ((SIZE) ==? (26)) ? (
+        26'h2000023
+    ) : ((SIZE) ==? (27)) ? (
+        27'h4000013
+    ) : ((SIZE) ==? (28)) ? (
+        28'h8000004
+    ) : ((SIZE) ==? (29)) ? (
+        29'h10000002
+    ) : ((SIZE) ==? (30)) ? (
+        30'h20000029
+    ) : ((SIZE) ==? (31)) ? (
+        31'h40000004
+    ) : ((SIZE) ==? (32)) ? (
+        32'h80000057
+    ) : ((SIZE) ==? (33)) ? (
+        33'h100000029
+    ) : ((SIZE) ==? (34)) ? (
+        34'h200000073
+    ) : ((SIZE) ==? (35)) ? (
+        35'h400000002
+    ) : ((SIZE) ==? (36)) ? (
+        36'h80000003b
+    ) : ((SIZE) ==? (37)) ? (
+        37'h100000001f
+    ) : ((SIZE) ==? (38)) ? (
+        38'h2000000031
+    ) : ((SIZE) ==? (39)) ? (
+        39'h4000000008
+    ) : ((SIZE) ==? (40)) ? (
+        40'h800000001c
+    ) : ((SIZE) ==? (41)) ? (
+        41'h10000000004
+    ) : ((SIZE) ==? (42)) ? (
+        42'h2000000001f
+    ) : ((SIZE) ==? (43)) ? (
+        43'h4000000002c
+    ) : ((SIZE) ==? (44)) ? (
+        44'h80000000032
+    ) : ((SIZE) ==? (45)) ? (
+        45'h10000000000d
+    ) : ((SIZE) ==? (46)) ? (
+        46'h200000000097
+    ) : ((SIZE) ==? (47)) ? (
+        47'h400000000010
+    ) : ((SIZE) ==? (48)) ? (
+        48'h80000000005b
+    ) : ((SIZE) ==? (49)) ? (
+        49'h1000000000038
+    ) : ((SIZE) ==? (50)) ? (
+        50'h200000000000e
+    ) : ((SIZE) ==? (51)) ? (
+        51'h4000000000025
+    ) : ((SIZE) ==? (52)) ? (
+        52'h8000000000004
+    ) : ((SIZE) ==? (53)) ? (
+        53'h10000000000023
+    ) : ((SIZE) ==? (54)) ? (
+        54'h2000000000003e
+    ) : ((SIZE) ==? (55)) ? (
+        55'h40000000000023
+    ) : ((SIZE) ==? (56)) ? (
+        56'h8000000000004a
+    ) : ((SIZE) ==? (57)) ? (
+        57'h100000000000016
+    ) : ((SIZE) ==? (58)) ? (
+        58'h200000000000031
+    ) : ((SIZE) ==? (59)) ? (
+        59'h40000000000003d
+    ) : ((SIZE) ==? (60)) ? (
+        60'h800000000000001
+    ) : ((SIZE) ==? (61)) ? (
+        61'h1000000000000013
+    ) : ((SIZE) ==? (62)) ? (
+        62'h2000000000000034
+    ) : ((SIZE) ==? (63)) ? (
+        63'h4000000000000001
+    ) : ((SIZE) ==? (64)) ? (
+        64'h800000000000000d
+    ) : (
+        '0
+    ))
+
+) (
+
+    input var logic i_clk,
+
+    input var logic i_en,
+
+    input var logic i_set,
+
+    input var logic [SIZE-1:0] i_setval,
+
+    output var logic [SIZE-1:0] o_val
+);
+
+    logic [SIZE-1:0] val_next;
+
+    always_comb val_next[SIZE - 1] = o_val[0];
+    for (genvar i = 0; i < (SIZE - 1); i++) begin :g_taps
+        localparam int unsigned K = SIZE - 2 - i;
+        if (TAPVEC[K]) begin :g_tap
+            always_comb val_next[K] = ((i_set) ? ( i_setval[K] ) : ( o_val[K + 1] ^ o_val[0] ));
+        end else begin :g_notap
+            always_comb val_next[K] = ((i_set) ? ( i_setval[K] ) : ( o_val[K + 1] ));
+        end
+    end
+
+    always_ff @ (posedge i_clk) begin
+        if (i_en) begin
+            o_val <= val_next;
+        end
+    end
+endmodule
+
+module Top (
+    input  var logic          clk     ,
+    input  var logic          rst     ,
+    input  var logic          i_en    ,
+    input  var logic          i_set   ,
+    input  var logic [32-1:0] i_setval,
+    output var logic [32-1:0] o_val
+);
+    lfsr_galois #(
+        .SIZE     (32      )
+    ) u (
+        .i_clk    (clk     ),
+        .i_en     (i_en    ),
+        .i_set    (i_set   ),
+        .i_setval (i_setval),
+        .o_val    (o_val   )
+    );
+endmodule

--- a/crates/celox-sv-analyzer/testdata/verilator/LinearSec.sv
+++ b/crates/celox-sv-analyzer/testdata/verilator/LinearSec.sv
@@ -1,0 +1,119 @@
+
+module linear_sec_encoder #(
+
+    parameter int unsigned P = 4,
+
+    parameter int unsigned K = (1 << P) - 1,
+
+    parameter int unsigned N = K - P
+) (
+    input  var logic [N-1:0] i_word    ,
+    output var logic [K-1:0] o_codeword
+);
+
+    logic [P-1:0][K-1:0] h;
+    for (genvar p = 0; p < P; p++) begin :gen_vector
+        for (genvar k = 0; k < K; k++) begin :gen_bit
+            localparam int unsigned IDX     = k + 1;
+            always_comb h[p][k] = IDX[p];
+        end
+    end
+
+    logic [K-1:0] codeword_data_only;
+    for (genvar k = 1; k < K + 1; k++) begin :gen_move_data
+        localparam int unsigned CODEWORD_IDX = k - 1;
+        if (!$onehot(k)) begin :gen_move_data_bit
+            localparam int unsigned WORD_IDX                         = k - $clog2(k) - 1;
+            always_comb codeword_data_only[CODEWORD_IDX] = i_word[WORD_IDX];
+        end else begin :gen_move_data_bit
+            always_comb codeword_data_only[CODEWORD_IDX] = 1'b0;
+        end
+    end
+
+    logic [K-1:0] codeword_parity_only;
+    for (genvar p = 0; p < P; p++) begin :gen_parities
+        localparam int unsigned CODEWORD_IDX                       = (1 << p) - 1;
+        always_comb codeword_parity_only[CODEWORD_IDX] = ^(h[p] & codeword_data_only);
+    end
+    for (genvar k = 0; k < K; k++) begin :gen_zeros
+        if (!$onehot(k + 1)) begin :gen_zero_bit
+            always_comb codeword_parity_only[k] = 1'b0;
+        end
+    end
+
+    always_comb o_codeword = codeword_data_only | codeword_parity_only;
+endmodule
+
+module linear_sec_decoder #(
+
+    parameter int unsigned P = 4,
+
+    parameter int unsigned K = (1 << P) - 1,
+
+    parameter int unsigned N = K - P
+) (
+    input  var logic [K-1:0] i_codeword,
+    output var logic [N-1:0] o_word    ,
+
+    output var logic o_corrected
+
+);
+
+    logic [(K + 1)-1:0] codeword          ; always_comb codeword           = {i_codeword, 1'b0};
+    logic [(K + 1)-1:0] codeword_corrected;
+
+    logic [P-1:0] errors;
+
+    for (genvar idx = 1; idx < (K + 2); idx++) begin :g_create_word
+        if (!$onehot(idx)) begin :g_data_bit
+            localparam int unsigned CEIL             = $clog2(idx);
+            localparam int unsigned WORD_IDX         = idx - 1 - CEIL;
+            always_comb o_word[WORD_IDX] = codeword_corrected[idx];
+        end
+    end
+
+    for (genvar pbit = 1; pbit < P + 1; pbit++) begin :g_check_parities
+        localparam int unsigned               ONE_IDX_SET_BIT = pbit - 1;
+        logic        [(K + 1)-1:0] masked_bits    ;
+        always_comb masked_bits[0]  = 1'b0;
+        for (genvar idx = 1; idx < K + 1; idx++) begin :g_check_bits
+            if (idx[ONE_IDX_SET_BIT]) begin :g_take_parity
+                always_comb masked_bits[idx] = codeword[idx];
+            end else begin :g_take_parity
+                always_comb masked_bits[idx] = 1'b0;
+            end
+        end
+        always_comb errors[ONE_IDX_SET_BIT] = ^masked_bits;
+    end
+
+    always_comb o_corrected = |errors;
+    always_comb begin
+        codeword_corrected         =  codeword;
+        codeword_corrected[errors] ^= 1;
+    end
+endmodule
+
+module Top #(
+    parameter  int unsigned P = 6           ,
+    localparam int unsigned K = (1 << P) - 1,
+    localparam int unsigned N = K - P
+) (
+    input  var logic [N-1:0] i_word     ,
+    output var logic [K-1:0] o_codeword ,
+    output var logic [N-1:0] o_word     ,
+    output var logic         o_corrected
+);
+    linear_sec_encoder #(
+        .P (P)
+    ) u_enc (
+        .i_word     (i_word    ),
+        .o_codeword (o_codeword)
+    );
+    linear_sec_decoder #(
+        .P (P)
+    ) u_dec (
+        .i_codeword  (o_codeword ),
+        .o_word      (o_word     ),
+        .o_corrected (o_corrected)
+    );
+endmodule

--- a/crates/celox-sv-analyzer/testdata/verilator/Onehot.sv
+++ b/crates/celox-sv-analyzer/testdata/verilator/Onehot.sv
@@ -1,0 +1,80 @@
+module onehot #(
+    parameter int unsigned W = 16
+) (
+    input var logic [W-1:0] i_data,
+
+    output var logic o_onehot,
+
+    output var logic o_zero
+);
+    logic o_gt_one;
+
+    _onehot #(
+        .W (W)
+    ) u_onehot (
+        .i_data   (i_data  ),
+        .o_zero   (o_zero  ),
+        .o_onehot (o_onehot),
+        .o_gt_one (o_gt_one)
+    );
+endmodule
+
+module _onehot #(
+    parameter int unsigned W = 16
+) (
+    input  var logic [W-1:0] i_data  ,
+    output var logic         o_onehot,
+    output var logic         o_zero  ,
+    output var logic         o_gt_one
+);
+    if ((W == 1)) begin :gen_base_case
+        always_comb o_onehot = i_data;
+        always_comb o_zero   = ~i_data;
+    end else begin :gen_rec_case
+        localparam int unsigned            WBOT       = W / 2;
+        localparam int unsigned            WTOP       = W - WBOT;
+        logic        [WBOT-1:0] data_bot  ; always_comb data_bot   = i_data[WBOT - 1:0];
+        logic        [WTOP-1:0] data_top  ; always_comb data_top   = i_data[W - 1:WBOT];
+        logic                   onehot_top;
+        logic                   onehot_bot;
+        logic                   zero_top  ;
+        logic                   zero_bot  ;
+        logic                   gt_one_top;
+        logic                   gt_one_bot;
+
+        _onehot #(
+            .W (WBOT)
+        ) u_bot (
+            .i_data   (data_bot  ),
+            .o_onehot (onehot_bot),
+            .o_zero   (zero_bot  ),
+            .o_gt_one (gt_one_bot)
+        );
+        _onehot #(
+            .W (WTOP)
+        ) u_top (
+            .i_data   (data_top  ),
+            .o_onehot (onehot_top),
+            .o_zero   (zero_top  ),
+            .o_gt_one (gt_one_top)
+        );
+        always_comb o_zero   = zero_top & zero_bot;
+        always_comb o_onehot = (onehot_top ^ onehot_bot) & ~gt_one_top & ~gt_one_bot;
+        always_comb o_gt_one = gt_one_top | gt_one_bot | (onehot_top & onehot_bot);
+    end
+
+endmodule
+
+module Top (
+    input  var logic [64-1:0] i_data  ,
+    output var logic          o_onehot,
+    output var logic          o_zero
+);
+    onehot #(
+        .W        (64      )
+    ) u (
+        .i_data   (i_data  ),
+        .o_onehot (o_onehot),
+        .o_zero   (o_zero  )
+    );
+endmodule

--- a/crates/celox-sv-analyzer/testdata/verilator/StdCounter.sv
+++ b/crates/celox-sv-analyzer/testdata/verilator/StdCounter.sv
@@ -1,0 +1,144 @@
+
+module counter #(
+
+    parameter int unsigned WIDTH = 2,
+
+    parameter bit [WIDTH-1:0] MAX_COUNT = '1,
+
+    parameter bit [WIDTH-1:0] MIN_COUNT = '0,
+
+    parameter bit [WIDTH-1:0] INITIAL_COUNT = MIN_COUNT,
+
+    parameter bit WRAP_AROUND = 1,
+
+    localparam type COUNT = logic [WIDTH-1:0]
+) (
+
+    input var logic i_clk,
+
+    input var logic i_rst,
+
+    input var logic i_clear,
+
+    input var logic i_set,
+
+    input var COUNT i_set_value,
+
+    input var logic i_up,
+
+    input var logic i_down,
+
+    output var COUNT o_count,
+
+    output var COUNT o_count_next,
+
+    output var logic o_wrap_around
+);
+    function automatic COUNT count_up(
+        input var COUNT current_count
+    ) ;
+        if (current_count == MAX_COUNT) begin
+            if (WRAP_AROUND) begin
+                return MIN_COUNT;
+            end else begin
+                return MAX_COUNT;
+            end
+        end else begin
+            return current_count + 1;
+        end
+    endfunction
+
+    function automatic COUNT count_down(
+        input var COUNT current_count
+    ) ;
+        if (current_count == MIN_COUNT) begin
+            if (WRAP_AROUND) begin
+                return MAX_COUNT;
+            end else begin
+                return MIN_COUNT;
+            end
+        end else begin
+            return current_count - 1;
+        end
+    endfunction
+
+    function automatic logic get_wrap_around_flag(
+        input var logic clear        ,
+        input var logic set          ,
+        input var logic up           ,
+        input var logic down         ,
+        input var COUNT current_count
+    ) ;
+        logic [2-1:0] up_down;
+        up_down = {up, down};
+        if (clear || set) begin
+            return '0;
+        end else if ((current_count == MAX_COUNT) && (up_down == 2'b10)) begin
+            return '1;
+        end else if ((current_count == MIN_COUNT) && (up_down == 2'b01)) begin
+            return '1;
+        end else begin
+            return '0;
+        end
+    endfunction
+
+    function automatic COUNT get_count_next(
+        input var logic clear        ,
+        input var logic set          ,
+        input var COUNT set_value    ,
+        input var logic up           ,
+        input var logic down         ,
+        input var COUNT current_count
+    ) ;
+        case (1'b1)
+            clear          : return INITIAL_COUNT;
+            set            : return set_value;
+            (up && (!down)): return count_up(current_count);
+            (down && (!up)): return count_down(current_count);
+            default        : return current_count;
+        endcase
+    endfunction
+
+    COUNT count     ;
+    COUNT count_next;
+
+    always_comb o_count      = count;
+    always_comb o_count_next = count_next;
+
+    always_comb count_next = get_count_next(i_clear, i_set, i_set_value, i_up, i_down, count);
+    always_ff @ (posedge i_clk, negedge i_rst) begin
+        if (!i_rst) begin
+            count <= INITIAL_COUNT;
+        end else begin
+            count <= count_next;
+        end
+    end
+
+    if ((WRAP_AROUND)) begin :g
+        always_comb o_wrap_around = get_wrap_around_flag(i_clear, i_set, i_up, i_down, count);
+    end else begin :g
+        always_comb o_wrap_around = '0;
+    end
+endmodule
+
+module Top (
+    input  var logic          clk    ,
+    input  var logic          rst    ,
+    input  var logic          i_up   ,
+    output var logic [32-1:0] o_count
+);
+    counter #(
+        .WIDTH         (32     )
+    ) u (
+        .i_clk         (clk    ),
+        .i_rst         (rst    ),
+        .i_clear       (1'b0   ),
+        .i_set         (1'b0   ),
+        .i_set_value   (32'b0  ),
+        .i_up          (i_up   ),
+        .i_down        (1'b0   ),
+        .o_count       (o_count),
+        .o_count_next  (       ),
+        .o_wrap_around (       )
+    );
+endmodule

--- a/crates/celox-sv-analyzer/testdata/verilator/Top.sv
+++ b/crates/celox-sv-analyzer/testdata/verilator/Top.sv
@@ -1,0 +1,19 @@
+module Top #(
+    parameter int unsigned N = 1000
+) (
+    input  var logic          clk     ,
+    input  var logic          rst     ,
+    output var logic [32-1:0] cnt  [N],
+    output var logic [32-1:0] cnt0
+);
+    always_comb cnt0 = cnt[0];
+    for (genvar i = 0; i < N; i++) begin :g
+        always_ff @ (posedge clk, negedge rst) begin
+            if (!rst) begin
+                cnt[i] <= 0;
+            end else begin
+                cnt[i] <= cnt[i] + (1);
+            end
+        end
+    end
+endmodule

--- a/crates/celox-testbench/Cargo.toml
+++ b/crates/celox-testbench/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name                  = "celox-testbench"
 version.workspace     = true
+publish               = ["crates-io"]
 authors.workspace     = true
 repository.workspace  = true
 license.workspace     = true
 description           = "Source-independent testbench bytecode contracts for Celox"
 edition.workspace     = true
+rust-version.workspace = true
 
 [dependencies]
 num-bigint = { workspace = true }

--- a/crates/celox-ts-gen/Cargo.toml
+++ b/crates/celox-ts-gen/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name                  = "celox-ts-gen"
 version.workspace     = true
-publish               = false
+publish               = ["crates-io"]
 authors.workspace     = true
 repository.workspace  = true
 license.workspace     = true
-description.workspace = true
+description           = "TypeScript definition generator used by Celox bindings"
 edition.workspace     = true
 
 [dependencies]

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name                  = "celox"
 version.workspace     = true
-publish               = false
+publish               = ["crates-io"]
 authors.workspace     = true
 repository.workspace  = true
 license.workspace     = true
 description.workspace = true
+readme                = "README.md"
 edition.workspace     = true
+rust-version.workspace = true
 
 [features]
 default = ["host-runtime"]
@@ -32,19 +34,19 @@ veryl-parser          = { workspace = true }
 veryl-path            = { workspace = true }
 veryl-component-sys   = { version = "0.1.1", optional = true }
 libloading            = { version = "0.9", optional = true }
-celox-analysis        = { path = "../celox-analysis" }
-celox-backend-wasm    = { path = "../celox-backend-wasm" }
-celox-design          = { path = "../celox-design" }
-celox-frontend-core   = { path = "../celox-frontend-core" }
-celox-frontend-sdk    = { path = "../celox-frontend-sdk" }
-celox-frontend-sv     = { path = "../celox-frontend-sv", optional = true }
-celox-frontend-veryl  = { path = "../celox-frontend-veryl" }
-celox-sir             = { path = "../celox-sir" }
-celox-sir-opt         = { path = "../celox-sir-opt", default-features = false }
-celox-slt             = { path = "../celox-slt" }
-celox-state-layout    = { path = "../celox-state-layout" }
-celox-runtime         = { path = "../celox-runtime" }
-celox-testbench       = { path = "../celox-testbench" }
+celox-analysis        = { workspace = true }
+celox-backend-wasm    = { workspace = true }
+celox-design          = { workspace = true }
+celox-frontend-core   = { workspace = true }
+celox-frontend-sdk    = { workspace = true }
+celox-frontend-sv     = { workspace = true, optional = true }
+celox-frontend-veryl  = { workspace = true }
+celox-sir             = { workspace = true }
+celox-sir-opt         = { workspace = true, default-features = false }
+celox-slt             = { workspace = true }
+celox-state-layout    = { workspace = true }
+celox-runtime         = { workspace = true }
+celox-testbench       = { workspace = true }
 fxhash                = { workspace = true }
 thiserror             = { workspace = true }
 clap                  = { workspace = true }
@@ -59,16 +61,16 @@ num-traits            = { workspace = true }
 bit-set               = { workspace = true }
 itertools             = { workspace = true }
 tracing               = { workspace = true }
-celox-macros          = { path = "../celox-macros", optional = true }
-celox-backend-cranelift = { path = "../celox-backend-cranelift", optional = true }
-celox-backend-arm64 = { path = "../celox-backend-arm64", optional = true }
+celox-macros          = { workspace = true, optional = true }
+celox-backend-cranelift = { workspace = true, optional = true }
+celox-backend-arm64   = { workspace = true, optional = true }
 wasmtime              = { version = "47", optional = true }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
-celox-backend-x86     = { path = "../celox-backend-x86", optional = true }
+celox-backend-x86     = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-celox-sir-opt         = { path = "../celox-sir-opt", default-features = false, features = ["wide-native-memory"] }
+celox-sir-opt         = { workspace = true, default-features = false, features = ["wide-native-memory"] }
 
 [dev-dependencies]
 insta      = "1.46"
@@ -98,6 +100,11 @@ required-features = ["systemverilog"]
 name = "compilation"
 harness = false
 bench = false
+
+[[example]]
+name = "frontend_binary"
+path = "examples/frontend_binary.rs"
+required-features = ["host-runtime"]
 
 [lints]
 workspace = true

--- a/crates/celox/README.md
+++ b/crates/celox/README.md
@@ -1,0 +1,39 @@
+# celox
+
+`celox` is the Rust host API for the Celox RTL simulator. External frontend
+crates use its low-level `Simulator::from_frontend` hook after lowering their
+own artifact through `celox-frontend-sdk`.
+
+A frontend crate should wrap that hook with a constructor named for its own
+artifact:
+
+```rust,ignore
+pub use celox::Simulator;
+
+pub trait MyFrontendSimulatorExt: Sized {
+    fn from_my_artifact(artifact: MyArtifact) -> Result<Self, MyError>;
+}
+
+impl MyFrontendSimulatorExt for Simulator {
+    fn from_my_artifact(artifact: MyArtifact) -> Result<Self, MyError> {
+        let celox_artifact = lower_to_celox(&artifact)?;
+        Ok(Simulator::from_frontend(celox_artifact).build()?)
+    }
+}
+```
+
+Applications then use the frontend API and do not depend on Celox's bridge
+artifact model:
+
+```rust,ignore
+use my_frontend::{MyFrontendSimulatorExt as _, Simulator};
+
+let artifact = my_frontend::load("design.myhdl")?;
+let mut sim = Simulator::from_my_artifact(artifact)?;
+```
+
+See the [external frontend guide](https://celox-sim.github.io/celox/guide/external-frontends)
+for the complete adapter pattern and artifact format limits.
+
+Celox is experimental and its Rust API is not yet covered by a 1.0 stability
+guarantee.

--- a/crates/celox/benches/compilation.rs
+++ b/crates/celox/benches/compilation.rs
@@ -4,7 +4,7 @@
 use celox::Simulator;
 use codspeed_criterion_compat::{Criterion, black_box, criterion_group, criterion_main};
 
-const COUNTER: &str = include_str!("../../../benches/veryl/top_n1000.veryl");
+const COUNTER: &str = include_str!("../testdata/veryl/top_n1000.veryl");
 const AXI_LITE_REG_FILE: &str = include_str!("../tests/fixtures/bitslice/axi_lite_reg_file.veryl");
 
 fn compile_default(source: &str, top: &str, parameter: Option<(&str, u64)>) {

--- a/crates/celox/benches/simulation.rs
+++ b/crates/celox/benches/simulation.rs
@@ -8,19 +8,19 @@ mod veryl_std;
 // Wrapper modules are shared with celox-bench-sv (Verilator SV generation)
 // via benches/veryl/*.veryl to guarantee identical circuits.
 
-const CODE: &str = include_str!("../../../benches/veryl/top_n1000.veryl");
+const CODE: &str = include_str!("../testdata/veryl/top_n1000.veryl");
 
 // Native testbench sources (DUT + TB module in one string)
 const NATIVE_TB_COUNTER_N1000: &str = concat!(
-    include_str!("../../../benches/veryl/top_n1000.veryl"),
-    include_str!("../../../benches/veryl/native_tb_counter_n1000.veryl"),
+    include_str!("../testdata/veryl/top_n1000.veryl"),
+    include_str!("../testdata/veryl/native_tb_counter_n1000.veryl"),
 );
 static NATIVE_TB_STD_COUNTER: LazyLock<String> = LazyLock::new(|| {
     format!(
         "{}\n{}\n{}",
         veryl_std::source(&["counter", "counter.veryl"]),
-        include_str!("../../../benches/veryl/std_counter_top.veryl"),
-        include_str!("../../../benches/veryl/native_tb_std_counter.veryl"),
+        include_str!("../testdata/veryl/std_counter_top.veryl"),
+        include_str!("../testdata/veryl/native_tb_std_counter.veryl"),
     )
 });
 
@@ -30,7 +30,7 @@ static LINEAR_SEC_SRC: LazyLock<String> = LazyLock::new(|| {
         "{}\n{}\n{}",
         veryl_std::source(&["coding", "linear_sec_encoder.veryl"]),
         veryl_std::source(&["coding", "linear_sec_decoder.veryl"]),
-        include_str!("../../../benches/veryl/linear_sec_top.veryl"),
+        include_str!("../testdata/veryl/linear_sec_top.veryl"),
     )
 });
 
@@ -39,7 +39,7 @@ static COUNTONES_SRC: LazyLock<String> = LazyLock::new(|| {
     format!(
         "{}\n{}",
         veryl_std::source(&["countones", "countones.veryl"]),
-        include_str!("../../../benches/veryl/countones_top.veryl"),
+        include_str!("../testdata/veryl/countones_top.veryl"),
     )
 });
 
@@ -48,7 +48,7 @@ static STD_COUNTER_SRC: LazyLock<String> = LazyLock::new(|| {
     format!(
         "{}\n{}",
         veryl_std::source(&["counter", "counter.veryl"]),
-        include_str!("../../../benches/veryl/std_counter_top.veryl"),
+        include_str!("../testdata/veryl/std_counter_top.veryl"),
     )
 });
 
@@ -59,7 +59,7 @@ static FIFO_SRC: LazyLock<String> = LazyLock::new(|| {
         veryl_std::source(&["ram", "ram.veryl"]),
         veryl_std::source(&["fifo", "fifo_controller.veryl"]),
         veryl_std::source(&["fifo", "fifo.veryl"]),
-        include_str!("../../../benches/veryl/fifo_top.veryl"),
+        include_str!("../testdata/veryl/fifo_top.veryl"),
     )
 });
 
@@ -69,7 +69,7 @@ static GRAY_CODEC_SRC: LazyLock<String> = LazyLock::new(|| {
         "{}\n{}\n{}",
         veryl_std::source(&["gray", "gray_encoder.veryl"]),
         veryl_std::source(&["gray", "gray_decoder.veryl"]),
-        include_str!("../../../benches/veryl/gray_codec_top.veryl"),
+        include_str!("../testdata/veryl/gray_codec_top.veryl"),
     )
 });
 
@@ -78,7 +78,7 @@ static EDGE_DETECTOR_SRC: LazyLock<String> = LazyLock::new(|| {
     format!(
         "{}\n{}",
         veryl_std::source(&["edge_detector", "edge_detector.veryl"]),
-        include_str!("../../../benches/veryl/edge_detector_top.veryl"),
+        include_str!("../testdata/veryl/edge_detector_top.veryl"),
     )
 });
 
@@ -87,7 +87,7 @@ static ONEHOT_SRC: LazyLock<String> = LazyLock::new(|| {
     format!(
         "{}\n{}",
         veryl_std::source(&["countones", "onehot.veryl"]),
-        include_str!("../../../benches/veryl/onehot_top.veryl"),
+        include_str!("../testdata/veryl/onehot_top.veryl"),
     )
 });
 
@@ -96,7 +96,7 @@ static LFSR_SRC: LazyLock<String> = LazyLock::new(|| {
     format!(
         "{}\n{}",
         veryl_std::source(&["lfsr", "lfsr_galois.veryl"]),
-        include_str!("../../../benches/veryl/lfsr_top.veryl"),
+        include_str!("../testdata/veryl/lfsr_top.veryl"),
     )
 });
 
@@ -107,7 +107,7 @@ static GRAY_COUNTER_SRC: LazyLock<String> = LazyLock::new(|| {
         veryl_std::source(&["counter", "counter.veryl"]),
         veryl_std::source(&["gray", "gray_encoder.veryl"]),
         veryl_std::source(&["gray", "gray_counter.veryl"]),
-        include_str!("../../../benches/veryl/gray_counter_top.veryl"),
+        include_str!("../testdata/veryl/gray_counter_top.veryl"),
     )
 });
 

--- a/crates/celox/examples/frontend_binary.rs
+++ b/crates/celox/examples/frontend_binary.rs
@@ -1,0 +1,52 @@
+mod my_frontend {
+    use celox::Simulator;
+    use celox_frontend_sdk::{BinaryOp, ModuleBuilder, ValueType};
+
+    pub struct MyArtifact {
+        pub module_name: String,
+        pub width: usize,
+    }
+
+    pub trait MyFrontendSimulatorExt: Sized {
+        fn from_my_artifact(artifact: MyArtifact) -> Result<Self, Box<dyn std::error::Error>>;
+    }
+
+    impl MyFrontendSimulatorExt for Simulator {
+        fn from_my_artifact(artifact: MyArtifact) -> Result<Self, Box<dyn std::error::Error>> {
+            let value_type = ValueType::bits(artifact.width)?;
+            let mut module = ModuleBuilder::new(artifact.module_name)?;
+            let a = module.input("a", value_type)?;
+            let b = module.input("b", value_type)?;
+            let y = module.output("y", value_type)?;
+            let a_expr = module.read(a)?;
+            let b_expr = module.read(b)?;
+            let sum = module.binary(BinaryOp::Add, a_expr, b_expr, value_type)?;
+            let y_target = module.whole(y)?;
+            module.assign(y_target, sum)?;
+
+            Ok(Simulator::from_frontend(module.finish()).build()?)
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use my_frontend::MyFrontendSimulatorExt as _;
+
+    let artifact = my_frontend::MyArtifact {
+        module_name: "NetAdder".into(),
+        width: 8,
+    };
+    let mut sim = celox::Simulator::from_my_artifact(artifact)?;
+    let a = sim.signal("a");
+    let b = sim.signal("b");
+    let y = sim.signal("y");
+    sim.modify(|io| {
+        io.set(a, 10u8);
+        io.set(b, 23u8);
+    })?;
+
+    let result = sim.get(y);
+    println!("10 + 23 = {result}");
+    assert_eq!(result, 33u8.into());
+    Ok(())
+}

--- a/crates/celox/examples/pass_benchmark.rs
+++ b/crates/celox/examples/pass_benchmark.rs
@@ -19,14 +19,14 @@ use celox::{
 #[path = "../tests/fixtures/veryl_std.rs"]
 mod veryl_std;
 
-const TOP_N1000: &str = include_str!("../../../benches/veryl/top_n1000.veryl");
+const TOP_N1000: &str = include_str!("../testdata/veryl/top_n1000.veryl");
 
 fn linear_sec_source() -> String {
     format!(
         "{}\n{}\n{}",
         veryl_std::source(&["coding", "linear_sec_encoder.veryl"]),
         veryl_std::source(&["coding", "linear_sec_decoder.veryl"]),
-        include_str!("../../../benches/veryl/linear_sec_top.veryl"),
+        include_str!("../testdata/veryl/linear_sec_top.veryl"),
     )
 }
 

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -853,7 +853,7 @@ impl JitBackend {
 
     /// Resolve an `AbsoluteAddr` (clock or async-reset signal) into an
     /// [`EventRef`] handle.  This does a one-time `HashMap` lookup; the
-    /// returned handle can then be passed to [`eval_apply_ff_at`] for zero-cost
+    /// returned handle can then be passed to [`Self::eval_apply_ff_at`] for zero-cost
     /// direct function-pointer dispatch.
     pub fn resolve_event(&self, addr: &AbsoluteAddr) -> EventRef {
         self.shared.event_map[addr]

--- a/crates/celox/src/simulation.rs
+++ b/crates/celox/src/simulation.rs
@@ -99,7 +99,10 @@ impl Simulation {
         crate::SimulatorBuilder::<Simulation>::from_sources(sources, top)
     }
 
-    /// Build a timed simulation from an elaborated external frontend artifact.
+    /// Low-level adapter hook for a timed simulation from an external artifact.
+    ///
+    /// Frontend crates should wrap this with a constructor named for their own
+    /// artifact type.
     pub fn from_frontend(
         artifact: celox_frontend_sdk::FrontendArtifact,
     ) -> crate::SimulatorBuilder<'static, Simulation> {

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -1477,14 +1477,18 @@ mod host {
             SimulatorBuilder::<Simulator>::from_sources(sources, top)
         }
 
-        /// Build a simulator from an elaborated external frontend artifact.
+        /// Low-level adapter hook for an elaborated external frontend artifact.
+        ///
+        /// Frontend crates should wrap this with a constructor named for their
+        /// own artifact type instead of exposing
+        /// [`celox_frontend_sdk::FrontendArtifact`] to applications.
         pub fn from_frontend(
             artifact: celox_frontend_sdk::FrontendArtifact,
         ) -> SimulatorBuilder<'static, Simulator> {
             SimulatorBuilder::<Simulator>::from_frontend(artifact)
         }
 
-        /// Build a Veryl native testbench around an external frontend module.
+        /// Low-level adapter hook for a Veryl testbench around an external module.
         pub fn from_frontend_with_testbench<'a>(
             artifact: celox_frontend_sdk::FrontendArtifact,
             sources: Vec<(&'a str, &'a std::path::Path)>,

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -1704,7 +1704,9 @@ mod host {
             }
         }
 
-        /// Build a simulator from a source-independent external frontend artifact.
+        /// Low-level adapter hook for a source-independent frontend artifact.
+        ///
+        /// Frontend crates should wrap this with an artifact-specific public API.
         pub fn from_frontend(
             artifact: celox_frontend_sdk::FrontendArtifact,
         ) -> SimulatorBuilder<'static, Simulator> {
@@ -1727,8 +1729,8 @@ mod host {
             }
         }
 
-        /// Build a Veryl native testbench whose `$sv::Module` instances are
-        /// resolved from an external frontend artifact.
+        /// Low-level adapter hook for a Veryl native testbench whose
+        /// `$sv::Module` instances resolve from an external frontend artifact.
         pub fn from_frontend_with_testbench(
             artifact: celox_frontend_sdk::FrontendArtifact,
             sources: Vec<(&'a str, &'a Path)>,

--- a/crates/celox/testdata/verilator/Countones.sv
+++ b/crates/celox/testdata/verilator/Countones.sv
@@ -1,0 +1,48 @@
+module countones #(
+    parameter  int unsigned W     = 16                                   ,
+    localparam int unsigned CLOGW = ((W > 1) ? ( $clog2(W) + 1 ) : ( 1 ))
+) (
+    input  var logic [W-1:0]     i_data,
+    output var logic [CLOGW-1:0] o_ones
+);
+    if ((W == 1)) begin :gen_base_case
+        always_comb o_ones = i_data;
+    end else begin :gen_rec_case
+        localparam int unsigned            WBOT     = W / 2;
+        localparam int unsigned            WTOP     = W - WBOT;
+        logic        [WBOT-1:0] data_bot; always_comb data_bot = i_data[WBOT - 1:0];
+        logic        [WTOP-1:0] data_top; always_comb data_top = i_data[W - 1:WBOT];
+
+        localparam int unsigned                CLOGWBOT = ((WBOT > 1) ? ( $clog2(WBOT) + 1 ) : ( 1 ));
+        localparam int unsigned                CLOGWTOP = ((WTOP > 1) ? ( $clog2(WTOP) + 1 ) : ( 1 ));
+        logic        [CLOGWBOT-1:0] ones_bot;
+        logic        [CLOGWTOP-1:0] ones_top;
+
+        countones #(
+            .W (WBOT)
+        ) u_bot (
+            .i_data (data_bot),
+            .o_ones (ones_bot)
+        );
+        countones #(
+            .W (WTOP)
+        ) u_top (
+            .i_data (data_top),
+            .o_ones (ones_top)
+        );
+        always_comb o_ones = {{(W - WTOP){1'b0}}, ones_top} + {{(W - WBOT){1'b0}}, ones_bot};
+
+    end
+endmodule
+
+module Top (
+    input  var logic [64-1:0] i_data,
+    output var logic [7-1:0]  o_ones
+);
+    countones #(
+        .W      (64    )
+    ) u (
+        .i_data (i_data),
+        .o_ones (o_ones)
+    );
+endmodule

--- a/crates/celox/testdata/verilator/EdgeDetector.sv
+++ b/crates/celox/testdata/verilator/EdgeDetector.sv
@@ -1,0 +1,59 @@
+
+module edge_detector #(
+
+    parameter int unsigned WIDTH = 1,
+
+    parameter bit [WIDTH-1:0] INITIAL_VALUE = '0
+) (
+
+    input var logic i_clk,
+
+    input var logic i_rst,
+
+    input var logic i_clear,
+
+    input var logic [WIDTH-1:0] i_data,
+
+    output var logic [WIDTH-1:0] o_edge,
+
+    output var logic [WIDTH-1:0] o_posedge,
+
+    output var logic [WIDTH-1:0] o_negedge
+);
+    logic [WIDTH-1:0] data;
+
+    always_comb o_edge    = (i_data) ^ (data) & (~i_clear);
+    always_comb o_posedge = (i_data) & (~data) & (~i_clear);
+    always_comb o_negedge = (~i_data) & (data) & (~i_clear);
+
+    always_ff @ (posedge i_clk, negedge i_rst) begin
+        if (!i_rst) begin
+            data <= INITIAL_VALUE;
+        end else if (i_clear) begin
+            data <= INITIAL_VALUE;
+        end else begin
+            data <= i_data;
+        end
+    end
+endmodule
+
+module Top (
+    input  var logic          clk      ,
+    input  var logic          rst      ,
+    input  var logic [32-1:0] i_data   ,
+    output var logic [32-1:0] o_edge   ,
+    output var logic [32-1:0] o_posedge,
+    output var logic [32-1:0] o_negedge
+);
+    edge_detector #(
+        .WIDTH     (32       )
+    ) u (
+        .i_clk     (clk      ),
+        .i_rst     (rst      ),
+        .i_clear   (1'b0     ),
+        .i_data    (i_data   ),
+        .o_edge    (o_edge   ),
+        .o_posedge (o_posedge),
+        .o_negedge (o_negedge)
+    );
+endmodule

--- a/crates/celox/testdata/verilator/Fifo.sv
+++ b/crates/celox/testdata/verilator/Fifo.sv
@@ -1,0 +1,551 @@
+module ram #(
+    parameter int unsigned WORD_SIZE     = 1                                                 ,
+    parameter int unsigned ADDRESS_WIDTH = ((WORD_SIZE >= 2) ? ( $clog2(WORD_SIZE) ) : ( 1 )),
+    parameter int unsigned DATA_WIDTH    = 8                                                 ,
+    parameter type         DATA_TYPE     = logic [DATA_WIDTH-1:0]                            ,
+    parameter bit          BUFFER_OUT    = 1'b0                                              ,
+    parameter bit          USE_RESET     = 1'b0                                              ,
+    parameter DATA_TYPE    INITIAL_VALUE = DATA_TYPE'(0                                     )
+) (
+    input  var logic                         i_clk ,
+    input  var logic                         i_rst ,
+    input  var logic                         i_clr ,
+    input  var logic                         i_mea ,
+    input  var logic                         i_wea ,
+    input  var logic     [ADDRESS_WIDTH-1:0] i_adra,
+    input  var DATA_TYPE                     i_da  ,
+    input  var logic                         i_meb ,
+    input  var logic     [ADDRESS_WIDTH-1:0] i_adrb,
+    output var DATA_TYPE                     o_qb
+);
+    logic [$bits(DATA_TYPE)-1:0] ram_data [WORD_SIZE];
+    logic [$bits(DATA_TYPE)-1:0] q                   ;
+
+    if (USE_RESET) begin :g_ram
+        always_ff @ (posedge i_clk, negedge i_rst) begin
+            if (!i_rst) begin
+                ram_data <= '{default: INITIAL_VALUE};
+            end else if (i_clr) begin
+                ram_data <= '{default: INITIAL_VALUE};
+            end else if (i_mea && i_wea) begin
+                ram_data[i_adra] <= i_da;
+            end
+        end
+    end else begin :g_ram
+        always_ff @ (posedge i_clk) begin
+            if (i_mea && i_wea) begin
+                ram_data[i_adra] <= i_da;
+            end
+        end
+    end
+
+    always_comb begin
+        o_qb = DATA_TYPE'(q);
+    end
+
+    if (!BUFFER_OUT) begin :g_out
+        always_comb begin
+            q = ram_data[i_adrb];
+        end
+    end else if (USE_RESET) begin :g_out
+        always_ff @ (posedge i_clk, negedge i_rst) begin
+            if (!i_rst) begin
+                q <= INITIAL_VALUE;
+            end else if (i_clr) begin
+                q <= INITIAL_VALUE;
+            end else if (i_meb) begin
+                q <= ram_data[i_adrb];
+            end
+        end
+    end else begin :g_out
+        always_ff @ (posedge i_clk) begin
+            if (i_meb) begin
+                q <= ram_data[i_adrb];
+            end
+        end
+    end
+endmodule
+
+module fifo_controller #(
+    parameter  type         TYPE              = logic                                             ,
+    parameter  int unsigned DEPTH             = 8                                                 ,
+    parameter  int unsigned THRESHOLD         = DEPTH                                             ,
+    parameter  bit          FLAG_FF_OUT       = 1'b1                                              ,
+    parameter  bit          DATA_FF_OUT       = 1'b1                                              ,
+    parameter  bit          PUSH_ON_CLEAR     = 1'b0                                              ,
+    parameter  int unsigned RAM_WORDS         = ((DATA_FF_OUT) ? ( DEPTH - 1 ) : ( DEPTH        )),
+    parameter  int unsigned RAM_POINTER_WIDTH = ((RAM_WORDS >= 2) ? ( $clog2(RAM_WORDS) ) : ( 1 )),
+    parameter  int unsigned MATCH_COUNT_WIDTH = 0                                                 ,
+    parameter  int unsigned POINTER_WIDTH     = ((DEPTH >= 2) ? ( $clog2(DEPTH) ) : ( 1         )),
+    localparam type         RAM_POINTER       = logic [RAM_POINTER_WIDTH-1:0]                     ,
+    localparam type         POINTER           = logic [POINTER_WIDTH-1:0]                         ,
+    localparam type         COUNTER           = logic [$clog2(DEPTH + 1)-1:0]
+) (
+    input  var logic       i_clk          ,
+    input  var logic       i_rst          ,
+    input  var logic       i_clear        ,
+    output var logic       o_empty        ,
+    output var logic       o_almost_full  ,
+    output var logic       o_full         ,
+    output var COUNTER     o_word_count   ,
+    input  var logic       i_push         ,
+    input  var TYPE        i_data         ,
+    input  var logic       i_pop          ,
+    output var RAM_POINTER o_write_pointer,
+    output var logic       o_write_to_ff  ,
+    output var logic       o_write_to_ram ,
+    output var RAM_POINTER o_read_pointer ,
+    output var logic       o_read_from_ram
+);
+    typedef struct packed {
+        logic empty      ;
+        logic almost_full;
+        logic full       ;
+    } s_status_flag;
+
+    logic                 push             ;
+    logic                 pop              ;
+    logic         [2-1:0] clear            ;
+    logic                 update_state     ;
+    COUNTER               word_counter     ;
+    COUNTER               word_counter_next;
+    logic                 word_counter_eq_1;
+    logic                 word_counter_eq_2;
+    logic                 word_counter_ge_2;
+    s_status_flag         status_flag      ;
+    logic                 write_to_ff      ;
+    logic                 write_to_ram     ;
+    RAM_POINTER           ram_write_pointer;
+    logic                 read_from_ram    ;
+    RAM_POINTER           ram_read_pointer ;
+    logic                 ram_empty_next   ;
+    logic                 match_data       ;
+    logic                 last_pop_data    ;
+
+    always_comb begin
+        push = i_push && ((PUSH_ON_CLEAR && i_clear) || ((!status_flag.full) && (!match_data)));
+        pop  = i_pop && (!status_flag.empty) && last_pop_data;
+    end
+
+    always_comb begin
+        clear[0] = i_clear && ((!PUSH_ON_CLEAR) || (!push));
+        clear[1] = i_clear && PUSH_ON_CLEAR && push;
+    end
+
+    always_comb begin
+        update_state = push || pop || i_clear;
+    end
+
+    function automatic COUNTER get_word_counter_next(
+        input var logic           push        ,
+        input var logic           pop         ,
+        input var logic   [2-1:0] clear       ,
+        input var COUNTER         word_counter
+    ) ;
+        logic up  ;
+        logic down;
+        up   = push && (!pop);
+        down = (!push) && pop;
+        case (1'b1)
+            clear[0]: return COUNTER'(0);
+            clear[1]: return COUNTER'(1);
+            up      : return word_counter + COUNTER'(1);
+            down    : return word_counter - COUNTER'(1);
+            default : return word_counter;
+        endcase
+    endfunction
+
+    always_comb begin
+        o_word_count = word_counter;
+    end
+
+    always_comb begin
+        word_counter_eq_1 = (DEPTH >= 1) && (word_counter == COUNTER'(1));
+        word_counter_eq_2 = (DEPTH >= 2) && (word_counter == COUNTER'(2));
+        word_counter_ge_2 = (DEPTH >= 2) && (word_counter >= COUNTER'(2));
+    end
+
+    always_comb begin
+        word_counter_next = get_word_counter_next(push, pop, clear, word_counter);
+    end
+
+    always_ff @ (posedge i_clk, negedge i_rst) begin
+        if (!i_rst) begin
+            word_counter <= '0;
+        end else if (update_state) begin
+            word_counter <= word_counter_next;
+        end
+    end
+
+    function automatic s_status_flag get_status_flag(
+        input var COUNTER word_count
+    ) ;
+        s_status_flag flag            ;
+        flag.empty       = word_count == 0;
+        flag.almost_full = word_count >= THRESHOLD;
+        flag.full        = word_count >= DEPTH;
+        return flag;
+    endfunction
+
+    always_comb begin
+        o_empty       = status_flag.empty;
+        o_almost_full = status_flag.almost_full;
+        o_full        = status_flag.full && (!match_data);
+    end
+
+    if (FLAG_FF_OUT) begin :g_flag_ff_out
+        always_ff @ (posedge i_clk, negedge i_rst) begin
+            if (!i_rst) begin
+                status_flag.empty       <= '1;
+                status_flag.almost_full <= '0;
+                status_flag.full        <= '0;
+            end else if (update_state) begin
+                status_flag <= get_status_flag(word_counter_next);
+            end
+        end
+    end else begin :g_flag_logic_out
+        always_comb begin
+            status_flag = get_status_flag(word_counter);
+        end
+    end
+
+    always_comb begin
+        o_write_pointer = ram_write_pointer;
+        o_write_to_ff   = write_to_ff;
+        o_write_to_ram  = write_to_ram;
+        o_read_pointer  = ram_read_pointer;
+        o_read_from_ram = read_from_ram;
+    end
+
+    if (DATA_FF_OUT) begin :g_data_ff_out
+        always_comb begin
+            if ((word_counter_eq_1 && pop) || status_flag.empty || clear[1]) begin
+                write_to_ff  = push;
+                write_to_ram = '0;
+            end else begin
+                write_to_ff  = '0;
+                write_to_ram = push;
+            end
+            read_from_ram  = pop && word_counter_ge_2;
+            ram_empty_next = read_from_ram && (!write_to_ram) && word_counter_eq_2;
+        end
+    end else begin :g_data_ram_out
+        always_comb begin
+            write_to_ff    = '0;
+            write_to_ram   = push;
+            read_from_ram  = pop;
+            ram_empty_next = read_from_ram && (!write_to_ram) && word_counter_eq_1;
+        end
+    end
+
+    if (RAM_WORDS >= 2) begin :g_multi_word_ram
+        always_ff @ (posedge i_clk, negedge i_rst) begin
+            if (!i_rst) begin
+                ram_write_pointer <= RAM_POINTER'(0);
+            end else if ((clear[0])) begin
+                ram_write_pointer <= RAM_POINTER'(0);
+            end else if ((clear[1])) begin
+                ram_write_pointer <= ((DATA_FF_OUT) ? ( RAM_POINTER'(0) ) : ( RAM_POINTER'(1) ));
+            end else if ((ram_empty_next)) begin
+                ram_write_pointer <= ram_read_pointer;
+            end else if ((write_to_ram)) begin
+                if ((ram_write_pointer == RAM_POINTER'((RAM_WORDS - 1)))) begin
+                    ram_write_pointer <= RAM_POINTER'(0);
+                end else begin
+                    ram_write_pointer <= ram_write_pointer + (RAM_POINTER'(1));
+                end
+            end
+        end
+
+        always_ff @ (posedge i_clk, negedge i_rst) begin
+            if (!i_rst) begin
+                ram_read_pointer <= RAM_POINTER'(0);
+            end else if ((i_clear)) begin
+                ram_read_pointer <= RAM_POINTER'(0);
+            end else if ((ram_empty_next)) begin
+                ram_read_pointer <= ram_read_pointer;
+            end else if ((read_from_ram)) begin
+                if ((ram_read_pointer == RAM_POINTER'((RAM_WORDS - 1)))) begin
+                    ram_read_pointer <= RAM_POINTER'(0);
+                end else begin
+                    ram_read_pointer <= ram_read_pointer + (RAM_POINTER'(1));
+                end
+            end
+        end
+    end else begin :g_single_word_ram
+        always_comb begin
+            ram_write_pointer = RAM_POINTER'(0);
+            ram_read_pointer  = RAM_POINTER'(0);
+        end
+    end
+
+    if (MATCH_COUNT_WIDTH > 0) begin :g_data_match
+        logic   [DEPTH-1:0][MATCH_COUNT_WIDTH-1:0] match_count     ;
+        logic   [DEPTH-1:0]                        match_count_full;
+        logic   [DEPTH-1:0]                        match_count_eq_1;
+        logic   [DEPTH-1:0]                        last_match_data ;
+        POINTER [2-1:0]                            write_pointer   ;
+        POINTER                                    read_pointer    ;
+        TYPE                                       data            ;
+
+        if (DEPTH == RAM_WORDS) begin :g_pointer
+            always_comb begin
+                write_pointer[0] = ram_write_pointer;
+                read_pointer     = ram_read_pointer;
+            end
+        end else begin :g_pointer
+            always_ff @ (posedge i_clk, negedge i_rst) begin
+                if (!i_rst) begin
+                    write_pointer[0] <= POINTER'(0);
+                end else if (clear[0]) begin
+                    write_pointer[0] <= POINTER'(0);
+                end else if (clear[1]) begin
+                    write_pointer[0] <= POINTER'(1);
+                end else if (push) begin
+                    if (write_pointer[0] == POINTER'((DEPTH - 1))) begin
+                        write_pointer[0] <= POINTER'(0);
+                    end else begin
+                        write_pointer[0] <= write_pointer[0] + (POINTER'(1));
+                    end
+                end
+            end
+
+            always_ff @ (posedge i_clk, negedge i_rst) begin
+                if (!i_rst) begin
+                    read_pointer <= POINTER'(0);
+                end else if (i_clear) begin
+                    read_pointer <= POINTER'(0);
+                end else if (pop) begin
+                    if (read_pointer == POINTER'((DEPTH - 1))) begin
+                        read_pointer <= POINTER'(0);
+                    end else begin
+                        read_pointer <= read_pointer + (POINTER'(1));
+                    end
+                end
+            end
+        end
+
+        always_comb begin
+            if (write_pointer[0] == POINTER'(0)) begin
+                write_pointer[1] = POINTER'((DEPTH - 1));
+            end else begin
+                write_pointer[1] = write_pointer[0] - POINTER'(1);
+            end
+        end
+
+        always_ff @ (posedge i_clk) begin
+            if (push) begin
+                data <= i_data;
+            end
+        end
+
+        always_comb begin
+            match_data    = (!status_flag.empty) && (i_data == data) && (!match_count_full[write_pointer[1]]);
+            last_pop_data = last_match_data[read_pointer];
+        end
+
+        for (genvar i = 0; i < DEPTH; i++) begin :g_match_count
+            logic [3-1:0] up_down;
+
+            always_comb begin
+                match_count_full[i] = match_count[i] == '1;
+                match_count_eq_1[i] = match_count[i] == MATCH_COUNT_WIDTH'(1);
+                last_match_data[i]  = match_count_eq_1[i] && (up_down[2:1] == '0);
+            end
+
+            always_comb begin
+                up_down[2] = (match_data == '0) && (write_pointer[0] == POINTER'(i)) && push;
+                up_down[1] = (match_data == '1) && (write_pointer[1] == POINTER'(i)) && i_push;
+                up_down[0] = (!status_flag.empty) && (read_pointer == POINTER'(i)) && i_pop;
+            end
+
+            always_ff @ (posedge i_clk, negedge i_rst) begin
+                if (!i_rst) begin
+                    match_count[i] <= MATCH_COUNT_WIDTH'(0);
+                end else if (clear[0] || (i_clear && (i >= 1))) begin
+                    match_count[i] <= MATCH_COUNT_WIDTH'(0);
+                end else if (clear[1] && (i == 0)) begin
+                    match_count[i] <= MATCH_COUNT_WIDTH'(1);
+                end else if (((up_down) inside {3'b1x0, 3'bx10})) begin
+                    match_count[i] <= match_count[i] + (MATCH_COUNT_WIDTH'(1));
+                end else if (up_down == 3'b001) begin
+                    match_count[i] <= match_count[i] - (MATCH_COUNT_WIDTH'(1));
+                end
+            end
+        end
+    end else begin :g
+        always_comb begin
+            match_data    = '0;
+            last_pop_data = '1;
+        end
+    end
+endmodule
+
+module fifo #(
+    parameter  int unsigned WIDTH             = 8                            ,
+    parameter  type         TYPE              = logic [WIDTH-1:0]            ,
+    parameter  int unsigned DEPTH             = 8                            ,
+    parameter  int unsigned THRESHOLD         = DEPTH                        ,
+    parameter  bit          FLAG_FF_OUT       = 1'b1                         ,
+    parameter  bit          DATA_FF_OUT       = 1'b1                         ,
+    parameter  bit          RESET_RAM         = 1'b0                         ,
+    parameter  bit          RESET_DATA_FF     = 1'b1                         ,
+    parameter  bit          CLEAR_DATA        = 1'b0                         ,
+    parameter  bit          PUSH_ON_CLEAR     = 1'b0                         ,
+    parameter  int unsigned MATCH_COUNT_WIDTH = 0                            ,
+    localparam type         COUNTER           = logic [$clog2(DEPTH + 1)-1:0]
+) (
+    input  var logic   i_clk        ,
+    input  var logic   i_rst        ,
+    input  var logic   i_clear      ,
+    output var logic   o_empty      ,
+    output var logic   o_almost_full,
+    output var logic   o_full       ,
+    output var COUNTER o_word_count ,
+    input  var logic   i_push       ,
+    input  var TYPE    i_data       ,
+    input  var logic   i_pop        ,
+    output var TYPE    o_data
+);
+    localparam int unsigned RAM_WORDS = ((DATA_FF_OUT) ? ( DEPTH - 1 ) : ( DEPTH ));
+
+    logic clear_data;
+
+    always_comb begin
+        clear_data = CLEAR_DATA && i_clear;
+    end
+
+    localparam int unsigned RAM_POINTER_WIDTH = ((RAM_WORDS >= 2) ? ( $clog2(RAM_WORDS) ) : ( 1 ));
+
+    logic [RAM_POINTER_WIDTH-1:0] write_pointer;
+    logic                         write_to_ff  ;
+    logic                         write_to_ram ;
+    logic [RAM_POINTER_WIDTH-1:0] read_pointer ;
+    logic                         read_from_ram;
+
+    fifo_controller #(
+        .TYPE              (TYPE             ),
+        .DEPTH             (DEPTH            ),
+        .THRESHOLD         (THRESHOLD        ),
+        .FLAG_FF_OUT       (FLAG_FF_OUT      ),
+        .DATA_FF_OUT       (DATA_FF_OUT      ),
+        .PUSH_ON_CLEAR     (PUSH_ON_CLEAR    ),
+        .RAM_WORDS         (RAM_WORDS        ),
+        .RAM_POINTER_WIDTH (RAM_POINTER_WIDTH),
+        .MATCH_COUNT_WIDTH (MATCH_COUNT_WIDTH)
+    ) u_controller (
+        .i_clk           (i_clk        ),
+        .i_rst           (i_rst        ),
+        .i_clear         (i_clear      ),
+        .o_empty         (o_empty      ),
+        .o_almost_full   (o_almost_full),
+        .o_full          (o_full       ),
+        .i_push          (i_push       ),
+        .i_data          (i_data       ),
+        .i_pop           (i_pop        ),
+        .o_word_count    (o_word_count ),
+        .o_write_pointer (write_pointer),
+        .o_write_to_ff   (write_to_ff  ),
+        .o_write_to_ram  (write_to_ram ),
+        .o_read_pointer  (read_pointer ),
+        .o_read_from_ram (read_from_ram)
+
+    );
+
+    TYPE ram_read_data;
+
+    if (RAM_WORDS >= 1) begin :g_ram
+        ram #(
+            .WORD_SIZE     (RAM_WORDS        ),
+            .ADDRESS_WIDTH (RAM_POINTER_WIDTH),
+            .DATA_TYPE     (TYPE             ),
+            .BUFFER_OUT    (0                ),
+            .USE_RESET     (RESET_RAM        )
+        ) u_ram (
+            .i_clk  (i_clk        ),
+            .i_rst  (i_rst        ),
+            .i_clr  (clear_data   ),
+            .i_mea  ('1           ),
+            .i_wea  (write_to_ram ),
+            .i_adra (write_pointer),
+            .i_da   (i_data       ),
+            .i_meb  ('1           ),
+            .i_adrb (read_pointer ),
+            .o_qb   (ram_read_data)
+        );
+    end else begin :g_no_ram
+        always_comb begin
+            ram_read_data = TYPE'(0);
+        end
+    end
+
+    if (DATA_FF_OUT) begin :g_data_out
+        TYPE data_out;
+
+        always_comb begin
+            o_data = data_out;
+        end
+
+        if (RESET_DATA_FF) begin :g
+            always_ff @ (posedge i_clk, negedge i_rst) begin
+                if (!i_rst) begin
+                    data_out <= TYPE'(0);
+                end else if (clear_data) begin
+                    data_out <= TYPE'(0);
+                end else if (write_to_ff) begin
+                    data_out <= i_data;
+                end else if (read_from_ram) begin
+                    data_out <= ram_read_data;
+                end
+            end
+        end else begin :g
+            always_ff @ (posedge i_clk) begin
+                if (clear_data) begin
+                    data_out <= TYPE'(0);
+                end else if (write_to_ff) begin
+                    data_out <= i_data;
+                end else if (read_from_ram) begin
+                    data_out <= ram_read_data;
+                end
+            end
+        end
+    end else begin :g
+        always_comb begin
+            o_data = ram_read_data;
+        end
+    end
+endmodule
+
+module Top (
+    input  var logic         clk         ,
+    input  var logic         rst         ,
+    input  var logic         i_push      ,
+    input  var logic [8-1:0] i_data      ,
+    input  var logic         i_pop       ,
+    output var logic [8-1:0] o_data      ,
+    output var logic         o_empty     ,
+    output var logic         o_full      ,
+    output var logic [5-1:0] o_word_count
+);
+    logic almost_full;
+    logic clear      ;
+    always_comb begin
+        clear       = '0;
+    end
+    fifo #(
+        .WIDTH (8 ),
+        .DEPTH (16)
+    ) u_fifo (
+        .i_clk         (clk         ),
+        .i_rst         (rst         ),
+        .i_clear       (clear       ),
+        .o_empty       (o_empty     ),
+        .o_almost_full (almost_full ),
+        .o_full        (o_full      ),
+        .o_word_count  (o_word_count),
+        .i_push        (i_push      ),
+        .i_data        (i_data      ),
+        .i_pop         (i_pop       ),
+        .o_data        (o_data      )
+    );
+endmodule

--- a/crates/celox/testdata/verilator/GrayCodec.sv
+++ b/crates/celox/testdata/verilator/GrayCodec.sv
@@ -1,0 +1,73 @@
+
+
+module gray_encoder #(
+
+    parameter int unsigned WIDTH = 32
+) (
+
+    input var logic [WIDTH-1:0] i_bin,
+
+    output var logic [WIDTH-1:0] o_gray
+);
+    always_comb o_gray = i_bin ^ (i_bin >> 1);
+endmodule
+
+module gray_decoder #(
+
+    parameter int unsigned WIDTH = 1
+) (
+
+    input var logic [WIDTH-1:0] i_gray,
+
+    output var logic [WIDTH-1:0] o_bin
+);
+    if (WIDTH == 1) begin :g_base
+        always_comb o_bin = i_gray;
+    end else begin :g_base
+        localparam int unsigned BWIDTH = WIDTH / 2;
+        localparam int unsigned TWIDTH = WIDTH - BWIDTH;
+
+        logic [TWIDTH-1:0] top_in ; always_comb top_in  = i_gray[WIDTH - 1:BWIDTH];
+        logic [TWIDTH-1:0] top_out;
+
+        gray_decoder #(
+            .WIDTH (TWIDTH)
+        ) u_top (
+            .i_gray (top_in ),
+            .o_bin  (top_out)
+        );
+
+        logic [BWIDTH-1:0] bot_in ; always_comb bot_in  = i_gray[BWIDTH - 1:0];
+        logic [BWIDTH-1:0] bot_out;
+
+        logic [BWIDTH-1:0] bot_red; always_comb bot_red = bot_out ^ {BWIDTH{top_out[0]}};
+
+        gray_decoder #(
+            .WIDTH (BWIDTH)
+        ) u_bot (
+            .i_gray (bot_in ),
+            .o_bin  (bot_out)
+        );
+
+        always_comb o_bin = {top_out, bot_red};
+    end
+endmodule
+
+module Top (
+    input  var logic [32-1:0] i_bin ,
+    output var logic [32-1:0] o_gray,
+    output var logic [32-1:0] o_bin
+);
+    gray_encoder #(
+        .WIDTH  (32    )
+    ) u_enc (
+        .i_bin  (i_bin ),
+        .o_gray (o_gray)
+    );
+    gray_decoder #(
+        .WIDTH  (32    )
+    ) u_dec (
+        .i_gray (o_gray),
+        .o_bin  (o_bin )
+    );
+endmodule

--- a/crates/celox/testdata/verilator/GrayCounter.sv
+++ b/crates/celox/testdata/verilator/GrayCounter.sv
@@ -1,0 +1,229 @@
+
+module counter #(
+
+    parameter int unsigned WIDTH = 2,
+
+    parameter bit [WIDTH-1:0] MAX_COUNT = '1,
+
+    parameter bit [WIDTH-1:0] MIN_COUNT = '0,
+
+    parameter bit [WIDTH-1:0] INITIAL_COUNT = MIN_COUNT,
+
+    parameter bit WRAP_AROUND = 1,
+
+    localparam type COUNT = logic [WIDTH-1:0]
+) (
+
+    input var logic i_clk,
+
+    input var logic i_rst,
+
+    input var logic i_clear,
+
+    input var logic i_set,
+
+    input var COUNT i_set_value,
+
+    input var logic i_up,
+
+    input var logic i_down,
+
+    output var COUNT o_count,
+
+    output var COUNT o_count_next,
+
+    output var logic o_wrap_around
+);
+    function automatic COUNT count_up(
+        input var COUNT current_count
+    ) ;
+        if (current_count == MAX_COUNT) begin
+            if (WRAP_AROUND) begin
+                return MIN_COUNT;
+            end else begin
+                return MAX_COUNT;
+            end
+        end else begin
+            return current_count + 1;
+        end
+    endfunction
+
+    function automatic COUNT count_down(
+        input var COUNT current_count
+    ) ;
+        if (current_count == MIN_COUNT) begin
+            if (WRAP_AROUND) begin
+                return MAX_COUNT;
+            end else begin
+                return MIN_COUNT;
+            end
+        end else begin
+            return current_count - 1;
+        end
+    endfunction
+
+    function automatic logic get_wrap_around_flag(
+        input var logic clear        ,
+        input var logic set          ,
+        input var logic up           ,
+        input var logic down         ,
+        input var COUNT current_count
+    ) ;
+        logic [2-1:0] up_down;
+        up_down = {up, down};
+        if (clear || set) begin
+            return '0;
+        end else if ((current_count == MAX_COUNT) && (up_down == 2'b10)) begin
+            return '1;
+        end else if ((current_count == MIN_COUNT) && (up_down == 2'b01)) begin
+            return '1;
+        end else begin
+            return '0;
+        end
+    endfunction
+
+    function automatic COUNT get_count_next(
+        input var logic clear        ,
+        input var logic set          ,
+        input var COUNT set_value    ,
+        input var logic up           ,
+        input var logic down         ,
+        input var COUNT current_count
+    ) ;
+        case (1'b1)
+            clear          : return INITIAL_COUNT;
+            set            : return set_value;
+            (up && (!down)): return count_up(current_count);
+            (down && (!up)): return count_down(current_count);
+            default        : return current_count;
+        endcase
+    endfunction
+
+    COUNT count     ;
+    COUNT count_next;
+
+    always_comb o_count      = count;
+    always_comb o_count_next = count_next;
+
+    always_comb count_next = get_count_next(i_clear, i_set, i_set_value, i_up, i_down, count);
+    always_ff @ (posedge i_clk, negedge i_rst) begin
+        if (!i_rst) begin
+            count <= INITIAL_COUNT;
+        end else begin
+            count <= count_next;
+        end
+    end
+
+    if ((WRAP_AROUND)) begin :g
+        always_comb o_wrap_around = get_wrap_around_flag(i_clear, i_set, i_up, i_down, count);
+    end else begin :g
+        always_comb o_wrap_around = '0;
+    end
+endmodule
+
+module gray_encoder #(
+
+    parameter int unsigned WIDTH = 32
+) (
+
+    input var logic [WIDTH-1:0] i_bin,
+
+    output var logic [WIDTH-1:0] o_gray
+);
+    always_comb o_gray = i_bin ^ (i_bin >> 1);
+endmodule
+
+module gray_counter #(
+
+    parameter int unsigned WIDTH = 2,
+
+    parameter bit [WIDTH-1:0] MAX_COUNT = '1,
+
+    parameter bit [WIDTH-1:0] MIN_COUNT = '0,
+
+    parameter bit [WIDTH-1:0] INITIAL_COUNT = MIN_COUNT,
+
+    parameter bit WRAP_AROUND = 1,
+
+    localparam type COUNT = logic [WIDTH-1:0]
+) (
+
+    input var logic i_clk,
+
+    input var logic i_rst,
+
+    input var logic i_clear,
+
+    input var logic i_set,
+
+    input var COUNT i_set_value,
+
+    input var logic i_up,
+
+    input var logic i_down,
+
+    output var COUNT o_count,
+
+    output var COUNT o_count_next,
+
+    output var logic o_wrap_around
+);
+
+    COUNT bin_count     ;
+    COUNT bin_count_next;
+
+    counter #(
+        .WIDTH         (WIDTH        ),
+        .MAX_COUNT     (MAX_COUNT    ),
+        .MIN_COUNT     (MIN_COUNT    ),
+        .INITIAL_COUNT (INITIAL_COUNT),
+        .WRAP_AROUND   (WRAP_AROUND  )
+    ) u_bin_counter (
+        .i_clk         (i_clk         ),
+        .i_rst         (i_rst         ),
+        .i_clear       (i_clear       ),
+        .i_set         (i_set         ),
+        .i_set_value   (i_set_value   ),
+        .i_up          (i_up          ),
+        .i_down        (i_down        ),
+        .o_count       (bin_count     ),
+        .o_count_next  (bin_count_next),
+        .o_wrap_around (o_wrap_around )
+    );
+
+    gray_encoder #(
+        .WIDTH (WIDTH)
+    ) u_gray_cur (
+        .i_bin  (bin_count),
+        .o_gray (o_count  )
+    );
+    gray_encoder #(
+        .WIDTH (WIDTH)
+    ) u_gray_next (
+        .i_bin  (bin_count_next),
+        .o_gray (o_count_next  )
+    );
+
+endmodule
+
+module Top (
+    input  var logic          clk    ,
+    input  var logic          rst    ,
+    input  var logic          i_up   ,
+    output var logic [32-1:0] o_count
+);
+    gray_counter #(
+        .WIDTH         (32     )
+    ) u (
+        .i_clk         (clk    ),
+        .i_rst         (rst    ),
+        .i_clear       (1'b0   ),
+        .i_set         (1'b0   ),
+        .i_set_value   (32'b0  ),
+        .i_up          (i_up   ),
+        .i_down        (1'b0   ),
+        .o_count       (o_count),
+        .o_count_next  (       ),
+        .o_wrap_around (       )
+    );
+endmodule

--- a/crates/celox/testdata/verilator/Lfsr.sv
+++ b/crates/celox/testdata/verilator/Lfsr.sv
@@ -1,0 +1,185 @@
+module lfsr_galois #(
+
+    parameter  int unsigned SIZE     = 64              ,
+    localparam type         TAPVEC_T = logic [SIZE-1:0],
+
+    parameter TAPVEC_T TAPVEC = (((SIZE) ==? (2)) ? (
+        2'h3
+    ) : ((SIZE) ==? (3)) ? (
+        3'h5
+    ) : ((SIZE) ==? (4)) ? (
+        4'h9
+    ) : ((SIZE) ==? (5)) ? (
+        5'h12
+    ) : ((SIZE) ==? (6)) ? (
+        6'h21
+    ) : ((SIZE) ==? (7)) ? (
+        7'h41
+    ) : ((SIZE) ==? (8)) ? (
+        8'h8e
+    ) : ((SIZE) ==? (9)) ? (
+        9'h108
+    ) : ((SIZE) ==? (10)) ? (
+        10'h204
+    ) : ((SIZE) ==? (11)) ? (
+        11'h402
+    ) : ((SIZE) ==? (12)) ? (
+        12'h829
+    ) : ((SIZE) ==? (13)) ? (
+        13'h100d
+    ) : ((SIZE) ==? (14)) ? (
+        14'h2015
+    ) : ((SIZE) ==? (15)) ? (
+        15'h4001
+    ) : ((SIZE) ==? (16)) ? (
+        16'h8016
+    ) : ((SIZE) ==? (17)) ? (
+        17'h10004
+    ) : ((SIZE) ==? (18)) ? (
+        18'h20013
+    ) : ((SIZE) ==? (19)) ? (
+        19'h40013
+    ) : ((SIZE) ==? (20)) ? (
+        20'h80004
+    ) : ((SIZE) ==? (21)) ? (
+        21'h100002
+    ) : ((SIZE) ==? (22)) ? (
+        22'h200001
+    ) : ((SIZE) ==? (23)) ? (
+        23'h400010
+    ) : ((SIZE) ==? (24)) ? (
+        24'h80000d
+    ) : ((SIZE) ==? (25)) ? (
+        25'h1000004
+    ) : ((SIZE) ==? (26)) ? (
+        26'h2000023
+    ) : ((SIZE) ==? (27)) ? (
+        27'h4000013
+    ) : ((SIZE) ==? (28)) ? (
+        28'h8000004
+    ) : ((SIZE) ==? (29)) ? (
+        29'h10000002
+    ) : ((SIZE) ==? (30)) ? (
+        30'h20000029
+    ) : ((SIZE) ==? (31)) ? (
+        31'h40000004
+    ) : ((SIZE) ==? (32)) ? (
+        32'h80000057
+    ) : ((SIZE) ==? (33)) ? (
+        33'h100000029
+    ) : ((SIZE) ==? (34)) ? (
+        34'h200000073
+    ) : ((SIZE) ==? (35)) ? (
+        35'h400000002
+    ) : ((SIZE) ==? (36)) ? (
+        36'h80000003b
+    ) : ((SIZE) ==? (37)) ? (
+        37'h100000001f
+    ) : ((SIZE) ==? (38)) ? (
+        38'h2000000031
+    ) : ((SIZE) ==? (39)) ? (
+        39'h4000000008
+    ) : ((SIZE) ==? (40)) ? (
+        40'h800000001c
+    ) : ((SIZE) ==? (41)) ? (
+        41'h10000000004
+    ) : ((SIZE) ==? (42)) ? (
+        42'h2000000001f
+    ) : ((SIZE) ==? (43)) ? (
+        43'h4000000002c
+    ) : ((SIZE) ==? (44)) ? (
+        44'h80000000032
+    ) : ((SIZE) ==? (45)) ? (
+        45'h10000000000d
+    ) : ((SIZE) ==? (46)) ? (
+        46'h200000000097
+    ) : ((SIZE) ==? (47)) ? (
+        47'h400000000010
+    ) : ((SIZE) ==? (48)) ? (
+        48'h80000000005b
+    ) : ((SIZE) ==? (49)) ? (
+        49'h1000000000038
+    ) : ((SIZE) ==? (50)) ? (
+        50'h200000000000e
+    ) : ((SIZE) ==? (51)) ? (
+        51'h4000000000025
+    ) : ((SIZE) ==? (52)) ? (
+        52'h8000000000004
+    ) : ((SIZE) ==? (53)) ? (
+        53'h10000000000023
+    ) : ((SIZE) ==? (54)) ? (
+        54'h2000000000003e
+    ) : ((SIZE) ==? (55)) ? (
+        55'h40000000000023
+    ) : ((SIZE) ==? (56)) ? (
+        56'h8000000000004a
+    ) : ((SIZE) ==? (57)) ? (
+        57'h100000000000016
+    ) : ((SIZE) ==? (58)) ? (
+        58'h200000000000031
+    ) : ((SIZE) ==? (59)) ? (
+        59'h40000000000003d
+    ) : ((SIZE) ==? (60)) ? (
+        60'h800000000000001
+    ) : ((SIZE) ==? (61)) ? (
+        61'h1000000000000013
+    ) : ((SIZE) ==? (62)) ? (
+        62'h2000000000000034
+    ) : ((SIZE) ==? (63)) ? (
+        63'h4000000000000001
+    ) : ((SIZE) ==? (64)) ? (
+        64'h800000000000000d
+    ) : (
+        '0
+    ))
+
+) (
+
+    input var logic i_clk,
+
+    input var logic i_en,
+
+    input var logic i_set,
+
+    input var logic [SIZE-1:0] i_setval,
+
+    output var logic [SIZE-1:0] o_val
+);
+
+    logic [SIZE-1:0] val_next;
+
+    always_comb val_next[SIZE - 1] = o_val[0];
+    for (genvar i = 0; i < (SIZE - 1); i++) begin :g_taps
+        localparam int unsigned K = SIZE - 2 - i;
+        if (TAPVEC[K]) begin :g_tap
+            always_comb val_next[K] = ((i_set) ? ( i_setval[K] ) : ( o_val[K + 1] ^ o_val[0] ));
+        end else begin :g_notap
+            always_comb val_next[K] = ((i_set) ? ( i_setval[K] ) : ( o_val[K + 1] ));
+        end
+    end
+
+    always_ff @ (posedge i_clk) begin
+        if (i_en) begin
+            o_val <= val_next;
+        end
+    end
+endmodule
+
+module Top (
+    input  var logic          clk     ,
+    input  var logic          rst     ,
+    input  var logic          i_en    ,
+    input  var logic          i_set   ,
+    input  var logic [32-1:0] i_setval,
+    output var logic [32-1:0] o_val
+);
+    lfsr_galois #(
+        .SIZE     (32      )
+    ) u (
+        .i_clk    (clk     ),
+        .i_en     (i_en    ),
+        .i_set    (i_set   ),
+        .i_setval (i_setval),
+        .o_val    (o_val   )
+    );
+endmodule

--- a/crates/celox/testdata/verilator/LinearSec.sv
+++ b/crates/celox/testdata/verilator/LinearSec.sv
@@ -1,0 +1,119 @@
+
+module linear_sec_encoder #(
+
+    parameter int unsigned P = 4,
+
+    parameter int unsigned K = (1 << P) - 1,
+
+    parameter int unsigned N = K - P
+) (
+    input  var logic [N-1:0] i_word    ,
+    output var logic [K-1:0] o_codeword
+);
+
+    logic [P-1:0][K-1:0] h;
+    for (genvar p = 0; p < P; p++) begin :gen_vector
+        for (genvar k = 0; k < K; k++) begin :gen_bit
+            localparam int unsigned IDX     = k + 1;
+            always_comb h[p][k] = IDX[p];
+        end
+    end
+
+    logic [K-1:0] codeword_data_only;
+    for (genvar k = 1; k < K + 1; k++) begin :gen_move_data
+        localparam int unsigned CODEWORD_IDX = k - 1;
+        if (!$onehot(k)) begin :gen_move_data_bit
+            localparam int unsigned WORD_IDX                         = k - $clog2(k) - 1;
+            always_comb codeword_data_only[CODEWORD_IDX] = i_word[WORD_IDX];
+        end else begin :gen_move_data_bit
+            always_comb codeword_data_only[CODEWORD_IDX] = 1'b0;
+        end
+    end
+
+    logic [K-1:0] codeword_parity_only;
+    for (genvar p = 0; p < P; p++) begin :gen_parities
+        localparam int unsigned CODEWORD_IDX                       = (1 << p) - 1;
+        always_comb codeword_parity_only[CODEWORD_IDX] = ^(h[p] & codeword_data_only);
+    end
+    for (genvar k = 0; k < K; k++) begin :gen_zeros
+        if (!$onehot(k + 1)) begin :gen_zero_bit
+            always_comb codeword_parity_only[k] = 1'b0;
+        end
+    end
+
+    always_comb o_codeword = codeword_data_only | codeword_parity_only;
+endmodule
+
+module linear_sec_decoder #(
+
+    parameter int unsigned P = 4,
+
+    parameter int unsigned K = (1 << P) - 1,
+
+    parameter int unsigned N = K - P
+) (
+    input  var logic [K-1:0] i_codeword,
+    output var logic [N-1:0] o_word    ,
+
+    output var logic o_corrected
+
+);
+
+    logic [(K + 1)-1:0] codeword          ; always_comb codeword           = {i_codeword, 1'b0};
+    logic [(K + 1)-1:0] codeword_corrected;
+
+    logic [P-1:0] errors;
+
+    for (genvar idx = 1; idx < (K + 2); idx++) begin :g_create_word
+        if (!$onehot(idx)) begin :g_data_bit
+            localparam int unsigned CEIL             = $clog2(idx);
+            localparam int unsigned WORD_IDX         = idx - 1 - CEIL;
+            always_comb o_word[WORD_IDX] = codeword_corrected[idx];
+        end
+    end
+
+    for (genvar pbit = 1; pbit < P + 1; pbit++) begin :g_check_parities
+        localparam int unsigned               ONE_IDX_SET_BIT = pbit - 1;
+        logic        [(K + 1)-1:0] masked_bits    ;
+        always_comb masked_bits[0]  = 1'b0;
+        for (genvar idx = 1; idx < K + 1; idx++) begin :g_check_bits
+            if (idx[ONE_IDX_SET_BIT]) begin :g_take_parity
+                always_comb masked_bits[idx] = codeword[idx];
+            end else begin :g_take_parity
+                always_comb masked_bits[idx] = 1'b0;
+            end
+        end
+        always_comb errors[ONE_IDX_SET_BIT] = ^masked_bits;
+    end
+
+    always_comb o_corrected = |errors;
+    always_comb begin
+        codeword_corrected         =  codeword;
+        codeword_corrected[errors] ^= 1;
+    end
+endmodule
+
+module Top #(
+    parameter  int unsigned P = 6           ,
+    localparam int unsigned K = (1 << P) - 1,
+    localparam int unsigned N = K - P
+) (
+    input  var logic [N-1:0] i_word     ,
+    output var logic [K-1:0] o_codeword ,
+    output var logic [N-1:0] o_word     ,
+    output var logic         o_corrected
+);
+    linear_sec_encoder #(
+        .P (P)
+    ) u_enc (
+        .i_word     (i_word    ),
+        .o_codeword (o_codeword)
+    );
+    linear_sec_decoder #(
+        .P (P)
+    ) u_dec (
+        .i_codeword  (o_codeword ),
+        .o_word      (o_word     ),
+        .o_corrected (o_corrected)
+    );
+endmodule

--- a/crates/celox/testdata/verilator/Onehot.sv
+++ b/crates/celox/testdata/verilator/Onehot.sv
@@ -1,0 +1,80 @@
+module onehot #(
+    parameter int unsigned W = 16
+) (
+    input var logic [W-1:0] i_data,
+
+    output var logic o_onehot,
+
+    output var logic o_zero
+);
+    logic o_gt_one;
+
+    _onehot #(
+        .W (W)
+    ) u_onehot (
+        .i_data   (i_data  ),
+        .o_zero   (o_zero  ),
+        .o_onehot (o_onehot),
+        .o_gt_one (o_gt_one)
+    );
+endmodule
+
+module _onehot #(
+    parameter int unsigned W = 16
+) (
+    input  var logic [W-1:0] i_data  ,
+    output var logic         o_onehot,
+    output var logic         o_zero  ,
+    output var logic         o_gt_one
+);
+    if ((W == 1)) begin :gen_base_case
+        always_comb o_onehot = i_data;
+        always_comb o_zero   = ~i_data;
+    end else begin :gen_rec_case
+        localparam int unsigned            WBOT       = W / 2;
+        localparam int unsigned            WTOP       = W - WBOT;
+        logic        [WBOT-1:0] data_bot  ; always_comb data_bot   = i_data[WBOT - 1:0];
+        logic        [WTOP-1:0] data_top  ; always_comb data_top   = i_data[W - 1:WBOT];
+        logic                   onehot_top;
+        logic                   onehot_bot;
+        logic                   zero_top  ;
+        logic                   zero_bot  ;
+        logic                   gt_one_top;
+        logic                   gt_one_bot;
+
+        _onehot #(
+            .W (WBOT)
+        ) u_bot (
+            .i_data   (data_bot  ),
+            .o_onehot (onehot_bot),
+            .o_zero   (zero_bot  ),
+            .o_gt_one (gt_one_bot)
+        );
+        _onehot #(
+            .W (WTOP)
+        ) u_top (
+            .i_data   (data_top  ),
+            .o_onehot (onehot_top),
+            .o_zero   (zero_top  ),
+            .o_gt_one (gt_one_top)
+        );
+        always_comb o_zero   = zero_top & zero_bot;
+        always_comb o_onehot = (onehot_top ^ onehot_bot) & ~gt_one_top & ~gt_one_bot;
+        always_comb o_gt_one = gt_one_top | gt_one_bot | (onehot_top & onehot_bot);
+    end
+
+endmodule
+
+module Top (
+    input  var logic [64-1:0] i_data  ,
+    output var logic          o_onehot,
+    output var logic          o_zero
+);
+    onehot #(
+        .W        (64      )
+    ) u (
+        .i_data   (i_data  ),
+        .o_onehot (o_onehot),
+        .o_zero   (o_zero  )
+    );
+endmodule

--- a/crates/celox/testdata/verilator/StdCounter.sv
+++ b/crates/celox/testdata/verilator/StdCounter.sv
@@ -1,0 +1,144 @@
+
+module counter #(
+
+    parameter int unsigned WIDTH = 2,
+
+    parameter bit [WIDTH-1:0] MAX_COUNT = '1,
+
+    parameter bit [WIDTH-1:0] MIN_COUNT = '0,
+
+    parameter bit [WIDTH-1:0] INITIAL_COUNT = MIN_COUNT,
+
+    parameter bit WRAP_AROUND = 1,
+
+    localparam type COUNT = logic [WIDTH-1:0]
+) (
+
+    input var logic i_clk,
+
+    input var logic i_rst,
+
+    input var logic i_clear,
+
+    input var logic i_set,
+
+    input var COUNT i_set_value,
+
+    input var logic i_up,
+
+    input var logic i_down,
+
+    output var COUNT o_count,
+
+    output var COUNT o_count_next,
+
+    output var logic o_wrap_around
+);
+    function automatic COUNT count_up(
+        input var COUNT current_count
+    ) ;
+        if (current_count == MAX_COUNT) begin
+            if (WRAP_AROUND) begin
+                return MIN_COUNT;
+            end else begin
+                return MAX_COUNT;
+            end
+        end else begin
+            return current_count + 1;
+        end
+    endfunction
+
+    function automatic COUNT count_down(
+        input var COUNT current_count
+    ) ;
+        if (current_count == MIN_COUNT) begin
+            if (WRAP_AROUND) begin
+                return MAX_COUNT;
+            end else begin
+                return MIN_COUNT;
+            end
+        end else begin
+            return current_count - 1;
+        end
+    endfunction
+
+    function automatic logic get_wrap_around_flag(
+        input var logic clear        ,
+        input var logic set          ,
+        input var logic up           ,
+        input var logic down         ,
+        input var COUNT current_count
+    ) ;
+        logic [2-1:0] up_down;
+        up_down = {up, down};
+        if (clear || set) begin
+            return '0;
+        end else if ((current_count == MAX_COUNT) && (up_down == 2'b10)) begin
+            return '1;
+        end else if ((current_count == MIN_COUNT) && (up_down == 2'b01)) begin
+            return '1;
+        end else begin
+            return '0;
+        end
+    endfunction
+
+    function automatic COUNT get_count_next(
+        input var logic clear        ,
+        input var logic set          ,
+        input var COUNT set_value    ,
+        input var logic up           ,
+        input var logic down         ,
+        input var COUNT current_count
+    ) ;
+        case (1'b1)
+            clear          : return INITIAL_COUNT;
+            set            : return set_value;
+            (up && (!down)): return count_up(current_count);
+            (down && (!up)): return count_down(current_count);
+            default        : return current_count;
+        endcase
+    endfunction
+
+    COUNT count     ;
+    COUNT count_next;
+
+    always_comb o_count      = count;
+    always_comb o_count_next = count_next;
+
+    always_comb count_next = get_count_next(i_clear, i_set, i_set_value, i_up, i_down, count);
+    always_ff @ (posedge i_clk, negedge i_rst) begin
+        if (!i_rst) begin
+            count <= INITIAL_COUNT;
+        end else begin
+            count <= count_next;
+        end
+    end
+
+    if ((WRAP_AROUND)) begin :g
+        always_comb o_wrap_around = get_wrap_around_flag(i_clear, i_set, i_up, i_down, count);
+    end else begin :g
+        always_comb o_wrap_around = '0;
+    end
+endmodule
+
+module Top (
+    input  var logic          clk    ,
+    input  var logic          rst    ,
+    input  var logic          i_up   ,
+    output var logic [32-1:0] o_count
+);
+    counter #(
+        .WIDTH         (32     )
+    ) u (
+        .i_clk         (clk    ),
+        .i_rst         (rst    ),
+        .i_clear       (1'b0   ),
+        .i_set         (1'b0   ),
+        .i_set_value   (32'b0  ),
+        .i_up          (i_up   ),
+        .i_down        (1'b0   ),
+        .o_count       (o_count),
+        .o_count_next  (       ),
+        .o_wrap_around (       )
+    );
+endmodule

--- a/crates/celox/testdata/verilator/Top.sv
+++ b/crates/celox/testdata/verilator/Top.sv
@@ -1,0 +1,19 @@
+module Top #(
+    parameter int unsigned N = 1000
+) (
+    input  var logic          clk     ,
+    input  var logic          rst     ,
+    output var logic [32-1:0] cnt  [N],
+    output var logic [32-1:0] cnt0
+);
+    always_comb cnt0 = cnt[0];
+    for (genvar i = 0; i < N; i++) begin :g
+        always_ff @ (posedge clk, negedge rst) begin
+            if (!rst) begin
+                cnt[i] <= 0;
+            end else begin
+                cnt[i] <= cnt[i] + (1);
+            end
+        end
+    end
+endmodule

--- a/crates/celox/testdata/veryl/countones_top.veryl
+++ b/crates/celox/testdata/veryl/countones_top.veryl
@@ -1,0 +1,9 @@
+module Top (
+    i_data: input  logic<64>,
+    o_ones: output logic<7>,
+) {
+    inst u: countones #(W: 64) (
+        i_data,
+        o_ones,
+    );
+}

--- a/crates/celox/testdata/veryl/edge_detector_top.veryl
+++ b/crates/celox/testdata/veryl/edge_detector_top.veryl
@@ -1,0 +1,18 @@
+module Top (
+    clk      : input  clock,
+    rst      : input  reset,
+    i_data   : input  logic<32>,
+    o_edge   : output logic<32>,
+    o_posedge: output logic<32>,
+    o_negedge: output logic<32>,
+) {
+    inst u: edge_detector #(WIDTH: 32) (
+        i_clk  : clk,
+        i_rst  : rst,
+        i_clear: 1'b0,
+        i_data,
+        o_edge,
+        o_posedge,
+        o_negedge,
+    );
+}

--- a/crates/celox/testdata/veryl/fifo_top.veryl
+++ b/crates/celox/testdata/veryl/fifo_top.veryl
@@ -1,0 +1,31 @@
+module Top (
+    clk        : input  clock,
+    rst        : input  reset,
+    i_push     : input  logic,
+    i_data     : input  logic<8>,
+    i_pop      : input  logic,
+    o_data     : output logic<8>,
+    o_empty    : output logic,
+    o_full     : output logic,
+    o_word_count: output logic<5>,
+) {
+    var almost_full: logic;
+    var clear: logic;
+    always_comb { clear = '0; }
+    inst u_fifo: fifo #(
+        WIDTH: 8,
+        DEPTH: 16,
+    ) (
+        i_clk: clk,
+        i_rst: rst,
+        i_clear: clear,
+        o_empty,
+        o_almost_full: almost_full,
+        o_full,
+        o_word_count,
+        i_push,
+        i_data,
+        i_pop,
+        o_data,
+    );
+}

--- a/crates/celox/testdata/veryl/gray_codec_top.veryl
+++ b/crates/celox/testdata/veryl/gray_codec_top.veryl
@@ -1,0 +1,14 @@
+module Top (
+    i_bin  : input  logic<32>,
+    o_gray : output logic<32>,
+    o_bin  : output logic<32>,
+) {
+    inst u_enc: gray_encoder #(WIDTH: 32) (
+        i_bin,
+        o_gray,
+    );
+    inst u_dec: gray_decoder #(WIDTH: 32) (
+        i_gray: o_gray,
+        o_bin,
+    );
+}

--- a/crates/celox/testdata/veryl/gray_counter_top.veryl
+++ b/crates/celox/testdata/veryl/gray_counter_top.veryl
@@ -1,0 +1,19 @@
+module Top (
+    clk    : input  clock,
+    rst    : input  reset,
+    i_up   : input  logic,
+    o_count: output logic<32>,
+) {
+    inst u: gray_counter #(WIDTH: 32) (
+        i_clk       : clk,
+        i_rst       : rst,
+        i_clear     : 1'b0,
+        i_set       : 1'b0,
+        i_set_value : 32'b0,
+        i_up,
+        i_down      : 1'b0,
+        o_count,
+        o_count_next: _,
+        o_wrap_around: _,
+    );
+}

--- a/crates/celox/testdata/veryl/lfsr_top.veryl
+++ b/crates/celox/testdata/veryl/lfsr_top.veryl
@@ -1,0 +1,16 @@
+module Top (
+    clk     : input  clock,
+    rst     : input  reset,
+    i_en    : input  logic,
+    i_set   : input  logic,
+    i_setval: input  logic<32>,
+    o_val   : output logic<32>,
+) {
+    inst u: lfsr_galois #(SIZE: 32) (
+        i_clk   : clk,
+        i_en,
+        i_set,
+        i_setval,
+        o_val,
+    );
+}

--- a/crates/celox/testdata/veryl/linear_sec_top.veryl
+++ b/crates/celox/testdata/veryl/linear_sec_top.veryl
@@ -1,0 +1,24 @@
+module Top #(
+    param P: u32 = 6,
+    const K: u32 = (1 << P) - 1,
+    const N: u32 = K - P,
+)(
+    i_word     : input  logic<N>,
+    o_codeword : output logic<K>,
+    o_word     : output logic<N>,
+    o_corrected: output logic,
+) {
+    inst u_enc: linear_sec_encoder #(
+        P: P,
+    ) (
+        i_word,
+        o_codeword,
+    );
+    inst u_dec: linear_sec_decoder #(
+        P: P,
+    ) (
+        i_codeword: o_codeword,
+        o_word,
+        o_corrected,
+    );
+}

--- a/crates/celox/testdata/veryl/native_tb_counter_n1000.veryl
+++ b/crates/celox/testdata/veryl/native_tb_counter_n1000.veryl
@@ -1,0 +1,22 @@
+/// Native testbench for Top (N=1000 counters).
+/// Equivalent to the manual `testbench_tick_top_n1000_x1000000` benchmark.
+#[test(bench_counter_n1000)]
+module bench_counter_n1000 {
+    inst clk: $tb::clock_gen;
+    inst rst: $tb::reset_gen(clk);
+    var cnt: logic<32>[1000];
+    var cnt0: logic<32>;
+
+    inst dut: Top (
+        clk,
+        rst,
+        cnt,
+        cnt0,
+    );
+
+    initial {
+        rst.assert(clk);
+        clk.next(1000000);
+        $finish();
+    }
+}

--- a/crates/celox/testdata/veryl/native_tb_std_counter.veryl
+++ b/crates/celox/testdata/veryl/native_tb_std_counter.veryl
@@ -1,0 +1,21 @@
+/// Native testbench for std::counter (WIDTH=32).
+/// Equivalent to the manual `testbench_tick_std_counter_w32_x1000000` benchmark.
+#[test(bench_std_counter)]
+module bench_std_counter {
+    inst clk: $tb::clock_gen;
+    inst rst: $tb::reset_gen(clk);
+    var o_count: logic<32>;
+
+    inst dut: Top (
+        clk,
+        rst,
+        i_up: 1'b1,
+        o_count,
+    );
+
+    initial {
+        rst.assert(clk);
+        clk.next(1000000);
+        $finish();
+    }
+}

--- a/crates/celox/testdata/veryl/onehot_top.veryl
+++ b/crates/celox/testdata/veryl/onehot_top.veryl
@@ -1,0 +1,11 @@
+module Top (
+    i_data  : input  logic<64>,
+    o_onehot: output logic,
+    o_zero  : output logic,
+) {
+    inst u: onehot #(W: 64) (
+        i_data,
+        o_onehot,
+        o_zero,
+    );
+}

--- a/crates/celox/testdata/veryl/std_counter_top.veryl
+++ b/crates/celox/testdata/veryl/std_counter_top.veryl
@@ -1,0 +1,19 @@
+module Top (
+    clk    : input  clock,
+    rst    : input  reset,
+    i_up   : input  logic,
+    o_count: output logic<32>,
+) {
+    inst u: counter #(WIDTH: 32) (
+        i_clk       : clk,
+        i_rst       : rst,
+        i_clear     : 1'b0,
+        i_set       : 1'b0,
+        i_set_value : 32'b0,
+        i_up,
+        i_down      : 1'b0,
+        o_count,
+        o_count_next: _,
+        o_wrap_around: _,
+    );
+}

--- a/crates/celox/testdata/veryl/top_n1000.veryl
+++ b/crates/celox/testdata/veryl/top_n1000.veryl
@@ -1,0 +1,19 @@
+module Top #(
+    param N: u32 = 1000,
+)(
+    clk: input clock,
+    rst: input reset,
+    cnt: output logic<32>[N],
+    cnt0: output logic<32>,
+) {
+    assign cnt0 = cnt[0];
+    for i in 0..N: g {
+        always_ff (clk, rst) {
+            if_reset {
+                cnt[i] = 0;
+            } else {
+                cnt[i] += 1;
+            }
+        }
+    }
+}

--- a/crates/celox/tests/frontends/systemverilog/hierarchy.rs
+++ b/crates/celox/tests/frontends/systemverilog/hierarchy.rs
@@ -266,7 +266,7 @@ sv_backends! {
 
     fn simulates_veryl_generated_countones_sv(sim) {
         @setup {
-    let sv = include_str!("../../../../../benches/verilator/Countones.sv");
+    let sv = include_str!("../../../testdata/verilator/Countones.sv");
         }
         @build Simulator::from_sv_sources(vec![(sv, Path::new("Countones.sv"))], "Top");
 
@@ -281,7 +281,7 @@ sv_backends! {
 
     fn simulates_veryl_generated_onehot_sv(sim) {
         @setup {
-    let sv = include_str!("../../../../../benches/verilator/Onehot.sv");
+    let sv = include_str!("../../../testdata/verilator/Onehot.sv");
         }
         @build Simulator::from_sv_sources(vec![(sv, Path::new("Onehot.sv"))], "Top");
 
@@ -298,7 +298,7 @@ sv_backends! {
 
     fn simulates_veryl_generated_edge_detector_sv(sim) {
         @setup {
-    let sv = include_str!("../../../../../benches/verilator/EdgeDetector.sv");
+    let sv = include_str!("../../../testdata/verilator/EdgeDetector.sv");
         }
         @build Simulator::from_sv_sources(vec![(sv, Path::new("EdgeDetector.sv"))], "Top");
 
@@ -337,7 +337,7 @@ sv_backends! {
 
     fn simulates_veryl_generated_std_counter_sv(sim) {
         @setup {
-    let sv = include_str!("../../../../../benches/verilator/StdCounter.sv");
+    let sv = include_str!("../../../testdata/verilator/StdCounter.sv");
         }
         @build Simulator::from_sv_sources(vec![(sv, Path::new("StdCounter.sv"))], "Top");
 
@@ -366,7 +366,7 @@ sv_backends! {
 
     fn simulates_veryl_generated_gray_counter_sv(sim) {
         @setup {
-    let sv = include_str!("../../../../../benches/verilator/GrayCounter.sv");
+    let sv = include_str!("../../../testdata/verilator/GrayCounter.sv");
         }
         @build Simulator::from_sv_sources(vec![(sv, Path::new("GrayCounter.sv"))], "Top");
 
@@ -395,7 +395,7 @@ sv_backends! {
 
     fn simulates_veryl_generated_lfsr_sv(sim) {
         @setup {
-    let sv = include_str!("../../../../../benches/verilator/Lfsr.sv");
+    let sv = include_str!("../../../testdata/verilator/Lfsr.sv");
         }
         @build Simulator::from_sv_sources(vec![(sv, Path::new("Lfsr.sv"))], "Top");
 
@@ -422,7 +422,7 @@ sv_backends! {
 
 #[test]
 fn simulates_veryl_generated_gray_codec_sv_smoke() {
-    let sv = include_str!("../../../../../benches/verilator/GrayCodec.sv");
+    let sv = include_str!("../../../testdata/verilator/GrayCodec.sv");
     let mut sim = Simulator::from_sv_sources(vec![(sv, Path::new("GrayCodec.sv"))], "Top")
         .build_native()
         .unwrap();
@@ -441,12 +441,12 @@ fn rejects_veryl_generated_sv_that_uses_unlowered_constructs() {
     for (name, sv, expected) in [
         (
             "Fifo.sv",
-            include_str!("../../../../../benches/verilator/Fifo.sv"),
+            include_str!("../../../testdata/verilator/Fifo.sv"),
             "cast expression",
         ),
         (
             "LinearSec.sv",
-            include_str!("../../../../../benches/verilator/LinearSec.sv"),
+            include_str!("../../../testdata/verilator/LinearSec.sv"),
             "local data declaration inside loop-generate",
         ),
     ] {
@@ -465,31 +465,31 @@ fn builds_veryl_generated_verilator_sv_smoke() {
     for (name, sv) in [
         (
             "Countones.sv",
-            include_str!("../../../../../benches/verilator/Countones.sv"),
+            include_str!("../../../testdata/verilator/Countones.sv"),
         ),
         (
             "EdgeDetector.sv",
-            include_str!("../../../../../benches/verilator/EdgeDetector.sv"),
+            include_str!("../../../testdata/verilator/EdgeDetector.sv"),
         ),
         (
             "GrayCodec.sv",
-            include_str!("../../../../../benches/verilator/GrayCodec.sv"),
+            include_str!("../../../testdata/verilator/GrayCodec.sv"),
         ),
         (
             "GrayCounter.sv",
-            include_str!("../../../../../benches/verilator/GrayCounter.sv"),
+            include_str!("../../../testdata/verilator/GrayCounter.sv"),
         ),
         (
             "Lfsr.sv",
-            include_str!("../../../../../benches/verilator/Lfsr.sv"),
+            include_str!("../../../testdata/verilator/Lfsr.sv"),
         ),
         (
             "Onehot.sv",
-            include_str!("../../../../../benches/verilator/Onehot.sv"),
+            include_str!("../../../testdata/verilator/Onehot.sv"),
         ),
         (
             "StdCounter.sv",
-            include_str!("../../../../../benches/verilator/StdCounter.sv"),
+            include_str!("../../../testdata/verilator/StdCounter.sv"),
         ),
     ] {
         Simulator::from_sv_sources(vec![(sv, Path::new(name))], "Top")

--- a/crates/celox/tests/linear_sec.rs
+++ b/crates/celox/tests/linear_sec.rs
@@ -12,7 +12,7 @@ fn linear_sec_source() -> String {
         "{}\n{}\n{}",
         test_utils::veryl_std::source(&["coding", "linear_sec_encoder.veryl"]),
         test_utils::veryl_std::source(&["coding", "linear_sec_decoder.veryl"]),
-        include_str!("../../../benches/veryl/linear_sec_top.veryl"),
+        include_str!("../testdata/veryl/linear_sec_top.veryl"),
     )
 }
 

--- a/crates/celox/tests/native_testbench.rs
+++ b/crates/celox/tests/native_testbench.rs
@@ -43,16 +43,16 @@ const CLOCK_TICK_COUNTER: &str = r#"
 "#;
 
 const BENCH_NATIVE_TB_COUNTER_N1000: &str = concat!(
-    include_str!("../../../benches/veryl/top_n1000.veryl"),
-    include_str!("../../../benches/veryl/native_tb_counter_n1000.veryl"),
+    include_str!("../testdata/veryl/top_n1000.veryl"),
+    include_str!("../testdata/veryl/native_tb_counter_n1000.veryl"),
 );
 
 fn bench_native_tb_std_counter() -> String {
     format!(
         "{}\n{}\n{}",
         test_utils::veryl_std::source(&["counter", "counter.veryl"]),
-        include_str!("../../../benches/veryl/std_counter_top.veryl"),
-        include_str!("../../../benches/veryl/native_tb_std_counter.veryl"),
+        include_str!("../testdata/veryl/std_counter_top.veryl"),
+        include_str!("../testdata/veryl/native_tb_std_counter.veryl"),
     )
 }
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -43,6 +43,10 @@ export default defineConfig({
               items: [
                 { text: "概要", link: "/ja/guide/introduction" },
                 { text: "はじめる", link: "/ja/guide/getting-started" },
+                {
+                  text: "外部フロントエンド",
+                  link: "/ja/guide/external-frontends",
+                },
               ],
             },
             {
@@ -143,6 +147,10 @@ export default defineConfig({
           items: [
             { text: "Introduction", link: "/guide/introduction" },
             { text: "Getting Started", link: "/guide/getting-started" },
+            {
+              text: "External Frontends",
+              link: "/guide/external-frontends",
+            },
           ],
         },
         {

--- a/docs/guide/external-frontends.md
+++ b/docs/guide/external-frontends.md
@@ -1,94 +1,131 @@
-# External Frontends
+# External Frontend Integration
 
-An external frontend can target Celox without depending on compiler-internal
-crates. Build a validated module with the published `celox-frontend-sdk` crate,
-serialize its versioned `FrontendArtifact`, and pass that JSON to a Celox host.
+This guide is for authors of frontend crates and packages. Applications should
+work with the frontend's own artifact type and constructor, such as
+`from_my_artifact`. `celox_frontend_sdk::FrontendArtifact` is the bridge from
+that frontend into Celox; it should not replace the frontend's public artifact
+model.
+
+## Lower into Celox inside the frontend
+
+Use `celox-frontend-sdk` in the frontend adapter. The adapter translates its
+own elaborated representation into a validated Celox module:
 
 ```rust
-use celox_frontend_sdk::{BinaryOp, ModuleBuilder, ValueType};
+use celox_frontend_sdk::{BinaryOp, FrontendArtifact, ModuleBuilder, ValueType};
 
-let byte = ValueType::bits(8)?;
-let mut module = ModuleBuilder::new("NetAdder")?;
-let a = module.input("a", byte)?;
-let b = module.input("b", byte)?;
-let y = module.output("y", byte)?;
-let a_expr = module.read(a)?;
-let b_expr = module.read(b)?;
-let sum = module.binary(BinaryOp::Add, a_expr, b_expr, byte)?;
-let y_target = module.whole(y)?;
-module.assign(y_target, sum)?;
-
-let artifact_json = module.finish().to_json()?;
-# Ok::<(), Box<dyn std::error::Error>>(())
+fn lower_to_celox(artifact: &MyArtifact) -> Result<FrontendArtifact, MyError> {
+    let byte = ValueType::bits(artifact.width)?;
+    let mut module = ModuleBuilder::new(&artifact.module_name)?;
+    let a = module.input("a", byte)?;
+    let b = module.input("b", byte)?;
+    let y = module.output("y", byte)?;
+    let a_expr = module.read(a)?;
+    let b_expr = module.read(b)?;
+    let sum = module.binary(BinaryOp::Add, a_expr, b_expr, byte)?;
+    let y_target = module.whole(y)?;
+    module.assign(y_target, sum)?;
+    Ok(module.finish())
+}
 ```
 
-The first SDK release represents one flattened module. It supports typed signals,
-constants, combinational expressions and assignments, edge-triggered registers,
-asynchronous reset, synchronous enable, and initial values. Hierarchical netlists,
-memories, latches, and custom primitives should be flattened or lowered by the
-external frontend before emitting an artifact. Bidirectional (`inout`) signals
-are also unsupported in artifact format version 1; lower them to separate input,
-output, and output-enable signals.
+`MyArtifact` and `MyError` belong to the frontend. Convert SDK validation
+failures into the frontend's error type instead of exposing a Celox JSON blob as
+the normal application API.
 
-## TypeScript testbenches
+## Expose a frontend-specific Rust constructor
 
-The artifact retains port and signal metadata, so the regular typed DUT API works:
+The frontend crate can add an artifact-specific associated function to the
+re-exported simulator with an extension trait:
 
-```ts
-import { Simulator } from "@celox-sim/celox";
+```rust
+pub use celox::Simulator;
 
-interface NetAdderPorts {
-  a: bigint;
-  b: bigint;
-  readonly y: bigint;
+pub trait MyFrontendSimulatorExt: Sized {
+    fn from_my_artifact(artifact: MyArtifact) -> Result<Self, MyError>;
 }
 
-const sim = Simulator.fromFrontendArtifact<NetAdderPorts>(artifactJson);
-sim.dut.a = 10n;
-sim.dut.b = 23n;
-console.assert(sim.dut.y === 33n);
-sim.dispose();
-```
-
-Use `Simulation.fromFrontendArtifact` when the testbench needs timed clocks and
-scheduled events.
-
-## Veryl native testbenches
-
-`runTestWithFrontendArtifact` compiles a Veryl test module and makes the artifact
-module available through the existing external-module namespace:
-
-```veryl
-#[test(t)]
-module NetlistTb {
-    var a: logic<8>;
-    var b: logic<8>;
-    var y: logic<8>;
-    inst dut: $sv::NetAdder (a, b, y);
-
-    initial {
-        a = 8'd10;
-        b = 8'd23;
-        $assert(y == 8'd33);
-        $finish();
+impl MyFrontendSimulatorExt for Simulator {
+    fn from_my_artifact(artifact: MyArtifact) -> Result<Self, MyError> {
+        let artifact = lower_to_celox(&artifact)?;
+        Ok(Simulator::from_frontend(artifact).build()?)
     }
 }
 ```
 
-```ts
-import { runTestWithFrontendArtifact } from "@celox-sim/celox";
+An application then depends on the frontend crate and builds an ordinary Rust
+binary without knowing about `FrontendArtifact`:
 
-const result = runTestWithFrontendArtifact(
-  artifactJson,
-  [{ path: "netlist_tb.veryl", content: testbenchSource }],
-  "NetlistTb",
-);
+```rust
+use my_frontend::{MyFrontendSimulatorExt as _, Simulator};
+
+fn main() -> Result<(), my_frontend::Error> {
+    let artifact = my_frontend::load("design.myhdl")?;
+    let mut sim = Simulator::from_my_artifact(artifact)?;
+
+    let a = sim.signal("a");
+    let b = sim.signal("b");
+    let y = sim.signal("y");
+    sim.modify(|io| {
+        io.set(a, 10u8);
+        io.set(b, 23u8);
+    })?;
+    assert_eq!(sim.get(y), 33u8.into());
+    Ok(())
+}
 ```
 
-Here `$sv` denotes Celox's existing external-module link namespace; the design
-itself still comes from exactly one external frontend artifact. This compatibility
-path does not turn the netlist frontend into a mixed Veryl/SystemVerilog frontend.
+```bash
+cargo build --release
+```
 
-Artifacts are validated again when Celox compiles them. Treat the
-`format_version` field as the wire-format compatibility boundary and use the SDK
-builder instead of constructing JSON by hand.
+The `celox` and `celox-frontend-sdk` dependencies in a Rust binary adapter must
+use matching versions. A JavaScript addon also uses the matching `celox-napi`
+version. Other published `celox-*` crates are implementation dependencies.
+
+## Expose `fromMyArtifact` from a TypeScript package
+
+A frontend that ships an N-API or WASI addon can accept `MyArtifact` in that
+addon and return Celox's standard raw simulator handle. `celox-napi` provides
+the Rust-only adapter constructor for both native and `wasm32` builds:
+
+```rust
+use celox_napi::NativeSimulatorHandle;
+use napi_derive::napi;
+
+#[napi]
+pub fn from_my_artifact(artifact: MyArtifact) -> napi::Result<NativeSimulatorHandle> {
+    let artifact = lower_to_celox(&artifact)
+        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+    NativeSimulatorHandle::from_frontend(artifact, None)
+}
+```
+
+The frontend's TypeScript entry point wraps that handle in the normal Celox
+runtime while retaining the frontend-specific public name:
+
+```ts
+import { Simulator, type FrontendSimulatorHandle } from "@celox-sim/celox";
+import { fromMyArtifact as nativeFromMyArtifact } from "./native.js";
+
+export function fromMyArtifact<P>(artifact: MyArtifact): Simulator<P> {
+  const handle: FrontendSimulatorHandle = nativeFromMyArtifact(artifact);
+  return Simulator.fromFrontendHandle<P>(handle);
+}
+```
+
+This path is `MyArtifact -> frontend Rust lowering -> FrontendArtifact` as an
+in-memory Rust value. It does not call `fromFrontendArtifact` and does not parse
+Celox artifact JSON. A buildable addon and load test live in
+`examples/my-frontend-napi`.
+
+## Artifact format limits
+
+Format version 1 accepts one flattened module. It supports typed signals,
+constants, combinational expressions and assignments, edge-triggered registers,
+asynchronous reset, synchronous enable, and initial values. A frontend must
+lower hierarchy, memories, latches, custom primitives, and bidirectional signals
+before calling the SDK builder.
+
+Celox validates the artifact again before compilation. Produce it through the
+SDK builder and pass the Rust value directly to `Simulator::from_frontend`.

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -179,8 +179,9 @@ The following rules define the intended architecture:
 1. Source-language types stop at the frontend boundary. One language adapter
    must not depend on another language frontend; shared assembly belongs in
    `celox-frontend-core`.
-2. External frontends depend only on `celox-frontend-sdk` and exchange a
-   versioned artifact; internal symbolic and scheduled types are not a public
+2. External frontend lowering depends on `celox-frontend-sdk`; a Rust simulator
+   adapter additionally depends on `celox`, and an N-API/WASI adapter on
+   `celox-napi`. Internal symbolic and scheduled types are not a public
    compatibility surface.
 3. Semantic state identities remain distinct from physical memory offsets until
    layout finalization.

--- a/docs/ja/guide/external-frontends.md
+++ b/docs/ja/guide/external-frontends.md
@@ -1,0 +1,132 @@
+# 外部フロントエンド連携
+
+このガイドは frontend crate/package の実装者向けです。アプリケーションには
+frontend 固有の artifact 型と `from_my_artifact` のような constructor を
+提供してください。`celox_frontend_sdk::FrontendArtifact` は frontend から
+Celox へ渡すための bridge であり、frontend の公開 artifact model の代わり
+ではありません。
+
+## frontend 内で Celox へ lower する
+
+frontend adapter から `celox-frontend-sdk` を使い、独自の elaboration 結果を
+検証済みの Celox module へ変換します。
+
+```rust
+use celox_frontend_sdk::{BinaryOp, FrontendArtifact, ModuleBuilder, ValueType};
+
+fn lower_to_celox(artifact: &MyArtifact) -> Result<FrontendArtifact, MyError> {
+    let byte = ValueType::bits(artifact.width)?;
+    let mut module = ModuleBuilder::new(&artifact.module_name)?;
+    let a = module.input("a", byte)?;
+    let b = module.input("b", byte)?;
+    let y = module.output("y", byte)?;
+    let a_expr = module.read(a)?;
+    let b_expr = module.read(b)?;
+    let sum = module.binary(BinaryOp::Add, a_expr, b_expr, byte)?;
+    let y_target = module.whole(y)?;
+    module.assign(y_target, sum)?;
+    Ok(module.finish())
+}
+```
+
+`MyArtifact` と `MyError` は frontend 側の型です。SDK の validation error は
+frontend の error 型へ変換し、通常のアプリケーション API に Celox の JSON
+を露出させないでください。
+
+## frontend 固有の Rust constructor を公開する
+
+frontend crate は extension trait を使い、re-export した simulator に
+artifact 固有の associated function を追加できます。
+
+```rust
+pub use celox::Simulator;
+
+pub trait MyFrontendSimulatorExt: Sized {
+    fn from_my_artifact(artifact: MyArtifact) -> Result<Self, MyError>;
+}
+
+impl MyFrontendSimulatorExt for Simulator {
+    fn from_my_artifact(artifact: MyArtifact) -> Result<Self, MyError> {
+        let artifact = lower_to_celox(&artifact)?;
+        Ok(Simulator::from_frontend(artifact).build()?)
+    }
+}
+```
+
+アプリケーションは `FrontendArtifact` を意識せず、frontend の API だけを
+使用します。
+
+```rust
+use my_frontend::{MyFrontendSimulatorExt as _, Simulator};
+
+fn main() -> Result<(), my_frontend::Error> {
+    let artifact = my_frontend::load("design.myhdl")?;
+    let mut sim = Simulator::from_my_artifact(artifact)?;
+
+    let a = sim.signal("a");
+    let b = sim.signal("b");
+    let y = sim.signal("y");
+    sim.modify(|io| {
+        io.set(a, 10u8);
+        io.set(b, 23u8);
+    })?;
+    assert_eq!(sim.get(y), 33u8.into());
+    Ok(())
+}
+```
+
+```bash
+cargo build --release
+```
+
+Rust binary adapter 内の `celox` と `celox-frontend-sdk` は同じ version を
+使用してください。JavaScript addon は同じ version の `celox-napi` も使用
+します。そのほかの `celox-*` crate は実装依存です。
+
+## TypeScript package から `fromMyArtifact` を公開する
+
+N-API または WASI addon を同梱する frontend は、その addon で
+`MyArtifact` を受け取り、Celox 標準の raw simulator handle を返せます。
+`celox-napi` は native build と `wasm32` build の両方で使える Rust 専用の
+adapter constructor を提供します。
+
+```rust
+use celox_napi::NativeSimulatorHandle;
+use napi_derive::napi;
+
+#[napi]
+pub fn from_my_artifact(artifact: MyArtifact) -> napi::Result<NativeSimulatorHandle> {
+    let artifact = lower_to_celox(&artifact)
+        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
+    NativeSimulatorHandle::from_frontend(artifact, None)
+}
+```
+
+frontend の TypeScript entry point では、この handle を通常の Celox runtime
+でwrapし、公開名は frontend 固有のままにします。
+
+```ts
+import { Simulator, type FrontendSimulatorHandle } from "@celox-sim/celox";
+import { fromMyArtifact as nativeFromMyArtifact } from "./native.js";
+
+export function fromMyArtifact<P>(artifact: MyArtifact): Simulator<P> {
+  const handle: FrontendSimulatorHandle = nativeFromMyArtifact(artifact);
+  return Simulator.fromFrontendHandle<P>(handle);
+}
+```
+
+この経路は `MyArtifact -> frontend の Rust lowering -> FrontendArtifact` を
+in-memory の Rust value として渡します。`fromFrontendArtifact` は呼ばず、
+Celox artifact JSON も parse しません。build 可能な addon と load test は
+`examples/my-frontend-napi` にあります。
+
+## artifact format の制限
+
+format version 1 が受け取るのは平坦化済みの1 module です。型付き signal、
+constant、組み合わせ式と代入、edge-triggered register、非同期 reset、同期
+enable、初期値を扱えます。hierarchy、memory、latch、custom primitive、
+bidirectional signal は SDK builder を呼ぶ前に frontend 側で lower して
+ください。
+
+Celox は compile 前に artifact を再検証します。artifact は SDK builder で
+生成し、Rust の値を直接 `Simulator::from_frontend` に渡してください。

--- a/examples/my-frontend-napi/Cargo.toml
+++ b/examples/my-frontend-napi/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "celox-example-my-frontend-napi"
+version.workspace = true
+publish = false
+edition.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+celox-frontend-sdk = { workspace = true }
+celox-napi = { workspace = true }
+napi = { version = "=3.12.1", features = ["napi8"] }
+napi-derive = "=3.6.3"
+
+[build-dependencies]
+napi-build = "=2.4.1"
+
+[lints]
+workspace = true

--- a/examples/my-frontend-napi/build.rs
+++ b/examples/my-frontend-napi/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    napi_build::setup();
+}

--- a/examples/my-frontend-napi/smoke.cjs
+++ b/examples/my-frontend-napi/smoke.cjs
@@ -1,0 +1,14 @@
+const assert = require("node:assert/strict");
+
+const addon = require(process.argv[2]);
+assert.equal(typeof addon.fromMyArtifact, "function");
+
+const handle = addon.fromMyArtifact({ moduleName: "NetAdder", width: 8 });
+const layout = JSON.parse(handle.layoutJson);
+assert.equal(typeof handle.sharedMemory, "function");
+const memory = handle.sharedMemory();
+memory[layout.a.offset] = 10;
+memory[layout.b.offset] = 23;
+handle.evalComb();
+assert.equal(memory[layout.y.offset], 33);
+handle.dispose();

--- a/examples/my-frontend-napi/src/lib.rs
+++ b/examples/my-frontend-napi/src/lib.rs
@@ -1,0 +1,36 @@
+use celox_frontend_sdk::{BinaryOp, FrontendArtifact, ModuleBuilder, ValueType};
+use celox_napi::NativeSimulatorHandle;
+use napi::{Error, Result};
+use napi_derive::napi;
+
+/// The frontend's own artifact type. It is not a Celox JSON artifact.
+#[napi(object)]
+pub struct MyArtifact {
+    pub module_name: String,
+    pub width: u32,
+}
+
+fn lower_to_celox(artifact: MyArtifact) -> Result<FrontendArtifact> {
+    let build = || -> std::result::Result<FrontendArtifact, Box<dyn std::error::Error>> {
+        let value_type = ValueType::bits(artifact.width as usize)?;
+        let mut module = ModuleBuilder::new(artifact.module_name)?;
+        let a = module.input("a", value_type)?;
+        let b = module.input("b", value_type)?;
+        let y = module.output("y", value_type)?;
+        let a_expr = module.read(a)?;
+        let b_expr = module.read(b)?;
+        let sum = module.binary(BinaryOp::Add, a_expr, b_expr, value_type)?;
+        let y_target = module.whole(y)?;
+        module.assign(y_target, sum)?;
+        Ok(module.finish())
+    };
+
+    build().map_err(|error| Error::from_reason(error.to_string()))
+}
+
+/// A frontend-owned JS constructor. The artifact stays typed from JS through
+/// the frontend's Rust lowering code and is never serialized as Celox JSON.
+#[napi]
+pub fn from_my_artifact(artifact: MyArtifact) -> Result<NativeSimulatorHandle> {
+    NativeSimulatorHandle::from_frontend(lower_to_celox(artifact)?, None)
+}

--- a/packages/celox/src/e2e.test.ts
+++ b/packages/celox/src/e2e.test.ts
@@ -267,7 +267,7 @@ module MuxX (
 // ---------------------------------------------------------------------------
 
 describe("E2E: external frontend artifact", () => {
-	test("drives a frontend SDK design from a TypeScript testbench", () => {
+	test("builds a simulator from a serialized frontend artifact", () => {
 		interface AdderPorts {
 			a: bigint;
 			b: bigint;

--- a/packages/celox/src/index.ts
+++ b/packages/celox/src/index.ts
@@ -64,6 +64,7 @@ export type {
 	EventHandle,
 	FourStateSignalValue,
 	FourStateValue,
+	FrontendSimulatorHandle,
 	LoopBreak,
 	ModuleDefinition,
 	NativeHandle,

--- a/packages/celox/src/index.ts
+++ b/packages/celox/src/index.ts
@@ -67,6 +67,7 @@ export type {
 	FrontendSimulatorHandle,
 	LoopBreak,
 	ModuleDefinition,
+	NativeFrontendSimulatorHandle,
 	NativeHandle,
 	NativeSimulationHandle,
 	NativeSimulatorHandle,
@@ -77,6 +78,7 @@ export type {
 	SimulatorOptions,
 	SourceFile,
 	TrueLoopSpec,
+	WasmFrontendSimulatorHandle,
 } from "./types.js";
 // 4-state helpers
 // Error types

--- a/packages/celox/src/napi-helpers.ts
+++ b/packages/celox/src/napi-helpers.ts
@@ -13,6 +13,7 @@ import type { NativeCreateSimulationFn } from "./simulation.js";
 import type { NativeCreateFn } from "./simulator.js";
 import type {
 	CreateResult,
+	FrontendSimulatorHandle,
 	LoopBreak,
 	NativeSimulationHandle,
 	NativeSimulatorHandle,
@@ -28,24 +29,7 @@ import { createWasmSimulatorBridge, isWasmHandle } from "./wasm-bridge.js";
 // Raw NAPI handle shapes (what the .node addon actually exports)
 // ---------------------------------------------------------------------------
 
-export interface RawNapiSimulatorHandle {
-	readonly layoutJson: string;
-	readonly eventsJson: string;
-	readonly hierarchyJson: string;
-	readonly warningsJson: string;
-	readonly stableSize: number;
-	readonly totalSize: number;
-	// Native (JIT) methods — present when built for native target
-	tick?(eventId: number): void;
-	tickN?(eventId: number, count: number): void;
-	evalComb?(): void;
-	dump?(timestamp: number): void;
-	sharedMemory?(): Uint8Array;
-	// WASM methods — present when built for wasm32 target
-	combWasmBytes?(): Uint8Array | number[];
-	eventWasmBytes?(name: string): Uint8Array | number[];
-	dispose(): void;
-}
+export type RawNapiSimulatorHandle = FrontendSimulatorHandle;
 
 export interface RawNapiSimulationHandle {
 	readonly layoutJson: string;

--- a/packages/celox/src/napi-helpers.ts
+++ b/packages/celox/src/napi-helpers.ts
@@ -15,6 +15,7 @@ import type {
 	CreateResult,
 	FrontendSimulatorHandle,
 	LoopBreak,
+	NativeFrontendSimulatorHandle,
 	NativeSimulationHandle,
 	NativeSimulatorHandle,
 	PortInfo,
@@ -195,7 +196,7 @@ export interface RawNapiAddon {
 			options?: NapiOptions,
 		): RawNapiSimulatorHandle;
 	};
-	NativeSimulationHandle: {
+	NativeSimulationHandle?: {
 		new (
 			sources: NapiSourceFile[],
 			top: string,
@@ -759,20 +760,20 @@ export function filterHierarchyForDse(
  * The buffer is shared between JS and Rust — no copies per tick.
  */
 export function wrapDirectSimulatorHandle(
-	raw: RawNapiSimulatorHandle,
+	raw: NativeFrontendSimulatorHandle,
 ): NativeSimulatorHandle {
 	return {
 		tick(eventId: number): void {
-			raw.tick!(eventId);
+			raw.tick(eventId);
 		},
 		tickN(eventId: number, count: number): void {
-			raw.tickN!(eventId, count);
+			raw.tickN(eventId, count);
 		},
 		evalComb(): void {
-			raw.evalComb!();
+			raw.evalComb();
 		},
 		dump(timestamp: number): void {
-			raw.dump!(timestamp);
+			raw.dump(timestamp);
 		},
 		dispose(): void {
 			raw.dispose();
@@ -875,7 +876,7 @@ export function createSimulatorBridge(addon: RawNapiAddon): NativeCreateFn {
 			buf = bridge.sharedMemory.buffer;
 			handle = bridge.handle;
 		} else {
-			buf = raw.sharedMemory!().buffer;
+			buf = raw.sharedMemory().buffer;
 			handle = wrapDirectSimulatorHandle(raw);
 		}
 

--- a/packages/celox/src/simulator.test.ts
+++ b/packages/celox/src/simulator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from "vitest";
 import { type NativeCreateFn, Simulator } from "./simulator.js";
 import type {
 	CreateResult,
+	FrontendSimulatorHandle,
 	ModuleDefinition,
 	NativeSimulatorHandle,
 } from "./types.js";
@@ -104,6 +105,54 @@ function createMockNative(): {
 // ---------------------------------------------------------------------------
 
 describe("Simulator", () => {
+	test("wraps a handle returned by a frontend-owned addon", () => {
+		const memory = new Uint8Array(64);
+		const signal = (offset: number, direction: "input" | "output") => ({
+			offset,
+			width: 8,
+			byte_size: 1,
+			is_4state: false,
+			direction,
+			type_kind: "bit",
+		});
+		const signals = {
+			a: signal(32, "input"),
+			b: signal(33, "input"),
+			y: signal(34, "output"),
+		};
+		const raw: FrontendSimulatorHandle = {
+			layoutJson: JSON.stringify(signals),
+			eventsJson: "{}",
+			hierarchyJson: JSON.stringify({
+				module_name: "NetAdder",
+				signals,
+				children: {},
+			}),
+			warningsJson: "[]",
+			stableSize: 35,
+			totalSize: 64,
+			sharedMemory: () => memory,
+			evalComb: vi.fn(() => {
+				memory[34] = (memory[32] ?? 0) + (memory[33] ?? 0);
+			}),
+			tick: vi.fn(),
+			tickN: vi.fn(),
+			dump: vi.fn(),
+			dispose: vi.fn(),
+		};
+
+		const sim = Simulator.fromFrontendHandle<{
+			a: bigint;
+			b: bigint;
+			readonly y: bigint;
+		}>(raw);
+		sim.dut.a = 10n;
+		sim.dut.b = 23n;
+		expect(sim.dut.y).toBe(33n);
+		sim.dispose();
+		expect(raw.dispose).toHaveBeenCalledOnce();
+	});
+
 	test("create and basic tick", () => {
 		const mock = createMockNative();
 		const sim = Simulator.create(AdderModule, {

--- a/packages/celox/src/simulator.ts
+++ b/packages/celox/src/simulator.ts
@@ -20,6 +20,7 @@ import type {
 	CreateResult,
 	EventHandle,
 	FourStateValue,
+	FrontendSimulatorHandle,
 	ModuleDefinition,
 	NativeSimulatorHandle,
 	SignalLayout,
@@ -271,6 +272,22 @@ export class Simulator<P = Record<string, unknown>> {
 			artifactJson,
 			buildNapiOpts(options),
 		);
+		return Simulator.fromFrontendHandle<P>(raw, options);
+	}
+
+	/**
+	 * Wrap a raw simulator handle returned by a frontend-owned native or WASM
+	 * addon.
+	 *
+	 * This is the adapter boundary for frontend packages. A frontend's public
+	 * API can accept its own artifact type, call its native `fromMyArtifact`
+	 * function, then pass the returned handle here. No Celox artifact JSON is
+	 * involved.
+	 */
+	static fromFrontendHandle<P = Record<string, unknown>>(
+		raw: FrontendSimulatorHandle,
+		options?: Pick<SimulatorOptions, "deadStorePolicy">,
+	): Simulator<P> {
 		const isWasm = isWasmHandle(raw);
 		// Frontend artifacts carry an exact state kind for every signal, including
 		// clock/reset ports. Do not apply the legacy WASM type-kind inference here.

--- a/packages/celox/src/simulator.ts
+++ b/packages/celox/src/simulator.ts
@@ -225,7 +225,7 @@ export class Simulator<P = Record<string, unknown>> {
 			buf = bridge.sharedMemory.buffer;
 			handle = bridge.handle;
 		} else {
-			buf = raw.sharedMemory!().buffer;
+			buf = raw.sharedMemory().buffer;
 			handle = wrapDirectSimulatorHandle(raw);
 		}
 
@@ -309,7 +309,7 @@ export class Simulator<P = Record<string, unknown>> {
 			buffer = bridge.sharedMemory.buffer;
 			handle = bridge.handle;
 		} else {
-			buffer = raw.sharedMemory!().buffer;
+			buffer = raw.sharedMemory().buffer;
 			handle = wrapDirectSimulatorHandle(raw);
 		}
 		const state: DirtyState = { dirty: isWasm };
@@ -382,7 +382,7 @@ export class Simulator<P = Record<string, unknown>> {
 			buf = bridge.sharedMemory.buffer;
 			handle = bridge.handle;
 		} else {
-			buf = raw.sharedMemory!().buffer;
+			buf = raw.sharedMemory().buffer;
 			handle = wrapDirectSimulatorHandle(raw);
 		}
 

--- a/packages/celox/src/types.ts
+++ b/packages/celox/src/types.ts
@@ -81,6 +81,29 @@ export interface SignalLayout {
 // ---------------------------------------------------------------------------
 
 /**
+ * Raw simulator handle returned by a frontend-owned native or WASM addon.
+ * Frontend packages pass this to `Simulator.fromFrontendHandle`.
+ */
+export interface FrontendSimulatorHandle {
+	readonly layoutJson: string;
+	readonly eventsJson: string;
+	readonly hierarchyJson: string;
+	readonly warningsJson: string;
+	readonly stableSize: number;
+	readonly totalSize: number;
+	// Native (JIT) methods.
+	tick?(eventId: number): void;
+	tickN?(eventId: number, count: number): void;
+	evalComb?(): void;
+	dump?(timestamp: number): void;
+	sharedMemory?(): Uint8Array;
+	// WASM methods.
+	combWasmBytes?(): Uint8Array | number[];
+	eventWasmBytes?(name: string): Uint8Array | number[];
+	dispose(): void;
+}
+
+/**
  * Opaque handle returned by NAPI for event-based simulation.
  * @internal
  */

--- a/packages/celox/src/types.ts
+++ b/packages/celox/src/types.ts
@@ -81,27 +81,51 @@ export interface SignalLayout {
 // ---------------------------------------------------------------------------
 
 /**
- * Raw simulator handle returned by a frontend-owned native or WASM addon.
- * Frontend packages pass this to `Simulator.fromFrontendHandle`.
+ * Metadata shared by frontend-owned native and WASM simulator handles.
  */
-export interface FrontendSimulatorHandle {
+interface FrontendSimulatorHandleMetadata {
 	readonly layoutJson: string;
 	readonly eventsJson: string;
 	readonly hierarchyJson: string;
 	readonly warningsJson: string;
 	readonly stableSize: number;
 	readonly totalSize: number;
-	// Native (JIT) methods.
-	tick?(eventId: number): void;
-	tickN?(eventId: number, count: number): void;
-	evalComb?(): void;
-	dump?(timestamp: number): void;
-	sharedMemory?(): Uint8Array;
-	// WASM methods.
-	combWasmBytes?(): Uint8Array | number[];
-	eventWasmBytes?(name: string): Uint8Array | number[];
 	dispose(): void;
 }
+
+/** Raw simulator handle returned by a frontend-owned native addon. */
+export interface NativeFrontendSimulatorHandle
+	extends FrontendSimulatorHandleMetadata {
+	tick(eventId: number): void;
+	tickN(eventId: number, count: number): void;
+	evalComb(): void;
+	dump(timestamp: number): void;
+	sharedMemory(): Uint8Array;
+	initialMemoryBytes?: never;
+	combWasmBytes?: never;
+	eventWasmBytes?: never;
+}
+
+/** Raw simulator handle returned by a frontend-owned WASM addon. */
+export interface WasmFrontendSimulatorHandle
+	extends FrontendSimulatorHandleMetadata {
+	initialMemoryBytes(): Uint8Array | number[];
+	combWasmBytes(): Uint8Array | number[];
+	eventWasmBytes(name: string): Uint8Array | number[];
+	tick?: never;
+	tickN?: never;
+	evalComb?: never;
+	dump?: never;
+	sharedMemory?: never;
+}
+
+/**
+ * Raw simulator handle returned by a frontend-owned native or WASM addon.
+ * Frontend packages pass this to `Simulator.fromFrontendHandle`.
+ */
+export type FrontendSimulatorHandle =
+	| NativeFrontendSimulatorHandle
+	| WasmFrontendSimulatorHandle;
 
 /**
  * Opaque handle returned by NAPI for event-based simulation.

--- a/packages/celox/src/wasm-bridge.test.ts
+++ b/packages/celox/src/wasm-bridge.test.ts
@@ -1,0 +1,25 @@
+import { expect, expectTypeOf, test, vi } from "vitest";
+import type { RawWasmSimulatorHandle } from "./wasm-bridge.js";
+import { isWasmHandle } from "./wasm-bridge.js";
+
+test("narrows an unknown frontend handle to the WASM contract", () => {
+	const handle: unknown = {
+		layoutJson: "{}",
+		eventsJson: "{}",
+		hierarchyJson: "{}",
+		warningsJson: "[]",
+		stableSize: 0,
+		totalSize: 0,
+		dispose: vi.fn(),
+		initialMemoryBytes: () => new Uint8Array(),
+		combWasmBytes: () => new Uint8Array(),
+		eventWasmBytes: () => new Uint8Array(),
+	};
+
+	expect(isWasmHandle(handle)).toBe(true);
+	if (!isWasmHandle(handle)) {
+		throw new Error("expected a WASM frontend handle");
+	}
+	expectTypeOf(handle).toEqualTypeOf<RawWasmSimulatorHandle>();
+	expect(handle.initialMemoryBytes()).toEqual(new Uint8Array());
+});

--- a/packages/celox/src/wasm-bridge.ts
+++ b/packages/celox/src/wasm-bridge.ts
@@ -12,6 +12,7 @@
 
 import type {
 	FrontendSimulatorHandle,
+	NativeSimulationHandle,
 	NativeSimulatorHandle,
 	WasmFrontendSimulatorHandle,
 } from "./types.js";
@@ -67,7 +68,8 @@ export type RawWasmSimulatorHandle = WasmFrontendSimulatorHandle;
 export function isWasmHandle(
 	handle: FrontendSimulatorHandle,
 ): handle is RawWasmSimulatorHandle;
-export function isWasmHandle(handle: unknown): boolean;
+export function isWasmHandle(handle: NativeSimulationHandle): boolean;
+export function isWasmHandle(handle: unknown): handle is RawWasmSimulatorHandle;
 export function isWasmHandle(handle: unknown): boolean {
 	return (
 		typeof handle === "object" &&

--- a/packages/celox/src/wasm-bridge.ts
+++ b/packages/celox/src/wasm-bridge.ts
@@ -10,7 +10,11 @@
  * @module
  */
 
-import type { NativeSimulatorHandle } from "./types.js";
+import type {
+	FrontendSimulatorHandle,
+	NativeSimulatorHandle,
+	WasmFrontendSimulatorHandle,
+} from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Minimal WebAssembly type declarations for environments without DOM lib.
@@ -49,18 +53,7 @@ declare namespace WebAssembly {
  * Handle shape returned by a wasm32-compiled NativeSimulatorHandle.
  * Extends the standard metadata getters with WASM bytecode accessors.
  */
-export interface RawWasmSimulatorHandle {
-	readonly layoutJson: string;
-	readonly eventsJson: string;
-	readonly hierarchyJson: string;
-	readonly warningsJson: string;
-	readonly stableSize: number;
-	readonly totalSize: number;
-	initialMemoryBytes(): Uint8Array | number[];
-	combWasmBytes(): Uint8Array | number[];
-	eventWasmBytes(name: string): Uint8Array | number[];
-	dispose(): void;
-}
+export type RawWasmSimulatorHandle = WasmFrontendSimulatorHandle;
 
 // ---------------------------------------------------------------------------
 // Detection
@@ -72,12 +65,17 @@ export interface RawWasmSimulatorHandle {
  * WASM handles expose `combWasmBytes()` instead of `tick()`.
  */
 export function isWasmHandle(
-	handle: unknown,
-): handle is RawWasmSimulatorHandle {
+	handle: FrontendSimulatorHandle,
+): handle is RawWasmSimulatorHandle;
+export function isWasmHandle(handle: unknown): boolean;
+export function isWasmHandle(handle: unknown): boolean {
 	return (
 		typeof handle === "object" &&
 		handle !== null &&
+		typeof (handle as Record<string, unknown>).initialMemoryBytes ===
+			"function" &&
 		typeof (handle as Record<string, unknown>).combWasmBytes === "function" &&
+		typeof (handle as Record<string, unknown>).eventWasmBytes === "function" &&
 		typeof (handle as Record<string, unknown>).tick !== "function"
 	);
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,15 @@
       "version-file": "VERSION",
       "extra-files": [
         {
+          "type": "generic",
+          "path": "Cargo.toml"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name.match(/^celox(?:-|$)/))].version"
+        },
+        {
           "type": "json",
           "path": "packages/celox/package.json",
           "jsonpath": "$.version"

--- a/scripts/bootstrap-crates-io.sh
+++ b/scripts/bootstrap-crates-io.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:-package}"
+confirmation="${2:-}"
+if [[ "$mode" != "package" && "$mode" != "publish" ]]; then
+  echo "usage: $0 [package|publish] [BOOTSTRAP-CELOX-CRATES]" >&2
+  exit 2
+fi
+
+if [[ "$mode" == "publish" ]]; then
+  if [[ "$confirmation" != "BOOTSTRAP-CELOX-CRATES" ]]; then
+    echo "publishing placeholder crates is permanent" >&2
+    echo "pass BOOTSTRAP-CELOX-CRATES as the second argument to continue" >&2
+    exit 2
+  fi
+  : "${CARGO_REGISTRY_TOKEN:?CARGO_REGISTRY_TOKEN is required for publication}"
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+mapfile -t crates < <("$script_dir/publish-crates.sh" list)
+if [[ ${#crates[@]} -eq 0 ]]; then
+  echo "no public crates were found" >&2
+  exit 1
+fi
+
+bootstrap_dir="$(mktemp -d -t celox-crates-bootstrap.XXXXXXXXXX)"
+cleanup() {
+  if [[ -n "${bootstrap_dir:-}" && -d "$bootstrap_dir" && ! -L "$bootstrap_dir" ]]; then
+    local name
+    name="$(basename -- "$bootstrap_dir")"
+    if [[ "$name" == celox-crates-bootstrap.* ]]; then
+      rm -rf -- "$bootstrap_dir"
+    fi
+  fi
+}
+trap cleanup EXIT
+
+crate_exists() {
+  local crate="$1"
+  curl --fail --silent --show-error \
+    --user-agent "celox-crates-bootstrap/0.0.0 (https://github.com/celox-sim/celox)" \
+    "https://crates.io/api/v1/crates/$crate" \
+    >/dev/null 2>&1
+}
+
+placeholder_exists() {
+  local crate="$1"
+  curl --fail --silent --show-error \
+    --user-agent "celox-crates-bootstrap/0.0.0 (https://github.com/celox-sim/celox)" \
+    "https://crates.io/api/v1/crates/$crate/0.0.0" \
+    >/dev/null 2>&1
+}
+
+wait_for_placeholder() {
+  local crate="$1"
+  for _ in {1..12}; do
+    if placeholder_exists "$crate"; then
+      return 0
+    fi
+    sleep 5
+  done
+  echo "$crate@0.0.0 was published but did not become visible on crates.io" >&2
+  return 1
+}
+
+for crate in "${crates[@]}"; do
+  if [[ ! "$crate" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+    echo "invalid crate name in publication list: $crate" >&2
+    exit 1
+  fi
+
+  crate_dir="$bootstrap_dir/$crate"
+  mkdir -p "$crate_dir/src"
+  printf '%s\n' \
+    '[package]' \
+    "name = \"$crate\"" \
+    'version = "0.0.0"' \
+    'edition = "2024"' \
+    'license = "MIT OR Apache-2.0"' \
+    'description = "Trusted Publishing bootstrap placeholder for the Celox simulator"' \
+    'repository = "https://github.com/celox-sim/celox"' \
+    'readme = "README.md"' \
+    'publish = ["crates-io"]' \
+    >"$crate_dir/Cargo.toml"
+  # The backticks are intentional Markdown and Rustdoc literals.
+  # shellcheck disable=SC2016
+  printf '# %s\n\nThis `0.0.0` package reserves the crate for the [Celox](https://github.com/celox-sim/celox) release workflow while crates.io Trusted Publishing is configured. Use a stable release for actual code.\n' \
+    "$crate" >"$crate_dir/README.md"
+  # shellcheck disable=SC2016
+  printf '#![doc = "Trusted Publishing bootstrap placeholder for `%s`."]\n' \
+    "$crate" >"$crate_dir/src/lib.rs"
+
+  if [[ "$mode" == "package" ]]; then
+    echo "validating $crate@0.0.0 placeholder"
+    cargo package --manifest-path "$crate_dir/Cargo.toml" >/dev/null
+    continue
+  fi
+
+  if placeholder_exists "$crate"; then
+    echo "$crate@0.0.0 already exists; skipping"
+    continue
+  fi
+  if crate_exists "$crate"; then
+    echo "$crate already exists without the expected 0.0.0 placeholder; stopping" >&2
+    exit 1
+  fi
+
+  echo "publishing $crate@0.0.0 placeholder"
+  cargo publish --manifest-path "$crate_dir/Cargo.toml"
+  wait_for_placeholder "$crate"
+done

--- a/scripts/check-release-version.mjs
+++ b/scripts/check-release-version.mjs
@@ -29,6 +29,31 @@ for (const [path, candidate] of versions) {
 }
 
 const cargoManifest = fs.readFileSync("Cargo.toml", "utf8");
+const releaseVersionLines = cargoManifest
+  .split("\n")
+  .filter((line) => line.includes("x-release-please-version"));
+if (releaseVersionLines.length === 0) {
+  throw new Error("Cargo.toml has no Release Please version markers");
+}
+for (const line of releaseVersionLines) {
+  const match = line.match(/\bversion\s*=\s*"=?([^"]+)"/);
+  if (!match || match[1] !== version) {
+    throw new Error(`Cargo.toml release version is not ${version}: ${line}`);
+  }
+}
+
+const cargoLock = fs.readFileSync("Cargo.lock", "utf8");
+for (const block of cargoLock.split("[[package]]").slice(1)) {
+  const name = block.match(/^\s*name = "([^"]+)"/m)?.[1];
+  const candidate = block.match(/^\s*version = "([^"]+)"/m)?.[1];
+  if (
+    (name === "celox" || name?.startsWith("celox-")) &&
+    candidate !== version
+  ) {
+    throw new Error(`Cargo.lock has ${name} ${candidate}; expected ${version}`);
+  }
+}
+
 for (const line of cargoManifest.split("\n")) {
   if (/^veryl-[a-z-]+\s*=/.test(line) && /\bgit\s*=/.test(line)) {
     throw new Error(`The stable lane cannot use a Veryl git dependency: ${line}`);

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:-package}"
+if [[ "$mode" != "list" && "$mode" != "package" && "$mode" != "publish" ]]; then
+  echo "usage: $0 [list|package|publish]" >&2
+  exit 2
+fi
+
+version="$(tr -d '\r\n' < VERSION)"
+if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+  echo "VERSION must contain a stable SemVer version, got $version" >&2
+  exit 1
+fi
+
+# Dependency order matters: crates.io only accepts dependencies that have
+# already been published. Keep each adapter after the crates it links.
+crates=(
+  celox-analysis
+  celox-backend-common
+  celox-design
+  celox-frontend-sdk
+  celox-macros
+  celox-ts-gen
+  celox-sv-analyzer
+  celox-testbench
+  celox-sir
+  celox-state-layout
+  celox-slt
+  celox-backend-cranelift
+  celox-backend-wasm
+  celox-frontend-core
+  celox-runtime
+  celox-sir-opt
+  celox-backend-x86
+  celox-backend-arm64
+  celox-frontend-sv
+  celox-frontend-veryl
+  celox
+  celox-napi
+)
+
+if [[ "$mode" == "list" ]]; then
+  printf '%s\n' "${crates[@]}"
+  exit 0
+fi
+
+if [[ "$mode" == "publish" ]]; then
+  : "${CARGO_REGISTRY_TOKEN:?CARGO_REGISTRY_TOKEN is required for publication}"
+fi
+
+crate_exists() {
+  local crate="$1"
+  curl --fail --silent --show-error \
+    --user-agent "celox-release-workflow/$version (https://github.com/celox-sim/celox)" \
+    "https://crates.io/api/v1/crates/$crate/$version" \
+    >/dev/null 2>&1
+}
+
+wait_for_crate() {
+  local crate="$1"
+  for _ in {1..12}; do
+    if crate_exists "$crate"; then
+      return 0
+    fi
+    sleep 5
+  done
+  echo "$crate@$version was published but did not become visible on crates.io" >&2
+  return 1
+}
+
+for crate in "${crates[@]}"; do
+  if [[ "$mode" == "package" ]]; then
+    # `cargo package` resolves normalized dependencies from crates.io, so a full
+    # archive cannot be created for dependent crates before their first release.
+    # Listing still exercises Cargo's package selection and inclusion checks;
+    # the publish pass creates each real archive after its dependencies exist.
+    echo "validating package contents for $crate@$version"
+    cargo package --locked --allow-dirty --no-verify --list -p "$crate" >/dev/null
+    continue
+  fi
+
+  if crate_exists "$crate"; then
+    echo "$crate@$version is already published; skipping"
+    continue
+  fi
+
+  published=false
+  for attempt in {1..6}; do
+    set +e
+    output="$(cargo publish --locked --no-verify -p "$crate" 2>&1)"
+    status=$?
+    set -e
+    printf '%s\n' "$output"
+
+    if [[ $status -eq 0 ]]; then
+      published=true
+      break
+    fi
+    if grep -Eqi 'already (exists|uploaded)|already been uploaded' <<<"$output"; then
+      published=true
+      break
+    fi
+    if [[ $attempt -lt 6 ]]; then
+      echo "publish attempt $attempt for $crate failed; retrying in 15 seconds" >&2
+      sleep 15
+    fi
+  done
+
+  if [[ "$published" != true ]]; then
+    echo "failed to publish $crate@$version" >&2
+    exit 1
+  fi
+  wait_for_crate "$crate"
+done

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -73,9 +73,9 @@ for crate in "${crates[@]}"; do
   if [[ "$mode" == "package" ]]; then
     # `cargo package` resolves normalized dependencies from crates.io, so a full
     # archive cannot be created for dependent crates before their first release.
-    # Listing still exercises Cargo's package selection and inclusion checks;
-    # the publish pass creates each real archive after its dependencies exist.
-    echo "validating package contents for $crate@$version"
+    # Check the file list here; the ordered publish pass builds and tests each
+    # real archive once its same-version dependencies are available.
+    echo "checking package file list for $crate@$version"
     cargo package --locked --allow-dirty --no-verify --list -p "$crate" >/dev/null
     continue
   fi
@@ -85,10 +85,24 @@ for crate in "${crates[@]}"; do
     continue
   fi
 
+  echo "building and testing package archive for $crate@$version"
+  cargo package --locked -p "$crate"
+  package_dir="$PWD/target/package/$crate-$version"
+  if [[ ! -f "$package_dir/Cargo.toml" || -L "$package_dir" ]]; then
+    echo "cargo did not create the expected package directory: $package_dir" >&2
+    exit 1
+  fi
+  cargo test \
+    --locked \
+    --all-targets \
+    --no-run \
+    --manifest-path "$package_dir/Cargo.toml" \
+    --target-dir "$PWD/target/package-tests/$crate"
+
   published=false
   for attempt in {1..6}; do
     set +e
-    output="$(cargo publish --locked --no-verify -p "$crate" 2>&1)"
+    output="$(cargo publish --locked -p "$crate" 2>&1)"
     status=$?
     set -e
     printf '%s\n' "$output"


### PR DESCRIPTION
## Summary

- publish the Rust SDK, simulator, N-API adapter, and required `celox-*` dependency graph as one lockstep crates.io release
- authenticate crates.io releases with GitHub Actions OIDC Trusted Publishing and keep the one-time empty `0.0.0` name bootstrap local
- let frontend crates expose artifact-specific Rust and TypeScript constructors without serializing a Celox artifact to JSON
- add buildable Rust binary and frontend-owned N-API addon examples, plus English and Japanese integration documentation

## Validation

- `cargo fmt --all --check`
- `cargo check --workspace --all-targets --locked`
- `cargo test --workspace --lib --tests --locked`
- `cargo test --locked -p celox-frontend-sdk`
- `cargo test --locked -p celox --test frontend_sdk`
- `cargo run --locked -p celox --example frontend_binary`
- built and loaded `celox-example-my-frontend-napi` in Node.js; simulated `10 + 23 = 33`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --workspace --no-deps`
- `pnpm --filter @celox-sim/celox test` (170 tests)
- TypeScript lint/build and documentation build
- packaged all 22 public crates and all 22 local `0.0.0` bootstrap placeholders
- release-script test suite (48 tests), ShellCheck, workflow YAML parsing, and `git diff --check`

## Required setup after merge

Before the first stable crates.io release:

1. Create the GitHub environment `crates-io`, restricted to protected tags matching `v*`.
2. Run `./scripts/bootstrap-crates-io.sh publish BOOTSTRAP-CELOX-CRATES` locally with a short-expiry crates.io token scoped to `publish-new` and `celox`/`celox-*`.
3. Register the following Trusted Publisher on every published Celox crate: owner `celox-sim`, repository `celox`, workflow `publish-crates.yml`, environment `crates-io`.
4. Revoke the bootstrap token, then run the normal stable release. Enable Trusted Publishing Only after the OIDC release succeeds.
