### PR TITLE
fix(release): automate trusted publisher bootstrap

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -90,12 +90,12 @@ the bootstrap is deliberately not a GitHub Actions job:
    ./scripts/bootstrap-crates-io.sh package
    ```
 
-2. Create a short-expiry crates.io API token with the `publish-new` endpoint
-   scope and a crate scope covering `celox` and `celox-*`. Do not save it in
-   GitHub Actions.
+2. Create a short-expiry crates.io API token with both the `publish-new` and
+   **Manage trusted publishing configurations** endpoint scopes, and a crate
+   scope covering `celox` and `celox-*`. Do not save it in GitHub Actions.
 3. Pass the token without putting it in shell history, then publish the
-   placeholders. The confirmation is required because crates.io releases are
-   permanent:
+   placeholders and register their Trusted Publisher configurations. The
+   confirmation is required because crates.io releases are permanent:
 
    ```bash
    read -rsp 'crates.io bootstrap token: ' CARGO_REGISTRY_TOKEN
@@ -105,8 +105,8 @@ the bootstrap is deliberately not a GitHub Actions job:
    unset CARGO_REGISTRY_TOKEN
    ```
 
-4. On the **Trusted Publishers** settings page of every published Celox crate,
-   register this exact identity:
+   The script uses the crates.io API to register this exact identity after each
+   placeholder becomes visible:
 
    | Field | Value |
    | --- | --- |
@@ -115,20 +115,22 @@ the bootstrap is deliberately not a GitHub Actions job:
    | Workflow filename | `publish-crates.yml` |
    | Environment | `crates-io` |
 
-   The crates to configure are the entries in the `crates` array in
-   `scripts/publish-crates.sh`.
-5. Revoke the bootstrap API token immediately. Add the intended crates.io team
+   Re-running the command skips published placeholders and correctly configured
+   publishers. It stops instead of deleting or replacing any unexpected
+   Trusted Publisher configuration. If crates.io rate-limits new crate creation,
+   unset the token, wait until the reported retry time, and run the same command
+   again to resume.
+4. Revoke the bootstrap API token immediately. Add the intended crates.io team
    or backup owners, because the account that performed the bootstrap is the
    initial owner of every new crate.
-6. Run the first stable release normally. It publishes the real lockstep version
+5. Run the first stable release normally. It publishes the real lockstep version
    through OIDC; `0.0.0` remains only as the name bootstrap. After this succeeds,
    optionally enable **Trusted Publishing Only** for each crate so ordinary API
    tokens cannot publish future versions.
 
 Adding another public crate later requires the same bounded bootstrap only for
-that new name, followed by registering the same trusted publisher. The local
-script skips existing `0.0.0` placeholders; existing crates continue to publish
-through OIDC.
+that new name. The local script skips existing `0.0.0` placeholders and Trusted
+Publisher configurations; existing crates continue to publish through OIDC.
 
 ## Veryl dependency lanes
 

--- a/scripts/bootstrap-crates-io.sh
+++ b/scripts/bootstrap-crates-io.sh
@@ -15,6 +15,10 @@ if [[ "$mode" == "publish" ]]; then
     exit 2
   fi
   : "${CARGO_REGISTRY_TOKEN:?CARGO_REGISTRY_TOKEN is required for publication}"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required to configure crates.io Trusted Publishing" >&2
+    exit 1
+  fi
 fi
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
@@ -36,11 +40,29 @@ cleanup() {
 }
 trap cleanup EXIT
 
+crates_io_api="https://crates.io/api/v1"
+trusted_repository_owner="celox-sim"
+trusted_repository_name="celox"
+trusted_workflow_filename="publish-crates.yml"
+trusted_environment="crates-io"
+curl_auth_config="$bootstrap_dir/curl-auth.conf"
+
+if [[ "$mode" == "publish" ]]; then
+  if [[ "$CARGO_REGISTRY_TOKEN" == *$'\n'* || "$CARGO_REGISTRY_TOKEN" == *$'\r'* ]]; then
+    echo "CARGO_REGISTRY_TOKEN must not contain a newline" >&2
+    exit 1
+  fi
+  (
+    umask 077
+    printf 'header = "Authorization: %s"\n' "$CARGO_REGISTRY_TOKEN" >"$curl_auth_config"
+  )
+fi
+
 crate_exists() {
   local crate="$1"
   curl --fail --silent --show-error \
     --user-agent "celox-crates-bootstrap/0.0.0 (https://github.com/celox-sim/celox)" \
-    "https://crates.io/api/v1/crates/$crate" \
+    "$crates_io_api/crates/$crate" \
     >/dev/null 2>&1
 }
 
@@ -48,7 +70,7 @@ placeholder_exists() {
   local crate="$1"
   curl --fail --silent --show-error \
     --user-agent "celox-crates-bootstrap/0.0.0 (https://github.com/celox-sim/celox)" \
-    "https://crates.io/api/v1/crates/$crate/0.0.0" \
+    "$crates_io_api/crates/$crate/0.0.0" \
     >/dev/null 2>&1
 }
 
@@ -62,6 +84,102 @@ wait_for_placeholder() {
   done
   echo "$crate@0.0.0 was published but did not become visible on crates.io" >&2
   return 1
+}
+
+trusted_publisher_configs() {
+  local crate="$1"
+  curl --config "$curl_auth_config" \
+    --fail-with-body --silent --show-error --get \
+    --data-urlencode "crate=$crate" \
+    --user-agent "celox-crates-bootstrap/0.0.0 (https://github.com/celox-sim/celox)" \
+    "$crates_io_api/trusted_publishing/github_configs"
+}
+
+ensure_trusted_publisher() {
+  local crate="$1"
+  local configs
+  configs="$(trusted_publisher_configs "$crate")"
+
+  if ! jq -e '.github_configs | type == "array"' <<<"$configs" >/dev/null; then
+    echo "crates.io returned an invalid Trusted Publishing response for $crate" >&2
+    return 1
+  fi
+
+  local config_count
+  local matching_count
+  config_count="$(jq '.github_configs | length' <<<"$configs")"
+  matching_count="$(
+    jq \
+      --arg owner "$trusted_repository_owner" \
+      --arg repository "$trusted_repository_name" \
+      --arg workflow "$trusted_workflow_filename" \
+      --arg environment "$trusted_environment" \
+      '[.github_configs[] | select(
+        .repository_owner == $owner and
+        .repository_name == $repository and
+        .workflow_filename == $workflow and
+        .environment == $environment
+      )] | length' <<<"$configs"
+  )"
+
+  if [[ "$config_count" -eq 1 && "$matching_count" -eq 1 ]]; then
+    echo "$crate Trusted Publisher is already configured; skipping"
+    return 0
+  fi
+
+  if [[ "$config_count" -ne 0 ]]; then
+    echo "$crate has unexpected Trusted Publisher configuration; stopping" >&2
+    jq -r \
+      '.github_configs[] | "  \(.repository_owner)/\(.repository_name) \(.workflow_filename) environment=\(.environment // "(none)")"' \
+      <<<"$configs" >&2
+    return 1
+  fi
+
+  local payload
+  payload="$(
+    jq -cn \
+      --arg crate "$crate" \
+      --arg owner "$trusted_repository_owner" \
+      --arg repository "$trusted_repository_name" \
+      --arg workflow "$trusted_workflow_filename" \
+      --arg environment "$trusted_environment" \
+      '{github_config: {
+        crate: $crate,
+        repository_owner: $owner,
+        repository_name: $repository,
+        workflow_filename: $workflow,
+        environment: $environment
+      }}'
+  )"
+
+  local response
+  response="$(
+    curl --config "$curl_auth_config" \
+      --fail-with-body --silent --show-error \
+      --request POST \
+      --header 'Content-Type: application/json' \
+      --data "$payload" \
+      --user-agent "celox-crates-bootstrap/0.0.0 (https://github.com/celox-sim/celox)" \
+      "$crates_io_api/trusted_publishing/github_configs"
+  )"
+
+  if ! jq -e \
+    --arg crate "$crate" \
+    --arg owner "$trusted_repository_owner" \
+    --arg repository "$trusted_repository_name" \
+    --arg workflow "$trusted_workflow_filename" \
+    --arg environment "$trusted_environment" \
+    '.github_config |
+      .crate == $crate and
+      .repository_owner == $owner and
+      .repository_name == $repository and
+      .workflow_filename == $workflow and
+      .environment == $environment' <<<"$response" >/dev/null; then
+    echo "crates.io returned an invalid Trusted Publishing configuration for $crate" >&2
+    return 1
+  fi
+
+  echo "configured $crate Trusted Publisher"
 }
 
 for crate in "${crates[@]}"; do
@@ -98,7 +216,8 @@ for crate in "${crates[@]}"; do
   fi
 
   if placeholder_exists "$crate"; then
-    echo "$crate@0.0.0 already exists; skipping"
+    echo "$crate@0.0.0 already exists; skipping publication"
+    ensure_trusted_publisher "$crate"
     continue
   fi
   if crate_exists "$crate"; then
@@ -109,4 +228,5 @@ for crate in "${crates[@]}"; do
   echo "publishing $crate@0.0.0 placeholder"
   cargo publish --manifest-path "$crate_dir/Cargo.toml"
   wait_for_placeholder "$crate"
+  ensure_trusted_publisher "$crate"
 done

--- a/scripts/bootstrap-crates-io.test.mjs
+++ b/scripts/bootstrap-crates-io.test.mjs
@@ -1,0 +1,214 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import http from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const bootstrapSource = join(repoRoot, "scripts/bootstrap-crates-io.sh");
+const expectedConfig = (crate) => ({
+  id: 1,
+  crate,
+  repository_owner: "celox-sim",
+  repository_owner_id: 1,
+  repository_name: "celox",
+  workflow_filename: "publish-crates.yml",
+  environment: "crates-io",
+  created_at: "2026-08-20T00:00:00Z",
+});
+
+async function startFixture({ crates, published = [], configs = new Map() }) {
+  const root = await mkdtemp(join(tmpdir(), "celox-bootstrap-test-"));
+  const scriptsDir = join(root, "scripts");
+  const binDir = join(root, "bin");
+  const publishedDir = join(root, "published");
+  const tempDir = join(root, "tmp");
+  const cargoLog = join(root, "cargo.log");
+  const posts = [];
+
+  await Promise.all([
+    mkdir(scriptsDir),
+    mkdir(binDir),
+    mkdir(publishedDir),
+    mkdir(tempDir),
+  ]);
+  await Promise.all(
+    published.map((crate) => writeFile(join(publishedDir, crate), "")),
+  );
+
+  const server = http.createServer(async (request, response) => {
+    const url = new URL(request.url, "http://localhost");
+    const cratePath = url.pathname.match(/^\/api\/v1\/crates\/([^/]+)(?:\/0\.0\.0)?$/);
+
+    if (request.method === "GET" && cratePath) {
+      const crate = decodeURIComponent(cratePath[1]);
+      try {
+        await readFile(join(publishedDir, crate));
+        response.writeHead(200).end("{}");
+      } catch {
+        response.writeHead(404).end('{"errors":[{"detail":"not found"}]}');
+      }
+      return;
+    }
+
+    if (url.pathname !== "/api/v1/trusted_publishing/github_configs") {
+      response.writeHead(404).end();
+      return;
+    }
+    if (request.headers.authorization !== "test-token") {
+      response
+        .writeHead(403, { "content-type": "application/json" })
+        .end('{"errors":[{"detail":"authentication required"}]}');
+      return;
+    }
+
+    if (request.method === "GET") {
+      const crate = url.searchParams.get("crate");
+      const githubConfigs = configs.get(crate) ?? [];
+      response
+        .writeHead(200, { "content-type": "application/json" })
+        .end(JSON.stringify({ github_configs: githubConfigs, meta: { total: githubConfigs.length } }));
+      return;
+    }
+
+    if (request.method === "POST") {
+      let body = "";
+      for await (const chunk of request) body += chunk;
+      const config = { ...expectedConfig(JSON.parse(body).github_config.crate), ...JSON.parse(body).github_config };
+      configs.set(config.crate, [config]);
+      posts.push(config);
+      response
+        .writeHead(200, { "content-type": "application/json" })
+        .end(JSON.stringify({ github_config: config }));
+      return;
+    }
+
+    response.writeHead(405).end();
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+  const address = server.address();
+  assert(address && typeof address !== "string");
+  const api = `http://127.0.0.1:${address.port}/api/v1`;
+  const source = (await readFile(bootstrapSource, "utf8")).replace(
+    'crates_io_api="https://crates.io/api/v1"',
+    `crates_io_api="${api}"`,
+  );
+  assert(source.includes(`crates_io_api="${api}"`));
+
+  const bootstrap = join(scriptsDir, "bootstrap-crates-io.sh");
+  const listScript = join(scriptsDir, "publish-crates.sh");
+  const cargo = join(binDir, "cargo");
+  await writeFile(bootstrap, source);
+  await writeFile(
+    listScript,
+    `#!/usr/bin/env bash\nset -euo pipefail\n[[ "\${1:-}" == list ]]\nprintf '%s\\n' ${crates.map((crate) => `'${crate}'`).join(" ")}\n`,
+  );
+  await writeFile(
+    cargo,
+    `#!/usr/bin/env bash
+set -euo pipefail
+mode="\${1:-}"
+shift || true
+manifest=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == --manifest-path ]]; then
+    manifest="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+crate="$(basename "$(dirname "$manifest")")"
+if [[ "$mode" == publish ]]; then
+  printf '%s\\n' "$crate" >>"$FAKE_CARGO_LOG"
+  : >"$FAKE_PUBLISHED_DIR/$crate"
+fi
+`,
+  );
+  await Promise.all([chmod(bootstrap, 0o755), chmod(listScript, 0o755), chmod(cargo, 0o755)]);
+
+  return {
+    async run() {
+      return execFileAsync(
+        bootstrap,
+        ["publish", "BOOTSTRAP-CELOX-CRATES"],
+        {
+          env: {
+            ...process.env,
+            CARGO_REGISTRY_TOKEN: "test-token",
+            FAKE_CARGO_LOG: cargoLog,
+            FAKE_PUBLISHED_DIR: publishedDir,
+            PATH: `${binDir}:${process.env.PATH}`,
+            TMPDIR: tempDir,
+          },
+          maxBuffer: 1024 * 1024,
+        },
+      );
+    },
+    cargoLog,
+    configs,
+    posts,
+    async close() {
+      await new Promise((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+      await rm(root, { recursive: true, force: true });
+    },
+  };
+}
+
+test("publishes missing placeholders and configures only missing publishers", async () => {
+  const configs = new Map([
+    ["celox-analysis", [expectedConfig("celox-analysis")]],
+  ]);
+  const fixture = await startFixture({
+    crates: ["celox-analysis", "celox-design", "celox-frontend-sdk"],
+    published: ["celox-analysis", "celox-design"],
+    configs,
+  });
+
+  try {
+    const { stdout, stderr } = await fixture.run();
+    assert.match(stdout, /celox-analysis Trusted Publisher is already configured; skipping/);
+    assert.match(stdout, /configured celox-design Trusted Publisher/);
+    assert.match(stdout, /publishing celox-frontend-sdk@0\.0\.0 placeholder/);
+    assert.match(stdout, /configured celox-frontend-sdk Trusted Publisher/);
+    assert.doesNotMatch(`${stdout}${stderr}`, /test-token/);
+    assert.deepEqual(
+      fixture.posts.map((config) => config.crate),
+      ["celox-design", "celox-frontend-sdk"],
+    );
+    assert.equal((await readFile(fixture.cargoLog, "utf8")).trim(), "celox-frontend-sdk");
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("stops instead of replacing an unexpected publisher", async () => {
+  const wrongConfig = {
+    ...expectedConfig("celox-analysis"),
+    repository_owner: "unexpected-owner",
+  };
+  const fixture = await startFixture({
+    crates: ["celox-analysis"],
+    published: ["celox-analysis"],
+    configs: new Map([["celox-analysis", [wrongConfig]]]),
+  });
+
+  try {
+    await assert.rejects(fixture.run(), (error) => {
+      assert.match(error.stderr, /unexpected Trusted Publisher configuration; stopping/);
+      assert.match(error.stderr, /unexpected-owner\/celox/);
+      return true;
+    });
+    assert.deepEqual(fixture.posts, []);
+  } finally {
+    await fixture.close();
+  }
+});


### PR DESCRIPTION
## Summary

- configure each crate's GitHub Actions Trusted Publisher through the crates.io API immediately after its placeholder is visible
- make reruns skip exact configurations and stop on unexpected configurations instead of replacing them
- document the combined publish-new and Trusted Publishing token scopes and rate-limit recovery
- add mocked API regression coverage for existing, missing, new, and unexpected configurations

## Validation

- node --test scripts/*.test.mjs (50 tests)
- shellcheck scripts/bootstrap-crates-io.sh
- ./scripts/bootstrap-crates-io.sh package (22 placeholders)
- pnpm docs:build
- node scripts/check-release-version.mjs
- pre-push hook: submodule check, Biome, cargo fmt, cargo check, clean tree
