### PR TITLE
perf(interpreter): reuse tier-zero register storage

### DIFF
--- a/crates/celox/src/backend/interp.rs
+++ b/crates/celox/src/backend/interp.rs
@@ -35,7 +35,10 @@ use crate::backend::memory_layout::{
     RUNTIME_EVENT_SLOT_PAYLOAD_OFFSET, RUNTIME_EVENT_SLOT_SEQ_OFFSET,
     RUNTIME_EVENT_SLOT_SITE_OFFSET, RUNTIME_EVENT_WRITING, STATE_HEADER_RUNTIME_EVENT_ADDR_OFFSET,
 };
-use crate::interpreter::{InterpError, InterpMachine, ResolvedAccess, StoreSnapshot, execute_unit};
+use crate::interpreter::{
+    InterpError, InterpMachine, Registers, ResolvedAccess, StoreSnapshot,
+    execute_unit_with_registers,
+};
 use crate::ir::{SPARSE_WORKING_REGION, STABLE_REGION, WORKING_REGION};
 use crate::{
     HashMap, SimulatorError, SimulatorOptions,
@@ -960,6 +963,7 @@ fn run_units(
     units: &[ExecutionUnit<RegionedAbsoluteAddr>],
     trigger_addrs: &[(AbsoluteAddr, u32)],
     trigger_snapshots: &mut Vec<((AbsoluteAddr, u32), u64)>,
+    registers: &mut Registers,
     emit_triggers: bool,
 ) -> Result<(), SimulatorErrorCode> {
     // Snapshot the first word of every trigger-bearing object at group
@@ -1002,7 +1006,8 @@ fn run_units(
         // Entry blocks of top-level execution units take no parameters: the
         // compiled ABI passes only the memory pointer, so all inputs arrive
         // through loads.
-        execute_unit(unit, &mut machine, &[], four_state).map_err(error_code)?;
+        execute_unit_with_registers(unit, &mut machine, &[], four_state, registers)
+            .map_err(error_code)?;
     }
     Ok(())
 }
@@ -1049,6 +1054,8 @@ pub struct InterpBackend {
     event_trigger_addrs: HashMap<AbsoluteAddr, Vec<(AbsoluteAddr, u32)>>,
     /// Reused group-entry trigger snapshots; sorted by address and region.
     trigger_snapshots: Vec<((AbsoluteAddr, u32), u64)>,
+    /// Register storage reused across sequential execution-unit invocations.
+    registers: Registers,
     /// Whether trigger detection marks bits; matches the compiled
     /// `emit_triggers` codegen flag.
     emit_triggers: bool,
@@ -1230,6 +1237,7 @@ impl InterpBackend {
             comb_trigger_addrs,
             event_trigger_addrs,
             trigger_snapshots: Vec::new(),
+            registers: Registers::default(),
             emit_triggers: options.emit_triggers,
         };
         backend.install_event_buffers();
@@ -1310,6 +1318,7 @@ impl SimBackend for InterpBackend {
             &self.program_sir.eval_comb,
             &self.comb_trigger_addrs,
             &mut self.trigger_snapshots,
+            &mut self.registers,
             self.emit_triggers,
         )
     }
@@ -1328,6 +1337,7 @@ impl SimBackend for InterpBackend {
                 .get(&event.addr())
                 .map_or(&[] as &[(AbsoluteAddr, u32)], Vec::as_slice),
             &mut self.trigger_snapshots,
+            &mut self.registers,
             self.emit_triggers,
         )
     }
@@ -1346,6 +1356,7 @@ impl SimBackend for InterpBackend {
             units,
             &self.event_trigger_addrs[&event.addr()],
             &mut self.trigger_snapshots,
+            &mut self.registers,
             self.emit_triggers,
         )
     }
@@ -1364,6 +1375,7 @@ impl SimBackend for InterpBackend {
                 .get(&event.addr())
                 .map_or(&[] as &[(AbsoluteAddr, u32)], Vec::as_slice),
             &mut self.trigger_snapshots,
+            &mut self.registers,
             self.emit_triggers,
         )
     }
@@ -1382,6 +1394,7 @@ impl SimBackend for InterpBackend {
                 .get(&event.addr())
                 .map_or(&[] as &[(AbsoluteAddr, u32)], Vec::as_slice),
             &mut self.trigger_snapshots,
+            &mut self.registers,
             self.emit_triggers,
         )
     }

