### PR TITLE
perf(napi): coalesce concurrent JIT compilation

### DIFF
--- a/crates/celox-napi/src/jit_cache.rs
+++ b/crates/celox-napi/src/jit_cache.rs
@@ -1,0 +1,269 @@
+//! Coalescing cache for expensive JIT builds.
+//!
+//! A normal lookup cache still permits a cache stampede: several callers can
+//! observe the same miss, compile the same design independently, and only then
+//! race to publish equivalent machine code. This cache reserves a missing key
+//! for one builder while concurrent callers wait for that exact build result.
+
+use fxhash::FxHashMap as HashMap;
+use std::{
+    collections::hash_map::Entry,
+    hash::Hash,
+    sync::{Arc, Mutex, OnceLock},
+};
+
+type BuildResult<V> = Result<Arc<V>, String>;
+type BuildCell<V> = OnceLock<BuildResult<V>>;
+
+/// Process-local cache which permits at most one in-flight build for each key.
+pub(crate) struct SingleFlightCache<K, V>
+where
+    K: Eq + Hash,
+{
+    entries: Mutex<HashMap<Arc<K>, Arc<BuildCell<V>>>>,
+}
+
+/// Result of looking up a cache key.
+pub(crate) enum CacheLookup<'a, K, V>
+where
+    K: Eq + Hash,
+{
+    /// A completed build was already cached, or an in-flight build completed.
+    Ready(Arc<V>),
+    /// This caller owns the reservation and must publish the build result.
+    Build(BuildPermit<'a, K, V>),
+    /// The caller joined an in-flight build which failed.
+    Failed(String),
+}
+
+/// Reservation for the sole builder of one cache key.
+///
+/// Dropping an incomplete permit removes the reservation and publishes an
+/// error, so an early return or panic cannot leave joined callers blocked.
+pub(crate) struct BuildPermit<'a, K, V>
+where
+    K: Eq + Hash,
+{
+    cache: &'a SingleFlightCache<K, V>,
+    key: Option<Arc<K>>,
+    cell: Arc<BuildCell<V>>,
+}
+
+impl<K, V> SingleFlightCache<K, V>
+where
+    K: Eq + Hash,
+{
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: Mutex::new(HashMap::default()),
+        }
+    }
+
+    /// Return a completed value, join its in-flight build, or reserve a miss.
+    pub(crate) fn lookup_or_reserve(&self, key: K) -> CacheLookup<'_, K, V> {
+        let key = Arc::new(key);
+        let (cell, should_build) = {
+            let mut entries = self
+                .entries
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            match entries.entry(Arc::clone(&key)) {
+                Entry::Occupied(entry) => (Arc::clone(entry.get()), false),
+                Entry::Vacant(entry) => {
+                    let cell = Arc::new(OnceLock::new());
+                    entry.insert(Arc::clone(&cell));
+                    (cell, true)
+                }
+            }
+        };
+
+        if should_build {
+            CacheLookup::Build(BuildPermit {
+                cache: self,
+                key: Some(key),
+                cell,
+            })
+        } else {
+            match cell.wait().clone() {
+                Ok(value) => CacheLookup::Ready(value),
+                Err(message) => CacheLookup::Failed(message),
+            }
+        }
+    }
+
+    /// Remove completed and in-flight entries.
+    ///
+    /// Builders and callers which already joined them keep their old cell
+    /// alive through `Arc`. A later build for the same key receives a different
+    /// cell, so a stale publisher cannot affect the new cache entry.
+    pub(crate) fn clear(&self) {
+        self.entries
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clear();
+    }
+
+    fn publish(
+        &self,
+        key: &Arc<K>,
+        cell: &Arc<BuildCell<V>>,
+        result: BuildResult<V>,
+    ) {
+        if result.is_err() {
+            let mut entries = self
+                .entries
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            let owns_entry = entries
+                .get(key)
+                .is_some_and(|current| Arc::ptr_eq(current, cell));
+            if owns_entry {
+                entries.remove(key);
+            }
+        }
+
+        assert!(
+            cell.set(result).is_ok(),
+            "single-flight build result published more than once"
+        );
+    }
+}
+
+impl<K, V> BuildPermit<'_, K, V>
+where
+    K: Eq + Hash,
+{
+    /// Publish the build result to both the cache and all joined callers.
+    pub(crate) fn complete(mut self, result: BuildResult<V>) {
+        let key = self
+            .key
+            .take()
+            .expect("single-flight build permit completed more than once");
+        self.cache.publish(&key, &self.cell, result);
+    }
+}
+
+impl<K, V> Drop for BuildPermit<'_, K, V>
+where
+    K: Eq + Hash,
+{
+    fn drop(&mut self) {
+        let Some(key) = self.key.take() else {
+            return;
+        };
+        self.cache.publish(
+            &key,
+            &self.cell,
+            Err("JIT compilation ended before publishing a cache result".to_string()),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        sync::{
+            Barrier,
+            atomic::{AtomicUsize, Ordering},
+        },
+        thread,
+        time::Duration,
+    };
+
+    fn get_or_build(
+        cache: &SingleFlightCache<u8, usize>,
+        key: u8,
+        build: impl FnOnce() -> Result<usize, String>,
+    ) -> Result<Arc<usize>, String> {
+        match cache.lookup_or_reserve(key) {
+            CacheLookup::Ready(value) => Ok(value),
+            CacheLookup::Failed(message) => Err(message),
+            CacheLookup::Build(permit) => {
+                let result = build().map(Arc::new);
+                permit.complete(result.clone());
+                result
+            }
+        }
+    }
+
+    #[test]
+    fn coalesces_concurrent_builds() {
+        const THREADS: usize = 8;
+
+        let cache = Arc::new(SingleFlightCache::new());
+        let build_count = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let handles = (0..THREADS)
+            .map(|_| {
+                let cache = Arc::clone(&cache);
+                let build_count = Arc::clone(&build_count);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    get_or_build(&cache, 7, || {
+                        build_count.fetch_add(1, Ordering::SeqCst);
+                        thread::sleep(Duration::from_millis(20));
+                        Ok(42)
+                    })
+                    .unwrap()
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let values = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(build_count.load(Ordering::SeqCst), 1);
+        assert!(values.iter().all(|value| **value == 42));
+        assert!(
+            values
+                .iter()
+                .skip(1)
+                .all(|value| Arc::ptr_eq(&values[0], value))
+        );
+    }
+
+    #[test]
+    fn failed_build_is_not_cached() {
+        let cache = SingleFlightCache::new();
+
+        assert_eq!(
+            get_or_build(&cache, 1, || Err("compile failed".to_string())).unwrap_err(),
+            "compile failed"
+        );
+        assert_eq!(*get_or_build(&cache, 1, || Ok(9)).unwrap(), 9);
+        assert_eq!(
+            *get_or_build(&cache, 1, || panic!("cached result expected")).unwrap(),
+            9
+        );
+    }
+
+    #[test]
+    fn clear_prevents_an_old_build_from_repopulating_the_cache() {
+        let cache = SingleFlightCache::new();
+        let old = match cache.lookup_or_reserve(3) {
+            CacheLookup::Build(permit) => permit,
+            CacheLookup::Ready(_) | CacheLookup::Failed(_) => panic!("first lookup must build"),
+        };
+
+        cache.clear();
+
+        let new = match cache.lookup_or_reserve(3) {
+            CacheLookup::Build(permit) => permit,
+            CacheLookup::Ready(_) | CacheLookup::Failed(_) => {
+                panic!("lookup after clear must build")
+            }
+        };
+        new.complete(Ok(Arc::new(2)));
+        old.complete(Ok(Arc::new(1)));
+
+        match cache.lookup_or_reserve(3) {
+            CacheLookup::Ready(value) => assert_eq!(*value, 2),
+            CacheLookup::Build(_) | CacheLookup::Failed(_) => {
+                panic!("new result must remain cached")
+            }
+        }
+    }
+}

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1,8 +1,10 @@
+#[cfg(not(target_arch = "wasm32"))]
+mod jit_cache;
 mod layout;
 
 use fxhash::FxHashMap as HashMap;
 #[cfg(not(target_arch = "wasm32"))]
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -13,6 +15,8 @@ use veryl_path::PathSet;
 
 #[cfg(not(target_arch = "wasm32"))]
 use celox::SimBackend;
+#[cfg(not(target_arch = "wasm32"))]
+use jit_cache::{CacheLookup, SingleFlightCache};
 #[cfg(not(target_arch = "wasm32"))]
 use layout::{build_event_map, build_hierarchy_node, build_signal_layout};
 
@@ -728,8 +732,8 @@ impl From<&celox::OptimizeOptions> for SirOptimizationCacheKey {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-static JIT_CACHE: std::sync::LazyLock<Mutex<HashMap<CacheKey, Arc<CachedBuild>>>> =
-    std::sync::LazyLock::new(|| Mutex::new(HashMap::default()));
+static JIT_CACHE: std::sync::LazyLock<SingleFlightCache<CacheKey, CachedBuild>> =
+    std::sync::LazyLock::new(SingleFlightCache::new);
 
 #[cfg(not(target_arch = "wasm32"))]
 /// Build a collision-free cache key from source content, top module, and options.
@@ -878,7 +882,7 @@ impl NativeSimulatorHandle {
     fn build_and_cache(
         sim: celox::Simulator,
         vcd_path: Option<&str>,
-        cache_key: Option<CacheKey>,
+        cache_build: Option<jit_cache::BuildPermit<'static, CacheKey, CachedBuild>>,
     ) -> Result<Self> {
         let four_state = sim.layout().four_state;
         let warnings_json = format_warnings_json(sim.warnings());
@@ -901,8 +905,8 @@ impl NativeSimulatorHandle {
         let hierarchy_json = serde_json::to_string(&hierarchy_node)
             .map_err(|e| Error::from_reason(format!("Failed to serialize hierarchy: {}", e)))?;
 
-        // Cache the compiled code + metadata for future instances
-        if let Some(key) = cache_key {
+        // Publish the compiled code + metadata to joined callers.
+        if let Some(cache_build) = cache_build {
             let cached = Arc::new(CachedBuild {
                 shared_code: sim.shared_code(),
                 runtime_errors: runtime_errors.clone(),
@@ -914,8 +918,7 @@ impl NativeSimulatorHandle {
                 total_size: total_size as u32,
                 vcd_descs: vcd_descs.clone(),
             });
-            let mut cache = JIT_CACHE.lock().unwrap_or_else(|e| e.into_inner());
-            cache.insert(key, cached);
+            cache_build.complete(Ok(cached));
         }
 
         // Create VcdWriter if requested
@@ -987,23 +990,29 @@ impl NativeSimulatorHandle {
 
         let cache_key = build_cache_key(&src_pairs, &top, &opts, None);
 
-        {
-            let cache = JIT_CACHE.lock().unwrap_or_else(|e| e.into_inner());
-            if let Some(cached) = cache.get(&cache_key) {
-                return Self::from_cached(cached, opts.vcd.as_deref());
+        let cache_build = match JIT_CACHE.lookup_or_reserve(cache_key) {
+            CacheLookup::Ready(cached) => {
+                return Self::from_cached(&cached, opts.vcd.as_deref());
             }
-        }
+            CacheLookup::Build(cache_build) => cache_build,
+            CacheLookup::Failed(message) => return Err(Error::from_reason(message)),
+        };
 
         let source_refs: Vec<(&str, &std::path::Path)> = src_pairs
             .iter()
             .map(|(s, p)| (s.as_str(), p.as_path()))
             .collect();
         let builder = apply_options(celox::Simulator::from_sources(source_refs, &top), &opts);
-        let sim = builder
-            .build()
-            .map_err(|e| Error::from_reason(format!("{}", e)))?;
+        let sim = match builder.build() {
+            Ok(sim) => sim,
+            Err(error) => {
+                let message = error.to_string();
+                cache_build.complete(Err(message.clone()));
+                return Err(Error::from_reason(message));
+            }
+        };
 
-        Self::build_and_cache(sim, opts.vcd.as_deref(), Some(cache_key))
+        Self::build_and_cache(sim, opts.vcd.as_deref(), Some(cache_build))
     }
 
     /// Create a simulator from a versioned external-frontend artifact.
@@ -1034,12 +1043,13 @@ impl NativeSimulatorHandle {
 
         let cache_key = build_cache_key(&sources, &top, &opts, Some(&metadata));
 
-        {
-            let cache = JIT_CACHE.lock().unwrap_or_else(|e| e.into_inner());
-            if let Some(cached) = cache.get(&cache_key) {
-                return Self::from_cached(cached, opts.vcd.as_deref());
+        let cache_build = match JIT_CACHE.lookup_or_reserve(cache_key) {
+            CacheLookup::Ready(cached) => {
+                return Self::from_cached(&cached, opts.vcd.as_deref());
             }
-        }
+            CacheLookup::Build(cache_build) => cache_build,
+            CacheLookup::Failed(message) => return Err(Error::from_reason(message)),
+        };
 
         let source_refs: Vec<(&str, &std::path::Path)> = sources
             .iter()
@@ -1050,11 +1060,16 @@ impl NativeSimulatorHandle {
             celox::Simulator::from_sources(source_refs, &top).with_metadata(metadata),
             &opts,
         );
-        let sim = builder
-            .build()
-            .map_err(|e| Error::from_reason(format!("{}", e)))?;
+        let sim = match builder.build() {
+            Ok(sim) => sim,
+            Err(error) => {
+                let message = error.to_string();
+                cache_build.complete(Err(message.clone()));
+                return Err(Error::from_reason(message));
+            }
+        };
 
-        Self::build_and_cache(sim, opts.vcd.as_deref(), Some(cache_key))
+        Self::build_and_cache(sim, opts.vcd.as_deref(), Some(cache_build))
     }
 
     /// Returns the signal layout as a JSON string.
@@ -2166,8 +2181,7 @@ fn format_errors_with_warnings(
 #[cfg(not(target_arch = "wasm32"))]
 #[napi]
 pub fn clear_jit_cache() {
-    let mut cache = JIT_CACHE.lock().unwrap_or_else(|e| e.into_inner());
-    cache.clear();
+    JIT_CACHE.clear();
 }
 
 /// Stub for wasm32: no JIT cache to clear.


### PR DESCRIPTION
## Summary

Celox already has target-owned native JIT backends for x86-64 and AArch64, with the Cranelift backend available on other native targets. The N-API layer also shares compiled code between simulator instances, but its previous check-then-build cache allowed concurrent constructors for the same design to all observe a miss and compile identical machine code independently.

This change turns that process-global cache into a single-flight cache:

- at most one caller compiles a given collision-free `CacheKey` at a time;
- concurrent callers wait without holding the global cache mutex, then reuse the same `Arc<CachedBuild>`;
- compilation failures are broadcast to joined callers but are not retained in the cache, so later calls can retry;
- an abandoned build permit publishes an error instead of leaving joined callers blocked;
- `clearJitCache()` detaches old build cells, so an in-flight stale publisher cannot affect a replacement entry for the same key;
- per-instance simulation memory and VCD writers remain independent, matching the existing cache-hit behavior.

## Implementation

`crates/celox-napi/src/jit_cache.rs` contains a small generic `SingleFlightCache<K, V>` built from `Mutex`, `OnceLock`, and `Arc`. The mutex protects only the key-to-cell map. Compilation happens outside that lock, and waiters block on the per-key `OnceLock`.

`NativeSimulatorHandle::new` and `NativeSimulatorHandle::from_project` reserve their cache key before compilation and publish either the completed shared build or the exact compilation error. The first caller continues using the backend from the freshly built `Simulator`; only joined and subsequent callers reconstruct a backend from the shared code image. This preserves the existing initialization path while eliminating duplicate compilation.

Cache keys are held through `Arc` while a build is in flight, avoiding another deep clone of the source-bearing `CacheKey`.

## Tests

Added unit coverage for:

- eight concurrent callers producing exactly one build and sharing one result;
- failed builds being retriable rather than cached;
- cache clearing winning against a stale in-flight publisher.

Repository CI provides workspace formatting, lint, native cross-platform build, WASM compatibility, correctness, and benchmark validation for the draft.