### PR TITLE
fix(ci): restore pull request merge checks

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -19,42 +19,6 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
 
-      # The default branch does not contain these files while PR #644 is being
-      # introduced. After it lands, queued changes cannot replace the validator
-      # scripts fetched by their own required check.
-      - name: Locate trusted release validators
-        id: release-validators
-        shell: bash
-        run: |
-          if [[ -f scripts/check-release-repository-settings.mjs && -f scripts/check-pr-release-impact.mjs ]]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Authorize the initial validator rollout
-        id: initial-rollout
-        if: github.event_name == 'merge_group' && steps.release-validators.outputs.available != 'true'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
-          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
-        run: |
-          rollout_head="$(gh api "repos/$GITHUB_REPOSITORY/pulls/644" --jq .head.sha)"
-          group_commits="$(gh api --paginate "repos/$GITHUB_REPOSITORY/compare/$MERGE_GROUP_BASE_SHA...$MERGE_GROUP_HEAD_SHA?per_page=100" --jq '.commits[].sha')"
-          if grep -Fxq "$rollout_head" <<< "$group_commits"; then
-            echo "authorized=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "authorized=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Validate release merge settings
-        if: steps.release-validators.outputs.available == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: node scripts/check-release-repository-settings.mjs
-
       - name: Validate pull request title
         if: github.event_name == 'pull_request_target'
         env:
@@ -62,7 +26,7 @@ jobs:
         run: node scripts/check-pr-title.mjs "$PR_TITLE"
 
       - name: Validate pull request commit release impact
-        if: github.event_name == 'pull_request_target' && github.event.pull_request.base.ref == github.event.repository.default_branch && steps.release-validators.outputs.available == 'true'
+        if: github.event_name == 'pull_request_target' && github.event.pull_request.base.ref == github.event.repository.default_branch
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -70,20 +34,10 @@ jobs:
         run: node scripts/check-pr-release-impact.mjs
 
       - name: Revalidate merge group release impact
-        if: github.event_name == 'merge_group' && github.event.merge_group.base_ref == format('refs/heads/{0}', github.event.repository.default_branch) && steps.release-validators.outputs.available == 'true'
+        if: github.event_name == 'merge_group' && github.event.merge_group.base_ref == format('refs/heads/{0}', github.event.repository.default_branch)
         env:
           GH_TOKEN: ${{ github.token }}
           MERGE_GROUP_BASE_REF: ${{ github.event.merge_group.base_ref }}
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
           MERGE_GROUP_SHA: ${{ github.event.merge_group.head_sha }}
         run: node scripts/check-pr-release-impact.mjs
-
-      - name: Preserve the initial validator rollout
-        if: steps.initial-rollout.outputs.authorized == 'true'
-        run: echo "This merge group introduces the trusted release validators."
-
-      - name: Reject missing trusted release validators
-        if: steps.release-validators.outputs.available != 'true' && steps.initial-rollout.outputs.authorized != 'true'
-        run: |
-          echo "Trusted release validators are missing from the default branch." >&2
-          exit 1

--- a/scripts/check-pr-title.test.mjs
+++ b/scripts/check-pr-title.test.mjs
@@ -35,7 +35,9 @@ test("guards the repository setting that exposes the title to release automation
     "utf8",
   );
 
-  assert.match(
+  // The Actions GITHUB_TOKEN cannot read repository administration settings;
+  // running that audit here would fail every required title check.
+  assert.doesNotMatch(
     workflow,
     /run: node scripts\/check-release-repository-settings\.mjs/,
   );
@@ -47,30 +49,10 @@ test("guards the repository setting that exposes the title to release automation
   );
   assert.match(
     workflow,
-    /Locate trusted release validators[\s\S]*id: release-validators[\s\S]*check-release-repository-settings\.mjs[\s\S]*check-pr-release-impact\.mjs/,
-  );
-  assert.match(
-    workflow,
-    /Authorize the initial validator rollout[\s\S]*id: initial-rollout[\s\S]*MERGE_GROUP_BASE_SHA:[\s\S]*MERGE_GROUP_HEAD_SHA:[\s\S]*compare\/\$MERGE_GROUP_BASE_SHA\.\.\.\$MERGE_GROUP_HEAD_SHA[\s\S]*grep -Fxq "\$rollout_head"/,
-  );
-  assert.match(
-    workflow,
-    /Validate release merge settings\n\s+if: steps\.release-validators\.outputs\.available == 'true'/,
-  );
-  assert.match(
-    workflow,
     /Validate pull request commit release impact\n\s+if: github\.event_name == 'pull_request_target' && github\.event\.pull_request\.base\.ref == github\.event\.repository\.default_branch/,
   );
   assert.match(
     workflow,
     /Revalidate merge group release impact\n\s+if: github\.event_name == 'merge_group' && github\.event\.merge_group\.base_ref == format\('refs\/heads\/\{0\}', github\.event\.repository\.default_branch\)[\s\S]*MERGE_GROUP_BASE_REF:[\s\S]*MERGE_GROUP_HEAD_REF:[\s\S]*MERGE_GROUP_SHA:[\s\S]*run: node scripts\/check-pr-release-impact\.mjs/,
-  );
-  assert.match(
-    workflow,
-    /Preserve the initial validator rollout\n\s+if: steps\.initial-rollout\.outputs\.authorized == 'true'/,
-  );
-  assert.match(
-    workflow,
-    /Reject missing trusted release validators\n\s+if: steps\.release-validators\.outputs\.available != 'true'/,
   );
 });


### PR DESCRIPTION
Remove the repository-administration audit from the required PR Title workflow. The workflow GITHUB_TOKEN cannot read those settings, so the audit returned undefined for every merge setting and blocked every pull request.\n\nKeep conventional-title and release-impact validation, and remove the completed one-time rollout scaffolding.\n\nValidation: node --test scripts/*.test.mjs (62 passed); pre-push cargo fmt, Biome, cargo check, submodule and clean-tree checks passed.