### PR TITLE
refactor(runtime)!: normalize runtime design metadata

### DIFF
--- a/crates/celox-design/src/lib.rs
+++ b/crates/celox-design/src/lib.rs
@@ -145,7 +145,11 @@ impl<A> Default for RuntimeSchema<A> {
 ///
 /// Addresses are already flattened. Source paths and frontend IDs used only
 /// for diagnostics or lookup deliberately live outside this structure.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "A: Serialize + Eq + std::hash::Hash + Ord",
+    deserialize = "A: Deserialize<'de> + Eq + std::hash::Hash + Ord"
+))]
 pub struct EventTopology<A> {
     /// Alias event address to the canonical event-domain address.
     pub aliases: HashMap<A, A>,
@@ -187,7 +191,11 @@ impl<A: Copy + Eq + std::hash::Hash> EventTopology<A> {
 /// This is intentionally not a frontend lookup table: every state object is
 /// keyed by its flattened semantic address, and no source-language AST or path
 /// type is retained.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "A: Serialize + Eq + std::hash::Hash + Ord",
+    deserialize = "A: Deserialize<'de> + Eq + std::hash::Hash + Ord"
+))]
 pub struct ElaboratedDesign<A> {
     pub state_objects: HashMap<A, VariableMetadata>,
     pub events: EventTopology<A>,

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1982,36 +1982,35 @@ impl NativeSimulatorHandle {
         let mut layout_map: BTreeMap<String, serde_json::Value> = BTreeMap::new();
 
         for addr in program.design.state_objects.keys() {
-            let Some(source) = program.frontend.source_address(addr) else {
+            let Some(variable) = program.design.variable(addr) else {
                 continue;
             };
-            let module_id = program.frontend.instance_module[&source.instance_id];
-            let variables = &program.frontend.module_variables[&module_id];
-            let Some(info) = variables.get(&source.var_id) else {
+            let Some(instance) = program.design.instance(addr.instance_id) else {
                 continue;
             };
-            if program.frontend.module_var_path_index[&module_id].get(&info.path) == Some(&None) {
+            if !instance.resolves_path_to(&variable.path, *addr) {
                 continue;
             }
+            let metadata = &program.design.state_objects[addr];
             let Some(&offset) = layout.offsets.get(addr) else {
                 continue;
             };
             let name = program.get_path(addr);
             let total_width = layout.widths.get(addr).copied().unwrap_or(0);
-            let (width, array_dims) = if info.array_dims.is_empty() {
+            let (width, array_dims) = if metadata.array_dims.is_empty() {
                 (total_width, None)
             } else {
-                let element_count = info.array_dims.iter().product::<usize>();
-                (total_width / element_count, Some(&info.array_dims))
+                let element_count = metadata.array_dims.iter().product::<usize>();
+                (total_width / element_count, Some(&metadata.array_dims))
             };
             let byte_size = celox::get_byte_size(width);
             let mut entry = serde_json::json!({
                 "offset": offset,
                 "width": width,
                 "byte_size": byte_size,
-                "is_4state": four_state && info.is_4state,
-                "direction": layout::direction_str(info.var_kind),
-                "type_kind": layout::type_kind_str(info.type_kind),
+                "is_4state": four_state && metadata.is_4state,
+                "direction": layout::direction_str(variable.var_kind),
+                "type_kind": layout::type_kind_str(metadata.type_kind),
             });
             if let Some(array_dims) = array_dims {
                 entry["array_dims"] = serde_json::json!(array_dims);

--- a/crates/celox-wasm/src/lib.rs
+++ b/crates/celox-wasm/src/lib.rs
@@ -114,17 +114,13 @@ impl SimHandle {
         let mut layout_map: BTreeMap<String, serde_json::Value> = BTreeMap::new();
 
         for addr in self.program().design.state_objects.keys() {
-            let Some(source) = self.program().frontend.source_address(addr) else {
+            let Some(variable) = self.program().design.variable(addr) else {
                 continue;
             };
-            let module_id = self.program().frontend.instance_module[&source.instance_id];
-            let variables = &self.program().frontend.module_variables[&module_id];
-            let Some(info) = variables.get(&source.var_id) else {
+            let Some(instance) = self.program().design.instance(addr.instance_id) else {
                 continue;
             };
-            if self.program().frontend.module_var_path_index[&module_id].get(&info.path)
-                == Some(&None)
-            {
+            if !instance.resolves_path_to(&variable.path, *addr) {
                 continue;
             }
 

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -9,8 +9,8 @@ use std::time::{Duration, Instant};
 
 use bit_set::BitSet;
 use celox_design::{
-    ElaboratedDesign, EventTopology, InitialStateData, InitialStateValue, InitialStateWriteRun,
-    RuntimeCombObserver, RuntimeErrorInfo, RuntimeEventSite, RuntimeSchema,
+    InitialStateData, InitialStateValue, InitialStateWriteRun, RuntimeCombObserver,
+    RuntimeErrorInfo, RuntimeEventSite, RuntimeSchema,
 };
 use celox_runtime::DesignReflection;
 use celox_runtime::backend::SimBackend;
@@ -329,20 +329,6 @@ pub(crate) struct NativeRuntimeSchema {
     pub(crate) rtl_writes: HashSet<celox_design::VarAtomBase<AbsoluteAddr>>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct NativeEventTopology {
-    aliases: HashMap<AbsoluteAddr, AbsoluteAddr>,
-    ordered_events: Vec<AbsoluteAddr>,
-    cascaded_events: std::collections::BTreeSet<AbsoluteAddr>,
-    reset_clocks: HashMap<AbsoluteAddr, AbsoluteAddr>,
-}
-
-impl NativeEventTopology {
-    pub(crate) fn canonical(&self, address: AbsoluteAddr) -> AbsoluteAddr {
-        self.aliases.get(&address).copied().unwrap_or(address)
-    }
-}
-
 /// Pointer-free native compiler artifact which can be attached to the
 /// precompiled Celox runtime.
 #[derive(Clone, Serialize, Deserialize)]
@@ -359,11 +345,9 @@ pub struct NativeProgramImage {
     id_to_addr: Vec<AbsoluteAddr>,
     id_to_event: Vec<NativeEventImageRef>,
     reflection: DesignReflection,
-    frontend: crate::ir::FrontendLookup,
-    initial_state: Vec<InitialStateValue<AbsoluteAddr>>,
+    design: crate::ir::RuntimeDesign,
     testbench: Option<TestbenchProgram<AbsoluteAddr>>,
     runtime_schema: NativeRuntimeSchema,
-    event_topology: NativeEventTopology,
     layout: MemoryLayout,
     native_memory_size: usize,
     options: NativeRuntimeOptions,
@@ -402,8 +386,8 @@ impl NativeProgramImage {
     }
 
     /// Canonical event-domain topology used by the runtime scheduler.
-    pub(crate) fn event_topology(&self) -> &NativeEventTopology {
-        &self.event_topology
+    pub(crate) fn event_topology(&self) -> &celox_design::EventTopology<AbsoluteAddr> {
+        &self.design.events
     }
 
     /// Reconstruct the source-independent runtime metadata retained by this
@@ -411,17 +395,7 @@ impl NativeProgramImage {
     /// execution side of a host-codegen workflow.
     pub(crate) fn runtime_program(&self) -> crate::ir::RuntimeProgram {
         crate::ir::RuntimeProgram {
-            design: ElaboratedDesign {
-                state_objects: HashMap::default(),
-                events: EventTopology {
-                    aliases: self.event_topology.aliases.clone(),
-                    ordered_events: self.event_topology.ordered_events.clone(),
-                    cascaded_events: self.event_topology.cascaded_events.clone(),
-                    reset_clocks: self.event_topology.reset_clocks.clone(),
-                },
-                initial_state: self.initial_state.clone(),
-            },
-            frontend: self.frontend.clone(),
+            design: self.design.clone(),
             runtime_schema: RuntimeSchema {
                 runtime_errors: self.runtime_schema.runtime_errors.clone(),
                 runtime_event_sites: self.runtime_schema.runtime_event_sites.clone(),
@@ -434,6 +408,9 @@ impl NativeProgramImage {
     }
 
     pub(super) fn validate(&self) -> Result<(), String> {
+        self.design
+            .validate()
+            .map_err(|error| format!("invalid runtime design: {error}"))?;
         self.reflection
             .validate()
             .map_err(|error| format!("invalid design reflection: {error}"))?;
@@ -1868,8 +1845,7 @@ fn compile_program(
             id_to_addr,
             id_to_event,
             reflection: sir.runtime().build_design_reflection(layout),
-            frontend: sir.runtime().frontend.clone(),
-            initial_state: sir.runtime().design.initial_state.clone(),
+            design: sir.runtime().design.clone(),
             testbench: sir.runtime().testbench.clone(),
             runtime_schema: NativeRuntimeSchema {
                 runtime_errors: sir.runtime().runtime_schema.runtime_errors.clone(),
@@ -1877,12 +1853,6 @@ fn compile_program(
                 comb_observers: sir.runtime().runtime_schema.comb_observers.clone(),
                 testbench_read_roots: sir.runtime().runtime_schema.testbench_read_roots.clone(),
                 rtl_writes: sir.runtime().runtime_schema.rtl_writes.clone(),
-            },
-            event_topology: NativeEventTopology {
-                aliases: sir.runtime().design.events.aliases.clone(),
-                ordered_events: sir.runtime().design.events.ordered_events.clone(),
-                cascaded_events: sir.runtime().design.events.cascaded_events.clone(),
-                reset_clocks: sir.runtime().design.events.reset_clocks.clone(),
             },
             layout: layout.clone(),
             native_memory_size,
@@ -2087,7 +2057,7 @@ impl NativeBackend {
         };
         backend.install_event_buffers();
         let compiled = Arc::clone(&backend.compiled);
-        backend.apply_initial_values(&compiled.program_image.initial_state);
+        backend.apply_initial_values(&compiled.program_image.design.initial_state);
         backend
     }
 

--- a/crates/celox/src/backend/native/image_file.rs
+++ b/crates/celox/src/backend/native/image_file.rs
@@ -6,7 +6,7 @@ use std::{fmt, path::Path};
 use super::backend::NativeProgramImage;
 
 const TRAILER_MAGIC: &[u8; 8] = b"CELOXNPI";
-const CONTAINER_VERSION: u16 = 3;
+const CONTAINER_VERSION: u16 = 4;
 const TRAILER_SIZE: usize = 32;
 const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
 const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;

--- a/crates/celox/src/backend/native/image_file.rs
+++ b/crates/celox/src/backend/native/image_file.rs
@@ -63,6 +63,13 @@ pub struct AppendedNativeImage {
     pub image: NativeProgramImage,
 }
 
+struct AppendedNativePayload<'a> {
+    runtime_len: usize,
+    version: u16,
+    architecture: u8,
+    payload: &'a [u8],
+}
+
 /// Failure while encoding or discovering a native image container.
 #[derive(Debug, thiserror::Error)]
 pub enum NativeImageContainerError {
@@ -155,7 +162,7 @@ impl NativeProgramImage {
         let output_path = output_path.as_ref();
         let metadata = std::fs::metadata(runtime_path)?;
         let runtime = std::fs::read(runtime_path)?;
-        let runtime_len = Self::discover_appended(&runtime)?
+        let runtime_len = discover_appended_payload(&runtime)?
             .map(|appended| appended.runtime_len)
             .unwrap_or(runtime.len());
         let output = self.append_to_runtime(&runtime[..runtime_len])?;
@@ -180,45 +187,27 @@ impl NativeProgramImage {
     pub fn discover_appended(
         bytes: &[u8],
     ) -> Result<Option<AppendedNativeImage>, NativeImageContainerError> {
-        let Some(trailer_start) = bytes.len().checked_sub(TRAILER_SIZE) else {
+        let Some(appended) = discover_appended_payload(bytes)? else {
             return Ok(None);
         };
-        let trailer = &bytes[trailer_start..];
-        if &trailer[..8] != TRAILER_MAGIC {
-            return Ok(None);
+        if appended.version != CONTAINER_VERSION {
+            return Err(NativeImageContainerError::UnsupportedVersion(
+                appended.version,
+            ));
         }
-
-        let version = u16::from_le_bytes(trailer[8..10].try_into().unwrap());
-        if version != CONTAINER_VERSION {
-            return Err(NativeImageContainerError::UnsupportedVersion(version));
-        }
-        let found = NativeImageArchitecture::decode(trailer[10])?;
+        let found = NativeImageArchitecture::decode(appended.architecture)?;
         let expected = NativeImageArchitecture::current();
         if found != expected {
             return Err(NativeImageContainerError::ArchitectureMismatch { expected, found });
         }
-        let trailer_size = u32::from_le_bytes(trailer[12..16].try_into().unwrap());
-        if trailer_size as usize != TRAILER_SIZE {
-            return Err(NativeImageContainerError::UnsupportedTrailerSize(
-                trailer_size,
-            ));
-        }
-        let payload_len = u64::from_le_bytes(trailer[16..24].try_into().unwrap());
-        let payload_len =
-            usize::try_from(payload_len).map_err(|_| NativeImageContainerError::SizeOverflow)?;
-        let runtime_len = trailer_start
-            .checked_sub(payload_len)
-            .ok_or(NativeImageContainerError::TruncatedPayload)?;
-        let payload = &bytes[runtime_len..trailer_start];
-        let expected_checksum = u64::from_le_bytes(trailer[24..32].try_into().unwrap());
-        if checksum(payload) != expected_checksum {
-            return Err(NativeImageContainerError::ChecksumMismatch);
-        }
-        let image: NativeProgramImage = postcard::from_bytes(payload)?;
+        let image: NativeProgramImage = postcard::from_bytes(appended.payload)?;
         image
             .validate()
             .map_err(NativeImageContainerError::InvalidImage)?;
-        Ok(Some(AppendedNativeImage { runtime_len, image }))
+        Ok(Some(AppendedNativeImage {
+            runtime_len: appended.runtime_len,
+            image,
+        }))
     }
 
     /// Read the running executable and discover an image attached at EOF.
@@ -228,6 +217,43 @@ impl NativeProgramImage {
         let bytes = std::fs::read(executable)?;
         Self::discover_appended(&bytes)
     }
+}
+
+fn discover_appended_payload(
+    bytes: &[u8],
+) -> Result<Option<AppendedNativePayload<'_>>, NativeImageContainerError> {
+    let Some(trailer_start) = bytes.len().checked_sub(TRAILER_SIZE) else {
+        return Ok(None);
+    };
+    let trailer = &bytes[trailer_start..];
+    if &trailer[..8] != TRAILER_MAGIC {
+        return Ok(None);
+    }
+
+    let trailer_size = u32::from_le_bytes(trailer[12..16].try_into().unwrap());
+    if trailer_size as usize != TRAILER_SIZE {
+        return Err(NativeImageContainerError::UnsupportedTrailerSize(
+            trailer_size,
+        ));
+    }
+    let payload_len = u64::from_le_bytes(trailer[16..24].try_into().unwrap());
+    let payload_len =
+        usize::try_from(payload_len).map_err(|_| NativeImageContainerError::SizeOverflow)?;
+    let runtime_len = trailer_start
+        .checked_sub(payload_len)
+        .ok_or(NativeImageContainerError::TruncatedPayload)?;
+    let payload = &bytes[runtime_len..trailer_start];
+    let expected_checksum = u64::from_le_bytes(trailer[24..32].try_into().unwrap());
+    if checksum(payload) != expected_checksum {
+        return Err(NativeImageContainerError::ChecksumMismatch);
+    }
+
+    Ok(Some(AppendedNativePayload {
+        runtime_len,
+        version: u16::from_le_bytes(trailer[8..10].try_into().unwrap()),
+        architecture: trailer[10],
+        payload,
+    }))
 }
 
 fn checksum(bytes: &[u8]) -> u64 {

--- a/crates/celox/src/flatting_tests.rs
+++ b/crates/celox/src/flatting_tests.rs
@@ -286,7 +286,7 @@ fn setup_and_parse(code: &str, top_name: &str) -> crate::ir::UnoptimizedSir {
         None,
     )
     .expect("Failed to flatten");
-    let (sir, runtime) = crate::ir::RuntimeProgram::from_scheduled(scheduled.scheduled);
+    let (sir, runtime) = crate::ir::RuntimeProgram::from_scheduled(scheduled.scheduled).unwrap();
     crate::ir::UnoptimizedSir::new(sir, runtime)
 }
 
@@ -328,35 +328,27 @@ fn test_instances_inherit_module_boundaries() {
     let c1_path = InstancePath(vec![("c1".to_string(), 0)]);
     let c2_path = InstancePath(vec![("c2".to_string(), 0)]);
 
-    let c1_id = program
-        .frontend
-        .instance_ids
-        .get(&c1_path)
+    let c1 = program
+        .design
+        .instance_at_path(&c1_path)
         .expect("c1 instance not found");
-    let c2_id = program
-        .frontend
-        .instance_ids
-        .get(&c2_path)
+    let c2 = program
+        .design
+        .instance_at_path(&c2_path)
         .expect("c2 instance not found");
 
-    // Find VarId for 'x' in Child module
-    let child_module_id = program
-        .frontend
-        .module_names
+    // Find the normalized runtime variable for 'x' in Child.
+    let x = c1
+        .state_addresses()
         .iter()
-        .find(|(_, name)| name.as_str() == "Child")
-        .map(|(id, _)| *id)
-        .expect("Child module not found");
-    let child_vars = &program.frontend.module_variables[&child_module_id];
-    let x_info = child_vars
-        .values()
-        .find(|info| info.path.as_slice() == ["x"])
+        .filter_map(|address| program.design.variable(address))
+        .find(|variable| variable.path.as_slice() == ["x"])
         .unwrap();
-    let x_id = x_info.id;
+    let x_id = x.source_id;
 
     // Verify that we actually have different instance IDs in the paths
-    let c1_x_stores = find_stores_to_var(&program, *c1_id, x_id);
-    let c2_x_stores = find_stores_to_var(&program, *c2_id, x_id);
+    let c1_x_stores = find_stores_to_var(&program, c1.id, x_id);
+    let c2_x_stores = find_stores_to_var(&program, c2.id, x_id);
 
     // We expect split stores.
     // Since we can't easily count exact atoms without knowing how scheduler optimizes,
@@ -469,8 +461,10 @@ fn find_stores_to_var(
     var_id: SourceVarId,
 ) -> Vec<StoreInfo> {
     let expected = program
-        .state_address_for_source(instance_id, var_id)
-        .expect("frontend state projection is complete");
+        .design
+        .instance_variable(instance_id, var_id)
+        .expect("runtime state projection is complete")
+        .address;
     let mut stores = Vec::new();
     for unit in &program.sir.eval_comb {
         for block in unit.blocks.values() {

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -301,6 +301,15 @@ impl RuntimeDesign {
                     "state/source variable count differs for {instance_id}"
                 ));
             }
+            if instance
+                .state_addresses
+                .windows(2)
+                .any(|addresses| addresses[0] >= addresses[1])
+            {
+                return Err(format!(
+                    "state addresses are not strictly sorted for {instance_id}"
+                ));
+            }
 
             for address in &instance.state_addresses {
                 if address.instance_id != *instance_id {
@@ -341,7 +350,7 @@ impl RuntimeDesign {
                 .instances
                 .get(&address.instance_id)
                 .ok_or_else(|| format!("runtime variable {address} references missing instance"))?;
-            if !instance.state_addresses.contains(address) {
+            if instance.state_addresses.binary_search(address).is_err() {
                 return Err(format!(
                     "runtime variable {address} is not indexed by instance"
                 ));

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -360,12 +360,14 @@ impl RuntimeDesign {
         Ok(())
     }
 
+    #[cfg(feature = "host-runtime")]
     pub(crate) fn take_initial_state(
         &mut self,
     ) -> Vec<celox_design::InitialStateValue<AbsoluteAddr>> {
         std::mem::take(&mut self.semantic.initial_state)
     }
 
+    #[cfg(feature = "host-runtime")]
     pub(crate) fn restore_initial_state(
         &mut self,
         initial_state: Vec<celox_design::InitialStateValue<AbsoluteAddr>>,

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -41,6 +41,330 @@ pub type AbsoluteAddr = celox_design::StateAddr;
 pub type RegionedAbsoluteAddr = celox_design::RegionedStateAddr;
 pub type SirProgram = celox_sir::SirProgram<AbsoluteAddr, RegionedAbsoluteAddr>;
 
+/// Source-facing metadata for one flattened runtime state object.
+///
+/// Storage metadata remains canonical in [`RuntimeDesign::semantic`]; this
+/// record only retains the hierarchy and source properties needed for lookup,
+/// diagnostics, testbench integration, and reflection.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct RuntimeVariable {
+    pub address: AbsoluteAddr,
+    pub source_id: SourceVarId,
+    pub path: Vec<String>,
+    pub var_kind: VariableKind,
+    pub signed: bool,
+    pub packed_dims: Vec<usize>,
+}
+
+/// One elaborated runtime instance with direct state-address indices.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct RuntimeInstance {
+    pub id: InstanceId,
+    pub module_id: ModuleId,
+    pub module_name: String,
+    pub path: InstancePath,
+    pub display_path: Vec<String>,
+    state_addresses: Vec<AbsoluteAddr>,
+    source_variables: HashMap<SourceVarId, AbsoluteAddr>,
+    path_index: HashMap<Vec<String>, Option<AbsoluteAddr>>,
+}
+
+impl RuntimeInstance {
+    pub fn state_addresses(&self) -> &[AbsoluteAddr] {
+        &self.state_addresses
+    }
+
+    pub fn resolves_path_to(&self, path: &[String], address: AbsoluteAddr) -> bool {
+        self.path_index.get(path) == Some(&Some(address))
+    }
+}
+
+/// Canonical runtime design model after frontend scheduling.
+///
+/// The semantic state table, hierarchy, paths, and source-facing variable
+/// properties are projected into this model once. The compiler can then drop
+/// [`FrontendLookup`] instead of retaining it beside a duplicate state table.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct RuntimeDesign {
+    semantic: celox_design::ElaboratedDesign<AbsoluteAddr>,
+    instances: HashMap<InstanceId, RuntimeInstance>,
+    instance_ids: HashMap<InstancePath, InstanceId>,
+    variables: HashMap<AbsoluteAddr, RuntimeVariable>,
+}
+
+impl std::ops::Deref for RuntimeDesign {
+    type Target = celox_design::ElaboratedDesign<AbsoluteAddr>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.semantic
+    }
+}
+
+impl RuntimeDesign {
+    fn from_projection(
+        semantic: celox_design::ElaboratedDesign<AbsoluteAddr>,
+        frontend: FrontendLookup,
+    ) -> Result<Self, DesignProjectionError> {
+        let expected_count = frontend
+            .instance_module
+            .values()
+            .map(|module_id| frontend.module_variables[module_id].len())
+            .sum::<usize>();
+        if semantic.state_objects.len() != expected_count {
+            return Err(DesignProjectionError::StateObjectCount {
+                design: semantic.state_objects.len(),
+                frontend: expected_count,
+            });
+        }
+
+        let mut instances = HashMap::default();
+        let mut variables = HashMap::default();
+        for (path, &instance_id) in &frontend.instance_ids {
+            let module_id = frontend.instance_module[&instance_id];
+            let module_variables = &frontend.module_variables[&module_id];
+            let display_path = frontend.instance_path_segments(path);
+            let mut state_addresses = Vec::with_capacity(module_variables.len());
+            let mut source_variables = HashMap::default();
+
+            for info in module_variables.values() {
+                let source_address = SourceAddr {
+                    instance_id,
+                    var_id: info.id,
+                };
+                let Some(address) = frontend.state_address(&source_address) else {
+                    return Err(DesignProjectionError::MissingStateProjection { source_address });
+                };
+                let Some(metadata) = semantic.state_objects.get(&address) else {
+                    return Err(DesignProjectionError::MissingStateObject { address });
+                };
+                if metadata != &info.metadata {
+                    return Err(DesignProjectionError::MetadataMismatch { address });
+                }
+
+                state_addresses.push(address);
+                source_variables.insert(info.id, address);
+                variables.insert(
+                    address,
+                    RuntimeVariable {
+                        address,
+                        source_id: info.id,
+                        path: info.path.clone(),
+                        var_kind: info.var_kind,
+                        signed: info.signed,
+                        packed_dims: info.packed_dims.clone(),
+                    },
+                );
+            }
+
+            state_addresses.sort_unstable();
+            let path_index = frontend.module_var_path_index[&module_id]
+                .iter()
+                .map(|(path, source_id)| {
+                    (
+                        path.clone(),
+                        source_id.and_then(|source_id| source_variables.get(&source_id).copied()),
+                    )
+                })
+                .collect();
+            instances.insert(
+                instance_id,
+                RuntimeInstance {
+                    id: instance_id,
+                    module_id,
+                    module_name: frontend
+                        .module_names
+                        .get(&module_id)
+                        .cloned()
+                        .unwrap_or_else(|| module_id.to_string()),
+                    path: path.clone(),
+                    display_path,
+                    state_addresses,
+                    source_variables,
+                    path_index,
+                },
+            );
+        }
+
+        let design = Self {
+            semantic,
+            instances,
+            instance_ids: frontend.instance_ids,
+            variables,
+        };
+        design
+            .validate()
+            .map_err(|reason| DesignProjectionError::InvalidRuntimeDesign { reason })?;
+        Ok(design)
+    }
+
+    pub fn semantic(&self) -> &celox_design::ElaboratedDesign<AbsoluteAddr> {
+        &self.semantic
+    }
+
+    pub fn instances(&self) -> impl Iterator<Item = &RuntimeInstance> {
+        self.instances.values()
+    }
+
+    pub fn instance(&self, id: InstanceId) -> Option<&RuntimeInstance> {
+        self.instances.get(&id)
+    }
+
+    pub fn instance_at_path(&self, path: &InstancePath) -> Option<&RuntimeInstance> {
+        self.instance_ids
+            .get(path)
+            .and_then(|instance_id| self.instances.get(instance_id))
+    }
+
+    pub fn root_instance(&self) -> Option<&RuntimeInstance> {
+        self.instance_at_path(&InstancePath(Vec::new()))
+    }
+
+    pub fn variable(&self, address: &AbsoluteAddr) -> Option<&RuntimeVariable> {
+        self.variables.get(address)
+    }
+
+    pub fn instance_variable(
+        &self,
+        instance_id: InstanceId,
+        source_id: SourceVarId,
+    ) -> Option<&RuntimeVariable> {
+        let address = self
+            .instances
+            .get(&instance_id)?
+            .source_variables
+            .get(&source_id)?;
+        self.variables.get(address)
+    }
+
+    pub fn variable_info(&self, address: &AbsoluteAddr) -> Option<VariableInfo> {
+        let variable = self.variables.get(address)?;
+        Some(VariableInfo {
+            id: variable.source_id,
+            path: variable.path.clone(),
+            var_kind: variable.var_kind,
+            signed: variable.signed,
+            metadata: self.semantic.state_objects.get(address)?.clone(),
+            packed_dims: variable.packed_dims.clone(),
+        })
+    }
+
+    pub fn get_path(&self, address: &AbsoluteAddr) -> String {
+        let Some(variable) = self.variables.get(address) else {
+            return address.to_string();
+        };
+        let Some(instance) = self.instances.get(&address.instance_id) else {
+            return address.to_string();
+        };
+        instance
+            .display_path
+            .iter()
+            .chain(&variable.path)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(".")
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), String> {
+        if self.variables.len() != self.semantic.state_objects.len() {
+            return Err(format!(
+                "state variable count differs: design={} runtime={}",
+                self.semantic.state_objects.len(),
+                self.variables.len()
+            ));
+        }
+        if self.instance_ids.len() != self.instances.len() {
+            return Err(format!(
+                "instance count differs: paths={} instances={}",
+                self.instance_ids.len(),
+                self.instances.len()
+            ));
+        }
+
+        for (path, instance_id) in &self.instance_ids {
+            let instance = self.instances.get(instance_id).ok_or_else(|| {
+                format!("instance path {path:?} references missing {instance_id}")
+            })?;
+            if instance.path != *path || instance.id != *instance_id {
+                return Err(format!("instance path index disagrees for {instance_id}"));
+            }
+        }
+
+        for (instance_id, instance) in &self.instances {
+            if instance.id != *instance_id {
+                return Err(format!("instance map key disagrees for {instance_id}"));
+            }
+            if self.instance_ids.get(&instance.path) != Some(instance_id) {
+                return Err(format!("missing path index for {instance_id}"));
+            }
+            if instance.state_addresses.len() != instance.source_variables.len() {
+                return Err(format!(
+                    "state/source variable count differs for {instance_id}"
+                ));
+            }
+
+            for address in &instance.state_addresses {
+                if address.instance_id != *instance_id {
+                    return Err(format!(
+                        "state address {address} belongs to another instance"
+                    ));
+                }
+                if !self.semantic.state_objects.contains_key(address) {
+                    return Err(format!("state address {address} has no semantic metadata"));
+                }
+                let variable = self
+                    .variables
+                    .get(address)
+                    .ok_or_else(|| format!("state address {address} has no runtime variable"))?;
+                if variable.address != *address
+                    || instance.source_variables.get(&variable.source_id) != Some(address)
+                {
+                    return Err(format!("source index disagrees for {address}"));
+                }
+            }
+
+            for (path, address) in &instance.path_index {
+                let Some(address) = address else {
+                    continue;
+                };
+                let variable = self
+                    .variables
+                    .get(address)
+                    .ok_or_else(|| format!("path index references missing {address}"))?;
+                if address.instance_id != *instance_id || variable.path != *path {
+                    return Err(format!("path index disagrees for {address}"));
+                }
+            }
+        }
+
+        for address in self.variables.keys() {
+            let instance = self
+                .instances
+                .get(&address.instance_id)
+                .ok_or_else(|| format!("runtime variable {address} references missing instance"))?;
+            if !instance.state_addresses.contains(address) {
+                return Err(format!(
+                    "runtime variable {address} is not indexed by instance"
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn take_initial_state(
+        &mut self,
+    ) -> Vec<celox_design::InitialStateValue<AbsoluteAddr>> {
+        std::mem::take(&mut self.semantic.initial_state)
+    }
+
+    pub(crate) fn restore_initial_state(
+        &mut self,
+        initial_state: Vec<celox_design::InitialStateValue<AbsoluteAddr>>,
+    ) {
+        self.semantic.initial_state = initial_state;
+    }
+}
+
 /// Error returned by [`RuntimeProgram::get_addr`] when a path-based variable lookup fails.
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum AddrLookupError {
@@ -52,8 +376,8 @@ pub enum AddrLookupError {
     AmbiguousPath { path: String },
 }
 
-/// Internal consistency failure while comparing frontend state lookup data
-/// with the source-independent elaborated design.
+/// Internal consistency failure while consuming the frontend projection into
+/// the canonical runtime design.
 #[derive(Debug, Clone, thiserror::Error)]
 pub(crate) enum DesignProjectionError {
     #[error("state object count differs: design={design} frontend={frontend}")]
@@ -64,6 +388,8 @@ pub(crate) enum DesignProjectionError {
     MissingStateObject { address: AbsoluteAddr },
     #[error("metadata differs for flattened state object {address}")]
     MetadataMismatch { address: AbsoluteAddr },
+    #[error("invalid normalized runtime design: {reason}")]
+    InvalidRuntimeDesign { reason: String },
 }
 
 #[cfg(feature = "host-runtime")]
@@ -78,8 +404,7 @@ pub type RuntimeErrorInfo<Addr = AbsoluteAddr> = celox_design::RuntimeErrorInfo<
 /// backend can therefore discard the compiler artifact after code generation.
 #[derive(Clone)]
 pub struct RuntimeProgram {
-    pub design: celox_design::ElaboratedDesign<AbsoluteAddr>,
-    pub frontend: FrontendLookup,
+    pub design: RuntimeDesign,
     pub runtime_schema: RuntimeSchema<AbsoluteAddr>,
     pub testbench: Option<TestbenchProgram<AbsoluteAddr>>,
 }
@@ -352,32 +677,18 @@ impl RuntimeProgram {
             module_name: String,
         }
 
-        let root_instance = self
-            .frontend
-            .instance_ids
-            .get(&InstancePath(Vec::new()))
-            .expect("top-level instance exists");
-        let root_module = self.frontend.instance_module[root_instance];
         let root_name = self
-            .frontend
-            .module_names
-            .get(&root_module)
-            .cloned()
-            .unwrap_or_else(|| root_module.to_string());
+            .design
+            .root_instance()
+            .expect("top-level instance exists")
+            .module_name
+            .clone();
 
         let mut scope_sources = self
-            .frontend
-            .instance_ids
-            .iter()
-            .map(|(path, &instance_id)| {
-                let module_id = self.frontend.instance_module[&instance_id];
-                let module_name = self
-                    .frontend
-                    .module_names
-                    .get(&module_id)
-                    .cloned()
-                    .unwrap_or_else(|| module_id.to_string());
-                let segments = self.frontend.instance_path_segments(path);
+            .design
+            .instances()
+            .map(|instance| {
+                let segments = &instance.display_path;
                 let name = segments
                     .last()
                     .cloned()
@@ -395,11 +706,11 @@ impl RuntimeProgram {
                     }
                 });
                 ScopeSource {
-                    instance_id,
+                    instance_id: instance.id,
                     name,
                     full_name,
                     parent_name,
-                    module_name,
+                    module_name: instance.module_name.clone(),
                 }
             })
             .collect::<Vec<_>>();
@@ -454,34 +765,31 @@ impl RuntimeProgram {
 
         let mut signals = Vec::new();
         for scope in &scope_sources {
-            let module_id = self.frontend.instance_module[&scope.instance_id];
-            let variables = &self.frontend.module_variables[&module_id];
-            let path_index = &self.frontend.module_var_path_index[&module_id];
-            for info in variables.values() {
+            let instance = self.design.instance(scope.instance_id).unwrap();
+            for state_address in instance.state_addresses() {
+                let variable = self.design.variable(state_address).unwrap();
                 if matches!(
-                    info.var_kind,
+                    variable.var_kind,
                     VariableKind::Parameter | VariableKind::Constant
                 ) {
                     continue;
                 }
-                if path_index.get(&info.path) != Some(&Some(info.id)) {
+                if instance.path_index.get(&variable.path) != Some(&Some(*state_address)) {
                     continue;
                 }
-                let name = info.path.join(".");
-                let state_address = self
-                    .state_address_for_source(scope.instance_id, info.id)
-                    .expect("frontend state projection is complete");
+                let metadata = &self.design.state_objects[state_address];
+                let name = variable.path.join(".");
                 let array_layout =
                     layout
                         .unpacked_arrays
-                        .get(&state_address)
+                        .get(state_address)
                         .map(|array| SignalArrayLayout {
                             element_width: array.element_width,
                             element_count: array.element_count,
                             element_stride: array.element_stride,
                             plane_size: array.plane_size,
                         });
-                let direction = match info.var_kind {
+                let direction = match variable.var_kind {
                     VariableKind::Input => SignalDirection::Input,
                     VariableKind::Output => SignalDirection::Output,
                     VariableKind::Inout => SignalDirection::Inout,
@@ -491,19 +799,19 @@ impl RuntimeProgram {
                     full_name: format!("{}.{}", scope.full_name, name),
                     name,
                     parent: instance_scopes[&scope.instance_id],
-                    state_address,
+                    state_address: *state_address,
                     signal: SignalRef {
-                        offset: layout.offsets[&state_address],
-                        width: layout.widths[&state_address],
-                        is_4state: layout.is_4states[&state_address],
+                        offset: layout.offsets[state_address],
+                        width: layout.widths[state_address],
+                        is_4state: layout.is_4states[state_address],
                         array_layout,
                     },
                     direction,
-                    domain_kind: info.kind,
-                    signed: info.signed,
-                    packed_dims: info.packed_dims.clone(),
-                    unpacked_dims: info.array_dims.clone(),
-                    type_kind: info.type_kind,
+                    domain_kind: metadata.kind,
+                    signed: variable.signed,
+                    packed_dims: variable.packed_dims.clone(),
+                    unpacked_dims: metadata.array_dims.clone(),
+                    type_kind: metadata.type_kind,
                 });
             }
         }
@@ -520,29 +828,18 @@ impl RuntimeProgram {
         reflection
     }
 
-    pub(crate) fn state_address_for_source(
-        &self,
-        instance_id: InstanceId,
-        var_id: SourceVarId,
-    ) -> Option<AbsoluteAddr> {
-        self.frontend.state_address(&SourceAddr {
-            instance_id,
-            var_id,
-        })
-    }
-
     pub(crate) fn from_scheduled(
         scheduled: celox_frontend_core::ScheduledRtl,
-    ) -> (SirProgram, Self) {
-        (
+    ) -> Result<(SirProgram, Self), DesignProjectionError> {
+        let design = RuntimeDesign::from_projection(scheduled.design, scheduled.frontend_lookup)?;
+        Ok((
             scheduled.sir,
             Self {
-                design: scheduled.design,
-                frontend: scheduled.frontend_lookup,
+                design,
                 runtime_schema: scheduled.runtime_schema,
                 testbench: None,
             },
-        )
+        ))
     }
 
     pub fn get_addr(
@@ -554,10 +851,9 @@ impl RuntimeProgram {
             .iter()
             .map(|(name, index)| ((*name).to_string(), *index))
             .collect();
-        let instance_id = *self
-            .frontend
-            .instance_ids
-            .get(&InstancePath(instance_path.clone()))
+        let instance = self
+            .design
+            .instance_at_path(&InstancePath(instance_path.clone()))
             .ok_or_else(|| AddrLookupError::InstanceNotFound {
                 path: instance_path
                     .iter()
@@ -565,79 +861,32 @@ impl RuntimeProgram {
                     .collect::<Vec<_>>()
                     .join("."),
             })?;
-        let module_id = self.frontend.instance_module[&instance_id];
         let target_path = var_path
             .iter()
             .map(|segment| (*segment).to_string())
             .collect::<Vec<_>>();
         let path_str = var_path.join(".");
-        let entry = self.frontend.module_var_path_index[&module_id]
-            .get(&target_path)
-            .ok_or_else(|| AddrLookupError::VariableNotFound {
+        let entry = instance.path_index.get(&target_path).ok_or_else(|| {
+            AddrLookupError::VariableNotFound {
                 path: path_str.clone(),
-            })?;
-        let var_id = entry.ok_or_else(|| AddrLookupError::AmbiguousPath { path: path_str })?;
-        let source_addr = SourceAddr {
-            instance_id,
-            var_id,
-        };
-        self.frontend
-            .state_address(&source_addr)
-            .ok_or_else(|| AddrLookupError::VariableNotFound {
-                path: var_path.join("."),
-            })
+            }
+        })?;
+        entry
+            .as_ref()
+            .copied()
+            .ok_or(AddrLookupError::AmbiguousPath { path: path_str })
     }
 
     pub fn get_path(&self, addr: &AbsoluteAddr) -> String {
-        self.frontend.get_state_path(addr)
+        self.design.get_path(addr)
     }
 
-    pub fn get_variable_info(&self, addr: &AbsoluteAddr) -> Option<&VariableInfo> {
-        let source = self.frontend.source_address(addr)?;
-        let module_id = self.frontend.instance_module.get(&source.instance_id)?;
-        let module_vars = self.frontend.module_variables.get(module_id)?;
-        module_vars.get(&source.var_id)
+    pub fn get_variable_info(&self, addr: &AbsoluteAddr) -> Option<VariableInfo> {
+        self.design.variable_info(addr)
     }
 
     pub fn num_events(&self) -> usize {
         self.design.events.len()
-    }
-
-    /// Verify the temporary migration projection from frontend lookup tables
-    /// into the source-independent elaborated design. This can be removed once
-    /// the frontend tables are consumed rather than retained beside `design`.
-    pub(crate) fn verify_design_projection(&self) -> Result<(), DesignProjectionError> {
-        let expected_count = self
-            .frontend
-            .instance_module
-            .values()
-            .map(|module_id| self.frontend.module_variables[module_id].len())
-            .sum::<usize>();
-        if self.design.state_objects.len() != expected_count {
-            return Err(DesignProjectionError::StateObjectCount {
-                design: self.design.state_objects.len(),
-                frontend: expected_count,
-            });
-        }
-
-        for (&instance_id, module_id) in &self.frontend.instance_module {
-            for info in self.frontend.module_variables[module_id].values() {
-                let source_address = SourceAddr {
-                    instance_id,
-                    var_id: info.id,
-                };
-                let Some(address) = self.frontend.state_address(&source_address) else {
-                    return Err(DesignProjectionError::MissingStateProjection { source_address });
-                };
-                let Some(metadata) = self.design.state_objects.get(&address) else {
-                    return Err(DesignProjectionError::MissingStateObject { address });
-                };
-                if metadata != &info.metadata {
-                    return Err(DesignProjectionError::MetadataMismatch { address });
-                }
-            }
-        }
-        Ok(())
     }
 }
 

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -42,8 +42,9 @@ pub(crate) use fxhash::FxHashMap as HashMap;
 pub(crate) use fxhash::FxHashSet as HashSet;
 pub use ir::{
     AbsoluteAddr, AddrLookupError, FrontendLookup, InstancePath, LaidOutProgram, OptimizedSir,
-    PortTypeKind, RuntimeErrorInfo, RuntimeProgram, SignalRef, SirProgram, SourceAddr, SourceVarId,
-    UnoptimizedSir, VariableInfo, VariableKind,
+    PortTypeKind, RuntimeDesign, RuntimeErrorInfo, RuntimeInstance, RuntimeProgram,
+    RuntimeVariable, SignalRef, SirProgram, SourceAddr, SourceVarId, UnoptimizedSir, VariableInfo,
+    VariableKind,
 };
 pub use num_bigint::BigUint;
 pub use optimizer::OptLevel;

--- a/crates/celox/src/parser.rs
+++ b/crates/celox/src/parser.rs
@@ -58,47 +58,37 @@ fn dump_addr_map_if_requested(program: &RuntimeProgram, diagnostics: &crate::Run
 
     let filter = parse_addr_map_filter(raw_filter);
     let mut entries = Vec::new();
-    for (&instance_id, &module_id) in &program.frontend.instance_module {
-        let Some(vars) = program.frontend.module_variables.get(&module_id) else {
-            continue;
-        };
-        for (&var_id, info) in vars {
-            let inst_key = instance_id.0.to_string();
-            let var_key = normalized_addr_id(&var_id.to_string());
+    for instance in program.design.instances() {
+        for address in instance.state_addresses() {
+            let variable = program.design.variable(address).unwrap();
+            let inst_key = instance.id.0.to_string();
+            let var_key = normalized_addr_id(&variable.source_id.to_string());
             if let Some(filter) = &filter
                 && !filter.contains(&(inst_key, var_key))
             {
                 continue;
             }
-            entries.push((instance_id, module_id, var_id, info));
+            entries.push((instance, variable));
         }
     }
 
-    entries.sort_by(|(a_inst, _, a_var, _), (b_inst, _, b_var, _)| {
-        (a_inst.0, a_var.to_string()).cmp(&(b_inst.0, b_var.to_string()))
+    entries.sort_by(|(a_instance, a_variable), (b_instance, b_variable)| {
+        (a_instance.id.0, a_variable.source_id).cmp(&(b_instance.id.0, b_variable.source_id))
     });
 
-    for (instance_id, module_id, var_id, info) in entries {
-        let module_name = program
-            .frontend
-            .module_names
-            .get(&module_id)
-            .cloned()
-            .unwrap_or_default();
-        let Some(addr) = program.state_address_for_source(instance_id, var_id) else {
-            continue;
-        };
+    for (instance, variable) in entries {
+        let metadata = &program.design.state_objects[&variable.address];
         tracing::debug!(
             "[addr-map] inst={} var={} module={} path={} width={} array_dims={:?} 4state={} kind={:?} var_kind={}",
-            instance_id,
-            var_id,
-            module_name,
-            program.get_path(&addr),
-            info.width,
-            info.array_dims,
-            info.is_4state,
-            info.kind,
-            info.var_kind.description(),
+            instance.id,
+            variable.source_id,
+            instance.module_name,
+            program.get_path(&variable.address),
+            metadata.width,
+            metadata.array_dims,
+            metadata.is_4state,
+            metadata.kind,
+            variable.var_kind.description(),
         );
     }
 }
@@ -133,9 +123,6 @@ fn verify_program_sir(
     program: &RuntimeProgram,
     phase: &'static str,
 ) -> Result<(), ParserError> {
-    program.verify_design_projection().map_err(|error| {
-        ParserError::illegal_context("elaborated design projection", error.to_string(), None)
-    })?;
     let units = sir
         .eval_comb
         .iter()
@@ -314,17 +301,28 @@ pub(crate) fn finalize_scheduled_rtl(
 
     apply_fused_optimization_hints(&mut scheduled.scheduled, scheduled.fused_optimization_hints)?;
     scheduled.scheduled.inject_triggers();
-    let (sir, mut runtime) = RuntimeProgram::from_scheduled(scheduled.scheduled);
-    if let Some(testbench_source) = testbench_source.as_mut() {
+    let testbench = if let Some(testbench_source) = testbench_source.as_mut() {
         testbench_source.component_libraries = component_libraries;
         testbench_source.component_file_base = component_file_base;
-        crate::testbench_compile::project_observability(&mut runtime, testbench_source)?;
-        runtime.testbench = crate::testbench_compile::compile_semantic_testbench(
-            &runtime,
+        crate::testbench_compile::project_observability(
+            &scheduled.scheduled.frontend_lookup,
+            &mut scheduled.scheduled.runtime_schema,
+            testbench_source,
+        )?;
+        crate::testbench_compile::compile_semantic_testbench(
+            &scheduled.scheduled.frontend_lookup,
+            scheduled.scheduled.runtime_schema.runtime_event_sites.len(),
             testbench_source,
             testbench_random_seed,
-        )?;
-    }
+        )?
+    } else {
+        None
+    };
+    let (sir, mut runtime) =
+        RuntimeProgram::from_scheduled(scheduled.scheduled).map_err(|error| {
+            ParserError::illegal_context("runtime design projection", error.to_string(), None)
+        })?;
+    runtime.testbench = testbench;
     dump_addr_map_if_requested(&runtime, diagnostics);
     let mut program = UnoptimizedSir::new(sir, runtime);
     if let Some(t) = trace.as_deref_mut()

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -615,7 +615,7 @@ mod host {
 
         pub(crate) fn apply_initial_values(&mut self) {
             let mut applied = false;
-            let initial_memory_values = std::mem::take(&mut self.program.design.initial_state);
+            let initial_memory_values = self.program.design.take_initial_state();
             for init in &initial_memory_values {
                 applied = true;
                 let signal = self.backend.resolve_signal(&init.address);
@@ -649,7 +649,9 @@ mod host {
             if applied {
                 self.dirty = true;
             }
-            self.program.design.initial_state = initial_memory_values;
+            self.program
+                .design
+                .restore_initial_state(initial_memory_values);
         }
 
         fn apply_initial_memory_writes(
@@ -1243,33 +1245,23 @@ mod host {
         /// paths without the original [`RuntimeProgram`].
         pub fn build_vcd_descs(&self, four_state_mode: bool) -> Vec<crate::VcdSignalDesc> {
             let mut descs = Vec::new();
-            let mut sorted_instances: Vec<_> =
-                self.program.frontend.instance_module.iter().collect();
-            sorted_instances.sort_by_key(|(id, _)| *id);
+            let mut sorted_instances = self.program.design.instances().collect::<Vec<_>>();
+            sorted_instances.sort_by_key(|instance| instance.id);
 
-            for (instance_id, module_id) in sorted_instances {
-                let variables = &self.program.frontend.module_variables[module_id];
-                let path_index = &self.program.frontend.module_var_path_index[module_id];
-                let scope = format!("{}", instance_id);
+            for instance in sorted_instances {
+                let scope = format!("{}", instance.id);
 
-                let mut sorted_vars: Vec<_> = variables
-                    .values()
-                    .filter(|info| path_index.get(&info.path) != Some(&None))
+                let mut sorted_vars: Vec<_> = instance
+                    .state_addresses()
+                    .iter()
+                    .filter_map(|address| self.program.design.variable(address))
+                    .filter(|variable| instance.resolves_path_to(&variable.path, variable.address))
                     .collect();
-                sorted_vars.sort_by(|a, b| {
-                    let name_a = a.path.join(".");
-                    let name_b = b.path.join(".");
-                    name_a.cmp(&name_b)
-                });
+                sorted_vars.sort_by(|a, b| a.path.cmp(&b.path));
 
-                for info in sorted_vars {
-                    let name = info.path.join(".");
-
-                    let addr = self
-                        .program
-                        .state_address_for_source(*instance_id, info.id)
-                        .expect("frontend state projection is complete");
-                    let signal = self.backend.resolve_signal(&addr);
+                for variable in sorted_vars {
+                    let name = variable.path.join(".");
+                    let signal = self.backend.resolve_signal(&variable.address);
 
                     descs.push(crate::VcdSignalDesc {
                         scope: scope.clone(),
@@ -1285,13 +1277,12 @@ mod host {
 
         /// Returns all ports of the top-level module with their resolved signal references.
         pub fn named_signals(&self) -> Vec<NamedSignal> {
-            let top_instance_id = self
+            let top_instance = self
                 .program
-                .frontend
-                .instance_ids
-                .get(&InstancePath(vec![]))
+                .design
+                .root_instance()
                 .expect("top-level instance not found");
-            self.build_signals_for_instance(*top_instance_id)
+            self.build_signals_for_instance(top_instance.id)
         }
 
         /// Returns all signals for the instance at the given hierarchical path.
@@ -1303,8 +1294,8 @@ mod host {
                 .iter()
                 .map(|(name, idx)| ((*name).to_string(), *idx))
                 .collect();
-            match self.program.frontend.instance_ids.get(&InstancePath(path)) {
-                Some(&instance_id) => self.build_signals_for_instance(instance_id),
+            match self.program.design.instance_at_path(&InstancePath(path)) {
+                Some(instance) => self.build_signals_for_instance(instance.id),
                 None => Vec::new(),
             }
         }
@@ -1318,22 +1309,17 @@ mod host {
             &self,
             instance_id: crate::ir::InstanceId,
         ) -> Vec<NamedSignal> {
-            let module_id = &self.program.frontend.instance_module[&instance_id];
-            let module_vars = &self.program.frontend.module_variables[module_id];
-            let path_index = &self.program.frontend.module_var_path_index[module_id];
+            let instance = self.program.design.instance(instance_id).unwrap();
 
             let mut result = Vec::new();
-            for info in module_vars.values() {
+            for address in instance.state_addresses() {
+                let variable = self.program.design.variable(address).unwrap();
                 // Skip variables whose VarPath is ambiguous (None in the path index).
-                if path_index.get(&info.path) == Some(&None) {
+                if !instance.resolves_path_to(&variable.path, *address) {
                     continue;
                 }
-                let name = info.path.join(".");
-                let addr = self
-                    .program
-                    .state_address_for_source(instance_id, info.id)
-                    .expect("frontend state projection is complete");
-                let signal = self.backend.resolve_signal(&addr);
+                let name = variable.path.join(".");
+                let signal = self.backend.resolve_signal(address);
 
                 // Resolve associated clock for reset signals
                 let associated_clock = self
@@ -1341,13 +1327,13 @@ mod host {
                     .design
                     .events
                     .reset_clocks
-                    .get(&addr)
+                    .get(address)
                     .map(|clock_addr| self.program.get_path(clock_addr));
 
                 result.push(NamedSignal {
                     name,
                     signal,
-                    info: info.clone(),
+                    info: self.program.design.variable_info(address).unwrap(),
                     associated_clock,
                 });
             }
@@ -1412,32 +1398,24 @@ mod host {
         }
 
         fn build_hierarchy(&self, current_path: &[(String, usize)]) -> InstanceHierarchy {
-            let instance_id = self
+            let instance = self
                 .program
-                .frontend
-                .instance_ids
-                .get(&InstancePath(current_path.to_vec()))
+                .design
+                .instance_at_path(&InstancePath(current_path.to_vec()))
                 .expect("instance not found");
-            let module_id = &self.program.frontend.instance_module[instance_id];
-            let module_name = self
-                .program
-                .frontend
-                .module_names
-                .get(module_id)
-                .cloned()
-                .unwrap_or_else(|| format!("{}", module_id));
+            let module_name = instance.module_name.clone();
 
-            let signals = self.build_signals_for_instance(*instance_id);
+            let signals = self.build_signals_for_instance(instance.id);
 
             // Find direct children: instance paths that extend current by exactly 1 segment
             let current_len = current_path.len();
             let mut children_map: crate::HashMap<String, Vec<(usize, InstanceHierarchy)>> =
                 crate::HashMap::default();
 
-            for path in self.program.frontend.instance_ids.keys() {
-                if path.0.len() == current_len + 1 && path.0.starts_with(current_path) {
-                    let (child_name, child_index) = &path.0[current_len];
-                    let child_hierarchy = self.build_hierarchy(&path.0);
+            for child in self.program.design.instances() {
+                if child.path.0.len() == current_len + 1 && child.path.0.starts_with(current_path) {
+                    let (child_name, child_index) = &child.path.0[current_len];
+                    let child_hierarchy = self.build_hierarchy(&child.path.0);
                     children_map
                         .entry(child_name.clone())
                         .or_default()

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -2470,7 +2470,6 @@ mod host {
         options: &SimulatorOptions,
     ) {
         use crate::HashSet;
-        use crate::ir::InstancePath;
         let mut externally_live = HashSet::default();
 
         // Native testbench expressions bypass SIR and read simulator memory
@@ -2489,20 +2488,10 @@ mod host {
 
         // PreserveTopPorts: auto-collect top module port addresses
         if options.dead_store_policy == DeadStorePolicy::PreserveTopPorts {
-            if let Some(&top_instance_id) = program.frontend.instance_ids.get(&InstancePath(vec![]))
-            {
-                if let Some(&top_module_id) = program.frontend.instance_module.get(&top_instance_id)
-                {
-                    if let Some(top_vars) = program.frontend.module_variables.get(&top_module_id) {
-                        for info in top_vars.values() {
-                            if info.var_kind.is_port() {
-                                if let Some(address) =
-                                    program.state_address_for_source(top_instance_id, info.id)
-                                {
-                                    externally_live.insert(address);
-                                }
-                            }
-                        }
+            if let Some(instance) = program.design.root_instance() {
+                for address in instance.state_addresses() {
+                    if program.design.variable(address).unwrap().var_kind.is_port() {
+                        externally_live.insert(*address);
                     }
                 }
             }
@@ -2510,16 +2499,10 @@ mod host {
 
         // PreserveAllPorts: collect port addresses from every instance
         if options.dead_store_policy == DeadStorePolicy::PreserveAllPorts {
-            for (&instance_id, &module_id) in &program.frontend.instance_module {
-                if let Some(vars) = program.frontend.module_variables.get(&module_id) {
-                    for info in vars.values() {
-                        if info.var_kind.is_port() {
-                            if let Some(address) =
-                                program.state_address_for_source(instance_id, info.id)
-                            {
-                                externally_live.insert(address);
-                            }
-                        }
+            for instance in program.design.instances() {
+                for address in instance.state_addresses() {
+                    if program.design.variable(address).unwrap().var_kind.is_port() {
+                        externally_live.insert(*address);
                     }
                 }
             }

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -1741,10 +1741,9 @@ fn apply_component_writes<B: SimBackend>(
 
 fn root_testbench_name<B: SimBackend>(sim: &Simulator<B>) -> String {
     sim.program
-        .frontend
-        .root_instance_and_module()
-        .and_then(|(_, module)| sim.program.frontend.module_names.get(&module))
-        .cloned()
+        .design
+        .root_instance()
+        .map(|instance| instance.module_name.clone())
         .unwrap_or_else(|| "testbench".to_string())
 }
 

--- a/crates/celox/src/testbench_compile.rs
+++ b/crates/celox/src/testbench_compile.rs
@@ -1,27 +1,29 @@
-use crate::ir::{AbsoluteAddr, RuntimeProgram};
+use crate::ir::{AbsoluteAddr, FrontendLookup, RuntimeSchema};
 use celox_frontend_veryl::VerylTestbenchSource;
 use celox_testbench::TestbenchProgram;
 
 pub(crate) fn project_observability(
-    program: &mut RuntimeProgram,
+    lookup: &FrontendLookup,
+    runtime_schema: &mut RuntimeSchema<AbsoluteAddr>,
     source: &VerylTestbenchSource,
 ) -> Result<(), celox_frontend_veryl::ParserError> {
     let (sites, read_variables) =
-        celox_frontend_veryl::collect_testbench_observability(&program.frontend, source)?;
-    program.runtime_schema.runtime_event_sites.extend(sites);
-    program.runtime_schema.testbench_read_roots = read_variables;
+        celox_frontend_veryl::collect_testbench_observability(lookup, source)?;
+    runtime_schema.runtime_event_sites.extend(sites);
+    runtime_schema.testbench_read_roots = read_variables;
     Ok(())
 }
 
 pub(crate) fn compile_semantic_testbench(
-    program: &RuntimeProgram,
+    lookup: &FrontendLookup,
+    runtime_event_site_count: usize,
     source: &VerylTestbenchSource,
     random_seed: Option<u64>,
 ) -> Result<Option<TestbenchProgram<AbsoluteAddr>>, celox_frontend_veryl::ParserError> {
     celox_frontend_veryl::compile_semantic_testbench(
-        &program.frontend,
+        lookup,
         source,
-        program.runtime_schema.runtime_event_sites.len(),
+        runtime_event_site_count,
         random_seed,
     )
 }

--- a/crates/celox/tests/shared_jit_cache.rs
+++ b/crates/celox/tests/shared_jit_cache.rs
@@ -31,6 +31,9 @@ const ADDER: &str = r#"
     }
 "#;
 
+const NATIVE_IMAGE_TRAILER_SIZE: usize = 32;
+const NATIVE_IMAGE_VERSION_OFFSET: usize = 8;
+
 const FF: &str = r#"
     module Top (
         i_clk: input  clock,
@@ -653,17 +656,15 @@ fn native_program_image_rejects_corrupt_appended_payload() {
 
 #[test]
 fn native_program_image_rejects_v3_before_decoding_changed_schema() {
-    const TRAILER_SIZE: usize = 32;
-    const VERSION_OFFSET: usize = 8;
-
     let sim = Simulator::builder(ADDER, "Top").build().unwrap();
     let mut encoded = sim
         .shared_code()
         .program_image()
         .to_container_bytes()
         .unwrap();
-    let trailer_start = encoded.len() - TRAILER_SIZE;
-    encoded[trailer_start + VERSION_OFFSET..trailer_start + VERSION_OFFSET + 2]
+    let trailer_start = encoded.len() - NATIVE_IMAGE_TRAILER_SIZE;
+    encoded[trailer_start + NATIVE_IMAGE_VERSION_OFFSET
+        ..trailer_start + NATIVE_IMAGE_VERSION_OFFSET + 2]
         .copy_from_slice(&3u16.to_le_bytes());
 
     assert!(matches!(
@@ -694,6 +695,17 @@ fn native_program_image_writes_an_executable_runtime_file() {
         .unwrap();
     // Replacing an existing attached image must strip the old trailer rather
     // than nesting containers indefinitely.
+    image
+        .write_attached_runtime(&output_path, &output_path)
+        .unwrap();
+    // Replacing an older schema must use only the version-independent trailer
+    // framing to strip it, without attempting to decode the v3 payload.
+    let mut old_version = std::fs::read(&output_path).unwrap();
+    let trailer_start = old_version.len() - NATIVE_IMAGE_TRAILER_SIZE;
+    old_version[trailer_start + NATIVE_IMAGE_VERSION_OFFSET
+        ..trailer_start + NATIVE_IMAGE_VERSION_OFFSET + 2]
+        .copy_from_slice(&3u16.to_le_bytes());
+    std::fs::write(&output_path, old_version).unwrap();
     image
         .write_attached_runtime(&output_path, &output_path)
         .unwrap();

--- a/crates/celox/tests/shared_jit_cache.rs
+++ b/crates/celox/tests/shared_jit_cache.rs
@@ -652,6 +652,27 @@ fn native_program_image_rejects_corrupt_appended_payload() {
 }
 
 #[test]
+fn native_program_image_rejects_v3_before_decoding_changed_schema() {
+    const TRAILER_SIZE: usize = 32;
+    const VERSION_OFFSET: usize = 8;
+
+    let sim = Simulator::builder(ADDER, "Top").build().unwrap();
+    let mut encoded = sim
+        .shared_code()
+        .program_image()
+        .to_container_bytes()
+        .unwrap();
+    let trailer_start = encoded.len() - TRAILER_SIZE;
+    encoded[trailer_start + VERSION_OFFSET..trailer_start + VERSION_OFFSET + 2]
+        .copy_from_slice(&3u16.to_le_bytes());
+
+    assert!(matches!(
+        celox::NativeProgramImage::discover_appended(&encoded),
+        Err(NativeImageContainerError::UnsupportedVersion(3))
+    ));
+}
+
+#[test]
 fn native_program_image_writes_an_executable_runtime_file() {
     let sim = Simulator::builder(ADDER, "Top").build().unwrap();
     let shared = sim.shared_code();

--- a/docs/internals/compiler-crate-architecture.md
+++ b/docs/internals/compiler-crate-architecture.md
@@ -66,6 +66,12 @@ therefore remain in the Veryl adapter and its source sidecars; they do not enter
 `celox-frontend-core`, `FrontendLookup`, or `ScheduledRtl`. Scheduled design
 state, SIR, optimization, layout, and backends use `celox-design` identities.
 
+`FrontendLookup` exists only through scheduling and source-testbench lowering.
+The compiler then consumes it into `RuntimeDesign`, whose flattened state table,
+instance hierarchy, and direct path/source indices form the canonical runtime
+metadata. `RuntimeProgram` and serialized native images do not retain frontend
+module-variable tables beside the elaborated design.
+
 `celox-backend-arm64` is wired directly into AArch64 native backend selection
 and emits complete scalar
 simulation kernels. Its production path temporarily uses the established

--- a/docs/internals/ir-reference.md
+++ b/docs/internals/ir-reference.md
@@ -33,10 +33,10 @@ arenas and source adapter references; `schedule_symbolic_rtl` consumes it and re
 source-independent artifacts. There is no general object whose valid fields depend on which
 passes happened to run.
 
-`FrontendLookup` also crosses this boundary, but it contains only `SourceVarId`, owned string
-paths, and their projection to `StateAddr`. Analyzer-native IDs such as Veryl's `VarId` and
-`StrId` remain in frontend compiler inputs used for testbench lowering and are discarded before
-`RuntimeProgram` is returned.
+`FrontendLookup` crosses the scheduling boundary temporarily. The compiler uses it for source
+testbench lowering, then consumes it together with `ElaboratedDesign` to construct one normalized
+`RuntimeDesign`. Analyzer-native IDs such as Veryl's `VarId` and `StrId` remain in frontend
+compiler inputs and are discarded before `RuntimeProgram` is returned.
 
 ```rust
 pub struct UnoptimizedSir {
@@ -58,8 +58,7 @@ pub struct LaidOutProgram {
 }
 
 pub struct RuntimeProgram {
-    pub design: ElaboratedDesign<AbsoluteAddr>,
-    pub frontend: FrontendLookup,
+    pub design: RuntimeDesign,
     pub runtime_schema: RuntimeSchema<AbsoluteAddr>,
     pub testbench: Option<TestbenchProgram<AbsoluteAddr>>,
 }
@@ -76,7 +75,7 @@ pub struct SirProgram {
 -   **`UnoptimizedSir`**: Internal compiler-driver result before the backend-independent SIR pass pipeline.
 -   **`OptimizedSir`**: The only pre-layout artifact accepted by layout construction.
 -   **`LaidOutProgram`**: Immutable SIR plus finalized physical layout accepted by concrete backends. Layout requirements have been consumed.
--   **`RuntimeProgram`**: Design, source lookup, runtime schema, and compiled testbench retained after code generation. It cannot contain SIR or layout requirements.
+-   **`RuntimeProgram`**: Normalized runtime design, runtime schema, and compiled testbench retained after code generation. `RuntimeDesign` is the sole owner of semantic state metadata, hierarchy, and path/source lookup indices; frontend module tables have already been discarded. It cannot contain SIR or layout requirements.
 -   **`eval_apply_ffs`**: Standard synchronous flip-flop evaluation. Used when operating in a single domain.
 -   **`eval_comb_apply_ffs`**: Fused comb/FF evaluation selected by the frontend scheduler.
 -   **`eval_only_ffs`**: Phase that only computes the next state and writes it to the Working region.


### PR DESCRIPTION
## Summary

- consume `FrontendLookup` after scheduling/testbench lowering and replace the duplicated runtime tables with a normalized `RuntimeDesign`
- use the normalized hierarchy, path, variable, and event indices for simulation, reflection, native images, Wasm, and N-API metadata
- validate runtime-design invariants at construction and native-image restoration boundaries, and document the new ownership boundary

## Validation

- `cargo check --workspace`
- `cargo clippy -p celox -p celox-design -p celox-wasm -p celox-napi --all-targets --no-deps -- -D warnings`
- `cargo test -p celox --lib flatting_tests`
- `cargo test -p celox --test hierarchy --test duplicate_varpath --test native_exec --test native_testbench --test shared_jit_cache`
- `cargo test -p celox-wasm -p celox-napi --lib`

## Notes

Workspace-wide Clippy currently stops on pre-existing Rust 1.98 lints in the unchanged ARM64 dynasm and x86 test code; linting the changed crates succeeds.