### PR TITLE
fix(sim): correct registered memory writes and reduce FF staging

### DIFF
--- a/crates/celox-backend-wasm/src/lib.rs
+++ b/crates/celox-backend-wasm/src/lib.rs
@@ -4581,7 +4581,10 @@ fn compile_store_at_offset(
     let store_bytes = get_byte_size(op_width);
     let num_chunks = num_i64_chunks(op_width);
 
-    if num_chunks == 1 && op_width <= 64 && (bit_shift != 0 || !op_width.is_multiple_of(8)) {
+    if num_chunks == 1
+        && bit_shift + op_width <= 64
+        && (bit_shift != 0 || !op_width.is_multiple_of(8))
+    {
         emit_partial_store_small(src, byte_offset, bit_shift, op_width, locals, instrs);
     } else if bit_shift == 0 {
         // Byte-aligned store. Break remaining bytes into power-of-2
@@ -6055,6 +6058,90 @@ mod bit_count_tests {
 
     fn read_bits(memory: &[u8], bit_offset: usize, width: usize) -> BigUint {
         read_bits_at(memory, OUTPUT_OFFSET, bit_offset, width)
+    }
+
+    #[test]
+    fn shifted_scalar_stores_preserve_spill_bits_and_neighbors() {
+        // A single source chunk can cover nine destination bytes. In particular,
+        // OptimizeBlocks coalesces four 15-bit array elements into a 60-bit store
+        // at bit 15; a u64 read-modify-write loses its final three bits.
+        for four_state in [false, true] {
+            for (offset, width) in [(0, 64), (1, 63), (1, 64), (7, 58), (7, 64), (15, 60)] {
+                for packed_elements in [false, true] {
+                    let initial = 0xa55a_3cc3_f00f_6996_9669_0ff0_c33c_5aa5u128;
+                    let initial_mask = 0x0ff0_9669_5aa5_c33c_3cc3_a55a_6996_f00fu128;
+                    let field_mask = (1u128 << width) - 1;
+                    let value = 0xd9e7_b3f5_a6c8_912fu128 & field_mask;
+                    let mask = 0xa55a_9669_3cc3_f00fu128 & field_mask;
+                    let destination =
+                        RegionedAbsoluteAddr::from_absolute_addr(STABLE_REGION, address());
+                    let store_offset = if packed_elements {
+                        SIROffset::PackedElements {
+                            bit_offset: offset,
+                            element_width: 15,
+                        }
+                    } else {
+                        SIROffset::Static(offset)
+                    };
+                    let block = BasicBlock {
+                        id: BlockId(0),
+                        params: Vec::new(),
+                        instructions: vec![
+                            SIRInstruction::Imm(
+                                RegisterId(0),
+                                SIRValue::new_four_state(initial, initial_mask),
+                            ),
+                            SIRInstruction::Store(
+                                destination,
+                                SIROffset::Static(0),
+                                128,
+                                RegisterId(0),
+                                Vec::new(),
+                                Vec::new(),
+                            ),
+                            SIRInstruction::Imm(
+                                RegisterId(1),
+                                SIRValue::new_four_state(value, mask),
+                            ),
+                            SIRInstruction::Store(
+                                destination,
+                                store_offset,
+                                width,
+                                RegisterId(1),
+                                Vec::new(),
+                                Vec::new(),
+                            ),
+                        ],
+                        terminator: SIRTerminator::Return,
+                    };
+                    let unit = ExecutionUnit {
+                        entry_block_id: BlockId(0),
+                        blocks: [(BlockId(0), block)].into_iter().collect(),
+                        register_map: [
+                            (RegisterId(0), RegisterType::Logic { width: 128 }),
+                            (RegisterId(1), RegisterType::Logic { width }),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    };
+                    let memory = run_wasm(&unit, &layout(128, four_state), four_state);
+                    let replace =
+                        |old: u128, new: u128| (old & !(field_mask << offset)) | (new << offset);
+                    assert_eq!(
+                        read_bits(&memory, 0, 128),
+                        BigUint::from(replace(initial, value)),
+                        "offset={offset}, width={width}, four_state={four_state}, packed_elements={packed_elements}"
+                    );
+                    if four_state {
+                        assert_eq!(
+                            read_bits_at(&memory, OUTPUT_OFFSET + 16, 0, 128),
+                            BigUint::from(replace(initial_mask, mask)),
+                            "mask at offset={offset}, width={width}, packed_elements={packed_elements}"
+                        );
+                    }
+                }
+            }
+        }
     }
 
     fn assert_results(cases: &[CountCase], memory: &[u8]) {

--- a/crates/celox-backend-x86/src/backend/native/isel.rs
+++ b/crates/celox-backend-x86/src/backend/native/isel.rs
@@ -6,6 +6,7 @@
 mod dynamic_load_cache;
 mod packed_bit_store;
 mod sparse;
+mod strided;
 mod target_policy;
 
 use super::mir::*;
@@ -940,6 +941,8 @@ pub fn lower_execution_unit_with_diagnostics(
     four_state: bool,
     diagnostics: &crate::NativeDiagnostics,
 ) -> MFunction {
+    let expanded = strided::expand_strided_accesses(eu, layout);
+    let eu = expanded.as_ref();
     if cfg!(debug_assertions) || diagnostics.verify_sir {
         if let Err(error) = eu.verify_result() {
             panic!("before native ISel: {error}");

--- a/crates/celox-backend-x86/src/backend/native/isel/strided.rs
+++ b/crates/celox-backend-x86/src/backend/native/isel/strided.rs
@@ -1,0 +1,116 @@
+//! Expand logical aggregate accesses across padded array elements before ISel.
+//!
+//! Native merged-chain optimization runs after layout and can create fresh
+//! PackedElements loads/stores. Their logical bits must not address padding.
+use std::borrow::Cow;
+
+use crate::{
+    ExecutionUnit, MemoryLayout, RegionedAbsoluteAddr, RegisterId, RegisterType, SIRInstruction,
+    SIROffset,
+};
+
+fn split_access(
+    instruction: &SIRInstruction<RegionedAbsoluteAddr>,
+    layout: &MemoryLayout,
+) -> Option<(usize, usize, usize)> {
+    let (address, offset, width) = match instruction {
+        SIRInstruction::Load(_, address, offset, width)
+        | SIRInstruction::Store(address, offset, width, ..) => (address, offset, *width),
+        _ => return None,
+    };
+    let start = match offset {
+        SIROffset::Static(start)
+        | SIROffset::PackedElements {
+            bit_offset: start, ..
+        } => *start,
+        _ => return None,
+    };
+    let array = layout.unpacked_arrays.get(&address.absolute_addr())?;
+    (width != 0
+        && array.element_stride * 8 != array.element_width
+        && width > array.element_width - start % array.element_width)
+        .then_some((start, width, array.element_width))
+}
+
+pub(super) fn expand_strided_accesses<'a>(
+    unit: &'a ExecutionUnit<RegionedAbsoluteAddr>,
+    layout: &MemoryLayout,
+) -> Cow<'a, ExecutionUnit<RegionedAbsoluteAddr>> {
+    if !unit
+        .blocks
+        .values()
+        .flat_map(|block| &block.instructions)
+        .any(|instruction| split_access(instruction, layout).is_some())
+    {
+        return Cow::Borrowed(unit);
+    }
+    let mut unit = unit.clone();
+    let mut next_register = unit
+        .register_map
+        .keys()
+        .map(|register| register.0)
+        .max()
+        .unwrap_or(0)
+        + 1;
+    for block in unit.blocks.values_mut() {
+        let mut instructions = Vec::new();
+        for instruction in std::mem::take(&mut block.instructions) {
+            let Some((start, width, element_width)) = split_access(&instruction, layout) else {
+                instructions.push(instruction);
+                continue;
+            };
+            let register = match &instruction {
+                SIRInstruction::Load(register, ..)
+                | SIRInstruction::Store(_, _, _, register, ..) => *register,
+                _ => unreachable!(),
+            };
+            let source_type = unit.register_map[&register].clone();
+            let mut copied = 0;
+            let mut pieces = Vec::new();
+            while copied < width {
+                let position = start + copied;
+                let count = (element_width - position % element_width).min(width - copied);
+                let piece = RegisterId(next_register);
+                next_register += 1;
+                let piece_type = match source_type {
+                    RegisterType::Logic { .. } => RegisterType::Logic { width: count },
+                    RegisterType::Bit { .. } => RegisterType::Bit {
+                        width: count,
+                        signed: false,
+                    },
+                };
+                unit.register_map.insert(piece, piece_type);
+                match &instruction {
+                    SIRInstruction::Load(_, address, ..) => {
+                        instructions.push(SIRInstruction::Load(
+                            piece,
+                            *address,
+                            SIROffset::Static(position),
+                            count,
+                        ));
+                        pieces.push(piece);
+                    }
+                    SIRInstruction::Store(address, _, _, source, triggers, captures) => {
+                        instructions.push(SIRInstruction::Slice(piece, *source, copied, count));
+                        instructions.push(SIRInstruction::Store(
+                            *address,
+                            SIROffset::Static(position),
+                            count,
+                            piece,
+                            triggers.clone(),
+                            captures.clone(),
+                        ));
+                    }
+                    _ => unreachable!(),
+                }
+                copied += count;
+            }
+            if let SIRInstruction::Load(destination, ..) = instruction {
+                pieces.reverse();
+                instructions.push(SIRInstruction::Concat(destination, pieces));
+            }
+        }
+        block.instructions = instructions;
+    }
+    Cow::Owned(unit)
+}

--- a/crates/celox-frontend-core/src/symbolic/assembly.rs
+++ b/crates/celox-frontend-core/src/symbolic/assembly.rs
@@ -45,9 +45,9 @@ pub struct FusedFfAction {
     pub runtime: FfRuntimeRelocation,
 }
 
-/// Adapter hook for source-aware FF lowering used by the optional fused
-/// comb/FF optimization. The scheduler and all identities crossing this trait
-/// remain source neutral.
+/// Adapter hook for source-aware FF lowering used by shared-clock scheduling,
+/// with or without a preceding comb phase. The scheduler and all identities
+/// crossing this trait remain source neutral.
 pub trait FusedFfLoweringFactory {
     fn create(
         &self,
@@ -665,21 +665,15 @@ pub fn schedule_symbolic_rtl(
         let mut fused_schedule_cache = HashMap::<
             Vec<usize>,
             (
+                Option<Vec<ExecutionUnit<RegionedAbsoluteAddr>>>,
                 Vec<ExecutionUnit<RegionedAbsoluteAddr>>,
                 Vec<VarAtomBase<RegionedAbsoluteAddr>>,
             ),
         >::default();
-        for (trigger, actions) in actions {
-            let action_ids = actions.iter().map(|action| action.id).collect::<Vec<_>>();
-            if let Some((units, direct_ff_writes)) = fused_schedule_cache.get(&action_ids) {
-                eval_comb_apply_ffs.insert(trigger, units.clone());
-                fused_direct_ff_writes.insert(trigger, direct_ff_writes.clone());
-                continue;
-            }
+        let schedule = |paths, actions| {
             let mut ff_lowering = factory.create(actions)?;
-            let fused_start = flatten_timing.then(std::time::Instant::now);
-            let fused = match scheduler::sort_clock(
-                clock_comb_blocks.clone(),
+            match scheduler::sort_clock(
+                paths,
                 &clock_arena,
                 &clock_ignored_loops,
                 &clock_true_loops,
@@ -689,21 +683,51 @@ pub fn schedule_symbolic_rtl(
                 next_runtime_error_code,
                 ff_lowering.as_mut(),
             ) {
-                Ok(schedule) => schedule,
-                Err(scheduler::ClockSortError::Lowering(error)) => return Err(error),
+                Ok(schedule) => Ok(schedule),
+                Err(scheduler::ClockSortError::Lowering(error)) => Err(error),
                 Err(scheduler::ClockSortError::Scheduler(error)) => {
                     let mut error_arena = SLTNodeArena::new();
                     let error =
                         error.map_addr(&clock_arena, &mut error_arena, &|addr| addr.to_string())?;
-                    return Err(ParserError::Scheduler(error));
+                    Err(ParserError::Scheduler(error))
                 }
+            }
+        };
+        for (trigger, actions) in actions {
+            let action_ids = actions.iter().map(|action| action.id).collect::<Vec<_>>();
+            if let Some((ff_only, units, direct_ff_writes)) = fused_schedule_cache.get(&action_ids)
+            {
+                if let Some(ff_only) = ff_only {
+                    eval_apply_ffs.insert(trigger, ff_only.clone());
+                }
+                eval_comb_apply_ffs.insert(trigger, units.clone());
+                fused_direct_ff_writes.insert(trigger, direct_ff_writes.clone());
+                continue;
+            }
+            let fused_start = flatten_timing.then(std::time::Instant::now);
+            // The ordinary tick already settled comb. Reuse the existing
+            // old-state dependency planner with no comb paths: acyclic readers
+            // run before writers, and only cyclic/aliased ranges need staging.
+            // Keep the merged eval-then-apply fallback for adapters without
+            // source-aware lowering and the existing single-action fast path.
+            let ff_only = if actions.len() > 1 {
+                Some(schedule(Vec::new(), actions.clone())?.execution_units)
+            } else {
+                None
             };
+            let fused = schedule(clock_comb_blocks.clone(), actions)?;
             if let Some(start) = fused_start {
                 tracing::debug!("[flatten] scheduler::sort_clock: {:?}", start.elapsed());
             }
             let direct_ff_writes = fused.direct_ff_writes;
             let units = fused.execution_units;
-            fused_schedule_cache.insert(action_ids, (units.clone(), direct_ff_writes.clone()));
+            fused_schedule_cache.insert(
+                action_ids,
+                (ff_only.clone(), units.clone(), direct_ff_writes.clone()),
+            );
+            if let Some(ff_only) = ff_only {
+                eval_apply_ffs.insert(trigger, ff_only);
+            }
             eval_comb_apply_ffs.insert(trigger, units);
             fused_direct_ff_writes.insert(trigger, direct_ff_writes);
         }
@@ -1764,6 +1788,32 @@ fn relocate_units(
                     ),
                 );
             }
+        }
+    }
+    // A canonical event may collect multiple reset groups or instances. The
+    // ordinary tick path must evaluate every group against pre-edge state
+    // before any group publishes its nonblocking assignments. Concatenating
+    // each module's eval+apply unit instead makes behavior depend on map order.
+    for (event, units) in &mut eval_apply_ffs {
+        if units.len() > 1 {
+            let evaluations = eval_only_ffs.get(event).ok_or_else(|| {
+                ParserError::illegal_context(
+                    "FF event assembly",
+                    "shared event has no evaluation phase",
+                    None,
+                )
+            })?;
+            let applications = apply_ffs.get(event).ok_or_else(|| {
+                ParserError::illegal_context(
+                    "FF event assembly",
+                    "shared event has no application phase",
+                    None,
+                )
+            })?;
+            let phases = evaluations.iter().chain(applications).collect::<Vec<_>>();
+            // Keep the staging stores and their commits in the same optimizer
+            // unit: WORKING-region stores are otherwise local dead stores.
+            *units = vec![celox_sir::merge_sir_eu_refs(&phases).0];
         }
     }
     Ok((

--- a/crates/celox-sir-opt/src/optimizer/passes/memory/pass_global_store_load_forwarding.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/memory/pass_global_store_load_forwarding.rs
@@ -556,7 +556,6 @@ impl WorkingValueKind {
 struct WorkingAddressFacts {
     endpoints: BTreeSet<usize>,
     accesses: Vec<(usize, usize)>,
-    seeds: Vec<(usize, usize)>,
     stores: Vec<(usize, usize)>,
     applies: Vec<(usize, usize)>,
     kind: Option<WorkingValueKind>,
@@ -591,10 +590,15 @@ impl WorkingAddressFacts {
         } else {
             WorkingValueKind::for_type(ty)
         };
-        if self.kind.is_some_and(|previous| previous != kind) {
-            self.invalid = true;
-        }
-        self.kind.get_or_insert(kind);
+        // A known reset constant is Bit even when another path stores Logic.
+        // Use a Logic SSA value for that join; normalization gives Bit inputs
+        // a zero unknown-mask plane instead of rejecting the entire slot.
+        self.kind = Some(match (self.kind, kind) {
+            (Some(WorkingValueKind::Logic), _) | (_, WorkingValueKind::Logic) => {
+                WorkingValueKind::Logic
+            }
+            _ => WorkingValueKind::Bit,
+        });
         self.record_range(offset, width)
     }
 }
@@ -888,9 +892,7 @@ pub(crate) fn promote_eval_apply_working_round_trips_with_mode(
                     && source.absolute_addr() == destination.absolute_addr() =>
                 {
                     let entry = facts.entry(destination.absolute_addr()).or_default();
-                    if let Some(range) = entry.record_range(*offset, *width) {
-                        entry.seeds.push(range);
-                    }
+                    entry.record_range(*offset, *width);
                     entry.invalid |= !triggers.is_empty();
                 }
                 SIRInstruction::Commit(
@@ -954,7 +956,10 @@ pub(crate) fn promote_eval_apply_working_round_trips_with_mode(
             if !covered(&facts.accesses) {
                 continue;
             }
-            if !covered(&facts.seeds) || !covered(&facts.stores) || !covered(&facts.applies) {
+            // Earlier DSE can remove a seed when every path defines the slot.
+            // The StateSSA preview below still rejects any remaining live-in,
+            // including a conditional store which needs the previous value.
+            if !covered(&facts.stores) || !covered(&facts.applies) {
                 complete = false;
                 break;
             }
@@ -1771,6 +1776,127 @@ mod tests {
             Some(SIRInstruction::Store(address, SIROffset::Static(0), 8, RegisterId(0), _, _))
                 if *address == stable
         ));
+    }
+
+    fn working_reset_diamond(seed: bool, mixed_types: bool) -> ExecutionUnit<RegionedAbsoluteAddr> {
+        let stable = address(0);
+        let working = RegionedAbsoluteAddr {
+            region: WORKING_REGION,
+            ..stable
+        };
+        let store = |register| {
+            SIRInstruction::Store(
+                working,
+                SIROffset::Static(0),
+                8,
+                register,
+                Vec::new(),
+                Vec::new(),
+            )
+        };
+        unit(
+            [
+                BasicBlock {
+                    id: BlockId(0),
+                    params: vec![RegisterId(0), RegisterId(1), RegisterId(2)],
+                    instructions: if seed {
+                        vec![SIRInstruction::Commit(
+                            stable,
+                            working,
+                            SIROffset::Static(0),
+                            8,
+                            Vec::new(),
+                        )]
+                    } else {
+                        Vec::new()
+                    },
+                    terminator: SIRTerminator::Branch {
+                        cond: RegisterId(0),
+                        true_block: (BlockId(1), Vec::new()),
+                        false_block: (BlockId(2), Vec::new()),
+                    },
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    params: Vec::new(),
+                    instructions: vec![store(RegisterId(1))],
+                    terminator: SIRTerminator::Jump(BlockId(3), Vec::new()),
+                },
+                BasicBlock {
+                    id: BlockId(2),
+                    params: Vec::new(),
+                    instructions: vec![store(RegisterId(2))],
+                    terminator: SIRTerminator::Jump(BlockId(3), Vec::new()),
+                },
+                BasicBlock {
+                    id: BlockId(3),
+                    params: Vec::new(),
+                    instructions: vec![
+                        // Another FF must still see pre-edge state at this point.
+                        SIRInstruction::Load(RegisterId(3), stable, SIROffset::Static(0), 8),
+                        SIRInstruction::Store(
+                            address_in_instance(1),
+                            SIROffset::Static(0),
+                            8,
+                            RegisterId(3),
+                            Vec::new(),
+                            Vec::new(),
+                        ),
+                        SIRInstruction::Commit(
+                            working,
+                            stable,
+                            SIROffset::Static(0),
+                            8,
+                            Vec::new(),
+                        ),
+                    ],
+                    terminator: SIRTerminator::Return,
+                },
+            ],
+            [
+                (RegisterId(0), bit(1)),
+                (RegisterId(1), bit(8)),
+                (
+                    RegisterId(2),
+                    if mixed_types {
+                        RegisterType::Logic { width: 8 }
+                    } else {
+                        bit(8)
+                    },
+                ),
+                (RegisterId(3), bit(8)),
+            ],
+        )
+    }
+
+    #[test]
+    fn promotes_fully_defined_working_joins_after_seed_dse_and_type_mixing() {
+        for (seed, mixed_types) in [(false, false), (true, true), (false, true)] {
+            let mut eu = working_reset_diamond(seed, mixed_types);
+            eu.verify_result().unwrap();
+            assert!(
+                promote_eval_apply_working_round_trips(&mut eu),
+                "seed={seed}, mixed_types={mixed_types}"
+            );
+            eu.verify_result().unwrap();
+            assert!(eu.blocks.values().flat_map(|block| &block.instructions).all(|instruction| !matches!(instruction,
+                SIRInstruction::Load(_, address, ..) | SIRInstruction::Store(address, ..) if address.region == WORKING_REGION
+            ) && !matches!(instruction, SIRInstruction::Commit(..))));
+            let join = &eu.blocks[&BlockId(3)].instructions;
+            let old_read = join.iter().position(|instruction| matches!(instruction, SIRInstruction::Load(_, address, ..) if *address == address_in_instance(0))).unwrap();
+            let publish = join.iter().position(|instruction| matches!(instruction, SIRInstruction::Store(address, ..) if *address == address_in_instance(0))).unwrap();
+            assert!(old_read < publish);
+        }
+    }
+
+    #[test]
+    fn keeps_seedless_working_storage_when_a_path_has_no_definition() {
+        let mut eu = working_reset_diamond(false, true);
+        eu.blocks.get_mut(&BlockId(2)).unwrap().instructions.clear();
+        let before = eu.clone();
+        assert!(!promote_eval_apply_working_round_trips(&mut eu));
+        assert_eq!(eu.blocks, before.blocks);
+        assert_eq!(eu.register_map, before.register_map);
     }
 
     #[test]

--- a/crates/celox/tests/ff_event_snapshot.rs
+++ b/crates/celox/tests/ff_event_snapshot.rs
@@ -10,6 +10,9 @@ fn reset_constants_and_unknown_values_share_a_working_join(sim) {
     // Veryl's reference simulator disagrees on the known payload bits of the
     // mixed-X 64-bit value below. Exercise the four Celox backends directly.
     @omit_veryl;
+    // The SV frontend rejects four-state always_ff event signals, as in the
+    // existing four_state FF tests. Keep every Celox execution backend covered.
+    @ignore_on(sv);
     @setup {
         let source = r#"
             module Top (

--- a/crates/celox/tests/ff_event_snapshot.rs
+++ b/crates/celox/tests/ff_event_snapshot.rs
@@ -1,0 +1,177 @@
+use celox::SimulatorBuilder;
+
+#[path = "test_utils/mod.rs"]
+#[macro_use]
+#[allow(unused_macros)]
+mod test_utils;
+
+all_backends! {
+fn reset_constants_and_unknown_values_share_a_working_join(sim) {
+    // Veryl's reference simulator disagrees on the known payload bits of the
+    // mixed-X 64-bit value below. Exercise the four Celox backends directly.
+    @omit_veryl;
+    @setup {
+        let source = r#"
+            module Top (
+                clk: input clock, rst_n: input reset_async_low,
+                enable: input logic, d: input logic<64>,
+                a: output logic<64>, b: output logic<64>,
+            ) {
+                always_ff (clk, rst_n) {
+                    if_reset { a = 64'h1357; }
+                    else if enable { a = d; }
+                }
+                always_ff (clk) {
+                    if !rst_n { b = 64'h2468; }
+                    else { b = a; }
+                }
+            }
+        "#;
+    }
+    @build SimulatorBuilder::new(source, "Top").opt_level(celox::OptLevel::O0).four_state(true);
+    let clk = sim.event("clk");
+    let rst = sim.signal("rst_n");
+    let enable = sim.signal("enable");
+    let d = sim.signal("d");
+    let a = sim.signal("a");
+    let b = sim.signal("b");
+    for _ in 0..2 {
+        sim.modify(|io| { io.set(rst, 0u8); io.set(enable, 0u8); io.set(d, 0u64); }).unwrap();
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get_four_state(a), (0x1357u32.into(), 0u8.into()));
+        assert_eq!(sim.get_four_state(b), (0x2468u32.into(), 0u8.into()));
+        sim.modify(|io| io.set(rst, 1u8)).unwrap();
+        let mut previous = sim.get_four_state(a);
+        for (value, mask, enabled) in [
+            (0x1234_5678_9abc_def0u64, 0xff00_1234_5678_00ffu64, true),
+            (0, 0, false),
+            (0, u64::MAX, true),
+            (u64::MAX, 0, false),
+            (0xfedc_ba98_7654_3210, 0, true),
+        ] {
+            let expected = if enabled { ((value | mask).into(), mask.into()) } else { previous.clone() };
+            sim.modify(|io| {
+                io.set_four_state(d, (value | mask).into(), mask.into());
+                io.set(enable, u8::from(enabled));
+            }).unwrap();
+            sim.tick(clk).unwrap();
+            assert_eq!(sim.get_four_state(a), expected);
+            assert_eq!(sim.get_four_state(b), previous);
+            previous = expected;
+        }
+    }
+}
+}
+
+const STREAM: &str = r#"
+module Top #(param UNUSED: u32 = 0,) (
+    clk: input clock, rst_n: input reset_async_low,
+    addr: input logic<4>, data: input logic<8>, q: output logic<8>,
+) {
+    var addr_q: logic<4>;
+    var data_q: logic<8>;
+    var ram: logic<8> [16];
+    always_ff (clk, rst_n) {
+        if_reset { addr_q = 0; data_q = 0; }
+        else { addr_q = addr; data_q = data; }
+    }
+    always_ff (clk) { ram[addr_q] = data_q; }
+    assign q = ram[addr];
+}
+"#;
+
+#[test]
+fn acyclic_shared_clock_inputs_do_not_require_a_working_copy() {
+    use celox_design::{STABLE_REGION, WORKING_REGION};
+    use celox_sir::SIRInstruction;
+    let result = SimulatorBuilder::new(STREAM, "Top")
+        .opt_level(celox::OptLevel::O0)
+        .trace_pre_optimized_sir()
+        .build_with_trace();
+    let clk = result.res.unwrap().event("clk").addr;
+    let program = result.trace.pre_optimized_sir.unwrap();
+    let mut stores = 0;
+    for instruction in program.sir.eval_apply_ffs[&clk]
+        .iter()
+        .flat_map(|unit| unit.blocks.values())
+        .flat_map(|block| &block.instructions)
+    {
+        match instruction {
+            SIRInstruction::Commit(source, destination, ..) => {
+                assert_ne!(source.region, WORKING_REGION, "{instruction:?}");
+                assert_ne!(destination.region, WORKING_REGION, "{instruction:?}");
+            }
+            SIRInstruction::Store(address, ..) => {
+                assert_ne!(address.region, WORKING_REGION, "{instruction:?}");
+                stores += usize::from(address.region == STABLE_REGION);
+            }
+            _ => {}
+        }
+    }
+    // Dynamic RAM writes may use the sparse dirty set. The two scalar input
+    // registers must update directly after their old values have been read.
+    assert!(stores >= 2);
+}
+
+all_backends! {
+fn acyclic_shared_clock_array_samples_the_previous_input_pair(sim) {
+    @build SimulatorBuilder::new(STREAM, "Top").opt_level(celox::OptLevel::O0);
+    let clk = sim.event("clk");
+    let rst = sim.signal("rst_n");
+    let addr = sim.signal("addr");
+    let data = sim.signal("data");
+    let q = sim.signal("q");
+    sim.modify(|io| { io.set(rst, 0u8); io.set(addr, 0u8); io.set(data, 0u8); }).unwrap();
+    sim.tick(clk).unwrap();
+    sim.modify(|io| io.set(rst, 1u8)).unwrap();
+    for index in 0u8..16 {
+        sim.modify(|io| { io.set(addr, index); io.set(data, index * 7 + 13); }).unwrap();
+        sim.tick(clk).unwrap();
+    }
+    sim.tick(clk).unwrap();
+    for index in 0u8..16 {
+        sim.modify(|io| io.set(addr, index)).unwrap();
+        assert_eq!(sim.get(q), (index * 7 + 13).into(), "row {index}");
+    }
+}
+}
+
+all_backends! {
+fn reset_groups_sample_the_same_pre_edge_state(sim) {
+    @setup {
+        let source = r#"
+            module Top #(param UNUSED: u32 = 0,) (
+                clk: input clock,
+                rst_n: input reset_async_low,
+                a: output logic<8>,
+                b: output logic<8>,
+            ) {
+                always_ff (clk, rst_n) {
+                    if_reset { a = 8'h13; }
+                    else { a = b; }
+                }
+                always_ff (clk) {
+                    if !rst_n { b = 8'h57; }
+                    else { b = a; }
+                }
+            }
+        "#;
+    }
+    @build SimulatorBuilder::new(source, "Top");
+    let clk = sim.event("clk");
+    let rst = sim.signal("rst_n");
+    let a = sim.signal("a");
+    let b = sim.signal("b");
+    sim.modify(|io| io.set(rst, 0u8)).unwrap();
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(a), 0x13u8.into());
+    assert_eq!(sim.get(b), 0x57u8.into());
+    sim.modify(|io| io.set(rst, 1u8)).unwrap();
+    for cycle in 0..8 {
+        sim.tick(clk).unwrap();
+        let (want_a, want_b) = if cycle % 2 == 0 { (0x57u8, 0x13u8) } else { (0x13u8, 0x57u8) };
+        assert_eq!(sim.get(a), want_a.into(), "cycle {cycle}");
+        assert_eq!(sim.get(b), want_b.into(), "cycle {cycle}");
+    }
+}
+}

--- a/crates/celox/tests/ff_narrow_arrays.rs
+++ b/crates/celox/tests/ff_narrow_arrays.rs
@@ -1,0 +1,59 @@
+use celox::{OptLevel, SimulatorBuilder};
+
+#[path = "test_utils/mod.rs"]
+#[macro_use]
+#[allow(unused_macros)]
+mod test_utils;
+
+all_backends! {
+fn ff_captures_every_one_bit_array_element_without_optimization(sim) {
+    @setup {
+        let source = r#"
+            module Top (clk: input clock, d: input logic<8>, q: output logic<8>) {
+                var flags: logic [8];
+                always_ff (clk) {
+                    for i in 0..8 { flags[i] = d[i]; }
+                }
+                assign q = {flags[7], flags[6], flags[5], flags[4], flags[3], flags[2], flags[1], flags[0]};
+            }
+        "#;
+    }
+    @build SimulatorBuilder::new(source, "Top").opt_level(OptLevel::O0);
+    let clk = sim.event("clk");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    for value in [0u8, 0xff, 0x55, 0xaa, 0x81, 0x7e] {
+        sim.modify(|io| io.set(d, value)).unwrap();
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get(q), value.into(), "input {value:#x}");
+    }
+}
+}
+
+all_backends! {
+fn ff_captures_padded_elements_and_unknown_masks(sim) {
+    @setup {
+        let source = r#"
+            module Top (clk: input clock, d: input logic<24>, q: output logic<24>) {
+                var lanes: logic<3> [8];
+                always_ff (clk) {
+                    for i in 0..8 { lanes[i] = d[i * 3 +: 3]; }
+                }
+                assign q = {lanes[7], lanes[6], lanes[5], lanes[4], lanes[3], lanes[2], lanes[1], lanes[0]};
+            }
+        "#;
+    }
+    @build SimulatorBuilder::new(source, "Top").opt_level(OptLevel::O0).four_state(true);
+    let clk = sim.event("clk");
+    let d = sim.signal("d");
+    let q = sim.signal("q");
+    for (value, mask) in [(0xffffffu32, 0u32), (0x91a653, 0x263ac9), (0x123456, 0xe39a58), (0, 0xffffff)] {
+        // Set masked bits to X (value=1, mask=1), including an all-X pattern.
+        let value = celox::BigUint::from(value | mask);
+        let mask = celox::BigUint::from(mask);
+        sim.modify(|io| io.set_four_state(d, value.clone(), mask.clone())).unwrap();
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get_four_state(q), (value, mask));
+    }
+}
+}

--- a/crates/celox/tests/ff_narrow_arrays.rs
+++ b/crates/celox/tests/ff_narrow_arrays.rs
@@ -32,6 +32,9 @@ fn ff_captures_every_one_bit_array_element_without_optimization(sim) {
 
 all_backends! {
 fn ff_captures_padded_elements_and_unknown_masks(sim) {
+    // The SV frontend currently rejects four-state always_ff event signals.
+    // This limitation does not apply to the four Celox execution backends.
+    @ignore_on(sv);
     @setup {
         let source = r#"
             module Top (clk: input clock, d: input logic<24>, q: output logic<24>) {


### PR DESCRIPTION
## Summary

Consecutive debug byte writes can shift by one byte after adding an unused module parameter to `HardwareMemory`. The parameter changes variable/map ordering: the ordinary `tick()` path publishes one FF reset group's updates before another group samples its inputs. Every group must observe the same pre-edge state.

This fixes that ordering and two independent backend defects exposed by the expanded memory regression, while removing avoidable FF staging:

- **Shared-clock FF assembly:** merge all evaluations followed by all publications into one optimization unit as the fallback. Separate units allow staging stores to be incorrectly treated as dead. For frontends with source-aware lowering, reuse the existing dependency scheduler with no preceding comb paths on ordinary multi-group ticks. Safe readers run before direct writers; cycles, dynamic addresses and aliased storage retain staging. Single-group events retain their existing path.
- **Native Working-state promotion:** allow fully defined joins after seed DSE and normalize mixed Bit reset constants / Logic values to Logic. The existing StateSSA analysis still rejects live-in, effectful and escaping storage. Preserve old-state reads before publication and reject undefined paths without changing the input IR.
- **WASM shifted stores:** select the scalar read-modify-write path by `bit_shift + op_width <= 64`. A 60-bit store at bit 15 covers 67 destination bits and previously lost the spill.
- **Native padded arrays:** split static aggregate accesses at logical element boundaries before instruction selection. Late optimization can combine one-bit FF elements even at O0, although their physical layout uses one byte per element.

Regressions cover FF swaps across reset groups, a registered consecutive-write stream, removal of redundant scalar staging, conditional holds with mixed known/X 64-bit values, padded narrow arrays, and both sides of the WASM store boundary including neighboring bits and unknown masks.

### Performance

Compared against the **correct two-phase version**, using identical precompiled Veryl models with native O1/two-state on a Ryzen 7 9800X3D under WSL2. Each experiment uses 9 alternating AB/BA samples, one live model at a time, with initialization/compilation outside the timer. The second experiment reverses the candidate order.

| Workload | Experiment 1 throughput change | Experiment 2 throughput change |
| --- | ---: | ---: |
| Two mutually dependent 64-bit FFs | +1.66% | +1.39% |
| Consecutive memory debug writes | +3.45% | +4.56% |
| RV64 CPU model executing an sd/ld/add loop | -2.03% | +7.38% |

CPU-wide speedup is **not established** because the timing difference changes sign. Static Working-region references in the ordinary CPU-clock IR drop from 59 to 10, and memory-clock references from 21 to 0; these are static instruction counts, not runtime access counts. The CPU image shrinks from 343,302 to 342,626 bytes. These downstream measurements used 0.4.5 with the identical implementation changes; they are not FPGA clock or IPC improvements.

## Validation

Local Rust validation uses **1.98.0**; the repository's pinned 1.98.1 toolchain is not installed locally.

- Latest `master` (`01acba6ec`) plus this PR: changed-component unit/doc tests **906 passed**, related Celox library/integration tests **1,541 passed, 171 existing ignored**; `cargo fmt --all --check`, all-targets clippy for the four changed crates, and `cargo check --workspace --locked` pass.
- The two new integration targets with `--features systemverilog`: **28 passed, 2 ignored**. The two four-state SV instances hit the frontend's existing rejection of four-state `always_ff` event signals; they use the same SV exclusion as the existing four-state FF tests. All four Celox execution backends remain enabled.
- The integration selection includes `ff_event_snapshot`, `ff_narrow_arrays`, `flip_flop`, `ff_comb_clock`, `multi_clock`, `cascade_race`, `bram_corruption`, `reset_edge_cases`, `std_ram`, `hierarchy`, `simulator_api`, `simulation_step`, `counter`, `tiered`, `four_state`, `native_boundary_hardening`, and `frontend_sdk`.
- Downstream Rica on 0.4.5 with these implementation changes: **24/24** original/parameterized memory combinations across native, Cranelift, interpreter and WASM at O0/O1/O2; **154 tests passed, 1 existing ignored**; the archived LSU memory's four tests pass for FAST_LSU=0/1/2.
- Normal and archived LSU-disabled CPU models: **400/400** runs (100 fixed ELFs per model, both coincident-clock orders). Commit counts and cycle metrics match each other and the earlier correct implementation; RTL/ELF hashes are unchanged.
- The correctness-only baseline has independent negative controls for its three fixes. Removing the new StateSSA change also makes its new promotion regression fail.
- The mixed-X 64-bit regression runs on all four Celox backends with explicit expected values. The separate Veryl reference simulator disagrees on known payload bits for that case, so it is not used as that test's oracle.
