### PR TITLE
fix(celox): preserve simulation API contracts

### DIFF
--- a/crates/celox-runtime/src/scheduler.rs
+++ b/crates/celox-runtime/src/scheduler.rs
@@ -9,12 +9,19 @@ pub struct ClockDef {
     pub period: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SimEventOrigin {
+    PeriodicClock,
+    OneShot,
+}
+
 #[derive(Debug, Clone)]
 pub struct SimEvent<B: SimBackend> {
     pub time: u64,
     pub event_ref: B::Event,
     pub signal: SignalRef,
     pub next_val: u8,
+    pub origin: SimEventOrigin,
 }
 
 impl<B: SimBackend> PartialEq for SimEvent<B> {
@@ -23,6 +30,7 @@ impl<B: SimBackend> PartialEq for SimEvent<B> {
             && self.event_ref.addr() == other.event_ref.addr()
             && self.signal == other.signal
             && self.next_val == other.next_val
+            && self.origin == other.origin
     }
 }
 
@@ -46,6 +54,8 @@ impl<B: SimBackend> Ord for SimEvent<B> {
                 id2.cmp(&id1)
             })
             .then_with(|| other.signal.cmp(&self.signal))
+            .then_with(|| other.next_val.cmp(&self.next_val))
+            .then_with(|| other.origin.cmp(&self.origin))
     }
 }
 

--- a/crates/celox-runtime/src/scheduler.rs
+++ b/crates/celox-runtime/src/scheduler.rs
@@ -9,19 +9,12 @@ pub struct ClockDef {
     pub period: u64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum SimEventOrigin {
-    PeriodicClock,
-    OneShot,
-}
-
 #[derive(Debug, Clone)]
 pub struct SimEvent<B: SimBackend> {
     pub time: u64,
     pub event_ref: B::Event,
     pub signal: SignalRef,
     pub next_val: u8,
-    pub origin: SimEventOrigin,
 }
 
 impl<B: SimBackend> PartialEq for SimEvent<B> {
@@ -30,7 +23,6 @@ impl<B: SimBackend> PartialEq for SimEvent<B> {
             && self.event_ref.addr() == other.event_ref.addr()
             && self.signal == other.signal
             && self.next_val == other.next_val
-            && self.origin == other.origin
     }
 }
 
@@ -55,7 +47,6 @@ impl<B: SimBackend> Ord for SimEvent<B> {
             })
             .then_with(|| other.signal.cmp(&self.signal))
             .then_with(|| other.next_val.cmp(&self.next_val))
-            .then_with(|| other.origin.cmp(&self.origin))
     }
 }
 

--- a/crates/celox-runtime/src/simulation.rs
+++ b/crates/celox-runtime/src/simulation.rs
@@ -5,7 +5,7 @@ use fxhash::FxHashMap;
 use crate::{
     SignalRef, SimulatorErrorCode,
     backend::{EventHandle, SimBackend},
-    scheduler::{ClockDef, Scheduler, SimEvent},
+    scheduler::{ClockDef, Scheduler, SimEvent, SimEventOrigin},
 };
 
 /// Backend execution hooks needed by the timed simulation engine.
@@ -179,6 +179,7 @@ impl<B: SimBackend> SimulationState<B> {
             event_ref: event,
             signal,
             next_val: 1,
+            origin: SimEventOrigin::PeriodicClock,
         });
     }
 
@@ -188,6 +189,7 @@ impl<B: SimBackend> SimulationState<B> {
             event_ref: event,
             signal,
             next_val: value,
+            origin: SimEventOrigin::OneShot,
         });
     }
 
