### PR TITLE
fix(release): correct Cargo.lock version selector

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,7 +19,7 @@
         {
           "type": "toml",
           "path": "Cargo.lock",
-          "jsonpath": "$.package[?(@.name.match(/^celox(?:-|$)/))].version"
+          "jsonpath": "$.package[?(@.name.value.match(/^celox(?:-|$)/))].version"
         },
         {
           "type": "json",


### PR DESCRIPTION
## Summary

- correct the Release Please Tagged TOML JSONPath for Cargo.lock package names
- restore release PR generation after Release Management run 32389815177 failed

## Validation

- jq empty release-please-config.json
- node scripts/check-release-version.mjs
- Release Please v17.6.0 GenericToml updater updated all 27 Celox Cargo.lock entries to 0.3.1 and no other lines
- pre-push hook: submodule check, cargo fmt, Biome, cargo check, clean tree
