### PR TITLE
fix(release): avoid crates publish disk exhaustion

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -76,8 +76,8 @@ If the publishing implementation itself must be fixed after a partial release,
 create a numbered `vX.Y.Z-recovery.N` tag from the reviewed fix commit and run
 **Publish Rust Crates** from that tag with `release_tag` set to `vX.Y.Z`. The
 workflow requires the source tag to use that exact recovery form, requires
-`VERSION` to match the stable release, and skips crate versions already visible
-on crates.io.
+the recovery tag to descend from the stable release tag, requires `VERSION` to
+match the stable release, and skips crate versions already visible on crates.io.
 
 Create a GitHub environment named `crates-io` before the first release. Limit
 deployments to protected tags matching `v*` and add required reviewers if

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -69,9 +69,15 @@ Publication uses crates.io Trusted Publishing. The publish job has
 `id-token: write`, runs in the `crates-io` GitHub environment, and exchanges its
 GitHub OIDC identity for a temporary crates.io token. There is no persistent
 `CARGO_REGISTRY_TOKEN` Actions secret. A manual retry must select the existing
-stable tag as the workflow ref; the workflow has no free-form revision input.
-It also requires a published GitHub Release, so it is safe to use for a failed
-or partially completed publication retry.
+stable tag as the workflow ref. It also requires a published GitHub Release, so
+it is safe to use for a failed or partially completed publication retry.
+
+If the publishing implementation itself must be fixed after a partial release,
+create a numbered `vX.Y.Z-recovery.N` tag from the reviewed fix commit and run
+**Publish Rust Crates** from that tag with `release_tag` set to `vX.Y.Z`. The
+workflow requires the source tag to use that exact recovery form, requires
+`VERSION` to match the stable release, and skips crate versions already visible
+on crates.io.
 
 Create a GitHub environment named `crates-io` before the first release. Limit
 deployments to protected tags matching `v*` and add required reviewers if

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -2,13 +2,19 @@ name: Publish Rust Crates
 
 on:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Stable release tag to resume from a numbered recovery tag
+        required: false
+        type: string
 
 concurrency:
   group: crates-publish-${{ github.ref }}
   cancel-in-progress: false
 
 env:
-  RELEASE_TAG: ${{ github.ref_name }}
+  RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
+  SOURCE_TAG: ${{ github.ref_name }}
 
 permissions:
   contents: read
@@ -29,6 +35,14 @@ jobs:
           if [[ "$GITHUB_REF_TYPE" != "tag" || ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Run this workflow from a v-prefixed stable release tag." >&2
             exit 1
+          fi
+          if [[ "$SOURCE_TAG" != "$RELEASE_TAG" ]]; then
+            recovery_prefix="$RELEASE_TAG-recovery."
+            recovery_number="${SOURCE_TAG#"$recovery_prefix"}"
+            if [[ "$SOURCE_TAG" != "$recovery_prefix"* || ! "$recovery_number" =~ ^[1-9][0-9]*$ ]]; then
+              echo "Recovery source tag must match $RELEASE_TAG-recovery.N." >&2
+              exit 1
+            fi
           fi
           expected_tag="v$(tr -d '\r\n' < VERSION)"
           if [[ "$RELEASE_TAG" != "$expected_tag" ]]; then

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -43,6 +43,10 @@ jobs:
               echo "Recovery source tag must match $RELEASE_TAG-recovery.N." >&2
               exit 1
             fi
+            if ! git merge-base --is-ancestor "$RELEASE_TAG" "$SOURCE_TAG"; then
+              echo "Recovery source tag $SOURCE_TAG must descend from $RELEASE_TAG." >&2
+              exit 1
+            fi
           fi
           expected_tag="v$(tr -d '\r\n' < VERSION)"
           if [[ "$RELEASE_TAG" != "$expected_tag" ]]; then

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -85,19 +85,23 @@ for crate in "${crates[@]}"; do
     continue
   fi
 
-  echo "building and testing package archive for $crate@$version"
+  echo "building and checking package archive for $crate@$version"
   cargo package --locked -p "$crate"
   package_dir="$PWD/target/package/$crate-$version"
   if [[ ! -f "$package_dir/Cargo.toml" || -L "$package_dir" ]]; then
     echo "cargo did not create the expected package directory: $package_dir" >&2
     exit 1
   fi
-  cargo test \
+  # The normal release checks already run the workspace tests. Check every
+  # target from the normalized archive here without linking a second copy of
+  # every test and benchmark binary; linking all of Celox exceeds the disk on a
+  # GitHub-hosted runner. A shared target directory also reuses dependencies
+  # between archives instead of keeping one full build tree per crate.
+  cargo check \
     --locked \
     --all-targets \
-    --no-run \
     --manifest-path "$package_dir/Cargo.toml" \
-    --target-dir "$PWD/target/package-tests/$crate"
+    --target-dir "$PWD/target/package-checks"
 
   published=false
   for attempt in {1..6}; do


### PR DESCRIPTION
## Summary

- replace archive test linking with `cargo check --all-targets` and a shared target directory
- add a constrained numbered recovery-tag path for partially published releases
- document the recovery flow

## Release incident

The v0.3.1 crates.io run published 20/22 crates, then exhausted the GitHub runner disk while linking all `celox` tests and benchmarks. A retry on a clean runner reproduced the same failure for `celox` alone.

## Validation

- `cargo package --locked -p celox`
- `cargo check --locked --all-targets --manifest-path target/package/celox-0.3.1/Cargo.toml --target-dir target/package-checks`
- `node --test scripts/*.test.mjs` (50/50)
- `shellcheck scripts/publish-crates.sh`
- YAML parse and recovery-tag validation cases
- pre-push hook: cargo fmt, cargo check, Biome, submodule and clean-tree checks
