### PR TITLE
fix(vite): invalidate generated types for every source change

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:vite-components": "vitest run --config test/fixtures/injected-components/vitest.config.ts && node test/fixtures/injected-components/dependency-e2e.mjs",
+    "test:vite-components": "vitest run test/vite-plugin-cache.test.ts && vitest run --config test/fixtures/injected-components/vitest.config.ts && node test/fixtures/injected-components/dependency-e2e.mjs",
     "test:lsp-components": "pnpm run test:vite-components && node test/fixtures/injected-components/lsp-e2e.mjs",
     "test:e2e": "pnpm run build && playwright test",
     "test:watch": "vitest",

--- a/packages/playground/test/vite-plugin-cache.test.ts
+++ b/packages/playground/test/vite-plugin-cache.test.ts
@@ -36,16 +36,16 @@ describe("GenTsCache", () => {
 		const newest = join(root, "newest.veryl");
 		writeFileSync(older, "module Older {}\n");
 		writeFileSync(newest, "module Newest {}\n");
-		utimesSync(older, 1_000, 1_000);
-		utimesSync(newest, 2_000, 2_000);
+		utimesSync(older, 1_700_000_000, 1_700_000_000);
+		utimesSync(newest, 1_700_000_100, 1_700_000_100);
 
 		const cache = new GenTsCache(root);
 		cache.get();
 		cache.get();
 		expect(runGenTs).toHaveBeenCalledTimes(1);
 
-		writeFileSync(older, "module Older { const CHANGED: u32 = 1; }\n");
-		utimesSync(older, 1_500, 1_500);
+		writeFileSync(older, "module Other {}\n");
+		utimesSync(older, 1_700_000_050, 1_700_000_050);
 
 		cache.get();
 		expect(runGenTs).toHaveBeenCalledTimes(2);

--- a/packages/playground/test/vite-plugin-cache.test.ts
+++ b/packages/playground/test/vite-plugin-cache.test.ts
@@ -1,0 +1,53 @@
+import {
+	mkdtempSync,
+	rmSync,
+	utimesSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("../../vite-plugin/src/generator.js", () => ({
+	runGenTs: vi.fn((projectRoot: string) => ({
+		projectPath: projectRoot,
+		modules: [],
+		fileModules: {},
+	})),
+}));
+
+import { GenTsCache } from "../../vite-plugin/src/cache.js";
+import { runGenTs } from "../../vite-plugin/src/generator.js";
+
+describe("GenTsCache", () => {
+	const temporaryRoots: string[] = [];
+
+	afterEach(() => {
+		vi.mocked(runGenTs).mockClear();
+		for (const root of temporaryRoots.splice(0)) {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("invalidates when an older source changes below the newest mtime", () => {
+		const root = mkdtempSync(join(tmpdir(), "celox-vite-cache-"));
+		temporaryRoots.push(root);
+		const older = join(root, "older.veryl");
+		const newest = join(root, "newest.veryl");
+		writeFileSync(older, "module Older {}\n");
+		writeFileSync(newest, "module Newest {}\n");
+		utimesSync(older, 1_000, 1_000);
+		utimesSync(newest, 2_000, 2_000);
+
+		const cache = new GenTsCache(root);
+		cache.get();
+		cache.get();
+		expect(runGenTs).toHaveBeenCalledTimes(1);
+
+		writeFileSync(older, "module Older { const CHANGED: u32 = 1; }\n");
+		utimesSync(older, 1_500, 1_500);
+
+		cache.get();
+		expect(runGenTs).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/vite-plugin/src/cache.ts
+++ b/packages/vite-plugin/src/cache.ts
@@ -1,11 +1,11 @@
 import { type Dirent, readdirSync, statSync } from "node:fs";
-import { extname, join } from "node:path";
+import { extname, join, relative } from "node:path";
 import { runGenTs } from "./generator.js";
 import type { GenTsJsonOutput, TestbenchComponentManifests } from "./types.js";
 
 export class GenTsCache {
 	private _data: GenTsJsonOutput | undefined;
-	private _mtimeKey = "";
+	private _sourceKey = "";
 
 	constructor(
 		private readonly _projectRoot: string,
@@ -19,36 +19,39 @@ export class GenTsCache {
 
 	/** Get cached data, refreshing if any .veryl file has changed. */
 	get(): GenTsJsonOutput {
-		const key = this.computeMtimeKey();
-		if (this._data && this._mtimeKey === key) {
+		const key = this.computeSourceKey();
+		if (this._data && this._sourceKey === key) {
 			return this._data;
 		}
 		this._data = runGenTs(this._projectRoot, this._testbenchComponents);
-		this._mtimeKey = key;
+		this._sourceKey = key;
 		return this._data;
 	}
 
 	/** Force invalidation — next `get()` will re-run the generator. */
 	invalidate(): void {
-		this._mtimeKey = "";
+		this._sourceKey = "";
 		this._data = undefined;
 	}
 
 	/**
-	 * Build a key from the max mtime of all .veryl files in the project.
-	 * This is intentionally cheap — only stats, no file reads.
+	 * Build a key from every .veryl file's path, mtime, and size.
+	 * This stays cheap — only stats, no file reads — while detecting changes to
+	 * older files whose mtime does not exceed the newest file in the project.
 	 */
-	private computeMtimeKey(): string {
-		let maxMtime = 0;
-		let count = 0;
-		this.walkVerylFiles(this._projectRoot, (mtimeMs) => {
-			if (mtimeMs > maxMtime) maxMtime = mtimeMs;
-			count++;
+	private computeSourceKey(): string {
+		const files: Array<[path: string, mtimeMs: number, size: number]> = [];
+		this.walkVerylFiles(this._projectRoot, (path, mtimeMs, size) => {
+			files.push([relative(this._projectRoot, path), mtimeMs, size]);
 		});
-		return `${count}:${maxMtime}`;
+		files.sort(([a], [b]) => a.localeCompare(b));
+		return JSON.stringify(files);
 	}
 
-	private walkVerylFiles(dir: string, cb: (mtimeMs: number) => void): void {
+	private walkVerylFiles(
+		dir: string,
+		cb: (path: string, mtimeMs: number, size: number) => void,
+	): void {
 		let entries: Dirent<string>[] | undefined;
 		try {
 			entries = readdirSync(dir, { withFileTypes: true });
@@ -70,7 +73,8 @@ export class GenTsCache {
 				this.walkVerylFiles(full, cb);
 			} else if (extname(entry.name) === ".veryl") {
 				try {
-					cb(statSync(full).mtimeMs);
+					const stat = statSync(full);
+					cb(full, stat.mtimeMs, stat.size);
 				} catch {
 					// file may have been deleted
 				}


### PR DESCRIPTION
## Summary

- fingerprint every Veryl source by relative path, mtime, and size instead of using only file count and the newest mtime
- invalidate generated TypeScript when an older source changes without becoming the newest file
- sort fingerprints so filesystem directory iteration order cannot cause spurious cache misses
- run the regression in the standard Vite plugin test suite

## Validation

- Vite cache regression test: 1 passed
- injected-component plugin tests: 2 passed
- injected-component dependency end-to-end test
- Playground unit suite: 24 passed, 9 skipped
- Vite plugin TypeScript build
- focused TypeScript typecheck for the new test
- Biome and git diff checks