### PR TITLE
ci: gate npm publishing behind the npm environment

### DIFF
--- a/.github/workflows/ci-napi.yml
+++ b/.github/workflows/ci-napi.yml
@@ -254,6 +254,7 @@ jobs:
     needs: [validate-release, test]
     runs-on: ubuntu-latest
     name: Publish
+    environment: npm
     permissions:
       contents: write
       id-token: write
@@ -360,6 +361,7 @@ jobs:
     needs: [validate-release, publish]
     runs-on: ubuntu-latest
     name: Publish JS Packages
+    environment: npm
     permissions:
       contents: read
       id-token: write

--- a/scripts/setup-npm-trusted-publish.sh
+++ b/scripts/setup-npm-trusted-publish.sh
@@ -9,10 +9,11 @@
 # trusted workflow identity:
 #   1. Go to https://www.npmjs.com/package/<name>/access for each package
 #   2. Add a trusted publisher:
-#        Provider:   GitHub Actions
-#        Owner:      celox-sim
-#        Repository: celox
-#        Workflow:   ci-napi.yml
+#        Provider:    GitHub Actions
+#        Owner:       celox-sim
+#        Repository:  celox
+#        Workflow:    ci-napi.yml
+#        Environment: npm
 set -euo pipefail
 
 PACKAGES=(


### PR DESCRIPTION
## Summary

- add `environment: npm` to the `publish` and `publish-js` jobs in `ci-napi.yml`, mirroring how the crates.io publish workflow uses the `crates-io` environment
- publishes already rely on npm Trusted Publishing (OIDC via `id-token: write`), so no token changes are needed

## Required before merge

npm has no public API for Trusted Publisher configuration, so the environment name must be updated manually on npmjs.com for every published package (Package settings → Trusted Publisher → set environment to `npm`):

- `@celox-sim/celox-napi`
- platform packages: `celox-linux-x64-gnu`, `celox-linux-arm64-gnu`, `celox-linux-x64-musl`, `celox-linux-arm64-musl`, `celox-darwin-x64`, `celox-darwin-arm64`, `celox-win32-x64-msvc`
- `@celox-sim/celox`
- `@celox-sim/vite-plugin`

Until each package's Trusted Publisher setting includes the environment, publishes from this workflow will fail the registry-side check.

## Validation

- confirmed the diff against master contains only the two `environment:` additions
- YAML parse check (`python3 -c yaml.safe_load`) passes
- no automated tests exercise this workflow; end-to-end verification requires a real release run