### PR TITLE
fix(veryl): restore coverage and typed array arguments

### DIFF
--- a/crates/celox-frontend-veryl/src/lowering/logic_tree.rs
+++ b/crates/celox-frontend-veryl/src/lowering/logic_tree.rs
@@ -2704,8 +2704,14 @@ fn eval_statement_form_function_call(
             )
         })?;
         let arg_width = resolve_total_width(module, formal)?;
-        let ((arg_node, arg_sources), arg_bounds) =
-            eval_assignment_expression_effectful(module, &mut store, arg_expr, arena, arg_width)?;
+        let ((arg_node, arg_sources), arg_bounds) = expr::eval_function_input_assignment_effectful(
+            module,
+            &mut store,
+            arg_expr,
+            &formal.r#type,
+            arg_width,
+            arena,
+        )?;
         let arg_node = if formal.r#type.is_2state() && !arg_expr.comptime().r#type.is_2state() {
             arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, arg_node))?
         } else {

--- a/crates/celox-frontend-veryl/src/lowering/logic_tree/effect.rs
+++ b/crates/celox-frontend-veryl/src/lowering/logic_tree/effect.rs
@@ -405,12 +405,13 @@ fn collect_function_call_effects(
 
         let formal = &module.variables[&arg_id];
         let arg_width = resolve_total_width(module, formal)?;
-        let ((arg_node, arg_sources), _) = eval_assignment_expression_effectful(
+        let ((arg_node, arg_sources), _) = expr::eval_function_input_assignment_effectful(
             module,
             &mut actual_store,
             arg_expr,
-            arena,
+            &formal.r#type,
             arg_width,
+            arena,
         )?;
         let arg_node = if formal.r#type.is_2state() && !arg_expr.comptime().r#type.is_2state() {
             arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, arg_node))?

--- a/crates/celox-frontend-veryl/src/lowering/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/lowering/logic_tree/expr.rs
@@ -256,6 +256,26 @@ fn eval_array_literal_item_in_store(
     Ok(((arena.alloc(SLTNode::Concat(parts))?, sources), bounds))
 }
 
+fn eval_array_literal_default_in_store(
+    module: &Module,
+    store: &mut ExpressionStore<'_>,
+    expr: &Expression,
+    context: Option<ArrayLiteralItemContext<'_>>,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+    // A scalar default fills scalar leaves even when the current literal level
+    // still represents additional unpacked dimensions. Convert it once as a
+    // formal element; the caller then replicates that converted element across
+    // all remaining aggregate width.
+    if let Some(context) = context
+        && expr.comptime().r#type.array.is_empty()
+    {
+        eval_assignment_expression_in_store(module, store, expr, arena, context.element_width)
+    } else {
+        eval_array_literal_item_in_store(module, store, expr, context, arena)
+    }
+}
+
 fn eval_array_literal_expression_with_item_context(
     module: &Module,
     store: &mut ExpressionStore<'_>,
@@ -312,7 +332,7 @@ fn eval_array_literal_expression_with_item_context(
                     ));
                 }
 
-                let ((part_expr, part_sources), p_bounds) = eval_array_literal_item_in_store(
+                let ((part_expr, part_sources), p_bounds) = eval_array_literal_default_in_store(
                     module,
                     store,
                     default_expr,

--- a/crates/celox-frontend-veryl/src/lowering/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/lowering/logic_tree/expr.rs
@@ -61,6 +61,72 @@ fn eval_array_literal_expression_in_store(
     )
 }
 
+fn eval_function_input_assignment_in_store(
+    module: &Module,
+    store: &mut ExpressionStore<'_>,
+    expr: &Expression,
+    target_type: &Type,
+    target_width: usize,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+    if target_type.array.is_empty() {
+        return eval_assignment_expression_in_store(module, store, expr, arena, target_width);
+    }
+
+    let element_width = target_type.total_width().ok_or_else(|| {
+        ParserError::illegal_context(
+            "function input argument",
+            format!("unresolved element width for {target_type}"),
+            Some(&expr.token_range()),
+        )
+    })?;
+    let value = if let Expression::ArrayLiteral(items, _) = expr {
+        eval_array_literal_expression_with_item_context(
+            module,
+            store,
+            items,
+            Some(target_width),
+            Some(ArrayLiteralItemContext {
+                array_shape: &target_type.array.as_slice()[1..],
+                element_width,
+            }),
+            arena,
+        )?
+    } else {
+        eval_array_literal_item_in_store(
+            module,
+            store,
+            expr,
+            Some(ArrayLiteralItemContext {
+                array_shape: target_type.array.as_slice(),
+                element_width,
+            }),
+            arena,
+        )?
+    };
+
+    finish_assignment_expression(expr, arena, target_width, value)
+}
+
+pub(crate) fn eval_function_input_assignment_effectful(
+    module: &Module,
+    store: &mut SymbolicStore<VarId>,
+    expr: &Expression,
+    target_type: &Type,
+    target_width: usize,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+    let mut store = ExpressionStore::Effectful(store);
+    eval_function_input_assignment_in_store(
+        module,
+        &mut store,
+        expr,
+        target_type,
+        target_width,
+        arena,
+    )
+}
+
 #[derive(Clone, Copy)]
 struct ArrayLiteralItemContext<'a> {
     array_shape: &'a [Option<usize>],
@@ -2244,27 +2310,14 @@ fn eval_function_call_expression(
             ));
         };
         let arg_width = resolve_total_width(module, arg_var)?;
-        let value = if let Expression::ArrayLiteral(items, _) = arg_expr
-            && !arg_var.r#type.array.is_empty()
-        {
-            let item_context = ArrayLiteralItemContext {
-                array_shape: &arg_var.r#type.array.as_slice()[1..],
-                element_width: arg_var.r#type.total_width().ok_or_else(|| {
-                    ParserError::unresolved_width(module, arg_var, arg_var.r#type.to_string())
-                })?,
-            };
-            let value = eval_array_literal_expression_with_item_context(
-                module,
-                store,
-                items,
-                Some(arg_width),
-                Some(item_context),
-                arena,
-            )?;
-            finish_assignment_expression(arg_expr, arena, arg_width, value)?
-        } else {
-            eval_assignment_expression_in_store(module, store, arg_expr, arena, arg_width)?
-        };
+        let value = eval_function_input_assignment_in_store(
+            module,
+            store,
+            arg_expr,
+            &arg_var.r#type,
+            arg_width,
+            arena,
+        )?;
         let ((arg_node, sources), bounds) = value;
         let arg_node = if arg_var.r#type.is_2state() && !arg_expr.comptime().r#type.is_2state() {
             arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, arg_node))?

