### PR TITLE
ci(napi): cache native build artifacts

### DIFF
--- a/.github/workflows/ci-napi.yml
+++ b/.github/workflows/ci-napi.yml
@@ -163,6 +163,10 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: napi-${{ matrix.target }}
+
       - name: Install ziglang (musl targets)
         if: matrix.zigbuild
         uses: goto-bus-stop/setup-zig@v2

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           targets: wasm32-wasip1-threads
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: playground
+
       - name: Install WASI SDK
         run: |
           curl -fsSL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/wasi-sdk-25.0-x86_64-linux.tar.gz | tar xz -C /opt


### PR DESCRIPTION
## Summary

- cache Cargo artifacts for each NAPI release target without matrix-key collisions
- cache native and WASM Cargo artifacts in the playground deployment workflow

## Validation

- `actionlint .github/workflows/ci-napi.yml .github/workflows/playground.yml`
- `node --test scripts/ci-changes.test.mjs`
- `git show --format= --check HEAD`