### PR TITLE
feat(backend): tier promotion policy and Node tiered bindings

### DIFF
--- a/crates/celox-bench/src/bin/celox-tiered.rs
+++ b/crates/celox-bench/src/bin/celox-tiered.rs
@@ -343,7 +343,7 @@ fn output_hex<B: celox::SimBackend>(sim: &mut celox::Simulator<B>, workload: Wor
             let done = sim.signal("done");
             let lanes = sim.get(d_out);
             let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
-            for (index, limb) in lanes.iter_u64_digits().enumerate().take(16) {
+            for (index, limb) in lanes.iter_u64_digits().enumerate() {
                 hash = hash.rotate_left(11) ^ hash.wrapping_add(limb.rotate_left(index as u32 % 7));
             }
             hash ^= u64::from(sim.get_as::<u8>(done));

--- a/crates/celox-bench/src/bin/celox-tiered.rs
+++ b/crates/celox-bench/src/bin/celox-tiered.rs
@@ -308,12 +308,15 @@ fn setup<B: celox::SimBackend>(
                 let value = 0x0100_0000_0000_0001u64.wrapping_mul(lane + 1);
                 pattern.extend_from_slice(&value.to_le_bytes());
             }
+            // `push` is an N-wide per-lane vector: assert every lane so
+            // each distinct d_in value is actually inserted.
+            let all_lanes = (celox::BigUint::from(1u8) << n as usize) - 1u8;
             let push = sim.signal("push");
             let last = sim.signal("last");
             let merge_en = sim.signal("merge_en");
             sim.modify(|io| {
                 io.set_wide(d_in, celox::BigUint::from_bytes_le(&pattern));
-                io.set(push, 1u8);
+                io.set_wide(push, all_lanes);
                 io.set(last, 1u8);
                 io.set(merge_en, 1u8);
             })?;

--- a/crates/celox-bench/src/bin/celox-tiered.rs
+++ b/crates/celox-bench/src/bin/celox-tiered.rs
@@ -1,0 +1,396 @@
+#![allow(clippy::disallowed_macros)] // CLI errors intentionally use stderr
+
+use std::time::{Duration, Instant};
+
+use celox::{SimulatorBuilder, TierPromotion};
+use clap::{Parser, ValueEnum};
+
+const LCG_SOURCE: &str = r#"
+module TieredBenchTop (
+    clk: input clock,
+    d: input logic<64>,
+    q: output logic<64>,
+) {
+    var acc: logic<64>;
+    always_ff (clk) {
+        acc = acc * 6364136223846793005 + d + 1442695040888963407;
+    }
+    assign q = acc;
+}
+"#;
+
+const SORTER_TOP: &str = "SorterTreeDistEntry";
+
+fn sorter_source() -> &'static str {
+    const FIXTURES: &[&str] = &[
+        "sorter_item.veryl",
+        "dist_entry.veryl",
+        "min_reduction_tree.veryl",
+        "linear_sorter_pull.veryl",
+        "linear_sorter.veryl",
+        "sorter_tree.veryl",
+    ];
+    let mut joined = String::new();
+    for file in FIXTURES {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../celox/tests/fixtures/sorter_tree/"
+        )
+        .to_owned()
+            + file;
+        joined.push_str(&std::fs::read_to_string(path).expect("sorter fixture"));
+        joined.push('\n');
+    }
+    Box::leak(joined.into_boxed_str())
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Workload {
+    Lcg,
+    Sorter { n: u64 },
+}
+
+impl Workload {
+    fn as_str(self) -> String {
+        match self {
+            Self::Lcg => "lcg".to_owned(),
+            Self::Sorter { n } => format!("sorter_n{n}"),
+        }
+    }
+}
+
+#[derive(Parser)]
+#[command(about = "Compare tiered startup/throughput against the compiled and interpreted tiers")]
+struct Cli {
+    #[arg(long)]
+    ticks: Option<u64>,
+    #[arg(long, value_enum, default_value = "tiered")]
+    mode: Mode,
+    #[arg(long, value_enum, default_value = "always")]
+    promotion: Promotion,
+    /// Minimum interpreted steps before adoption when --promotion after-steps.
+    #[arg(long, default_value_t = 0)]
+    threshold: u64,
+    /// Ticks per timing sample; promotion is observed once per chunk.
+    #[arg(long, default_value_t = 1_000)]
+    chunk: u32,
+    /// Run the SorterTreeDistEntry fixture at the given N instead of the
+    /// tiny LCG module.
+    #[arg(long)]
+    sorter_n: Option<u64>,
+}
+
+impl Cli {
+    fn workload(&self) -> Workload {
+        match self.sorter_n {
+            Some(n) => Workload::Sorter { n },
+            None => Workload::Lcg,
+        }
+    }
+
+    fn tick_count(&self) -> u64 {
+        self.ticks.unwrap_or(match self.workload() {
+            Workload::Lcg => 100_000,
+            Workload::Sorter { .. } => 2_000,
+        })
+    }
+
+    fn source(&self) -> &'static str {
+        match self.workload() {
+            Workload::Lcg => LCG_SOURCE,
+            Workload::Sorter { .. } => sorter_source(),
+        }
+    }
+
+    fn builder(&self) -> SimulatorBuilder<'static> {
+        let mut builder = Simulator::builder(self.source(), self.top());
+        if let Workload::Sorter { n } = self.workload() {
+            builder = builder
+                .param("N", n)
+                .param("LEAF_DEPTH", 4)
+                .param("OUT_DEPTH", 16);
+        }
+        builder
+    }
+
+    fn top(&self) -> &'static str {
+        match self.workload() {
+            Workload::Lcg => "TieredBenchTop",
+            Workload::Sorter { .. } => SORTER_TOP,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum Mode {
+    Native,
+    Cranelift,
+    Interpreter,
+    Tiered,
+}
+
+impl Mode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::Cranelift => "cranelift",
+            Self::Interpreter => "interpreter",
+            Self::Tiered => "tiered",
+        }
+    }
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum Promotion {
+    Always,
+    AfterSteps,
+    Never,
+}
+
+impl Promotion {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Always => "always",
+            Self::AfterSteps => "after-steps",
+            Self::Never => "never",
+        }
+    }
+}
+
+enum BenchSim {
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    Native(Box<celox::Simulator<celox::NativeBackend>>),
+    Cranelift(Box<celox::Simulator<celox::JitBackend>>),
+    Interpreter(Box<celox::Simulator<celox::InterpBackend>>),
+    Tiered(Box<celox::Simulator<celox::TieredBackend>>),
+}
+
+#[derive(Debug, thiserror::Error)]
+enum BenchError {
+    #[error("Celox build failed: {0:?}")]
+    Build(#[from] celox::SimulatorError),
+    #[error("{message}")]
+    InvalidConfiguration { message: &'static str },
+    #[error("runtime error during execution: {0:?}")]
+    Runtime(#[from] celox::RuntimeErrorCode),
+}
+
+use celox::RuntimeErrorCode;
+
+impl BenchSim {
+    fn build(mode: Mode, cli: &Cli) -> Result<(Self, Duration), BenchError> {
+        let build_start = Instant::now();
+        let sim = match mode {
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            Mode::Native => {
+                let mut sim = cli.builder().build_native()?;
+                setup(&mut sim, cli)?;
+                BenchSim::Native(Box::new(sim))
+            }
+            Mode::Cranelift => {
+                let mut sim = cli.builder().build_cranelift()?;
+                setup(&mut sim, cli)?;
+                BenchSim::Cranelift(Box::new(sim))
+            }
+            Mode::Interpreter => {
+                let mut sim = cli.builder().build_interpreter()?;
+                setup(&mut sim, cli)?;
+                BenchSim::Interpreter(Box::new(sim))
+            }
+            Mode::Tiered => {
+                let policy = match cli.promotion {
+                    Promotion::Always => TierPromotion::Always,
+                    Promotion::AfterSteps => TierPromotion::AfterSteps(cli.threshold),
+                    Promotion::Never => TierPromotion::Never,
+                };
+                let mut sim = cli.builder().tier_promotion(policy).build_tiered()?;
+                setup(&mut sim, cli)?;
+                BenchSim::Tiered(Box::new(sim))
+            }
+        };
+        Ok((sim, build_start.elapsed()))
+    }
+
+    fn clk_event_id(&self) -> usize {
+        match self {
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            BenchSim::Native(sim) => clk_id(sim),
+            BenchSim::Cranelift(sim) => clk_id(sim),
+            BenchSim::Interpreter(sim) => clk_id(sim),
+            BenchSim::Tiered(sim) => clk_id(sim),
+        }
+    }
+
+    fn tick_chunk(&mut self, event_id: usize, chunk: u32) -> Result<(), RuntimeErrorCode> {
+        match self {
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            BenchSim::Native(sim) => sim.tick_by_id_n(event_id, chunk),
+            BenchSim::Cranelift(sim) => sim.tick_by_id_n(event_id, chunk),
+            BenchSim::Interpreter(sim) => sim.tick_by_id_n(event_id, chunk),
+            BenchSim::Tiered(sim) => sim.tick_by_id_n(event_id, chunk),
+        }
+    }
+
+    fn is_compiled(&self) -> bool {
+        match self {
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            BenchSim::Native(_) => true,
+            BenchSim::Cranelift(_) | BenchSim::Interpreter(_) => true,
+            BenchSim::Tiered(sim) => sim.is_compiled(),
+        }
+    }
+
+    fn output_hex(&mut self, workload: Workload) -> String {
+        match self {
+            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            BenchSim::Native(sim) => output_hex(sim, workload),
+            BenchSim::Cranelift(sim) => output_hex(sim, workload),
+            BenchSim::Interpreter(sim) => output_hex(sim, workload),
+            BenchSim::Tiered(sim) => output_hex(sim, workload),
+        }
+    }
+}
+
+fn clk_id<B: celox::SimBackend>(sim: &celox::Simulator<B>) -> usize {
+    sim.named_events()
+        .iter()
+        .find(|e| e.name == "clk")
+        .expect("clk event")
+        .id
+}
+
+fn setup<B: celox::SimBackend>(
+    sim: &mut celox::Simulator<B>,
+    cli: &Cli,
+) -> Result<(), RuntimeErrorCode> {
+    match cli.workload() {
+        Workload::Lcg => {
+            let d = sim.signal("d");
+            sim.modify(|io| io.set(d, 0x9E37_79B9_7F4A_7C15u64))?;
+        }
+        Workload::Sorter { .. } => {
+            let rst = sim.signal("rst");
+            sim.modify(|io| io.set(rst, 1u8))?;
+            let clk = clk_id(sim);
+            sim.tick_by_id(clk)?;
+            sim.modify(|io| io.set(rst, 0u8))?;
+        }
+    }
+    Ok(())
+}
+
+fn output_hex<B: celox::SimBackend>(sim: &mut celox::Simulator<B>, workload: Workload) -> String {
+    match workload {
+        Workload::Lcg => {
+            let q = sim.signal("q");
+            format!("{:#018x}", sim.get_as::<u64>(q))
+        }
+        // The sorter has no single wide output; hash the whole sorted-lane
+        // vector plus `done` so modes can be cross-checked.
+        Workload::Sorter { .. } => {
+            let d_out = sim.signal("d_out");
+            let done = sim.signal("done");
+            let lanes = sim.get(d_out);
+            let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+            for (index, limb) in lanes.iter_u64_digits().enumerate().take(16) {
+                hash = hash.rotate_left(11) ^ hash.wrapping_add(limb.rotate_left(index as u32 % 7));
+            }
+            hash ^= u64::from(sim.get_as::<u8>(done));
+            format!("{hash:#018x}")
+        }
+    }
+}
+
+type Simulator<B> = celox::Simulator<B>;
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("error: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), BenchError> {
+    let cli = Cli::parse();
+    if matches!(cli.mode, Mode::Native) && !native_available() {
+        return Err(BenchError::InvalidConfiguration {
+            message: "the native backend is unavailable on this host",
+        });
+    }
+    let workload = cli.workload();
+
+    println!(
+        "CELOX_TIERED_CONFIG workload={} mode={} ticks={} promotion={} threshold={} chunk={}",
+        workload.as_str(),
+        cli.mode.as_str(),
+        cli.tick_count(),
+        cli.promotion.as_str(),
+        cli.threshold,
+        cli.chunk
+    );
+
+    let (mut sim, build_elapsed) = BenchSim::build(cli.mode, &cli)?;
+    println!(
+        "CELOX_TIERED_BUILD workload={} mode={} build_ns={}",
+        workload.as_str(),
+        cli.mode.as_str(),
+        build_elapsed.as_nanos()
+    );
+
+    let clk = sim.clk_event_id();
+    let ticks = cli.tick_count();
+
+    let first_tick_start = Instant::now();
+    sim.tick_chunk(clk, 1)?;
+    let first_tick_elapsed = first_tick_start.elapsed();
+    println!(
+        "CELOX_TIERED_FIRST_TICK workload={} mode={} first_tick_ns={} compiled_after_first_tick={}",
+        workload.as_str(),
+        cli.mode.as_str(),
+        first_tick_elapsed.as_nanos(),
+        sim.is_compiled()
+    );
+
+    let run_start = Instant::now();
+    let mut executed: u64 = 1;
+    let mut promoted_at: Option<u64> = None;
+    while executed < ticks {
+        let chunk = u32::try_from(ticks - executed)
+            .unwrap_or(u32::MAX)
+            .min(cli.chunk);
+        sim.tick_chunk(clk, chunk)?;
+        executed += u64::from(chunk);
+        if promoted_at.is_none() && sim.is_compiled() {
+            promoted_at = Some(executed);
+        }
+    }
+    let run_elapsed = run_start.elapsed();
+
+    if let Some(tick) = promoted_at {
+        println!(
+            "CELOX_TIERED_PROMOTED workload={} mode={} tick={tick}",
+            workload.as_str(),
+            cli.mode.as_str()
+        );
+    } else {
+        println!(
+            "CELOX_TIERED_PROMOTED workload={} mode={} tick=-1",
+            workload.as_str(),
+            cli.mode.as_str()
+        );
+    }
+    println!(
+        "CELOX_TIERED_RUN workload={} mode={} ticks={executed} total_ns={} ns_per_tick={} promoted={} output={}",
+        workload.as_str(),
+        cli.mode.as_str(),
+        run_elapsed.as_nanos(),
+        run_elapsed.as_nanos() / u128::from(executed.max(1)),
+        sim.is_compiled(),
+        sim.output_hex(workload)
+    );
+    Ok(())
+}
+
+fn native_available() -> bool {
+    cfg!(any(target_arch = "x86_64", target_arch = "aarch64"))
+}

--- a/crates/celox-bench/src/bin/celox-tiered.rs
+++ b/crates/celox-bench/src/bin/celox-tiered.rs
@@ -103,7 +103,11 @@ impl Cli {
     }
 
     fn builder(&self) -> SimulatorBuilder<'static> {
-        let mut builder = Simulator::builder(self.source(), self.top());
+        let mut builder = Simulator::builder(self.source(), self.top())
+            // Explicit active-high reset: the sorter fixture's plain `reset`
+            // port would otherwise default to AsyncLow and invert the
+            // assert/deassert sequence below.
+            .reset_type(celox::ResetType::AsyncHigh);
         if let Workload::Sorter { n } = self.workload() {
             builder = builder
                 .param("N", n)
@@ -158,7 +162,10 @@ impl Promotion {
 }
 
 enum BenchSim {
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[cfg(any(
+        all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+        all(target_arch = "aarch64", not(feature = "x86_64-codegen"))
+    ))]
     Native(Box<celox::Simulator<celox::NativeBackend>>),
     Cranelift(Box<celox::Simulator<celox::JitBackend>>),
     Interpreter(Box<celox::Simulator<celox::InterpBackend>>),
@@ -181,12 +188,20 @@ impl BenchSim {
     fn build(mode: Mode, cli: &Cli) -> Result<(Self, Duration), BenchError> {
         let build_start = Instant::now();
         let sim = match mode {
-            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            #[cfg(any(
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", not(feature = "x86_64-codegen"))
+            ))]
             Mode::Native => {
                 let mut sim = cli.builder().build_native()?;
                 setup(&mut sim, cli)?;
                 BenchSim::Native(Box::new(sim))
             }
+            #[cfg(not(any(
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", not(feature = "x86_64-codegen"))
+            )))]
+            Mode::Native => unreachable!("native availability checked in run()"),
             Mode::Cranelift => {
                 let mut sim = cli.builder().build_cranelift()?;
                 setup(&mut sim, cli)?;
@@ -213,7 +228,10 @@ impl BenchSim {
 
     fn clk_event_id(&self) -> usize {
         match self {
-            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            #[cfg(any(
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", not(feature = "x86_64-codegen"))
+            ))]
             BenchSim::Native(sim) => clk_id(sim),
             BenchSim::Cranelift(sim) => clk_id(sim),
             BenchSim::Interpreter(sim) => clk_id(sim),
@@ -223,7 +241,10 @@ impl BenchSim {
 
     fn tick_chunk(&mut self, event_id: usize, chunk: u32) -> Result<(), RuntimeErrorCode> {
         match self {
-            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            #[cfg(any(
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", not(feature = "x86_64-codegen"))
+            ))]
             BenchSim::Native(sim) => sim.tick_by_id_n(event_id, chunk),
             BenchSim::Cranelift(sim) => sim.tick_by_id_n(event_id, chunk),
             BenchSim::Interpreter(sim) => sim.tick_by_id_n(event_id, chunk),
@@ -233,16 +254,25 @@ impl BenchSim {
 
     fn is_compiled(&self) -> bool {
         match self {
-            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            #[cfg(any(
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", not(feature = "x86_64-codegen"))
+            ))]
             BenchSim::Native(_) => true,
-            BenchSim::Cranelift(_) | BenchSim::Interpreter(_) => true,
+            BenchSim::Cranelift(_) => true,
+            // The interpreter has no compiled tier; report it as such so the
+            // machine-readable records classify the baseline correctly.
+            BenchSim::Interpreter(_) => false,
             BenchSim::Tiered(sim) => sim.is_compiled(),
         }
     }
 
     fn output_hex(&mut self, workload: Workload) -> String {
         match self {
-            #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+            #[cfg(any(
+                all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+                all(target_arch = "aarch64", not(feature = "x86_64-codegen"))
+            ))]
             BenchSim::Native(sim) => output_hex(sim, workload),
             BenchSim::Cranelift(sim) => output_hex(sim, workload),
             BenchSim::Interpreter(sim) => output_hex(sim, workload),
