### PR TITLE
fix(docs): sync benchmark tabs with URL

### DIFF
--- a/docs/.vitepress/components/BenchmarkDashboard.vue
+++ b/docs/.vitepress/components/BenchmarkDashboard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from "vue";
+import { ref, computed, onBeforeUnmount, onMounted } from "vue";
 import { Line } from "vue-chartjs";
 import {
   Chart as ChartJS,
@@ -62,8 +62,7 @@ interface Series {
     | "heliodor-tiered-x86_64"
     | "heliodor-veryl-x86_64"
     | "heliodor-native-aarch64"
-    | "heliodor-veryl-aarch64"
-    | "unknown";
+    | "heliodor-veryl-aarch64";
   points: SeriesPoint[];
 }
 
@@ -247,7 +246,6 @@ const RUNTIME_COLORS: Record<string, string> = {
   "native-tb": "#f43f5e",
   ts: "#22c55e",
   verilator: "#f97316",
-  unknown: "#9ca3af",
   "heliodor-native-x86_64-jit": "#06b6d4",
   "heliodor-native-x86_64": "#2563eb",
   "heliodor-tiered-x86_64": "#8b5cf6",
@@ -262,7 +260,6 @@ const RUNTIME_LABELS: Record<string, string> = {
   "native-tb": "Celox (native-tb)",
   ts: "Celox (ts)",
   verilator: "Verilator",
-  unknown: "Unknown",
   "heliodor-native-x86_64-jit": "Native x86-64 (JIT code only)",
   "heliodor-native-x86_64": "Native x86-64",
   "heliodor-tiered-x86_64": "Tiered JIT x86-64",
@@ -313,7 +310,7 @@ function normalizeBenchName(benchName: string): string {
   return benchName;
 }
 
-function runtime(name: string): Series["runtime"] {
+function runtime(name: string): Series["runtime"] | null {
   if (name.startsWith("heliodor-celox-jit/")) return "heliodor-native-x86_64-jit";
   if (name.startsWith("heliodor-celox-total/")) return "heliodor-native-x86_64";
   if (name.startsWith("heliodor-celox-compile/")) return "heliodor-native-x86_64";
@@ -329,7 +326,7 @@ function runtime(name: string): Series["runtime"] {
   if (name.startsWith("rust/")) return "rust";
   if (name.startsWith("ts/")) return "ts";
   if (name.startsWith("verilator/")) return "verilator";
-  return "unknown";
+  return null;
 }
 
 function toMicroseconds(value: number, unit: string): number {
@@ -421,6 +418,7 @@ const allSeries = computed<Series[]>(() => {
       for (const b of entry.benches) {
         if (isRetiredBenchmark(b.name)) continue;
         const seriesRuntime = runtime(b.name);
+        if (!seriesRuntime) continue;
         const benchName = normalizeBenchName(stripPrefix(b.name));
         const key = `${seriesRuntime}/${benchName}`;
         let series = seriesByKey.get(key);
@@ -583,9 +581,48 @@ function makeChartOptions() {
 
 const chartOptions = makeChartOptions();
 
+// --- URL synchronization ---
+
+const TAB_QUERY_PARAM = "tab";
+
+function activateTabFromUrl(): boolean {
+  const requestedTab = new URL(window.location.href).searchParams.get(
+    TAB_QUERY_PARAM,
+  );
+  if (!requestedTab || !availableTabs.value.some((tab) => tab.key === requestedTab)) {
+    return false;
+  }
+
+  activeTab.value = requestedTab;
+  return true;
+}
+
+function updateTabInUrl(tab: string, replace = false) {
+  const url = new URL(window.location.href);
+  if (url.searchParams.get(TAB_QUERY_PARAM) === tab) return;
+
+  url.searchParams.set(TAB_QUERY_PARAM, tab);
+  const method = replace ? "replaceState" : "pushState";
+  window.history[method](window.history.state, "", url);
+}
+
+function selectTab(tab: string) {
+  activeTab.value = tab;
+  updateTabInUrl(tab);
+}
+
+function handlePopState() {
+  if (!activateTabFromUrl() && availableTabs.value.length > 0) {
+    activeTab.value = availableTabs.value[0].key;
+    updateTabInUrl(activeTab.value, true);
+  }
+}
+
 // --- Fetch data ---
 
 onMounted(async () => {
+  window.addEventListener("popstate", handlePopState);
+
   try {
     const res = await fetch("/celox/dev/bench/data.js");
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -600,10 +637,15 @@ onMounted(async () => {
     loading.value = false;
   }
 
-  // Default to first tab that has data
-  if (availableTabs.value.length > 0) {
+  // Restore a linked tab, or default to the first tab that has data.
+  if (!activateTabFromUrl() && availableTabs.value.length > 0) {
     activeTab.value = availableTabs.value[0].key;
+    updateTabInUrl(activeTab.value, true);
   }
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener("popstate", handlePopState);
 });
 </script>
 
@@ -628,7 +670,7 @@ onMounted(async () => {
           v-for="tab in availableTabs"
           :key="tab.key"
           :class="['bench-tab', { active: activeTab === tab.key }]"
-          @click="activeTab = tab.key"
+          @click="selectTab(tab.key)"
         >
           {{ tab.label }}
         </button>

--- a/docs/.vitepress/components/BenchmarkDashboard.vue
+++ b/docs/.vitepress/components/BenchmarkDashboard.vue
@@ -584,6 +584,7 @@ const chartOptions = makeChartOptions();
 // --- URL synchronization ---
 
 const TAB_QUERY_PARAM = "tab";
+let dashboardPathname = "";
 
 function activateTabFromUrl(): boolean {
   const requestedTab = new URL(window.location.href).searchParams.get(
@@ -612,6 +613,8 @@ function selectTab(tab: string) {
 }
 
 function handlePopState() {
+  if (window.location.pathname !== dashboardPathname) return;
+
   if (!activateTabFromUrl() && availableTabs.value.length > 0) {
     activeTab.value = availableTabs.value[0].key;
     updateTabInUrl(activeTab.value, true);
@@ -621,6 +624,7 @@ function handlePopState() {
 // --- Fetch data ---
 
 onMounted(async () => {
+  dashboardPathname = window.location.pathname;
   window.addEventListener("popstate", handlePopState);
 
   try {


### PR DESCRIPTION
## Summary

- omit unclassified benchmark series instead of rendering an Unknown legend
- reflect the selected dashboard tab in the `?tab=` query parameter
- restore linked tabs and support browser back/forward navigation

## Validation

- `node_modules/.bin/vitepress build docs`
- confirmed the generated dashboard bundle contains no Unknown label