### PR TITLE
fix(ci): discard incomplete Criterion cache

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,6 +29,11 @@ jobs:
       - uses: ./.github/actions/setup-rust
       - uses: Swatinem/rust-cache@v2
 
+      # rust-cache prunes Criterion's sample data while retaining its baseline
+      # directories, which makes Criterion try to compare against incomplete data.
+      - name: Discard cached Criterion data
+        run: rm -rf target/criterion
+
       - name: Run Rust benchmarks
         shell: bash
         run: set -o pipefail && cargo bench --locked -p celox --bench simulation --bench overhead --bench tiered -- --output-format bencher | tee rust-output.txt


### PR DESCRIPTION
## Summary

- discard restored Criterion benchmark data before running Rust benchmarks
- prevent incomplete cached baselines from splitting bencher output and producing an empty converted result

## Root cause

`Swatinem/rust-cache` restored Criterion baseline directories without their `sample.json` files. Criterion then emitted an error between each benchmark name and its `bench:` result, so `convert-rust-bench.mjs` matched zero benchmarks and `github-action-benchmark` rejected `[]`.

Failing job: https://github.com/celox-sim/celox/actions/runs/33513594616/job/99894248706?pr=719

## Validation

- `git diff --check`
- parsed `.github/workflows/bench.yml` with PyYAML
- verified the cleanup removes only `target/criterion` and preserves other `target` contents

`actionlint` was not available locally.