### PR TITLE
fix(optimizer): preserve oversized concat slice runs

### DIFF
--- a/crates/celox-sir-opt/src/optimizer/passes/dataflow/pass_concat_folding.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/dataflow/pass_concat_folding.rs
@@ -134,7 +134,18 @@ impl ExecutionUnitPass for ConcatFoldingPass {
                                 if prev_info.base == run_base
                                     && prev_info.bit_offset == run_start + run_width
                                 {
-                                    let combined_width = run_width + prev_info.width;
+                                    let Some(combined_width) =
+                                        run_width.checked_add(prev_info.width)
+                                    else {
+                                        break;
+                                    };
+                                    // Leave the first operand which does not fit
+                                    // for the next outer iteration. Consuming the
+                                    // whole run and then rejecting it below drops
+                                    // every operand except `arg` from the Concat.
+                                    if combined_width > self.max_load_width {
+                                        break;
+                                    }
                                     if let BitSourceBase::Load(address) = run_base
                                         && let Some(&element_width) = self
                                             .unpacked_element_widths
@@ -396,6 +407,75 @@ mod tests {
             inst,
             SIRInstruction::Concat(RegisterId(4), args) if args.len() == 1
         )));
+    }
+
+    #[test]
+    fn splits_slice_runs_at_the_fold_width_without_dropping_operands() {
+        const SOURCE_WIDTH: usize = 129;
+        const MAX_FOLD_WIDTH: usize = 128;
+        let bit = |width| RegisterType::Bit {
+            width,
+            signed: false,
+        };
+        let register_map = HashMap::from_iter([
+            (RegisterId(0), bit(SOURCE_WIDTH)),
+            (RegisterId(1), bit(64)),
+            (RegisterId(2), bit(64)),
+            (RegisterId(3), bit(1)),
+            (RegisterId(4), bit(SOURCE_WIDTH)),
+        ]);
+        let instructions = vec![
+            SIRInstruction::Slice(RegisterId(1), RegisterId(0), 0, 64),
+            SIRInstruction::Slice(RegisterId(2), RegisterId(0), 64, 64),
+            SIRInstruction::Slice(RegisterId(3), RegisterId(0), 128, 1),
+            SIRInstruction::Concat(
+                RegisterId(4),
+                vec![RegisterId(3), RegisterId(2), RegisterId(1)],
+            ),
+            SIRInstruction::RuntimeEvent {
+                site_id: 0,
+                args: vec![RegisterId(4)],
+            },
+        ];
+
+        let mut eu = make_eu(instructions, register_map);
+        eu.blocks
+            .get_mut(&BlockId(0))
+            .unwrap()
+            .params
+            .push(RegisterId(0));
+        eu.verify_result().unwrap();
+        ConcatFoldingPass::new(Arc::default(), MAX_FOLD_WIDTH)
+            .run(&mut eu, &PassOptions::default());
+        eu.verify_result().unwrap();
+
+        let concat_args = eu.blocks[&BlockId(0)]
+            .instructions
+            .iter()
+            .find_map(|instruction| match instruction {
+                SIRInstruction::Concat(RegisterId(4), args) => Some(args),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(concat_args.len(), 2);
+        assert_eq!(
+            concat_args
+                .iter()
+                .map(|argument| eu.register_map[argument].width())
+                .sum::<usize>(),
+            SOURCE_WIDTH,
+        );
+        assert!(
+            eu.blocks[&BlockId(0)]
+                .instructions
+                .iter()
+                .any(|instruction| {
+                    matches!(
+                        instruction,
+                        SIRInstruction::Slice(_, RegisterId(0), 0, MAX_FOLD_WIDTH)
+                    )
+                })
+        );
     }
 
     #[test]

--- a/crates/celox/tests/native_concat_width.rs
+++ b/crates/celox/tests/native_concat_width.rs
@@ -1,0 +1,83 @@
+//! Regression coverage for wide SDK concatenations in the native backend.
+
+#![cfg(target_arch = "x86_64")]
+
+use celox::frontend_sdk::{BinaryOp, Edge, FrontendArtifact, ModuleBuilder, ValueType};
+use celox::{DiagnosticsOptions, Simulator};
+
+fn artifact(data_width: usize) -> FrontendArtifact {
+    let bit = ValueType::bits(1).unwrap();
+    let mut builder = ModuleBuilder::new("NativeConcatWidth").unwrap();
+    let clock = builder.input("clock", bit).unwrap();
+    let data = builder
+        .input("data", ValueType::bits(data_width).unwrap())
+        .unwrap();
+    let select = builder
+        .input("select", ValueType::bits(2).unwrap())
+        .unwrap();
+    let result = builder.output("result", bit).unwrap();
+    let bank_width = data_width + 3;
+    let bank = builder
+        .internal("bank", ValueType::bits(bank_width).unwrap())
+        .unwrap();
+
+    let mut next_bits = Vec::with_capacity(bank_width);
+    for lsb in 0..data_width {
+        let slice = builder.slice(data, lsb, 1).unwrap();
+        next_bits.push(builder.read_slice(slice).unwrap());
+    }
+    for lsb in 0..2 {
+        let slice = builder.slice(select, lsb, 1).unwrap();
+        next_bits.push(builder.read_slice(slice).unwrap());
+    }
+    let data_q0 = builder
+        .read_slice(builder.slice(bank, 0, 1).unwrap())
+        .unwrap();
+    let select_q0 = builder
+        .read_slice(builder.slice(bank, data_width, 1).unwrap())
+        .unwrap();
+    next_bits.push(
+        builder
+            .binary(BinaryOp::Xor, data_q0, select_q0, bit)
+            .unwrap(),
+    );
+    next_bits.reverse();
+
+    let next = builder.concat(next_bits).unwrap();
+    builder
+        .register(
+            builder.whole(bank).unwrap(),
+            next,
+            clock,
+            Edge::Posedge,
+            None,
+            None,
+        )
+        .unwrap();
+    let result_q = builder
+        .read_slice(builder.slice(bank, data_width + 2, 1).unwrap())
+        .unwrap();
+    builder
+        .assign(builder.whole(result).unwrap(), result_q)
+        .unwrap();
+
+    let artifact = builder.finish();
+    artifact.validate().unwrap();
+    artifact
+}
+
+#[test]
+fn native_wide_concat_folding_preserves_all_operands() {
+    let mut diagnostics = DiagnosticsOptions::default();
+    diagnostics.sir.verify_passes = true;
+    Simulator::from_frontend(artifact(129))
+        .diagnostics(diagnostics)
+        .build_wasm()
+        .unwrap();
+    Simulator::from_frontend(artifact(128))
+        .build_native()
+        .unwrap();
+    Simulator::from_frontend(artifact(129))
+        .build_native()
+        .unwrap();
+}


### PR DESCRIPTION
## Summary

- split consecutive slice runs at `max_load_width` instead of consuming and dropping an oversized suffix
- add a pass-level regression which verifies the resulting SIR and preserves all 129 bits as 128+1
- add the public frontend-SDK MRE covering 131-bit control, 132-bit native, and 132-bit WASM builds

## Root cause

`ConcatFoldingPass` consumed every consecutive slice before checking whether the combined run fit the native 128-bit fold limit. For a 129-bit data run, the fold was rejected only after all 129 operands had been consumed; the fallback restored just the first one. The surrounding selector and XOR bits made the 132-bit destination receive a four-bit `Concat`.

The release error surfaced during native single-predecessor jump inlining because that was the next strict SIR verification boundary. With per-pass verification enabled, the first invalid transformation is `concat_folding`; jump inlining itself does not corrupt the types.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked --offline -p celox-sir-opt --lib` (402 passed)
- `cargo test --locked --offline -p celox --test native_concat_width`
- `cargo test --release --locked --offline -p celox --test native_concat_width`
- `cargo clippy --locked --offline -p celox-sir-opt --lib --tests -- -D warnings`
- `cargo clippy --locked --offline -p celox --test native_concat_width -- -D warnings`