--- a/crates/celox-frontend-veryl/src/lowering/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/lowering/logic_tree/expr.rs
@@ -77,7 +77,54 @@ fn eval_array_literal_item_in_store(
     let Some(context) = context else {
         return eval_expression_in_context(module, store, expr, arena, None);
     };
+
+    // A nested literal occupies the remaining unpacked dimensions. Keep
+    // carrying the formal shape down so every level gets the same index-order
+    // conversion, and the scalar leaves are sized as formal elements.
+    if let Expression::ArrayLiteral(items, _) = expr
+        && !context.array_shape.is_empty()
+    {
+        let target_width = context
+            .array_shape
+            .iter()
+            .try_fold(context.element_width, |width, dim| {
+                width.checked_mul((*dim)?)
+            })
+            .ok_or_else(|| {
+                ParserError::illegal_context(
+                    "array literal item",
+                    "unresolved or overflowing nested array shape",
+                    Some(&expr.token_range()),
+                )
+            })?;
+        let value = eval_array_literal_expression_with_item_context(
+            module,
+            store,
+            items,
+            Some(target_width),
+            Some(ArrayLiteralItemContext {
+                array_shape: &context.array_shape[1..],
+                element_width: context.element_width,
+            }),
+            arena,
+        )?;
+        return finish_assignment_expression(expr, arena, target_width, value);
+    }
+
     let source_type = &expr.comptime().r#type;
+
+    // A scalar leaf is assigned to one formal element, not concatenated at
+    // its natural width and widened after the aggregate has been assembled.
+    if source_type.array.is_empty() && context.array_shape.is_empty() {
+        return eval_assignment_expression_in_store(
+            module,
+            store,
+            expr,
+            arena,
+            context.element_width,
+        );
+    }
+
     if source_type.array.as_slice() != context.array_shape || source_type.array.is_empty() {
         return eval_expression_in_context(module, store, expr, arena, None);
     }

--- a/crates/celox-frontend-veryl/src/lowering/logic_tree/expr.rs
+++ b/crates/celox-frontend-veryl/src/lowering/logic_tree/expr.rs
@@ -51,6 +51,106 @@ fn eval_array_literal_expression_in_store(
     expected_width: Option<usize>,
     arena: &mut SLTNodeArena<VarId>,
 ) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+    eval_array_literal_expression_with_item_context(
+        module,
+        store,
+        items,
+        expected_width,
+        None,
+        arena,
+    )
+}
+
+#[derive(Clone, Copy)]
+struct ArrayLiteralItemContext<'a> {
+    array_shape: &'a [Option<usize>],
+    element_width: usize,
+}
+
+fn eval_array_literal_item_in_store(
+    module: &Module,
+    store: &mut ExpressionStore<'_>,
+    expr: &Expression,
+    context: Option<ArrayLiteralItemContext<'_>>,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
+    let Some(context) = context else {
+        return eval_expression_in_context(module, store, expr, arena, None);
+    };
+    let source_type = &expr.comptime().r#type;
+    if source_type.array.as_slice() != context.array_shape || source_type.array.is_empty() {
+        return eval_expression_in_context(module, store, expr, arena, None);
+    }
+
+    // An array-valued item occupies one aggregate slot in the surrounding
+    // assignment pattern. Evaluate it once, then apply the destination's
+    // scalar conversion independently to every element. Coercing the flattened
+    // value as a whole would put all extension bits at one end of the array.
+    let ((source, sources), bounds) = eval_expression_in_context(module, store, expr, arena, None)?;
+    let source_element_width = source_type.total_width().ok_or_else(|| {
+        ParserError::illegal_context(
+            "array literal item",
+            format!("unresolved element width for {source_type}"),
+            Some(&expr.token_range()),
+        )
+    })?;
+    let element_count = source_type.total_array().ok_or_else(|| {
+        ParserError::illegal_context(
+            "array literal item",
+            format!("unresolved array shape for {source_type}"),
+            Some(&expr.token_range()),
+        )
+    })?;
+    let expected_source_width =
+        source_element_width
+            .checked_mul(element_count)
+            .ok_or_else(|| {
+                ParserError::illegal_context(
+                    "array literal item",
+                    "array item width overflows usize",
+                    Some(&expr.token_range()),
+                )
+            })?;
+    let source_width = get_width(source, arena);
+    if source_width != expected_source_width {
+        return Err(ParserError::illegal_context(
+            "array literal item",
+            format!(
+                "expression width {source_width} does not match its array type width {expected_source_width}"
+            ),
+            Some(&expr.token_range()),
+        ));
+    }
+
+    // Array index zero is stored at the least-significant end. Concat accepts
+    // most-significant parts first, so visit semantic elements in reverse.
+    let mut parts = Vec::with_capacity(element_count);
+    for index in (0..element_count).rev() {
+        let lsb = index * source_element_width;
+        let element = arena.alloc(SLTNode::Slice {
+            expr: source,
+            access: BitAccess::new(lsb, lsb + source_element_width - 1),
+        })?;
+        let element = coerce_node_width(
+            arena,
+            element,
+            Some(context.element_width),
+            expression_signed(expr),
+        )?;
+        parts.push((element, context.element_width));
+    }
+
+    Ok(((arena.alloc(SLTNode::Concat(parts))?, sources), bounds))
+}
+
+fn eval_array_literal_expression_with_item_context(
+    module: &Module,
+    store: &mut ExpressionStore<'_>,
+    items: &[ArrayLiteralItem],
+    expected_width: Option<usize>,
+    item_context: Option<ArrayLiteralItemContext<'_>>,
+    arena: &mut SLTNodeArena<VarId>,
+) -> Result<((NodeId, HashSet<VarAtomBase<VarId>>), BoundaryMap<VarId>), ParserError> {
     let mut parts = Vec::new();
     let mut all_bounds = BoundaryMap::default();
     let mut total_sources = HashSet::default();
@@ -62,7 +162,7 @@ fn eval_array_literal_expression_in_store(
         match item {
             ArrayLiteralItem::Value(sub_expr, repeat) => {
                 let ((part_expr, part_sources), p_bounds) =
-                    eval_expression_in_context(module, store, sub_expr, arena, None)?;
+                    eval_array_literal_item_in_store(module, store, sub_expr, item_context, arena)?;
                 all_bounds = merge_boundaries(all_bounds, p_bounds);
                 total_sources.extend(part_sources);
 
@@ -99,8 +199,13 @@ fn eval_array_literal_expression_in_store(
                     ));
                 }
 
-                let ((part_expr, part_sources), p_bounds) =
-                    eval_expression_in_context(module, store, default_expr, arena, None)?;
+                let ((part_expr, part_sources), p_bounds) = eval_array_literal_item_in_store(
+                    module,
+                    store,
+                    default_expr,
+                    item_context,
+                    arena,
+                )?;
                 all_bounds = merge_boundaries(all_bounds, p_bounds);
                 total_sources.extend(part_sources);
                 let width = get_width(part_expr, arena);
@@ -150,10 +255,13 @@ fn eval_array_literal_expression_in_store(
         }
     }
 
-    Ok((
-        (arena.alloc(SLTNode::Concat(parts))?, total_sources),
-        all_bounds,
-    ))
+    // Unpacked array index zero is stored at the least-significant end, while
+    // source-order evaluation must remain left-to-right.
+    if item_context.is_some() {
+        parts.reverse();
+    }
+    let result = arena.alloc(SLTNode::Concat(parts))?;
+    Ok(((result, total_sources), all_bounds))
 }
 
 pub(super) fn eval_function_body_return(
@@ -2089,8 +2197,28 @@ fn eval_function_call_expression(
             ));
         };
         let arg_width = resolve_total_width(module, arg_var)?;
