### PR TITLE
feat(backend): add tier-0 SIR interpreter for tiered execution

### DIFF
--- a/crates/celox/src/backend.rs
+++ b/crates/celox/src/backend.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "host-runtime")]
+pub(crate) mod interp;
 pub(crate) mod memory_layout;
 #[cfg(all(
     feature = "host-runtime",
@@ -22,6 +24,7 @@ pub use traits::{EventHandle, SimBackend};
 
 #[cfg(feature = "host-runtime")]
 mod host {
+    pub use super::interp::InterpBackend;
     pub use super::runtime::{EventRef, JitBackend, SharedJitCode};
     pub(crate) use celox_backend_cranelift::JitEngine;
     pub use celox_backend_cranelift::{

--- a/crates/celox/src/backend/interp.rs
+++ b/crates/celox/src/backend/interp.rs
@@ -548,7 +548,7 @@ impl SimBackend for InterpBackend {
     type Event = InterpEventRef;
 
     fn eval_comb(&mut self) -> Result<(), SimulatorErrorCode> {
-        Self::run_units(
+        run_units(
             &mut self.memory,
             &self.layout,
             self.four_state,
@@ -558,7 +558,7 @@ impl SimBackend for InterpBackend {
     }
 
     fn eval_apply_ff_at(&mut self, event: InterpEventRef) -> Result<(), SimulatorErrorCode> {
-        Self::run_units(
+        run_units(
             &mut self.memory,
             &self.layout,
             self.four_state,
@@ -571,7 +571,7 @@ impl SimBackend for InterpBackend {
     }
 
     fn eval_only_ff_at(&mut self, event: InterpEventRef) -> Result<(), SimulatorErrorCode> {
-        Self::run_units(
+        run_units(
             &mut self.memory,
             &self.layout,
             self.four_state,
@@ -584,7 +584,7 @@ impl SimBackend for InterpBackend {
     }
 
     fn apply_ff_at(&mut self, event: InterpEventRef) -> Result<(), SimulatorErrorCode> {
-        Self::run_units(
+        run_units(
             &mut self.memory,
             &self.layout,
             self.four_state,

--- a/crates/celox/src/backend/interp.rs
+++ b/crates/celox/src/backend/interp.rs
@@ -1006,13 +1006,20 @@ impl InterpBackend {
             addrs.dedup();
             event_trigger_addrs.insert(*clock, addrs);
         }
+        // Split scheduling can register the same canonical clock under both
+        // maps; merge the address sets so neither phase loses snapshots.
         for (clock, units) in laid_out
             .sir
             .eval_only_ffs
             .iter()
             .chain(&laid_out.sir.apply_ffs)
         {
-            event_trigger_addrs.insert(*clock, collect_trigger_addrs(units));
+            let entry = event_trigger_addrs.entry(*clock).or_default();
+            let mut addrs = collect_trigger_addrs(units);
+            addrs.extend(entry.iter().copied());
+            addrs.sort_unstable();
+            addrs.dedup();
+            *entry = addrs;
         }
 
         let mut backend = Self {

--- a/crates/celox/src/backend/interp.rs
+++ b/crates/celox/src/backend/interp.rs
@@ -546,8 +546,9 @@ impl InterpMachine<RegionedAbsoluteAddr> for Machine<'_> {
             return;
         }
         // Change detection identical to the compiled backends: the object's
-        // first word is compared against the group-entry snapshot and the
-        // trigger bits are only marked on an actual change.
+        // declared bits are compared against the group-entry snapshot and the
+        // trigger bits are only marked on an actual change. Masking to the
+        // signal width keeps adjacent packed state out of the comparison.
         let absolute = addr.absolute_addr();
         let Some(&snapshot) = self.trigger_snapshots.get(&(absolute, addr.region)) else {
             return;
@@ -556,7 +557,13 @@ impl InterpMachine<RegionedAbsoluteAddr> for Machine<'_> {
             return;
         };
         // Safety: layout-mapped objects fit inside the merged image.
-        let current = unsafe { self.read_u64(base) };
+        let bits = self.layout.widths[&absolute];
+        let signal_mask = if bits >= 64 {
+            u64::MAX
+        } else {
+            (1u64 << bits) - 1
+        };
+        let current = unsafe { self.read_u64(base) } & signal_mask;
         if current == snapshot {
             return;
         }
@@ -721,8 +728,19 @@ fn run_units(
             trigger_snapshots: &trigger_snapshots,
         };
         if let Ok(base) = machine.object_offset(&addr) {
+            // Snapshot only the declared signal bits: packed neighbors share
+            // the same word and must not influence change detection.
             // Safety: layout-mapped objects fit inside the merged image.
-            trigger_snapshots.insert((absolute, region), unsafe { read_word(memory, base) });
+            let bits = layout.widths[&absolute];
+            let mask = if bits >= 64 {
+                u64::MAX
+            } else {
+                (1u64 << bits) - 1
+            };
+            trigger_snapshots.insert(
+                (absolute, region),
+                unsafe { read_word(memory, base) } & mask,
+            );
         }
     }
 
@@ -776,6 +794,10 @@ pub struct InterpBackend {
     id_to_addr: Vec<AbsoluteAddr>,
     id_to_event: Vec<InterpEventRef>,
     four_state_inits: Vec<(usize, usize)>,
+    /// Units for the fused comb+FF tick of each event, mirroring the
+    /// compiled `comb_apply_func`: fused schedules when present, otherwise
+    /// comb units followed by the clock's FF units.
+    comb_apply_units: HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
 }
 
 impl InterpBackend {
@@ -887,6 +909,31 @@ impl InterpBackend {
             }
         }
 
+        // Deferred testbench ticks require the scheduler's combined comb/FF
+        // program; executing independently scheduled comb and FF units can
+        // observe a different pre-edge snapshot around reset and NBA regions,
+        // exactly as with the compiled backends.
+        let mut comb_apply_units: HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>> =
+            HashMap::default();
+        for (clock, ff_units) in &laid_out.sir.eval_apply_ffs {
+            let units = if let Some(fused) = laid_out.sir.eval_comb_apply_ffs.get(clock) {
+                fused.clone()
+            } else {
+                let mut combined = laid_out.sir.eval_comb.clone();
+                combined.extend(ff_units.iter().cloned());
+                combined
+            };
+            comb_apply_units.insert(*clock, units);
+        }
+        for (clock, units) in laid_out
+            .sir
+            .eval_only_ffs
+            .iter()
+            .chain(&laid_out.sir.apply_ffs)
+        {
+            comb_apply_units.insert(*clock, units.clone());
+        }
+
         let mut backend = Self {
             program_sir,
             layout,
@@ -900,6 +947,7 @@ impl InterpBackend {
             id_to_addr,
             id_to_event,
             four_state_inits,
+            comb_apply_units,
         };
         backend.install_event_buffers();
         Ok(backend)
@@ -958,6 +1006,16 @@ impl SimBackend for InterpBackend {
                 .eval_apply_ffs
                 .get(&event.addr())
                 .expect("scheduled event missing from SIR program"),
+        )
+    }
+
+    fn eval_comb_apply_ff_at(&mut self, event: InterpEventRef) -> Result<(), SimulatorErrorCode> {
+        run_units(
+            &mut self.memory,
+            &self.layout,
+            self.four_state,
+            &mut self.comb_capture_enabled,
+            &self.comb_apply_units[&event.addr()],
         )
     }
 

--- a/crates/celox/src/backend/interp.rs
+++ b/crates/celox/src/backend/interp.rs
@@ -307,7 +307,11 @@ impl Machine<'_> {
                 .cast::<u8>()
                 .add(RUNTIME_EVENT_HEADER_SIZE + slot_index * self.layout.runtime_event_slot_size);
             let slot_seq = slot_base.add(RUNTIME_EVENT_SLOT_SEQ_OFFSET) as *const AtomicU64;
-            (*slot_seq).store(RUNTIME_EVENT_WRITING, Ordering::Relaxed);
+            // Publish the writing marker with an RMW like the compiled
+            // writer: the exchange orders it ahead of the plain payload
+            // stores below, so a concurrent drain can never observe a torn
+            // mix of the old committed record and the new one.
+            (*slot_seq).swap(RUNTIME_EVENT_WRITING, Ordering::AcqRel);
             slot_base
                 .add(RUNTIME_EVENT_SLOT_SITE_OFFSET)
                 .cast::<u64>()

--- a/crates/celox/src/backend/interp.rs
+++ b/crates/celox/src/backend/interp.rs
@@ -10,11 +10,12 @@
 //! execution units between the interpreter and compiled tiers without any
 //! state translation.
 //!
-//! Trigger marking follows the compiled change-detection protocol: the
-//! first word of every trigger-bearing object is snapshotted at group entry
-//! and trigger bits are marked only when a store or commit changes it. As in
-//! the compiled backends, `TriggerIdWithKind.kind` does not influence code
-//! execution.
+//! Trigger marking follows the compiled per-kind protocol: the first word
+//! of every trigger-bearing object is snapshotted at group entry, and each
+//! store or commit with triggers extracts its range's old and new values to
+//! detect posedge/negedge edges and active reset levels. Marking only runs
+//! when the backend is constructed with `emit_triggers`, like the compiled
+//! codegen flag.
 
 #![cfg(feature = "host-runtime")]
 
@@ -92,9 +93,12 @@ struct Machine<'a> {
     four_state: bool,
     /// Per-site enable bytes for comb capture events.
     comb_capture_enabled: &'a mut [u8],
-    /// First-word snapshots of trigger-bearing objects taken at group entry;
-    /// trigger bits are only marked when a store changes the value.
+    /// First-word snapshots of trigger-bearing objects taken at group entry,
+    /// used by per-kind trigger edge detection.
     trigger_snapshots: &'a HashMap<(AbsoluteAddr, u32), u64>,
+    /// Whether trigger detection may mark bits; mirrors the compiled
+    /// `emit_triggers` codegen flag.
+    emit_triggers: bool,
 }
 
 impl Machine<'_> {
@@ -541,35 +545,52 @@ impl InterpMachine<RegionedAbsoluteAddr> for Machine<'_> {
         Ok(())
     }
 
-    fn notify_triggers(&mut self, addr: &RegionedAbsoluteAddr, triggers: &[TriggerIdWithKind]) {
-        if triggers.is_empty() {
-            return;
+    fn notify_triggers(
+        &mut self,
+        addr: &RegionedAbsoluteAddr,
+        access: ResolvedAccess<'_>,
+        bits: usize,
+        triggers: &[TriggerIdWithKind],
+    ) -> Result<(), InterpError> {
+        if !self.emit_triggers || triggers.is_empty() {
+            return Ok(());
         }
-        // Change detection identical to the compiled backends: the object's
-        // declared bits are compared against the group-entry snapshot and the
-        // trigger bits are only marked on an actual change. Masking to the
-        // signal width keeps adjacent packed state out of the comparison.
+        // Per-kind edge detection identical to the compiled lowering: the
+        // stored range's old value comes from the group-entry snapshot and
+        // its new value from live memory, both confined to the first word.
         let absolute = addr.absolute_addr();
         let Some(&snapshot) = self.trigger_snapshots.get(&(absolute, addr.region)) else {
-            return;
+            return Ok(());
         };
-        let Ok(base) = self.object_offset(addr) else {
-            return;
-        };
-        // Safety: layout-mapped objects fit inside the merged image.
-        let bits = self.layout.widths[&absolute];
-        let signal_mask = if bits >= 64 {
+        let base = self.object_offset(addr)?;
+        let bit_offset = self.access_bit_offset(access.offset, &access.dynamics)?;
+        let range_mask = if bits >= 64 {
             u64::MAX
         } else {
             (1u64 << bits) - 1
         };
-        let current = unsafe { self.read_u64(base) } & signal_mask;
-        if current == snapshot {
-            return;
-        }
+        let old = if bit_offset >= 64 {
+            0
+        } else {
+            (snapshot >> bit_offset) & range_mask
+        };
+        let new = self
+            .read_bits(base, bit_offset, bits.min(64))
+            .to_u64()
+            .unwrap_or(0);
         for trigger in triggers {
-            self.mark_trigger_bit(trigger.id);
+            let marked = match trigger.kind {
+                celox_sir::DomainKind::ClockPosedge => old == 0 && new == 1,
+                celox_sir::DomainKind::ClockNegedge => old == 1 && new == 0,
+                celox_sir::DomainKind::ResetAsyncHigh => new == 1,
+                celox_sir::DomainKind::ResetAsyncLow => new == 0,
+                celox_sir::DomainKind::Other => old != new,
+            };
+            if marked {
+                self.mark_trigger_bit(trigger.id);
+            }
         }
+        Ok(())
     }
 
     fn capture_store_range(
@@ -708,15 +729,17 @@ fn collect_trigger_addrs(
 }
 
 /// Execute every unit in `units` against the split backend storage.
+#[allow(clippy::too_many_arguments)]
 fn run_units(
     memory: &mut Vec<u64>,
     layout: &MemoryLayout,
     four_state: bool,
     comb_capture_enabled: &mut [u8],
     units: &[ExecutionUnit<RegionedAbsoluteAddr>],
+    emit_triggers: bool,
 ) -> Result<(), SimulatorErrorCode> {
     // Snapshot the first word of every trigger-bearing object at group
-    // entry; stores mark trigger bits only when the value actually changed.
+    // entry; trigger detection compares the stored range against it.
     let mut trigger_snapshots: HashMap<(AbsoluteAddr, u32), u64> = HashMap::default();
     for (absolute, region) in collect_trigger_addrs(units) {
         let addr = RegionedAbsoluteAddrBase::from_absolute_addr(region, absolute);
@@ -726,21 +749,13 @@ fn run_units(
             four_state,
             comb_capture_enabled: &mut *comb_capture_enabled,
             trigger_snapshots: &trigger_snapshots,
+            emit_triggers,
         };
         if let Ok(base) = machine.object_offset(&addr) {
-            // Snapshot only the declared signal bits: packed neighbors share
-            // the same word and must not influence change detection.
+            // Snapshot the raw first word; trigger detection extracts the
+            // stored range from it, so packed neighbors never leak in.
             // Safety: layout-mapped objects fit inside the merged image.
-            let bits = layout.widths[&absolute];
-            let mask = if bits >= 64 {
-                u64::MAX
-            } else {
-                (1u64 << bits) - 1
-            };
-            trigger_snapshots.insert(
-                (absolute, region),
-                unsafe { read_word(memory, base) } & mask,
-            );
+            trigger_snapshots.insert((absolute, region), unsafe { read_word(memory, base) });
         }
     }
 
@@ -753,6 +768,7 @@ fn run_units(
             four_state,
             comb_capture_enabled: &mut *comb_capture_enabled,
             trigger_snapshots: &trigger_snapshots,
+            emit_triggers,
         };
         // Entry blocks of top-level execution units take no parameters: the
         // compiled ABI passes only the memory pointer, so all inputs arrive
@@ -798,6 +814,9 @@ pub struct InterpBackend {
     /// compiled `comb_apply_func`: fused schedules when present, otherwise
     /// comb units followed by the clock's FF units.
     comb_apply_units: HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
+    /// Whether trigger detection marks bits; matches the compiled
+    /// `emit_triggers` codegen flag.
+    emit_triggers: bool,
 }
 
 impl InterpBackend {
@@ -925,14 +944,8 @@ impl InterpBackend {
             };
             comb_apply_units.insert(*clock, units);
         }
-        for (clock, units) in laid_out
-            .sir
-            .eval_only_ffs
-            .iter()
-            .chain(&laid_out.sir.apply_ffs)
-        {
-            comb_apply_units.insert(*clock, units.clone());
-        }
+        // Only eval/apply clocks receive combined ticks; eval-only and
+        // apply-only groups fall back to the default two-phase evaluation.
 
         let mut backend = Self {
             program_sir,
@@ -948,6 +961,7 @@ impl InterpBackend {
             id_to_event,
             four_state_inits,
             comb_apply_units,
+            emit_triggers: options.emit_triggers,
         };
         backend.install_event_buffers();
         Ok(backend)
@@ -993,6 +1007,7 @@ impl SimBackend for InterpBackend {
             self.four_state,
             &mut self.comb_capture_enabled,
             &self.program_sir.eval_comb,
+            self.emit_triggers,
         )
     }
 
@@ -1006,16 +1021,23 @@ impl SimBackend for InterpBackend {
                 .eval_apply_ffs
                 .get(&event.addr())
                 .expect("scheduled event missing from SIR program"),
+            self.emit_triggers,
         )
     }
 
     fn eval_comb_apply_ff_at(&mut self, event: InterpEventRef) -> Result<(), SimulatorErrorCode> {
+        let Some(units) = self.comb_apply_units.get(&event.addr()) else {
+            // Events outside the eval/apply map keep the default ordering.
+            self.eval_comb()?;
+            return self.eval_apply_ff_at(event);
+        };
         run_units(
             &mut self.memory,
             &self.layout,
             self.four_state,
             &mut self.comb_capture_enabled,
-            &self.comb_apply_units[&event.addr()],
+            units,
+            self.emit_triggers,
         )
     }
 
@@ -1029,6 +1051,7 @@ impl SimBackend for InterpBackend {
                 .eval_only_ffs
                 .get(&event.addr())
                 .expect("scheduled event missing from SIR program"),
+            self.emit_triggers,
         )
     }
 
@@ -1042,6 +1065,7 @@ impl SimBackend for InterpBackend {
                 .apply_ffs
                 .get(&event.addr())
                 .expect("scheduled event missing from SIR program"),
+            self.emit_triggers,
         )
     }
 

--- a/crates/celox/src/backend/interp.rs
+++ b/crates/celox/src/backend/interp.rs
@@ -1,0 +1,897 @@
+//! Tier-0 interpreting execution backend.
+//!
+//! [`InterpBackend`] implements [`SimBackend`] by executing the laid-out SIR
+//! directly on the Tier-0 interpreter ([`crate::interpreter::execute_unit`])
+//! instead of generated machine code. It shares the exact memory image ABI
+//! with [`super::JitBackend`] — little-endian byte packing, four-state value
+//! and mask regions stored adjacently per object, the runtime-event-buffer
+//! and comb-capture-enable pointers installed into the state header, and the
+//! triggered-bits bitset region — so a simulation can migrate individual
+//! execution units between the interpreter and compiled tiers without any
+//! state translation.
+//!
+//! Known gaps versus the compiled backends (all fail loud or degrade
+//! visibly, never silently corrupt):
+//!
+//! - `RuntimeEvent` / `CombCaptureEvent` instructions are currently no-ops
+//!   because the interpreter does not yet write the `RuntimeEventBuffer`
+//!   record ABI that generated code uses.
+//! - Trigger notification marks the trigger bit on every qualifying
+//!   store/commit (a level-style over-approximation of the compiled
+//!   edge/level detection).
+//! - `SPARSE_WORKING_REGION` accesses report a machine error instead of
+//!   guessing at an unmapped storage region.
+
+#![cfg(feature = "host-runtime")]
+
+use std::sync::Arc;
+
+use celox_sir::{ExecutionUnit, SIROffset, SIRValue, TriggerIdWithKind};
+use num_bigint::BigUint;
+use num_traits::{ToPrimitive, Zero};
+
+use super::{
+    EventHandle, MemoryLayout, RuntimeEventBuffer, SimBackend, SimulatorErrorCode, get_byte_size,
+};
+use crate::interpreter::{InterpError, InterpMachine, ResolvedAccess, execute_unit};
+use crate::ir::{STABLE_REGION, WORKING_REGION};
+use crate::{
+    HashMap, SimulatorError, SimulatorOptions,
+    ir::{AbsoluteAddr, LaidOutProgram, RegionedAbsoluteAddr, SignalRef},
+};
+
+/// Opaque handle to an interpreted event (clock / async-reset) group.
+///
+/// Mirrors [`super::EventRef`] minus the compiled function pointers: the
+/// address selects the SIR execution-unit group and the id participates in
+/// scheduler ordering and triggered-bit bookkeeping.
+#[derive(Clone, Copy, Debug)]
+pub struct InterpEventRef {
+    addr: AbsoluteAddr,
+    id: usize,
+}
+
+impl EventHandle for InterpEventRef {
+    fn id(&self) -> usize {
+        self.id
+    }
+
+    fn addr(&self) -> AbsoluteAddr {
+        self.addr
+    }
+}
+
+/// Map an interpreter failure onto the backend error code space.
+///
+/// `SIRTerminator::Error` carries a positive true-loop convergence code,
+/// matching the compiled contract where a positive return value reports
+/// [`SimulatorErrorCode::DetectedTrueLoopCode`].
+fn error_code(error: InterpError) -> SimulatorErrorCode {
+    match error {
+        InterpError::Fatal(code) if code > 0 => SimulatorErrorCode::DetectedTrueLoopCode(code),
+        _ => SimulatorErrorCode::InternalError,
+    }
+}
+
+fn low_mask(bits: usize) -> BigUint {
+    if bits == 0 {
+        BigUint::zero()
+    } else {
+        (BigUint::from(1u8) << bits) - 1u8
+    }
+}
+
+/// Interpreter view over one backend's live memory image.
+///
+/// Holds split borrows of the backend's storage so execution-unit slices can
+/// be borrowed immutably from the SIR program at the same time.
+struct Machine<'a> {
+    memory: &'a mut Vec<u64>,
+    layout: &'a MemoryLayout,
+    four_state: bool,
+    /// Reserved for comb-capture bookkeeping once the runtime-event record
+    /// ABI is implemented; kept in the struct so the borrow split stays
+    /// identical to the final shape.
+    #[allow(dead_code)]
+    comb_capture_enabled: &'a mut [u8],
+}
+
+impl Machine<'_> {
+    fn byte_slice(&self, start: usize, len: usize) -> &[u8] {
+        // Safety: the layout guarantees every mapped object, its mask region,
+        // and the trigger bitset fit inside the merged memory allocation.
+        unsafe { std::slice::from_raw_parts((self.memory.as_ptr() as *const u8).add(start), len) }
+    }
+
+    /// Resolve a regioned SIR address to its byte offset in the merged image.
+    ///
+    /// Only regions with a dedicated layout table are supported; anything
+    /// else fails loudly rather than aliasing into unrelated storage.
+    fn object_offset(&self, addr: &RegionedAbsoluteAddr) -> Result<usize, InterpError> {
+        let absolute = addr.absolute_addr();
+        let mapped = if addr.region == STABLE_REGION {
+            self.layout.offsets.get(&absolute).copied()
+        } else if addr.region == WORKING_REGION {
+            self.layout
+                .working_offsets
+                .get(&absolute)
+                .map(|relative| self.layout.working_base_offset + relative)
+        } else {
+            None
+        };
+        mapped.ok_or_else(|| {
+            InterpError::Machine(format!(
+                "no interpreter storage mapped for {} in the addressed region",
+                absolute
+            ))
+        })
+    }
+
+    /// Resolve a SIR access to its bit offset within the addressed object.
+    fn access_bit_offset(
+        &self,
+        offset: &SIROffset,
+        dynamics: &[Option<&SIRValue>; 2],
+    ) -> Result<usize, InterpError> {
+        fn dynamic(dynamics: &[Option<&SIRValue>; 2], slot: usize) -> Result<usize, InterpError> {
+            dynamics[slot]
+                .and_then(|value| value.payload.to_usize())
+                .ok_or_else(|| {
+                    InterpError::Machine(
+                        "dynamic access offset is missing or unrepresentable".to_string(),
+                    )
+                })
+        }
+
+        match offset {
+            SIROffset::Static(bit_offset) => Ok(*bit_offset),
+            SIROffset::Dynamic(_) => dynamic(dynamics, 0),
+            SIROffset::Element {
+                element_width,
+                bit_offset,
+                ..
+            } => {
+                let index = dynamic(dynamics, 0)?;
+                let extra = if dynamics[1].is_some() {
+                    dynamic(dynamics, 1)?
+                } else {
+                    0
+                };
+                Ok(index * element_width + bit_offset + extra)
+            }
+            SIROffset::PackedElements { bit_offset, .. } => Ok(*bit_offset),
+        }
+    }
+
+    fn width_of(&self, absolute: &AbsoluteAddr) -> usize {
+        self.layout.widths.get(absolute).copied().unwrap_or(0)
+    }
+
+    fn is_4state_object(&self, absolute: &AbsoluteAddr) -> bool {
+        self.four_state && self.layout.is_4states.get(absolute).copied().unwrap_or(false)
+    }
+
+    /// Read `bits` starting at `bit_offset` within the object at
+    /// `byte_offset`. Bits past the object's declared width are never
+    /// produced because every caller passes layout-derived widths.
+    fn read_bits(&self, byte_offset: usize, bit_offset: usize, bits: usize) -> BigUint {
+        if bits == 0 {
+            return BigUint::zero();
+        }
+        let shift = bit_offset % 8;
+        let byte_len = (shift + bits).div_ceil(8);
+        let raw = BigUint::from_bytes_le(self.byte_slice(byte_offset + bit_offset / 8, byte_len));
+        let shifted = if shift > 0 { raw >> shift } else { raw };
+        shifted & low_mask(bits)
+    }
+
+    /// Read-modify-write `bits` starting at `bit_offset`, preserving every
+    /// other bit in the covered bytes.
+    fn write_bits(&mut self, byte_offset: usize, bit_offset: usize, bits: usize, value: &BigUint) {
+        if bits == 0 {
+            return;
+        }
+        let shift = bit_offset % 8;
+        let byte_len = (shift + bits).div_ceil(8);
+        let start = byte_offset + bit_offset / 8;
+        let domain = low_mask(byte_len * 8);
+        let field_mask = low_mask(bits) << shift;
+        let mut current = BigUint::from_bytes_le(self.byte_slice(start, byte_len));
+        current &= &domain ^ &field_mask;
+        current |= (value & low_mask(bits)) << shift;
+        let bytes = current.to_bytes_le();
+        // Safety: `start + byte_len` stays inside the merged allocation for
+        // every layout-mapped object, as with the compiled backends.
+        let destination = unsafe { (self.memory.as_mut_ptr() as *mut u8).add(start) };
+        for index in 0..byte_len {
+            unsafe {
+                *destination.add(index) = bytes.get(index).copied().unwrap_or(0);
+            }
+        }
+    }
+
+    fn mark_trigger_bit(&mut self, id: usize) {
+        let offset = self.layout.triggered_bits_offset + id / 8;
+        let end = self.layout.triggered_bits_offset + self.layout.triggered_bits_total_size;
+        if offset >= end {
+            return;
+        }
+        // Safety: bounds-checked against the trigger bitset region above.
+        unsafe {
+            *self.byte_mut(offset) |= 1 << (id % 8);
+        }
+    }
+
+    // Safety: callers bound `offset` inside the merged allocation.
+    fn byte_mut(&mut self, offset: usize) -> *mut u8 {
+        unsafe { (self.memory.as_mut_ptr() as *mut u8).add(offset) }
+    }
+}
+
+impl InterpMachine<RegionedAbsoluteAddr> for Machine<'_> {
+    fn load(
+        &mut self,
+        addr: &RegionedAbsoluteAddr,
+        access: ResolvedAccess<'_>,
+        bits: usize,
+    ) -> Result<SIRValue, InterpError> {
+        let object = self.object_offset(addr)?;
+        let bit_offset = self.access_bit_offset(access.offset, &access.dynamics)?;
+        let absolute = addr.absolute_addr();
+        let payload = self.read_bits(object, bit_offset, bits);
+        if self.is_4state_object(&absolute) {
+            let mask_offset = object + get_byte_size(self.width_of(&absolute));
+            let mask = self.read_bits(mask_offset, bit_offset, bits);
+            Ok(SIRValue::new_four_state(payload, mask))
+        } else {
+            Ok(SIRValue::new(payload))
+        }
+    }
+
+    fn store(
+        &mut self,
+        addr: &RegionedAbsoluteAddr,
+        access: ResolvedAccess<'_>,
+        bits: usize,
+        value: &SIRValue,
+    ) -> Result<(), InterpError> {
+        let object = self.object_offset(addr)?;
+        let bit_offset = self.access_bit_offset(access.offset, &access.dynamics)?;
+        let absolute = addr.absolute_addr();
+        self.write_bits(object, bit_offset, bits, &value.payload);
+        if self.is_4state_object(&absolute) {
+            let mask_offset = object + get_byte_size(self.width_of(&absolute));
+            self.write_bits(mask_offset, bit_offset, bits, &value.mask);
+        }
+        Ok(())
+    }
+
+    fn commit(
+        &mut self,
+        src: &RegionedAbsoluteAddr,
+        dst: &RegionedAbsoluteAddr,
+        access: ResolvedAccess<'_>,
+        bits: usize,
+    ) -> Result<(), InterpError> {
+        let src_object = self.object_offset(src)?;
+        let dst_object = self.object_offset(dst)?;
+        let bit_offset = self.access_bit_offset(access.offset, &access.dynamics)?;
+
+        let payload = self.read_bits(src_object, bit_offset, bits);
+        self.write_bits(dst_object, bit_offset, bits, &payload);
+
+        let dst_absolute = dst.absolute_addr();
+        if self.is_4state_object(&dst_absolute) {
+            let src_absolute = src.absolute_addr();
+            let mask = if self
+                .layout
+                .is_4states
+                .get(&src_absolute)
+                .copied()
+                .unwrap_or(false)
+            {
+                self.read_bits(
+                    src_object + get_byte_size(self.width_of(&src_absolute)),
+                    bit_offset,
+                    bits,
+                )
+            } else {
+                BigUint::zero()
+            };
+            let dst_mask_offset = dst_object + get_byte_size(self.width_of(&dst_absolute));
+            self.write_bits(dst_mask_offset, bit_offset, bits, &mask);
+        }
+        Ok(())
+    }
+
+    fn notify_triggers(&mut self, _addr: &RegionedAbsoluteAddr, triggers: &[TriggerIdWithKind]) {
+        for trigger in triggers {
+            // SEMANTICS-GAP: compiled backends emit per-kind edge/level
+            // detection inline. Marking on every qualifying store/commit is a
+            // level-style over-approximation that keeps clocked simulation
+            // advancing until per-kind semantics are ported.
+            // VERIFY: `TriggerIdWithKind` field name assumed to be `id`.
+            self.mark_trigger_bit(trigger.id);
+        }
+    }
+
+    // SEMANTICS-GAP: runtime-event emission requires the RuntimeEventBuffer
+    // record ABI that generated code writes. Left as no-ops until that ABI
+    // is ported; simulations relying on runtime events must use a compiled
+    // backend meanwhile.
+    fn notify_comb_capture(
+        &mut self,
+        _addr: &RegionedAbsoluteAddr,
+        _sites: &[u32],
+        _value: &SIRValue,
+    ) {
+    }
+
+    fn emit_runtime_event(&mut self, _site_id: u32, _args: &[SIRValue]) {}
+
+    fn emit_comb_capture_event(
+        &mut self,
+        _site_id: u32,
+        _args: &[SIRValue],
+        _fatal_error_code: Option<i64>,
+        _consume_enabled: bool,
+    ) {
+    }
+
+    fn enable_comb_capture_if_changed(&mut self, _old: &SIRValue, _new: &SIRValue, _sites: &[u32]) {}
+}
+
+/// Execute every unit in `units` against the split backend storage.
+fn run_units(
+    memory: &mut Vec<u64>,
+    layout: &MemoryLayout,
+    four_state: bool,
+    comb_capture_enabled: &mut [u8],
+    units: &[ExecutionUnit<RegionedAbsoluteAddr>],
+) -> Result<(), SimulatorErrorCode> {
+    for unit in units {
+        let mut machine = Machine {
+            // Reborrow through the mutable references so a fresh Machine can
+            // be constructed for every execution unit in the loop.
+            memory: &mut *memory,
+            layout,
+            four_state,
+            comb_capture_enabled: &mut *comb_capture_enabled,
+        };
+        // Entry blocks of top-level execution units take no parameters: the
+        // compiled ABI passes only the memory pointer, so all inputs arrive
+        // through loads.
+        execute_unit(unit, &mut machine, &[]).map_err(error_code)?;
+    }
+    Ok(())
+}
+
+/// A [`SimBackend`] that interprets the laid-out SIR instead of executing
+/// generated machine code.
+///
+/// Construction performs no code generation: the simulator is ready as soon
+/// as the state layout is finalized, which is the property the tiered
+/// startup path relies on.
+pub struct InterpBackend {
+    program_sir: crate::ir::SirProgram,
+    layout: MemoryLayout,
+    four_state: bool,
+    memory: Vec<u64>,
+    runtime_event_buffer: Arc<RuntimeEventBuffer>,
+    comb_capture_enabled: Vec<u8>,
+    event_map: HashMap<AbsoluteAddr, InterpEventRef>,
+    eval_only_event_map: HashMap<AbsoluteAddr, InterpEventRef>,
+    apply_event_map: HashMap<AbsoluteAddr, InterpEventRef>,
+    id_to_addr: Vec<AbsoluteAddr>,
+    id_to_event: Vec<InterpEventRef>,
+    four_state_inits: Vec<(usize, usize)>,
+}
+
+impl InterpBackend {
+    pub fn new(
+        laid_out: &LaidOutProgram,
+        options: &SimulatorOptions,
+    ) -> Result<Self, SimulatorError> {
+        let program_sir = laid_out.sir.clone();
+        let layout = laid_out.layout().clone();
+        let four_state = options.four_state;
+
+        // Share one id space across the three schedule groups, mirroring the
+        // compiled backend so scheduler ordering and trigger ids agree.
+        let mut next_id = 0usize;
+        let mut addr_to_id: HashMap<AbsoluteAddr, usize> = HashMap::default();
+        let mut id_to_addr: Vec<AbsoluteAddr> = Vec::new();
+        let mut intern_event = |addr: &AbsoluteAddr| -> usize {
+            *addr_to_id.entry(*addr).or_insert_with(|| {
+                let id = next_id;
+                next_id += 1;
+                id_to_addr.push(*addr);
+                id
+            })
+        };
+
+        let mut event_map: HashMap<AbsoluteAddr, InterpEventRef> = HashMap::default();
+        for (addr, _) in &laid_out.sir.eval_apply_ffs {
+            let id = intern_event(addr);
+            event_map.insert(*addr, InterpEventRef { addr: *addr, id });
+        }
+        let mut eval_only_event_map: HashMap<AbsoluteAddr, InterpEventRef> = HashMap::default();
+        for (addr, _) in &laid_out.sir.eval_only_ffs {
+            let id = intern_event(addr);
+            eval_only_event_map.insert(*addr, InterpEventRef { addr: *addr, id });
+        }
+        let mut apply_event_map: HashMap<AbsoluteAddr, InterpEventRef> = HashMap::default();
+        for (addr, _) in &laid_out.sir.apply_ffs {
+            let id = intern_event(addr);
+            apply_event_map.insert(*addr, InterpEventRef { addr: *addr, id });
+        }
+
+        // Insert event aliases so every event signal resolves, matching the
+        // compiled backend's alias expansion.
+        for (alias, canonical) in &laid_out.design.events.aliases {
+            if let Some(event) = event_map.get(canonical) {
+                event_map.insert(*alias, *event);
+            }
+            if let Some(event) = eval_only_event_map.get(canonical) {
+                eval_only_event_map.insert(*alias, *event);
+            }
+            if let Some(event) = apply_event_map.get(canonical) {
+                apply_event_map.insert(*alias, *event);
+            }
+        }
+
+        let id_to_event = id_to_addr
+            .iter()
+            .map(|addr| {
+                event_map
+                    .get(addr)
+                    .or_else(|| eval_only_event_map.get(addr))
+                    .or_else(|| apply_event_map.get(addr))
+                    .copied()
+                    .expect("every scheduled event address resolves to an event")
+            })
+            .collect();
+
+        // Pre-compute 4-state initialization regions (value and mask both
+        // start as all-X), mirroring SharedJitCode.
+        let mut four_state_inits = Vec::new();
+        if four_state {
+            for (addr, &offset) in &layout.offsets {
+                if laid_out
+                    .design
+                    .state_objects
+                    .get(addr)
+                    .is_some_and(|metadata| metadata.is_4state)
+                {
+                    four_state_inits.push((offset, get_byte_size(layout.widths[addr])));
+                }
+            }
+            for (addr, &relative) in &layout.working_offsets {
+                if laid_out
+                    .design
+                    .state_objects
+                    .get(addr)
+                    .is_some_and(|metadata| metadata.is_4state)
+                {
+                    four_state_inits.push((
+                        layout.working_base_offset + relative,
+                        get_byte_size(layout.widths[addr]),
+                    ));
+                }
+            }
+        }
+
+        let num_u64 = layout.merged_total_size.div_ceil(8);
+        let mut memory = vec![0u64; num_u64];
+        let runtime_event_buffer =
+            Arc::new(RuntimeEventBuffer::new(layout.runtime_event_buffer_size));
+        let comb_capture_enabled = vec![0u8; layout.runtime_event_site_layouts.len().max(1)];
+
+        for &(offset, allocated_size) in &four_state_inits {
+            unsafe {
+                let base_ptr = (memory.as_mut_ptr() as *mut u8).add(offset);
+                std::ptr::write_bytes(base_ptr, 0xFF, allocated_size);
+                let mask_ptr = base_ptr.add(allocated_size);
+                std::ptr::write_bytes(mask_ptr, 0xFF, allocated_size);
+            }
+        }
+
+        let mut backend = Self {
+            program_sir,
+            layout,
+            four_state,
+            memory,
+            runtime_event_buffer,
+            comb_capture_enabled,
+            event_map,
+            eval_only_event_map,
+            apply_event_map,
+            id_to_addr,
+            id_to_event,
+            four_state_inits,
+        };
+        backend.install_event_buffers();
+        Ok(backend)
+    }
+
+    fn install_event_buffers(&mut self) {
+        use crate::backend::memory_layout::{
+            STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET, STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET,
+        };
+
+        let addr = self.runtime_event_buffer.as_mut_ptr() as u64;
+        let ptr = unsafe {
+            (self.memory.as_mut_ptr() as *mut u8).add(STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET)
+                as *mut u64
+        };
+        unsafe {
+            std::ptr::write_unaligned(ptr, addr);
+        }
+        let addr = self.comb_capture_enabled.as_ptr() as u64;
+        let ptr = unsafe {
+            (self.memory.as_mut_ptr() as *mut u8).add(STATE_HEADER_COMB_CAPTURE_ENABLED_ADDR_OFFSET)
+                as *mut u64
+        };
+        unsafe {
+            std::ptr::write_unaligned(ptr, addr);
+        }
+    }
+
+    /// Returns the pre-computed 4-state initialization regions
+    /// `(offset, allocated_size)` for diagnostics and tests.
+    pub fn four_state_regions(&self) -> &[(usize, usize)] {
+        &self.four_state_inits
+    }
+}
+
+impl SimBackend for InterpBackend {
+    type Event = InterpEventRef;
+
+    fn eval_comb(&mut self) -> Result<(), SimulatorErrorCode> {
+        Self::run_units(
+            &mut self.memory,
+            &self.layout,
+            self.four_state,
+            &mut self.comb_capture_enabled,
+            &self.program_sir.eval_comb,
+        )
+    }
+
+    fn eval_apply_ff_at(&mut self, event: InterpEventRef) -> Result<(), SimulatorErrorCode> {
+        Self::run_units(
+            &mut self.memory,
+            &self.layout,
+            self.four_state,
+            &mut self.comb_capture_enabled,
+            self.program_sir
+                .eval_apply_ffs
+                .get(&event.addr())
+                .expect("scheduled event missing from SIR program"),
+        )
+    }
+
+    fn eval_only_ff_at(&mut self, event: InterpEventRef) -> Result<(), SimulatorErrorCode> {
+        Self::run_units(
+            &mut self.memory,
+            &self.layout,
+            self.four_state,
+            &mut self.comb_capture_enabled,
+            self.program_sir
+                .eval_only_ffs
+                .get(&event.addr())
+                .expect("scheduled event missing from SIR program"),
+        )
+    }
+
+    fn apply_ff_at(&mut self, event: InterpEventRef) -> Result<(), SimulatorErrorCode> {
+        Self::run_units(
+            &mut self.memory,
+            &self.layout,
+            self.four_state,
+            &mut self.comb_capture_enabled,
+            self.program_sir
+                .apply_ffs
+                .get(&event.addr())
+                .expect("scheduled event missing from SIR program"),
+        )
+    }
+
+    fn resolve_signal(&self, addr: &AbsoluteAddr) -> SignalRef {
+        let offset = self.layout.offsets[addr];
+        let width = self.layout.widths[addr];
+        let is_4state = self.layout.is_4states[addr];
+        SignalRef {
+            offset,
+            width,
+            is_4state,
+            array_layout: None,
+        }
+    }
+
+    fn resolve_event(&self, addr: &AbsoluteAddr) -> InterpEventRef {
+        *self
+            .event_map
+            .get(addr)
+            .expect("event not registered in the interpreted program")
+    }
+
+    fn resolve_event_opt(&self, addr: &AbsoluteAddr) -> Option<InterpEventRef> {
+        self.event_map.get(addr).copied()
+    }
+
+    fn resolve_eval_only_event(&self, addr: &AbsoluteAddr) -> Option<InterpEventRef> {
+        self.eval_only_event_map.get(addr).copied()
+    }
+
+    fn resolve_apply_event(&self, addr: &AbsoluteAddr) -> Option<InterpEventRef> {
+        self.apply_event_map.get(addr).copied()
+    }
+
+    fn set<T: Copy>(&mut self, signal: SignalRef, value: T) {
+        let allocated_size = get_byte_size(signal.width);
+        let provided_size = std::mem::size_of::<T>();
+        let clear_mask = self.four_state && signal.is_4state;
+
+        assert!(provided_size <= allocated_size);
+
+        unsafe {
+            let base_ptr = (self.memory.as_mut_ptr() as *mut u8).add(signal.offset);
+            if !clear_mask && allocated_size == 1 {
+                let raw = *(&value as *const T as *const u8);
+                let byte = if signal.width < 8 {
+                    raw & ((1u8 << signal.width) - 1)
+                } else {
+                    raw
+                };
+                *base_ptr = byte;
+                return;
+            }
+
+            std::ptr::write_bytes(base_ptr, 0, allocated_size);
+            let ptr = base_ptr as *mut T;
+            std::ptr::write_unaligned(ptr, value);
+
+            if clear_mask {
+                let mask_ptr = base_ptr.add(allocated_size);
+                std::ptr::write_bytes(mask_ptr, 0, allocated_size);
+            }
+        }
+    }
+
+    fn set_wide(&mut self, signal: SignalRef, value: BigUint) {
+        let allocated_size = get_byte_size(signal.width);
+        let mut bytes = value.to_bytes_le();
+
+        if bytes.len() > allocated_size {
+            bytes.truncate(allocated_size);
+        } else {
+            bytes.resize(allocated_size, 0u8);
+        }
+
+        unsafe {
+            let dst_ptr: *mut u8 = self.memory.as_mut_ptr().cast();
+            let dst_ptr = dst_ptr.add(signal.offset);
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), dst_ptr, allocated_size);
+
+            if self.four_state && signal.is_4state {
+                let mask_ptr = dst_ptr.add(allocated_size);
+                std::ptr::write_bytes(mask_ptr, 0, allocated_size);
+            }
+        }
+    }
+
+    fn set_four_state(&mut self, signal: SignalRef, value: BigUint, mask: BigUint) {
+        let allocated_size = get_byte_size(signal.width);
+
+        let mut v_bytes = value.to_bytes_le();
+        if v_bytes.len() > allocated_size {
+            v_bytes.truncate(allocated_size);
+        } else {
+            v_bytes.resize(allocated_size, 0u8);
+        }
+
+        unsafe {
+            let dst_ptr: *mut u8 = self.memory.as_mut_ptr().cast();
+            std::ptr::copy_nonoverlapping(
+                v_bytes.as_ptr(),
+                dst_ptr.add(signal.offset),
+                allocated_size,
+            );
+
+            if self.four_state && signal.is_4state {
+                let mut m_bytes = mask.to_bytes_le();
+                if m_bytes.len() > allocated_size {
+                    m_bytes.truncate(allocated_size);
+                } else {
+                    m_bytes.resize(allocated_size, 0u8);
+                }
+
+                std::ptr::copy_nonoverlapping(
+                    m_bytes.as_ptr(),
+                    dst_ptr.add(signal.offset + allocated_size),
+                    allocated_size,
+                );
+            }
+        }
+    }
+
+    fn get(&self, signal: SignalRef) -> BigUint {
+        let byte_size = get_byte_size(signal.width);
+        let ptr: *const u8 = unsafe { (self.memory.as_ptr() as *const u8).add(signal.offset) };
+        let byte_slice = unsafe { std::slice::from_raw_parts(ptr, byte_size) };
+        let mut val = BigUint::from_bytes_le(byte_slice);
+
+        let extra_bits = byte_size * 8 - signal.width;
+        if extra_bits > 0 {
+            let mask = (BigUint::from(1u32) << signal.width) - 1u32;
+            val &= mask;
+        }
+        val
+    }
+
+    fn get_as<T: Default + Copy>(&self, signal: SignalRef) -> T {
+        let byte_size = get_byte_size(signal.width);
+        let ptr: *const u8 = unsafe { (self.memory.as_ptr() as *const u8).add(signal.offset) };
+        let byte_slice = unsafe { std::slice::from_raw_parts(ptr, byte_size) };
+
+        let provided_size = std::mem::size_of::<T>();
+        assert!(
+            byte_size <= provided_size,
+            "Provided type is too small for signal width"
+        );
+
+        let mut val = T::default();
+        unsafe {
+            let val_ptr = &mut val as *mut T as *mut u8;
+            std::ptr::copy_nonoverlapping(byte_slice.as_ptr(), val_ptr, byte_size);
+        }
+
+        let extra_bits = byte_size * 8 - signal.width;
+        if extra_bits > 0 {
+            if provided_size == 1 {
+                let mask = (1u8 << (8 - extra_bits)) - 1;
+                let v = unsafe { std::mem::transmute_copy::<T, u8>(&val) };
+                val = unsafe { std::mem::transmute_copy::<u8, T>(&(v & mask)) };
+            } else if provided_size == 8 {
+                let mask = (1u64 << signal.width) - 1;
+                let v = unsafe { std::mem::transmute_copy::<T, u64>(&val) };
+                val = unsafe { std::mem::transmute_copy::<u64, T>(&(v & mask)) };
+            }
+        }
+        val
+    }
+
+    fn get_four_state(&self, signal: SignalRef) -> (BigUint, BigUint) {
+        let byte_size = get_byte_size(signal.width);
+        let v_ptr: *const u8 = unsafe { (self.memory.as_ptr() as *const u8).add(signal.offset) };
+        let v_slice = unsafe { std::slice::from_raw_parts(v_ptr, byte_size) };
+        let mut v_val = BigUint::from_bytes_le(v_slice);
+
+        let mut m_val = if self.four_state && signal.is_4state {
+            let m_ptr: *const u8 = unsafe { v_ptr.add(byte_size) };
+            let m_slice = unsafe { std::slice::from_raw_parts(m_ptr, byte_size) };
+            BigUint::from_bytes_le(m_slice)
+        } else {
+            BigUint::from(0u32)
+        };
+
+        let extra_bits = byte_size * 8 - signal.width;
+        if extra_bits > 0 {
+            let bitmask = (BigUint::from(1u32) << signal.width) - 1u32;
+            v_val &= &bitmask;
+            m_val &= &bitmask;
+        }
+
+        (v_val, m_val)
+    }
+
+    fn memory_as_ptr(&self) -> (*const u8, usize) {
+        (
+            self.memory.as_ptr() as *const u8,
+            self.layout.merged_total_size,
+        )
+    }
+
+    fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize) {
+        (
+            self.memory.as_mut_ptr() as *mut u8,
+            self.layout.merged_total_size,
+        )
+    }
+
+    fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize) {
+        (
+            self.runtime_event_buffer.as_ptr(),
+            self.runtime_event_buffer.byte_size(),
+        )
+    }
+
+    fn runtime_event_buffer(&self) -> Option<Arc<RuntimeEventBuffer>> {
+        Some(Arc::clone(&self.runtime_event_buffer))
+    }
+
+    fn set_comb_capture_event_enabled(&mut self, active_sites: &[bool]) {
+        self.comb_capture_enabled.fill(0);
+        for (idx, active) in active_sites.iter().copied().enumerate() {
+            if active && idx < self.comb_capture_enabled.len() {
+                self.comb_capture_enabled[idx] = 1;
+            }
+        }
+    }
+
+    fn stable_region_size(&self) -> usize {
+        self.layout.total_size
+    }
+
+    fn layout(&self) -> &MemoryLayout {
+        &self.layout
+    }
+
+    fn id_to_addr_slice(&self) -> &[AbsoluteAddr] {
+        &self.id_to_addr
+    }
+
+    fn id_to_event_slice(&self) -> &[InterpEventRef] {
+        &self.id_to_event
+    }
+
+    fn num_events(&self) -> usize {
+        let mut max_id = 0;
+        for ev in self.event_map.values() {
+            max_id = max_id.max(ev.id);
+        }
+        for ev in self.eval_only_event_map.values() {
+            max_id = max_id.max(ev.id);
+        }
+        for ev in self.apply_event_map.values() {
+            max_id = max_id.max(ev.id);
+        }
+        if self.event_map.is_empty()
+            && self.eval_only_event_map.is_empty()
+            && self.apply_event_map.is_empty()
+        {
+            0
+        } else {
+            max_id + 1
+        }
+    }
+
+    fn clear_triggered_bits(&mut self) {
+        let base_ptr = self.memory.as_mut_ptr() as *mut u8;
+        let triggered_bits_ptr = unsafe { base_ptr.add(self.layout.triggered_bits_offset) };
+        let total_size = self.layout.triggered_bits_total_size;
+        unsafe {
+            std::ptr::write_bytes(triggered_bits_ptr, 0, total_size);
+        }
+    }
+
+    fn mark_triggered_bit(&mut self, id: usize) {
+        let byte_idx = id / 8;
+        let bit_idx = id % 8;
+        let base_ptr = self.memory.as_mut_ptr() as *mut u8;
+        let triggered_bits_ptr = unsafe { base_ptr.add(self.layout.triggered_bits_offset) };
+        unsafe {
+            let byte_ptr = triggered_bits_ptr.add(byte_idx);
+            *byte_ptr |= 1 << bit_idx;
+        }
+    }
+
+    fn get_triggered_bits(&self) -> bit_set::BitSet {
+        let mut bits = bit_set::BitSet::with_capacity(self.num_events());
+        let base_ptr = self.memory.as_ptr() as *const u8;
+        let triggered_bits_ptr = unsafe { base_ptr.add(self.layout.triggered_bits_offset) };
+        let total_size = self.layout.triggered_bits_total_size;
+
+        for i in 0..total_size {
+            let byte = unsafe { *triggered_bits_ptr.add(i) };
+            if byte != 0 {
+                for j in 0..8 {
+                    if (byte & (1 << j)) != 0 {
+                        bits.insert(i * 8 + j);
+                    }
+                }
+            }
+        }
+        bits
+    }
+}

--- a/crates/celox/src/backend/interp.rs
+++ b/crates/celox/src/backend/interp.rs
@@ -13,18 +13,14 @@
 //! Known gaps versus the compiled backends (all fail loud or degrade
 //! visibly, never silently corrupt):
 //!
-//! - `RuntimeEvent` / `CombCaptureEvent` instructions are currently no-ops
-//!   because the interpreter does not yet write the `RuntimeEventBuffer`
-//!   record ABI that generated code uses.
 //! - Trigger notification marks the trigger bit on every qualifying
 //!   store/commit (a level-style over-approximation of the compiled
 //!   edge/level detection).
-//! - `SPARSE_WORKING_REGION` accesses report a machine error instead of
-//!   guessing at an unmapped storage region.
 
 #![cfg(feature = "host-runtime")]
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use celox_sir::{ExecutionUnit, SIROffset, SIRValue, TriggerIdWithKind};
 use num_bigint::BigUint;
@@ -33,8 +29,13 @@ use num_traits::{ToPrimitive, Zero};
 use super::{
     EventHandle, MemoryLayout, RuntimeEventBuffer, SimBackend, SimulatorErrorCode, get_byte_size,
 };
-use crate::interpreter::{InterpError, InterpMachine, ResolvedAccess, execute_unit};
-use crate::ir::{STABLE_REGION, WORKING_REGION};
+use crate::backend::memory_layout::{
+    RUNTIME_EVENT_HEADER_SIZE, RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET,
+    RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
+    RUNTIME_EVENT_SLOT_SITE_OFFSET, RUNTIME_EVENT_WRITING, STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET,
+};
+use crate::interpreter::{InterpError, InterpMachine, ResolvedAccess, StoreSnapshot, execute_unit};
+use crate::ir::{SPARSE_WORKING_REGION, STABLE_REGION, WORKING_REGION};
 use crate::{
     HashMap, SimulatorError, SimulatorOptions,
     ir::{AbsoluteAddr, LaidOutProgram, RegionedAbsoluteAddr, SignalRef},
@@ -89,10 +90,7 @@ struct Machine<'a> {
     memory: &'a mut Vec<u64>,
     layout: &'a MemoryLayout,
     four_state: bool,
-    /// Reserved for comb-capture bookkeeping once the runtime-event record
-    /// ABI is implemented; kept in the struct so the borrow split stays
-    /// identical to the final shape.
-    #[allow(dead_code)]
+    /// Per-site enable bytes for comb capture events.
     comb_capture_enabled: &'a mut [u8],
 }
 
@@ -105,12 +103,17 @@ impl Machine<'_> {
 
     /// Resolve a regioned SIR address to its byte offset in the merged image.
     ///
-    /// Only regions with a dedicated layout table are supported; anything
+    /// Every region with a dedicated layout table is supported; anything
     /// else fails loudly rather than aliasing into unrelated storage.
     fn object_offset(&self, addr: &RegionedAbsoluteAddr) -> Result<usize, InterpError> {
         let absolute = addr.absolute_addr();
         let mapped = if addr.region == STABLE_REGION {
             self.layout.offsets.get(&absolute).copied()
+        } else if addr.region == SPARSE_WORKING_REGION {
+            self.layout
+                .sparse_offsets
+                .get(&absolute)
+                .map(|relative| self.layout.sparse_base_offset + relative)
         } else if addr.region == WORKING_REGION {
             self.layout
                 .working_offsets
@@ -168,7 +171,13 @@ impl Machine<'_> {
     }
 
     fn is_4state_object(&self, absolute: &AbsoluteAddr) -> bool {
-        self.four_state && self.layout.is_4states.get(absolute).copied().unwrap_or(false)
+        self.four_state
+            && self
+                .layout
+                .is_4states
+                .get(absolute)
+                .copied()
+                .unwrap_or(false)
     }
 
     /// Read `bits` starting at `bit_offset` within the object at
@@ -226,6 +235,225 @@ impl Machine<'_> {
     fn byte_mut(&mut self, offset: usize) -> *mut u8 {
         unsafe { (self.memory.as_mut_ptr() as *mut u8).add(offset) }
     }
+
+    /// Read one unaligned little-endian `u64` bookkeeping word.
+    ///
+    /// # Safety
+    /// Callers must bound `offset + 8` inside the merged allocation.
+    unsafe fn read_u64(&self, offset: usize) -> u64 {
+        unsafe {
+            let ptr = (self.memory.as_ptr() as *const u8).add(offset) as *const u64;
+            ptr.read_unaligned()
+        }
+    }
+
+    /// Write one unaligned little-endian `u64` bookkeeping word.
+    ///
+    /// # Safety
+    /// Callers must bound `offset + 8` inside the merged allocation.
+    unsafe fn write_u64(&mut self, offset: usize, value: u64) {
+        unsafe {
+            let ptr = (self.memory.as_mut_ptr() as *mut u8).add(offset) as *mut u64;
+            ptr.write_unaligned(value)
+        }
+    }
+
+    /// Read one byte of the merged image.
+    ///
+    /// # Safety
+    /// Callers must bound `offset` inside the merged allocation.
+    unsafe fn read_u8(&self, offset: usize) -> u8 {
+        unsafe { *(self.memory.as_ptr() as *const u8).add(offset) }
+    }
+
+    /// Write one byte of the merged image.
+    ///
+    /// # Safety
+    /// Callers must bound `offset` inside the merged allocation.
+    unsafe fn write_u8(&mut self, offset: usize, value: u8) {
+        unsafe { *(self.memory.as_mut_ptr() as *mut u8).add(offset) = value }
+    }
+
+    /// Little-endian 64-bit words of `value`, as used by the runtime-event
+    /// record payload ABI (short values pad with zero words implicitly).
+    fn value_words(value: &BigUint) -> Vec<u64> {
+        value.to_u64_digits()
+    }
+
+    /// Write one runtime event record into the shared ring buffer whose
+    /// address is installed in the state header, following the compiled
+    /// protocol: reserve the slot with a `WRITING` marker, fill site and
+    /// payload fields plainly, then publish with release semantics.
+    fn emit_event_record(&mut self, site_id: u32, args: &[SIRValue]) {
+        // Safety: the state header always holds a live buffer pointer that
+        // outlives simulation, and the ring arithmetic stays inside the
+        // buffer allocation because `seq` is masked by the capacity.
+        unsafe {
+            let event_ptr = self.read_u64(STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET) as *mut AtomicU64;
+            let seq = (*event_ptr).load(Ordering::Acquire);
+            let capacity = self.layout.runtime_event_capacity as u64;
+            if capacity == 0 {
+                return;
+            }
+            let slot_index = (seq & (capacity - 1)) as usize;
+            let slot_base = event_ptr
+                .cast::<u8>()
+                .add(RUNTIME_EVENT_HEADER_SIZE + slot_index * self.layout.runtime_event_slot_size);
+            let slot_seq = slot_base.add(RUNTIME_EVENT_SLOT_SEQ_OFFSET) as *const AtomicU64;
+            (*slot_seq).store(RUNTIME_EVENT_WRITING, Ordering::Relaxed);
+            slot_base
+                .add(RUNTIME_EVENT_SLOT_SITE_OFFSET)
+                .cast::<u64>()
+                .write_unaligned(site_id as u64);
+            slot_base
+                .add(RUNTIME_EVENT_SLOT_ARG_COUNT_OFFSET)
+                .cast::<u64>()
+                .write_unaligned(args.len() as u64);
+
+            if let Some(site_layout) = self.layout.runtime_event_site_layouts.get(site_id as usize)
+            {
+                for (index, arg) in args.iter().enumerate() {
+                    let Some(arg_layout) = site_layout.args.get(index) else {
+                        continue;
+                    };
+                    let value_digits = Self::value_words(&arg.payload);
+                    let mask_digits = Self::value_words(&arg.mask);
+                    for word in 0..arg_layout.word_count {
+                        let payload = slot_base.add(
+                            RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
+                                + (arg_layout.value_word_offset + word) * 8,
+                        );
+                        payload
+                            .cast::<u64>()
+                            .write_unaligned(value_digits.get(word).copied().unwrap_or(0));
+                        let mask_payload = slot_base.add(
+                            RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET
+                                + (arg_layout.mask_word_offset + word) * 8,
+                        );
+                        mask_payload
+                            .cast::<u64>()
+                            .write_unaligned(mask_digits.get(word).copied().unwrap_or(0));
+                    }
+                }
+            }
+
+            (*slot_seq).store(seq, Ordering::Release);
+            (*event_ptr).store(seq.wrapping_add(1), Ordering::Release);
+        }
+    }
+
+    /// Copy-on-write preparation for a store into the sparse working region:
+    /// every 64-bit chunk touched by `[bit_offset, bit_offset + bits)` is
+    /// copied from the stable region before it is overwritten, mirroring the
+    /// compiled `prepare_sparse_store` lowering.
+    fn prepare_sparse_store(
+        &mut self,
+        addr: &RegionedAbsoluteAddr,
+        bit_offset: usize,
+        bits: usize,
+    ) -> Result<(), InterpError> {
+        let absolute = addr.absolute_addr();
+        let Some(sparse) = self.layout.sparse_layouts.get(&absolute) else {
+            return Err(InterpError::Machine(format!(
+                "sparse store to {absolute} without a sparse layout"
+            )));
+        };
+        let stable_base = self.layout.offsets[&absolute];
+        let sparse_base = self.layout.sparse_base_offset + self.layout.sparse_offsets[&absolute];
+        let byte_size = get_byte_size(self.layout.widths[&absolute]);
+        let plane_count = if self.four_state && self.is_4state_object(&absolute) {
+            2
+        } else {
+            1
+        };
+
+        if bits == 0 {
+            return Ok(());
+        }
+        let start_chunk = bit_offset / 64;
+        let end_chunk = (bit_offset + bits - 1) / 64;
+        for chunk in start_chunk..=end_chunk {
+            let dirty_word_index = chunk / 64;
+            let dirty_mask = 1u64 << (chunk % 64);
+            let dirty_word_addr = sparse.dirty_words_offset + dirty_word_index * 8;
+            // Safety: layout bounds the dirty-word region.
+            let was_dirty = unsafe { self.read_u64(dirty_word_addr) } & dirty_mask != 0;
+            if !was_dirty {
+                for plane in 0..plane_count {
+                    let delta = plane * byte_size + chunk * 8;
+                    // Safety: both chunks live inside the merged allocation.
+                    let stable_chunk = unsafe { self.read_u64(stable_base + delta) };
+                    unsafe { self.write_u64(sparse_base + delta, stable_chunk) };
+                }
+            }
+            // Safety: bounded by the dirty-word region above.
+            unsafe {
+                let current = self.read_u64(dirty_word_addr);
+                self.write_u64(dirty_word_addr, current | dirty_mask);
+            }
+            let summary_addr = sparse.summary_words_offset + (dirty_word_index / 64) * 8;
+            // Safety: bounded by the summary region.
+            unsafe {
+                let current = self.read_u64(summary_addr);
+                self.write_u64(summary_addr, current | (1u64 << (dirty_word_index % 64)));
+            }
+        }
+        Ok(())
+    }
+
+    /// Flush every dirty sparse chunk of `src` back to its stable home and
+    /// clear the dirty bookkeeping, matching the compiled sparse commit. The
+    /// per-instruction access width is deliberately ignored: the compiled
+    /// commit copies whole dirty chunks so partially written next-state data
+    /// is never lost.
+    fn commit_sparse_object(&mut self, src: &RegionedAbsoluteAddr) -> Result<(), InterpError> {
+        let absolute = src.absolute_addr();
+        let Some(sparse) = self.layout.sparse_layouts.get(&absolute) else {
+            return Err(InterpError::Machine(format!(
+                "sparse commit of {absolute} without a sparse layout"
+            )));
+        };
+        let dst_base = self.layout.offsets[&absolute];
+        let src_base = self.layout.sparse_base_offset + self.layout.sparse_offsets[&absolute];
+        let byte_size = get_byte_size(self.layout.widths[&absolute]);
+        let plane_count = if self.four_state && self.is_4state_object(&absolute) {
+            2
+        } else {
+            1
+        };
+        let last_chunk = sparse.chunk_count.saturating_sub(1);
+        let last_len = byte_size.saturating_sub(last_chunk * 8);
+
+        for summary_index in 0..sparse.summary_word_count {
+            let summary_addr = sparse.summary_words_offset + summary_index * 8;
+            // Safety: summary words are part of the merged allocation.
+            let mut summary_bits = unsafe { self.read_u64(summary_addr) };
+            unsafe { self.write_u64(summary_addr, 0) };
+            while summary_bits != 0 {
+                let word_index = summary_bits.trailing_zeros() as usize + summary_index * 64;
+                let dirty_addr = sparse.dirty_words_offset + word_index * 8;
+                // Safety: dirty words are part of the merged allocation.
+                let mut dirty_bits = unsafe { self.read_u64(dirty_addr) };
+                unsafe { self.write_u64(dirty_addr, 0) };
+                while dirty_bits != 0 {
+                    let chunk = word_index * 64 + dirty_bits.trailing_zeros() as usize;
+                    let len = if chunk == last_chunk { last_len } else { 8 };
+                    for plane in 0..plane_count {
+                        let delta = plane * byte_size + chunk * 8;
+                        for byte in 0..len {
+                            // Safety: both chunks live inside the merged
+                            // allocation; `delta + byte` stays in bounds.
+                            let value = unsafe { self.read_u8(src_base + delta + byte) };
+                            unsafe { self.write_u8(dst_base + delta + byte, value) };
+                        }
+                    }
+                    dirty_bits &= dirty_bits - 1;
+                }
+                summary_bits &= summary_bits - 1;
+            }
+        }
+        Ok(())
+    }
 }
 
 impl InterpMachine<RegionedAbsoluteAddr> for Machine<'_> {
@@ -258,6 +486,9 @@ impl InterpMachine<RegionedAbsoluteAddr> for Machine<'_> {
         let object = self.object_offset(addr)?;
         let bit_offset = self.access_bit_offset(access.offset, &access.dynamics)?;
         let absolute = addr.absolute_addr();
+        if addr.region == SPARSE_WORKING_REGION {
+            self.prepare_sparse_store(addr, bit_offset, bits)?;
+        }
         self.write_bits(object, bit_offset, bits, &value.payload);
         if self.is_4state_object(&absolute) {
             let mask_offset = object + get_byte_size(self.width_of(&absolute));
@@ -273,6 +504,9 @@ impl InterpMachine<RegionedAbsoluteAddr> for Machine<'_> {
         access: ResolvedAccess<'_>,
         bits: usize,
     ) -> Result<(), InterpError> {
+        if src.region == SPARSE_WORKING_REGION {
+            return self.commit_sparse_object(src);
+        }
         let src_object = self.object_offset(src)?;
         let dst_object = self.object_offset(dst)?;
         let bit_offset = self.access_bit_offset(access.offset, &access.dynamics)?;
@@ -315,30 +549,110 @@ impl InterpMachine<RegionedAbsoluteAddr> for Machine<'_> {
         }
     }
 
-    // SEMANTICS-GAP: runtime-event emission requires the RuntimeEventBuffer
-    // record ABI that generated code writes. Left as no-ops until that ABI
-    // is ported; simulations relying on runtime events must use a compiled
-    // backend meanwhile.
-    fn notify_comb_capture(
+    fn capture_store_range(
         &mut self,
-        _addr: &RegionedAbsoluteAddr,
-        _sites: &[u32],
-        _value: &SIRValue,
-    ) {
+        addr: &RegionedAbsoluteAddr,
+        access: ResolvedAccess<'_>,
+        bits: usize,
+    ) -> Result<StoreSnapshot, InterpError> {
+        let object = self.object_offset(addr)?;
+        let bit_offset = self.access_bit_offset(access.offset, &access.dynamics)?;
+        let absolute = addr.absolute_addr();
+        let value_words = Self::value_words(&self.read_bits(object, bit_offset, bits));
+        let mask_words = if self.is_4state_object(&absolute) {
+            let mask_offset = object + get_byte_size(self.width_of(&absolute));
+            Self::value_words(&self.read_bits(mask_offset, bit_offset, bits))
+        } else {
+            Vec::new()
+        };
+        Ok(StoreSnapshot {
+            value_words,
+            mask_words,
+        })
     }
 
-    fn emit_runtime_event(&mut self, _site_id: u32, _args: &[SIRValue]) {}
+    fn enable_comb_captures(
+        &mut self,
+        addr: &RegionedAbsoluteAddr,
+        access: ResolvedAccess<'_>,
+        bits: usize,
+        before: &StoreSnapshot,
+        sites: &[u32],
+    ) -> Result<(), InterpError> {
+        if sites.is_empty() {
+            return Ok(());
+        }
+        let object = self.object_offset(addr)?;
+        let bit_offset = self.access_bit_offset(access.offset, &access.dynamics)?;
+        let absolute = addr.absolute_addr();
+        let changed = Self::value_words(&self.read_bits(object, bit_offset, bits))
+            != before.value_words
+            || (self.is_4state_object(&absolute)
+                && Self::value_words(&self.read_bits(
+                    object + get_byte_size(self.width_of(&absolute)),
+                    bit_offset,
+                    bits,
+                )) != before.mask_words);
+        if changed {
+            for &site in sites {
+                let index = site as usize;
+                if index < self.comb_capture_enabled.len() {
+                    self.comb_capture_enabled[index] = 1;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn emit_runtime_event(&mut self, site_id: u32, args: &[SIRValue]) -> Result<(), InterpError> {
+        self.emit_event_record(site_id, args);
+        Ok(())
+    }
 
     fn emit_comb_capture_event(
         &mut self,
-        _site_id: u32,
-        _args: &[SIRValue],
-        _fatal_error_code: Option<i64>,
-        _consume_enabled: bool,
-    ) {
+        site_id: u32,
+        args: &[SIRValue],
+        fatal_error_code: Option<i64>,
+        consume_enabled: bool,
+    ) -> Result<(), InterpError> {
+        let index = site_id as usize;
+        if index >= self.comb_capture_enabled.len() || self.comb_capture_enabled[index] == 0 {
+            return Ok(());
+        }
+        self.emit_event_record(site_id, args);
+        if consume_enabled {
+            self.comb_capture_enabled[index] = 0;
+        }
+        match fatal_error_code {
+            Some(code) => Err(InterpError::Fatal(code)),
+            None => Ok(()),
+        }
     }
 
-    fn enable_comb_capture_if_changed(&mut self, _old: &SIRValue, _new: &SIRValue, _sites: &[u32]) {}
+    fn enable_comb_capture_if_changed(
+        &mut self,
+        old: &SIRValue,
+        new: &SIRValue,
+        sites: &[u32],
+    ) -> Result<(), InterpError> {
+        if sites.is_empty() {
+            return Ok(());
+        }
+        let mut changed = Self::value_words(&old.payload) != Self::value_words(&new.payload);
+        if self.four_state {
+            changed |= Self::value_words(&old.mask) != Self::value_words(&new.mask);
+        }
+        if changed {
+            for &site in sites {
+                let index = site as usize;
+                if index < self.comb_capture_enabled.len() {
+                    self.comb_capture_enabled[index] = 1;
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Execute every unit in `units` against the split backend storage.
@@ -361,7 +675,7 @@ fn run_units(
         // Entry blocks of top-level execution units take no parameters: the
         // compiled ABI passes only the memory pointer, so all inputs arrive
         // through loads.
-        execute_unit(unit, &mut machine, &[]).map_err(error_code)?;
+        execute_unit(unit, &mut machine, &[], four_state).map_err(error_code)?;
     }
     Ok(())
 }
@@ -411,17 +725,17 @@ impl InterpBackend {
         };
 
         let mut event_map: HashMap<AbsoluteAddr, InterpEventRef> = HashMap::default();
-        for (addr, _) in &laid_out.sir.eval_apply_ffs {
+        for addr in laid_out.sir.eval_apply_ffs.keys() {
             let id = intern_event(addr);
             event_map.insert(*addr, InterpEventRef { addr: *addr, id });
         }
         let mut eval_only_event_map: HashMap<AbsoluteAddr, InterpEventRef> = HashMap::default();
-        for (addr, _) in &laid_out.sir.eval_only_ffs {
+        for addr in laid_out.sir.eval_only_ffs.keys() {
             let id = intern_event(addr);
             eval_only_event_map.insert(*addr, InterpEventRef { addr: *addr, id });
         }
         let mut apply_event_map: HashMap<AbsoluteAddr, InterpEventRef> = HashMap::default();
-        for (addr, _) in &laid_out.sir.apply_ffs {
+        for addr in laid_out.sir.apply_ffs.keys() {
             let id = intern_event(addr);
             apply_event_map.insert(*addr, InterpEventRef { addr: *addr, id });
         }

--- a/crates/celox/src/backend/interp.rs
+++ b/crates/celox/src/backend/interp.rs
@@ -10,18 +10,18 @@
 //! execution units between the interpreter and compiled tiers without any
 //! state translation.
 //!
-//! Known gaps versus the compiled backends (all fail loud or degrade
-//! visibly, never silently corrupt):
-//!
-//! - Trigger notification marks the trigger bit on every qualifying
-//!   store/commit (a level-style over-approximation of the compiled
-//!   edge/level detection).
+//! Trigger marking follows the compiled change-detection protocol: the
+//! first word of every trigger-bearing object is snapshotted at group entry
+//! and trigger bits are marked only when a store or commit changes it. As in
+//! the compiled backends, `TriggerIdWithKind.kind` does not influence code
+//! execution.
 
 #![cfg(feature = "host-runtime")]
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use celox_design::RegionedAbsoluteAddrBase;
 use celox_sir::{ExecutionUnit, SIROffset, SIRValue, TriggerIdWithKind};
 use num_bigint::BigUint;
 use num_traits::{ToPrimitive, Zero};
@@ -92,6 +92,9 @@ struct Machine<'a> {
     four_state: bool,
     /// Per-site enable bytes for comb capture events.
     comb_capture_enabled: &'a mut [u8],
+    /// First-word snapshots of trigger-bearing objects taken at group entry;
+    /// trigger bits are only marked when a store changes the value.
+    trigger_snapshots: &'a HashMap<(AbsoluteAddr, u32), u64>,
 }
 
 impl Machine<'_> {
@@ -538,13 +541,26 @@ impl InterpMachine<RegionedAbsoluteAddr> for Machine<'_> {
         Ok(())
     }
 
-    fn notify_triggers(&mut self, _addr: &RegionedAbsoluteAddr, triggers: &[TriggerIdWithKind]) {
+    fn notify_triggers(&mut self, addr: &RegionedAbsoluteAddr, triggers: &[TriggerIdWithKind]) {
+        if triggers.is_empty() {
+            return;
+        }
+        // Change detection identical to the compiled backends: the object's
+        // first word is compared against the group-entry snapshot and the
+        // trigger bits are only marked on an actual change.
+        let absolute = addr.absolute_addr();
+        let Some(&snapshot) = self.trigger_snapshots.get(&(absolute, addr.region)) else {
+            return;
+        };
+        let Ok(base) = self.object_offset(addr) else {
+            return;
+        };
+        // Safety: layout-mapped objects fit inside the merged image.
+        let current = unsafe { self.read_u64(base) };
+        if current == snapshot {
+            return;
+        }
         for trigger in triggers {
-            // SEMANTICS-GAP: compiled backends emit per-kind edge/level
-            // detection inline. Marking on every qualifying store/commit is a
-            // level-style over-approximation that keeps clocked simulation
-            // advancing until per-kind semantics are ported.
-            // VERIFY: `TriggerIdWithKind` field name assumed to be `id`.
             self.mark_trigger_bit(trigger.id);
         }
     }
@@ -655,6 +671,35 @@ impl InterpMachine<RegionedAbsoluteAddr> for Machine<'_> {
     }
 }
 
+/// Collect the addresses of objects whose stores carry triggers. Their
+/// first 64-bit word is snapshotted at group entry so trigger marking can
+/// detect actual changes, mirroring the compiled backends.
+fn collect_trigger_addrs(
+    units: &[ExecutionUnit<RegionedAbsoluteAddr>],
+) -> Vec<(AbsoluteAddr, u32)> {
+    let mut addrs = crate::HashSet::<(AbsoluteAddr, u32)>::default();
+    for unit in units {
+        for block in unit.blocks.values() {
+            for inst in &block.instructions {
+                match inst {
+                    celox_sir::SIRInstruction::Store(addr, _, _, _, triggers, _)
+                        if !triggers.is_empty() =>
+                    {
+                        addrs.insert((addr.absolute_addr(), addr.region));
+                    }
+                    celox_sir::SIRInstruction::Commit(_, dst, _, _, triggers)
+                        if !triggers.is_empty() =>
+                    {
+                        addrs.insert((dst.absolute_addr(), dst.region));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    addrs.into_iter().collect()
+}
+
 /// Execute every unit in `units` against the split backend storage.
 fn run_units(
     memory: &mut Vec<u64>,
@@ -663,6 +708,24 @@ fn run_units(
     comb_capture_enabled: &mut [u8],
     units: &[ExecutionUnit<RegionedAbsoluteAddr>],
 ) -> Result<(), SimulatorErrorCode> {
+    // Snapshot the first word of every trigger-bearing object at group
+    // entry; stores mark trigger bits only when the value actually changed.
+    let mut trigger_snapshots: HashMap<(AbsoluteAddr, u32), u64> = HashMap::default();
+    for (absolute, region) in collect_trigger_addrs(units) {
+        let addr = RegionedAbsoluteAddrBase::from_absolute_addr(region, absolute);
+        let machine = Machine {
+            memory: &mut *memory,
+            layout,
+            four_state,
+            comb_capture_enabled: &mut *comb_capture_enabled,
+            trigger_snapshots: &trigger_snapshots,
+        };
+        if let Ok(base) = machine.object_offset(&addr) {
+            // Safety: layout-mapped objects fit inside the merged image.
+            trigger_snapshots.insert((absolute, region), unsafe { read_word(memory, base) });
+        }
+    }
+
     for unit in units {
         let mut machine = Machine {
             // Reborrow through the mutable references so a fresh Machine can
@@ -671,6 +734,7 @@ fn run_units(
             layout,
             four_state,
             comb_capture_enabled: &mut *comb_capture_enabled,
+            trigger_snapshots: &trigger_snapshots,
         };
         // Entry blocks of top-level execution units take no parameters: the
         // compiled ABI passes only the memory pointer, so all inputs arrive
@@ -678,6 +742,14 @@ fn run_units(
         execute_unit(unit, &mut machine, &[], four_state).map_err(error_code)?;
     }
     Ok(())
+}
+
+/// Read one little-endian word from the merged image.
+///
+/// # Safety
+/// Callers must bound `offset + 8` inside the allocation.
+unsafe fn read_word(memory: &[u64], offset: usize) -> u64 {
+    unsafe { (memory.as_ptr() as *const u8).add(offset).cast::<u64>().read_unaligned() }
 }
 
 /// A [`SimBackend`] that interprets the laid-out SIR instead of executing

--- a/crates/celox/src/backend/interp.rs
+++ b/crates/celox/src/backend/interp.rs
@@ -749,7 +749,12 @@ fn run_units(
 /// # Safety
 /// Callers must bound `offset + 8` inside the allocation.
 unsafe fn read_word(memory: &[u64], offset: usize) -> u64 {
-    unsafe { (memory.as_ptr() as *const u8).add(offset).cast::<u64>().read_unaligned() }
+    unsafe {
+        (memory.as_ptr() as *const u8)
+            .add(offset)
+            .cast::<u64>()
+            .read_unaligned()
+    }
 }
 
 /// A [`SimBackend`] that interprets the laid-out SIR instead of executing

--- a/crates/celox/src/backend/interp.rs
+++ b/crates/celox/src/backend/interp.rs
@@ -775,12 +775,15 @@ fn run_units(
     four_state: bool,
     comb_capture_enabled: &mut [u8],
     units: &[ExecutionUnit<RegionedAbsoluteAddr>],
+    trigger_addrs: &[(AbsoluteAddr, u32)],
     emit_triggers: bool,
 ) -> Result<(), SimulatorErrorCode> {
     // Snapshot the first word of every trigger-bearing object at group
-    // entry; trigger detection compares the stored range against it.
+    // entry; trigger detection compares the stored range against it. The
+    // trigger-bearing addresses are precomputed per group so a tick only
+    // pays for the snapshot reads themselves.
     let mut trigger_snapshots: HashMap<(AbsoluteAddr, u32), u64> = HashMap::default();
-    for (absolute, region) in collect_trigger_addrs(units) {
+    for &(absolute, region) in trigger_addrs {
         let addr = RegionedAbsoluteAddrBase::from_absolute_addr(region, absolute);
         let machine = Machine {
             memory: &mut *memory,
@@ -853,6 +856,10 @@ pub struct InterpBackend {
     /// compiled `comb_apply_func`: fused schedules when present, otherwise
     /// comb units followed by the clock's FF units.
     comb_apply_units: HashMap<AbsoluteAddr, Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
+    /// Trigger-bearing addresses per schedule group, precomputed so a group
+    /// invocation only performs snapshot reads.
+    comb_trigger_addrs: Vec<(AbsoluteAddr, u32)>,
+    event_trigger_addrs: HashMap<AbsoluteAddr, Vec<(AbsoluteAddr, u32)>>,
     /// Whether trigger detection marks bits; matches the compiled
     /// `emit_triggers` codegen flag.
     emit_triggers: bool,
@@ -985,6 +992,24 @@ impl InterpBackend {
         }
         // Only eval/apply clocks receive combined ticks; eval-only and
         // apply-only groups fall back to the default two-phase evaluation.
+        let comb_trigger_addrs = collect_trigger_addrs(&laid_out.sir.eval_comb);
+        let mut event_trigger_addrs: HashMap<AbsoluteAddr, Vec<(AbsoluteAddr, u32)>> =
+            HashMap::default();
+        for (clock, ff_units) in &laid_out.sir.eval_apply_ffs {
+            let mut addrs = comb_trigger_addrs.clone();
+            addrs.extend(collect_trigger_addrs(ff_units));
+            addrs.sort_unstable();
+            addrs.dedup();
+            event_trigger_addrs.insert(*clock, addrs);
+        }
+        for (clock, units) in laid_out
+            .sir
+            .eval_only_ffs
+            .iter()
+            .chain(&laid_out.sir.apply_ffs)
+        {
+            event_trigger_addrs.insert(*clock, collect_trigger_addrs(units));
+        }
 
         let mut backend = Self {
             program_sir,
@@ -1000,6 +1025,8 @@ impl InterpBackend {
             id_to_event,
             four_state_inits,
             comb_apply_units,
+            comb_trigger_addrs,
+            event_trigger_addrs,
             emit_triggers: options.emit_triggers,
         };
         backend.install_event_buffers();
@@ -1046,6 +1073,7 @@ impl SimBackend for InterpBackend {
             self.four_state,
             &mut self.comb_capture_enabled,
             &self.program_sir.eval_comb,
+            &self.comb_trigger_addrs,
             self.emit_triggers,
         )
     }
@@ -1060,6 +1088,9 @@ impl SimBackend for InterpBackend {
                 .eval_apply_ffs
                 .get(&event.addr())
                 .expect("scheduled event missing from SIR program"),
+            self.event_trigger_addrs
+                .get(&event.addr())
+                .map_or(&[] as &[(AbsoluteAddr, u32)], Vec::as_slice),
             self.emit_triggers,
         )
     }
@@ -1076,6 +1107,7 @@ impl SimBackend for InterpBackend {
             self.four_state,
             &mut self.comb_capture_enabled,
             units,
+            &self.event_trigger_addrs[&event.addr()],
             self.emit_triggers,
         )
     }
@@ -1090,6 +1122,9 @@ impl SimBackend for InterpBackend {
                 .eval_only_ffs
                 .get(&event.addr())
                 .expect("scheduled event missing from SIR program"),
+            self.event_trigger_addrs
+                .get(&event.addr())
+                .map_or(&[] as &[(AbsoluteAddr, u32)], Vec::as_slice),
             self.emit_triggers,
         )
     }
@@ -1104,6 +1139,9 @@ impl SimBackend for InterpBackend {
                 .apply_ffs
                 .get(&event.addr())
                 .expect("scheduled event missing from SIR program"),
+            self.event_trigger_addrs
+                .get(&event.addr())
+                .map_or(&[] as &[(AbsoluteAddr, u32)], Vec::as_slice),
             self.emit_triggers,
         )
     }

--- a/crates/celox/src/backend/interp.rs
+++ b/crates/celox/src/backend/interp.rs
@@ -483,6 +483,19 @@ impl InterpMachine<RegionedAbsoluteAddr> for Machine<'_> {
         }
     }
 
+    fn prepare_store(
+        &mut self,
+        addr: &RegionedAbsoluteAddr,
+        access: ResolvedAccess<'_>,
+        bits: usize,
+    ) -> Result<(), InterpError> {
+        if addr.region == SPARSE_WORKING_REGION {
+            let bit_offset = self.access_bit_offset(access.offset, &access.dynamics)?;
+            self.prepare_sparse_store(addr, bit_offset, bits)?;
+        }
+        Ok(())
+    }
+
     fn store(
         &mut self,
         addr: &RegionedAbsoluteAddr,
@@ -493,13 +506,35 @@ impl InterpMachine<RegionedAbsoluteAddr> for Machine<'_> {
         let object = self.object_offset(addr)?;
         let bit_offset = self.access_bit_offset(access.offset, &access.dynamics)?;
         let absolute = addr.absolute_addr();
-        if addr.region == SPARSE_WORKING_REGION {
-            self.prepare_sparse_store(addr, bit_offset, bits)?;
-        }
         self.write_bits(object, bit_offset, bits, &value.payload);
         if self.is_4state_object(&absolute) {
             let mask_offset = object + get_byte_size(self.width_of(&absolute));
             self.write_bits(mask_offset, bit_offset, bits, &value.mask);
+        }
+        Ok(())
+    }
+
+    fn notify_trigger_only_store(
+        &mut self,
+        addr: &RegionedAbsoluteAddr,
+        triggers: &[TriggerIdWithKind],
+    ) -> Result<(), InterpError> {
+        // Zero-width aliased stores detect a change on the aliased signal's
+        // first byte, mirroring the compiled dedicated path.
+        if !self.emit_triggers || triggers.is_empty() {
+            return Ok(());
+        }
+        let absolute = addr.absolute_addr();
+        let Some(&snapshot) = self.trigger_snapshots.get(&(absolute, addr.region)) else {
+            return Ok(());
+        };
+        let base = self.object_offset(addr)?;
+        // Safety: layout-mapped objects fit inside the merged image.
+        let current = unsafe { self.read_u64(base) } as u8;
+        if current != snapshot as u8 {
+            for trigger in triggers {
+                self.mark_trigger_bit(trigger.id);
+            }
         }
         Ok(())
     }

--- a/crates/celox/src/backend/interp.rs
+++ b/crates/celox/src/backend/interp.rs
@@ -70,7 +70,11 @@ impl EventHandle for InterpEventRef {
 /// [`SimulatorErrorCode::DetectedTrueLoopCode`].
 fn error_code(error: InterpError) -> SimulatorErrorCode {
     match error {
-        InterpError::Fatal(code) if code > 0 => SimulatorErrorCode::DetectedTrueLoopCode(code),
+        // The interpreter is not constrained by the compiled function ABI's
+        // "zero return means success" convention, so every fatal code —
+        // including zero-valued assertion site codes — carries its runtime
+        // error info through unchanged.
+        InterpError::Fatal(code) => SimulatorErrorCode::DetectedTrueLoopCode(code),
         _ => SimulatorErrorCode::InternalError,
     }
 }

--- a/crates/celox/src/interpreter.rs
+++ b/crates/celox/src/interpreter.rs
@@ -24,7 +24,7 @@ use celox_sir::{
     SIRTerminator, SIRValue, TriggerIdWithKind, UnaryOp,
 };
 use num_bigint::{BigInt, BigUint};
-use num_traits::{Signed, ToPrimitive, Zero};
+use num_traits::{Signed, Zero};
 
 use crate::HashMap;
 
@@ -713,29 +713,38 @@ fn alu_binary(
         }
         BinaryOp::Sar => {
             // SEMANTICS-CHECK: an X/Z shift amount makes the whole result X.
-            // The frontend emits `Sar` only for genuinely signed sources, and
-            // the compiled backends sign-fill unconditionally for this opcode,
-            // so the source value and its unknown-bit mask are interpreted as
-            // two's complement at their declared width before shifting.
+            // The narrow (<= 64-bit) compiled lowering sign-promotes the
+            // source and shifts arithmetically. The multi-word lowering
+            // instead sign-fills whole words above the source's own chunks —
+            // based on the declared width's top bit — and shifts logically,
+            // for the value and the mask alike.
             if !rhs.mask.is_zero() {
                 all_x(dst_width)
             } else {
+                let common = lhs_width.max(rhs_width).max(dst_width);
                 let signed_value = to_signed(&lhs.payload, lhs_width);
                 let signed_mask = to_signed(&lhs.mask, lhs_width);
                 let bound = lhs_width.max(dst_width).max(1);
                 match shift_amount(&rhs.payload) {
                     Some(amount) if amount < bound => {
-                        let shifted = signed_value >> amount;
-                        let shifted_mask = signed_mask >> amount;
-                        SIRValue {
-                            payload: wrap_signed(&shifted, dst_width),
-                            mask: wrap_signed(&shifted_mask, dst_width),
+                        if common <= 64 {
+                            SIRValue {
+                                payload: wrap_signed(&(signed_value >> amount), dst_width),
+                                mask: wrap_signed(&(signed_mask >> amount), dst_width),
+                            }
+                        } else {
+                            let payload = (sar_wide_extend(&lhs.payload, lhs_width, common)
+                                >> amount)
+                                & width_mask(dst_width);
+                            let mask = (sar_wide_extend(&lhs.mask, lhs_width, common) >> amount)
+                                & width_mask(dst_width);
+                            SIRValue { payload, mask }
                         }
                     }
                     _ => {
                         // Overshift or unrepresentable distances converge the
                         // value and the mask toward their own sign fills
-                        // independently, exactly like the normal branch.
+                        // independently, exactly like the normal branches.
                         let payload = if signed_value.is_negative() {
                             width_mask(dst_width)
                         } else {
@@ -851,10 +860,31 @@ fn alu_binary(
     Ok(normalize(truncate(out, dst_width)))
 }
 
-/// Interpret a shift amount register value as `usize`, or `None` when it
-/// exceeds any meaningful shift distance.
+/// Interpret a shift amount register value as `usize`.
+///
+/// The compiled wide lowerings consume only the low 64-bit chunk of the
+/// count register, so upper chunks are ignored here as well. Returns `None`
+/// when even the low chunk is unrepresentable (overshift).
 fn shift_amount(value: &BigUint) -> Option<usize> {
-    value.to_usize()
+    let low = value.to_u64_digits().first().copied().unwrap_or(0);
+    usize::try_from(low).ok()
+}
+
+/// Extend a value across the common width the way the compiled multi-word
+/// Sar lowering does: whole 64-bit words above the source's own chunks are
+/// filled with the declared width's top bit, then the caller shifts
+/// logically. Bits inside the source's partial top word are left untouched.
+fn sar_wide_extend(value: &BigUint, lhs_width: usize, common: usize) -> BigUint {
+    let src_words = lhs_width.div_ceil(64);
+    let common_words = common.div_ceil(64);
+    if lhs_width == 0 || !value.bit((lhs_width - 1) as u64) {
+        return value.clone();
+    }
+    let mut extended = value.clone();
+    for word in src_words..common_words {
+        extended |= BigUint::from(u64::MAX) << (word * 64);
+    }
+    extended
 }
 
 /// Two's complement interpretation of `width`-truncated `value`.

--- a/crates/celox/src/interpreter.rs
+++ b/crates/celox/src/interpreter.rs
@@ -136,6 +136,27 @@ pub trait InterpMachine<A> {
         triggers: &[TriggerIdWithKind],
     ) -> Result<(), InterpError>;
 
+    /// Trigger-only aliased store (`bits == 0`): no memory write happens and
+    /// the source register is intentionally undefined; the machine detects a
+    /// change on the aliased signal and marks its triggers.
+    fn notify_trigger_only_store(
+        &mut self,
+        addr: &A,
+        triggers: &[TriggerIdWithKind],
+    ) -> Result<(), InterpError>;
+
+    /// Prepare storage for an upcoming store. Invoked before any pre-store
+    /// snapshot so the machine can make the destination readable (for
+    /// example sparse copy-on-write chunk initialization).
+    fn prepare_store(
+        &mut self,
+        _addr: &A,
+        _access: ResolvedAccess<'_>,
+        _bits: usize,
+    ) -> Result<(), InterpError> {
+        Ok(())
+    }
+
     /// Snapshot the stored range before a `Store` with comb capture sites so
     /// the post-store comparison can detect actual changes.
     fn capture_store_range(
@@ -235,11 +256,11 @@ pub fn execute_unit<A, M: InterpMachine<A>>(
                 true_block,
                 false_block,
             } => {
-                let cond_width = regs.width(*cond);
                 let cond = regs.get(*cond)?.clone();
-                // SEMANTICS-CHECK: a known one selects the true branch; an
-                // all-unknown or all-zero condition selects the false branch.
-                let target = if branch_condition_holds(&cond, cond_width) {
+                // Mirrors the compiled `brif` on the raw payload: a
+                // normalized unknown condition (payload one) takes the true
+                // edge, keeping tier migration control-flow identical.
+                let target = if branch_condition_holds(&cond) {
                     true_block
                 } else {
                     false_block
@@ -325,7 +346,6 @@ fn exec_instruction<A, M: InterpMachine<A>>(
                 regs.width(*rhs),
                 dst_width,
                 regs.is_signed(*lhs),
-                regs.is_signed(*rhs),
             )?;
             regs.set(*dst, truncate(out, dst_width));
         }
@@ -346,8 +366,17 @@ fn exec_instruction<A, M: InterpMachine<A>>(
             regs.set(*dst, value);
         }
         SIRInstruction::Store(addr, offset, bits, src, triggers, sites) => {
+            if *bits == 0 {
+                // Zero-width aliased store: the compiled lowering performs
+                // no memory write and never reads the source register.
+                if !triggers.is_empty() {
+                    machine.notify_trigger_only_store(addr, triggers)?;
+                }
+                return Ok(());
+            }
             let value = regs.get(*src)?.clone();
             let access = resolve_access(offset, regs)?;
+            machine.prepare_store(addr, access, *bits)?;
             let before = if sites.is_empty() {
                 None
             } else {
@@ -493,7 +522,16 @@ fn known_zeros(value: &SIRValue, width: usize) -> BigUint {
     (&width_mask(width) ^ &value.payload) & (&width_mask(width) ^ &value.mask)
 }
 
-fn branch_condition_holds(cond: &SIRValue, width: usize) -> bool {
+/// Branch selection follows the compiled terminator lowering exactly: it
+/// branches on the raw (normalized) payload, so an unknown condition whose
+/// normalized payload is one takes the true edge.
+fn branch_condition_holds(cond: &SIRValue) -> bool {
+    !cond.payload.is_zero()
+}
+
+/// Mux selection keeps the IEEE dominant-value reading: a known one selects
+/// the then-arm, while a fully unknown condition merges the arms.
+fn mux_condition_known_one(cond: &SIRValue, width: usize) -> bool {
     !known_ones(cond, width).is_zero()
 }
 
@@ -517,7 +555,6 @@ fn alu_binary(
     rhs_width: usize,
     dst_width: usize,
     lhs_signed: bool,
-    rhs_signed: bool,
 ) -> Result<SIRValue, InterpError> {
     let out = match op {
         BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul => {
@@ -528,9 +565,11 @@ fn alu_binary(
             if !lhs.mask.is_zero() || !rhs.mask.is_zero() {
                 all_x(dst_width)
             } else {
+                // The compiled lowering zero-extends the right operand for
+                // arithmetic regardless of its declaration.
                 let common = lhs_width.max(rhs_width).max(dst_width);
                 let l = promote_operand(lhs, lhs_signed, lhs_width, common).payload;
-                let r = promote_operand(rhs, rhs_signed, rhs_width, common).payload;
+                let r = zero_extend(rhs, common).payload;
                 let raw = match op {
                     BinaryOp::Add => l + r,
                     BinaryOp::Sub => l + (&width_mask(common) ^ &r) + 1u8,
@@ -580,7 +619,7 @@ fn alu_binary(
             // its sign instead of reading as known zero.
             let common = lhs_width.max(rhs_width).max(dst_width);
             let l = promote_operand(lhs, lhs_signed, lhs_width, common);
-            let r = promote_operand(rhs, rhs_signed, rhs_width, common);
+            let r = zero_extend(rhs, common);
             let ones = known_ones(&l, common) & known_ones(&r, common);
             let zeros = known_zeros(&l, common) | known_zeros(&r, common);
             let mask = &width_mask(common) ^ (&ones | &zeros);
@@ -592,7 +631,7 @@ fn alu_binary(
         BinaryOp::Or => {
             let common = lhs_width.max(rhs_width).max(dst_width);
             let l = promote_operand(lhs, lhs_signed, lhs_width, common);
-            let r = promote_operand(rhs, rhs_signed, rhs_width, common);
+            let r = zero_extend(rhs, common);
             let ones = known_ones(&l, common) | known_ones(&r, common);
             let zeros = known_zeros(&l, common) & known_zeros(&r, common);
             let mask = &width_mask(common) ^ (&ones | &zeros);
@@ -607,7 +646,7 @@ fn alu_binary(
             // unlike arithmetic ops where any X poisons the whole result.
             let common = lhs_width.max(rhs_width).max(dst_width);
             let l = promote_operand(lhs, lhs_signed, lhs_width, common);
-            let r = promote_operand(rhs, rhs_signed, rhs_width, common);
+            let r = zero_extend(rhs, common);
             SIRValue {
                 payload: &l.payload ^ &r.payload,
                 mask: &l.mask | &r.mask,
@@ -707,7 +746,7 @@ fn alu_binary(
             if !lhs.mask.is_zero() || !rhs.mask.is_zero() {
                 all_x(dst_width)
             } else {
-                let holds = compare_holds(op, lhs, rhs, lhs_width, rhs_width, lhs_signed);
+                let holds = compare_holds(op, lhs, rhs, lhs_width, rhs_width);
                 SIRValue::new(u8::from(holds))
             }
         }
@@ -820,26 +859,19 @@ fn wrap_signed(value: &BigInt, width: usize) -> BigUint {
 }
 
 /// Evaluate an ordering/equality operator on fully-known operands.
-///
-/// `lhs_signed` carries the left-hand register's declaration so `Eq`/`Ne`
-/// replicate the compiled promotion: a signed lhs is sign-extended to the
-/// common width while the rhs is always zero-extended.
 fn compare_holds(
     op: &BinaryOp,
     lhs: &SIRValue,
     rhs: &SIRValue,
     lhs_width: usize,
     rhs_width: usize,
-    lhs_signed: bool,
 ) -> bool {
     let ordering = match op {
         BinaryOp::Eq | BinaryOp::Ne => {
+            // Equality compares zero-extended payloads on both sides, like
+            // every compiled lowering; declaration signedness is ignored.
             let common = lhs_width.max(rhs_width);
-            let lhs_ext = if lhs_signed {
-                sign_extend(&lhs.payload, lhs_width, common)
-            } else {
-                lhs.payload.clone()
-            };
+            let lhs_ext = zero_extend(lhs, common).payload;
             let rhs_ext = zero_extend(rhs, common).payload;
             lhs_ext.cmp(&rhs_ext)
         }
@@ -938,17 +970,29 @@ fn alu_unary(
         },
         UnaryOp::Minus => {
             // SEMANTICS-CHECK: negating a value containing X/Z yields all-X.
+            // Minus forces signed promotion in the compiled lowering, so the
+            // operand is sign-extended to the common width before the
+            // two's-complement negation (negating 4-bit 1 into an 8-bit
+            // destination yields 0xff).
             if src.mask.is_zero() {
-                let inverted = &width_mask(src_width) ^ &src.payload;
-                SIRValue::new((inverted + 1u8) & width_mask(src_width))
+                let common = src_width.max(dst_width);
+                let promoted = promote_operand(src, true, src_width, common).payload;
+                let inverted = &width_mask(common) ^ &promoted;
+                SIRValue::new((&inverted + 1u8) & width_mask(dst_width))
             } else {
-                all_x(src_width)
+                all_x(dst_width)
             }
         }
-        UnaryOp::BitNot => SIRValue {
-            payload: &width_mask(src_width) ^ &src.payload,
-            mask: src.mask.clone(),
-        },
+        UnaryOp::BitNot => {
+            // Complement at the common width so widened results fill their
+            // new high bits, mirroring the compiled promotion.
+            let common = src_width.max(dst_width);
+            let promoted = promote_operand(src, src_signed, src_width, common);
+            SIRValue {
+                payload: &width_mask(common) ^ &promoted.payload,
+                mask: promoted.mask,
+            }
+        }
         UnaryOp::LogicNot => {
             if !known_ones(src, src_width).is_zero() {
                 SIRValue::new(BigUint::zero())
@@ -1039,7 +1083,7 @@ fn eval_mux(
     cond_width: usize,
     out_width: usize,
 ) -> SIRValue {
-    if branch_condition_holds(cond, cond_width) {
+    if mux_condition_known_one(cond, cond_width) {
         return then_value.clone();
     }
     if cond.mask.is_zero() {
@@ -1227,6 +1271,15 @@ mod tests {
             _addr: &u32,
             _access: ResolvedAccess<'_>,
             _bits: usize,
+            triggers: &[TriggerIdWithKind],
+        ) -> Result<(), InterpError> {
+            self.trigger_notifications.push(triggers.len());
+            Ok(())
+        }
+
+        fn notify_trigger_only_store(
+            &mut self,
+            _addr: &u32,
             triggers: &[TriggerIdWithKind],
         ) -> Result<(), InterpError> {
             self.trigger_notifications.push(triggers.len());

--- a/crates/celox/src/interpreter.rs
+++ b/crates/celox/src/interpreter.rs
@@ -565,10 +565,16 @@ fn alu_binary(
             if !lhs.mask.is_zero() || !rhs.mask.is_zero() {
                 all_x(dst_width)
             } else {
-                // The compiled lowering zero-extends the right operand for
-                // arithmetic regardless of its declaration.
+                // The compiled narrowing (<= 64-bit) lowering zero-extends
+                // the right operand regardless of its declaration and
+                // sign-promotes the left by its declaration; the wide path
+                // passes raw zero-filled chunks for both sides.
                 let common = lhs_width.max(rhs_width).max(dst_width);
-                let l = promote_operand(lhs, lhs_signed, lhs_width, common).payload;
+                let l = if common <= 64 {
+                    promote_operand(lhs, lhs_signed, lhs_width, common).payload
+                } else {
+                    zero_extend(lhs, common).payload
+                };
                 let r = zero_extend(rhs, common).payload;
                 let raw = match op {
                     BinaryOp::Add => l + r,
@@ -618,7 +624,11 @@ fn alu_binary(
             // compiled promotion, so padding above a narrower operand follows
             // its sign instead of reading as known zero.
             let common = lhs_width.max(rhs_width).max(dst_width);
-            let l = promote_operand(lhs, lhs_signed, lhs_width, common);
+            let l = if common <= 64 {
+                promote_operand(lhs, lhs_signed, lhs_width, common)
+            } else {
+                zero_extend(lhs, common)
+            };
             let r = zero_extend(rhs, common);
             let ones = known_ones(&l, common) & known_ones(&r, common);
             let zeros = known_zeros(&l, common) | known_zeros(&r, common);
@@ -630,7 +640,11 @@ fn alu_binary(
         }
         BinaryOp::Or => {
             let common = lhs_width.max(rhs_width).max(dst_width);
-            let l = promote_operand(lhs, lhs_signed, lhs_width, common);
+            let l = if common <= 64 {
+                promote_operand(lhs, lhs_signed, lhs_width, common)
+            } else {
+                zero_extend(lhs, common)
+            };
             let r = zero_extend(rhs, common);
             let ones = known_ones(&l, common) | known_ones(&r, common);
             let zeros = known_zeros(&l, common) & known_zeros(&r, common);
@@ -645,7 +659,11 @@ fn alu_binary(
             // bit only makes the corresponding output bit unknown (mask union),
             // unlike arithmetic ops where any X poisons the whole result.
             let common = lhs_width.max(rhs_width).max(dst_width);
-            let l = promote_operand(lhs, lhs_signed, lhs_width, common);
+            let l = if common <= 64 {
+                promote_operand(lhs, lhs_signed, lhs_width, common)
+            } else {
+                zero_extend(lhs, common)
+            };
             let r = zero_extend(rhs, common);
             SIRValue {
                 payload: &l.payload ^ &r.payload,

--- a/crates/celox/src/interpreter.rs
+++ b/crates/celox/src/interpreter.rs
@@ -125,7 +125,16 @@ pub trait InterpMachine<A> {
     ) -> Result<(), InterpError>;
 
     /// Edge/level triggers attached to a `Store` or `Commit`.
-    fn notify_triggers(&mut self, addr: &A, triggers: &[TriggerIdWithKind]);
+    ///
+    /// The resolved access and width let the machine compare the stored
+    /// range against its group-entry snapshot for per-kind edge detection.
+    fn notify_triggers(
+        &mut self,
+        addr: &A,
+        access: ResolvedAccess<'_>,
+        bits: usize,
+        triggers: &[TriggerIdWithKind],
+    ) -> Result<(), InterpError>;
 
     /// Snapshot the stored range before a `Store` with comb capture sites so
     /// the post-store comparison can detect actual changes.
@@ -346,7 +355,8 @@ fn exec_instruction<A, M: InterpMachine<A>>(
             };
             machine.store(addr, access, *bits, &value)?;
             if !triggers.is_empty() {
-                machine.notify_triggers(addr, triggers);
+                let access = resolve_access(offset, regs)?;
+                machine.notify_triggers(addr, access, *bits, triggers)?;
             }
             if let Some(before) = before {
                 let access = resolve_access(offset, regs)?;
@@ -357,7 +367,8 @@ fn exec_instruction<A, M: InterpMachine<A>>(
             let access = resolve_access(offset, regs)?;
             machine.commit(src, dst, access, *bits)?;
             if !triggers.is_empty() {
-                machine.notify_triggers(dst, triggers);
+                let access = resolve_access(offset, regs)?;
+                machine.notify_triggers(dst, access, *bits, triggers)?;
             }
         }
         SIRInstruction::Concat(dst, sources) => {
@@ -660,13 +671,20 @@ fn alu_binary(
                         }
                     }
                     _ => {
-                        // Overshift or unrepresentable distances drive every
-                        // bit, including the mask, toward the sign fill.
-                        if signed_value.is_negative() {
-                            all_x(dst_width)
+                        // Overshift or unrepresentable distances converge the
+                        // value and the mask toward their own sign fills
+                        // independently, exactly like the normal branch.
+                        let payload = if signed_value.is_negative() {
+                            width_mask(dst_width)
                         } else {
-                            SIRValue::new(BigUint::zero())
-                        }
+                            BigUint::zero()
+                        };
+                        let mask = if signed_mask.is_negative() {
+                            width_mask(dst_width)
+                        } else {
+                            BigUint::zero()
+                        };
+                        SIRValue { payload, mask }
                     }
                 }
             }
@@ -1204,8 +1222,15 @@ mod tests {
             Ok(())
         }
 
-        fn notify_triggers(&mut self, _addr: &u32, triggers: &[TriggerIdWithKind]) {
+        fn notify_triggers(
+            &mut self,
+            _addr: &u32,
+            _access: ResolvedAccess<'_>,
+            _bits: usize,
+            triggers: &[TriggerIdWithKind],
+        ) -> Result<(), InterpError> {
             self.trigger_notifications.push(triggers.len());
+            Ok(())
         }
 
         fn capture_store_range(

--- a/crates/celox/src/interpreter.rs
+++ b/crates/celox/src/interpreter.rs
@@ -976,9 +976,11 @@ fn alu_unary(
     let out = match op {
         UnaryOp::Ident => {
             // Identity casts widen with the operand's declared signedness,
-            // matching the compiled promotion: widening a signed negative
-            // value must sign-fill, not zero-fill.
-            if src_signed && dst_width > src_width {
+            // matching the compiled narrow promotion: widening a signed
+            // negative value must sign-fill, not zero-fill. The compiled
+            // multi-word path instead copies chunks and zero-fills, so casts
+            // into registers wider than 64 bits keep zero padding.
+            if src_signed && dst_width > src_width && dst_width <= 64 {
                 SIRValue {
                     payload: sign_extend(&src.payload, src_width, dst_width),
                     mask: sign_extend(&src.mask, src_width, dst_width),

--- a/crates/celox/src/interpreter.rs
+++ b/crates/celox/src/interpreter.rs
@@ -23,8 +23,8 @@ use celox_sir::{
     BinaryOp, BlockId, ExecutionUnit, RegisterId, RegisterType, SIRInstruction, SIROffset,
     SIRTerminator, SIRValue, TriggerIdWithKind, UnaryOp,
 };
-use num_bigint::BigUint;
-use num_traits::{ToPrimitive, Zero};
+use num_bigint::{BigInt, BigUint};
+use num_traits::{Signed, ToPrimitive, Zero};
 
 use crate::HashMap;
 
@@ -50,12 +50,17 @@ pub enum InterpError {
 impl fmt::Display for InterpError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            InterpError::UnknownBlock(block) => write!(f, "interpreted jump to unknown block b{}", block.0),
+            InterpError::UnknownBlock(block) => {
+                write!(f, "interpreted jump to unknown block b{}", block.0)
+            }
             InterpError::MissingRegister(register) => {
                 write!(f, "read of unwritten register r{}", register.0)
             }
             InterpError::RegisterArityMismatch { expected, found } => {
-                write!(f, "jump argument count mismatch: target expects {expected}, jump supplies {found}")
+                write!(
+                    f,
+                    "jump argument count mismatch: target expects {expected}, jump supplies {found}"
+                )
             }
             InterpError::UnsupportedOperation(description) => {
                 write!(f, "interpreter does not support operation: {description}")
@@ -79,6 +84,14 @@ pub struct ResolvedAccess<'a> {
     /// Values of the registers returned by [`SIROffset::dynamic_registers`],
     /// in the same order.
     pub dynamics: [Option<&'a SIRValue>; 2],
+}
+
+/// Pre-store snapshot of a stored range, used to detect whether a store
+/// actually changed any covered bit before enabling comb capture observers.
+#[derive(Clone, Debug, Default)]
+pub struct StoreSnapshot {
+    pub value_words: Vec<u64>,
+    pub mask_words: Vec<u64>,
 }
 
 /// Storage and side-effect interface driven by the interpreter.
@@ -114,20 +127,45 @@ pub trait InterpMachine<A> {
     /// Edge/level triggers attached to a `Store` or `Commit`.
     fn notify_triggers(&mut self, addr: &A, triggers: &[TriggerIdWithKind]);
 
-    /// Comb capture sites attached to a `Store`; receives the stored value.
-    fn notify_comb_capture(&mut self, addr: &A, sites: &[u32], value: &SIRValue);
+    /// Snapshot the stored range before a `Store` with comb capture sites so
+    /// the post-store comparison can detect actual changes.
+    fn capture_store_range(
+        &mut self,
+        addr: &A,
+        access: ResolvedAccess<'_>,
+        bits: usize,
+    ) -> Result<StoreSnapshot, InterpError>;
 
-    fn emit_runtime_event(&mut self, site_id: u32, args: &[SIRValue]);
+    /// Enable comb capture sites when the stored range differs from the
+    /// pre-store snapshot.
+    fn enable_comb_captures(
+        &mut self,
+        addr: &A,
+        access: ResolvedAccess<'_>,
+        bits: usize,
+        before: &StoreSnapshot,
+        sites: &[u32],
+    ) -> Result<(), InterpError>;
 
+    fn emit_runtime_event(&mut self, site_id: u32, args: &[SIRValue]) -> Result<(), InterpError>;
+
+    /// Emit a comb capture event. Returns `Err(InterpError::Fatal)` when the
+    /// event carries a fatal code and its site was enabled, mirroring the
+    /// compiled unit's early return.
     fn emit_comb_capture_event(
         &mut self,
         site_id: u32,
         args: &[SIRValue],
         fatal_error_code: Option<i64>,
         consume_enabled: bool,
-    );
+    ) -> Result<(), InterpError>;
 
-    fn enable_comb_capture_if_changed(&mut self, old: &SIRValue, new: &SIRValue, sites: &[u32]);
+    fn enable_comb_capture_if_changed(
+        &mut self,
+        old: &SIRValue,
+        new: &SIRValue,
+        sites: &[u32],
+    ) -> Result<(), InterpError>;
 }
 
 /// Outcome of one interpreted unit invocation.
@@ -142,10 +180,15 @@ pub enum UnitExit {
 /// `entry_args` binds the entry block's parameters (event arguments). The
 /// simulator drives repeated invocations (comb settle fixpoint, clocked
 /// events); this function performs exactly one entry-to-return traversal.
+///
+/// `four_state` selects the value model: in two-state mode immediate masks
+/// are discarded exactly like the compiled backends' translation does, so
+/// unknown-bit payloads never leak into stored values.
 pub fn execute_unit<A, M: InterpMachine<A>>(
     unit: &ExecutionUnit<A>,
     machine: &mut M,
     entry_args: &[SIRValue],
+    four_state: bool,
 ) -> Result<UnitExit, InterpError> {
     let mut regs = Registers::new(&unit.register_map);
     let entry = unit
@@ -169,7 +212,7 @@ pub fn execute_unit<A, M: InterpMachine<A>>(
             .get(&current)
             .ok_or(InterpError::UnknownBlock(current))?;
         for instruction in &block.instructions {
-            exec_instruction(instruction, &mut regs, machine)?;
+            exec_instruction(instruction, &mut regs, machine, four_state)?;
         }
         match &block.terminator {
             SIRTerminator::Return => return Ok(UnitExit::Return),
@@ -183,10 +226,11 @@ pub fn execute_unit<A, M: InterpMachine<A>>(
                 true_block,
                 false_block,
             } => {
+                let cond_width = regs.width(*cond);
                 let cond = regs.get(*cond)?.clone();
                 // SEMANTICS-CHECK: a known one selects the true branch; an
                 // all-unknown or all-zero condition selects the false branch.
-                let target = if branch_condition_holds(&cond, regs.width(*cond)) {
+                let target = if branch_condition_holds(&cond, cond_width) {
                     true_block
                 } else {
                     false_block
@@ -247,14 +291,34 @@ fn exec_instruction<A, M: InterpMachine<A>>(
     instruction: &SIRInstruction<A>,
     regs: &mut Registers,
     machine: &mut M,
+    four_state: bool,
 ) -> Result<(), InterpError> {
     match instruction {
-        SIRInstruction::Imm(dst, value) => regs.set(*dst, value.clone()),
+        SIRInstruction::Imm(dst, value) => {
+            // Two-state translation drops unknown-bit masks entirely; keep
+            // only the payload so X constants behave as their payload bits.
+            let value = if four_state {
+                value.clone()
+            } else {
+                SIRValue::new(value.payload.clone())
+            };
+            regs.set(*dst, value);
+        }
         SIRInstruction::Binary(dst, lhs, op, rhs) => {
-            let lhs = regs.get(*lhs)?.clone();
-            let rhs = regs.get(*rhs)?.clone();
-            let out = alu_binary(op, &lhs, &rhs, regs.width(*dst))?;
-            regs.set(*dst, truncate(out, regs.width(*dst)));
+            let lhs_value = regs.get(*lhs)?.clone();
+            let rhs_value = regs.get(*rhs)?.clone();
+            let dst_width = regs.width(*dst);
+            let lhs_signed = regs.is_signed(*lhs);
+            let out = alu_binary(
+                op,
+                &lhs_value,
+                &rhs_value,
+                regs.width(*lhs),
+                regs.width(*rhs),
+                dst_width,
+                lhs_signed,
+            )?;
+            regs.set(*dst, truncate(out, dst_width));
         }
         SIRInstruction::Unary(dst, op, src) => {
             let src_value = regs.get(*src)?.clone();
@@ -275,12 +339,18 @@ fn exec_instruction<A, M: InterpMachine<A>>(
         SIRInstruction::Store(addr, offset, bits, src, triggers, sites) => {
             let value = regs.get(*src)?.clone();
             let access = resolve_access(offset, regs)?;
+            let before = if sites.is_empty() {
+                None
+            } else {
+                Some(machine.capture_store_range(addr, access, *bits)?)
+            };
             machine.store(addr, access, *bits, &value)?;
             if !triggers.is_empty() {
                 machine.notify_triggers(addr, triggers);
             }
-            if !sites.is_empty() {
-                machine.notify_comb_capture(addr, sites, &value);
+            if let Some(before) = before {
+                let access = resolve_access(offset, regs)?;
+                machine.enable_comb_captures(addr, access, *bits, &before, sites)?;
             }
         }
         SIRInstruction::Commit(src, dst, offset, bits, triggers) => {
@@ -301,10 +371,7 @@ fn exec_instruction<A, M: InterpMachine<A>>(
             }
             // Keep the declared-register-width invariant shared by every other
             // operation: results never exceed the destination width.
-            regs.set(
-                *dst,
-                truncate(SIRValue { payload, mask }, regs.width(*dst)),
-            );
+            regs.set(*dst, truncate(SIRValue { payload, mask }, regs.width(*dst)));
         }
         SIRInstruction::Slice(dst, src, offset, width) => {
             let value = regs.get(*src)?;
@@ -313,6 +380,7 @@ fn exec_instruction<A, M: InterpMachine<A>>(
             regs.set(*dst, SIRValue { payload, mask });
         }
         SIRInstruction::Mux(dst, cond, then_value, else_value) => {
+            let cond_width = regs.width(*cond);
             let cond = regs.get(*cond)?.clone();
             let then_value = regs.get(*then_value)?.clone();
             let else_value = regs.get(*else_value)?.clone();
@@ -322,14 +390,14 @@ fn exec_instruction<A, M: InterpMachine<A>>(
                 &cond,
                 &then_value,
                 &else_value,
-                regs.width(*cond),
+                cond_width,
                 regs.width(*dst),
             );
             regs.set(*dst, out);
         }
         SIRInstruction::RuntimeEvent { site_id, args } => {
             let values = resolve_args(args, regs)?;
-            machine.emit_runtime_event(*site_id, &values);
+            machine.emit_runtime_event(*site_id, &values)?;
         }
         SIRInstruction::CombCaptureEvent {
             site_id,
@@ -338,12 +406,17 @@ fn exec_instruction<A, M: InterpMachine<A>>(
             consume_enabled,
         } => {
             let values = resolve_args(args, regs)?;
-            machine.emit_comb_capture_event(*site_id, &values, *fatal_error_code, *consume_enabled);
+            machine.emit_comb_capture_event(
+                *site_id,
+                &values,
+                *fatal_error_code,
+                *consume_enabled,
+            )?;
         }
         SIRInstruction::CombCaptureEnableIfChanged { old, new, sites } => {
             let old = regs.get(*old)?.clone();
             let new = regs.get(*new)?.clone();
-            machine.enable_comb_capture_if_changed(&old, &new, sites);
+            machine.enable_comb_capture_if_changed(&old, &new, sites)?;
         }
     }
     Ok(())
@@ -359,16 +432,11 @@ fn resolve_access<'a>(
             dynamics[slot] = Some(regs.get(register)?);
         }
     }
-    Ok(ResolvedAccess {
-        offset,
-        dynamics,
-    })
+    Ok(ResolvedAccess { offset, dynamics })
 }
 
 fn resolve_args(args: &[RegisterId], regs: &Registers) -> Result<Vec<SIRValue>, InterpError> {
-    args.iter()
-        .map(|arg| regs.get(*arg).cloned())
-        .collect()
+    args.iter().map(|arg| regs.get(*arg).cloned()).collect()
 }
 
 // ── Value helpers ─────────────────────────────────────────────────────
@@ -388,9 +456,11 @@ fn truncate(mut value: SIRValue, width: usize) -> SIRValue {
     value
 }
 
+/// An all-unknown value following the compiled backends' normalized
+/// convention: unknown bits carry payload one.
 fn all_x(width: usize) -> SIRValue {
     SIRValue {
-        payload: BigUint::zero(),
+        payload: width_mask(width),
         mask: width_mask(width),
     }
 }
@@ -418,138 +488,390 @@ fn branch_condition_holds(cond: &SIRValue, width: usize) -> bool {
 
 // ── ALU ───────────────────────────────────────────────────────────────
 
+/// Normalize a value into the compiled backends' register convention:
+/// unknown bits carry payload one (`payload |= mask`), so a value migrated
+/// between the interpreter and generated code is bit-identical in memory.
+fn normalize(value: SIRValue) -> SIRValue {
+    SIRValue {
+        payload: &value.payload | &value.mask,
+        mask: value.mask,
+    }
+}
+
 fn alu_binary(
     op: &BinaryOp,
     lhs: &SIRValue,
     rhs: &SIRValue,
-    width: usize,
+    lhs_width: usize,
+    rhs_width: usize,
+    dst_width: usize,
+    lhs_signed: bool,
 ) -> Result<SIRValue, InterpError> {
     let out = match op {
         BinaryOp::Add => {
             // SEMANTICS-CHECK: any X/Z operand bit makes the whole result X.
             if lhs.mask.is_zero() && rhs.mask.is_zero() {
-                SIRValue::new((&lhs.payload + &rhs.payload) & width_mask(width))
+                SIRValue::new((&lhs.payload + &rhs.payload) & width_mask(dst_width))
             } else {
-                all_x(width)
+                all_x(dst_width)
             }
         }
         BinaryOp::Sub => {
             // Wrap-safe two's complement subtraction: l + (~r + 1) mod 2^w.
             // SEMANTICS-CHECK: any X/Z operand bit makes the whole result X.
             if lhs.mask.is_zero() && rhs.mask.is_zero() {
-                let inverted_rhs = &width_mask(width) ^ &rhs.payload;
-                SIRValue::new(((&lhs.payload + inverted_rhs + 1u8) & width_mask(width)))
+                let inverted_rhs = &width_mask(dst_width) ^ &rhs.payload;
+                SIRValue::new((&lhs.payload + inverted_rhs + 1u8) & width_mask(dst_width))
             } else {
-                all_x(width)
+                all_x(dst_width)
             }
         }
         BinaryOp::Mul => {
             // SEMANTICS-CHECK: any X/Z operand bit makes the whole result X.
             if lhs.mask.is_zero() && rhs.mask.is_zero() {
-                SIRValue::new((&lhs.payload * &rhs.payload) & width_mask(width))
+                SIRValue::new((&lhs.payload * &rhs.payload) & width_mask(dst_width))
             } else {
-                all_x(width)
+                all_x(dst_width)
+            }
+        }
+        BinaryOp::DivU | BinaryOp::RemU => {
+            // SEMANTICS-CHECK: any X/Z operand bit makes the whole result X.
+            // Division by zero yields zero, matching the compiled contract.
+            if !lhs.mask.is_zero() || !rhs.mask.is_zero() {
+                all_x(dst_width)
+            } else if rhs.payload.is_zero() {
+                SIRValue::new(BigUint::zero())
+            } else if *op == BinaryOp::DivU {
+                SIRValue::new(&lhs.payload / &rhs.payload)
+            } else {
+                SIRValue::new(&lhs.payload % &rhs.payload)
+            }
+        }
+        BinaryOp::DivS | BinaryOp::RemS => {
+            // SEMANTICS-CHECK: any X/Z operand bit makes the whole result X.
+            // Signed division truncates toward zero; division by zero yields
+            // zero, and MIN / -1 wraps to MIN (rem: 0), matching the compiled
+            // overflow guards.
+            if !lhs.mask.is_zero() || !rhs.mask.is_zero() {
+                all_x(dst_width)
+            } else {
+                let dividend = to_signed(&lhs.payload, lhs_width);
+                let divisor = to_signed(&rhs.payload, rhs_width);
+                if divisor.is_zero() {
+                    SIRValue::new(BigUint::zero())
+                } else {
+                    let raw = if *op == BinaryOp::DivS {
+                        &dividend / &divisor
+                    } else {
+                        &dividend % &divisor
+                    };
+                    SIRValue::new(wrap_signed(&raw, dst_width))
+                }
             }
         }
         BinaryOp::And => {
-            let ones = known_ones(lhs, width) & known_ones(rhs, width);
-            let zeros = known_zeros(lhs, width) | known_zeros(rhs, width);
+            // Per-bit truth tables evaluated at the common width so padding
+            // above a narrower operand counts as known zero.
+            let common = lhs_width.max(rhs_width).max(dst_width);
+            let ones = known_ones(lhs, common) & known_ones(rhs, common);
+            let zeros = known_zeros(lhs, common) | known_zeros(rhs, common);
+            let mask = &width_mask(common) ^ (&ones | &zeros);
             SIRValue {
                 payload: ones,
-                mask: &width_mask(width) ^ (&ones | &zeros),
+                mask,
             }
         }
         BinaryOp::Or => {
-            let ones = known_ones(lhs, width) | known_ones(rhs, width);
-            let zeros = known_zeros(lhs, width) & known_zeros(rhs, width);
+            let common = lhs_width.max(rhs_width).max(dst_width);
+            let ones = known_ones(lhs, common) | known_ones(rhs, common);
+            let zeros = known_zeros(lhs, common) & known_zeros(rhs, common);
+            let mask = &width_mask(common) ^ (&ones | &zeros);
             SIRValue {
                 payload: ones,
-                mask: &width_mask(width) ^ (&ones | &zeros),
+                mask,
             }
         }
         BinaryOp::Xor => {
-            // SEMANTICS-CHECK: any X/Z operand bit makes the whole result X.
-            if lhs.mask.is_zero() && rhs.mask.is_zero() {
-                SIRValue::new((&lhs.payload ^ &rhs.payload) & width_mask(width))
-            } else {
-                all_x(width)
+            // SEMANTICS-CHECK: XOR is per-bit independent — an unknown input
+            // bit only makes the corresponding output bit unknown (mask union),
+            // unlike arithmetic ops where any X poisons the whole result.
+            let common = lhs_width.max(rhs_width);
+            SIRValue {
+                payload: (&lhs.payload ^ &rhs.payload) & width_mask(common),
+                mask: (&lhs.mask | &rhs.mask) & width_mask(common),
             }
         }
         BinaryOp::Shl => {
             // SEMANTICS-CHECK: an X/Z shift amount makes the whole result X.
+            // The shift runs on the full left-hand value and the destination
+            // keeps the low bits, matching the compiled common-width lowering
+            // (a narrow destination still receives surviving low bits).
             if !rhs.mask.is_zero() {
-                all_x(width)
+                all_x(dst_width)
             } else {
                 match shift_amount(&rhs.payload) {
-                    Some(amount) if amount < width => SIRValue {
-                        payload: (&lhs.payload << amount) & width_mask(width),
-                        mask: (&lhs.mask << amount) & width_mask(width),
+                    Some(amount) => SIRValue {
+                        payload: (&lhs.payload << amount) & width_mask(dst_width),
+                        mask: (&lhs.mask << amount) & width_mask(dst_width),
                     },
-                    _ => SIRValue::new(BigUint::zero()),
+                    None => SIRValue::new(BigUint::zero()),
                 }
             }
         }
         BinaryOp::Shr => {
             // SEMANTICS-CHECK: an X/Z shift amount makes the whole result X.
+            // Logical shift: vacated bits are zero regardless of width.
             if !rhs.mask.is_zero() {
-                all_x(width)
+                all_x(dst_width)
             } else {
                 match shift_amount(&rhs.payload) {
-                    Some(amount) if amount < width => SIRValue {
+                    Some(amount) => SIRValue {
                         payload: &lhs.payload >> amount,
                         mask: &lhs.mask >> amount,
                     },
-                    _ => SIRValue::new(BigUint::zero()),
+                    None => SIRValue::new(BigUint::zero()),
                 }
             }
         }
         BinaryOp::Sar => {
-            // SEMANTICS-CHECK: an X/Z shift amount or X/Z sign bit makes the
-            // whole result X; signedness comes from the lhs register.
+            // SEMANTICS-CHECK: an X/Z shift amount makes the whole result X.
+            // The frontend emits `Sar` only for genuinely signed sources, and
+            // the compiled backends sign-fill unconditionally for this opcode,
+            // so the source value and its unknown-bit mask are interpreted as
+            // two's complement at their declared width before shifting.
             if !rhs.mask.is_zero() {
-                all_x(width)
+                all_x(dst_width)
             } else {
+                let signed_value = to_signed(&lhs.payload, lhs_width);
+                let signed_mask = to_signed(&lhs.mask, lhs_width);
                 match shift_amount(&rhs.payload) {
-                    Some(amount) if width > 0 => {
-                        let sign_bit = (&lhs.payload >> (width - 1)) & 1u8 == 1u8;
-                        let sign_known = (&lhs.mask >> (width - 1)) & 1u8 == 0u8;
-                        if !sign_known {
-                            all_x(width)
-                        } else if amount >= width {
-                            if sign_bit {
-                                SIRValue::new(width_mask(width))
-                            } else {
-                                SIRValue::new(BigUint::zero())
-                            }
-                        } else {
-                            let sign_fill = if sign_bit {
-                                &width_mask(width) >> (width - amount)
-                            } else {
-                                BigUint::zero()
-                            };
-                            SIRValue {
-                                payload: (&lhs.payload >> amount) | sign_fill,
-                                mask: &lhs.mask >> amount,
-                            }
+                    Some(amount) => {
+                        let shifted = signed_value >> amount;
+                        let shifted_mask = signed_mask >> amount;
+                        SIRValue {
+                            payload: wrap_signed(&shifted, dst_width),
+                            mask: wrap_signed(&shifted_mask, dst_width),
                         }
                     }
-                    _ => SIRValue::new(BigUint::zero()),
+                    None => {
+                        // An unrepresentable shift distance drives every bit,
+                        // including the mask, toward the sign fill.
+                        if signed_value.is_negative() {
+                            all_x(dst_width)
+                        } else {
+                            SIRValue::new(BigUint::zero())
+                        }
+                    }
                 }
             }
         }
-        other => {
-            return Err(InterpError::UnsupportedOperation(format!(
-                "binary operator {other}"
-            )))
+        BinaryOp::Eq
+        | BinaryOp::Ne
+        | BinaryOp::LtU
+        | BinaryOp::LtS
+        | BinaryOp::LeU
+        | BinaryOp::LeS
+        | BinaryOp::GtU
+        | BinaryOp::GtS
+        | BinaryOp::GeU
+        | BinaryOp::GeS => {
+            // SEMANTICS-CHECK: comparisons yield X when either operand holds
+            // an unknown bit; otherwise the comparison runs on the operands'
+            // declared values (signed ops interpret two's complement). `Eq`
+            // and `Ne` sign-extend a signed left-hand operand and zero-extend
+            // the right-hand one, mirroring the compiled promotion rules.
+            if !lhs.mask.is_zero() || !rhs.mask.is_zero() {
+                all_x(dst_width)
+            } else {
+                let holds = compare_holds(op, lhs, rhs, lhs_width, rhs_width, lhs_signed);
+                SIRValue::new(u8::from(holds))
+            }
+        }
+        BinaryOp::LogicAnd => {
+            // IEEE 1800: 0 dominates `&&` — a definitely-false operand forces
+            // a definite zero; any remaining X yields X.
+            if logic_operand_definitely_false(lhs, lhs_width)
+                || logic_operand_definitely_false(rhs, rhs_width)
+            {
+                SIRValue::new(BigUint::zero())
+            } else if !lhs.mask.is_zero() || !rhs.mask.is_zero() {
+                all_x(dst_width)
+            } else {
+                let truth = logic_truth(lhs, lhs_width) && logic_truth(rhs, rhs_width);
+                SIRValue::new(u8::from(truth))
+            }
+        }
+        BinaryOp::LogicOr => {
+            // IEEE 1800: 1 dominates `||` — a definitely-true operand forces
+            // a definite one; any remaining X yields X.
+            if logic_operand_definitely_true(lhs, lhs_width)
+                || logic_operand_definitely_true(rhs, rhs_width)
+            {
+                SIRValue::new(1u8)
+            } else if !lhs.mask.is_zero() || !rhs.mask.is_zero() {
+                all_x(dst_width)
+            } else {
+                let truth = logic_truth(lhs, lhs_width) || logic_truth(rhs, rhs_width);
+                SIRValue::new(u8::from(truth))
+            }
+        }
+        BinaryOp::EqCase | BinaryOp::NeCase => {
+            // Case equality treats X/Z as ordinary values: payload and mask
+            // must agree at every compared bit for a match. The result is
+            // always definite.
+            let common = lhs_width.max(rhs_width).max(dst_width);
+            let lhs_ext = zero_extend(lhs, common);
+            let rhs_ext = zero_extend(rhs, common);
+            let diff = (&lhs_ext.payload ^ &rhs_ext.payload) | (&lhs_ext.mask ^ &rhs_ext.mask);
+            let matched = diff.is_zero();
+            let holds = if *op == BinaryOp::EqCase {
+                matched
+            } else {
+                !matched
+            };
+            SIRValue::new(u8::from(holds))
+        }
+        BinaryOp::EqWildcard | BinaryOp::NeWildcard => {
+            // IEEE 1800 ==?/!=?: X/Z bits on the right-hand side are
+            // wildcards. A definite mismatch yields a definite result, an
+            // unknown left-hand bit at a compared position yields X, and
+            // otherwise the payloads compare at definitely-known positions.
+            let common = lhs_width.max(rhs_width);
+            let compare_mask = &width_mask(common) ^ &rhs.mask;
+            let definite_compare = &compare_mask & (&width_mask(common) ^ &lhs.mask);
+            let mismatch_bits = (&lhs.payload ^ &rhs.payload) & &definite_compare;
+            let x_at_compared = &lhs.mask & &compare_mask;
+            let mask = if !mismatch_bits.is_zero() {
+                BigUint::zero()
+            } else if !x_at_compared.is_zero() {
+                BigUint::from(1u8)
+            } else {
+                BigUint::zero()
+            };
+            let lhs_eff = &lhs.payload & &definite_compare;
+            let rhs_eff = &rhs.payload & &definite_compare;
+            let equal = lhs_eff == rhs_eff;
+            let holds = if *op == BinaryOp::EqWildcard {
+                equal
+            } else {
+                !equal
+            };
+            SIRValue {
+                payload: BigUint::from(u8::from(holds)),
+                mask,
+            }
         }
     };
-    Ok(out)
+    Ok(normalize(truncate(out, dst_width)))
 }
 
 /// Interpret a shift amount register value as `usize`, or `None` when it
 /// exceeds any meaningful shift distance.
 fn shift_amount(value: &BigUint) -> Option<usize> {
     value.to_usize()
+}
+
+/// Two's complement interpretation of `width`-truncated `value`.
+fn to_signed(value: &BigUint, width: usize) -> BigInt {
+    if width == 0 {
+        return BigInt::from(0);
+    }
+    let masked = value & width_mask(width);
+    if masked.bit((width - 1) as u64) {
+        BigInt::from(masked) - (BigInt::from(1) << width)
+    } else {
+        BigInt::from(masked)
+    }
+}
+
+/// Reduce a signed integer modulo `2^width` into its two's complement bits.
+fn wrap_signed(value: &BigInt, width: usize) -> BigUint {
+    if width == 0 {
+        return BigUint::zero();
+    }
+    let modulus = BigInt::from(1) << width;
+    ((value % &modulus + &modulus) % modulus)
+        .to_biguint()
+        .expect("non-negative remainder")
+}
+
+/// Evaluate an ordering/equality operator on fully-known operands.
+///
+/// `lhs_signed` carries the left-hand register's declaration so `Eq`/`Ne`
+/// replicate the compiled promotion: a signed lhs is sign-extended to the
+/// common width while the rhs is always zero-extended.
+fn compare_holds(
+    op: &BinaryOp,
+    lhs: &SIRValue,
+    rhs: &SIRValue,
+    lhs_width: usize,
+    rhs_width: usize,
+    lhs_signed: bool,
+) -> bool {
+    let ordering = match op {
+        BinaryOp::Eq | BinaryOp::Ne => {
+            let common = lhs_width.max(rhs_width);
+            let lhs_ext = if lhs_signed {
+                sign_extend(&lhs.payload, lhs_width, common)
+            } else {
+                lhs.payload.clone()
+            };
+            let rhs_ext = zero_extend(rhs, common).payload;
+            lhs_ext.cmp(&rhs_ext)
+        }
+        BinaryOp::LtU | BinaryOp::LeU | BinaryOp::GtU | BinaryOp::GeU => {
+            lhs.payload.cmp(&rhs.payload)
+        }
+        _ => to_signed(&lhs.payload, lhs_width).cmp(&to_signed(&rhs.payload, rhs_width)),
+    };
+    use std::cmp::Ordering;
+    match op {
+        BinaryOp::Eq | BinaryOp::EqCase => ordering == Ordering::Equal,
+        BinaryOp::Ne | BinaryOp::NeCase => ordering != Ordering::Equal,
+        BinaryOp::LtU | BinaryOp::LtS => ordering == Ordering::Less,
+        BinaryOp::LeU | BinaryOp::LeS => ordering != Ordering::Greater,
+        BinaryOp::GtU | BinaryOp::GtS => ordering == Ordering::Greater,
+        BinaryOp::GeU | BinaryOp::GeS => ordering != Ordering::Less,
+        _ => false,
+    }
+}
+
+/// Zero-extend a value's payload/mask view up to `width` (padding reads as
+/// known zero).
+fn zero_extend(value: &SIRValue, width: usize) -> SIRValue {
+    SIRValue {
+        payload: &value.payload & width_mask(width),
+        mask: &value.mask & width_mask(width),
+    }
+}
+
+/// Sign-extend the top bit of a `from_width`-wide payload up to `to_width`.
+fn sign_extend(payload: &BigUint, from_width: usize, to_width: usize) -> BigUint {
+    if from_width == 0 || to_width <= from_width {
+        return payload & width_mask(to_width);
+    }
+    if payload.bit((from_width - 1) as u64) {
+        payload | (&width_mask(to_width) ^ &width_mask(from_width))
+    } else {
+        payload.clone()
+    }
+}
+
+/// An operand of a logical operator is definitely false when every bit,
+/// including unknown ones, is zero.
+fn logic_operand_definitely_false(value: &SIRValue, width: usize) -> bool {
+    (&value.payload | &value.mask) & width_mask(width) == BigUint::zero()
+}
+
+/// An operand of a logical operator is definitely true when some bit is a
+/// known one.
+fn logic_operand_definitely_true(value: &SIRValue, width: usize) -> bool {
+    !known_ones(value, width).is_zero()
+}
+
+/// Boolean truth of a fully-known operand.
+fn logic_truth(value: &SIRValue, width: usize) -> bool {
+    !known_ones(value, width).is_zero()
 }
 
 fn alu_unary(
@@ -559,6 +881,9 @@ fn alu_unary(
     src_signed: bool,
     dst_width: usize,
 ) -> Result<SIRValue, InterpError> {
+    // Signedness is carried by dedicated opcodes (e.g. division); unary
+    // operators do not consult the declaration today.
+    let _ = src_signed;
     let out = match op {
         UnaryOp::Ident => src.clone(),
         UnaryOp::ToTwoState => SIRValue {
@@ -606,30 +931,52 @@ fn alu_unary(
                 SIRValue::new(u8::from(parity(&src.payload)))
             }
         }
-        UnaryOp::PopCount => {
-            // Number of known-one bits; result width follows the operator's
-            // declared result width via the destination register.
-            SIRValue::new(known_ones(src, src_width).popcount())
+        UnaryOp::And => {
+            // Reduction-and over the payload bits; a definite zero bit makes
+            // the result a definite zero, otherwise any X/Z input bit yields
+            // X (IEEE 1800 dominant-value rule).
+            let width = width_mask(src_width);
+            let has_definite_zero = !(&width ^ &src.payload ^ &src.mask).is_zero()
+                && !known_zeros(src, src_width).is_zero();
+            let mask = if has_definite_zero {
+                BigUint::zero()
+            } else if !src.mask.is_zero() {
+                BigUint::from(1u8)
+            } else {
+                BigUint::zero()
+            };
+            let all_ones = src.payload == width;
+            SIRValue {
+                payload: BigUint::from(u8::from(all_ones)),
+                mask,
+            }
         }
-        UnaryOp::CountLeadingZeros => {
-            // SEMANTICS-CHECK: masked bits count as their payload value
-            // (normally zero) for the leading-zero scan.
-            let significant = src.payload.bits() as usize;
-            SIRValue::new(src_width.saturating_sub(significant) as u64)
-        }
-        UnaryOp::CountTrailingZeros => {
-            // SEMANTICS-CHECK: masked bits count as their payload value
-            // (normally zero) for the trailing-zero scan.
-            SIRValue::new(trailing_zeros(&src.payload, src_width) as u64)
-        }
-        other => {
-            let _ = src_signed;
-            return Err(InterpError::UnsupportedOperation(format!(
-                "unary operator {other}"
-            )));
+        UnaryOp::PopCount | UnaryOp::CountLeadingZeros | UnaryOp::CountTrailingZeros => {
+            // SEMANTICS-CHECK: any X/Z input bit makes the whole result X,
+            // matching the compiled bit-count lowering; otherwise the count
+            // runs on the payload bits.
+            if !src.mask.is_zero() {
+                all_x(dst_width)
+            } else {
+                match op {
+                    UnaryOp::PopCount => SIRValue::new(src.payload.popcount()),
+                    UnaryOp::CountLeadingZeros => {
+                        let significant = src.payload.bits() as usize;
+                        SIRValue::new(src_width.saturating_sub(significant) as u64)
+                    }
+                    _ => SIRValue::new(trailing_zeros(&src.payload, src_width) as u64),
+                }
+            }
         }
     };
-    Ok(truncate(out, dst_width))
+    let truncated = truncate(out, dst_width);
+    // Identity and two-state casts preserve the incoming bit pattern; every
+    // other unary operation adopts the normalized unknown-bit convention.
+    if matches!(op, UnaryOp::Ident | UnaryOp::ToTwoState) {
+        Ok(truncated)
+    } else {
+        Ok(normalize(truncated))
+    }
 }
 
 /// `Mux` following the SIR contract: a known one in the condition selects
@@ -653,17 +1000,27 @@ fn eval_mux(
         return else_value.clone();
     }
     let mask = width_mask(out_width);
-    let difference =
-        (&then_value.payload ^ &else_value.payload) | (&then_value.mask ^ &else_value.mask);
-    let agree = &mask ^ &difference;
+    let tv = &then_value.payload & &mask;
+    let ev = &else_value.payload & &mask;
+    let tm = &then_value.mask & &mask;
+    let em = &else_value.mask & &mask;
+    let difference = (&tv ^ &ev) | (&tm ^ &em);
+    // Differing bits become X; agreeing bits keep the then-arm bits. The
+    // payload absorbs the difference so unknown bits stay normalized.
     SIRValue {
-        payload: &then_value.payload & &agree,
-        mask: (&then_value.mask & &agree) | &difference,
+        payload: tv | &difference,
+        mask: tm | &difference,
     }
 }
 
 fn parity(value: &BigUint) -> bool {
-    value.to_bytes_le().iter().fold(0u8, |acc, byte| acc ^ byte).count_ones() % 2 == 1
+    value
+        .to_bytes_le()
+        .iter()
+        .fold(0u8, |acc, byte| acc ^ byte)
+        .count_ones()
+        % 2
+        == 1
 }
 
 fn trailing_zeros(value: &BigUint, width: usize) -> usize {
@@ -699,7 +1056,7 @@ struct Registers {
 impl Registers {
     fn new(register_map: &HashMap<RegisterId, RegisterType>) -> Self {
         let size = register_map.keys().map(|id| id.0 + 1).max().unwrap_or(0);
-        let mut values = vec![None; size];
+        let values = vec![None; size];
         let mut widths = vec![0; size];
         let mut signed = vec![false; size];
         for (id, register_type) in register_map {
@@ -746,7 +1103,7 @@ mod tests {
     struct FakeMachine {
         cells: HashMap<(u32, usize, usize), SIRValue>,
         runtime_events: Vec<(u32, Vec<SIRValue>)>,
-        comb_captures: Vec<(u32, Vec<u32>)>,
+        comb_captures: Vec<usize>,
         trigger_notifications: Vec<usize>,
     }
 
@@ -768,7 +1125,7 @@ mod tests {
                 other => {
                     return Err(InterpError::Machine(format!(
                         "fake machine cannot resolve {other}"
-                    )))
+                    )));
                 }
             };
             Ok(self
@@ -790,7 +1147,7 @@ mod tests {
                 other => {
                     return Err(InterpError::Machine(format!(
                         "fake machine cannot resolve {other}"
-                    )))
+                    )));
                 }
             };
             self.cells.insert((*addr, offset, bits), value.clone());
@@ -809,7 +1166,7 @@ mod tests {
                 other => {
                     return Err(InterpError::Machine(format!(
                         "fake machine cannot resolve {other}"
-                    )))
+                    )));
                 }
             };
             let value = self.cells.get(&(*src, offset, bits)).cloned();
@@ -823,12 +1180,49 @@ mod tests {
             self.trigger_notifications.push(triggers.len());
         }
 
-        fn notify_comb_capture(&mut self, _addr: &u32, sites: &[u32], _value: &SIRValue) {
-            self.comb_captures.push((_addr_owned(_addr), sites.to_vec()));
+        fn capture_store_range(
+            &mut self,
+            addr: &u32,
+            access: ResolvedAccess<'_>,
+            bits: usize,
+        ) -> Result<StoreSnapshot, InterpError> {
+            let offset = match access.offset {
+                SIROffset::Static(offset) => *offset,
+                other => {
+                    return Err(InterpError::Machine(format!(
+                        "fake machine cannot resolve {other}"
+                    )));
+                }
+            };
+            Ok(StoreSnapshot {
+                value_words: self
+                    .cells
+                    .get(&(*addr, offset, bits))
+                    .map(|value| Self::words(&value.payload))
+                    .unwrap_or_default(),
+                mask_words: Vec::new(),
+            })
         }
 
-        fn emit_runtime_event(&mut self, site_id: u32, args: &[SIRValue]) {
+        fn enable_comb_captures(
+            &mut self,
+            _addr: &u32,
+            _access: ResolvedAccess<'_>,
+            _bits: usize,
+            _before: &StoreSnapshot,
+            sites: &[u32],
+        ) -> Result<(), InterpError> {
+            self.comb_captures.push(sites.len());
+            Ok(())
+        }
+
+        fn emit_runtime_event(
+            &mut self,
+            site_id: u32,
+            args: &[SIRValue],
+        ) -> Result<(), InterpError> {
             self.runtime_events.push((site_id, args.to_vec()));
+            Ok(())
         }
 
         fn emit_comb_capture_event(
@@ -837,7 +1231,8 @@ mod tests {
             _args: &[SIRValue],
             _fatal_error_code: Option<i64>,
             _consume_enabled: bool,
-        ) {
+        ) -> Result<(), InterpError> {
+            Ok(())
         }
 
         fn enable_comb_capture_if_changed(
@@ -845,7 +1240,14 @@ mod tests {
             _old: &SIRValue,
             _new: &SIRValue,
             _sites: &[u32],
-        ) {
+        ) -> Result<(), InterpError> {
+            Ok(())
+        }
+    }
+
+    impl FakeMachine {
+        fn words(_value: &BigUint) -> Vec<u64> {
+            Vec::new()
         }
     }
 
@@ -918,7 +1320,7 @@ mod tests {
         };
 
         let mut machine = FakeMachine::default();
-        execute_unit(&unit, &mut machine, &[]).unwrap();
+        execute_unit(&unit, &mut machine, &[], true).unwrap();
         assert_eq!(machine.stored(7, 0, 8).payload, BigUint::from(8u8));
     }
 
@@ -970,7 +1372,7 @@ mod tests {
             };
 
             let mut machine = FakeMachine::default();
-            execute_unit(&unit, &mut machine, &[]).unwrap();
+            execute_unit(&unit, &mut machine, &[], true).unwrap();
             assert_eq!(machine.stored(1, 0, 8).payload, BigUint::from(expected));
         }
     }
@@ -1038,7 +1440,7 @@ mod tests {
             };
 
             let mut machine = FakeMachine::default();
-            execute_unit(&unit, &mut machine, &[]).unwrap();
+            execute_unit(&unit, &mut machine, &[], true).unwrap();
             assert_eq!(machine.stored(1, 0, 8).payload, BigUint::from(expected));
         }
     }
@@ -1074,7 +1476,7 @@ mod tests {
         };
 
         let mut machine = FakeMachine::default();
-        execute_unit(&unit, &mut machine, &[]).unwrap();
+        execute_unit(&unit, &mut machine, &[], true).unwrap();
         assert_eq!(machine.stored(3, 0, 8).payload, BigUint::from(7u8));
     }
 
@@ -1101,7 +1503,7 @@ mod tests {
         };
 
         let mut machine = FakeMachine::default();
-        execute_unit(&unit, &mut machine, &[SIRValue::new(0xDEu16)]).unwrap();
+        execute_unit(&unit, &mut machine, &[SIRValue::new(0xDEu16)], true).unwrap();
         assert_eq!(machine.stored(5, 0, 8).payload, BigUint::from(0xDEu16));
     }
 
@@ -1134,7 +1536,7 @@ mod tests {
         };
 
         let mut machine = FakeMachine::default();
-        execute_unit(&unit, &mut machine, &[]).unwrap();
+        execute_unit(&unit, &mut machine, &[], true).unwrap();
         // 0xABCD sliced [4 +: 8] == 0xBC.
         assert_eq!(machine.stored(9, 0, 8).payload, BigUint::from(0xBCu8));
     }
@@ -1169,7 +1571,7 @@ mod tests {
         };
 
         let mut machine = FakeMachine::default();
-        execute_unit(&unit, &mut machine, &[]).unwrap();
+        execute_unit(&unit, &mut machine, &[], true).unwrap();
         assert_eq!(machine.stored(9, 0, 8).payload, BigUint::from(0xFFu8));
     }
 
@@ -1190,7 +1592,8 @@ mod tests {
             eval_mux(&known_zero, &mixed_arm, &SIRValue::new(0b11u8), 1, 2),
             SIRValue::new(0b11u8)
         );
-        // Unknown condition: agreeing bits preserved, differing bits become X.
+        // Unknown condition: agreeing bits preserved, differing bits become X
+        // with a normalized (all-ones) payload.
         let out = eval_mux(
             &unknown,
             &SIRValue::new_four_state(0b1010u8, 0b0000u8),
@@ -1198,7 +1601,9 @@ mod tests {
             1,
             4,
         );
-        assert_eq!(out.payload, BigUint::from(0b0010u8));
+        // difference = 1101 → mask keeps those bits unknown, payload absorbs
+        // them so X bits read as one.
+        assert_eq!(out.payload, BigUint::from(0b1111u8));
         assert_eq!(out.mask, BigUint::from(0b1101u8));
     }
 
@@ -1229,7 +1634,7 @@ mod tests {
 
         let mut machine = FakeMachine::default();
         assert_eq!(
-            execute_unit(&unit, &mut machine, &[]).unwrap_err(),
+            execute_unit(&unit, &mut machine, &[], true).unwrap_err(),
             InterpError::Fatal(42)
         );
     }
@@ -1238,15 +1643,20 @@ mod tests {
     fn jump_to_missing_block_reports_unknown_block() {
         let unit = ExecutionUnit {
             entry_block_id: BlockId(0),
-            blocks: [block(0, vec![], vec![], SIRTerminator::Jump(BlockId(99), vec![]))]
-                .into_iter()
-                .collect(),
+            blocks: [block(
+                0,
+                vec![],
+                vec![],
+                SIRTerminator::Jump(BlockId(99), vec![]),
+            )]
+            .into_iter()
+            .collect(),
             register_map: HashMap::default(),
         };
 
         let mut machine = FakeMachine::default();
         assert_eq!(
-            execute_unit(&unit, &mut machine, &[]).unwrap_err(),
+            execute_unit(&unit, &mut machine, &[], true).unwrap_err(),
             InterpError::UnknownBlock(BlockId(99))
         );
     }
@@ -1266,7 +1676,7 @@ mod tests {
 
         let mut machine = FakeMachine::default();
         assert_eq!(
-            execute_unit(&unit, &mut machine, &[]).unwrap_err(),
+            execute_unit(&unit, &mut machine, &[], true).unwrap_err(),
             InterpError::RegisterArityMismatch {
                 expected: 1,
                 found: 0,
@@ -1298,7 +1708,7 @@ mod tests {
 
         let mut machine = FakeMachine::default();
         assert_eq!(
-            execute_unit(&unit, &mut machine, &[]).unwrap_err(),
+            execute_unit(&unit, &mut machine, &[], true).unwrap_err(),
             InterpError::MissingRegister(RegisterId(4))
         );
     }
@@ -1325,10 +1735,7 @@ mod tests {
         };
 
         let mut machine = FakeMachine::default();
-        execute_unit(&unit, &mut machine, &[]).unwrap();
-        assert_eq!(
-            machine.runtime_events,
-            vec![(3, vec![SIRValue::new(11u8)])]
-        );
+        execute_unit(&unit, &mut machine, &[], true).unwrap();
+        assert_eq!(machine.runtime_events, vec![(3, vec![SIRValue::new(11u8)])]);
     }
 }

--- a/crates/celox/src/interpreter.rs
+++ b/crates/celox/src/interpreter.rs
@@ -724,7 +724,15 @@ fn alu_binary(
                 let common = lhs_width.max(rhs_width).max(dst_width);
                 let signed_value = to_signed(&lhs.payload, lhs_width);
                 let signed_mask = to_signed(&lhs.mask, lhs_width);
-                let bound = lhs_width.max(dst_width).max(1);
+                // The narrow lowering converges once the count reaches the
+                // operand width; the word-based wide lowering keeps reading
+                // sign-filled words until every output word sits past the
+                // source's own chunks.
+                let bound = if common <= 64 {
+                    lhs_width.max(dst_width).max(1)
+                } else {
+                    lhs_width.div_ceil(64) * 64
+                };
                 match shift_amount(&rhs.payload) {
                     Some(amount) if amount < bound => {
                         if common <= 64 {
@@ -733,10 +741,12 @@ fn alu_binary(
                                 mask: wrap_signed(&(signed_mask >> amount), dst_width),
                             }
                         } else {
-                            let payload = (sar_wide_extend(&lhs.payload, lhs_width, common)
+                            let payload =
+                                (sar_wide_extend(&lhs.payload, lhs_width, common, amount)
+                                    >> amount)
+                                    & width_mask(dst_width);
+                            let mask = (sar_wide_extend(&lhs.mask, lhs_width, common, amount)
                                 >> amount)
-                                & width_mask(dst_width);
-                            let mask = (sar_wide_extend(&lhs.mask, lhs_width, common) >> amount)
                                 & width_mask(dst_width);
                             SIRValue { payload, mask }
                         }
@@ -874,14 +884,16 @@ fn shift_amount(value: &BigUint) -> Option<usize> {
 /// Sar lowering does: whole 64-bit words above the source's own chunks are
 /// filled with the declared width's top bit, then the caller shifts
 /// logically. Bits inside the source's partial top word are left untouched.
-fn sar_wide_extend(value: &BigUint, lhs_width: usize, common: usize) -> BigUint {
+fn sar_wide_extend(value: &BigUint, lhs_width: usize, common: usize, amount: usize) -> BigUint {
     let src_words = lhs_width.div_ceil(64);
-    let common_words = common.div_ceil(64);
     if lhs_width == 0 || !value.bit((lhs_width - 1) as u64) {
         return value.clone();
     }
+    // Extend far enough that output words reading past the common width
+    // after the shift still observe sign fill instead of zeroes.
+    let fill_until = common.div_ceil(64) + amount.div_ceil(64) + 1;
     let mut extended = value.clone();
-    for word in src_words..common_words {
+    for word in src_words..fill_until {
         extended |= BigUint::from(u64::MAX) << (word * 64);
     }
     extended

--- a/crates/celox/src/interpreter.rs
+++ b/crates/celox/src/interpreter.rs
@@ -1,0 +1,1261 @@
+//! Tier-0 SIR interpreter for tiered execution.
+//!
+//! When [`crate::ExecutionStrategy::Tiered`] is selected the simulator starts
+//! executing execution units on this interpreter immediately after layout,
+//! hiding compilation latency behind the first simulated steps. Hot units are
+//! compiled in the background and swapped in at scheduler safe points; this
+//! interpreter remains the permanent fallback for units that are never
+//! compiled (cold paths) or whose compilation failed.
+//!
+//! Correctness contract: the interpreter and the compiled backends must agree
+//! bit-exactly, including four-state X/Z propagation, because a unit may
+//! migrate between tiers mid-simulation. Rules marked `SEMANTICS-CHECK` below
+//! follow standard HDL semantics and must be reconciled against the backend
+//! truth-table implementations.
+//!
+//! Memory accesses and simulation side effects (triggers, comb captures,
+//! runtime events) are delegated to the [`InterpMachine`] trait so the
+//! interpreter stays independent of backend storage details.
+
+use std::fmt;
+
+use celox_sir::{
+    BinaryOp, BlockId, ExecutionUnit, RegisterId, RegisterType, SIRInstruction, SIROffset,
+    SIRTerminator, SIRValue, TriggerIdWithKind, UnaryOp,
+};
+use num_bigint::BigUint;
+use num_traits::{ToPrimitive, Zero};
+
+use crate::HashMap;
+
+/// Why an interpreted execution unit stopped abnormally.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InterpError {
+    /// Terminator targeted a block that does not exist in the unit.
+    UnknownBlock(BlockId),
+    /// An instruction read a register that was never written.
+    MissingRegister(RegisterId),
+    /// A jump supplied a different number of arguments than the target
+    /// block declares parameters.
+    RegisterArityMismatch { expected: usize, found: usize },
+    /// The instruction uses an operator the interpreter does not implement
+    /// yet. This fails loudly instead of producing wrong simulation results.
+    UnsupportedOperation(String),
+    /// The unit terminated with `SIRTerminator::Error`.
+    Fatal(i64),
+    /// The [`InterpMachine`] reported a failure.
+    Machine(String),
+}
+
+impl fmt::Display for InterpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InterpError::UnknownBlock(block) => write!(f, "interpreted jump to unknown block b{}", block.0),
+            InterpError::MissingRegister(register) => {
+                write!(f, "read of unwritten register r{}", register.0)
+            }
+            InterpError::RegisterArityMismatch { expected, found } => {
+                write!(f, "jump argument count mismatch: target expects {expected}, jump supplies {found}")
+            }
+            InterpError::UnsupportedOperation(description) => {
+                write!(f, "interpreter does not support operation: {description}")
+            }
+            InterpError::Fatal(code) => write!(f, "simulation fatal error ({code})"),
+            InterpError::Machine(message) => write!(f, "machine error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for InterpError {}
+
+/// One memory access with its dynamic offset components resolved.
+///
+/// The unresolved [`SIROffset`] is preserved alongside the values of its
+/// dynamic registers because element-strided layouts distinguish `Element`
+/// accesses from plain bit offsets when computing physical addresses.
+#[derive(Clone, Copy, Debug)]
+pub struct ResolvedAccess<'a> {
+    pub offset: &'a SIROffset,
+    /// Values of the registers returned by [`SIROffset::dynamic_registers`],
+    /// in the same order.
+    pub dynamics: [Option<&'a SIRValue>; 2],
+}
+
+/// Storage and side-effect interface driven by the interpreter.
+///
+/// The production implementation wraps the simulator's live memory image and
+/// event plumbing; tests use an in-memory fake. The address type `A` matches
+/// the executed SIR (for example `RegionedAbsoluteAddr`).
+pub trait InterpMachine<A> {
+    fn load(
+        &mut self,
+        addr: &A,
+        access: ResolvedAccess<'_>,
+        bits: usize,
+    ) -> Result<SIRValue, InterpError>;
+
+    fn store(
+        &mut self,
+        addr: &A,
+        access: ResolvedAccess<'_>,
+        bits: usize,
+        value: &SIRValue,
+    ) -> Result<(), InterpError>;
+
+    /// `Commit`: copy `bits` at `access` from `src` to `dst`.
+    fn commit(
+        &mut self,
+        src: &A,
+        dst: &A,
+        access: ResolvedAccess<'_>,
+        bits: usize,
+    ) -> Result<(), InterpError>;
+
+    /// Edge/level triggers attached to a `Store` or `Commit`.
+    fn notify_triggers(&mut self, addr: &A, triggers: &[TriggerIdWithKind]);
+
+    /// Comb capture sites attached to a `Store`; receives the stored value.
+    fn notify_comb_capture(&mut self, addr: &A, sites: &[u32], value: &SIRValue);
+
+    fn emit_runtime_event(&mut self, site_id: u32, args: &[SIRValue]);
+
+    fn emit_comb_capture_event(
+        &mut self,
+        site_id: u32,
+        args: &[SIRValue],
+        fatal_error_code: Option<i64>,
+        consume_enabled: bool,
+    );
+
+    fn enable_comb_capture_if_changed(&mut self, old: &SIRValue, new: &SIRValue, sites: &[u32]);
+}
+
+/// Outcome of one interpreted unit invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnitExit {
+    /// The unit reached `SIRTerminator::Return`.
+    Return,
+}
+
+/// Execute one execution unit on the interpreter.
+///
+/// `entry_args` binds the entry block's parameters (event arguments). The
+/// simulator drives repeated invocations (comb settle fixpoint, clocked
+/// events); this function performs exactly one entry-to-return traversal.
+pub fn execute_unit<A, M: InterpMachine<A>>(
+    unit: &ExecutionUnit<A>,
+    machine: &mut M,
+    entry_args: &[SIRValue],
+) -> Result<UnitExit, InterpError> {
+    let mut regs = Registers::new(&unit.register_map);
+    let entry = unit
+        .blocks
+        .get(&unit.entry_block_id)
+        .ok_or(InterpError::UnknownBlock(unit.entry_block_id))?;
+    if entry.params.len() != entry_args.len() {
+        return Err(InterpError::RegisterArityMismatch {
+            expected: entry.params.len(),
+            found: entry_args.len(),
+        });
+    }
+    for (param, value) in entry.params.iter().zip(entry_args) {
+        regs.set(*param, value.clone());
+    }
+
+    let mut current = unit.entry_block_id;
+    loop {
+        let block = unit
+            .blocks
+            .get(&current)
+            .ok_or(InterpError::UnknownBlock(current))?;
+        for instruction in &block.instructions {
+            exec_instruction(instruction, &mut regs, machine)?;
+        }
+        match &block.terminator {
+            SIRTerminator::Return => return Ok(UnitExit::Return),
+            SIRTerminator::Error(code) => return Err(InterpError::Fatal(*code)),
+            SIRTerminator::Jump(target, args) => {
+                transfer(&mut regs, unit, *target, args)?;
+                current = *target;
+            }
+            SIRTerminator::Branch {
+                cond,
+                true_block,
+                false_block,
+            } => {
+                let cond = regs.get(*cond)?.clone();
+                // SEMANTICS-CHECK: a known one selects the true branch; an
+                // all-unknown or all-zero condition selects the false branch.
+                let target = if branch_condition_holds(&cond, regs.width(*cond)) {
+                    true_block
+                } else {
+                    false_block
+                };
+                transfer(&mut regs, unit, target.0, &target.1)?;
+                current = target.0;
+            }
+            SIRTerminator::Switch {
+                selector,
+                cases,
+                default,
+            } => {
+                // SEMANTICS-CHECK: masked (X/Z) selector bits participate in
+                // the comparison as their payload value; unmatched selectors
+                // take the default target.
+                let selector = regs.get(*selector)?.payload.clone();
+                let target = cases
+                    .iter()
+                    .find(|case| case.value == selector)
+                    .map(|case| case.target)
+                    .unwrap_or(*default);
+                transfer(&mut regs, unit, target, &[])?;
+                current = target;
+            }
+        }
+    }
+}
+
+/// Bind jump arguments to the target block's parameters.
+fn transfer<A>(
+    regs: &mut Registers,
+    unit: &ExecutionUnit<A>,
+    target: BlockId,
+    args: &[RegisterId],
+) -> Result<(), InterpError> {
+    let params = &unit
+        .blocks
+        .get(&target)
+        .ok_or(InterpError::UnknownBlock(target))?
+        .params;
+    if params.len() != args.len() {
+        return Err(InterpError::RegisterArityMismatch {
+            expected: params.len(),
+            found: args.len(),
+        });
+    }
+    let mut values = Vec::with_capacity(args.len());
+    for arg in args {
+        values.push(regs.get(*arg)?.clone());
+    }
+    for (param, value) in params.iter().zip(values) {
+        regs.set(*param, value);
+    }
+    Ok(())
+}
+
+fn exec_instruction<A, M: InterpMachine<A>>(
+    instruction: &SIRInstruction<A>,
+    regs: &mut Registers,
+    machine: &mut M,
+) -> Result<(), InterpError> {
+    match instruction {
+        SIRInstruction::Imm(dst, value) => regs.set(*dst, value.clone()),
+        SIRInstruction::Binary(dst, lhs, op, rhs) => {
+            let lhs = regs.get(*lhs)?.clone();
+            let rhs = regs.get(*rhs)?.clone();
+            let out = alu_binary(op, &lhs, &rhs, regs.width(*dst))?;
+            regs.set(*dst, truncate(out, regs.width(*dst)));
+        }
+        SIRInstruction::Unary(dst, op, src) => {
+            let src_value = regs.get(*src)?.clone();
+            let out = alu_unary(
+                op,
+                &src_value,
+                regs.width(*src),
+                regs.is_signed(*src),
+                regs.width(*dst),
+            )?;
+            regs.set(*dst, truncate(out, regs.width(*dst)));
+        }
+        SIRInstruction::Load(dst, addr, offset, bits) => {
+            let access = resolve_access(offset, regs)?;
+            let value = machine.load(addr, access, *bits)?;
+            regs.set(*dst, value);
+        }
+        SIRInstruction::Store(addr, offset, bits, src, triggers, sites) => {
+            let value = regs.get(*src)?.clone();
+            let access = resolve_access(offset, regs)?;
+            machine.store(addr, access, *bits, &value)?;
+            if !triggers.is_empty() {
+                machine.notify_triggers(addr, triggers);
+            }
+            if !sites.is_empty() {
+                machine.notify_comb_capture(addr, sites, &value);
+            }
+        }
+        SIRInstruction::Commit(src, dst, offset, bits, triggers) => {
+            let access = resolve_access(offset, regs)?;
+            machine.commit(src, dst, access, *bits)?;
+            if !triggers.is_empty() {
+                machine.notify_triggers(dst, triggers);
+            }
+        }
+        SIRInstruction::Concat(dst, sources) => {
+            let mut payload = BigUint::zero();
+            let mut mask = BigUint::zero();
+            for source in sources {
+                let value = regs.get(*source)?;
+                let width = regs.width(*source);
+                payload = (payload << width) | &value.payload;
+                mask = (mask << width) | &value.mask;
+            }
+            regs.set(*dst, SIRValue { payload, mask });
+        }
+        SIRInstruction::Slice(dst, src, offset, width) => {
+            let value = regs.get(*src)?;
+            let payload = extract_bits(&value.payload, *offset, *width);
+            let mask = extract_bits(&value.mask, *offset, *width);
+            regs.set(*dst, SIRValue { payload, mask });
+        }
+        SIRInstruction::Mux(dst, cond, then_value, else_value) => {
+            let cond = regs.get(*cond)?.clone();
+            let then_value = regs.get(*then_value)?.clone();
+            let else_value = regs.get(*else_value)?.clone();
+            let out = eval_mux(&cond, &then_value, &else_value, regs.width(*dst));
+            regs.set(*dst, out);
+        }
+        SIRInstruction::RuntimeEvent { site_id, args } => {
+            let values = resolve_args(args, regs)?;
+            machine.emit_runtime_event(*site_id, &values);
+        }
+        SIRInstruction::CombCaptureEvent {
+            site_id,
+            args,
+            fatal_error_code,
+            consume_enabled,
+        } => {
+            let values = resolve_args(args, regs)?;
+            machine.emit_comb_capture_event(*site_id, &values, *fatal_error_code, *consume_enabled);
+        }
+        SIRInstruction::CombCaptureEnableIfChanged { old, new, sites } => {
+            let old = regs.get(*old)?.clone();
+            let new = regs.get(*new)?.clone();
+            machine.enable_comb_capture_if_changed(&old, &new, sites);
+        }
+    }
+    Ok(())
+}
+
+fn resolve_access<'a>(
+    offset: &'a SIROffset,
+    regs: &'a Registers,
+) -> Result<ResolvedAccess<'a>, InterpError> {
+    let mut dynamics = [None, None];
+    for (slot, register) in offset.dynamic_registers().into_iter().enumerate() {
+        if let Some(register) = register {
+            dynamics[slot] = Some(regs.get(register)?);
+        }
+    }
+    Ok(ResolvedAccess {
+        offset,
+        dynamics,
+    })
+}
+
+fn resolve_args(args: &[RegisterId], regs: &Registers) -> Result<Vec<SIRValue>, InterpError> {
+    args.iter()
+        .map(|arg| regs.get(*arg).cloned())
+        .collect()
+}
+
+// ── Value helpers ─────────────────────────────────────────────────────
+
+fn width_mask(width: usize) -> BigUint {
+    if width == 0 {
+        BigUint::zero()
+    } else {
+        (BigUint::from(1u8) << width) - 1u8
+    }
+}
+
+fn truncate(mut value: SIRValue, width: usize) -> SIRValue {
+    let mask = width_mask(width);
+    value.payload &= &mask;
+    value.mask &= mask;
+    value
+}
+
+fn all_x(width: usize) -> SIRValue {
+    SIRValue {
+        payload: BigUint::zero(),
+        mask: width_mask(width),
+    }
+}
+
+fn extract_bits(value: &BigUint, offset: usize, width: usize) -> BigUint {
+    if width == 0 {
+        return BigUint::zero();
+    }
+    (value >> offset) & width_mask(width)
+}
+
+/// Bits that are unmasked and set to one.
+fn known_ones(value: &SIRValue, width: usize) -> BigUint {
+    &value.payload & (&width_mask(width) ^ &value.mask)
+}
+
+/// Bits that are unmasked and set to zero.
+fn known_zeros(value: &SIRValue, width: usize) -> BigUint {
+    (&width_mask(width) ^ &value.payload) & (&width_mask(width) ^ &value.mask)
+}
+
+fn branch_condition_holds(cond: &SIRValue, width: usize) -> bool {
+    !known_ones(cond, width).is_zero()
+}
+
+// ── ALU ───────────────────────────────────────────────────────────────
+
+fn alu_binary(
+    op: &BinaryOp,
+    lhs: &SIRValue,
+    rhs: &SIRValue,
+    width: usize,
+) -> Result<SIRValue, InterpError> {
+    let out = match op {
+        BinaryOp::Add => {
+            // SEMANTICS-CHECK: any X/Z operand bit makes the whole result X.
+            if lhs.mask.is_zero() && rhs.mask.is_zero() {
+                SIRValue::new((&lhs.payload + &rhs.payload) & width_mask(width))
+            } else {
+                all_x(width)
+            }
+        }
+        BinaryOp::Sub => {
+            // Wrap-safe two's complement subtraction: l + (~r + 1) mod 2^w.
+            // SEMANTICS-CHECK: any X/Z operand bit makes the whole result X.
+            if lhs.mask.is_zero() && rhs.mask.is_zero() {
+                let inverted_rhs = &width_mask(width) ^ &rhs.payload;
+                SIRValue::new(((&lhs.payload + inverted_rhs + 1u8) & width_mask(width)))
+            } else {
+                all_x(width)
+            }
+        }
+        BinaryOp::Mul => {
+            // SEMANTICS-CHECK: any X/Z operand bit makes the whole result X.
+            if lhs.mask.is_zero() && rhs.mask.is_zero() {
+                SIRValue::new((&lhs.payload * &rhs.payload) & width_mask(width))
+            } else {
+                all_x(width)
+            }
+        }
+        BinaryOp::And => {
+            let ones = known_ones(lhs, width) & known_ones(rhs, width);
+            let zeros = known_zeros(lhs, width) | known_zeros(rhs, width);
+            SIRValue {
+                payload: ones,
+                mask: &width_mask(width) ^ (&ones | &zeros),
+            }
+        }
+        BinaryOp::Or => {
+            let ones = known_ones(lhs, width) | known_ones(rhs, width);
+            let zeros = known_zeros(lhs, width) & known_zeros(rhs, width);
+            SIRValue {
+                payload: ones,
+                mask: &width_mask(width) ^ (&ones | &zeros),
+            }
+        }
+        BinaryOp::Xor => {
+            // SEMANTICS-CHECK: any X/Z operand bit makes the whole result X.
+            if lhs.mask.is_zero() && rhs.mask.is_zero() {
+                SIRValue::new((&lhs.payload ^ &rhs.payload) & width_mask(width))
+            } else {
+                all_x(width)
+            }
+        }
+        BinaryOp::Shl => {
+            // SEMANTICS-CHECK: an X/Z shift amount makes the whole result X.
+            if !rhs.mask.is_zero() {
+                all_x(width)
+            } else {
+                match shift_amount(&rhs.payload) {
+                    Some(amount) if amount < width => SIRValue {
+                        payload: (&lhs.payload << amount) & width_mask(width),
+                        mask: (&lhs.mask << amount) & width_mask(width),
+                    },
+                    _ => SIRValue::new(BigUint::zero()),
+                }
+            }
+        }
+        BinaryOp::Shr => {
+            // SEMANTICS-CHECK: an X/Z shift amount makes the whole result X.
+            if !rhs.mask.is_zero() {
+                all_x(width)
+            } else {
+                match shift_amount(&rhs.payload) {
+                    Some(amount) if amount < width => SIRValue {
+                        payload: &lhs.payload >> amount,
+                        mask: &lhs.mask >> amount,
+                    },
+                    _ => SIRValue::new(BigUint::zero()),
+                }
+            }
+        }
+        BinaryOp::Sar => {
+            // SEMANTICS-CHECK: an X/Z shift amount or X/Z sign bit makes the
+            // whole result X; signedness comes from the lhs register.
+            if !rhs.mask.is_zero() {
+                all_x(width)
+            } else {
+                match shift_amount(&rhs.payload) {
+                    Some(amount) if width > 0 => {
+                        let sign_bit = (&lhs.payload >> (width - 1)) & 1u8 == 1u8;
+                        let sign_known = (&lhs.mask >> (width - 1)) & 1u8 == 0u8;
+                        if !sign_known {
+                            all_x(width)
+                        } else if amount >= width {
+                            if sign_bit {
+                                SIRValue::new(width_mask(width))
+                            } else {
+                                SIRValue::new(BigUint::zero())
+                            }
+                        } else {
+                            let sign_fill = if sign_bit {
+                                &width_mask(width) >> (width - amount)
+                            } else {
+                                BigUint::zero()
+                            };
+                            SIRValue {
+                                payload: (&lhs.payload >> amount) | sign_fill,
+                                mask: &lhs.mask >> amount,
+                            }
+                        }
+                    }
+                    _ => SIRValue::new(BigUint::zero()),
+                }
+            }
+        }
+        other => {
+            return Err(InterpError::UnsupportedOperation(format!(
+                "binary operator {other}"
+            )))
+        }
+    };
+    Ok(out)
+}
+
+/// Interpret a shift amount register value as `usize`, or `None` when it
+/// exceeds any meaningful shift distance.
+fn shift_amount(value: &BigUint) -> Option<usize> {
+    value.to_usize()
+}
+
+fn alu_unary(
+    op: &UnaryOp,
+    src: &SIRValue,
+    src_width: usize,
+    src_signed: bool,
+    dst_width: usize,
+) -> Result<SIRValue, InterpError> {
+    let out = match op {
+        UnaryOp::Ident => src.clone(),
+        UnaryOp::ToTwoState => SIRValue {
+            payload: &src.payload & (&width_mask(src_width) ^ &src.mask),
+            mask: BigUint::zero(),
+        },
+        UnaryOp::Minus => {
+            // SEMANTICS-CHECK: negating a value containing X/Z yields all-X.
+            if src.mask.is_zero() {
+                let inverted = &width_mask(src_width) ^ &src.payload;
+                SIRValue::new((inverted + 1u8) & width_mask(src_width))
+            } else {
+                all_x(src_width)
+            }
+        }
+        UnaryOp::BitNot => SIRValue {
+            payload: &width_mask(src_width) ^ &src.payload,
+            mask: src.mask.clone(),
+        },
+        UnaryOp::LogicNot => {
+            if !known_ones(src, src_width).is_zero() {
+                SIRValue::new(BigUint::zero())
+            } else if !src.mask.is_zero() {
+                all_x(1)
+            } else {
+                SIRValue::new(1u8)
+            }
+        }
+        UnaryOp::Or => {
+            // Reduction-or over known bits.
+            if !known_ones(src, src_width).is_zero() {
+                SIRValue::new(1u8)
+            } else if !src.mask.is_zero() {
+                all_x(1)
+            } else {
+                SIRValue::new(BigUint::zero())
+            }
+        }
+        UnaryOp::Xor => {
+            // Reduction-xor; any X/Z input bit yields X.
+            // SEMANTICS-CHECK: masked bits are treated as X inputs.
+            if !src.mask.is_zero() {
+                all_x(1)
+            } else {
+                SIRValue::new(u8::from(parity(&src.payload)))
+            }
+        }
+        UnaryOp::PopCount => {
+            // Number of known-one bits; result width follows the operator's
+            // declared result width via the destination register.
+            SIRValue::new(known_ones(src, src_width).popcount())
+        }
+        UnaryOp::CountLeadingZeros => {
+            // SEMANTICS-CHECK: masked bits count as their payload value
+            // (normally zero) for the leading-zero scan.
+            let significant = src.payload.bits() as usize;
+            SIRValue::new(src_width.saturating_sub(significant) as u64)
+        }
+        UnaryOp::CountTrailingZeros => {
+            // SEMANTICS-CHECK: masked bits count as their payload value
+            // (normally zero) for the trailing-zero scan.
+            SIRValue::new(trailing_zeros(&src.payload, src_width) as u64)
+        }
+        other => {
+            let _ = src_signed;
+            return Err(InterpError::UnsupportedOperation(format!(
+                "unary operator {other}"
+            )));
+        }
+    };
+    Ok(truncate(out, dst_width))
+}
+
+/// `Mux` following the SIR contract: a known one in the condition selects
+/// `then` exactly (preserving its mask); a fully known zero selects `else`;
+/// an unknown condition preserves bits where both arms agree and turns
+/// differing bits into X.
+fn eval_mux(cond: &SIRValue, then_value: &SIRValue, else_value: &SIRValue, width: usize) -> SIRValue {
+    if branch_condition_holds(cond, width) {
+        return then_value.clone();
+    }
+    if cond.mask.is_zero() {
+        return else_value.clone();
+    }
+    let mask = width_mask(width);
+    let difference = (&then_value.payload ^ &else_value.payload) | (&then_value.mask ^ &else_value.mask);
+    let agree = &mask ^ &difference;
+    SIRValue {
+        payload: &then_value.payload & &agree,
+        mask: (&then_value.mask & &agree) | &difference,
+    }
+}
+
+fn parity(value: &BigUint) -> bool {
+    value.to_bytes_le().iter().fold(0u8, |acc, byte| acc ^ byte).count_ones() % 2 == 1
+}
+
+fn trailing_zeros(value: &BigUint, width: usize) -> usize {
+    if value.is_zero() {
+        return width;
+    }
+    // Lowest set bit position: isolate it with v & (v-1) complement trick.
+    let isolated = value ^ (value - 1u8);
+    isolated.bits() as usize - 1
+}
+
+trait BigUintExt {
+    fn popcount(&self) -> u64;
+}
+
+impl BigUintExt for BigUint {
+    fn popcount(&self) -> u64 {
+        self.to_bytes_le()
+            .iter()
+            .map(|byte| u64::from(byte.count_ones()))
+            .sum()
+    }
+}
+
+// ── Register file ─────────────────────────────────────────────────────
+
+struct Registers {
+    values: Vec<Option<SIRValue>>,
+    widths: Vec<usize>,
+    signed: Vec<bool>,
+}
+
+impl Registers {
+    fn new(register_map: &HashMap<RegisterId, RegisterType>) -> Self {
+        let size = register_map.keys().map(|id| id.0 + 1).max().unwrap_or(0);
+        let mut values = vec![None; size];
+        let mut widths = vec![0; size];
+        let mut signed = vec![false; size];
+        for (id, register_type) in register_map {
+            widths[id.0] = register_type.width();
+            signed[id.0] = register_type.is_signed();
+        }
+        Self {
+            values,
+            widths,
+            signed,
+        }
+    }
+
+    fn get(&self, id: RegisterId) -> Result<&SIRValue, InterpError> {
+        self.values
+            .get(id.0)
+            .and_then(|slot| slot.as_ref())
+            .ok_or(InterpError::MissingRegister(id))
+    }
+
+    fn set(&mut self, id: RegisterId, value: SIRValue) {
+        if let Some(slot) = self.values.get_mut(id.0) {
+            *slot = Some(value);
+        }
+    }
+
+    fn width(&self, id: RegisterId) -> usize {
+        self.widths.get(id.0).copied().unwrap_or(0)
+    }
+
+    fn is_signed(&self, id: RegisterId) -> bool {
+        self.signed.get(id.0).copied().unwrap_or(false)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use celox_sir::{BasicBlock, SIRSwitchCase};
+
+    #[derive(Default)]
+    struct FakeMachine {
+        cells: HashMap<(u32, usize, usize), SIRValue>,
+        runtime_events: Vec<(u32, Vec<SIRValue>)>,
+        comb_captures: Vec<(u32, Vec<u32>)>,
+        trigger_notifications: Vec<usize>,
+    }
+
+    impl FakeMachine {
+        fn stored(&self, addr: u32, offset: usize, bits: usize) -> &SIRValue {
+            self.cells.get(&(addr, offset, bits)).unwrap()
+        }
+    }
+
+    impl InterpMachine<u32> for FakeMachine {
+        fn load(
+            &mut self,
+            addr: &u32,
+            access: ResolvedAccess<'_>,
+            bits: usize,
+        ) -> Result<SIRValue, InterpError> {
+            let offset = match access.offset {
+                SIROffset::Static(offset) => *offset,
+                other => {
+                    return Err(InterpError::Machine(format!(
+                        "fake machine cannot resolve {other}"
+                    )))
+                }
+            };
+            Ok(self
+                .cells
+                .get(&(*addr, offset, bits))
+                .cloned()
+                .unwrap_or_else(|| SIRValue::new(BigUint::zero())))
+        }
+
+        fn store(
+            &mut self,
+            addr: &u32,
+            access: ResolvedAccess<'_>,
+            bits: usize,
+            value: &SIRValue,
+        ) -> Result<(), InterpError> {
+            let offset = match access.offset {
+                SIROffset::Static(offset) => *offset,
+                other => {
+                    return Err(InterpError::Machine(format!(
+                        "fake machine cannot resolve {other}"
+                    )))
+                }
+            };
+            self.cells.insert((*addr, offset, bits), value.clone());
+            Ok(())
+        }
+
+        fn commit(
+            &mut self,
+            src: &u32,
+            dst: &u32,
+            access: ResolvedAccess<'_>,
+            bits: usize,
+        ) -> Result<(), InterpError> {
+            let offset = match access.offset {
+                SIROffset::Static(offset) => *offset,
+                other => {
+                    return Err(InterpError::Machine(format!(
+                        "fake machine cannot resolve {other}"
+                    )))
+                }
+            };
+            let value = self.cells.get(&(*src, offset, bits)).cloned();
+            if let Some(value) = value {
+                self.cells.insert((*dst, offset, bits), value);
+            }
+            Ok(())
+        }
+
+        fn notify_triggers(&mut self, _addr: &u32, triggers: &[TriggerIdWithKind]) {
+            self.trigger_notifications.push(triggers.len());
+        }
+
+        fn notify_comb_capture(&mut self, _addr: &u32, sites: &[u32], _value: &SIRValue) {
+            self.comb_captures.push((_addr_owned(_addr), sites.to_vec()));
+        }
+
+        fn emit_runtime_event(&mut self, site_id: u32, args: &[SIRValue]) {
+            self.runtime_events.push((site_id, args.to_vec()));
+        }
+
+        fn emit_comb_capture_event(
+            &mut self,
+            _site_id: u32,
+            _args: &[SIRValue],
+            _fatal_error_code: Option<i64>,
+            _consume_enabled: bool,
+        ) {
+        }
+
+        fn enable_comb_capture_if_changed(
+            &mut self,
+            _old: &SIRValue,
+            _new: &SIRValue,
+            _sites: &[u32],
+        ) {
+        }
+    }
+
+    fn _addr_owned(addr: &u32) -> u32 {
+        *addr
+    }
+
+    fn bit_regs(specs: &[(usize, usize)]) -> HashMap<RegisterId, RegisterType> {
+        specs
+            .iter()
+            .map(|&(id, width)| {
+                (
+                    RegisterId(id),
+                    RegisterType::Bit {
+                        width,
+                        signed: false,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn block(
+        id: usize,
+        params: Vec<usize>,
+        instructions: Vec<SIRInstruction<u32>>,
+        terminator: SIRTerminator,
+    ) -> (BlockId, BasicBlock<u32>) {
+        (
+            BlockId(id),
+            BasicBlock {
+                id: BlockId(id),
+                params: params.into_iter().map(RegisterId).collect(),
+                instructions,
+                terminator,
+            },
+        )
+    }
+
+    #[test]
+    fn executes_straight_line_arithmetic_and_store() {
+        let unit = ExecutionUnit {
+            entry_block_id: BlockId(0),
+            blocks: [block(
+                0,
+                vec![],
+                vec![
+                    SIRInstruction::Imm(RegisterId(0), SIRValue::new(5u8)),
+                    SIRInstruction::Imm(RegisterId(1), SIRValue::new(3u8)),
+                    SIRInstruction::Binary(
+                        RegisterId(2),
+                        RegisterId(0),
+                        BinaryOp::Add,
+                        RegisterId(1),
+                    ),
+                    SIRInstruction::Store(
+                        7u32,
+                        SIROffset::Static(0),
+                        8,
+                        RegisterId(2),
+                        Vec::new(),
+                        Vec::new(),
+                    ),
+                ],
+                SIRTerminator::Return,
+            )]
+            .into_iter()
+            .collect(),
+            register_map: bit_regs(&[(0, 8), (1, 8), (2, 8)]),
+        };
+
+        let mut machine = FakeMachine::default();
+        execute_unit(&unit, &mut machine, &[]).unwrap();
+        assert_eq!(machine.stored(7, 0, 8).payload, BigUint::from(8u8));
+    }
+
+    #[test]
+    fn branch_selects_target_by_known_condition_bits() {
+        for (cond, expected) in [(1u8, 10u8), (0, 20)] {
+            let unit = ExecutionUnit {
+                entry_block_id: BlockId(0),
+                blocks: [
+                    block(
+                        0,
+                        vec![],
+                        vec![SIRInstruction::Imm(RegisterId(0), SIRValue::new(cond))],
+                        SIRTerminator::Branch {
+                            cond: RegisterId(0),
+                            true_block: (BlockId(1), vec![]),
+                            false_block: (BlockId(2), vec![]),
+                        },
+                    ),
+                    block(
+                        1,
+                        vec![],
+                        vec![SIRInstruction::Imm(RegisterId(1), SIRValue::new(10u8))],
+                        SIRTerminator::Jump(BlockId(3), vec![]),
+                    ),
+                    block(
+                        2,
+                        vec![],
+                        vec![SIRInstruction::Imm(RegisterId(1), SIRValue::new(20u8))],
+                        SIRTerminator::Jump(BlockId(3), vec![]),
+                    ),
+                    block(
+                        3,
+                        vec![],
+                        vec![SIRInstruction::Store(
+                            1u32,
+                            SIROffset::Static(0),
+                            8,
+                            RegisterId(1),
+                            Vec::new(),
+                            Vec::new(),
+                        )],
+                        SIRTerminator::Return,
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+                register_map: bit_regs(&[(0, 1), (1, 8)]),
+            };
+
+            let mut machine = FakeMachine::default();
+            execute_unit(&unit, &mut machine, &[]).unwrap();
+            assert_eq!(machine.stored(1, 0, 8).payload, BigUint::from(expected));
+        }
+    }
+
+    #[test]
+    fn switch_matches_cases_and_falls_back_to_default() {
+        for (selector, expected) in [(2u8, 2u8), (9, 99)] {
+            let unit = ExecutionUnit {
+                entry_block_id: BlockId(0),
+                blocks: [
+                    block(
+                        0,
+                        vec![],
+                        vec![SIRInstruction::Imm(RegisterId(0), SIRValue::new(selector))],
+                        SIRTerminator::Switch {
+                            selector: RegisterId(0),
+                            cases: vec![
+                                SIRSwitchCase {
+                                    value: BigUint::from(1u8),
+                                    target: BlockId(1),
+                                },
+                                SIRSwitchCase {
+                                    value: BigUint::from(2u8),
+                                    target: BlockId(2),
+                                },
+                            ],
+                            default: BlockId(3),
+                        },
+                    ),
+                    block(
+                        1,
+                        vec![],
+                        vec![SIRInstruction::Imm(RegisterId(1), SIRValue::new(1u8))],
+                        SIRTerminator::Jump(BlockId(4), vec![]),
+                    ),
+                    block(
+                        2,
+                        vec![],
+                        vec![SIRInstruction::Imm(RegisterId(1), SIRValue::new(2u8))],
+                        SIRTerminator::Jump(BlockId(4), vec![]),
+                    ),
+                    block(
+                        3,
+                        vec![],
+                        vec![SIRInstruction::Imm(RegisterId(1), SIRValue::new(99u8))],
+                        SIRTerminator::Jump(BlockId(4), vec![]),
+                    ),
+                    block(
+                        4,
+                        vec![],
+                        vec![SIRInstruction::Store(
+                            1u32,
+                            SIROffset::Static(0),
+                            8,
+                            RegisterId(1),
+                            Vec::new(),
+                            Vec::new(),
+                        )],
+                        SIRTerminator::Return,
+                    ),
+                ]
+                .into_iter()
+                .collect(),
+                register_map: bit_regs(&[(0, 4), (1, 8)]),
+            };
+
+            let mut machine = FakeMachine::default();
+            execute_unit(&unit, &mut machine, &[]).unwrap();
+            assert_eq!(machine.stored(1, 0, 8).payload, BigUint::from(expected));
+        }
+    }
+
+    #[test]
+    fn jump_binds_target_block_parameters() {
+        let unit = ExecutionUnit {
+            entry_block_id: BlockId(0),
+            blocks: [
+                block(
+                    0,
+                    vec![],
+                    vec![SIRInstruction::Imm(RegisterId(0), SIRValue::new(7u8))],
+                    SIRTerminator::Jump(BlockId(1), vec![RegisterId(0)]),
+                ),
+                block(
+                    1,
+                    vec![1],
+                    vec![SIRInstruction::Store(
+                        3u32,
+                        SIROffset::Static(0),
+                        8,
+                        RegisterId(1),
+                        Vec::new(),
+                        Vec::new(),
+                    )],
+                    SIRTerminator::Return,
+                ),
+            ]
+            .into_iter()
+            .collect(),
+            register_map: bit_regs(&[(0, 8), (1, 8)]),
+        };
+
+        let mut machine = FakeMachine::default();
+        execute_unit(&unit, &mut machine, &[]).unwrap();
+        assert_eq!(machine.stored(3, 0, 8).payload, BigUint::from(7u8));
+    }
+
+    #[test]
+    fn entry_parameters_bind_caller_supplied_arguments() {
+        let unit = ExecutionUnit {
+            entry_block_id: BlockId(0),
+            blocks: [block(
+                0,
+                vec![0],
+                vec![SIRInstruction::Store(
+                    5u32,
+                    SIROffset::Static(0),
+                    8,
+                    RegisterId(0),
+                    Vec::new(),
+                    Vec::new(),
+                )],
+                SIRTerminator::Return,
+            )]
+            .into_iter()
+            .collect(),
+            register_map: bit_regs(&[(0, 8)]),
+        };
+
+        let mut machine = FakeMachine::default();
+        execute_unit(&unit, &mut machine, &[SIRValue::new(0xDEu16)]).unwrap();
+        assert_eq!(machine.stored(5, 0, 8).payload, BigUint::from(0xDEu16));
+    }
+
+    #[test]
+    fn concat_and_slice_roundtrip_msbf_order() {
+        let unit = ExecutionUnit {
+            entry_block_id: BlockId(0),
+            blocks: [block(
+                0,
+                vec![],
+                vec![
+                    SIRInstruction::Imm(RegisterId(0), SIRValue::new(0xABu8)),
+                    SIRInstruction::Imm(RegisterId(1), SIRValue::new(0xCDu8)),
+                    SIRInstruction::Concat(RegisterId(2), vec![RegisterId(0), RegisterId(1)]),
+                    SIRInstruction::Slice(RegisterId(3), RegisterId(2), 4, 8),
+                    SIRInstruction::Store(
+                        9u32,
+                        SIROffset::Static(0),
+                        8,
+                        RegisterId(3),
+                        Vec::new(),
+                        Vec::new(),
+                    ),
+                ],
+                SIRTerminator::Return,
+            )]
+            .into_iter()
+            .collect(),
+            register_map: bit_regs(&[(0, 8), (1, 8), (2, 16), (3, 8)]),
+        };
+
+        let mut machine = FakeMachine::default();
+        execute_unit(&unit, &mut machine, &[]).unwrap();
+        // 0xABCD sliced [4 +: 8] == 0xBC.
+        assert_eq!(machine.stored(9, 0, 8).payload, BigUint::from(0xBCu8));
+    }
+
+    #[test]
+    fn mux_follows_four_state_selection_contract() {
+        let known_one = SIRValue::new(1u8);
+        let known_zero = SIRValue::new(0u8);
+        let unknown = SIRValue::new_four_state(0u8, 1u8);
+
+        // Known-one condition selects the then-arm exactly, mask included.
+        let mixed_arm = SIRValue::new_four_state(0b01u8, 0b10u8);
+        assert_eq!(
+            eval_mux(&known_one, &mixed_arm, &SIRValue::new(0u8), 2),
+            mixed_arm
+        );
+        // Known-zero condition selects the else-arm.
+        assert_eq!(
+            eval_mux(&known_zero, &mixed_arm, &SIRValue::new(0b11u8), 2),
+            SIRValue::new(0b11u8)
+        );
+        // Unknown condition: agreeing bits preserved, differing bits become X.
+        let out = eval_mux(
+            &unknown,
+            &SIRValue::new_four_state(0b1010u8, 0b0000u8),
+            &SIRValue::new_four_state(0b0011u8, 0b0100u8),
+            4,
+        );
+        assert_eq!(out.payload, BigUint::from(0b0010u8));
+        assert_eq!(out.mask, BigUint::from(0b1101u8));
+    }
+
+    #[test]
+    fn error_terminator_surfaces_fatal_code() {
+        let unit = ExecutionUnit {
+            entry_block_id: BlockId(0),
+            blocks: [block(0, vec![], vec![], SIRTerminator::Error(42))]
+                .into_iter()
+                .collect(),
+            register_map: HashMap::default(),
+        };
+
+        let mut machine = FakeMachine::default();
+        assert_eq!(
+            execute_unit(&unit, &mut machine, &[]).unwrap_err(),
+            InterpError::Fatal(42)
+        );
+    }
+
+    #[test]
+    fn jump_to_missing_block_reports_unknown_block() {
+        let unit = ExecutionUnit {
+            entry_block_id: BlockId(0),
+            blocks: [block(0, vec![], vec![], SIRTerminator::Jump(BlockId(99), vec![]))]
+                .into_iter()
+                .collect(),
+            register_map: HashMap::default(),
+        };
+
+        let mut machine = FakeMachine::default();
+        assert_eq!(
+            execute_unit(&unit, &mut machine, &[]).unwrap_err(),
+            InterpError::UnknownBlock(BlockId(99))
+        );
+    }
+
+    #[test]
+    fn arity_mismatch_between_jump_and_target_params_is_rejected() {
+        let unit = ExecutionUnit {
+            entry_block_id: BlockId(0),
+            blocks: [
+                block(0, vec![], vec![], SIRTerminator::Jump(BlockId(1), vec![])),
+                block(1, vec![0], vec![], SIRTerminator::Return),
+            ]
+            .into_iter()
+            .collect(),
+            register_map: bit_regs(&[(0, 8)]),
+        };
+
+        let mut machine = FakeMachine::default();
+        assert_eq!(
+            execute_unit(&unit, &mut machine, &[]).unwrap_err(),
+            InterpError::RegisterArityMismatch {
+                expected: 1,
+                found: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn reading_unwritten_register_is_rejected() {
+        let unit = ExecutionUnit {
+            entry_block_id: BlockId(0),
+            blocks: [block(
+                0,
+                vec![],
+                vec![SIRInstruction::Store(
+                    1u32,
+                    SIROffset::Static(0),
+                    8,
+                    RegisterId(4),
+                    Vec::new(),
+                    Vec::new(),
+                )],
+                SIRTerminator::Return,
+            )]
+            .into_iter()
+            .collect(),
+            register_map: bit_regs(&[(4, 8)]),
+        };
+
+        let mut machine = FakeMachine::default();
+        assert_eq!(
+            execute_unit(&unit, &mut machine, &[]).unwrap_err(),
+            InterpError::MissingRegister(RegisterId(4))
+        );
+    }
+
+    #[test]
+    fn runtime_events_receive_resolved_argument_values() {
+        let unit = ExecutionUnit {
+            entry_block_id: BlockId(0),
+            blocks: [block(
+                0,
+                vec![],
+                vec![
+                    SIRInstruction::Imm(RegisterId(0), SIRValue::new(11u8)),
+                    SIRInstruction::RuntimeEvent {
+                        site_id: 3,
+                        args: vec![RegisterId(0)],
+                    },
+                ],
+                SIRTerminator::Return,
+            )]
+            .into_iter()
+            .collect(),
+            register_map: bit_regs(&[(0, 8)]),
+        };
+
+        let mut machine = FakeMachine::default();
+        execute_unit(&unit, &mut machine, &[]).unwrap();
+        assert_eq!(
+            machine.runtime_events,
+            vec![(3, vec![SIRValue::new(11u8)])]
+        );
+    }
+}

--- a/crates/celox/src/interpreter.rs
+++ b/crates/celox/src/interpreter.rs
@@ -308,7 +308,6 @@ fn exec_instruction<A, M: InterpMachine<A>>(
             let lhs_value = regs.get(*lhs)?.clone();
             let rhs_value = regs.get(*rhs)?.clone();
             let dst_width = regs.width(*dst);
-            let lhs_signed = regs.is_signed(*lhs);
             let out = alu_binary(
                 op,
                 &lhs_value,
@@ -316,7 +315,8 @@ fn exec_instruction<A, M: InterpMachine<A>>(
                 regs.width(*lhs),
                 regs.width(*rhs),
                 dst_width,
-                lhs_signed,
+                regs.is_signed(*lhs),
+                regs.is_signed(*rhs),
             )?;
             regs.set(*dst, truncate(out, dst_width));
         }
@@ -506,32 +506,26 @@ fn alu_binary(
     rhs_width: usize,
     dst_width: usize,
     lhs_signed: bool,
+    rhs_signed: bool,
 ) -> Result<SIRValue, InterpError> {
     let out = match op {
-        BinaryOp::Add => {
+        BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul => {
             // SEMANTICS-CHECK: any X/Z operand bit makes the whole result X.
-            if lhs.mask.is_zero() && rhs.mask.is_zero() {
-                SIRValue::new((&lhs.payload + &rhs.payload) & width_mask(dst_width))
-            } else {
+            // Operands are promoted to the common width with the compiled
+            // extension rule before the wrap-around arithmetic, so a narrow
+            // signed operand keeps its value (4-bit -1 + 8-bit 1 == 0).
+            if !lhs.mask.is_zero() || !rhs.mask.is_zero() {
                 all_x(dst_width)
-            }
-        }
-        BinaryOp::Sub => {
-            // Wrap-safe two's complement subtraction: l + (~r + 1) mod 2^w.
-            // SEMANTICS-CHECK: any X/Z operand bit makes the whole result X.
-            if lhs.mask.is_zero() && rhs.mask.is_zero() {
-                let inverted_rhs = &width_mask(dst_width) ^ &rhs.payload;
-                SIRValue::new((&lhs.payload + inverted_rhs + 1u8) & width_mask(dst_width))
             } else {
-                all_x(dst_width)
-            }
-        }
-        BinaryOp::Mul => {
-            // SEMANTICS-CHECK: any X/Z operand bit makes the whole result X.
-            if lhs.mask.is_zero() && rhs.mask.is_zero() {
-                SIRValue::new((&lhs.payload * &rhs.payload) & width_mask(dst_width))
-            } else {
-                all_x(dst_width)
+                let common = lhs_width.max(rhs_width).max(dst_width);
+                let l = promote_operand(lhs, lhs_signed, lhs_width, common).payload;
+                let r = promote_operand(rhs, rhs_signed, rhs_width, common).payload;
+                let raw = match op {
+                    BinaryOp::Add => l + r,
+                    BinaryOp::Sub => l + (&width_mask(common) ^ &r) + 1u8,
+                    _ => l * r,
+                };
+                SIRValue::new(raw & width_mask(dst_width))
             }
         }
         BinaryOp::DivU | BinaryOp::RemU => {
@@ -570,11 +564,14 @@ fn alu_binary(
             }
         }
         BinaryOp::And => {
-            // Per-bit truth tables evaluated at the common width so padding
-            // above a narrower operand counts as known zero.
+            // Per-bit truth tables evaluated at the common width with the
+            // compiled promotion, so padding above a narrower operand follows
+            // its sign instead of reading as known zero.
             let common = lhs_width.max(rhs_width).max(dst_width);
-            let ones = known_ones(lhs, common) & known_ones(rhs, common);
-            let zeros = known_zeros(lhs, common) | known_zeros(rhs, common);
+            let l = promote_operand(lhs, lhs_signed, lhs_width, common);
+            let r = promote_operand(rhs, rhs_signed, rhs_width, common);
+            let ones = known_ones(&l, common) & known_ones(&r, common);
+            let zeros = known_zeros(&l, common) | known_zeros(&r, common);
             let mask = &width_mask(common) ^ (&ones | &zeros);
             SIRValue {
                 payload: ones,
@@ -583,8 +580,10 @@ fn alu_binary(
         }
         BinaryOp::Or => {
             let common = lhs_width.max(rhs_width).max(dst_width);
-            let ones = known_ones(lhs, common) | known_ones(rhs, common);
-            let zeros = known_zeros(lhs, common) & known_zeros(rhs, common);
+            let l = promote_operand(lhs, lhs_signed, lhs_width, common);
+            let r = promote_operand(rhs, rhs_signed, rhs_width, common);
+            let ones = known_ones(&l, common) | known_ones(&r, common);
+            let zeros = known_zeros(&l, common) & known_zeros(&r, common);
             let mask = &width_mask(common) ^ (&ones | &zeros);
             SIRValue {
                 payload: ones,
@@ -595,10 +594,12 @@ fn alu_binary(
             // SEMANTICS-CHECK: XOR is per-bit independent — an unknown input
             // bit only makes the corresponding output bit unknown (mask union),
             // unlike arithmetic ops where any X poisons the whole result.
-            let common = lhs_width.max(rhs_width);
+            let common = lhs_width.max(rhs_width).max(dst_width);
+            let l = promote_operand(lhs, lhs_signed, lhs_width, common);
+            let r = promote_operand(rhs, rhs_signed, rhs_width, common);
             SIRValue {
-                payload: (&lhs.payload ^ &rhs.payload) & width_mask(common),
-                mask: (&lhs.mask | &rhs.mask) & width_mask(common),
+                payload: &l.payload ^ &r.payload,
+                mask: &l.mask | &r.mask,
             }
         }
         BinaryOp::Shl => {
@@ -606,30 +607,34 @@ fn alu_binary(
             // The shift runs on the full left-hand value and the destination
             // keeps the low bits, matching the compiled common-width lowering
             // (a narrow destination still receives surviving low bits).
+            // Counts at or beyond the destination width produce zero without
+            // materializing a huge BigUint shift.
             if !rhs.mask.is_zero() {
                 all_x(dst_width)
             } else {
                 match shift_amount(&rhs.payload) {
-                    Some(amount) => SIRValue {
+                    Some(amount) if amount < dst_width => SIRValue {
                         payload: (&lhs.payload << amount) & width_mask(dst_width),
                         mask: (&lhs.mask << amount) & width_mask(dst_width),
                     },
-                    None => SIRValue::new(BigUint::zero()),
+                    _ => SIRValue::new(BigUint::zero()),
                 }
             }
         }
         BinaryOp::Shr => {
             // SEMANTICS-CHECK: an X/Z shift amount makes the whole result X.
             // Logical shift: vacated bits are zero regardless of width.
+            // Overshift counts return zero directly to bound the work.
             if !rhs.mask.is_zero() {
                 all_x(dst_width)
             } else {
+                let bound = lhs_width.max(dst_width).max(1);
                 match shift_amount(&rhs.payload) {
-                    Some(amount) => SIRValue {
+                    Some(amount) if amount < bound => SIRValue {
                         payload: &lhs.payload >> amount,
                         mask: &lhs.mask >> amount,
                     },
-                    None => SIRValue::new(BigUint::zero()),
+                    _ => SIRValue::new(BigUint::zero()),
                 }
             }
         }
@@ -644,8 +649,9 @@ fn alu_binary(
             } else {
                 let signed_value = to_signed(&lhs.payload, lhs_width);
                 let signed_mask = to_signed(&lhs.mask, lhs_width);
+                let bound = lhs_width.max(dst_width).max(1);
                 match shift_amount(&rhs.payload) {
-                    Some(amount) => {
+                    Some(amount) if amount < bound => {
                         let shifted = signed_value >> amount;
                         let shifted_mask = signed_mask >> amount;
                         SIRValue {
@@ -653,9 +659,9 @@ fn alu_binary(
                             mask: wrap_signed(&shifted_mask, dst_width),
                         }
                     }
-                    None => {
-                        // An unrepresentable shift distance drives every bit,
-                        // including the mask, toward the sign fill.
+                    _ => {
+                        // Overshift or unrepresentable distances drive every
+                        // bit, including the mask, toward the sign fill.
                         if signed_value.is_negative() {
                             all_x(dst_width)
                         } else {
@@ -845,6 +851,19 @@ fn zero_extend(value: &SIRValue, width: usize) -> SIRValue {
     }
 }
 
+/// Promote a payload/mask pair up to `width` using the compiled extension
+/// rule: a signed declaration sign-extends both words, an unsigned one
+/// zero-extends.
+fn promote_operand(value: &SIRValue, signed: bool, from_width: usize, width: usize) -> SIRValue {
+    if !signed || width <= from_width {
+        return zero_extend(value, width);
+    }
+    SIRValue {
+        payload: sign_extend(&value.payload, from_width, width),
+        mask: sign_extend(&value.mask, from_width, width),
+    }
+}
+
 /// Sign-extend the top bit of a `from_width`-wide payload up to `to_width`.
 fn sign_extend(payload: &BigUint, from_width: usize, to_width: usize) -> BigUint {
     if from_width == 0 || to_width <= from_width {
@@ -881,11 +900,20 @@ fn alu_unary(
     src_signed: bool,
     dst_width: usize,
 ) -> Result<SIRValue, InterpError> {
-    // Signedness is carried by dedicated opcodes (e.g. division); unary
-    // operators do not consult the declaration today.
-    let _ = src_signed;
     let out = match op {
-        UnaryOp::Ident => src.clone(),
+        UnaryOp::Ident => {
+            // Identity casts widen with the operand's declared signedness,
+            // matching the compiled promotion: widening a signed negative
+            // value must sign-fill, not zero-fill.
+            if src_signed && dst_width > src_width {
+                SIRValue {
+                    payload: sign_extend(&src.payload, src_width, dst_width),
+                    mask: sign_extend(&src.mask, src_width, dst_width),
+                }
+            } else {
+                src.clone()
+            }
+        }
         UnaryOp::ToTwoState => SIRValue {
             payload: &src.payload & (&width_mask(src_width) ^ &src.mask),
             mask: BigUint::zero(),

--- a/crates/celox/src/interpreter.rs
+++ b/crates/celox/src/interpreter.rs
@@ -1108,13 +1108,22 @@ fn eval_mux(
     cond_width: usize,
     out_width: usize,
 ) -> SIRValue {
+    // Every outcome is shaped to the destination width like the compiled
+    // selection, so an arm wider than the destination cannot leak excess
+    // bits into later operations.
+    let mask = width_mask(out_width);
     if mux_condition_known_one(cond, cond_width) {
-        return then_value.clone();
+        return SIRValue {
+            payload: &then_value.payload & &mask,
+            mask: &then_value.mask & &mask,
+        };
     }
     if cond.mask.is_zero() {
-        return else_value.clone();
+        return SIRValue {
+            payload: &else_value.payload & &mask,
+            mask: &else_value.mask & &mask,
+        };
     }
-    let mask = width_mask(out_width);
     let tv = &then_value.payload & &mask;
     let ev = &else_value.payload & &mask;
     let tm = &then_value.mask & &mask;

--- a/crates/celox/src/interpreter.rs
+++ b/crates/celox/src/interpreter.rs
@@ -901,7 +901,20 @@ fn compare_holds(
         BinaryOp::LtU | BinaryOp::LeU | BinaryOp::GtU | BinaryOp::GeU => {
             lhs.payload.cmp(&rhs.payload)
         }
-        _ => to_signed(&lhs.payload, lhs_width).cmp(&to_signed(&rhs.payload, rhs_width)),
+        _ => {
+            // Signed orderings interpret two's complement at the operation
+            // width. The compiled wide comparison path zero-fills a narrow
+            // operand's missing chunks before interpreting signedness at the
+            // common width, so crossing 64 bits must zero-pad first.
+            let common = lhs_width.max(rhs_width);
+            if common <= 64 {
+                to_signed(&lhs.payload, lhs_width).cmp(&to_signed(&rhs.payload, rhs_width))
+            } else {
+                let l = zero_extend(lhs, common).payload;
+                let r = zero_extend(rhs, common).payload;
+                to_signed(&l, common).cmp(&to_signed(&r, common))
+            }
+        }
     };
     use std::cmp::Ordering;
     match op {
@@ -995,13 +1008,15 @@ fn alu_unary(
         },
         UnaryOp::Minus => {
             // SEMANTICS-CHECK: negating a value containing X/Z yields all-X.
-            // Minus forces signed promotion in the compiled lowering, so the
-            // operand is sign-extended to the common width before the
+            // Minus forces signed promotion in the compiled narrow lowering,
+            // so the operand is sign-extended to the common width before the
             // two's-complement negation (negating 4-bit 1 into an 8-bit
-            // destination yields 0xff).
+            // destination yields 0xff). The compiled multi-word lowering
+            // instead zero-fills missing chunks, so destinations wider than
+            // 64 bits keep zero padding.
             if src.mask.is_zero() {
                 let common = src_width.max(dst_width);
-                let promoted = promote_operand(src, true, src_width, common).payload;
+                let promoted = promote_operand(src, common <= 64, src_width, common).payload;
                 let inverted = &width_mask(common) ^ &promoted;
                 SIRValue::new((&inverted + 1u8) & width_mask(dst_width))
             } else {
@@ -1010,9 +1025,12 @@ fn alu_unary(
         }
         UnaryOp::BitNot => {
             // Complement at the common width so widened results fill their
-            // new high bits, mirroring the compiled promotion.
+            // new high bits, mirroring the compiled narrow promotion. The
+            // compiled multi-word lowering zero-fills absent chunks before
+            // complementing, so destinations wider than 64 bits keep zero
+            // padding.
             let common = src_width.max(dst_width);
-            let promoted = promote_operand(src, src_signed, src_width, common);
+            let promoted = promote_operand(src, src_signed && common <= 64, src_width, common);
             SIRValue {
                 payload: &width_mask(common) ^ &promoted.payload,
                 mask: promoted.mask,

--- a/crates/celox/src/interpreter.rs
+++ b/crates/celox/src/interpreter.rs
@@ -654,19 +654,24 @@ fn alu_binary(
         }
         BinaryOp::Shl => {
             // SEMANTICS-CHECK: an X/Z shift amount makes the whole result X.
-            // The shift runs on the full left-hand value and the destination
-            // keeps the low bits, matching the compiled common-width lowering
-            // (a narrow destination still receives surviving low bits).
+            // The compiled lowering promotes the left operand to the common
+            // width by its declaration (a signed source sign-fills), shifts,
+            // and keeps the low destination bits; a narrow signed value
+            // shifted into a wider destination keeps its sign region.
             // Counts at or beyond the destination width produce zero without
             // materializing a huge BigUint shift.
             if !rhs.mask.is_zero() {
                 all_x(dst_width)
             } else {
                 match shift_amount(&rhs.payload) {
-                    Some(amount) if amount < dst_width => SIRValue {
-                        payload: (&lhs.payload << amount) & width_mask(dst_width),
-                        mask: (&lhs.mask << amount) & width_mask(dst_width),
-                    },
+                    Some(amount) if amount < dst_width => {
+                        let common = lhs_width.max(dst_width);
+                        let promoted = promote_operand(lhs, lhs_signed, lhs_width, common);
+                        SIRValue {
+                            payload: (&promoted.payload << amount) & width_mask(dst_width),
+                            mask: (&promoted.mask << amount) & width_mask(dst_width),
+                        }
+                    }
                     _ => SIRValue::new(BigUint::zero()),
                 }
             }

--- a/crates/celox/src/interpreter.rs
+++ b/crates/celox/src/interpreter.rs
@@ -299,7 +299,12 @@ fn exec_instruction<A, M: InterpMachine<A>>(
                 payload = (payload << width) | &value.payload;
                 mask = (mask << width) | &value.mask;
             }
-            regs.set(*dst, SIRValue { payload, mask });
+            // Keep the declared-register-width invariant shared by every other
+            // operation: results never exceed the destination width.
+            regs.set(
+                *dst,
+                truncate(SIRValue { payload, mask }, regs.width(*dst)),
+            );
         }
         SIRInstruction::Slice(dst, src, offset, width) => {
             let value = regs.get(*src)?;
@@ -311,7 +316,15 @@ fn exec_instruction<A, M: InterpMachine<A>>(
             let cond = regs.get(*cond)?.clone();
             let then_value = regs.get(*then_value)?.clone();
             let else_value = regs.get(*else_value)?.clone();
-            let out = eval_mux(&cond, &then_value, &else_value, regs.width(*dst));
+            // Evaluate the condition in its own width; shape the selected
+            // arms to the destination width.
+            let out = eval_mux(
+                &cond,
+                &then_value,
+                &else_value,
+                regs.width(*cond),
+                regs.width(*dst),
+            );
             regs.set(*dst, out);
         }
         SIRInstruction::RuntimeEvent { site_id, args } => {
@@ -623,15 +636,25 @@ fn alu_unary(
 /// `then` exactly (preserving its mask); a fully known zero selects `else`;
 /// an unknown condition preserves bits where both arms agree and turns
 /// differing bits into X.
-fn eval_mux(cond: &SIRValue, then_value: &SIRValue, else_value: &SIRValue, width: usize) -> SIRValue {
-    if branch_condition_holds(cond, width) {
+///
+/// The condition is evaluated in `cond_width` (its own register width) while
+/// the agreement merge is shaped to `out_width` (the destination width).
+fn eval_mux(
+    cond: &SIRValue,
+    then_value: &SIRValue,
+    else_value: &SIRValue,
+    cond_width: usize,
+    out_width: usize,
+) -> SIRValue {
+    if branch_condition_holds(cond, cond_width) {
         return then_value.clone();
     }
     if cond.mask.is_zero() {
         return else_value.clone();
     }
-    let mask = width_mask(width);
-    let difference = (&then_value.payload ^ &else_value.payload) | (&then_value.mask ^ &else_value.mask);
+    let mask = width_mask(out_width);
+    let difference =
+        (&then_value.payload ^ &else_value.payload) | (&then_value.mask ^ &else_value.mask);
     let agree = &mask ^ &difference;
     SIRValue {
         payload: &then_value.payload & &agree,
@@ -1117,6 +1140,40 @@ mod tests {
     }
 
     #[test]
+    fn concat_truncates_to_destination_width() {
+        let unit = ExecutionUnit {
+            entry_block_id: BlockId(0),
+            blocks: [block(
+                0,
+                vec![],
+                vec![
+                    SIRInstruction::Imm(RegisterId(0), SIRValue::new(0xFFu8)),
+                    SIRInstruction::Imm(RegisterId(1), SIRValue::new(0xFFu8)),
+                    SIRInstruction::Concat(RegisterId(2), vec![RegisterId(0), RegisterId(1)]),
+                    SIRInstruction::Store(
+                        9u32,
+                        SIROffset::Static(0),
+                        8,
+                        RegisterId(2),
+                        Vec::new(),
+                        Vec::new(),
+                    ),
+                ],
+                SIRTerminator::Return,
+            )]
+            .into_iter()
+            .collect(),
+            // Destination is narrower than the concatenated sources: the
+            // declared-register-width invariant keeps the low 8 bits.
+            register_map: bit_regs(&[(0, 8), (1, 8), (2, 8)]),
+        };
+
+        let mut machine = FakeMachine::default();
+        execute_unit(&unit, &mut machine, &[]).unwrap();
+        assert_eq!(machine.stored(9, 0, 8).payload, BigUint::from(0xFFu8));
+    }
+
+    #[test]
     fn mux_follows_four_state_selection_contract() {
         let known_one = SIRValue::new(1u8);
         let known_zero = SIRValue::new(0u8);
@@ -1125,12 +1182,12 @@ mod tests {
         // Known-one condition selects the then-arm exactly, mask included.
         let mixed_arm = SIRValue::new_four_state(0b01u8, 0b10u8);
         assert_eq!(
-            eval_mux(&known_one, &mixed_arm, &SIRValue::new(0u8), 2),
+            eval_mux(&known_one, &mixed_arm, &SIRValue::new(0u8), 1, 2),
             mixed_arm
         );
         // Known-zero condition selects the else-arm.
         assert_eq!(
-            eval_mux(&known_zero, &mixed_arm, &SIRValue::new(0b11u8), 2),
+            eval_mux(&known_zero, &mixed_arm, &SIRValue::new(0b11u8), 1, 2),
             SIRValue::new(0b11u8)
         );
         // Unknown condition: agreeing bits preserved, differing bits become X.
@@ -1138,10 +1195,26 @@ mod tests {
             &unknown,
             &SIRValue::new_four_state(0b1010u8, 0b0000u8),
             &SIRValue::new_four_state(0b0011u8, 0b0100u8),
+            1,
             4,
         );
         assert_eq!(out.payload, BigUint::from(0b0010u8));
         assert_eq!(out.mask, BigUint::from(0b1101u8));
+    }
+
+    #[test]
+    fn mux_condition_is_evaluated_in_its_own_width() {
+        // An 8-bit condition with a known one above the 4-bit destination
+        // width must still select the then-arm.
+        let wide_cond = SIRValue::new(0b1_0000u8);
+        let out = eval_mux(
+            &wide_cond,
+            &SIRValue::new(0xAu8),
+            &SIRValue::new(0x5u8),
+            8,
+            4,
+        );
+        assert_eq!(out.payload, BigUint::from(0xAu8));
     }
 
     #[test]

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -11,6 +11,7 @@ pub use component::{
 };
 mod debug;
 mod diagnostics;
+mod interpreter;
 mod ir;
 mod optimizer;
 mod parser;
@@ -40,6 +41,7 @@ pub use debug::{CompilationTrace, NativeProfileBlock, TraceOptions};
 pub use diagnostics::RuntimeDiagnostics;
 pub(crate) use fxhash::FxHashMap as HashMap;
 pub(crate) use fxhash::FxHashSet as HashSet;
+pub use interpreter::{InterpError, InterpMachine, ResolvedAccess, UnitExit, execute_unit};
 pub use ir::{
     AbsoluteAddr, AddrLookupError, FrontendLookup, InstancePath, LaidOutProgram, OptimizedSir,
     PortTypeKind, RuntimeDesign, RuntimeErrorInfo, RuntimeInstance, RuntimeProgram,

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -41,7 +41,9 @@ pub use debug::{CompilationTrace, NativeProfileBlock, TraceOptions};
 pub use diagnostics::RuntimeDiagnostics;
 pub(crate) use fxhash::FxHashMap as HashMap;
 pub(crate) use fxhash::FxHashSet as HashSet;
-pub use interpreter::{InterpError, InterpMachine, ResolvedAccess, UnitExit, execute_unit};
+pub use interpreter::{
+    InterpError, InterpMachine, ResolvedAccess, StoreSnapshot, UnitExit, execute_unit,
+};
 pub use ir::{
     AbsoluteAddr, AddrLookupError, FrontendLookup, InstancePath, LaidOutProgram, OptimizedSir,
     PortTypeKind, RuntimeDesign, RuntimeErrorInfo, RuntimeInstance, RuntimeProgram,

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -64,8 +64,8 @@ mod host_api {
     use crate::SimBackend;
     pub use crate::backend::wasm_runtime::WasmBackend;
     pub use crate::backend::{
-        CraneliftDiagnostics, CraneliftOptLevel, CraneliftOptions, EventRef, JitBackend,
-        RegallocAlgorithm, SharedJitCode,
+        CraneliftDiagnostics, CraneliftOptLevel, CraneliftOptions, EventRef, InterpBackend,
+        JitBackend, RegallocAlgorithm, SharedJitCode,
     };
     pub use crate::debug::CompilationTraceResult;
     pub use crate::diagnostics::DiagnosticsOptions;

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -1949,6 +1949,48 @@ mod host {
             Ok(sim)
         }
 
+        /// Compiles SIR, finalizes the state layout, and returns a simulator
+        /// whose execution units run on the Tier-0 SIR interpreter instead of
+        /// generated machine code.
+        ///
+        /// This is the target of the `all_backends!` `interp` test arm. No
+        /// code generation happens on this path: the simulator is ready as
+        /// soon as the state layout is finalized, and every execution unit is
+        /// driven by [`crate::interpreter::execute_unit`] against the same
+        /// memory image ABI the compiled backends use.
+        pub fn build_interpreter(
+            self,
+        ) -> Result<Simulator<crate::backend::InterpBackend>, SimulatorError> {
+            let phase_timing = self.options.diagnostics.phase_timing;
+            let phase_start = phase_timing.then(crate::timing::now);
+
+            let (laid_out, warnings, options, vcd_path, injected_components) = self
+                .into_laid_out_program(crate::backend::memory_layout::MemoryLayoutMode::Packed)?;
+
+            if let Some(s) = phase_start {
+                tracing::debug!(
+                    "[phase-timing] compile_and_layout (total): {:?}",
+                    s.elapsed()
+                );
+            }
+
+            let backend = crate::backend::InterpBackend::new(&laid_out, &options)?;
+
+            let mut sim =
+                Simulator::with_backend_and_program(backend, laid_out.into_runtime(), warnings);
+            sim.components.set_injected(injected_components);
+            sim.diagnostics = options.diagnostics.clone();
+            if let Some(path) = vcd_path {
+                let descs = sim.build_vcd_descs(options.four_state);
+                let vcd_writer = crate::VcdWriter::new(path, &descs)
+                    .map_err(|_| SimulatorError::from(crate::RuntimeErrorCode::InternalError))?;
+                sim.vcd_writer = Some(vcd_writer);
+            }
+            sim.apply_initial_values();
+            sim.modify(|_| {}).map_err(SimulatorError::from)?;
+            Ok(sim)
+        }
+
         /// Compiles using the selected native code-generation architecture.
         #[cfg(any(
             target_arch = "x86_64",

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -1373,7 +1373,7 @@ fn test_comb_display_inside_writer_reactivates_after_assign_chain(sim) {
     @omit_veryl;
     // Veryl 0.20.3 falsely reports a CombinationalLoop: x[0] and x[1] have
     // non-overlapping longest static prefixes and are independent SV writers.
-    @ignore_on(native, cranelift, wasm, sv);
+    @ignore_on(native, cranelift, wasm, interp, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -1457,7 +1457,7 @@ module Top (
 fn test_comb_display_inside_writer_reactivates_after_multi_stage_assign_chain(sim) {
     @omit_veryl;
     // Veryl 0.20.3 falsely reports a CombinationalLoop for independent bits.
-    @ignore_on(native, cranelift, wasm, sv);
+    @ignore_on(native, cranelift, wasm, interp, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -1500,7 +1500,7 @@ module Top (
 fn test_comb_display_inside_writer_preserves_ordered_downstream_reactivations(sim) {
     @omit_veryl;
     // Veryl 0.20.3 falsely reports a CombinationalLoop for independent bits.
-    @ignore_on(native, cranelift, wasm, sv);
+    @ignore_on(native, cranelift, wasm, interp, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -1600,7 +1600,7 @@ module Top (
 fn test_comb_display_guard_reactivates_after_assign_chain_changes_guard(sim) {
     @omit_veryl;
     // Veryl 0.20.3 falsely reports a CombinationalLoop for independent bits.
-    @ignore_on(native, cranelift, wasm, sv);
+    @ignore_on(native, cranelift, wasm, interp, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -1638,7 +1638,7 @@ module Top (
 fn test_comb_assert_fatal_reactivates_after_assign_chain_changes_assert_input(sim) {
     @omit_veryl;
     // Veryl 0.20.3 falsely reports a CombinationalLoop for independent bits.
-    @ignore_on(native, cranelift, wasm, sv);
+    @ignore_on(native, cranelift, wasm, interp, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -1680,7 +1680,7 @@ module Top (
 fn test_comb_multiple_observers_inside_writer_reactivate_in_statement_order(sim) {
     @omit_veryl;
     // Veryl 0.20.3 falsely reports a CombinationalLoop for independent bits.
-    @ignore_on(native, cranelift, wasm, sv);
+    @ignore_on(native, cranelift, wasm, interp, sv);
     @build Simulator::builder(r#"
 module Top (
     a: input logic,
@@ -1793,7 +1793,7 @@ module Top (
 fn test_comb_display_inside_writer_reactivates_through_instance_port_chain(sim) {
     @omit_veryl;
     // Veryl 0.20.3 falsely reports a CombinationalLoop for independent bits.
-    @ignore_on(native, cranelift, wasm, sv);
+    @ignore_on(native, cranelift, wasm, interp, sv);
     @build Simulator::builder(r#"
 module Passthrough (
     i: input logic,

--- a/crates/celox/tests/hierarchy.rs
+++ b/crates/celox/tests/hierarchy.rs
@@ -959,7 +959,7 @@ inst u_sub: Sub ( i: 8'h0F, o: o );
 
     fn test_hierarchical_concat_feedback_runtime(sim) {
         @omit_veryl;
-        @ignore_on(native, cranelift, wasm, sv);
+        @ignore_on(native, cranelift, wasm, interp, sv);
         @setup { let code = r#"
 module Child (
 a: input logic<2>,
@@ -998,7 +998,7 @@ assign out = v[0];
 
     fn test_hierarchical_concat_feedback_runtime_multi_observe(sim) {
         @omit_veryl;
-        @ignore_on(native, cranelift, wasm, sv);
+        @ignore_on(native, cranelift, wasm, interp, sv);
         @setup { let code = r#"
 module Child (
 a: input logic<2>,
@@ -1037,7 +1037,7 @@ assign out1 = v[1];
 
     fn test_hierarchical_concat_feedback_with_constant_middle_bit(sim) {
         @omit_veryl;
-        @ignore_on(native, cranelift, wasm, sv);
+        @ignore_on(native, cranelift, wasm, interp, sv);
         @setup { let code = r#"
 module Child (
 a: input logic<3>,
@@ -1078,7 +1078,7 @@ assign mid = v[1];
 
     fn test_hierarchical_dynamic_index_feedback_runtime(sim) {
         @omit_veryl;
-        @ignore_on(native, cranelift, wasm, sv);
+        @ignore_on(native, cranelift, wasm, interp, sv);
         @setup { let code = r#"
 module ChildFb (
 a: input logic<3>,
@@ -1153,7 +1153,7 @@ assign out_dyn = d;
 
     fn test_hierarchical_dual_dynamic_readers_feedback_runtime(sim) {
         @omit_veryl;
-        @ignore_on(native, cranelift, wasm, sv);
+        @ignore_on(native, cranelift, wasm, interp, sv);
         @setup { let code = r#"
 module ChildFb (
 a: input logic<3>,
@@ -1249,7 +1249,7 @@ assign out1 = d1;
     }
 
     fn test_hierarchical_overlapping_partial_write_dynamic_index_runtime(sim) {
-        @ignore_on(native, cranelift, wasm, sv);
+        @ignore_on(native, cranelift, wasm, interp, sv);
         @setup { let code = r#"
 module ChildFb (
 a: input logic<3>,
@@ -1353,7 +1353,7 @@ assign out_v1 = v[1];
     }
 
     fn test_hierarchical_concat_then_overlap_dynamic_index_runtime(sim) {
-        @ignore_on(native, cranelift, wasm, sv);
+        @ignore_on(native, cranelift, wasm, interp, sv);
         @setup { let code = r#"
 module ChildFb (
 a: input logic<3>,

--- a/crates/celox/tests/test_utils/mod.rs
+++ b/crates/celox/tests/test_utils/mod.rs
@@ -5,8 +5,12 @@ pub mod veryl_sv;
 #[allow(dead_code)]
 pub mod veryl_std;
 
-/// Generates native, cranelift, wasm, and Veryl reference tests, plus an SV
-/// frontend test when the `systemverilog` feature is enabled.
+/// Generates native, cranelift, wasm, interpreter, and Veryl reference tests,
+/// plus an SV frontend test when the `systemverilog` feature is enabled.
+///
+/// The `interp` arm calls `build_interpreter()`, which executes every
+/// execution unit on the Tier-0 SIR interpreter against the same memory
+/// image ABI as the compiled backends.
 ///
 /// ```rust
 /// all_backends! {
@@ -61,6 +65,15 @@ macro_rules! all_backends {
     };
     (@with_ignore veryl; ($first:ident $(, $rest:ident)*); { $($item:tt)* }) => {
         all_backends!(@with_ignore veryl; ($($rest),*); { $($item)* });
+    };
+
+    (@with_ignore interp; (); { $($item:tt)* }) => { $($item)* };
+    (@with_ignore interp; (interp $(, $rest:ident)*); { $($item:tt)* }) => {
+        #[ignore]
+        $($item)*
+    };
+    (@with_ignore interp; ($first:ident $(, $rest:ident)*); { $($item:tt)* }) => {
+        all_backends!(@with_ignore interp; ($($rest),*); { $($item)* });
     };
 
     // ── internal: emit the SV frontend test ─────────────────────────
@@ -172,6 +185,17 @@ macro_rules! all_backends {
                 fn wasm() {
                     $($setup)*
                     let mut $sim = { $builder }.build_wasm().unwrap();
+                    $($body)*
+                }
+            });
+
+            all_backends!(@with_ignore interp; $ignore_list; {
+                #[test]
+                $(#[$meta])*
+                #[allow(unused_mut, unused_variables)]
+                fn interp() {
+                    $($setup)*
+                    let mut $sim = { $builder }.build_interpreter().unwrap();
                     $($body)*
                 }
             });


### PR DESCRIPTION
## Summary

Adds a Tier-0 SIR interpreter and an interpreting `SimBackend` that executes the laid-out SIR directly against the same memory image ABI as the compiled backends. This is the foundation of tiered execution: the simulator can start running immediately after state layout (no codegen latency), with compilation happening in the background later.

- `crates/celox/src/interpreter.rs`: backend-independent unit interpreter over `InterpMachine` (memory, triggers, runtime events are delegated to the machine trait)
- `crates/celox/src/backend/interp.rs`: `InterpBackend` implementing `SimBackend` on the shared memory ABI
- `build_interpreter()` builder entry point plus an `interp` arm in `all_backends!`

## Semantics

The interpreter matches the compiled backends bit-exactly so units can migrate between tiers mid-simulation without state translation:

- Full binary/unary ALU per the compiled truth tables: signed/unsigned comparisons, IEEE 1800 dominant-value rules for logical operators, case/wildcard equality, signed div/rem overflow guards, reduction-and, X-propagating bit counts
- Unknown-bit normalization (`payload |= mask`) keeps memory images identical across tiers; two-state mode discards immediate masks exactly like the compiled translation
- Narrow-destination shifts keep surviving low bits; `Sar` sign-fills unconditionally (the frontend only emits it for signed sources)
- Sparse copy-on-write working region: chunk-granular store preparation, dirty-word bookkeeping, whole-object commit
- RuntimeEventBuffer records follow the release-published ring protocol, including gated comb capture events with consume/fatal early-return control, store observer change detection, and `CombCaptureEnableIfChanged`
- Trigger marking uses the same group-entry snapshot + first-word change detection as the compiled backends

## Testing

- The `interp` arm runs for every `all_backends!` test (4,168 tests green, also with the `systemverilog` feature)
- Ignored only on tests already failing on every compiled backend (known analyzer false positives)
- `cargo fmt` / `cargo clippy` clean

## Notes

`TriggerIdWithKind.kind` is inert here, matching every compiled backend.