@@ -357,6 +359,9 @@ impl<B: SimBackend> SimulationState<B> {
         }
 
         for event in &events_to_process {
+            if event.origin != SimEventOrigin::PeriodicClock {
+                continue;
+            }
             let event_id = event.event_ref.id();
             if let Some(Some(clock)) = self.scheduler.clocks.get(event_id) {
                 self.scheduler.push(SimEvent {
@@ -364,6 +369,7 @@ impl<B: SimBackend> SimulationState<B> {
                     event_ref: event.event_ref,
                     signal: event.signal,
                     next_val: 1 - event.next_val,
+                    origin: SimEventOrigin::PeriodicClock,
                 });
             }
         }

--- a/crates/celox-runtime/src/simulation.rs
+++ b/crates/celox-runtime/src/simulation.rs
@@ -3,9 +3,9 @@ use celox_design::DomainKind;
 use fxhash::FxHashMap;
 
 use crate::{
-    SignalRef, SimulatorErrorCode,
+    AbsoluteAddr, SignalRef, SimulatorErrorCode,
     backend::{EventHandle, SimBackend},
-    scheduler::{ClockDef, Scheduler, SimEvent, SimEventOrigin},
+    scheduler::{ClockDef, Scheduler, SimEvent},
 };
 
 /// Backend execution hooks needed by the timed simulation engine.
@@ -84,9 +84,31 @@ impl<B: SimBackend> std::fmt::Debug for EventInfo<B> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct PeriodicEventKey {
+    time: u64,
+    event_id: usize,
+    event_addr: AbsoluteAddr,
+    signal: SignalRef,
+    next_val: u8,
+}
+
+impl PeriodicEventKey {
+    fn from_event<B: SimBackend>(event: &SimEvent<B>) -> Self {
+        Self {
+            time: event.time,
+            event_id: event.event_ref.id(),
+            event_addr: event.event_ref.addr(),
+            signal: event.signal,
+            next_val: event.next_val,
+        }
+    }
+}
+
 /// Backend-independent state and execution rules for timed simulation.
 pub struct SimulationState<B: SimBackend> {
     scheduler: Scheduler<B>,
+    periodic_events: FxHashMap<PeriodicEventKey, usize>,
     last_clock_values: BitSet,
     topo_signals: Vec<(SignalRef, usize, usize)>,
     domain_kinds: Vec<Option<DomainKind>>,
@@ -154,6 +176,7 @@ impl<B: SimBackend> SimulationState<B> {
 
         Self {
             scheduler: Scheduler::new(),
+            periodic_events: FxHashMap::default(),
             last_clock_values,
             topo_signals,
             domain_kinds,
@@ -174,12 +197,11 @@ impl<B: SimBackend> SimulationState<B> {
             self.scheduler.clocks.resize(event_id + 1, None);
         }
         self.scheduler.clocks[event_id] = Some(ClockDef { period });
-        self.scheduler.push(SimEvent {
+        self.push_periodic_event(SimEvent {
             time: initial_delay,
             event_ref: event,
             signal,
             next_val: 1,
-            origin: SimEventOrigin::PeriodicClock,
         });
     }
 
@@ -189,8 +211,15 @@ impl<B: SimBackend> SimulationState<B> {
             event_ref: event,
             signal,
             next_val: value,
-            origin: SimEventOrigin::OneShot,
         });
+    }
+
+    fn push_periodic_event(&mut self, event: SimEvent<B>) {
+        *self
+            .periodic_events
+            .entry(PeriodicEventKey::from_event(&event))
+            .or_default() += 1;
+        self.scheduler.push(event);
     }
 
     pub fn step<E>(&mut self, executor: &mut E) -> Result<Option<u64>, SimulatorErrorCode>
@@ -202,6 +231,34 @@ impl<B: SimBackend> SimulationState<B> {
             None => return Ok(None),
         };
         self.scheduler.time = current_time;
+
+        // Keep periodic provenance private so the public SimEvent shape stays
+        // stable. Consume matching sidecar counts before fallible work so an
+        // execution error cannot leave a stale periodic marker behind.
+        let mut periodic_events_to_process: Vec<SimEvent<B>> = Vec::new();
+        for event in &events_to_process {
+            let key = PeriodicEventKey::from_event(event);
+            let mut remove_key = false;
+            if let Some(count) = self.periodic_events.get_mut(&key) {
+                periodic_events_to_process.push(SimEvent {
+                    time: event.time,
+                    event_ref: event.event_ref,
+                    signal: event.signal,
+                    next_val: event.next_val,
+                });
+                *count -= 1;
+                remove_key = *count == 0;
+            }
+            if remove_key {
+                self.periodic_events.remove(&key);
+            }
+        }
+        debug_assert!(
+            self.periodic_events
+                .keys()
+                .all(|event| event.time > current_time),
+            "periodic event sidecar fell behind the scheduler"
+        );
 
         let num_events = executor.backend().num_events();
         for event in &events_to_process {
@@ -358,18 +415,14 @@ impl<B: SimBackend> SimulationState<B> {
             }
         }
 
-        for event in &events_to_process {
-            if event.origin != SimEventOrigin::PeriodicClock {
-                continue;
-            }
+        for event in periodic_events_to_process {
             let event_id = event.event_ref.id();
             if let Some(Some(clock)) = self.scheduler.clocks.get(event_id) {
-                self.scheduler.push(SimEvent {
+                self.push_periodic_event(SimEvent {
                     time: current_time + clock.period / 2,
                     event_ref: event.event_ref,
                     signal: event.signal,
                     next_val: 1 - event.next_val,
-                    origin: SimEventOrigin::PeriodicClock,
                 });
             }
         }

--- a/crates/celox/tests/simulation_step.rs
+++ b/crates/celox/tests/simulation_step.rs
@@ -66,6 +66,25 @@ fn test_next_event_time() {
 }
 
 #[test]
+fn test_scheduled_clock_event_remains_one_shot() {
+    let code = r#"
+        module Top (
+            clk: input clock
+        ) {
+            always_ff (clk) {}
+        }
+    "#;
+    let mut vsim = Simulation::builder(code, "Top").build().unwrap();
+    vsim.add_clock("clk", 10, 0);
+    vsim.schedule("clk", 2, 0).unwrap();
+
+    let event_times: Vec<_> = (0..4).map(|_| vsim.step().unwrap().unwrap()).collect();
+
+    assert_eq!(event_times, vec![0, 2, 5, 10]);
+    assert_eq!(vsim.next_event_time(), Some(15));
+}
+
+#[test]
 fn test_step_decorates_runtime_errors() {
     let code = r#"
         module Top (

--- a/crates/celox/tests/simulation_step.rs
+++ b/crates/celox/tests/simulation_step.rs
@@ -85,6 +85,28 @@ fn test_scheduled_clock_event_remains_one_shot() {
 }
 
 #[test]
+fn test_scheduled_clock_event_does_not_duplicate_a_periodic_edge() {
+    let code = r#"
+        module Top (
+            clk: input clock
+        ) {
+            always_ff (clk) {}
+        }
+    "#;
+    let mut vsim = Simulation::builder(code, "Top").build().unwrap();
+    let clk = vsim.signal("clk");
+    vsim.add_clock("clk", 10, 0);
+    vsim.schedule("clk", 0, 0).unwrap();
+
+    assert_eq!(vsim.step().unwrap(), Some(0));
+    assert_eq!(vsim.get(clk), 1u8.into());
+
+    assert_eq!(vsim.step().unwrap(), Some(5));
+    assert_eq!(vsim.get(clk), 0u8.into());
+    assert_eq!(vsim.next_event_time(), Some(10));
+}
+
+#[test]
 fn test_step_decorates_runtime_errors() {
     let code = r#"
         module Top (

--- a/packages/celox/src/simulation.test.ts
+++ b/packages/celox/src/simulation.test.ts
@@ -421,6 +421,24 @@ describe("Simulation", () => {
 		expect(mock.handle.step).toHaveBeenCalledTimes(3);
 	});
 
+	test("reset: releasing reset leaves outputs ready for lazy re-evaluation", () => {
+		const mock = createMockNative({ associatedClock: "clk" });
+		const sim = Simulation.create(TopModule, {
+			__nativeCreate: mock.create,
+		});
+		const view = new DataView(mock.buffer);
+		vi.mocked(mock.handle.evalComb).mockImplementation(() => {
+			view.setUint8(4, view.getUint8(0));
+		});
+
+		sim.dut.d = 42n;
+		sim.addClock("clk", { period: 10 });
+		sim.reset("rst");
+
+		expect(sim.dut.q).toBe(0n);
+		expect(mock.handle.evalComb).toHaveBeenCalledTimes(1);
+	});
+
 	test("reset: throws when no associatedClock and no duration", () => {
 		// No associatedClock in layout
 		const mock = createMockNative();
@@ -429,6 +447,7 @@ describe("Simulation", () => {
 		});
 
 		expect(() => sim.reset("rst")).toThrow("has no associated clock");
+		expect(new DataView(mock.buffer).getUint8(0)).toBe(0);
 	});
 
 	test("reset: no associatedClock but duration specified works", () => {
@@ -449,6 +468,37 @@ describe("Simulation", () => {
 		});
 		// addClock not called
 		expect(() => sim.reset("rst")).toThrow("No clock registered for 'clk'");
+		expect(new DataView(mock.buffer).getUint8(0)).toBe(0);
+	});
+
+	test("reset: releases the signal when advancing the simulation fails", () => {
+		const mock = createMockNative({ associatedClock: "clk" });
+		const sim = Simulation.create(TopModule, {
+			__nativeCreate: mock.create,
+		});
+		sim.addClock("clk", { period: 10 });
+		vi.mocked(mock.handle.step).mockImplementationOnce(() => {
+			throw new Error("step failed");
+		});
+
+		expect(() => sim.reset("rst")).toThrow("step failed");
+		expect(new DataView(mock.buffer).getUint8(0)).toBe(0);
+		expect(mock.handle.evalComb).not.toHaveBeenCalled();
+		void sim.dut.q;
+		expect(mock.handle.evalComb).toHaveBeenCalledTimes(1);
+	});
+
+	test("reset: releases the signal when duration-based advancement fails", () => {
+		const mock = createMockNative();
+		const sim = Simulation.create(TopModule, {
+			__nativeCreate: mock.create,
+		});
+		vi.mocked(mock.handle.runUntil).mockImplementationOnce(() => {
+			throw new Error("runUntil failed");
+		});
+
+		expect(() => sim.reset("rst", { duration: 10 })).toThrow("runUntil failed");
+		expect(new DataView(mock.buffer).getUint8(0)).toBe(0);
 	});
 
 	test("reset: throws on non-reset port", () => {

--- a/packages/celox/src/simulation.test.ts
+++ b/packages/celox/src/simulation.test.ts
@@ -4,6 +4,7 @@ import type {
 	CreateResult,
 	ModuleDefinition,
 	NativeSimulationHandle,
+	SimulatorOptions,
 } from "./types.js";
 import { SimulationTimeoutError } from "./types.js";
 
@@ -128,6 +129,56 @@ describe("Simulation", () => {
 
 		sim.addClock("clk", { period: 10 });
 		expect(mock.handle.addClock).toHaveBeenCalledWith(0, 10, 0);
+	});
+
+	test("create forwards merged public options without the native override", () => {
+		const mock = createMockNative();
+		const defaultOptions = {
+			fourState: true,
+			vcd: "default.vcd",
+			optLevel: "O2",
+			passOverrides: ["-sir:gvn"],
+			optimize: true,
+			optimizeOptions: { reschedule: true },
+			craneliftOptLevel: "speed",
+			regallocAlgorithm: "backtracking",
+			enableAliasAnalysis: true,
+			enableVerifier: true,
+			falseLoops: [{ from: "d", to: "q" }],
+			trueLoops: [{ from: "rst", to: "q", maxIter: 8 }],
+			clockType: "posedge",
+			resetType: "async_low",
+			extraSource: "module DefaultHelper {}",
+			parameters: [{ name: "WIDTH", value: 8 }],
+			deadStorePolicy: "preserveTopPorts",
+		} satisfies SimulatorOptions;
+		const module = { ...TopModule, defaultOptions };
+
+		const sim = Simulation.create(module, {
+			__nativeCreate: mock.create,
+			optLevel: "O0",
+			optimizeOptions: { reschedule: false },
+			craneliftOptLevel: "none",
+			regallocAlgorithm: "singlePass",
+			enableAliasAnalysis: false,
+			enableVerifier: false,
+			extraSource: "module OverrideHelper {}",
+		});
+
+		expect(mock.create).toHaveBeenCalledWith(module.sources, module.name, {
+			...defaultOptions,
+			optLevel: "O0",
+			optimizeOptions: { reschedule: false },
+			craneliftOptLevel: "none",
+			regallocAlgorithm: "singlePass",
+			enableAliasAnalysis: false,
+			enableVerifier: false,
+			extraSource: "module OverrideHelper {}",
+		});
+		expect(vi.mocked(mock.create).mock.calls[0]?.[2]).not.toHaveProperty(
+			"__nativeCreate",
+		);
+		sim.dispose();
 	});
 
 	test("addClock with initialDelay", () => {

--- a/packages/celox/src/simulation.ts
+++ b/packages/celox/src/simulation.ts
@@ -129,33 +129,16 @@ export class Simulation<P = Record<string, unknown>> {
 			);
 		}
 
-		const {
-			fourState,
-			vcd,
-			optimize,
-			falseLoops,
-			trueLoops,
-			clockType,
-			resetType,
-			parameters,
-			deadStorePolicy,
-		} = merged ?? {};
-		const result = createFn(module.sources, module.name, {
-			fourState,
-			vcd,
-			optimize,
-			falseLoops,
-			trueLoops,
-			clockType,
-			resetType,
-			parameters,
-			deadStorePolicy,
-		});
+		// Forward every public SimulatorOptions field so newly added options do not
+		// require this factory to maintain a second allowlist. The create override is
+		// test-only plumbing and must not cross the native factory boundary.
+		const { __nativeCreate: _createOverride, ...nativeOptions } = merged;
+		const result = createFn(module.sources, module.name, nativeOptions);
 		const state: DirtyState = { dirty: false };
 
 		// Always prefer NAPI-derived ports over module.ports (see simulator.ts).
 		const hierarchy = result.hierarchy
-			? filterHierarchyForDse(result.hierarchy, deadStorePolicy)
+			? filterHierarchyForDse(result.hierarchy, nativeOptions.deadStorePolicy)
 			: undefined;
 		const portDefs = hierarchy?.ports ?? module.ports;
 		const dut = createDut<P>(

--- a/packages/celox/src/simulation.ts
+++ b/packages/celox/src/simulation.ts
@@ -580,28 +580,48 @@ export class Simulation<P = Record<string, unknown>> {
 			typeKind === "reset_async_low" || typeKind === "reset_sync_low";
 		const activeValue = isActiveLow ? 0n : 1n;
 		const inactiveValue = isActiveLow ? 1n : 0n;
+		const associatedClock = sig.associatedClock;
+		const duration = opts?.duration;
+
+		// Validate the execution strategy before changing DUT state. A rejected
+		// reset call must not leave the signal asserted.
+		let execution:
+			| { kind: "duration"; duration: number }
+			| { kind: "cycles"; clock: string; cycles: number };
+		if (duration != null) {
+			execution = { kind: "duration", duration };
+		} else {
+			if (!associatedClock) {
+				throw new Error(
+					`Reset '${signal}' has no associated clock. Specify opts.duration.`,
+				);
+			}
+			if (!this._clocks.has(associatedClock)) {
+				throw new Error(
+					`No clock registered for '${associatedClock}'. Call addClock() first.`,
+				);
+			}
+			execution = {
+				kind: "cycles",
+				clock: associatedClock,
+				cycles: opts?.activeCycles ?? 2,
+			};
+		}
 
 		const dut = this._dut as Record<string, unknown>;
 		dut[signal] = activeValue;
-
-		const associatedClock = sig.associatedClock;
-
-		if (opts?.duration != null) {
-			// Explicit duration (works for both sync and async resets)
-			this._handle.runUntil(this._handle.time() + opts.duration);
-		} else if (associatedClock) {
-			// Clock-associated reset → advance by activeCycles
-			const cycles = opts?.activeCycles ?? 2;
-			this.waitForCycles(associatedClock, cycles);
-		} else {
-			// No associated clock and no explicit duration → error
-			throw new Error(
-				`Reset '${signal}' has no associated clock. Specify opts.duration.`,
-			);
+		try {
+			if (execution.kind === "duration") {
+				// Explicit duration (works for both sync and async resets)
+				this.runUntil(this.time() + execution.duration);
+			} else {
+				this.waitForCycles(execution.clock, execution.cycles);
+			}
+		} finally {
+			// Releasing reset changes an input after the final timed step. Keep the
+			// DUT dirty so the next output read observes the released state.
+			dut[signal] = inactiveValue;
 		}
-
-		dut[signal] = inactiveValue;
-		this._state.dirty = false;
 	}
 
 	/**

--- a/packages/celox/src/simulator.test.ts
+++ b/packages/celox/src/simulator.test.ts
@@ -5,6 +5,7 @@ import type {
 	FrontendSimulatorHandle,
 	ModuleDefinition,
 	NativeSimulatorHandle,
+	SimulatorOptions,
 } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -165,6 +166,57 @@ describe("Simulator", () => {
 
 		expect(sim.dut.sum).toBe(300n);
 		expect(mock.handle.tick).toHaveBeenCalledTimes(1);
+	});
+
+	test("create forwards merged public options without the native override", () => {
+		const mock = createMockNative();
+		const defaultOptions = {
+			fourState: true,
+			vcd: "default.vcd",
+			optLevel: "O2",
+			passOverrides: ["-sir:gvn"],
+			optimize: true,
+			optimizeOptions: { reschedule: true },
+			craneliftOptLevel: "speed",
+			regallocAlgorithm: "backtracking",
+			enableAliasAnalysis: true,
+			enableVerifier: true,
+			falseLoops: [{ from: "a", to: "sum" }],
+			trueLoops: [{ from: "b", to: "sum", maxIter: 8 }],
+			clockType: "posedge",
+			resetType: "async_low",
+			extraSource: "module DefaultHelper {}",
+			parameters: [{ name: "WIDTH", value: 16 }],
+			deadStorePolicy: "preserveTopPorts",
+			tier: true,
+		} satisfies SimulatorOptions;
+		const module = { ...AdderModule, defaultOptions };
+
+		const sim = Simulator.create(module, {
+			__nativeCreate: mock.create,
+			optLevel: "O0",
+			optimizeOptions: { reschedule: false },
+			craneliftOptLevel: "none",
+			regallocAlgorithm: "singlePass",
+			enableAliasAnalysis: false,
+			enableVerifier: false,
+			extraSource: "module OverrideHelper {}",
+		});
+
+		expect(mock.create).toHaveBeenCalledWith(module.sources, module.name, {
+			...defaultOptions,
+			optLevel: "O0",
+			optimizeOptions: { reschedule: false },
+			craneliftOptLevel: "none",
+			regallocAlgorithm: "singlePass",
+			enableAliasAnalysis: false,
+			enableVerifier: false,
+			extraSource: "module OverrideHelper {}",
+		});
+		expect(vi.mocked(mock.create).mock.calls[0]?.[2]).not.toHaveProperty(
+			"__nativeCreate",
+		);
+		sim.dispose();
 	});
 
 	test("tick with count", () => {

--- a/packages/celox/src/simulator.ts
+++ b/packages/celox/src/simulator.ts
@@ -118,30 +118,11 @@ export class Simulator<P = Record<string, unknown>> {
 			);
 		}
 
-		const {
-			fourState,
-			vcd,
-			optimize,
-			falseLoops,
-			trueLoops,
-			clockType,
-			resetType,
-			parameters,
-			deadStorePolicy,
-			tier,
-		} = merged ?? {};
-		const result = createFn(module.sources, module.name, {
-			fourState,
-			vcd,
-			optimize,
-			falseLoops,
-			trueLoops,
-			clockType,
-			resetType,
-			parameters,
-			deadStorePolicy,
-			tier,
-		});
+		// Forward every public SimulatorOptions field so newly added options do not
+		// require this factory to maintain a second allowlist. The create override is
+		// test-only plumbing and must not cross the native factory boundary.
+		const { __nativeCreate: _createOverride, ...nativeOptions } = merged;
+		const result = createFn(module.sources, module.name, nativeOptions);
 		const state: DirtyState = { dirty: false };
 
 		// Always prefer NAPI-derived ports (from hierarchy) over module.ports.
@@ -149,7 +130,7 @@ export class Simulator<P = Record<string, unknown>> {
 		// stale when parameters are overridden. hierarchy.ports reflects the actual
 		// compiled layout, consistent with fromSource()/fromProject().
 		const hierarchy = result.hierarchy
-			? filterHierarchyForDse(result.hierarchy, deadStorePolicy)
+			? filterHierarchyForDse(result.hierarchy, nativeOptions.deadStorePolicy)
 			: undefined;
 		const portDefs = hierarchy?.ports ?? module.ports;
 		const dut = createDut<P>(


### PR DESCRIPTION
## Summary

- keep explicitly scheduled signal changes one-shot even when they target a registered clock
- track periodic event provenance internally without changing the public SimEvent shape
- forward every public SimulatorOptions field from generated module factories while excluding the test-only native override
- validate reset execution before assertion and always release reset signals after success or failure
- preserve lazy combinational re-evaluation after reset release

## Validation

- cargo fmt --all -- --check
- cargo clippy -p celox-runtime -p celox --tests -- -D warnings
- cargo test -p celox-runtime
- cargo test -p celox --test simulation_step --test simulation_limits
- cargo test -p celox --test vip_registry with a writable temporary Veryl cache
- rebuilt the debug N-API addon
- TypeScript package tests: 179 passed
- TypeScript typecheck and Biome checks