-        let ((arg_node, sources), bounds) =
-            eval_assignment_expression_in_store(module, store, arg_expr, arena, arg_width)?;
+        let value = if let Expression::ArrayLiteral(items, _) = arg_expr
+            && !arg_var.r#type.array.is_empty()
+        {
+            let item_context = ArrayLiteralItemContext {
+                array_shape: &arg_var.r#type.array.as_slice()[1..],
+                element_width: arg_var.r#type.total_width().ok_or_else(|| {
+                    ParserError::unresolved_width(module, arg_var, arg_var.r#type.to_string())
+                })?,
+            };
+            let value = eval_array_literal_expression_with_item_context(
+                module,
+                store,
+                items,
+                Some(arg_width),
+                Some(item_context),
+                arena,
+            )?;
+            finish_assignment_expression(arg_expr, arena, arg_width, value)?
+        } else {
+            eval_assignment_expression_in_store(module, store, arg_expr, arena, arg_width)?
+        };
+        let ((arg_node, sources), bounds) = value;
         let arg_node = if arg_var.r#type.is_2state() && !arg_expr.comptime().r#type.is_2state() {
             arena.alloc(SLTNode::Unary(UnaryOp::ToTwoState, arg_node))?
         } else {

--- a/crates/celox/tests/array_literal.rs
+++ b/crates/celox/tests/array_literal.rs
@@ -143,7 +143,7 @@ arr[0] = 8'hAB;
     }
 
     fn test_array_literal_single_element_size_one_array(sim) {
-        @ignore_on(veryl, sv);
+        @ignore_on(sv);
         @setup { // '{val} on a 1-element array should still assign that one element correctly.
 let code = r#"
 module Top (
@@ -316,7 +316,7 @@ assign o3 = a[3];
 
     // '{default: 0} in always_ff if_reset: array reset via default fill.
     fn test_array_literal_default_in_ff_reset(sim) {
-        @ignore_on(veryl, sv);
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 clk: input clock,

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -2543,6 +2543,90 @@ module Top (
     assert_eq!(sim.drain_runtime_events(), vec![]);
 }
 
+fn test_comb_function_packed_array_literal_preserves_source_order(sim) {
+    @ignore_on(veryl, sv); // https://github.com/veryl-lang/veryl/pull/3131
+    @build Simulator::builder(r#"
+module Top (
+    q: output logic<2>,
+    side: output logic<8>,
+) {
+    function observe (
+        value: input logic<8>,
+        written: output logic<8>,
+    ) -> logic {
+        written = value;
+        return value[0];
+    }
+    function identity (x: input logic<2>) -> logic<2> {
+        return x;
+    }
+
+    always_comb {
+        side = 0;
+        q = identity('{default: observe(8'h11, side), observe(8'h22, side)});
+    }
+}
+"#, "Top");
+
+    let side = sim.signal("side");
+    assert_eq!(sim.get_as::<u8>(side), 0x22);
+}
+
+fn test_comb_function_array_literal_array_item_preserves_element_type(sim) {
+    @ignore_on(veryl, sv); // https://github.com/veryl-lang/veryl/pull/3131
+    @build Simulator::builder(r#"
+module Top (
+    q: output signed logic<8>,
+) {
+    function first (x: input signed logic<8> [2, 2]) -> signed logic<8> {
+        return x[0][0];
+    }
+    function pass (
+        row0: input signed logic<4> [2],
+        row1: input signed logic<4> [2],
+    ) -> signed logic<8> {
+        return first('{row0, row1});
+    }
+
+    always_comb {
+        q = pass('{4'h8, 4'h0}, '{4'h1, 4'h2});
+    }
+}
+"#, "Top");
+
+    let q = sim.signal("q");
+    assert_eq!(sim.get_as::<u8>(q), 0xf8);
+}
+
+fn test_comb_function_array_literal_accepts_array_returning_items(sim) {
+    @ignore_on(veryl, sv); // https://github.com/veryl-lang/veryl/pull/3131
+    @build Simulator::builder(r#"
+module Top (
+    q: output logic<4>,
+) {
+    type row_t = logic<4> [2];
+    type matrix_t = logic<4> [2, 2];
+
+    function make_row (base: input logic<4>) -> row_t {
+        var row: row_t;
+        row[0] = base;
+        row[1] = base + 1;
+        return row;
+    }
+    function pick (x: input matrix_t) -> logic<4> {
+        return x[1][0];
+    }
+
+    always_comb {
+        q = pick('{make_row(1), make_row(3)});
+    }
+}
+"#, "Top");
+
+    let q = sim.signal("q");
+    assert_eq!(sim.get_as::<u8>(q), 3);
+}
+
 fn test_named_function_inputs_evaluate_in_source_order(sim) {
     @ignore_on(sv);
     @build Simulator::builder(r#"

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -2760,6 +2760,90 @@ module Top (
     assert_eq!(sim.get_as::<u8>(q), 3);
 }
 
+fn test_comb_function_direct_array_argument_converts_each_element(sim) {
+    @ignore_on(veryl, sv);
+    @build Simulator::builder(r#"
+module Top (
+    q0: output signed logic<8>,
+    q1: output signed logic<8>,
+) {
+    function pick (
+        x: input signed logic<8> [2],
+        index: input logic,
+    ) -> signed logic<8> {
+        return x[index];
+    }
+
+    var narrow: signed logic<4> [2];
+    always_comb {
+        narrow[0] = 4'sh8;
+        narrow[1] = 4'sh1;
+        q0 = pick(narrow, 0);
+        q1 = pick(narrow, 1);
+    }
+}
+"#, "Top");
+
+    let q0 = sim.signal("q0");
+    let q1 = sim.signal("q1");
+    assert_eq!(sim.get_as::<u8>(q0), 0xf8);
+    assert_eq!(sim.get_as::<u8>(q1), 0x01);
+}
+
+fn test_comb_function_direct_array_return_preserves_all_elements(sim) {
+    @ignore_on(veryl, sv);
+    @build Simulator::builder(r#"
+module Top (
+    q: output logic<4>,
+) {
+    type row_t = logic<4> [2];
+
+    function make_row () -> row_t {
+        var row: row_t;
+        row[0] = 4'd3;
+        row[1] = 4'd4;
+        return row;
+    }
+    function pick (x: input row_t) -> logic<4> {
+        return x[1];
+    }
+
+    always_comb {
+        q = pick(make_row());
+    }
+}
+"#, "Top");
+
+    let q = sim.signal("q");
+    assert_eq!(sim.get_as::<u8>(q), 4);
+}
+
+fn test_comb_statement_function_direct_array_argument_converts_each_element(sim) {
+    @ignore_on(veryl, sv);
+    @build Simulator::builder(r#"
+module Top (
+    q: output signed logic<8>,
+) {
+    function capture (
+        x: input signed logic<8> [2],
+        dst: output signed logic<8>,
+    ) {
+        dst = x[0];
+    }
+
+    var narrow: signed logic<4> [2];
+    always_comb {
+        narrow[0] = 4'sh8;
+        narrow[1] = 4'sh1;
+        capture(narrow, q);
+    }
+}
+"#, "Top");
+
+    let q = sim.signal("q");
+    assert_eq!(sim.get_as::<u8>(q), 0xf8);
+}
+
 fn test_named_function_inputs_evaluate_in_source_order(sim) {
     @ignore_on(sv);
     @build Simulator::builder(r#"

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -807,6 +807,52 @@ module Top {
     );
 }
 
+fn test_veryl_adapter_modify_rechecks_constant_initial_fatal(sim) {
+    @ignore_on(native, cranelift, wasm, interp, sv);
+    @build Simulator::builder(r#"
+module Top (
+    trigger: input logic,
+) {
+    always_comb {
+        $assert(1'd0, "constant fatal after modify");
+    }
+}
+"#, "Top");
+
+    let trigger = sim.signal("trigger");
+    let err = sim.modify(|io| io.set(trigger, 1u8)).unwrap_err();
+    assert_eq!(
+        err,
+        celox::RuntimeErrorCode::Runtime {
+            message: "constant fatal after modify".to_string(),
+            signals: Vec::new(),
+        },
+    );
+}
+
+fn test_veryl_adapter_does_not_parse_user_assertion_as_true_loop(sim) {
+    @ignore_on(native, cranelift, wasm, interp, sv);
+    @build Simulator::builder(r#"
+module Top {
+    always_comb {
+        $assert(
+            1'd0,
+            "user says for-loop step does not advance the loop variable"
+        );
+    }
+}
+"#, "Top");
+
+    let err = sim.eval_comb().unwrap_err();
+    assert_eq!(
+        err,
+        celox::RuntimeErrorCode::Runtime {
+            message: "user says for-loop step does not advance the loop variable".to_string(),
+            signals: Vec::new(),
+        },
+    );
+}
+
 fn test_comb_sensitive_display_runs_on_initial_eval(sim) {
     @omit_veryl;
     @ignore_on(wasm, sv);
@@ -2590,6 +2636,73 @@ module Top (
 
     let side = sim.signal("side");
     assert_eq!(sim.get_as::<u8>(side), 0x22);
+}
+
+fn test_comb_function_nested_array_literals_preserve_each_dimension_order(sim) {
+    @ignore_on(veryl, sv); // https://github.com/veryl-lang/veryl/pull/3131
+    @build Simulator::builder(r#"
+module Top (
+    q00: output logic<4>,
+    q01: output logic<4>,
+    q10: output logic<4>,
+    q11: output logic<4>,
+) {
+    function pick (
+        x: input logic<4> [2, 2],
+        row: input logic,
+        col: input logic,
+    ) -> logic<4> {
+        return x[row][col];
+    }
+
+    always_comb {
+        q00 = pick('{'{4'h1, 4'h2}, '{4'h3, 4'h4}}, 0, 0);
+        q01 = pick('{'{4'h1, 4'h2}, '{4'h3, 4'h4}}, 0, 1);
+        q10 = pick('{'{4'h1, 4'h2}, '{4'h3, 4'h4}}, 1, 0);
+        q11 = pick('{'{4'h1, 4'h2}, '{4'h3, 4'h4}}, 1, 1);
+    }
+}
+"#, "Top");
+
+    let q00 = sim.signal("q00");
+    let q01 = sim.signal("q01");
+    let q10 = sim.signal("q10");
+    let q11 = sim.signal("q11");
+    assert_eq!(sim.get_as::<u8>(q00), 1);
+    assert_eq!(sim.get_as::<u8>(q01), 2);
+    assert_eq!(sim.get_as::<u8>(q10), 3);
+    assert_eq!(sim.get_as::<u8>(q11), 4);
+}
+
+fn test_comb_function_array_literal_converts_scalar_items_per_element(sim) {
+    @ignore_on(veryl, sv); // https://github.com/veryl-lang/veryl/pull/3131
+    @build Simulator::builder(r#"
+module Top (
+    q0: output signed logic<8>,
+    q1: output signed logic<8>,
+    q_default: output signed logic<8>,
+) {
+    function pick (
+        x: input signed logic<8> [2],
+        index: input logic,
+    ) -> signed logic<8> {
+        return x[index];
+    }
+
+    always_comb {
+        q0 = pick('{4'sh8, 4'sh1}, 0);
+        q1 = pick('{4'sh8, 4'sh1}, 1);
+        q_default = pick('{default: 4'sh8}, 1);
+    }
+}
+"#, "Top");
+
+    let q0 = sim.signal("q0");
+    let q1 = sim.signal("q1");
+    let q_default = sim.signal("q_default");
+    assert_eq!(sim.get_as::<u8>(q0), 0xf8);
+    assert_eq!(sim.get_as::<u8>(q1), 0x01);
+    assert_eq!(sim.get_as::<u8>(q_default), 0xf8);
 }
 
 fn test_comb_function_array_literal_array_item_preserves_element_type(sim) {

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -2705,6 +2705,42 @@ module Top (
     assert_eq!(sim.get_as::<u8>(q_default), 0xf8);
 }
 
+fn test_comb_function_nested_array_scalar_default_converts_each_element(sim) {
+    @ignore_on(veryl, sv);
+    @build Simulator::builder(r#"
+module Top (
+    q00: output signed logic<8>,
+    q01: output signed logic<8>,
+    q10: output signed logic<8>,
+    q11: output signed logic<8>,
+) {
+    function pick (
+        x: input signed logic<8> [2, 2],
+        row: input logic,
+        col: input logic,
+    ) -> signed logic<8> {
+        return x[row][col];
+    }
+
+    always_comb {
+        q00 = pick('{default: 4'sh8}, 0, 0);
+        q01 = pick('{default: 4'sh8}, 0, 1);
+        q10 = pick('{default: 4'sh8}, 1, 0);
+        q11 = pick('{default: 4'sh8}, 1, 1);
+    }
+}
+"#, "Top");
+
+    let q00 = sim.signal("q00");
+    let q01 = sim.signal("q01");
+    let q10 = sim.signal("q10");
+    let q11 = sim.signal("q11");
+    assert_eq!(sim.get_as::<u8>(q00), 0xf8);
+    assert_eq!(sim.get_as::<u8>(q01), 0xf8);
+    assert_eq!(sim.get_as::<u8>(q10), 0xf8);
+    assert_eq!(sim.get_as::<u8>(q11), 0xf8);
+}
+
 fn test_comb_function_array_literal_array_item_preserves_element_type(sim) {
     @ignore_on(veryl, sv); // https://github.com/veryl-lang/veryl/pull/3131
     @build Simulator::builder(r#"
@@ -2842,6 +2878,29 @@ module Top (
 
     let q = sim.signal("q");
     assert_eq!(sim.get_as::<u8>(q), 0xf8);
+}
+
+fn test_comb_function_effects_use_typed_array_arguments(sim) {
+    @omit_veryl;
+    @ignore_on(wasm, sv);
+    @build Simulator::builder(r#"
+module Top (
+    q: output signed logic<8>,
+) {
+    function check (x: input signed logic<8> [2]) -> signed logic<8> {
+        $assert_continue(x[0] == 8'shf8, "bad typed array value");
+        return x[0];
+    }
+
+    always_comb {
+        q = check('{4'sh8, 4'sh1});
+    }
+}
+"#, "Top");
+
+    let q = sim.signal("q");
+    assert_eq!(sim.get_as::<u8>(q), 0xf8);
+    assert_eq!(sim.drain_runtime_events(), vec![]);
 }
 
 fn test_named_function_inputs_evaluate_in_source_order(sim) {

--- a/crates/celox/tests/comb_observer.rs
+++ b/crates/celox/tests/comb_observer.rs
@@ -787,6 +787,26 @@ module Top {
     );
 }
 
+fn test_veryl_adapter_preserves_fatal_from_initial_settle(sim) {
+    @ignore_on(native, cranelift, wasm, interp, sv);
+    @build Simulator::builder(r#"
+module Top {
+    always_comb {
+        $assert(1'd0, "initial fatal");
+    }
+}
+"#, "Top");
+
+    let err = sim.eval_comb().unwrap_err();
+    assert_eq!(
+        err,
+        celox::RuntimeErrorCode::Runtime {
+            message: "initial fatal".to_string(),
+            signals: Vec::new(),
+        },
+    );
+}
+
 fn test_comb_sensitive_display_runs_on_initial_eval(sim) {
     @omit_veryl;
     @ignore_on(wasm, sv);

--- a/crates/celox/tests/context_width.rs
+++ b/crates/celox/tests/context_width.rs
@@ -159,7 +159,6 @@ fn test_addition_different_widths(sim) {
 }
 
 fn test_ff_width_propagation(sim) {
-    @ignore_on(veryl);
     @setup { let code = r#"
         module Top (
             clk: input clock,

--- a/crates/celox/tests/counter.rs
+++ b/crates/celox/tests/counter.rs
@@ -8,7 +8,7 @@ all_backends! {
 
     // Simple counter: increment on each tick, reset to 0
     fn test_counter_n4_basic(sim) {
-        @ignore_on(veryl, sv);
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 clk: input clock,
@@ -64,7 +64,7 @@ else { cnt[i] += 1; }
 
     // Large counter array (similar to bench)
     fn test_counter_n100_wrap(sim) {
-        @ignore_on(veryl, sv);
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top #(param N: u32 = 100) (
 clk: input clock,

--- a/crates/celox/tests/false_loop.rs
+++ b/crates/celox/tests/false_loop.rs
@@ -282,7 +282,6 @@ fn test_large_scc_dynamic_loop_convergence(sim) {
 fn test_read_then_overwrite_convergence(sim) {
     // This exercises Celox's fixed-point scheduling. The Veryl simulator
     // adapter evaluates these continuous assignments in source order.
-    @ignore_on(veryl);
     @setup { let code = r#"
         module Top (
             i: input logic,

--- a/crates/celox/tests/flip_flop.rs
+++ b/crates/celox/tests/flip_flop.rs
@@ -4973,7 +4973,6 @@ fn test_ff_runtime_for_unsigned_slice_bound_zero_extends_signed_source(sim) {
 }
 
 fn test_ff_if_reset_basic(sim) {
-    @ignore_on(veryl);
     @setup { let code = r#"
         module Top (clk: input clock, rst: input reset, d: input logic<8>, q: output logic<8>) {
             always_ff (clk, rst) {
@@ -5040,7 +5039,6 @@ fn test_async_reset(sim) {
 }
 
 fn test_ff_swap_correctness(sim) {
-    @ignore_on(veryl);
     @setup { let code = r#"
         module Top (clk: input clock, rst: input reset, a: output logic<8>, b: output logic<8>) {
             var r1: logic<8>;
@@ -5168,7 +5166,6 @@ fn test_multiple_async_resets(sim) {
 }
 
 fn test_ff_if_reset_multi_cycle(sim) {
-    @ignore_on(veryl);
     @setup { let code = r#"
         module Top (clk: input clock, rst: input reset, q: output logic<8>) {
             always_ff (clk, rst) {

--- a/crates/celox/tests/four_state.rs
+++ b/crates/celox/tests/four_state.rs
@@ -9,7 +9,6 @@ all_backends! {
 
 
 fn test_four_state_and_or(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -242,7 +241,6 @@ fn test_four_state_mixing_propagation(sim) {
 }
 
 fn test_read_a(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -262,7 +260,6 @@ fn test_read_a(sim) {
 }
 
 fn test_four_state_arithmetic_ops(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -304,7 +301,6 @@ fn test_four_state_arithmetic_ops(sim) {
 }
 
 fn test_four_state_unary_ops(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -352,7 +348,6 @@ fn test_four_state_unary_ops(sim) {
 // Bitwise XOR with partial X
 // ==========================================================================
 fn test_four_state_xor_partial_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -391,7 +386,6 @@ fn test_four_state_xor_partial_x(sim) {
 // Concatenation with X
 // ==========================================================================
 fn test_four_state_concat(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -432,7 +426,6 @@ fn test_four_state_concat(sim) {
 // Shift with constant amount (mask should shift too)
 // ==========================================================================
 fn test_four_state_shift_by_constant(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -480,7 +473,6 @@ fn test_four_state_shift_by_constant(sim) {
 // Shift by X amount → full X output
 // ==========================================================================
 fn test_four_state_shift_by_x_amount(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -609,7 +601,6 @@ fn test_four_state_mux_x_condition(sim) {
 // Mux with defined condition, X in selected branch
 // ==========================================================================
 fn test_four_state_mux_x_in_branch(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -665,7 +656,6 @@ fn test_four_state_mux_x_in_branch(sim) {
 // Multi-word (128-bit) with X mask
 // ==========================================================================
 fn test_four_state_wide_128bit(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -720,7 +710,6 @@ fn test_four_state_wide_128bit(sim) {
 // always_comb chain with X propagation
 // ==========================================================================
 fn test_four_state_always_comb_chain(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -767,7 +756,7 @@ fn test_four_state_always_comb_chain(sim) {
 // always_ff: X captured in FF, reset clears X
 // ==========================================================================
 fn test_four_state_ff_capture_and_reset(sim) {
-    @ignore_on(veryl, sv);
+    @ignore_on(sv);
     @setup {
     let code = r#"
         module Top (
@@ -842,7 +831,6 @@ fn test_four_state_ff_capture_and_reset(sim) {
 // Defined inputs in 4-state mode → same as 2-state behavior
 // ==========================================================================
 fn test_four_state_all_defined(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -900,7 +888,6 @@ fn test_four_state_all_defined(sim) {
 }
 
 fn test_four_state_wide_128bit_simple(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1002,7 +989,6 @@ fn test_four_state_wide_shifts(sim) {
 // Multi-word (128-bit) Arithmetic with X (Conservative all-X)
 // ==========================================================================
 fn test_four_state_wide_arith(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1047,7 +1033,6 @@ fn test_four_state_wide_arith(sim) {
 // Multi-word (128-bit) Signed Ops with X
 // ==========================================================================
 fn test_four_state_wide_signed(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1105,7 +1090,6 @@ fn test_four_state_wide_signed(sim) {
 // Multi-word (128-bit) Concatenation with Mixed 2-state/4-state
 // ==========================================================================
 fn test_four_state_wide_concat_mixed(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1147,7 +1131,6 @@ fn test_four_state_wide_concat_mixed(sim) {
 // P0: MUL / DIV / MOD + X (conservative all-X)
 // ==========================================================================
 fn test_four_state_mul_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1195,7 +1178,6 @@ fn test_four_state_mul_with_x(sim) {
 }
 
 fn test_four_state_div_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1243,7 +1225,6 @@ fn test_four_state_div_with_x(sim) {
 }
 
 fn test_four_state_mod_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1333,7 +1314,6 @@ fn test_four_state_ne_with_x(sim) {
 }
 
 fn test_four_state_gt_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1372,7 +1352,6 @@ fn test_four_state_gt_with_x(sim) {
 }
 
 fn test_four_state_ge_le_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1419,7 +1398,6 @@ fn test_four_state_ge_le_with_x(sim) {
 }
 
 fn test_four_state_signed_comparison_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1479,7 +1457,6 @@ fn test_four_state_signed_comparison_with_x(sim) {
 // P0: Reduction XOR + X
 // ==========================================================================
 fn test_four_state_reduction_xor_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1522,7 +1499,6 @@ fn test_four_state_reduction_xor_with_x(sim) {
 // P0: 65-bit width (1→2 chunk boundary)
 // ==========================================================================
 fn test_four_state_65bit_boundary(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1583,7 +1559,6 @@ fn test_four_state_65bit_boundary(sim) {
 // P1: Negation (-) + X
 // ==========================================================================
 fn test_four_state_negation_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1628,7 +1603,6 @@ fn test_four_state_negation_with_x(sim) {
 // P1: Logical NOT (!) + X
 // ==========================================================================
 fn test_four_state_logical_not_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1676,7 +1650,6 @@ fn test_four_state_logical_not_with_x(sim) {
 // P1: SAR + X shift amount
 // ==========================================================================
 fn test_four_state_sar_x_shift_amount(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1724,7 +1697,6 @@ fn test_four_state_sar_x_shift_amount(sim) {
 // P1: 3+ element concatenation with X
 // ==========================================================================
 fn test_four_state_concat_three_elements(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1817,7 +1789,7 @@ fn test_four_state_wide_comparison_with_x(sim) {
 // P2: Multi-bit selector (case) with X
 // ==========================================================================
 fn test_four_state_multibit_mux_with_x(sim) {
-    @ignore_on(veryl, sv);
+    @ignore_on(sv);
     @setup {
     let code = r#"
         module Top (
@@ -1868,7 +1840,7 @@ fn test_four_state_multibit_mux_with_x(sim) {
 }
 
 fn test_four_state_procedural_case_x_uses_default(sim) {
-    @ignore_on(veryl, sv);
+    @ignore_on(sv);
     @setup {
     let code = r#"
         module Top (
@@ -1901,7 +1873,7 @@ fn test_four_state_procedural_case_x_uses_default(sim) {
 }
 
 fn test_four_state_procedural_if_known_nonzero_with_x_is_true(sim) {
-    @ignore_on(veryl, sv);
+    @ignore_on(sv);
     @setup {
     let code = r#"
         module Top (
@@ -1938,7 +1910,6 @@ fn test_four_state_procedural_if_known_nonzero_with_x_is_true(sim) {
 // P2: Width narrowing (wide → narrow) with X
 // ==========================================================================
 fn test_four_state_width_narrowing_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -1978,7 +1949,6 @@ fn test_four_state_width_narrowing_with_x(sim) {
 // P2: Width widening (narrow → wide) with X
 // ==========================================================================
 fn test_four_state_width_widening_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -2019,7 +1989,7 @@ fn test_four_state_width_widening_with_x(sim) {
 // P2: FF with conditional assignment + X
 // ==========================================================================
 fn test_four_state_ff_conditional_with_x(sim) {
-    @ignore_on(veryl, sv);
+    @ignore_on(sv);
     @setup {
     let code = r#"
         module Top (
@@ -2095,7 +2065,6 @@ fn test_four_state_ff_conditional_with_x(sim) {
 // P2: Odd-width concatenation (3bit + 5bit) with X
 // ==========================================================================
 fn test_four_state_concat_odd_width(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -2139,7 +2108,6 @@ fn test_four_state_concat_odd_width(sim) {
 // P2: 127-bit width test
 // ==========================================================================
 fn test_four_state_127bit(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -2178,7 +2146,6 @@ fn test_four_state_127bit(sim) {
 // Wide (128-bit) Unary NOT + X
 // ==========================================================================
 fn test_four_state_wide_unary_not_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -2218,7 +2185,6 @@ fn test_four_state_wide_unary_not_with_x(sim) {
 // Wide (128-bit) Negation + X
 // ==========================================================================
 fn test_four_state_wide_negation_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -2254,7 +2220,6 @@ fn test_four_state_wide_negation_with_x(sim) {
 // Wide (128-bit) Reduction AND/OR/XOR + X
 // ==========================================================================
 fn test_four_state_wide_reduction_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -2315,7 +2280,6 @@ fn test_four_state_wide_reduction_with_x(sim) {
 // Mux: both branches X
 // ==========================================================================
 fn test_four_state_mux_both_branches_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -2448,7 +2412,6 @@ fn test_four_state_cascaded_mux_with_x(sim) {
 // Shift: both data and amount have X
 // ==========================================================================
 fn test_four_state_shift_both_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -2487,7 +2450,6 @@ fn test_four_state_shift_both_x(sim) {
 // Case statement with 4-state (EqWildcard)
 // ==========================================================================
 fn test_four_state_case_defined_selector(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -2563,7 +2525,6 @@ fn test_four_state_case_x_in_selector(sim) {
 // Reduction OR/AND dominant-value semantics
 // ==========================================================================
 fn test_four_state_reduction_or_dominant_one(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -2613,7 +2574,6 @@ fn test_four_state_reduction_or_dominant_one(sim) {
 }
 
 fn test_four_state_reduction_and_dominant_zero(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -2663,7 +2623,6 @@ fn test_four_state_reduction_and_dominant_zero(sim) {
 }
 
 fn test_four_state_wide_reduction_or_dominant(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -2702,7 +2661,6 @@ fn test_four_state_wide_reduction_or_dominant(sim) {
 }
 
 fn test_four_state_wide_reduction_and_dominant(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -2816,7 +2774,6 @@ fn test_four_state_logic_and_dominant_zero(sim) {
 // IEEE 1800 LogicOr (||) dominant-value: 1 || x = 1
 // ==========================================================================
 fn test_four_state_logic_or_dominant_one(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -2888,7 +2845,6 @@ fn test_four_state_logic_or_dominant_one(sim) {
 // IEEE 1800 EqWildcard (==?) with LHS value at wildcard positions
 // ==========================================================================
 fn test_four_state_eq_wildcard_value_at_wildcard_pos(sim) {
-    @ignore_on(veryl);
     @setup {
     // Test that LHS values at RHS wildcard (X) positions are correctly ignored
     let code = r#"
@@ -2985,7 +2941,6 @@ fn test_four_state_eq_wildcard_value_at_wildcard_pos(sim) {
 }
 
 fn test_four_state_ne_wildcard_value_at_wildcard_pos(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -3036,7 +2991,6 @@ fn test_four_state_ne_wildcard_value_at_wildcard_pos(sim) {
 }
 
 fn test_four_state_wide_wildcard_equality(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -3113,7 +3067,6 @@ fn test_four_state_wide_wildcard_equality(sim) {
 // Wide MUL + X (128-bit)
 // ==========================================================================
 fn test_four_state_wide_mul_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -3160,7 +3113,6 @@ fn test_four_state_wide_mul_with_x(sim) {
 // Wide DIV + X (128-bit)
 // ==========================================================================
 fn test_four_state_wide_div_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -3205,7 +3157,6 @@ fn test_four_state_wide_div_with_x(sim) {
 // Wide MOD + X (128-bit)
 // ==========================================================================
 fn test_four_state_wide_mod_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -3251,7 +3202,6 @@ fn test_four_state_wide_mod_with_x(sim) {
 // SAR with both data and shift amount having X
 // ==========================================================================
 fn test_four_state_sar_both_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -3348,7 +3298,6 @@ fn test_four_state_wide_ne_with_x(sim) {
 // Wide GT + X (128-bit unsigned)
 // ==========================================================================
 fn test_four_state_wide_gt_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -3397,7 +3346,6 @@ fn test_four_state_wide_gt_with_x(sim) {
 // Wide GE/LE + X (128-bit unsigned)
 // ==========================================================================
 fn test_four_state_wide_ge_le_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -3449,7 +3397,6 @@ fn test_four_state_wide_ge_le_with_x(sim) {
 // Wide signed comparison + X (128-bit)
 // ==========================================================================
 fn test_four_state_wide_signed_comparison_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -3535,7 +3482,6 @@ fn test_four_state_wide_signed_comparison_with_x(sim) {
 // Wide logical NOT + X (128-bit)
 // ==========================================================================
 fn test_four_state_wide_logical_not_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (
@@ -3589,7 +3535,6 @@ fn test_four_state_wide_logical_not_with_x(sim) {
 // Concat: X crossing chunk boundary (64-bit)
 // ==========================================================================
 fn test_four_state_concat_chunk_boundary_x(sim) {
-    @ignore_on(veryl);
     @setup {
     // a (48-bit) is placed at bits [127:80] — no X
     // b (32-bit) is placed at bits [79:48] — all X, crosses the 64-bit chunk boundary
@@ -3653,7 +3598,7 @@ fn test_four_state_concat_chunk_boundary_x(sim) {
 // FF: synchronous reset + X
 // ==========================================================================
 fn test_four_state_ff_sync_reset_with_x(sim) {
-    @ignore_on(veryl, sv);
+    @ignore_on(sv);
     @setup {
     let code = r#"
         module Top (
@@ -3752,7 +3697,6 @@ fn test_four_state_ff_sync_reset_with_x(sim) {
 // Explicit cast + X: signed↔unsigned conversion preserves X
 // ==========================================================================
 fn test_four_state_explicit_cast_with_x(sim) {
-    @ignore_on(veryl);
     @setup {
     // Test signed → unsigned reinterpretation with X propagation
     let code = r#"
@@ -3844,7 +3788,6 @@ fn test_four_state_explicit_cast_with_x(sim) {
 // ==========================================================================
 
 fn test_z_literal_passthrough(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (a: input logic<8>, y: output logic<8>) {
@@ -3865,7 +3808,6 @@ fn test_z_literal_passthrough(sim) {
 }
 
 fn test_z_mux_tristate_pattern(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (en: input logic, d: input logic<8>, y: output logic<8>) {
@@ -3910,7 +3852,6 @@ fn test_z_mux_tristate_pattern(sim) {
 }
 
 fn test_x_literal_encoding(sim) {
-    @ignore_on(veryl);
     @setup {
     let code = r#"
         module Top (y: output logic<8>) {

--- a/crates/celox/tests/linear_sorter_pull.rs
+++ b/crates/celox/tests/linear_sorter_pull.rs
@@ -143,7 +143,7 @@ pub module Top #(
 all_backends! {
 
     fn test_sorter_push_pop_empty(sim) {
-        @ignore_on(veryl, sv);
+        @ignore_on(sv);
         @build Simulator::builder(sorter_code(), "Top");
     let clk = sim.event("clk");
     let rst = sim.signal("rst");
@@ -289,7 +289,7 @@ all_backends! {
 
     // Test: push+pop simultaneously — count should not change.
     fn test_sorter_simultaneous_push_pop(sim) {
-        @ignore_on(veryl, sv);
+        @ignore_on(sv);
         @build Simulator::builder(sorter_code(), "Top");
     let clk = sim.event("clk");
     let rst = sim.signal("rst");

--- a/crates/celox/tests/multi_clock.rs
+++ b/crates/celox/tests/multi_clock.rs
@@ -8,7 +8,7 @@ all_backends! {
 
     // Two independent clock domains: each FF only advances on its own clock.
     fn test_independent_clock_domains(sim) {
-        @ignore_on(veryl, sv);
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 clk_a: input  'a clock,
@@ -80,7 +80,7 @@ assign qb = rb;
     // A counter in one clock domain feeding into another (CDC pattern).
     // Tests that domains are truly independent.
     fn test_clock_domain_crossing_pattern(sim) {
-        @ignore_on(veryl, sv);
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 clk_fast: input  'a clock,
@@ -153,7 +153,6 @@ assign sample_out = sample;
 
     // FF with separate clocks and separate resets.
     fn test_separate_resets_per_domain(sim) {
-        @ignore_on(veryl);
         @setup { let code = r#"
 module Top (
 clk_a: input  'a clock,

--- a/crates/celox/tests/nba_cross_block.rs
+++ b/crates/celox/tests/nba_cross_block.rs
@@ -10,7 +10,7 @@ all_backends! {
     // In RTL, two always_ff blocks on the same clock should both read OLD values
     // (pre-edge) and write NEW values (post-edge), regardless of textual order.
     fn test_nba_separate_blocks_swap(sim) {
-        @ignore_on(veryl, sv);
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (clk: input clock, rst: input reset, a: output logic<8>, b: output logic<8>) {
 var r1: logic<8>;

--- a/crates/celox/tests/operators.rs
+++ b/crates/celox/tests/operators.rs
@@ -857,7 +857,7 @@ assign y = a ~^ b;
 
     // XNOR in always_ff.
     fn test_ff_bitxnor(sim) {
-        @ignore_on(veryl, sv);
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 clk: input  clock,
@@ -981,7 +981,6 @@ assign y = ~^a;
 
     // Reduction NAND in always_ff.
     fn test_ff_reduction_nand(sim) {
-        @ignore_on(veryl);
         @setup { let code = r#"
 module Top (
 clk: input  clock,
@@ -1066,7 +1065,6 @@ o_comb = 32'hffff_ffff + 1;
 
     // Reduction NOR in always_ff.
     fn test_ff_reduction_nor(sim) {
-        @ignore_on(veryl);
         @setup { let code = r#"
 module Top (
 clk: input  clock,

--- a/crates/celox/tests/reset_edge_cases.rs
+++ b/crates/celox/tests/reset_edge_cases.rs
@@ -8,7 +8,6 @@ all_backends! {
 
     // Test `reset_async_high`: the FF resets when the reset signal is HIGH.
     fn test_reset_async_high(sim) {
-        @ignore_on(veryl);
         @setup { let code = r#"
 module Top (
 clk: input  clock,
@@ -61,7 +60,6 @@ assign q = r;
 
     // Test `reset_sync_high`: synchronous reset, active HIGH.
     fn test_reset_sync_high(sim) {
-        @ignore_on(veryl);
         @setup { let code = r#"
 module Top (
 clk: input  clock,
@@ -104,7 +102,6 @@ assign q = r;
 
     // Test `reset_sync_low`: synchronous reset, active LOW.
     fn test_reset_sync_low(sim) {
-        @ignore_on(veryl);
         @setup { let code = r#"
 module Top (
 clk: input  clock,
@@ -147,7 +144,6 @@ assign q = r;
 
     // Test multiple FF blocks sharing the same reset signal.
     fn test_shared_reset(sim) {
-        @ignore_on(veryl);
         @setup { let code = r#"
 module Top (
 clk: input  clock,
@@ -207,7 +203,6 @@ assign q2 = r2;
     // Reset value that is non-zero: verifies the reset assignment uses
     // the specified value, not just zero.
     fn test_nonzero_reset_value(sim) {
-        @ignore_on(veryl);
         @setup { let code = r#"
 module Top (
 clk: input  clock,

--- a/crates/celox/tests/shift_bug_test.rs
+++ b/crates/celox/tests/shift_bug_test.rs
@@ -21,7 +21,6 @@ mod test_utils;
 all_backends! {
 
     fn test_shift_in_if_reset(sim) {
-        @ignore_on(veryl);
         @setup { let code = r#"
 module Top (
 clk: input  clock,
@@ -94,7 +93,7 @@ o = a << 4;
     }
 
     fn test_shift_ifreset_for(sim) {
-        @ignore_on(veryl, sv);
+        @ignore_on(sv);
         @setup { let code = r#"
 module Top (
 clk: input  clock,
@@ -192,7 +191,6 @@ assign o_shl = r_shl;
     }
 
     fn test_dynamic_shift_in_if_reset(sim) {
-        @ignore_on(veryl);
         @setup { let code = r#"
 module Top (
 clk: input  clock,

--- a/crates/celox/tests/simulator_api.rs
+++ b/crates/celox/tests/simulator_api.rs
@@ -93,7 +93,6 @@ assign b = a;
 
     // Test rapid clock toggling: tick many times and verify counter state.
     fn test_rapid_tick_counter(sim) {
-        @ignore_on(veryl);
         @setup { let code = r#"
 module Top (
 clk: input  clock,

--- a/crates/celox/tests/synth_dynamic_loop.rs
+++ b/crates/celox/tests/synth_dynamic_loop.rs
@@ -393,7 +393,7 @@ fn test_i32_shl_step_overflow_reports_true_loop(sim) {
 }
 
 fn test_runtime_bounds_terminal_inclusive_mul_loop_reports_true_loop(sim) {
-    @ignore_on(veryl, sv);
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             count: input logic<32>,
@@ -588,7 +588,7 @@ fn test_runtime_bounds_stalled_step_with_break_exits_cleanly(sim) {
 }
 
 fn test_runtime_bounds_stalled_step_with_break_guard_false_reports_true_loop(sim) {
-    @ignore_on(veryl, sv);
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             start: input logic<32>,
@@ -964,7 +964,7 @@ fn test_runtime_break_condition_dependency_across_module_boundary(sim) {
 }
 
 fn test_runtime_bounds_stalled_step_reports_true_loop(sim) {
-    @ignore_on(veryl, sv);
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             start: input logic<32>,

--- a/crates/celox/tests/test_unimplemented_paths.rs
+++ b/crates/celox/tests/test_unimplemented_paths.rs
@@ -36,7 +36,7 @@ fn wide_dynamic_shift_works(sim) {
 // Dynamic offset Store with 4-state mask: array write with variable index
 // on a logic (4-state) type must correctly store the mask.
 fn dynamic_mask_store(sim) {
-    @ignore_on(veryl, sv);
+    @ignore_on(sv);
     @setup { let code = r#"
         module Top (
             clk: input '_ clock,

--- a/crates/celox/tests/test_utils/veryl_sim.rs
+++ b/crates/celox/tests/test_utils/veryl_sim.rs
@@ -32,25 +32,22 @@ pub struct VerylEventRef(usize);
 pub struct VerylIOContext<'a> {
     sim: &'a mut VerylSim,
     names: &'a [String],
-    initial_diagnostics_pending: &'a mut bool,
+    input_written: &'a mut bool,
 }
 
 impl VerylIOContext<'_> {
-    fn prepare_input_write(&mut self) {
-        if *self.initial_diagnostics_pending {
-            assert_buffer::reset();
-            *self.initial_diagnostics_pending = false;
-        }
+    fn note_input_write(&mut self) {
+        *self.input_written = true;
     }
 
     pub fn set<T: Copy>(&mut self, signal: VerylSignalRef, val: T) {
-        self.prepare_input_write();
+        self.note_input_write();
         let name = &self.names[signal.0];
         self.sim.set(name, t_to_value(val));
     }
 
     pub fn set_wide(&mut self, signal: VerylSignalRef, val: BigUint) {
-        self.prepare_input_write();
+        self.note_input_write();
         let name = &self.names[signal.0];
         let width = val.bits() as usize;
         self.sim
@@ -58,7 +55,7 @@ impl VerylIOContext<'_> {
     }
 
     pub fn set_four_state(&mut self, signal: VerylSignalRef, val: BigUint, mask: BigUint) {
-        self.prepare_input_write();
+        self.note_input_write();
         let name = &self.names[signal.0];
         let width = self
             .sim
@@ -115,6 +112,32 @@ fn four_state_value(payload: BigUint, mask: BigUint, width: usize) -> Value {
     }
 }
 
+fn is_non_progressing_loop_diagnostic(message: &str) -> bool {
+    let Some(rest) =
+        message.strip_prefix("for-loop step does not advance the loop variable (stuck at ")
+    else {
+        return false;
+    };
+    let Some((stuck_at, location)) = rest.split_once(") at ") else {
+        return false;
+    };
+    if stuck_at.parse::<u64>().is_err() {
+        return false;
+    }
+
+    let mut location = location.rsplitn(3, ':');
+    let Some(column) = location.next() else {
+        return false;
+    };
+    let Some(line) = location.next() else {
+        return false;
+    };
+    let Some(_source) = location.next() else {
+        return false;
+    };
+    line.parse::<u32>().is_ok() && column.parse::<u32>().is_ok()
+}
+
 fn take_runtime_error() -> Result<(), RuntimeErrorCode> {
     if !assert_buffer::has_fatal() {
         // `$assert_continue` reports are not execution errors for this adapter,
@@ -126,7 +149,7 @@ fn take_runtime_error() -> Result<(), RuntimeErrorCode> {
     let Some(message) = assert_buffer::take_failure() else {
         return Ok(());
     };
-    if message.contains("for-loop step does not advance the loop variable") {
+    if is_non_progressing_loop_diagnostic(&message) {
         Err(RuntimeErrorCode::DetectedTrueLoop)
     } else {
         Err(RuntimeErrorCode::Runtime {
@@ -188,12 +211,25 @@ impl VerylSimAdapter {
     where
         F: FnOnce(&mut VerylIOContext<'_>),
     {
-        let mut ctx = VerylIOContext {
-            sim: &mut self.sim,
-            names: &self.names,
-            initial_diagnostics_pending: &mut self.initial_diagnostics_pending,
-        };
-        f(&mut ctx);
+        let mut input_written = false;
+        {
+            let mut ctx = VerylIOContext {
+                sim: &mut self.sim,
+                names: &self.names,
+                input_written: &mut input_written,
+            };
+            f(&mut ctx);
+        }
+        if input_written && self.initial_diagnostics_pending {
+            // The constructor settled with provisional input values. Replace
+            // those diagnostics with a forced settle after the first write;
+            // constant processes must run again even though they do not depend
+            // on the input that changed.
+            assert_buffer::reset();
+            self.initial_diagnostics_pending = false;
+            self.sim.mark_comb_dirty();
+            self.sim.ensure_comb_updated();
+        }
         self.finish_runtime_operation()
     }
 

--- a/crates/celox/tests/test_utils/veryl_sim.rs
+++ b/crates/celox/tests/test_utils/veryl_sim.rs
@@ -12,6 +12,7 @@ use veryl_analyzer::{Analyzer, Context, attribute_table, symbol_table};
 use veryl_metadata::Metadata;
 use veryl_parser::Parser;
 use veryl_simulator::Simulator as VerylSim;
+use veryl_simulator::assert_buffer;
 use veryl_simulator::ir::{Config, Event, build_ir};
 
 // ---------------------------------------------------------------------------
@@ -103,6 +104,27 @@ fn four_state_value(payload: BigUint, mask: BigUint, width: usize) -> Value {
     }
 }
 
+fn take_runtime_error() -> Result<(), RuntimeErrorCode> {
+    if !assert_buffer::has_fatal() {
+        // `$assert_continue` reports are not execution errors for this adapter,
+        // but must not leak into the next comparison test.
+        let _ = assert_buffer::take_failure();
+        return Ok(());
+    }
+
+    let Some(message) = assert_buffer::take_failure() else {
+        return Ok(());
+    };
+    if message.contains("for-loop step does not advance the loop variable") {
+        Err(RuntimeErrorCode::DetectedTrueLoop)
+    } else {
+        Err(RuntimeErrorCode::Runtime {
+            message,
+            signals: Vec::new(),
+        })
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Adapter
 // ---------------------------------------------------------------------------
@@ -147,7 +169,7 @@ impl VerylSimAdapter {
             names: unsafe { &*names_ptr },
         };
         f(&mut ctx);
-        Ok(())
+        take_runtime_error()
     }
 
     pub fn get(&mut self, signal: VerylSignalRef) -> BigUint {
@@ -190,7 +212,7 @@ impl VerylSimAdapter {
 
     pub fn tick(&mut self, event: VerylEventRef) -> Result<(), RuntimeErrorCode> {
         self.sim.step(&self.events[event.0]);
-        Ok(())
+        take_runtime_error()
     }
 
     pub fn set<T: Copy>(&mut self, signal: VerylSignalRef, val: T) {
@@ -223,7 +245,7 @@ impl VerylSimAdapter {
 
     pub fn eval_comb(&mut self) -> Result<(), RuntimeErrorCode> {
         self.sim.ensure_comb_updated();
-        Ok(())
+        take_runtime_error()
     }
 
     pub fn try_event(&mut self, port: &str) -> Result<VerylEventRef, AddrLookupError> {
@@ -252,6 +274,7 @@ pub fn build_veryl_adapter(
     // Clear global tables (same as Celox does)
     symbol_table::clear();
     attribute_table::clear();
+    assert_buffer::reset();
 
     let metadata = Metadata::create_default("prj").unwrap();
     let analyzer = Analyzer::new(&metadata);
@@ -285,6 +308,9 @@ pub fn build_veryl_adapter(
 
     let mut sim = VerylSim::new(sim_ir, None);
     sim.ensure_comb_updated();
+    // Inputs still contain their initial values during construction. Discard
+    // diagnostics from that provisional settle before the test drives them.
+    assert_buffer::reset();
 
     VerylSimAdapter {
         sim,

--- a/crates/celox/tests/test_utils/veryl_sim.rs
+++ b/crates/celox/tests/test_utils/veryl_sim.rs
@@ -32,15 +32,25 @@ pub struct VerylEventRef(usize);
 pub struct VerylIOContext<'a> {
     sim: &'a mut VerylSim,
     names: &'a [String],
+    initial_diagnostics_pending: &'a mut bool,
 }
 
 impl VerylIOContext<'_> {
+    fn prepare_input_write(&mut self) {
+        if *self.initial_diagnostics_pending {
+            assert_buffer::reset();
+            *self.initial_diagnostics_pending = false;
+        }
+    }
+
     pub fn set<T: Copy>(&mut self, signal: VerylSignalRef, val: T) {
+        self.prepare_input_write();
         let name = &self.names[signal.0];
         self.sim.set(name, t_to_value(val));
     }
 
     pub fn set_wide(&mut self, signal: VerylSignalRef, val: BigUint) {
+        self.prepare_input_write();
         let name = &self.names[signal.0];
         let width = val.bits() as usize;
         self.sim
@@ -48,6 +58,7 @@ impl VerylIOContext<'_> {
     }
 
     pub fn set_four_state(&mut self, signal: VerylSignalRef, val: BigUint, mask: BigUint) {
+        self.prepare_input_write();
         let name = &self.names[signal.0];
         let width = self
             .sim
@@ -131,6 +142,9 @@ fn take_runtime_error() -> Result<(), RuntimeErrorCode> {
 
 pub struct VerylSimAdapter {
     sim: VerylSim,
+    /// The constructor settles once so undriven outputs are readable. Keep its
+    /// diagnostics until either the caller observes them or drives an input.
+    initial_diagnostics_pending: bool,
     /// Signal name table: VerylSignalRef(i) → names[i]
     names: Vec<String>,
     /// Event table: VerylEventRef(i) → events[i]
@@ -138,6 +152,18 @@ pub struct VerylSimAdapter {
 }
 
 impl VerylSimAdapter {
+    fn discard_initial_diagnostics(&mut self) {
+        if self.initial_diagnostics_pending {
+            assert_buffer::reset();
+            self.initial_diagnostics_pending = false;
+        }
+    }
+
+    fn finish_runtime_operation(&mut self) -> Result<(), RuntimeErrorCode> {
+        self.initial_diagnostics_pending = false;
+        take_runtime_error()
+    }
+
     pub fn signal(&mut self, name: &str) -> VerylSignalRef {
         // Reuse existing entry if present
         if let Some(idx) = self.names.iter().position(|n| n == name) {
@@ -162,14 +188,13 @@ impl VerylSimAdapter {
     where
         F: FnOnce(&mut VerylIOContext<'_>),
     {
-        // Split borrow: names is read-only, sim is mutated through ctx
-        let names_ptr = &self.names as *const Vec<String>;
         let mut ctx = VerylIOContext {
             sim: &mut self.sim,
-            names: unsafe { &*names_ptr },
+            names: &self.names,
+            initial_diagnostics_pending: &mut self.initial_diagnostics_pending,
         };
         f(&mut ctx);
-        take_runtime_error()
+        self.finish_runtime_operation()
     }
 
     pub fn get(&mut self, signal: VerylSignalRef) -> BigUint {
@@ -212,16 +237,18 @@ impl VerylSimAdapter {
 
     pub fn tick(&mut self, event: VerylEventRef) -> Result<(), RuntimeErrorCode> {
         self.sim.step(&self.events[event.0]);
-        take_runtime_error()
+        self.finish_runtime_operation()
     }
 
     pub fn set<T: Copy>(&mut self, signal: VerylSignalRef, val: T) {
+        self.discard_initial_diagnostics();
         let name = &self.names[signal.0];
         self.sim.set(name, t_to_value(val));
         self.sim.mark_comb_dirty();
     }
 
     pub fn set_wide(&mut self, signal: VerylSignalRef, val: BigUint) {
+        self.discard_initial_diagnostics();
         let name = &self.names[signal.0];
         let width = val.bits() as usize;
         self.sim
@@ -245,7 +272,7 @@ impl VerylSimAdapter {
 
     pub fn eval_comb(&mut self) -> Result<(), RuntimeErrorCode> {
         self.sim.ensure_comb_updated();
-        take_runtime_error()
+        self.finish_runtime_operation()
     }
 
     pub fn try_event(&mut self, port: &str) -> Result<VerylEventRef, AddrLookupError> {
@@ -308,12 +335,10 @@ pub fn build_veryl_adapter(
 
     let mut sim = VerylSim::new(sim_ir, None);
     sim.ensure_comb_updated();
-    // Inputs still contain their initial values during construction. Discard
-    // diagnostics from that provisional settle before the test drives them.
-    assert_buffer::reset();
 
     VerylSimAdapter {
         sim,
+        initial_diagnostics_pending: true,
         names: Vec::new(),
         events: Vec::new(),
     }


### PR DESCRIPTION
## Summary

- propagate fatal diagnostics from the reference Veryl simulator adapter as `RuntimeErrorCode`, including non-progressing loops as `DetectedTrueLoop`
- reset and drain the Veryl assertion buffer so diagnostics do not leak between comparison tests
- re-enable 96 Veryl backend cases verified to pass while preserving ignores for unsupported backends
- lower function-call assignment patterns with the formal unpacked-array shape
- preserve source evaluation order and array storage order while coercing array-valued items element by element
- cover packed effect ordering, signed row widening, and array-returning function items
- leave reference Veryl coverage for the three new regressions ignored until the upstream simulator fix is released

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p celox-frontend-veryl` (81 passed)
- `cargo test -p celox --test comb_observer` (322 passed, 136 ignored)
- `cargo clippy -p celox-frontend-veryl -p celox --all-targets -- -D warnings`
- earlier full suite: `cargo test -p celox --tests --no-fail-fast`
- earlier Veryl backend suite: `cargo test -p celox --tests --no-fail-fast "::veryl"` (495 passed, 0 failed)
- earlier ignored Veryl audit (0 passed, 119 failed)