@@ -268,7 +298,25 @@ fn setup<B: celox::SimBackend>(
             let d = sim.signal("d");
             sim.modify(|io| io.set(d, 0x9E37_79B9_7F4A_7C15u64))?;
         }
-        Workload::Sorter { .. } => {
+        Workload::Sorter { n } => {
+            // Drive non-trivial stimulus so the timed ticks exercise real
+            // sort/merge paths instead of an idle pipeline: continuous
+            // pushes of distinct per-lane data.
+            let d_in = sim.signal("d_in");
+            let mut pattern = Vec::with_capacity(8 * n as usize);
+            for lane in 0..n {
+                let value = 0x0100_0000_0000_0001u64.wrapping_mul(lane + 1);
+                pattern.extend_from_slice(&value.to_le_bytes());
+            }
+            let push = sim.signal("push");
+            let last = sim.signal("last");
+            let merge_en = sim.signal("merge_en");
+            sim.modify(|io| {
+                io.set_wide(d_in, celox::BigUint::from_bytes_le(&pattern));
+                io.set(push, 1u8);
+                io.set(last, 1u8);
+                io.set(merge_en, 1u8);
+            })?;
             let rst = sim.signal("rst");
             sim.modify(|io| io.set(rst, 1u8))?;
             let clk = clk_id(sim);
@@ -314,7 +362,17 @@ fn run() -> Result<(), BenchError> {
     let cli = Cli::parse();
     if matches!(cli.mode, Mode::Native) && !native_available() {
         return Err(BenchError::InvalidConfiguration {
-            message: "the native backend is unavailable on this host",
+            message: "the native backend is unavailable on this host or target",
+        });
+    }
+    if cli.chunk == 0 {
+        return Err(BenchError::InvalidConfiguration {
+            message: "--chunk must be at least 1",
+        });
+    }
+    if cli.tick_count() == 0 {
+        return Err(BenchError::InvalidConfiguration {
+            message: "--ticks must be at least 1",
         });
     }
     let workload = cli.workload();
@@ -343,17 +401,19 @@ fn run() -> Result<(), BenchError> {
     let first_tick_start = Instant::now();
     sim.tick_chunk(clk, 1)?;
     let first_tick_elapsed = first_tick_start.elapsed();
+    // The first tick is measured separately; remember whether it already
+    // promoted so the promotion record matches this observation.
+    let compiled_after_first_tick = sim.is_compiled();
     println!(
-        "CELOX_TIERED_FIRST_TICK workload={} mode={} first_tick_ns={} compiled_after_first_tick={}",
+        "CELOX_TIERED_FIRST_TICK workload={} mode={} first_tick_ns={} compiled_after_first_tick={compiled_after_first_tick}",
         workload.as_str(),
         cli.mode.as_str(),
-        first_tick_elapsed.as_nanos(),
-        sim.is_compiled()
+        first_tick_elapsed.as_nanos()
     );
 
     let run_start = Instant::now();
     let mut executed: u64 = 1;
-    let mut promoted_at: Option<u64> = None;
+    let mut promoted_at: Option<u64> = compiled_after_first_tick.then_some(1);
     while executed < ticks {
         let chunk = u32::try_from(ticks - executed)
             .unwrap_or(u32::MAX)
@@ -379,12 +439,13 @@ fn run() -> Result<(), BenchError> {
             cli.mode.as_str()
         );
     }
+    let timed_ticks = executed - 1;
     println!(
-        "CELOX_TIERED_RUN workload={} mode={} ticks={executed} total_ns={} ns_per_tick={} promoted={} output={}",
+        "CELOX_TIERED_RUN workload={} mode={} ticks={timed_ticks} total_ns={} ns_per_tick={} promoted={} output={}",
         workload.as_str(),
         cli.mode.as_str(),
         run_elapsed.as_nanos(),
-        run_elapsed.as_nanos() / u128::from(executed.max(1)),
+        run_elapsed.as_nanos() / u128::from(timed_ticks.max(1)),
         sim.is_compiled(),
         sim.output_hex(workload)
     );
@@ -392,5 +453,8 @@ fn run() -> Result<(), BenchError> {
 }
 
 fn native_available() -> bool {
-    cfg!(any(target_arch = "x86_64", target_arch = "aarch64"))
+    cfg!(any(
+        all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+        all(target_arch = "aarch64", not(feature = "x86_64-codegen"))
+    ))
 }

--- a/crates/celox-napi/src/layout.rs
+++ b/crates/celox-napi/src/layout.rs
@@ -1,8 +1,6 @@
 #[cfg(not(target_arch = "wasm32"))]
-use celox::{DefaultBackend, InstanceHierarchy, NamedSignal, get_byte_size};
+use celox::{InstanceHierarchy, NamedSignal, get_byte_size};
 use celox::{PortTypeKind, VariableKind};
-#[cfg(not(target_arch = "wasm32"))]
-type NamedEvent = celox::NamedEvent<DefaultBackend>;
 #[cfg(not(target_arch = "wasm32"))]
 use fxhash::FxHashMap as HashMap;
 #[cfg(not(target_arch = "wasm32"))]
@@ -134,7 +132,10 @@ pub fn build_hierarchy_node(h: &InstanceHierarchy, four_state: bool) -> Hierarch
 
 /// Build a map of event name -> event ID from named events.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn build_event_map(events: &[NamedEvent]) -> HashMap<String, u32> {
+pub fn build_event_map<B>(events: &[celox::NamedEvent<B>]) -> HashMap<String, u32>
+where
+    B: celox::SimBackend,
+{
     let mut map = HashMap::default();
     for ne in events {
         map.insert(ne.name.clone(), ne.id as u32);

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -822,13 +822,72 @@ fn napi_runtime_error(
     }
 }
 
+/// The backend driving a [`NativeSimulatorHandle`].
+///
+/// Either the default compiled backend (as before) or the tiered backend,
+/// which starts on the interpreter and promotes to generated code in the
+/// background. Dispatch goes through the shared [`SimBackend`] surface the
+/// handle actually uses.
+#[cfg(not(target_arch = "wasm32"))]
+enum HandleBackend {
+    Default(celox::DefaultBackend),
+    Tiered(Box<celox::TieredBackend>),
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl HandleBackend {
+    fn eval_comb(&mut self) -> std::result::Result<(), celox::RuntimeErrorCode> {
+        match self {
+            Self::Default(backend) => backend.eval_comb(),
+            Self::Tiered(backend) => backend.eval_comb(),
+        }
+    }
+
+    fn eval_apply_ff_at(
+        &mut self,
+        event_id: usize,
+    ) -> std::result::Result<(), celox::RuntimeErrorCode> {
+        match self {
+            Self::Default(backend) => {
+                let event = backend.id_to_event_slice()[event_id];
+                backend.eval_apply_ff_at(event)
+            }
+            Self::Tiered(backend) => {
+                let event = backend.id_to_event_slice()[event_id];
+                backend.eval_apply_ff_at(event)
+            }
+        }
+    }
+
+    fn memory_as_ptr(&self) -> (*const u8, usize) {
+        match self {
+            Self::Default(backend) => backend.memory_as_ptr(),
+            Self::Tiered(backend) => backend.memory_as_ptr(),
+        }
+    }
+
+    fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize) {
+        match self {
+            Self::Default(backend) => backend.memory_as_mut_ptr(),
+            Self::Tiered(backend) => backend.memory_as_mut_ptr(),
+        }
+    }
+
+    fn stable_region_size(&self) -> usize {
+        match self {
+            Self::Default(backend) => backend.stable_region_size(),
+            Self::Tiered(backend) => backend.stable_region_size(),
+        }
+    }
+}
+
 /// Low-level handle wrapping the default backend and optional VCD writer.
 ///
 /// JS holds this as an opaque class; all operations go through methods.
 #[cfg(not(target_arch = "wasm32"))]
 #[napi]
 pub struct NativeSimulatorHandle {
-    backend: Option<celox::DefaultBackend>,
+    backend: Option<HandleBackend>,
     runtime_errors: HashMap<i64, (String, Vec<String>)>,
     vcd_writer: Option<celox::VcdWriter>,
     layout_json: String,
@@ -929,7 +988,63 @@ impl NativeSimulatorHandle {
         };
 
         // Extract the backend from Simulator (drops runtime metadata which is no longer needed)
-        let backend = sim.into_backend();
+        let backend = HandleBackend::Default(sim.into_backend());
+
+        Ok(Self {
+            backend: Some(backend),
+            runtime_errors,
+            vcd_writer,
+            layout_json,
+            events_json,
+            hierarchy_json,
+            warnings_json,
+            stable_size: stable_size as u32,
+            total_size: total_size as u32,
+        })
+    }
+
+    /// Extract metadata from a tiered simulator and wrap its backend.
+    ///
+    /// Mirrors [`Self::build_and_cache`] minus the shared-code cache: the
+    /// tiered backend owns its interpreter state and compiles in the
+    /// background, so there is no compiled artifact to reuse yet.
+    fn build_and_cache_tiered(
+        sim: celox::Simulator<celox::TieredBackend>,
+        vcd_path: Option<&str>,
+    ) -> Result<Self> {
+        let four_state = sim.layout().four_state;
+        let warnings_json = format_warnings_json(sim.warnings());
+        let signals = sim.named_signals();
+        let events = sim.named_events();
+        let hierarchy = sim.named_hierarchy();
+        let (_, total_size) = sim.memory_as_ptr();
+        let stable_size = sim.stable_region_size();
+        let vcd_descs = sim.build_vcd_descs(four_state);
+        let runtime_errors = runtime_errors_by_name(sim.program());
+
+        let layout_map = build_signal_layout(&signals, four_state);
+        let event_map = build_event_map(&events);
+        let hierarchy_node = build_hierarchy_node(&hierarchy, four_state);
+
+        let layout_json = serde_json::to_string(&layout_map)
+            .map_err(|e| Error::from_reason(format!("Failed to serialize layout: {}", e)))?;
+        let events_json = serde_json::to_string(&event_map)
+            .map_err(|e| Error::from_reason(format!("Failed to serialize events: {}", e)))?;
+        let hierarchy_json = serde_json::to_string(&hierarchy_node)
+            .map_err(|e| Error::from_reason(format!("Failed to serialize hierarchy: {}", e)))?;
+
+        let vcd_writer = if let Some(path) = vcd_path {
+            Some(
+                celox::VcdWriter::new(path, &vcd_descs)
+                    .map_err(|e| Error::from_reason(format!("Failed to create VCD: {}", e)))?,
+            )
+        } else {
+            None
+        };
+
+        // Extract the backend from Simulator (drops runtime metadata which is
+        // no longer needed).
+        let backend = HandleBackend::Tiered(Box::new(sim.into_backend()));
 
         Ok(Self {
             backend: Some(backend),
@@ -947,9 +1062,13 @@ impl NativeSimulatorHandle {
     /// Create a handle from a cached build (shared compiled code + fresh memory).
     fn from_cached(cached: &CachedBuild, vcd_path: Option<&str>) -> Result<Self> {
         #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-        let backend = celox::NativeBackend::from_shared(Arc::clone(&cached.shared_code));
+        let backend = HandleBackend::Default(celox::NativeBackend::from_shared(Arc::clone(
+            &cached.shared_code,
+        )));
         #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
-        let backend = celox::JitBackend::from_shared(Arc::clone(&cached.shared_code));
+        let backend = HandleBackend::Default(celox::JitBackend::from_shared(Arc::clone(
+            &cached.shared_code,
+        )));
         let vcd_writer = if let Some(path) = vcd_path {
             Some(
                 celox::VcdWriter::new(path, &cached.vcd_descs)
@@ -1004,6 +1123,39 @@ impl NativeSimulatorHandle {
             .map_err(|e| Error::from_reason(format!("{}", e)))?;
 
         Self::build_and_cache(sim, opts.vcd.as_deref(), Some(cache_key))
+    }
+
+    /// Create a new tiered simulator from Veryl source code.
+    ///
+    /// Execution starts on the interpreter immediately while the host's
+    /// default compiled tier (native where available) is prepared on a
+    /// background thread. The first safe point after compilation completes
+    /// adopts the compiled code; observe progress through
+    /// [`Self::tier_compiled`](Self::tier_compiled). Tiered builds bypass the
+    /// JIT cache because the interpreter already removes startup latency.
+    #[napi(factory)]
+    pub fn new_tiered(
+        sources: Vec<NapiSourceFile>,
+        top: String,
+        options: Option<NapiOptions>,
+    ) -> Result<Self> {
+        let opts = parse_options(&options)?;
+        let mut src_pairs: Vec<(String, std::path::PathBuf)> = sources
+            .into_iter()
+            .map(|s| (s.content, std::path::PathBuf::from(s.path)))
+            .collect();
+        append_extra_source(&mut src_pairs, &opts.extra_source);
+
+        let source_refs: Vec<(&str, &std::path::Path)> = src_pairs
+            .iter()
+            .map(|(s, p)| (s.as_str(), p.as_path()))
+            .collect();
+        let builder = apply_options(celox::Simulator::from_sources(source_refs, &top), &opts);
+        let sim = builder
+            .build_tiered()
+            .map_err(|e| Error::from_reason(format!("{}", e)))?;
+
+        Self::build_and_cache_tiered(sim, opts.vcd.as_deref())
     }
 
     /// Create a simulator from a versioned external-frontend artifact.
@@ -1093,6 +1245,25 @@ impl NativeSimulatorHandle {
         self.total_size
     }
 
+    /// Whether this handle drives the tiered backend.
+    #[napi(getter)]
+    pub fn is_tiered(&self) -> bool {
+        matches!(self.backend, Some(HandleBackend::Tiered(_)))
+    }
+
+    /// Whether the tiered backend has adopted its compiled tier.
+    ///
+    /// `None` when the handle is not tiered; `false` while background
+    /// compilation is still running or after it failed (the interpreter then
+    /// remains the permanent tier).
+    #[napi(getter)]
+    pub fn tier_compiled(&self) -> Option<bool> {
+        match &self.backend {
+            Some(HandleBackend::Tiered(backend)) => Some(backend.is_compiled()),
+            _ => None,
+        }
+    }
+
     /// Trigger a clock/event by its numeric ID.
     #[napi]
     pub fn tick(&mut self, event_id: u32) -> Result<()> {
@@ -1101,10 +1272,9 @@ impl NativeSimulatorHandle {
             .backend
             .as_mut()
             .ok_or_else(|| Error::from_reason("Simulator has been disposed"))?;
-        let event = b.id_to_event_slice()[event_id as usize];
         b.eval_comb()
             .map_err(|e| napi_runtime_error(&runtime_errors, e))?;
-        b.eval_apply_ff_at(event)
+        b.eval_apply_ff_at(event_id as usize)
             .map_err(|e| napi_runtime_error(&runtime_errors, e))?;
         b.eval_comb()
             .map_err(|e| napi_runtime_error(&runtime_errors, e))
@@ -1118,11 +1288,10 @@ impl NativeSimulatorHandle {
             .backend
             .as_mut()
             .ok_or_else(|| Error::from_reason("Simulator has been disposed"))?;
-        let event = b.id_to_event_slice()[event_id as usize];
         for _ in 0..count {
             b.eval_comb()
                 .map_err(|e| napi_runtime_error(&runtime_errors, e))?;
-            b.eval_apply_ff_at(event)
+            b.eval_apply_ff_at(event_id as usize)
                 .map_err(|e| napi_runtime_error(&runtime_errors, e))?;
             b.eval_comb()
                 .map_err(|e| napi_runtime_error(&runtime_errors, e))?;

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1008,10 +1008,11 @@ impl NativeSimulatorHandle {
     /// Mirrors [`Self::build_and_cache`] minus the shared-code cache: the
     /// tiered backend owns its interpreter state and compiles in the
     /// background, so there is no compiled artifact to reuse yet.
-    fn build_and_cache_tiered(
-        sim: celox::Simulator<celox::TieredBackend>,
-        vcd_path: Option<&str>,
-    ) -> Result<Self> {
+    fn build_and_cache_tiered(mut sim: celox::Simulator<celox::TieredBackend>) -> Result<Self> {
+        // The builder creates the VCD writer itself when recording was
+        // requested, selecting a VCD-compatible packed layout in the process;
+        // reuse that writer instead of rebuilding descriptors here.
+        let vcd_writer = sim.take_vcd_writer();
         let four_state = sim.layout().four_state;
         let warnings_json = format_warnings_json(sim.warnings());
         let signals = sim.named_signals();
@@ -1019,7 +1020,6 @@ impl NativeSimulatorHandle {
         let hierarchy = sim.named_hierarchy();
         let (_, total_size) = sim.memory_as_ptr();
         let stable_size = sim.stable_region_size();
-        let vcd_descs = sim.build_vcd_descs(four_state);
         let runtime_errors = runtime_errors_by_name(sim.program());
 
         let layout_map = build_signal_layout(&signals, four_state);
@@ -1032,15 +1032,6 @@ impl NativeSimulatorHandle {
             .map_err(|e| Error::from_reason(format!("Failed to serialize events: {}", e)))?;
         let hierarchy_json = serde_json::to_string(&hierarchy_node)
             .map_err(|e| Error::from_reason(format!("Failed to serialize hierarchy: {}", e)))?;
-
-        let vcd_writer = if let Some(path) = vcd_path {
-            Some(
-                celox::VcdWriter::new(path, &vcd_descs)
-                    .map_err(|e| Error::from_reason(format!("Failed to create VCD: {}", e)))?,
-            )
-        } else {
-            None
-        };
 
         // Extract the backend from Simulator (drops runtime metadata which is
         // no longer needed).
@@ -1150,12 +1141,18 @@ impl NativeSimulatorHandle {
             .iter()
             .map(|(s, p)| (s.as_str(), p.as_path()))
             .collect();
-        let builder = apply_options(celox::Simulator::from_sources(source_refs, &top), &opts);
+        let mut builder = apply_options(celox::Simulator::from_sources(source_refs, &top), &opts);
+        // Forward VCD before building: tiered layout selection must know that
+        // recording was requested so it picks the packed layout the VCD
+        // descriptors require (see `build_and_cache_tiered`).
+        if let Some(path) = opts.vcd.as_deref() {
+            builder = builder.vcd(path);
+        }
         let sim = builder
             .build_tiered()
             .map_err(|e| Error::from_reason(format!("{}", e)))?;
 
-        Self::build_and_cache_tiered(sim, opts.vcd.as_deref())
+        Self::build_and_cache_tiered(sim)
     }
 
     /// Create a new tiered simulator from a Veryl project directory.
@@ -1180,15 +1177,21 @@ impl NativeSimulatorHandle {
             .map(|(s, p)| (s.as_str(), p.as_path()))
             .collect();
 
-        let builder = apply_options(
+        let mut builder = apply_options(
             celox::Simulator::from_sources(source_refs, &top).with_metadata(metadata),
             &opts,
         );
+        // Forward VCD before building: tiered layout selection must know that
+        // recording was requested so it picks the packed layout the VCD
+        // descriptors require (see `build_and_cache_tiered`).
+        if let Some(path) = opts.vcd.as_deref() {
+            builder = builder.vcd(path);
+        }
         let sim = builder
             .build_tiered()
             .map_err(|e| Error::from_reason(format!("{}", e)))?;
 
-        Self::build_and_cache_tiered(sim, opts.vcd.as_deref())
+        Self::build_and_cache_tiered(sim)
     }
 
     /// Create a simulator from a versioned external-frontend artifact.

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1158,6 +1158,39 @@ impl NativeSimulatorHandle {
         Self::build_and_cache_tiered(sim, opts.vcd.as_deref())
     }
 
+    /// Create a new tiered simulator from a Veryl project directory.
+    ///
+    /// Tiered counterpart of [`Self::from_project`]: searches upward from
+    /// `project_path` for `Veryl.toml`, starts on the interpreter
+    /// immediately, and promotes to the host's default compiled tier in the
+    /// background. Bypasses the JIT cache for the same reason as
+    /// [`Self::new_tiered`].
+    #[napi(factory)]
+    pub fn new_tiered_from_project(
+        project_path: String,
+        top: String,
+        options: Option<NapiOptions>,
+    ) -> Result<Self> {
+        let opts = parse_options(&options)?;
+        let (mut sources, metadata, _celox_cfg) = load_project_sources(&project_path)?;
+        append_extra_source(&mut sources, &opts.extra_source);
+
+        let source_refs: Vec<(&str, &std::path::Path)> = sources
+            .iter()
+            .map(|(s, p)| (s.as_str(), p.as_path()))
+            .collect();
+
+        let builder = apply_options(
+            celox::Simulator::from_sources(source_refs, &top).with_metadata(metadata),
+            &opts,
+        );
+        let sim = builder
+            .build_tiered()
+            .map_err(|e| Error::from_reason(format!("{}", e)))?;
+
+        Self::build_and_cache_tiered(sim, opts.vcd.as_deref())
+    }
+
     /// Create a simulator from a versioned external-frontend artifact.
     #[napi(factory)]
     pub fn from_frontend_artifact(

--- a/crates/celox/src/backend/interp.rs
+++ b/crates/celox/src/backend/interp.rs
@@ -1260,6 +1260,26 @@ impl InterpBackend {
             std::mem::take(&mut self.comb_capture_enabled),
         )
     }
+
+    /// Current image length in `u64` words.
+    pub(crate) fn image_word_len(&self) -> usize {
+        self.memory.len()
+    }
+
+    /// Current image allocation capacity in `u64` words.
+    pub(crate) fn image_word_capacity(&self) -> usize {
+        self.memory.capacity()
+    }
+
+    /// Reserve capacity so the image can grow to `total_words` words without
+    /// reallocating. Tiered builds use this up front so a later promotion
+    /// grows within the existing allocation and never moves the live image.
+    pub(crate) fn reserve_image_capacity(&mut self, total_words: usize) {
+        let spare = total_words.saturating_sub(self.memory.capacity());
+        if spare > 0 {
+            self.memory.reserve(spare);
+        }
+    }
 }
 
 impl SimBackend for InterpBackend {

--- a/crates/celox/src/backend/tiered.rs
+++ b/crates/celox/src/backend/tiered.rs
@@ -114,11 +114,14 @@ enum CompiledTier {
 
 impl CompiledCode {
     /// Image size in `u64` words the compiled tier requires its host
-    /// allocation to cover, or `None` when the transferred interpreter image
-    /// is adopted as-is.
+    /// allocation to cover.
     fn required_image_words(&self) -> usize {
         match self {
-            CompiledCode::Cranelift(_) => 0,
+            // A MemorySpilled Cranelift plan extends the layout with backend
+            // scratch beyond the semantic state, and adoption resizes the
+            // transferred image to the compiled layout's total size; report
+            // that requirement so promotion stays inside the reservation.
+            CompiledCode::Cranelift(shared) => shared.layout.merged_total_size.div_ceil(8),
             #[cfg(any(
                 target_arch = "x86_64",
                 feature = "arm64-codegen",
@@ -500,17 +503,16 @@ impl TieredBackend {
                 .expect("interpreter construction cannot fail for a laid-out program"),
         );
         // Reserve promotion headroom before anything can observe the image:
-        // native emission appends a spill/scratch arena beyond the semantic
-        // state, and adoption must grow within this allocation so the live
-        // image never moves. The slack covers the measured arena sizes with
+        // the compiled tier's adoption may grow the image beyond the semantic
+        // state (native spill/scratch arenas, Cranelift MemorySpilled plans),
+        // and adoption must grow within this allocation so the live image
+        // never moves. The slack covers the measured arena sizes with
         // margin; a design that outgrows it declines promotion (recorded via
         // `promotion_error`) instead of reallocating.
-        if native_is_default_target()
-            && !matches!(
-                options.tier_promotion,
-                crate::simulator::TierPromotion::Never
-            )
-        {
+        if !matches!(
+            options.tier_promotion,
+            crate::simulator::TierPromotion::Never
+        ) {
             let len = interp.image_word_len();
             let slack = len.max(1024) / 8;
             interp.reserve_image_capacity(len + slack.max(1024));
@@ -1885,5 +1887,63 @@ module Top (
         }
         assert!(sim.is_compiled());
         assert!(sim.promotion_error().is_none());
+    }
+
+    /// Promoting to the Cranelift tier must report an image requirement that
+    /// covers adoption's resize target (a MemorySpilled plan grows the layout
+    /// beyond the interpreter's semantic state), and the growth must stay
+    /// within the reserved arena so the live image never moves.
+    #[test]
+    fn cranelift_promotion_covers_its_image_requirement_without_moving_the_image() {
+        use std::sync::Mutex;
+
+        let gate = Gate::closed();
+        let worker_gate = gate.0.clone();
+        let observed: Arc<Mutex<Option<(usize, usize)>>> = Arc::new(Mutex::new(None));
+        let worker_observed = observed.clone();
+
+        let mut sim: Simulator<TieredBackend> = SimulatorBuilder::<Simulator>::new(PIPELINE, "Top")
+            .build_tiered_with_compiler(move |laid_out, options, _cancel| {
+                while !worker_gate.load(Ordering::Acquire) {
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                }
+                let shared = Arc::new(JitBackend::compile(laid_out, options, None)?);
+                let code = CompiledCode::Cranelift(Arc::clone(&shared));
+                // (adoption resize target in words, reported requirement)
+                *worker_observed.lock().unwrap() = Some((
+                    shared.layout.merged_total_size.div_ceil(8),
+                    code.required_image_words(),
+                ));
+                Ok(code)
+            })
+            .unwrap();
+
+        let clk = sim.event("clk");
+        for _ in 0..2 {
+            sim.tick(clk).unwrap();
+        }
+        let (base_before, _) = sim.memory_as_ptr();
+
+        gate.open();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        while !sim.is_compiled() && std::time::Instant::now() < deadline {
+            sim.tick(clk).unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        assert!(sim.is_compiled());
+        assert!(sim.promotion_error().is_none());
+
+        let (adopt_target, required) = observed.lock().unwrap().expect("compiler ran");
+        assert!(
+            required >= adopt_target,
+            "required_image_words ({required}) must cover the Cranelift \
+             adoption resize target ({adopt_target})"
+        );
+
+        let (base_after, _) = sim.memory_as_ptr();
+        assert_eq!(
+            base_before, base_after,
+            "promotion must not move the live memory image"
+        );
     }
 }

--- a/crates/celox/src/backend/tiered.rs
+++ b/crates/celox/src/backend/tiered.rs
@@ -505,7 +505,12 @@ impl TieredBackend {
         // image never moves. The slack covers the measured arena sizes with
         // margin; a design that outgrows it declines promotion (recorded via
         // `promotion_error`) instead of reallocating.
-        if native_is_default_target() {
+        if native_is_default_target()
+            && !matches!(
+                options.tier_promotion,
+                crate::simulator::TierPromotion::Never
+            )
+        {
             let len = interp.image_word_len();
             let slack = len.max(1024) / 8;
             interp.reserve_image_capacity(len + slack.max(1024));

--- a/crates/celox/src/backend/tiered.rs
+++ b/crates/celox/src/backend/tiered.rs
@@ -12,7 +12,12 @@
 //!
 //! Promotion is whole-program: once the compiled tier is adopted it is used
 //! for the remainder of the simulation. The interpreter remains the permanent
-//! fallback whenever background compilation fails.
+//! fallback whenever background compilation fails, and
+//! [`TierPromotion::Never`] skips background compilation entirely so the
+//! simulation stays interpreted without paying for a worker thread.
+//! [`TierPromotion::AfterSteps`] keeps compiling eagerly but delays adoption
+//! until the interpreter has executed a minimum number of evaluation steps,
+//! protecting short simulations from the promotion cost.
 //!
 //! Background compilation is cooperatively cancellable on the native tier:
 //! dropping the backend (or calling
@@ -342,6 +347,9 @@ enum Promotion {
     Pending(mpsc::Receiver<Result<CompiledCode, SimulatorError>>),
     /// Compilation failed permanently; remain on the interpreter forever.
     Failed(SimulatorError),
+    /// [`TierPromotion::Never`] — no worker was ever spawned and the
+    /// simulation stays interpreted by policy (not by failure).
+    Disabled,
     Promoted,
 }
 
@@ -361,6 +369,12 @@ pub struct TieredBackend {
     /// observes the interpreted evaluate-only results through an intact
     /// sparse-metadata image.
     pending_split_applies: usize,
+    /// Minimum number of interpreted evaluation steps required before
+    /// adoption ([`TierPromotion::AfterSteps`]). Zero means "as soon as the
+    /// compiled tier is ready".
+    promotion_threshold: u64,
+    /// Evaluation steps executed on the interpreted tier so far.
+    interpreted_steps: u64,
 }
 
 impl TieredBackend {
@@ -470,35 +484,49 @@ impl TieredBackend {
             })
             .collect();
 
-        let (sender, receiver) = mpsc::channel();
-        let background_laid_out = laid_out.clone();
-        let background_options = options.clone();
         let cancel = CompileCancel::new();
         let worker_cancel = cancel.clone();
         // A failed spawn keeps the interpreter as the permanent tier with the
         // reason recorded, matching the background-failure policy instead of
         // panicking the embedding application.
-        let promotion = match std::thread::Builder::new()
-            .name("celox-jit-compile".to_string())
-            .spawn(move || {
-                // The result is delivered through the channel instead of the
-                // join handle so safe-point polls never block on compilation.
-                // A panicked worker surfaces as a disconnected channel and
-                // keeps the simulation on the interpreter permanently.
-                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    compile(&background_laid_out, &background_options, &worker_cancel)
-                }))
-                .unwrap_or_else(|_| {
-                    Err(SimulatorError::from(crate::RuntimeErrorCode::InternalError))
-                });
-                let _ = sender.send(result);
-            }) {
-            Ok(_handle) => Promotion::Pending(receiver),
-            Err(error) => Promotion::Failed(SimulatorError::new(
-                crate::SimulatorErrorKind::Codegen(crate::CodegenError::message(format!(
-                    "failed to spawn the background compiler thread: {error}"
-                ))),
-            )),
+        let promotion = if matches!(
+            options.tier_promotion,
+            crate::simulator::TierPromotion::Never
+        ) {
+            // Policy says interpreted-only: skip the worker entirely so a
+            // never-promoted simulation pays nothing beyond the interpreter.
+            Promotion::Disabled
+        } else {
+            let (sender, receiver) = mpsc::channel();
+            let background_laid_out = laid_out.clone();
+            let background_options = options.clone();
+            match std::thread::Builder::new()
+                .name("celox-jit-compile".to_string())
+                .spawn(move || {
+                    // The result is delivered through the channel instead of the
+                    // join handle so safe-point polls never block on compilation.
+                    // A panicked worker surfaces as a disconnected channel and
+                    // keeps the simulation on the interpreter permanently.
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        compile(&background_laid_out, &background_options, &worker_cancel)
+                    }))
+                    .unwrap_or_else(|_| {
+                        Err(SimulatorError::from(crate::RuntimeErrorCode::InternalError))
+                    });
+                    let _ = sender.send(result);
+                }) {
+                Ok(_handle) => Promotion::Pending(receiver),
+                Err(error) => Promotion::Failed(SimulatorError::new(
+                    crate::SimulatorErrorKind::Codegen(crate::CodegenError::message(format!(
+                        "failed to spawn the background compiler thread: {error}"
+                    ))),
+                )),
+            }
+        };
+
+        let promotion_threshold = match options.tier_promotion {
+            crate::simulator::TierPromotion::AfterSteps(steps) => steps,
+            _ => 0,
         };
 
         Self {
@@ -507,6 +535,8 @@ impl TieredBackend {
             events,
             cancel,
             pending_split_applies: 0,
+            promotion_threshold,
+            interpreted_steps: 0,
         }
     }
 
@@ -545,6 +575,14 @@ impl TieredBackend {
         pending
     }
 
+    /// Record one evaluation step executed on the interpreted tier. Feeds
+    /// the [`TierPromotion::AfterSteps`] adoption threshold.
+    fn count_interpreted_step_if_interpreting(&mut self) {
+        if matches!(self.phase, Phase::Interpreting(Some(_))) {
+            self.interpreted_steps = self.interpreted_steps.saturating_add(1);
+        }
+    }
+
     /// Adopt the compiled tier if background compilation finished. Called at
     /// scheduler safe points (between evaluation phases) where no unit is
     /// mid-execution and the memory image can move atomically from the
@@ -557,6 +595,11 @@ impl TieredBackend {
         // apply phase must observe the interpreted evaluate-only results,
         // and adoption clears the sparse metadata they are tracked in.
         if self.pending_split_applies > 0 {
+            return;
+        }
+        // Honor the minimum interpreted-step count so short simulations are
+        // not disrupted by an adoption their remaining run cannot amortize.
+        if self.interpreted_steps < self.promotion_threshold {
             return;
         }
         let Promotion::Pending(receiver) = &self.promotion else {
@@ -637,6 +680,7 @@ impl SimBackend for TieredBackend {
 
     fn eval_comb(&mut self) -> Result<(), SimulatorErrorCode> {
         self.maybe_promote();
+        self.count_interpreted_step_if_interpreting();
         match &mut self.phase {
             Phase::Interpreting(Some(interp)) => interp.eval_comb(),
             Phase::Compiled(compiled) => compiled.eval_comb(),
@@ -646,6 +690,7 @@ impl SimBackend for TieredBackend {
 
     fn eval_apply_ff_at(&mut self, event: TieredEventRef) -> Result<(), SimulatorErrorCode> {
         self.maybe_promote();
+        self.count_interpreted_step_if_interpreting();
         match &mut self.phase {
             Phase::Interpreting(Some(interp)) => interp.eval_apply_ff_at(
                 super::interp::InterpEventRef::from_parts(event.addr(), event.id()),
@@ -657,6 +702,7 @@ impl SimBackend for TieredBackend {
 
     fn eval_comb_apply_ff_at(&mut self, event: TieredEventRef) -> Result<(), SimulatorErrorCode> {
         self.maybe_promote();
+        self.count_interpreted_step_if_interpreting();
         match &mut self.phase {
             Phase::Interpreting(Some(interp)) => interp.eval_comb_apply_ff_at(
                 super::interp::InterpEventRef::from_parts(event.addr(), event.id()),
@@ -677,6 +723,8 @@ impl SimBackend for TieredBackend {
             return (0, Ok(()));
         }
         self.maybe_promote();
+        // The interpreting arm below delegates to `eval_comb_apply_ff_at`,
+        // which performs the step count itself.
         match &mut self.phase {
             Phase::Interpreting(Some(_)) => (1, self.eval_comb_apply_ff_at(event)),
             Phase::Compiled(compiled) => compiled.eval_comb_apply_ff_many_at(event.id(), count),
@@ -686,6 +734,7 @@ impl SimBackend for TieredBackend {
 
     fn eval_only_ff_at(&mut self, event: TieredEventRef) -> Result<(), SimulatorErrorCode> {
         self.maybe_promote();
+        self.count_interpreted_step_if_interpreting();
         let result = match &mut self.phase {
             Phase::Interpreting(Some(interp)) => interp.eval_only_ff_at(
                 super::interp::InterpEventRef::from_parts(event.addr(), event.id()),
@@ -702,6 +751,7 @@ impl SimBackend for TieredBackend {
     fn apply_ff_at(&mut self, event: TieredEventRef) -> Result<(), SimulatorErrorCode> {
         // Never promote between the evaluate-only and apply phases.
         self.maybe_promote();
+        self.count_interpreted_step_if_interpreting();
         let result = match &mut self.phase {
             Phase::Interpreting(Some(interp)) => interp.apply_ff_at(
                 super::interp::InterpEventRef::from_parts(event.addr(), event.id()),
@@ -1713,5 +1763,68 @@ module Top (
             std::thread::sleep(std::time::Duration::from_millis(1));
         }
         assert!(saw_cancel.load(Ordering::Acquire));
+    }
+
+    /// `TierPromotion::Never` never spawns the background worker and keeps
+    /// the simulation interpreted permanently without recording an error.
+    #[test]
+    fn tier_promotion_never_skips_background_compilation() {
+        let invoked = Arc::new(AtomicBool::new(false));
+        let worker_invoked = Arc::clone(&invoked);
+        let mut sim: Simulator<TieredBackend> = SimulatorBuilder::<Simulator>::new(PIPELINE, "Top")
+            .tier_promotion(crate::TierPromotion::Never)
+            .build_tiered_with_compiler(move |_laid_out, _options, _cancel| {
+                worker_invoked.store(true, Ordering::SeqCst);
+                Err(SimulatorError::from(crate::RuntimeErrorCode::InternalError))
+            })
+            .unwrap();
+
+        // Give a hypothetical worker ample time to start; the policy must
+        // have prevented the spawn entirely.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert!(!invoked.load(Ordering::SeqCst));
+        assert!(!sim.is_compiled());
+        assert!(sim.promotion_error().is_none());
+
+        // The interpreted tier still produces correct results.
+        let inputs: Vec<u8> = (0..8).collect();
+        assert_eq!(drive(&mut sim, &inputs), reference_outputs(&inputs));
+    }
+
+    /// `TierPromotion::AfterSteps` lets background compilation finish but
+    /// defers adoption until the interpreter crosses the step threshold.
+    #[test]
+    fn tier_promotion_after_steps_defers_adoption() {
+        const THRESHOLD: u64 = 1000;
+        let sim_build: Simulator<TieredBackend> =
+            SimulatorBuilder::<Simulator>::new(PIPELINE, "Top")
+                .tier_promotion(crate::TierPromotion::AfterSteps(THRESHOLD))
+                .build_tiered_with_compiler(|laid_out, options, _cancel| {
+                    let image = NativeBackend::compile_image(laid_out, options)?;
+                    let shared = unsafe { SharedNativeCode::from_image(image)? };
+                    Ok(CompiledCode::Native(Arc::new(shared)))
+                })
+                .unwrap();
+        let mut sim = sim_build;
+        let clk = sim.event("clk");
+
+        // A handful of ticks stay far below the threshold; even once the
+        // compiled tier is ready, adoption must not land.
+        for _ in 0..4 {
+            sim.tick(clk).unwrap();
+        }
+        assert!(
+            !sim.is_compiled(),
+            "adopted before the interpreted-step threshold"
+        );
+
+        // Crossing the threshold lets subsequent safe points adopt.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        while !sim.is_compiled() && std::time::Instant::now() < deadline {
+            sim.tick(clk).unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        assert!(sim.is_compiled());
+        assert!(sim.promotion_error().is_none());
     }
 }

--- a/crates/celox/src/backend/tiered.rs
+++ b/crates/celox/src/backend/tiered.rs
@@ -19,6 +19,12 @@
 //! until the interpreter has executed a minimum number of evaluation steps,
 //! protecting short simulations from the promotion cost.
 //!
+//! Adoption never moves the live memory image: tiered builds reserve arena
+//! headroom up front and grow within that allocation, so views handed out
+//! before promotion (for example zero-copy host buffers) stay valid. If a
+//! compiled image would exceed the reserved arena, adoption is declined and
+//! the reason is reported through [`TieredBackend::promotion_error`].
+//!
 //! Background compilation is cooperatively cancellable on the native tier:
 //! dropping the backend (or calling
 //! [`TieredBackend::cancel_background_compilation`]) flags the worker, which
@@ -106,15 +112,42 @@ enum CompiledTier {
     Native(Box<crate::backend::native::NativeBackend>),
 }
 
+impl CompiledCode {
+    /// Image size in `u64` words the compiled tier requires its host
+    /// allocation to cover, or `None` when the transferred interpreter image
+    /// is adopted as-is.
+    fn required_image_words(&self) -> usize {
+        match self {
+            CompiledCode::Cranelift(_) => 0,
+            #[cfg(any(
+                target_arch = "x86_64",
+                feature = "arm64-codegen",
+                target_arch = "aarch64"
+            ))]
+            CompiledCode::Native(shared) => shared.native_memory_size.div_ceil(8) + 1,
+        }
+    }
+}
+
 impl CompiledTier {
     /// Bind compiled code to a live simulation state handed over by the
     /// interpreter during promotion.
+    ///
+    /// Callers must have verified [`CompiledCode::required_image_words`]
+    /// against the image's spare capacity first: growth stays within the
+    /// existing allocation so promotion never moves the live memory image,
+    /// which external views (zero-copy host buffers) may still reference.
     fn adopt(
         code: CompiledCode,
-        memory: Vec<u64>,
+        mut memory: Vec<u64>,
         runtime_event_buffer: Arc<RuntimeEventBuffer>,
         comb_capture_enabled: Vec<u8>,
     ) -> Self {
+        debug_assert!(memory.capacity() >= code.required_image_words());
+        if memory.len() < code.required_image_words() {
+            // Growth within capacity never reallocates.
+            memory.resize(code.required_image_words(), 0);
+        }
         match code {
             CompiledCode::Cranelift(shared) => {
                 Self::Jit(Box::new(JitBackend::adopt_shared_with_state(
@@ -129,23 +162,14 @@ impl CompiledTier {
                 feature = "arm64-codegen",
                 target_arch = "aarch64"
             ))]
-            CompiledCode::Native(shared) => {
-                // Native emission reserves trailing spill/scratch arena beyond
-                // the semantic state, so grow the transferred image to the
-                // size `NativeBackend::from_shared` would allocate; the extra
-                // tail is fresh scratch the interpreter never touched.
-                let target_words = shared.native_memory_size.div_ceil(8) + 1;
-                let mut memory = memory;
-                memory.resize(target_words, 0);
-                Self::Native(Box::new(
-                    crate::backend::native::NativeBackend::adopt_shared_with_state(
-                        shared,
-                        memory,
-                        runtime_event_buffer,
-                        comb_capture_enabled,
-                    ),
-                ))
-            }
+            CompiledCode::Native(shared) => Self::Native(Box::new(
+                crate::backend::native::NativeBackend::adopt_shared_with_state(
+                    shared,
+                    memory,
+                    runtime_event_buffer,
+                    comb_capture_enabled,
+                ),
+            )),
         }
     }
 
@@ -471,10 +495,21 @@ impl TieredBackend {
             + Send
             + 'static,
     {
-        let interp = Box::new(
+        let mut interp = Box::new(
             InterpBackend::new(laid_out, options)
                 .expect("interpreter construction cannot fail for a laid-out program"),
         );
+        // Reserve promotion headroom before anything can observe the image:
+        // native emission appends a spill/scratch arena beyond the semantic
+        // state, and adoption must grow within this allocation so the live
+        // image never moves. The slack covers the measured arena sizes with
+        // margin; a design that outgrows it declines promotion (recorded via
+        // `promotion_error`) instead of reallocating.
+        if native_is_default_target() {
+            let len = interp.image_word_len();
+            let slack = len.max(1024) / 8;
+            interp.reserve_image_capacity(len + slack.max(1024));
+        }
         let events = interp
             .id_to_event_slice()
             .iter()
@@ -624,6 +659,25 @@ impl TieredBackend {
             };
             return;
         };
+        // Adoption grows the transferred image within its existing allocation
+        // so promotion never moves the live memory image (external views such
+        // as zero-copy host buffers may still reference it). If the compiled
+        // tier outgrew the reserved interpreter arena, decline promotion and
+        // stay interpreted instead of reallocating.
+        if let Phase::Interpreting(Some(interp)) = &mut self.phase {
+            let required = code.required_image_words();
+            if interp.image_word_capacity() < required {
+                self.promotion = Promotion::Failed(SimulatorError::new(
+                    crate::SimulatorErrorKind::Codegen(crate::CodegenError::message(format!(
+                        "native image needs {required} words but the reserved interpreter \
+                         image only has {} words of capacity; refusing to move the live \
+                         memory image and staying interpreted",
+                        interp.image_word_capacity()
+                    ))),
+                ));
+                return;
+            }
+        }
         let mut adopted = None;
         if let Phase::Interpreting(slot) = &mut self.phase {
             if let Some(mut interp) = slot.take() {

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -80,6 +80,7 @@ mod host_api {
     pub use crate::simulator::{
         DeadStorePolicy, InstanceHierarchy, NamedEvent, NamedSignal, RuntimeEvent,
         RuntimeEventDrain, RuntimeFormatContext, Simulator, SimulatorBuilder, SimulatorOptions,
+        TierPromotion,
     };
     pub use crate::testbench::{AssertionResult, SourceLocation, TestResult, TestResultDetailed};
     pub use celox_macros::veryl_test;

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -11,7 +11,7 @@ mod error;
 ))]
 pub use builder::NativeCompilation;
 #[cfg(feature = "host-runtime")]
-pub use builder::{DeadStorePolicy, SimulatorBuilder, SimulatorOptions};
+pub use builder::{DeadStorePolicy, SimulatorBuilder, SimulatorOptions, TierPromotion};
 pub use builder::{compile_frontend_to_sir, compile_to_sir};
 #[cfg(feature = "systemverilog")]
 pub use builder::{compile_mixed_to_sir, compile_sv_to_sir};
@@ -1536,6 +1536,11 @@ mod host {
         /// whether a background compilation was still pending.
         pub fn cancel_background_compilation(&mut self) -> bool {
             self.backend.cancel_background_compilation()
+        }
+
+        /// Consume the simulator and return the inner tiered backend.
+        pub fn into_backend(self) -> crate::backend::TieredBackend {
+            self.backend
         }
     }
 

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -1238,6 +1238,15 @@ mod host {
             self.backend.layout()
         }
 
+        /// Take ownership of the VCD writer, if one was configured at build time.
+        ///
+        /// Builders create the writer themselves so that layout selection can
+        /// account for VCD recording; callers building handles around a backend
+        /// use this to keep tracing alive without rebuilding descriptors.
+        pub fn take_vcd_writer(&mut self) -> Option<crate::VcdWriter> {
+            self.vcd_writer.take()
+        }
+
         /// Build VCD signal descriptors for all instances.
         ///
         /// The returned descriptors are self-contained (no IR references) and can

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -1043,6 +1043,23 @@ mod host {
         PreserveAllPorts,
     }
 
+    /// Controls when the tiered backend adopts background-compiled code.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum TierPromotion {
+        /// Adopt compiled code at the first scheduler safe point after
+        /// background compilation completes. Default.
+        Always,
+        /// Adopt compiled code only once the interpreter has executed at
+        /// least this many evaluation steps. Background compilation still
+        /// starts immediately; short simulations that finish before the
+        /// threshold simply never pay the adoption cost. `AfterSteps(0)`
+        /// behaves like [`TierPromotion::Always`].
+        AfterSteps(u64),
+        /// Stay interpreted permanently and skip background compilation
+        /// entirely — no worker thread is spawned.
+        Never,
+    }
+
     #[derive(Debug, Clone)]
     pub struct SimulatorOptions {
         pub four_state: bool,
@@ -1066,6 +1083,8 @@ mod host {
         pub native_force_support: bool,
         /// Dead store elimination policy.
         pub dead_store_policy: DeadStorePolicy,
+        /// When the tiered backend adopts background-compiled code.
+        pub tier_promotion: TierPromotion,
     }
 
     /// A code-generated native program that has not been loaded into
@@ -1237,6 +1256,7 @@ mod host {
                 emit_triggers: false,
                 native_force_support: false,
                 dead_store_policy: DeadStorePolicy::Off,
+                tier_promotion: TierPromotion::Always,
             }
         }
     }
@@ -1470,6 +1490,12 @@ mod host {
         /// Set the dead store elimination policy.
         pub fn dead_store_policy(mut self, policy: DeadStorePolicy) -> Self {
             self.options.dead_store_policy = policy;
+            self
+        }
+
+        /// Set when the tiered backend adopts background-compiled code.
+        pub fn tier_promotion(mut self, policy: TierPromotion) -> Self {
+            self.options.tier_promotion = policy;
             self
         }
 

--- a/crates/celox/tests/vcd.rs
+++ b/crates/celox/tests/vcd.rs
@@ -5,7 +5,7 @@ mod test_utils;
 
 #[cfg(test)]
 mod tests {
-    use celox::{IOContext, SimulatorBuilder};
+    use celox::{IOContext, SimBackend, SimulatorBuilder};
     use std::fs;
     use std::path::Path;
 
@@ -42,5 +42,129 @@ mod tests {
         assert!(content.contains("#10"));
 
         fs::remove_file(vcd_path).unwrap();
+    }
+
+    /// VCD descriptors assume contiguous packed storage, so a tiered build
+    /// that records traces must lay out unpacked arrays packed instead of the
+    /// element-strided form its compiled tier prefers. Regression guard for
+    /// the tiered factories that create their VCD writer post-build. The
+    /// dynamically indexed array matters: only designs that would otherwise
+    /// adopt element-strided storage expose the divergence.
+    #[test]
+    fn test_tiered_vcd_matches_packed_reference_for_unpacked_arrays() {
+        let code = r#"
+        module Top (
+            clk: input clock,
+            rst: input reset,
+            d: input logic<3>,
+            widx: input logic<2>,
+            ridx: input logic<2>,
+            q0: output logic<3>,
+        ) {
+            var mem: logic<3>[4];
+            always_ff (clk, rst) {
+                if_reset {
+                    mem[0] = 3'd0;
+                } else {
+                    mem[widx] = d;
+                }
+            }
+            assign q0 = mem[ridx];
+        }
+        "#;
+
+        let reference_path = "test_vcd_packed_reference.vcd";
+        let tiered_path = "test_vcd_tiered.vcd";
+
+        let mut reference = SimulatorBuilder::new(code, "Top")
+            .vcd(reference_path)
+            .build_interpreter()
+            .unwrap();
+        let mut tiered = SimulatorBuilder::new(code, "Top")
+            .vcd(tiered_path)
+            .build_tiered()
+            .unwrap();
+
+        assert!(
+            tiered.layout().unpacked_arrays.is_empty(),
+            "VCD recording must force the packed layout for tiered builds"
+        );
+
+        // Sanity: without VCD the same build does adopt element-strided
+        // storage for `mem`, so this test actually exercises both layouts.
+        let strided = SimulatorBuilder::new(code, "Top").build_tiered().unwrap();
+        assert_eq!(
+            strided.layout().unpacked_arrays.len(),
+            1,
+            "expected `mem` to be element-strided when not recording VCD"
+        );
+        drop(strided);
+
+        drive(&mut reference);
+        dump_at(&mut reference, 10);
+
+        drive(&mut tiered);
+        dump_at(&mut tiered, 10);
+
+        assert_eq!(without_date(reference_path), without_date(tiered_path));
+
+        fs::remove_file(reference_path).unwrap();
+        fs::remove_file(tiered_path).unwrap();
+    }
+
+    /// Identical stimulus for every backend under comparison.
+    fn drive<B: SimBackend>(sim: &mut celox::Simulator<B>) {
+        let rst = sim.signal("rst");
+        let d = sim.signal("d");
+        let widx = sim.signal("widx");
+        sim.modify(|io| {
+            io.set(rst, 1u8);
+        })
+        .unwrap();
+        tick(sim, 1);
+        for lane in 0..4u8 {
+            sim.modify(|io| {
+                io.set(rst, 0u8);
+                io.set(d, lane + 1);
+                io.set(widx, lane);
+            })
+            .unwrap();
+            tick(sim, 1);
+        }
+    }
+
+    fn dump_at<B: SimBackend>(sim: &mut celox::Simulator<B>, timestamp: u64) {
+        sim.dump(timestamp);
+    }
+
+    fn tick<B: SimBackend>(sim: &mut celox::Simulator<B>, ticks: usize) {
+        let clk = sim
+            .named_events()
+            .iter()
+            .find(|event| event.name == "clk")
+            .expect("clk event")
+            .id;
+        sim.tick_by_id_n(clk, ticks as u32).unwrap();
+    }
+
+    /// File contents with the `$date` block removed so runs are comparable.
+    fn without_date(path: &str) -> String {
+        let mut out = String::new();
+        let mut in_date_block = false;
+        for line in fs::read_to_string(path).unwrap().lines() {
+            if in_date_block {
+                if line.trim() == "$end" {
+                    in_date_block = false;
+                }
+                continue;
+            }
+            if line.trim() == "$date" {
+                in_date_block = true;
+                continue;
+            }
+            out.push_str(line);
+            out.push('\n');
+        }
+        out
     }
 }

--- a/crates/celox/tests/vcd.rs
+++ b/crates/celox/tests/vcd.rs
@@ -90,15 +90,19 @@ mod tests {
             "VCD recording must force the packed layout for tiered builds"
         );
 
-        // Sanity: without VCD the same build does adopt element-strided
-        // storage for `mem`, so this test actually exercises both layouts.
-        let strided = SimulatorBuilder::new(code, "Top").build_tiered().unwrap();
-        assert_eq!(
-            strided.layout().unpacked_arrays.len(),
-            1,
-            "expected `mem` to be element-strided when not recording VCD"
-        );
-        drop(strided);
+        // Sanity: without VCD the same build adopts element-strided storage
+        // for `mem` on hosts whose default compiled tier is native, so the
+        // trace comparison really exercises both layouts. Cross-codegen
+        // builds default to Cranelift, whose tiered target layout is packed
+        // either way.
+        if native_default_compiled_tier() {
+            let strided = SimulatorBuilder::new(code, "Top").build_tiered().unwrap();
+            assert_eq!(
+                strided.layout().unpacked_arrays.len(),
+                1,
+                "expected `mem` to be element-strided when not recording VCD"
+            );
+        }
 
         drive(&mut reference);
         dump_at(&mut reference, 10);
@@ -110,6 +114,27 @@ mod tests {
 
         fs::remove_file(reference_path).unwrap();
         fs::remove_file(tiered_path).unwrap();
+    }
+
+    /// Whether the host's default compiled tier is the native backend.
+    ///
+    /// Mirrors the crate's `native_is_default_target` selection, which is
+    /// not public; cross-codegen builds fall back to Cranelift.
+    fn native_default_compiled_tier() -> bool {
+        #[cfg(any(
+            all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+            all(target_arch = "aarch64", not(feature = "x86_64-codegen"))
+        ))]
+        {
+            true
+        }
+        #[cfg(not(any(
+            all(target_arch = "x86_64", not(feature = "arm64-codegen")),
+            all(target_arch = "aarch64", not(feature = "x86_64-codegen"))
+        )))]
+        {
+            false
+        }
     }
 
     /// Identical stimulus for every backend under comparison.

--- a/packages/celox/src/e2e.test.ts
+++ b/packages/celox/src/e2e.test.ts
@@ -8,6 +8,7 @@
  * `celox-napi` native addon compiled from the Rust simulator.
  */
 
+import { readFileSync, rmSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 import { readFourState } from "./dut.js";
@@ -3388,5 +3389,86 @@ module InjectedFailureTb {
 
 		expect(result.passed).toBe(false);
 		expect(result.error).toContain("TypeScript component failed");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tiered + VCD e2e tests
+// ---------------------------------------------------------------------------
+
+const TIERED_VCD_ARRAY_SOURCE = `
+module TieredVcdArray (
+    clk: input clock,
+    rst: input reset,
+    d: input logic<3>,
+    widx: input logic<2>,
+    ridx: input logic<2>,
+    q0: output logic<3>,
+) {
+    var mem: logic<3>[4];
+    always_ff (clk, rst) {
+        if_reset {
+            mem[0] = 3'd0;
+        } else {
+            mem[widx] = d;
+        }
+    }
+    assign q0 = mem[ridx];
+}
+`;
+
+describe("E2E: tiered + VCD", () => {
+	test("tiered build with vcd records packed array traces", () => {
+		const addon = loadNativeAddon();
+		if (!addon.NativeSimulatorHandle.newTiered) {
+			return; // addon built before tiering was exposed
+		}
+
+		const vcdPath = path.join(
+			import.meta.dirname ?? __dirname,
+			"tiered_vcd_array.tmp.vcd",
+		);
+		const sim = Simulator.fromSource(
+			TIERED_VCD_ARRAY_SOURCE,
+			"TieredVcdArray",
+			{
+				tier: true,
+				vcd: vcdPath,
+			},
+		);
+
+		const dut = sim.dut as unknown as Record<string, bigint>;
+		dut.rst = 1n;
+		for (let lane = 0; lane < 4; lane++) {
+			dut.d = BigInt(lane + 1);
+			dut.widx = BigInt(lane);
+			sim.tick();
+		}
+		dut.ridx = 0n;
+		expect(dut.q0).toBe(1n);
+		sim.dump(10);
+		sim.dispose();
+
+		try {
+			const content = readFileSync(vcdPath, "utf8");
+			// The array must be dumped as one contiguous packed value; a
+			// strided layout would place element padding between lanes and
+			// yield a different bit pattern.
+			const varMatch = content.match(/\$var wire (\d+) (.) mem \$end/);
+			expect(varMatch).not.toBeNull();
+			const valueLines = [
+				...content.matchAll(new RegExp(`^b([01]+) ${varMatch![2]}$`, "gm")),
+			];
+			expect(valueLines.length).toBeGreaterThan(0);
+			const dumped = BigInt(`0b${valueLines.at(-1)![1]}`);
+			const lanes = [1n, 2n, 3n, 4n];
+			const expected = lanes.reduce(
+				(acc, lane, index) => acc | (lane << BigInt(3 * index)),
+				0n,
+			);
+			expect(dumped).toBe(expected);
+		} finally {
+			rmSync(vcdPath, { force: true });
+		}
 	});
 });

--- a/packages/celox/src/napi-helpers.ts
+++ b/packages/celox/src/napi-helpers.ts
@@ -205,6 +205,15 @@ export interface RawNapiAddon {
 			top: string,
 			options?: NapiOptions,
 		): RawNapiSimulatorHandle;
+		/**
+		 * Tiered counterpart of `fromProject`. Optional — absent on addons
+		 * built before tiering was exposed.
+		 */
+		newTieredFromProject?(
+			projectPath: string,
+			top: string,
+			options?: NapiOptions,
+		): RawNapiSimulatorHandle;
 	};
 	NativeSimulationHandle?: {
 		new (

--- a/packages/celox/src/napi-helpers.ts
+++ b/packages/celox/src/napi-helpers.ts
@@ -882,14 +882,15 @@ export function createSimulatorBridge(addon: RawNapiAddon): NativeCreateFn {
 			content: s.content,
 			path: s.path,
 		}));
-		const raw =
-			options.tier && addon.NativeSimulatorHandle.newTiered
-				? addon.NativeSimulatorHandle.newTiered(
-						napiSources,
-						moduleName,
-						napiOpts,
-					)
-				: new addon.NativeSimulatorHandle(napiSources, moduleName, napiOpts);
+		const handleCtor = addon.NativeSimulatorHandle;
+		if (options.tier && !handleCtor.newTiered) {
+			throw new Error(
+				"The loaded Celox native addon does not support tiered execution.",
+			);
+		}
+		const raw = options.tier
+			? handleCtor.newTiered!(napiSources, moduleName, napiOpts)
+			: new handleCtor(napiSources, moduleName, napiOpts);
 		const layout = parseLegacyLayout(raw.layoutJson);
 		const events: Record<string, number> = JSON.parse(raw.eventsJson);
 		const hierarchy = parseHierarchyLayout(raw.hierarchyJson, events);

--- a/packages/celox/src/napi-helpers.ts
+++ b/packages/celox/src/napi-helpers.ts
@@ -195,6 +195,16 @@ export interface RawNapiAddon {
 			artifactJson: string,
 			options?: NapiOptions,
 		): RawNapiSimulatorHandle;
+		/**
+		 * Create a tiered simulator: interprets immediately while the
+		 * compiled tier is prepared on a background thread. Optional —
+		 * absent on addons built before tiering was exposed.
+		 */
+		newTiered?(
+			sources: NapiSourceFile[],
+			top: string,
+			options?: NapiOptions,
+		): RawNapiSimulatorHandle;
 	};
 	NativeSimulationHandle?: {
 		new (
@@ -778,6 +788,11 @@ export function wrapDirectSimulatorHandle(
 		dispose(): void {
 			raw.dispose();
 		},
+		tierCompiled(): boolean | null {
+			const value = (raw as { tierCompiled?: boolean | null | undefined })
+				.tierCompiled;
+			return value ?? null;
+		},
 	};
 }
 
@@ -858,12 +873,14 @@ export function createSimulatorBridge(addon: RawNapiAddon): NativeCreateFn {
 			content: s.content,
 			path: s.path,
 		}));
-		const raw = new addon.NativeSimulatorHandle(
-			napiSources,
-			moduleName,
-			napiOpts,
-		);
-
+		const raw =
+			options.tier && addon.NativeSimulatorHandle.newTiered
+				? addon.NativeSimulatorHandle.newTiered(
+						napiSources,
+						moduleName,
+						napiOpts,
+					)
+				: new addon.NativeSimulatorHandle(napiSources, moduleName, napiOpts);
 		const layout = parseLegacyLayout(raw.layoutJson);
 		const events: Record<string, number> = JSON.parse(raw.eventsJson);
 		const hierarchy = parseHierarchyLayout(raw.hierarchyJson, events);

--- a/packages/celox/src/simulation.test.ts
+++ b/packages/celox/src/simulation.test.ts
@@ -417,4 +417,25 @@ describe("Simulation", () => {
 
 		expect(() => sim.reset("nonexistent")).toThrow("Unknown port");
 	});
+
+	test("tier: rejected on every entry point instead of silently ignored", () => {
+		const message = "tiered execution is not supported";
+		expect(() => Simulation.create(TopModule, { tier: true })).toThrow(message);
+		expect(() =>
+			Simulation.fromSource("module T {}", "T", { tier: true }),
+		).toThrow(message);
+		expect(() =>
+			Simulation.fromProject("./project", "T", { tier: true }),
+		).toThrow(message);
+	});
+
+	test("tier: rejected when it arrives through module.defaultOptions", () => {
+		const moduleWithTier: ModuleDefinition<TopPorts> = {
+			...TopModule,
+			defaultOptions: { tier: true },
+		};
+		expect(() => Simulation.create(moduleWithTier)).toThrow(
+			"tiered execution is not supported",
+		);
+	});
 });

--- a/packages/celox/src/simulation.ts
+++ b/packages/celox/src/simulation.ts
@@ -110,6 +110,12 @@ export class Simulation<P = Record<string, unknown>> {
 	): Simulation<P> {
 		const merged = { ...module.defaultOptions, ...options };
 
+		if (merged.tier) {
+			throw new Error(
+				"tiered execution is not supported for time-based Simulation handles.",
+			);
+		}
+
 		// When the module was produced by the Vite plugin, delegate to fromProject()
 		if (module.projectPath && !merged?.__nativeCreate) {
 			return Simulation.fromProject<P>(module.projectPath, module.name, merged);
@@ -189,6 +195,11 @@ export class Simulation<P = Record<string, unknown>> {
 		top: string,
 		options?: SimulatorOptions & { nativeAddonPath?: string },
 	): Simulation<P> {
+		if (options?.tier) {
+			throw new Error(
+				"tiered execution is not supported for time-based Simulation handles.",
+			);
+		}
 		const addon = loadNativeAddon(options?.nativeAddonPath);
 		const napiOpts = buildNapiOpts(options);
 		// WASM addon does not support time-based Simulation (no NativeSimulationHandle).
@@ -257,6 +268,11 @@ export class Simulation<P = Record<string, unknown>> {
 		artifactJson: string,
 		options?: SimulatorOptions & { nativeAddonPath?: string },
 	): Simulation<P> {
+		if (options?.tier) {
+			throw new Error(
+				"tiered execution is not supported for time-based Simulation handles.",
+			);
+		}
 		const addon = loadNativeAddon(options?.nativeAddonPath);
 		const factory = addon.NativeSimulationHandle?.fromFrontendArtifact;
 		if (!factory) {
@@ -316,6 +332,11 @@ export class Simulation<P = Record<string, unknown>> {
 		top: string,
 		options?: SimulatorOptions & { nativeAddonPath?: string },
 	): Simulation<P> {
+		if (options?.tier) {
+			throw new Error(
+				"tiered execution is not supported for time-based Simulation handles.",
+			);
+		}
 		const addon = loadNativeAddon(options?.nativeAddonPath);
 		const napiOpts = buildNapiOpts(options);
 

--- a/packages/celox/src/simulator.ts
+++ b/packages/celox/src/simulator.ts
@@ -370,11 +370,7 @@ export class Simulator<P = Record<string, unknown>> {
 						top,
 						napiOpts,
 					)
-				: addon.NativeSimulatorHandle.fromProject(
-						projectPath,
-						top,
-						napiOpts,
-					);
+				: addon.NativeSimulatorHandle.fromProject(projectPath, top, napiOpts);
 		const isWasm = isWasmHandle(raw);
 
 		const layout =

--- a/packages/celox/src/simulator.ts
+++ b/packages/celox/src/simulator.ts
@@ -192,19 +192,23 @@ export class Simulator<P = Record<string, unknown>> {
 		options?: SimulatorOptions & { nativeAddonPath?: string },
 	): Simulator<P> {
 		const addon = loadNativeAddon(options?.nativeAddonPath);
+		if (options?.tier && !addon.NativeSimulatorHandle.newTiered) {
+			throw new Error(
+				"The loaded Celox native addon does not support tiered execution.",
+			);
+		}
 		const napiOpts = buildNapiOpts(options);
-		const raw =
-			options?.tier && addon.NativeSimulatorHandle.newTiered
-				? addon.NativeSimulatorHandle.newTiered(
-						[{ content: source, path: "" }],
-						top,
-						napiOpts,
-					)
-				: new addon.NativeSimulatorHandle(
-						[{ content: source, path: "" }],
-						top,
-						napiOpts,
-					);
+		const raw = options?.tier
+			? addon.NativeSimulatorHandle.newTiered!(
+					[{ content: source, path: "" }],
+					top,
+					napiOpts,
+				)
+			: new addon.NativeSimulatorHandle(
+					[{ content: source, path: "" }],
+					top,
+					napiOpts,
+				);
 		const isWasm = isWasmHandle(raw);
 
 		const layout =
@@ -364,15 +368,19 @@ export class Simulator<P = Record<string, unknown>> {
 		options?: SimulatorOptions & { nativeAddonPath?: string },
 	): Simulator<P> {
 		const addon = loadNativeAddon(options?.nativeAddonPath);
+		if (options?.tier && !addon.NativeSimulatorHandle.newTieredFromProject) {
+			throw new Error(
+				"The loaded Celox native addon does not support tiered execution.",
+			);
+		}
 		const napiOpts = buildNapiOpts(options);
-		const raw =
-			options?.tier && addon.NativeSimulatorHandle.newTieredFromProject
-				? addon.NativeSimulatorHandle.newTieredFromProject(
-						projectPath,
-						top,
-						napiOpts,
-					)
-				: addon.NativeSimulatorHandle.fromProject(projectPath, top, napiOpts);
+		const raw = options?.tier
+			? addon.NativeSimulatorHandle.newTieredFromProject!(
+					projectPath,
+					top,
+					napiOpts,
+				)
+			: addon.NativeSimulatorHandle.fromProject(projectPath, top, napiOpts);
 		const isWasm = isWasmHandle(raw);
 
 		const layout =

--- a/packages/celox/src/simulator.ts
+++ b/packages/celox/src/simulator.ts
@@ -128,6 +128,7 @@ export class Simulator<P = Record<string, unknown>> {
 			resetType,
 			parameters,
 			deadStorePolicy,
+			tier,
 		} = merged ?? {};
 		const result = createFn(module.sources, module.name, {
 			fourState,
@@ -139,6 +140,7 @@ export class Simulator<P = Record<string, unknown>> {
 			resetType,
 			parameters,
 			deadStorePolicy,
+			tier,
 		});
 		const state: DirtyState = { dirty: false };
 

--- a/packages/celox/src/simulator.ts
+++ b/packages/celox/src/simulator.ts
@@ -191,11 +191,18 @@ export class Simulator<P = Record<string, unknown>> {
 	): Simulator<P> {
 		const addon = loadNativeAddon(options?.nativeAddonPath);
 		const napiOpts = buildNapiOpts(options);
-		const raw = new addon.NativeSimulatorHandle(
-			[{ content: source, path: "" }],
-			top,
-			napiOpts,
-		);
+		const raw =
+			options?.tier && addon.NativeSimulatorHandle.newTiered
+				? addon.NativeSimulatorHandle.newTiered(
+						[{ content: source, path: "" }],
+						top,
+						napiOpts,
+					)
+				: new addon.NativeSimulatorHandle(
+						[{ content: source, path: "" }],
+						top,
+						napiOpts,
+					);
 		const isWasm = isWasmHandle(raw);
 
 		const layout =
@@ -260,6 +267,11 @@ export class Simulator<P = Record<string, unknown>> {
 		artifactJson: string,
 		options?: SimulatorOptions & { nativeAddonPath?: string },
 	): Simulator<P> {
+		if (options?.tier) {
+			throw new Error(
+				"tiered execution is not supported for frontend artifact handles.",
+			);
+		}
 		const addon = loadNativeAddon(options?.nativeAddonPath);
 		const factory = addon.NativeSimulatorHandle.fromFrontendArtifact;
 		if (!factory) {
@@ -351,11 +363,18 @@ export class Simulator<P = Record<string, unknown>> {
 	): Simulator<P> {
 		const addon = loadNativeAddon(options?.nativeAddonPath);
 		const napiOpts = buildNapiOpts(options);
-		const raw = addon.NativeSimulatorHandle.fromProject(
-			projectPath,
-			top,
-			napiOpts,
-		);
+		const raw =
+			options?.tier && addon.NativeSimulatorHandle.newTieredFromProject
+				? addon.NativeSimulatorHandle.newTieredFromProject(
+						projectPath,
+						top,
+						napiOpts,
+					)
+				: addon.NativeSimulatorHandle.fromProject(
+						projectPath,
+						top,
+						napiOpts,
+					);
 		const isWasm = isWasmHandle(raw);
 
 		const layout =

--- a/packages/celox/src/types.ts
+++ b/packages/celox/src/types.ts
@@ -293,8 +293,8 @@ export interface SimulatorOptions {
 	 * Default: false (compile up front before the first tick).
 	 *
 	 * Honored by `Simulator.create`, `fromSource`, and `fromProject`;
-	 * rejected by `fromFrontendArtifact`, which has no tiered build path.
-	 * Throws when the loaded addon lacks tiered support (e.g. WASM).
+	 * rejected by `fromFrontendArtifact`, the time-based `Simulation`
+	 * factories, and addons without tiered support (e.g. WASM).
 	 */
 	tier?: boolean;
 }

--- a/packages/celox/src/types.ts
+++ b/packages/celox/src/types.ts
@@ -291,6 +291,9 @@ export interface SimulatorOptions {
 	 * host's compiled tier is prepared on a background thread, and the
 	 * simulation adopts it at the next safe point after compilation.
 	 * Default: false (compile up front before the first tick).
+	 *
+	 * Honored by `Simulator.create`, `fromSource`, and `fromProject`;
+	 * rejected by `fromFrontendArtifact`, which has no tiered build path.
 	 */
 	tier?: boolean;
 }

--- a/packages/celox/src/types.ts
+++ b/packages/celox/src/types.ts
@@ -137,6 +137,12 @@ export interface NativeSimulatorHandle {
 	evalComb(): void;
 	dump(timestamp: number): void;
 	dispose(): void;
+	/**
+	 * Whether the tiered backend has adopted its compiled tier.
+	 * Present only on handles created through `newTiered()`; reads live so
+	 * repeated calls track promotion progress.
+	 */
+	tierCompiled?(): boolean | null;
 }
 
 /**
@@ -280,6 +286,13 @@ export interface SimulatorOptions {
 	 * When `optLevel` is "O2", defaults to "preserveTopPorts" unless explicitly set.
 	 */
 	deadStorePolicy?: "off" | "preserveTopPorts" | "preserveAllPorts";
+	/**
+	 * Run tiered: execution starts on the interpreter immediately while the
+	 * host's compiled tier is prepared on a background thread, and the
+	 * simulation adopts it at the next safe point after compilation.
+	 * Default: false (compile up front before the first tick).
+	 */
+	tier?: boolean;
 }
 
 /** A parameter override for a top-level module parameter. */

--- a/packages/celox/src/types.ts
+++ b/packages/celox/src/types.ts
@@ -294,6 +294,7 @@ export interface SimulatorOptions {
 	 *
 	 * Honored by `Simulator.create`, `fromSource`, and `fromProject`;
 	 * rejected by `fromFrontendArtifact`, which has no tiered build path.
+	 * Throws when the loaded addon lacks tiered support (e.g. WASM).
 	 */
 	tier?: boolean;
 }


### PR DESCRIPTION
## Summary

Follow-up to #668 (tiered execution):

- **Tier promotion policy**: new `TierPromotion` option (`Always` default / `AfterSteps(u64)` / `Never`) controls when the tiered backend adopts background-compiled code. `AfterSteps` protects short simulations from the adoption cost; `Never` skips the worker thread entirely and stays interpreted. Set via `SimulatorOptions.tier_promotion` or `.tier_promotion()` on the builder.
- **Node bindings**: `NativeSimulatorHandle.newTiered()` factory plus `isTiered` / `tierCompiled` getters. TS-side: `SimulatorOptions.tier` routes through `newTiered`, and the wrapped handle exposes live `tierCompiled()`. WASM is out of scope (`celox-wasm` only emits bytecode; it does not execute backends).
- **Macro-benchmark**: `celox-tiered` bench compares tiered/native/cranelift/interpreter startup and throughput on a tiny LCG module and on the SorterTreeDistEntry fixture (`--sorter-n N`).

## Benchmark (release, Linux aarch64, sorter fixture)

| workload | mode | time-to-ready | ns/tick |
|---|---|---|---|
| sorter N=64 | native | 1.64s | 1,670 |
| sorter N=64 | interpreter | 0.87s | ~1,100,000 |
| sorter N=64 | tiered | **0.88s** | promoted by tick ~1001, then native rate |

## Validation

- `cargo test -p celox`: 100 test targets pass (incl. 2 new policy unit tests + 3 tiered integration tests)
- clippy/fmt clean for celox, celox-napi, celox-bench
- biome + tsc clean for packages/celox; napi addon built and `newTiered` smoke-tested end-to-end
- Note: `SimulatorOptions` gains one field (`tier_promotion`); construction is via `Default`/builder