--- a/crates/celox/src/interpreter.rs
+++ b/crates/celox/src/interpreter.rs
@@ -220,7 +220,23 @@ pub fn execute_unit<A, M: InterpMachine<A>>(
     entry_args: &[SIRValue],
     four_state: bool,
 ) -> Result<UnitExit, InterpError> {
-    let mut regs = Registers::new(&unit.register_map);
+    let mut regs = Registers::default();
+    execute_unit_with_registers(unit, machine, entry_args, four_state, &mut regs)
+}
+
+/// Execute a unit with backend-owned register storage.
+///
+/// The Tier-0 backend invokes many units per evaluation. Reusing this storage
+/// avoids allocating three register vectors for every invocation while still
+/// clearing values and rebuilding unit-specific type metadata at entry.
+pub(crate) fn execute_unit_with_registers<A, M: InterpMachine<A>>(
+    unit: &ExecutionUnit<A>,
+    machine: &mut M,
+    entry_args: &[SIRValue],
+    four_state: bool,
+    regs: &mut Registers,
+) -> Result<UnitExit, InterpError> {
+    regs.prepare(&unit.register_map);
     let entry = unit
         .blocks
         .get(&unit.entry_block_id)
@@ -242,13 +258,13 @@ pub fn execute_unit<A, M: InterpMachine<A>>(
             .get(&current)
             .ok_or(InterpError::UnknownBlock(current))?;
         for instruction in &block.instructions {
-            exec_instruction(instruction, &mut regs, machine, four_state)?;
+            exec_instruction(instruction, regs, machine, four_state)?;
         }
         match &block.terminator {
             SIRTerminator::Return => return Ok(UnitExit::Return),
             SIRTerminator::Error(code) => return Err(InterpError::Fatal(*code)),
             SIRTerminator::Jump(target, args) => {
-                transfer(&mut regs, unit, *target, args)?;
+                transfer(regs, unit, *target, args)?;
                 current = *target;
             }
             SIRTerminator::Branch {
@@ -265,7 +281,7 @@ pub fn execute_unit<A, M: InterpMachine<A>>(
                 } else {
                     false_block
                 };
-                transfer(&mut regs, unit, target.0, &target.1)?;
+                transfer(regs, unit, target.0, &target.1)?;
                 current = target.0;
             }
             SIRTerminator::Switch {
@@ -282,7 +298,7 @@ pub fn execute_unit<A, M: InterpMachine<A>>(
                     .find(|case| case.value == selector)
                     .map(|case| case.target)
                     .unwrap_or(*default);
-                transfer(&mut regs, unit, target, &[])?;
+                transfer(regs, unit, target, &[])?;
                 current = target;
             }
         }
@@ -1231,26 +1247,25 @@ impl BigUintExt for BigUint {
 
 // ── Register file ─────────────────────────────────────────────────────
 
-struct Registers {
+#[derive(Default)]
+pub(crate) struct Registers {
     values: Vec<Option<SIRValue>>,
     widths: Vec<usize>,
     signed: Vec<bool>,
 }
 
 impl Registers {
-    fn new(register_map: &HashMap<RegisterId, RegisterType>) -> Self {
+    fn prepare(&mut self, register_map: &HashMap<RegisterId, RegisterType>) {
         let size = register_map.keys().map(|id| id.0 + 1).max().unwrap_or(0);
-        let values = vec![None; size];
-        let mut widths = vec![0; size];
-        let mut signed = vec![false; size];
+        self.values.clear();
+        self.values.resize_with(size, || None);
+        self.widths.clear();
+        self.widths.resize(size, 0);
+        self.signed.clear();
+        self.signed.resize(size, false);
         for (id, register_type) in register_map {
-            widths[id.0] = register_type.width();
-            signed[id.0] = register_type.is_signed();
-        }
-        Self {
-            values,
-            widths,
-            signed,
+            self.widths[id.0] = register_type.width();
+            self.signed[id.0] = register_type.is_signed();
         }
     }
 
@@ -1522,6 +1537,48 @@ mod tests {
         let mut machine = FakeMachine::default();
         execute_unit(&unit, &mut machine, &[], true).unwrap();
         assert_eq!(machine.stored(7, 0, 8).payload, BigUint::from(8u8));
+    }
+
+    #[test]
+    fn reused_register_storage_clears_values_between_units() {
+        let producer = ExecutionUnit {
+            entry_block_id: BlockId(0),
+            blocks: [block(
+                0,
+                vec![],
+                vec![SIRInstruction::Imm(RegisterId(0), SIRValue::new(0xabu8))],
+                SIRTerminator::Return,
+            )]
+            .into_iter()
+            .collect(),
+            register_map: bit_regs(&[(0, 8)]),
+        };
+        let consumer = ExecutionUnit {
+            entry_block_id: BlockId(0),
+            blocks: [block(
+                0,
+                vec![],
+                vec![SIRInstruction::Store(
+                    1u32,
+                    SIROffset::Static(0),
+                    8,
+                    RegisterId(0),
+                    Vec::new(),
+                    Vec::new(),
+                )],
+                SIRTerminator::Return,
+            )]
+            .into_iter()
+            .collect(),
+            register_map: bit_regs(&[(0, 8)]),
+        };
+
+        let mut machine = FakeMachine::default();
+        let mut registers = Registers::default();
+        execute_unit_with_registers(&producer, &mut machine, &[], true, &mut registers).unwrap();
+        let error = execute_unit_with_registers(&consumer, &mut machine, &[], true, &mut registers)
+            .unwrap_err();
+        assert_eq!(error, InterpError::MissingRegister(RegisterId(0)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reuse backend-owned register storage across sequential Tier-0 execution-unit invocations
- keep the standalone interpreter API behavior unchanged while routing InterpBackend through the reusable path
- add a regression test proving register values cannot leak between units

## Performance

Criterion with the heliodor-dev profile, LCG interpreter steady-state, batch size 1000:

- before: 1.0968-1.1361 ms, median 1.1154 ms
- after: 985.86-1012.4 us, median 998.59 us
- median time: -10.621 percent
- throughput: +11.883 percent
- p = 0.00

A separate compiler-artifact move experiment did not produce a statistically significant startup improvement and is intentionally excluded from this PR.

## Validation

- cargo fmt --all -- --check
- cargo clippy -p celox --all-targets -- -D warnings
- cargo test -p celox
- cargo test -p celox --test vip_registry with filesystem access
- all test targets after vip_registry, which the sandboxed full run could not reach
- optimized Criterion tiered steady-state and sorter startup benchmarks

## Dependency

This is temporarily stacked on #686 because GitHub still reports that PR as open. Retarget to master after #686 is merged.