### PR TITLE
fix(deps): centralize napi workspace versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,9 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.12.1"
+version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459197f1592f4c3dbbf9c1b13f5a4599a343e4ef66b96bc340e2a518b36a6662"
+checksum = "58c5f4d5375213fdb7be2655e152386e82f026f9a5ba36a75556e11359aafe09"
 dependencies = [
  "bitflags 2.13.0",
  "ctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,9 @@ fxhash          = "0.2.1"
 itertools       = "0.15.0"
 libc            = "0.2"
 miette          = { version = "7.6" }
+napi            = "=3.12.2"
+napi-build      = "=2.4.1"
+napi-derive     = "=3.6.3"
 num-bigint      = { version = "0.5", features = ["serde"] }
 num-traits      = "0.2.19"
 rand            = { version = "0.10", default-features = false }

--- a/crates/celox-napi/Cargo.toml
+++ b/crates/celox-napi/Cargo.toml
@@ -13,8 +13,8 @@ edition.workspace     = true
 crate-type = ["rlib", "cdylib"]
 
 [dependencies]
-napi              = { version = "=3.12.1", features = ["napi8", "serde-json"] }
-napi-derive       = "=3.6.3"
+napi              = { workspace = true, features = ["napi8", "serde-json"] }
+napi-derive       = { workspace = true }
 celox-ts-gen      = { workspace = true }
 celox-design      = { workspace = true }
 veryl-analyzer    = { workspace = true }
@@ -35,7 +35,7 @@ celox = { workspace = true, features = ["host-runtime"] }
 celox = { workspace = true }
 
 [build-dependencies]
-napi-build = "=2.4.1"
+napi-build.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/examples/my-frontend-napi/Cargo.toml
+++ b/examples/my-frontend-napi/Cargo.toml
@@ -10,11 +10,11 @@ crate-type = ["cdylib"]
 [dependencies]
 celox-frontend-sdk = { workspace = true }
 celox-napi = { workspace = true }
-napi = { version = "=3.12.1", features = ["napi8"] }
-napi-derive = "=3.6.3"
+napi = { workspace = true, features = ["napi8"] }
+napi-derive.workspace = true
 
 [build-dependencies]
-napi-build = "=2.4.1"
+napi-build.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

- define napi, napi-build, and napi-derive once in workspace dependencies
- inherit those versions from celox-napi and the frontend NAPI example
- update napi to 3.12.2 and refresh Cargo.lock

This supersedes #678, whose partial napi update leaves the Cargo workspace with conflicting exact version requirements.

## Validation

- cargo fmt --all -- --check
- cargo metadata --locked --no-deps --format-version 1
- cargo test --locked -p celox-napi -p celox-example-my-frontend-napi
- cargo clippy --locked -p celox -p celox-frontend-core -p celox-frontend-sv -p celox-frontend-veryl -p celox-macros -p celox-napi -p celox-sv-analyzer -p celox-ts-gen -p celox-vpi --all-targets --features celox/systemverilog --no-deps
- cargo tree --locked -i napi@3.12.2