### PR TITLE
perf(x86): restore Heliodor speedups with padded array fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
         run: cargo check --locked -p celox -p celox-bench
 
       - name: Test AArch64 facade integration
-        run: cargo test --locked -p celox --lib
+        run: cargo test --locked -p celox --lib --test native_exec
 
       - name: Check x86-64 cross-codegen from AArch64
         run: >-

--- a/crates/celox-backend-arm64/src/isel.rs
+++ b/crates/celox-backend-arm64/src/isel.rs
@@ -7,6 +7,7 @@
 mod dynamic_load_cache;
 mod packed_compare;
 mod sparse;
+mod strided;
 
 use super::mir::*;
 use super::sparse_write_state::{
@@ -80,6 +81,8 @@ pub fn lower_execution_unit_with_diagnostics(
     four_state: bool,
     diagnostics: &crate::NativeDiagnostics,
 ) -> MFunction {
+    let expanded = strided::expand_strided_accesses(eu, layout);
+    let eu = expanded.as_ref();
     if cfg!(debug_assertions) || diagnostics.verify_sir {
         if let Err(error) = eu.verify_result() {
             panic!("before native ISel: {error}");
@@ -5501,12 +5504,27 @@ fn lower_instruction(
                         && let Some(load_size) =
                             ctx.full_static_load_size(addr, *bit_off, *width_bits)
                     {
+                        // Padding can retain unrelated bits after partial writes.
+                        // Strip it before the element participates in a concat.
+                        let padded_element = ctx
+                            .layout
+                            .unpacked_arrays
+                            .contains_key(&addr.absolute_addr())
+                            && ISelContext::access_size_has_padding(load_size, *width_bits);
+                        let raw = if padded_element {
+                            ctx.alloc_vreg(SpillDesc::transient())
+                        } else {
+                            vreg
+                        };
                         block.push(MInst::Load {
-                            dst: vreg,
+                            dst: raw,
                             base: BaseReg::SimState,
                             offset: byte_off,
                             size: load_size,
                         });
+                        if padded_element {
+                            ctx.emit_and_imm(block, vreg, raw, mask_for_width(*width_bits));
+                        }
                         ctx.known_bits.insert(vreg, *width_bits);
                     } else if intra_byte == 0 && OpSize::from_bits(*width_bits).is_some() {
                         // Word-aligned, native size: single load.
@@ -13093,6 +13111,8 @@ fn lower_wide_unary_mask(
 }
 #[cfg(test)]
 mod tests {
+    mod strided;
+
     use super::*;
     use crate::{AbsoluteAddr, SIRValue};
     use celox_design::{InstanceId, StateObjectId};

--- a/crates/celox-backend-arm64/src/isel/strided.rs
+++ b/crates/celox-backend-arm64/src/isel/strided.rs
@@ -1,0 +1,116 @@
+//! Expand logical aggregate accesses across padded array elements before ISel.
+//!
+//! Native merged-chain optimization runs after layout and can create fresh
+//! PackedElements loads/stores. Their logical bits must not address padding.
+use std::borrow::Cow;
+
+use crate::{
+    ExecutionUnit, MemoryLayout, RegionedAbsoluteAddr, RegisterId, RegisterType, SIRInstruction,
+    SIROffset,
+};
+
+fn split_access(
+    instruction: &SIRInstruction<RegionedAbsoluteAddr>,
+    layout: &MemoryLayout,
+) -> Option<(usize, usize, usize)> {
+    let (address, offset, width) = match instruction {
+        SIRInstruction::Load(_, address, offset, width)
+        | SIRInstruction::Store(address, offset, width, ..) => (address, offset, *width),
+        _ => return None,
+    };
+    let start = match offset {
+        SIROffset::Static(start)
+        | SIROffset::PackedElements {
+            bit_offset: start, ..
+        } => *start,
+        _ => return None,
+    };
+    let array = layout.unpacked_arrays.get(&address.absolute_addr())?;
+    (width != 0
+        && array.element_stride * 8 != array.element_width
+        && width > array.element_width - start % array.element_width)
+        .then_some((start, width, array.element_width))
+}
+
+pub(super) fn expand_strided_accesses<'a>(
+    unit: &'a ExecutionUnit<RegionedAbsoluteAddr>,
+    layout: &MemoryLayout,
+) -> Cow<'a, ExecutionUnit<RegionedAbsoluteAddr>> {
+    if !unit
+        .blocks
+        .values()
+        .flat_map(|block| &block.instructions)
+        .any(|instruction| split_access(instruction, layout).is_some())
+    {
+        return Cow::Borrowed(unit);
+    }
+    let mut unit = unit.clone();
+    let mut next_register = unit
+        .register_map
+        .keys()
+        .map(|register| register.0)
+        .max()
+        .unwrap_or(0)
+        + 1;
+    for block in unit.blocks.values_mut() {
+        let mut instructions = Vec::new();
+        for instruction in std::mem::take(&mut block.instructions) {
+            let Some((start, width, element_width)) = split_access(&instruction, layout) else {
+                instructions.push(instruction);
+                continue;
+            };
+            let register = match &instruction {
+                SIRInstruction::Load(register, ..)
+                | SIRInstruction::Store(_, _, _, register, ..) => *register,
+                _ => unreachable!(),
+            };
+            let source_type = unit.register_map[&register].clone();
+            let mut copied = 0;
+            let mut pieces = Vec::new();
+            while copied < width {
+                let position = start + copied;
+                let count = (element_width - position % element_width).min(width - copied);
+                let piece = RegisterId(next_register);
+                next_register += 1;
+                let piece_type = match source_type {
+                    RegisterType::Logic { .. } => RegisterType::Logic { width: count },
+                    RegisterType::Bit { .. } => RegisterType::Bit {
+                        width: count,
+                        signed: false,
+                    },
+                };
+                unit.register_map.insert(piece, piece_type);
+                match &instruction {
+                    SIRInstruction::Load(_, address, ..) => {
+                        instructions.push(SIRInstruction::Load(
+                            piece,
+                            *address,
+                            SIROffset::Static(position),
+                            count,
+                        ));
+                        pieces.push(piece);
+                    }
+                    SIRInstruction::Store(address, _, _, source, triggers, captures) => {
+                        instructions.push(SIRInstruction::Slice(piece, *source, copied, count));
+                        instructions.push(SIRInstruction::Store(
+                            *address,
+                            SIROffset::Static(position),
+                            count,
+                            piece,
+                            triggers.clone(),
+                            captures.clone(),
+                        ));
+                    }
+                    _ => unreachable!(),
+                }
+                copied += count;
+            }
+            if let SIRInstruction::Load(destination, ..) = instruction {
+                pieces.reverse();
+                instructions.push(SIRInstruction::Concat(destination, pieces));
+            }
+        }
+        block.instructions = instructions;
+    }
+    Cow::Owned(unit)
+}

--- a/crates/celox-backend-arm64/src/isel/tests/strided.rs
+++ b/crates/celox-backend-arm64/src/isel/tests/strided.rs
@@ -1,0 +1,228 @@
+//! Execute aggregate accesses against independently initialized physical lanes.
+use super::*;
+use celox_state_layout::{SparseWorkingLayout, UnpackedArrayLayout};
+use num_bigint::BigUint;
+
+fn set_bit(bytes: &mut [u8], bit: usize, value: bool) {
+    bytes[bit / 8] = (bytes[bit / 8] & !(1 << (bit % 8))) | ((value as u8) << (bit % 8));
+}
+
+#[test]
+fn aggregate_accesses_preserve_strided_elements_and_masks() {
+    const OUTPUT: usize = 256;
+    const SPARSE: usize = 512;
+    const DIRTY: usize = 896;
+    const SUMMARY: usize = 904;
+    const ACTIVE: usize = 912;
+    const STATE_SIZE: usize = 1024;
+    for element_width in [1usize, 3, 7, 8, 17, 24, 33, 51, 57, 64, 65] {
+        for four_state in [false, true] {
+            for sparse in [false, true] {
+                for packed_offset in [false, true] {
+                    let width = element_width * 4;
+                    let stride = element_width.div_ceil(8).next_power_of_two();
+                    let plane_size = stride * 4;
+                    let start = if packed_offset { element_width } else { 1 };
+                    let count = element_width * 2 + usize::from(!packed_offset);
+                    let absolute = AbsoluteAddr {
+                        instance_id: InstanceId(0),
+                        var_id: StateObjectId(0),
+                    };
+                    let output_absolute = AbsoluteAddr {
+                        var_id: StateObjectId(1),
+                        ..absolute
+                    };
+                    let stable = RegionedAbsoluteAddr::from_absolute_addr(STABLE_REGION, absolute);
+                    let destination = RegionedAbsoluteAddr::from_absolute_addr(
+                        if sparse {
+                            crate::SPARSE_WORKING_REGION
+                        } else {
+                            STABLE_REGION
+                        },
+                        absolute,
+                    );
+                    let output =
+                        RegionedAbsoluteAddr::from_absolute_addr(STABLE_REGION, output_absolute);
+                    let offset = |bit_offset| {
+                        if packed_offset {
+                            SIROffset::PackedElements {
+                                bit_offset,
+                                element_width,
+                            }
+                        } else {
+                            SIROffset::Static(bit_offset)
+                        }
+                    };
+                    let mut value = vec![0u8; count.div_ceil(8)];
+                    let mut mask = value.clone();
+                    for bit in 0..count {
+                        let unknown = four_state && bit % 5 == 1;
+                        set_bit(&mut value, bit, bit % 3 != 0 || unknown);
+                        set_bit(&mut mask, bit, unknown);
+                    }
+                    let replacement = RegisterId(0);
+                    let loaded = RegisterId(1);
+                    let mut instructions = vec![
+                        SIRInstruction::Imm(
+                            replacement,
+                            SIRValue::new_four_state(
+                                BigUint::from_bytes_le(&value),
+                                BigUint::from_bytes_le(&mask),
+                            ),
+                        ),
+                        SIRInstruction::Store(
+                            destination,
+                            offset(start),
+                            count,
+                            replacement,
+                            vec![],
+                            vec![],
+                        ),
+                    ];
+                    if sparse {
+                        instructions.push(SIRInstruction::Commit(
+                            destination,
+                            stable,
+                            SIROffset::Static(0),
+                            width,
+                            vec![],
+                        ));
+                    }
+                    instructions.extend([
+                        SIRInstruction::Load(loaded, stable, offset(0), width),
+                        SIRInstruction::Store(
+                            output,
+                            SIROffset::Static(0),
+                            width,
+                            loaded,
+                            vec![],
+                            vec![],
+                        ),
+                    ]);
+                    let unit = ExecutionUnit {
+                        entry_block_id: SirBlockId(0),
+                        blocks: [(
+                            SirBlockId(0),
+                            BasicBlock {
+                                id: SirBlockId(0),
+                                params: vec![],
+                                instructions,
+                                terminator: SIRTerminator::Return,
+                            },
+                        )]
+                        .into_iter()
+                        .collect(),
+                        register_map: [(replacement, count), (loaded, width)]
+                            .into_iter()
+                            .map(|(register, width)| {
+                                (
+                                    register,
+                                    if four_state {
+                                        RegisterType::Logic { width }
+                                    } else {
+                                        RegisterType::Bit {
+                                            width,
+                                            signed: false,
+                                        }
+                                    },
+                                )
+                            })
+                            .collect(),
+                    };
+                    let mut layout = layout_for(absolute, width, four_state);
+                    layout.mode = MemoryLayoutMode::ElementStrided;
+                    layout.unpacked_arrays.insert(
+                        absolute,
+                        UnpackedArrayLayout {
+                            element_width,
+                            element_count: 4,
+                            element_stride: stride,
+                            plane_size,
+                        },
+                    );
+                    layout.offsets.insert(output_absolute, OUTPUT);
+                    layout.widths.insert(output_absolute, width);
+                    layout.is_4states.insert(output_absolute, four_state);
+                    layout.total_size = SPARSE;
+                    layout.working_base_offset = SPARSE;
+                    layout.sparse_base_offset = SPARSE;
+                    if sparse {
+                        layout.sparse_offsets.insert(absolute, 0);
+                        layout.sparse_layouts.insert(
+                            absolute,
+                            SparseWorkingLayout {
+                                active_index: 0,
+                                chunk_count: plane_size.div_ceil(8),
+                                dirty_words_offset: DIRTY,
+                                dirty_word_count: 1,
+                                summary_words_offset: SUMMARY,
+                                summary_word_count: 1,
+                            },
+                        );
+                        layout.sparse_active_capacity = 1;
+                    }
+                    layout.sparse_active_bits_offset = ACTIVE;
+                    layout.merged_total_size = STATE_SIZE;
+                    layout.triggered_bits_offset = STATE_SIZE;
+                    layout.scratch_base_offset = STATE_SIZE;
+                    let result = crate::scalar::emit_prepared_eu(
+                        &unit,
+                        &layout,
+                        four_state,
+                        "strided_aggregate",
+                        false,
+                        None,
+                        || false,
+                    )
+                    .unwrap();
+                    assert!(!result.code.is_empty());
+
+                    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+                    {
+                        let jit = crate::jit_mem::JitCode::new(&result.code).unwrap();
+                        let mut state = vec![0xa5; STATE_SIZE];
+                        state[DIRTY..ACTIVE + 8].fill(0);
+                        for plane in 0..if four_state { 2 } else { 1 } {
+                            for bit in 0..width {
+                                let initial = if plane == 0 {
+                                    bit % 2 == 0
+                                } else {
+                                    bit % 7 == 0
+                                };
+                                let physical = (plane * plane_size + bit / element_width * stride)
+                                    * 8
+                                    + bit % element_width;
+                                set_bit(&mut state, physical, initial);
+                            }
+                        }
+                        assert_eq!(unsafe { jit.call(&mut state) }, 0);
+                        for plane in 0..if four_state { 2 } else { 1 } {
+                            for bit in 0..width {
+                                let expected = if (start..start + count).contains(&bit) {
+                                    let source = if plane == 0 { &value } else { &mask };
+                                    (source[(bit - start) / 8] >> ((bit - start) % 8)) & 1
+                                } else if plane == 0 {
+                                    (bit % 2 == 0) as u8
+                                } else {
+                                    (bit % 7 == 0) as u8
+                                };
+                                let physical = (plane * plane_size + bit / element_width * stride)
+                                    * 8
+                                    + bit % element_width;
+                                let gathered = (OUTPUT + plane * width.div_ceil(8)) * 8 + bit;
+                                for location in [physical, gathered] {
+                                    assert_eq!(
+                                        (state[location / 8] >> (location % 8)) & 1,
+                                        expected,
+                                        "element_width={element_width}, four_state={four_state}, sparse={sparse}, packed_offset={packed_offset}, plane={plane}, bit={bit}, location={location}"
+                                    );
+                                }
+                            }
+                        }
+                        assert_eq!(&state[DIRTY..ACTIVE + 8], &[0; ACTIVE + 8 - DIRTY]);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/celox-backend-x86/src/backend/native/emit.rs
+++ b/crates/celox-backend-x86/src/backend/native/emit.rs
@@ -793,6 +793,192 @@ fn emit_sparse_runtime_plane_copy(asm: &mut CodeAssembler) -> Result<(), IcedErr
     Ok(())
 }
 
+/// Commit small regions with fixed addresses and copy widths. Keep large
+/// regions in the runtime worklist so their bitmap scans do not inflate code
+/// size. R13 holds the captured active bits and RDI is the chunk index; all
+/// scratch registers belong to SparseCommitWorklist's existing clobber set.
+fn emit_sparse_inline_commits(
+    asm: &mut CodeAssembler,
+    descriptors: &[u64],
+    active_bits_offset: i32,
+) -> Result<(), IcedError> {
+    let Ok(active_start) = u64::try_from(active_bits_offset) else {
+        return Ok(());
+    };
+    let rows = descriptors
+        .as_chunks::<{ SparseCommitDescriptor::WORDS }>()
+        .0;
+    let is_small = |row: &[u64; SparseCommitDescriptor::WORDS]| {
+        (1..=512).contains(&row[2])
+            && row[4] == 1
+            && row[6] == 1
+            && [row[0], row[1]].into_iter().all(|offset| {
+                offset
+                    .checked_add(row[2] * if row[7] != 0 { 2 } else { 1 })
+                    .is_some_and(|end| end <= i32::MAX as u64)
+            })
+            && [row[3], row[5]].into_iter().all(|offset| {
+                offset
+                    .checked_add(8)
+                    .is_some_and(|end| end <= i32::MAX as u64)
+            })
+    };
+    // Bound the extra text independently of the size of the descriptor table.
+    let inline_count = rows.iter().filter(|row| is_small(row)).count();
+    if inline_count == 0 || inline_count > 256 {
+        return Ok(());
+    }
+    // Pulling small commits ahead of large ones is safe only when their data
+    // and metadata do not overlap. MemoryLayout normally guarantees this;
+    // retain the ordered runtime loop for hand-built or imported MIR as well.
+    let mut ranges = vec![(
+        active_start,
+        active_start + rows.len().div_ceil(64) as u64 * 8,
+    )];
+    for row in rows {
+        let Some(bytes) = row[2].checked_mul(if row[7] != 0 { 2 } else { 1 }) else {
+            return Ok(());
+        };
+        let Some(dirty_bytes) = row[4].checked_mul(8) else {
+            return Ok(());
+        };
+        let Some(summary_bytes) = row[6].checked_mul(8) else {
+            return Ok(());
+        };
+        for (start, size) in [
+            (row[0], bytes),
+            (row[1], bytes),
+            (row[3], dirty_bytes),
+            (row[5], summary_bytes),
+        ] {
+            if size == 0 {
+                continue;
+            }
+            let Some(end) = start.checked_add(size) else {
+                return Ok(());
+            };
+            ranges.push((start, end));
+        }
+    }
+    ranges.sort_unstable();
+    if ranges.windows(2).any(|pair| pair[0].1 > pair[1].0) {
+        return Ok(());
+    }
+    for (word_index, word) in rows.chunks(64).enumerate() {
+        let small = word
+            .iter()
+            .enumerate()
+            .filter(|(_, row)| is_small(row))
+            .collect::<Vec<_>>();
+        if small.is_empty() {
+            continue;
+        }
+        let mask = small.iter().fold(0u64, |mask, (bit, _)| mask | (1 << bit));
+        let offset = active_bits_offset + (word_index * 8) as i32;
+        let mut word_done = asm.create_label();
+        asm.mov(r13, qword_ptr(mem_operand(BaseReg::SimState, offset)))?;
+        asm.mov(rax, mask)?;
+        asm.and(r13, rax)?;
+        asm.je(word_done)?;
+        asm.not(rax)?;
+        asm.and(qword_ptr(mem_operand(BaseReg::SimState, offset)), rax)?;
+        for (position, &(bit, row)) in small.iter().enumerate() {
+            let last = position + 1 == small.len();
+            let mut next = if last { word_done } else { asm.create_label() };
+            asm.bt(r13, bit as u32)?;
+            asm.jae(next)?;
+            emit_sparse_fixed_commit(asm, row, next)?;
+            if !last {
+                asm.set_label(&mut next)?;
+            }
+        }
+        asm.set_label(&mut word_done)?;
+        // The next word (or the generic loop) starts with emitted instructions.
+        // No extra label is bound here, preserving fallthrough label sharing.
+    }
+    Ok(())
+}
+
+/// A fixed descriptor whose dirty chunks fit in one word. Bound and mask the
+/// dirty bitmap once, then copy using immediate addresses and plane widths.
+fn emit_sparse_fixed_commit(
+    asm: &mut CodeAssembler,
+    row: &[u64],
+    next: CodeLabel,
+) -> Result<(), IcedError> {
+    let bytes = row[2] as usize;
+    let planes = if row[7] != 0 { 2 } else { 1 };
+    let summary = qword_ptr(mem_operand(BaseReg::SimState, row[5] as i32));
+    let dirty = qword_ptr(mem_operand(BaseReg::SimState, row[3] as i32));
+    if bytes <= 8 {
+        // The generic single-chunk path visits any nonempty dirty word, even
+        // if restored metadata has a missing summary bit or dirty padding.
+        asm.mov(summary, 0i32)?;
+        asm.mov(rax, dirty)?;
+        asm.mov(dirty, 0i32)?;
+        asm.test(rax, rax)?;
+        asm.je(next)?;
+        asm.xor(edi, edi)?;
+        for plane in 0..planes {
+            let delta = (plane * bytes) as i32;
+            emit_sparse_chunk_copy(
+                asm,
+                row[0] as i32 + delta,
+                row[1] as i32 + delta,
+                rdi,
+                bytes,
+            )?;
+        }
+        return Ok(());
+    }
+    asm.mov(rax, summary)?;
+    asm.mov(summary, 0i32)?;
+    asm.test(al, 1u32)?;
+    asm.je(next)?;
+    asm.mov(r8, dirty)?;
+    asm.mov(dirty, 0i32)?;
+    let chunks = bytes.div_ceil(8);
+    if chunks < 64 {
+        let mask = (1u64 << chunks) - 1;
+        if mask <= i32::MAX as u64 {
+            asm.and(r8, mask as i32)?;
+        } else {
+            asm.mov(rax, mask)?;
+            asm.and(r8, rax)?;
+        }
+    }
+    let mut dirty_loop = asm.create_label();
+    asm.set_label(&mut dirty_loop)?;
+    asm.test(r8, r8)?;
+    asm.je(next)?;
+    asm.bsf(rdi, r8)?;
+    asm.btr(r8, rdi)?;
+    asm.shl(rdi, 3)?;
+    if !bytes.is_multiple_of(8) {
+        let mut full_chunk = asm.create_label();
+        asm.cmp(rdi, ((chunks - 1) * 8) as i32)?;
+        asm.jne(full_chunk)?;
+        for plane in 0..planes {
+            let delta = (plane * bytes) as i32;
+            emit_sparse_chunk_copy(
+                asm,
+                row[0] as i32 + delta,
+                row[1] as i32 + delta,
+                rdi,
+                bytes % 8,
+            )?;
+        }
+        asm.jmp(dirty_loop)?;
+        asm.set_label(&mut full_chunk)?;
+    }
+    for plane in 0..planes {
+        let delta = (plane * bytes) as i32;
+        emit_sparse_chunk_copy(asm, row[0] as i32 + delta, row[1] as i32 + delta, rdi, 8)?;
+    }
+    asm.jmp(dirty_loop)?;
+    Ok(())
+}
+
 fn emit_sparse_commit_worklist(
     asm: &mut CodeAssembler,
     descriptor_label: CodeLabel,
@@ -2159,7 +2345,7 @@ fn emit_planned(
             );
         uses_popcnt |= matches!(inst, MInst::Popcnt { .. });
     }
-    let required_image_features = super::features::emitted_image_feature_bits(
+    let mut required_image_features = super::features::emitted_image_feature_bits(
         func.target_features,
         uses_bmi2,
         uses_avx,
@@ -2441,8 +2627,22 @@ fn emit_planned(
                     emit_divrem(&mut asm, assignment, *dst, *lhs, *rhs, DivOp::SRem)?;
                 }
                 _ => {
+                    if func.target_features.bmi1()
+                        && inst_idx + 1 < block.insts.len()
+                        && try_emit_not_and_fold(
+                            &mut asm,
+                            inst,
+                            &block.insts[inst_idx + 1],
+                            &use_counts,
+                            assignment,
+                        )?
+                    {
+                        required_image_features |= super::features::IMAGE_FEATURE_BMI1;
+                        inst_idx += 2;
+                        continue;
+                    }
                     if inst_idx + 1 < block.insts.len()
-                        && try_emit_stack_reload_fold(
+                        && try_emit_load_fold(
                             &mut asm,
                             inst,
                             &block.insts[inst_idx + 1],
@@ -2697,7 +2897,51 @@ fn count_vreg_uses(func: &MFunction, plan: &SsaDestructionPlan) -> HashMap<VReg,
     counts
 }
 
-fn try_emit_stack_reload_fold(
+fn try_emit_not_and_fold(
+    asm: &mut CodeAssembler,
+    first: &MInst,
+    second: &MInst,
+    uses: &HashMap<VReg, usize>,
+    assignment: &AssignmentMap,
+) -> Result<bool, IcedError> {
+    let MInst::BitNot { dst: inverted, src } = first else {
+        return Ok(false);
+    };
+    if uses.get(inverted).copied() != Some(1) {
+        return Ok(false);
+    }
+    let (dst, lhs, rhs, word32) = match *second {
+        MInst::And { dst, lhs, rhs } => (dst, lhs, rhs, false),
+        MInst::And32 { dst, lhs, rhs } => (dst, lhs, rhs, true),
+        _ => return Ok(false),
+    };
+    let other = if lhs == *inverted {
+        rhs
+    } else if rhs == *inverted {
+        lhs
+    } else {
+        return Ok(false);
+    };
+    let destination = resolve(assignment, dst);
+    let source = resolve(assignment, *src);
+    let other = resolve(assignment, other);
+    if word32 {
+        asm.andn(
+            preg_to_reg32(destination),
+            preg_to_reg32(source),
+            preg_to_reg32(other),
+        )?;
+    } else {
+        asm.andn(
+            preg_to_reg64(destination),
+            preg_to_reg64(source),
+            preg_to_reg64(other),
+        )?;
+    }
+    Ok(true)
+}
+
+fn try_emit_load_fold(
     asm: &mut CodeAssembler,
     inst: &MInst,
     next: &MInst,
@@ -2708,42 +2952,77 @@ fn try_emit_stack_reload_fold(
 ) -> Result<bool, IcedError> {
     let MInst::Load {
         dst,
-        base: BaseReg::StackFrame,
+        base,
         offset,
-        size: OpSize::S64,
+        size,
     } = inst
     else {
         return Ok(false);
     };
-    if spill_register_cache.register(*offset).is_some() {
+    if *base == BaseReg::StackFrame && spill_register_cache.register(*offset).is_some() {
         return Ok(false);
     }
     if use_counts.get(dst).copied().unwrap_or(0) != 1 || !next.uses().contains(dst) {
         return Ok(false);
     }
-    emit_inst_with_stack_mem(asm, next, *dst, *offset, assignment, func)
+    let memory = mem_operand(*base, *offset);
+    if *size == OpSize::S64 {
+        return emit_inst_with_memory(asm, next, *dst, memory, assignment, func);
+    }
+    if let MInst::CmpImm {
+        dst: result,
+        lhs,
+        imm,
+        kind,
+    } = *next
+        && lhs == *dst
+        && imm >= 0
+        && (imm as u64) <= ((1u64 << (size.bytes() * 8)) - 1)
+    {
+        match size {
+            OpSize::S8 => asm.cmp(byte_ptr(memory), imm)?,
+            OpSize::S16 => asm.cmp(word_ptr(memory), imm)?,
+            OpSize::S32 => asm.cmp(dword_ptr(memory), imm)?,
+            OpSize::S64 => unreachable!(),
+        }
+        // The original narrow load zero-extends to 64 bits, so both operands
+        // of a signed comparison against a nonnegative immediate are positive.
+        let kind = match kind {
+            CmpKind::LtS => CmpKind::LtU,
+            CmpKind::LeS => CmpKind::LeU,
+            CmpKind::GtS => CmpKind::GtU,
+            CmpKind::GeS => CmpKind::GeU,
+            other => other,
+        };
+        let d8 = preg_to_reg8(resolve(assignment, result));
+        let d32 = preg_to_reg32(resolve(assignment, result));
+        emit_setcc(asm, d8, kind)?;
+        asm.movzx(d32, d8)?;
+        return Ok(true);
+    }
+    Ok(false)
 }
 
-fn emit_inst_with_stack_mem(
+fn emit_inst_with_memory(
     asm: &mut CodeAssembler,
     inst: &MInst,
-    stack_vreg: VReg,
-    stack_offset: i32,
+    memory_vreg: VReg,
+    memory: AsmMemoryOperand,
     assignment: &AssignmentMap,
     _func: &MFunction,
 ) -> Result<bool, IcedError> {
     match inst {
-        MInst::Mov { dst, src } if *src == stack_vreg => {
+        MInst::Mov { dst, src } if *src == memory_vreg => {
             let d = preg_to_reg64(resolve(assignment, *dst));
-            asm.mov(d, qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+            asm.mov(d, qword_ptr(memory))?;
             Ok(true)
         }
-        MInst::Mov32 { dst, src } if *src == stack_vreg => {
+        MInst::Mov32 { dst, src } if *src == memory_vreg => {
             let d = preg_to_reg32(resolve(assignment, *dst));
-            asm.mov(d, dword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+            asm.mov(d, dword_ptr(memory))?;
             Ok(true)
         }
-        MInst::Add { dst, lhs, rhs } => emit_binop_stack_mem(
+        MInst::Add { dst, lhs, rhs } => emit_binop_memory(
             asm,
             assignment,
             BinOp::Add,
@@ -2751,10 +3030,10 @@ fn emit_inst_with_stack_mem(
             *dst,
             *lhs,
             *rhs,
-            stack_vreg,
-            stack_offset,
+            memory_vreg,
+            memory,
         ),
-        MInst::Add32 { dst, lhs, rhs } => emit_binop_stack_mem(
+        MInst::Add32 { dst, lhs, rhs } => emit_binop_memory(
             asm,
             assignment,
             BinOp::Add,
@@ -2762,10 +3041,10 @@ fn emit_inst_with_stack_mem(
             *dst,
             *lhs,
             *rhs,
-            stack_vreg,
-            stack_offset,
+            memory_vreg,
+            memory,
         ),
-        MInst::Sub { dst, lhs, rhs } => emit_binop_stack_mem(
+        MInst::Sub { dst, lhs, rhs } => emit_binop_memory(
             asm,
             assignment,
             BinOp::Sub,
@@ -2773,10 +3052,10 @@ fn emit_inst_with_stack_mem(
             *dst,
             *lhs,
             *rhs,
-            stack_vreg,
-            stack_offset,
+            memory_vreg,
+            memory,
         ),
-        MInst::Sub32 { dst, lhs, rhs } => emit_binop_stack_mem(
+        MInst::Sub32 { dst, lhs, rhs } => emit_binop_memory(
             asm,
             assignment,
             BinOp::Sub,
@@ -2784,10 +3063,10 @@ fn emit_inst_with_stack_mem(
             *dst,
             *lhs,
             *rhs,
-            stack_vreg,
-            stack_offset,
+            memory_vreg,
+            memory,
         ),
-        MInst::Mul { dst, lhs, rhs } => emit_binop_stack_mem(
+        MInst::Mul { dst, lhs, rhs } => emit_binop_memory(
             asm,
             assignment,
             BinOp::Mul,
@@ -2795,10 +3074,10 @@ fn emit_inst_with_stack_mem(
             *dst,
             *lhs,
             *rhs,
-            stack_vreg,
-            stack_offset,
+            memory_vreg,
+            memory,
         ),
-        MInst::Mul32 { dst, lhs, rhs } => emit_binop_stack_mem(
+        MInst::Mul32 { dst, lhs, rhs } => emit_binop_memory(
             asm,
             assignment,
             BinOp::Mul,
@@ -2806,10 +3085,10 @@ fn emit_inst_with_stack_mem(
             *dst,
             *lhs,
             *rhs,
-            stack_vreg,
-            stack_offset,
+            memory_vreg,
+            memory,
         ),
-        MInst::And { dst, lhs, rhs } => emit_binop_stack_mem(
+        MInst::And { dst, lhs, rhs } => emit_binop_memory(
             asm,
             assignment,
             BinOp::And,
@@ -2817,10 +3096,10 @@ fn emit_inst_with_stack_mem(
             *dst,
             *lhs,
             *rhs,
-            stack_vreg,
-            stack_offset,
+            memory_vreg,
+            memory,
         ),
-        MInst::And32 { dst, lhs, rhs } => emit_binop_stack_mem(
+        MInst::And32 { dst, lhs, rhs } => emit_binop_memory(
             asm,
             assignment,
             BinOp::And,
@@ -2828,10 +3107,10 @@ fn emit_inst_with_stack_mem(
             *dst,
             *lhs,
             *rhs,
-            stack_vreg,
-            stack_offset,
+            memory_vreg,
+            memory,
         ),
-        MInst::Or { dst, lhs, rhs } => emit_binop_stack_mem(
+        MInst::Or { dst, lhs, rhs } => emit_binop_memory(
             asm,
             assignment,
             BinOp::Or,
@@ -2839,10 +3118,10 @@ fn emit_inst_with_stack_mem(
             *dst,
             *lhs,
             *rhs,
-            stack_vreg,
-            stack_offset,
+            memory_vreg,
+            memory,
         ),
-        MInst::Or32 { dst, lhs, rhs } => emit_binop_stack_mem(
+        MInst::Or32 { dst, lhs, rhs } => emit_binop_memory(
             asm,
             assignment,
             BinOp::Or,
@@ -2850,10 +3129,10 @@ fn emit_inst_with_stack_mem(
             *dst,
             *lhs,
             *rhs,
-            stack_vreg,
-            stack_offset,
+            memory_vreg,
+            memory,
         ),
-        MInst::Xor { dst, lhs, rhs } => emit_binop_stack_mem(
+        MInst::Xor { dst, lhs, rhs } => emit_binop_memory(
             asm,
             assignment,
             BinOp::Xor,
@@ -2861,10 +3140,10 @@ fn emit_inst_with_stack_mem(
             *dst,
             *lhs,
             *rhs,
-            stack_vreg,
-            stack_offset,
+            memory_vreg,
+            memory,
         ),
-        MInst::Xor32 { dst, lhs, rhs } => emit_binop_stack_mem(
+        MInst::Xor32 { dst, lhs, rhs } => emit_binop_memory(
             asm,
             assignment,
             BinOp::Xor,
@@ -2872,54 +3151,54 @@ fn emit_inst_with_stack_mem(
             *dst,
             *lhs,
             *rhs,
-            stack_vreg,
-            stack_offset,
+            memory_vreg,
+            memory,
         ),
-        MInst::AndImm { dst, src, imm } if *src == stack_vreg => {
+        MInst::AndImm { dst, src, imm } if *src == memory_vreg => {
             let d = preg_to_reg64(resolve(assignment, *dst));
-            asm.mov(d, qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+            asm.mov(d, qword_ptr(memory))?;
             emit_and_imm64(asm, d, *imm)?;
             Ok(true)
         }
-        MInst::AndImm32 { dst, src, imm } if *src == stack_vreg => {
+        MInst::AndImm32 { dst, src, imm } if *src == memory_vreg => {
             let d = preg_to_reg32(resolve(assignment, *dst));
-            asm.mov(d, dword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+            asm.mov(d, dword_ptr(memory))?;
             asm.and(d, *imm as i32)?;
             Ok(true)
         }
-        MInst::OrImm { dst, src, imm } if *src == stack_vreg => {
+        MInst::OrImm { dst, src, imm } if *src == memory_vreg => {
             let d = preg_to_reg64(resolve(assignment, *dst));
-            asm.mov(d, qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+            asm.mov(d, qword_ptr(memory))?;
             emit_or_imm64(asm, d, *imm)?;
             Ok(true)
         }
-        MInst::AddImm { dst, src, imm } if *src == stack_vreg => {
+        MInst::AddImm { dst, src, imm } if *src == memory_vreg => {
             let d = preg_to_reg64(resolve(assignment, *dst));
-            asm.mov(d, qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+            asm.mov(d, qword_ptr(memory))?;
             asm.add(d, *imm)?;
             Ok(true)
         }
-        MInst::SubImm { dst, src, imm } if *src == stack_vreg => {
+        MInst::SubImm { dst, src, imm } if *src == memory_vreg => {
             let d = preg_to_reg64(resolve(assignment, *dst));
-            asm.mov(d, qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+            asm.mov(d, qword_ptr(memory))?;
             asm.sub(d, *imm)?;
             Ok(true)
         }
-        MInst::ShrImm { dst, src, imm } if *src == stack_vreg => {
+        MInst::ShrImm { dst, src, imm } if *src == memory_vreg => {
             let d = preg_to_reg64(resolve(assignment, *dst));
-            asm.mov(d, qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+            asm.mov(d, qword_ptr(memory))?;
             asm.shr(d, *imm as u32)?;
             Ok(true)
         }
-        MInst::ShlImm { dst, src, imm } if *src == stack_vreg => {
+        MInst::ShlImm { dst, src, imm } if *src == memory_vreg => {
             let d = preg_to_reg64(resolve(assignment, *dst));
-            asm.mov(d, qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+            asm.mov(d, qword_ptr(memory))?;
             asm.shl(d, *imm as u32)?;
             Ok(true)
         }
-        MInst::SarImm { dst, src, imm } if *src == stack_vreg => {
+        MInst::SarImm { dst, src, imm } if *src == memory_vreg => {
             let d = preg_to_reg64(resolve(assignment, *dst));
-            asm.mov(d, qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+            asm.mov(d, qword_ptr(memory))?;
             asm.sar(d, *imm as u32)?;
             Ok(true)
         }
@@ -2928,9 +3207,9 @@ fn emit_inst_with_stack_mem(
             lhs,
             rhs,
             kind,
-        } if *lhs == stack_vreg || *rhs == stack_vreg => {
-            let mem = qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset));
-            if *lhs == stack_vreg {
+        } if *lhs == memory_vreg || *rhs == memory_vreg => {
+            let mem = qword_ptr(memory);
+            if *lhs == memory_vreg {
                 let r = preg_to_reg64(resolve(assignment, *rhs));
                 asm.cmp(mem, r)?;
             } else {
@@ -2948,42 +3227,39 @@ fn emit_inst_with_stack_mem(
             lhs,
             imm,
             kind,
-        } if *lhs == stack_vreg => {
-            asm.cmp(
-                qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)),
-                *imm,
-            )?;
+        } if *lhs == memory_vreg => {
+            asm.cmp(qword_ptr(memory), *imm)?;
             let d8 = preg_to_reg8(resolve(assignment, *dst));
             let d32 = preg_to_reg32(resolve(assignment, *dst));
             emit_setcc(asm, d8, *kind)?;
             asm.movzx(d32, d8)?;
             Ok(true)
         }
-        MInst::BitNot { dst, src } if *src == stack_vreg => {
+        MInst::BitNot { dst, src } if *src == memory_vreg => {
             let d = preg_to_reg64(resolve(assignment, *dst));
-            asm.mov(d, qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+            asm.mov(d, qword_ptr(memory))?;
             asm.not(d)?;
             Ok(true)
         }
-        MInst::Neg { dst, src } if *src == stack_vreg => {
+        MInst::Neg { dst, src } if *src == memory_vreg => {
             let d = preg_to_reg64(resolve(assignment, *dst));
-            asm.mov(d, qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+            asm.mov(d, qword_ptr(memory))?;
             asm.neg(d)?;
             Ok(true)
         }
-        MInst::Popcnt { dst, src } if *src == stack_vreg => {
+        MInst::Popcnt { dst, src } if *src == memory_vreg => {
             let d = preg_to_reg64(resolve(assignment, *dst));
-            asm.popcnt(d, qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+            asm.popcnt(d, qword_ptr(memory))?;
             Ok(true)
         }
-        MInst::Bsf { dst, src } if *src == stack_vreg => {
+        MInst::Bsf { dst, src } if *src == memory_vreg => {
             let d = preg_to_reg64(resolve(assignment, *dst));
-            asm.bsf(d, qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+            asm.bsf(d, qword_ptr(memory))?;
             Ok(true)
         }
-        MInst::Bsr { dst, src } if *src == stack_vreg => {
+        MInst::Bsr { dst, src } if *src == memory_vreg => {
             let d = preg_to_reg64(resolve(assignment, *dst));
-            asm.bsr(d, qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+            asm.bsr(d, qword_ptr(memory))?;
             Ok(true)
         }
         MInst::Select {
@@ -2991,15 +3267,15 @@ fn emit_inst_with_stack_mem(
             cond,
             true_val,
             false_val,
-        } => emit_select_stack_mem(
+        } => emit_select_memory(
             asm,
             assignment,
             *dst,
             *cond,
             *true_val,
             *false_val,
-            stack_vreg,
-            stack_offset,
+            memory_vreg,
+            memory,
         ),
         _ => Ok(false),
     }
@@ -3698,6 +3974,12 @@ fn emit_inst(
             active_bits_offset,
             active_capacity,
         } => {
+            emit_sparse_inline_commits(
+                asm,
+                func.constant_table(*descriptor_table)
+                    .expect("verified sparse descriptor table"),
+                *active_bits_offset,
+            )?;
             bound_continuation = emit_sparse_commit_worklist(
                 asm,
                 constant_table_labels[descriptor_table.0],
@@ -4297,10 +4579,20 @@ fn emit_inst(
         MInst::ShlImm { dst, src, imm } => {
             let d = preg_to_reg64(resolve(assignment, *dst));
             let s = preg_to_reg64(resolve(assignment, *src));
-            if d != s {
-                asm.mov(d, s)?;
+            if d != s && (1..=3).contains(imm) {
+                // Array strides can use the scaled index without first copying
+                // a source that must remain live after the shift.
+                if *imm == 1 {
+                    asm.lea(d, ptr(s + s))?;
+                } else {
+                    asm.lea(d, ptr(s * (1u32 << imm)))?;
+                }
+            } else {
+                if d != s {
+                    asm.mov(d, s)?;
+                }
+                asm.shl(d, *imm as u32)?;
             }
-            asm.shl(d, *imm as u32)?;
         }
         MInst::SarImm { dst, src, imm } => {
             let d = preg_to_reg64(resolve(assignment, *dst));
@@ -4324,10 +4616,16 @@ fn emit_inst(
         MInst::SubImm { dst, src, imm } => {
             let d = preg_to_reg64(resolve(assignment, *dst));
             let s = preg_to_reg64(resolve(assignment, *src));
-            if d != s {
-                asm.mov(d, s)?;
+            if d != s
+                && let Some(displacement) = imm.checked_neg()
+            {
+                asm.lea(d, ptr(s + displacement))?;
+            } else {
+                if d != s {
+                    asm.mov(d, s)?;
+                }
+                asm.sub(d, *imm)?;
             }
-            asm.sub(d, *imm)?;
         }
 
         MInst::Cmp {
@@ -4970,7 +5268,7 @@ fn emit_binop_rr(
     }
 }
 
-fn emit_binop_stack_mem(
+fn emit_binop_memory(
     asm: &mut CodeAssembler,
     assignment: &AssignmentMap,
     op: BinOp,
@@ -4978,10 +5276,10 @@ fn emit_binop_stack_mem(
     dst: VReg,
     lhs: VReg,
     rhs: VReg,
-    stack_vreg: VReg,
-    stack_offset: i32,
+    memory_vreg: VReg,
+    memory: AsmMemoryOperand,
 ) -> Result<bool, IcedError> {
-    if rhs == stack_vreg {
+    if rhs == memory_vreg {
         let other = lhs;
         if narrow32 {
             let d = preg_to_reg32(resolve(assignment, dst));
@@ -4989,7 +5287,7 @@ fn emit_binop_stack_mem(
             if d != o {
                 asm.mov(d, o)?;
             }
-            let mem = dword_ptr(mem_operand(BaseReg::StackFrame, stack_offset));
+            let mem = dword_ptr(memory);
             match op {
                 BinOp::Add => asm.add(d, mem)?,
                 BinOp::Sub => asm.sub(d, mem)?,
@@ -5004,7 +5302,7 @@ fn emit_binop_stack_mem(
             if d != o {
                 asm.mov(d, o)?;
             }
-            let mem = qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset));
+            let mem = qword_ptr(memory);
             match op {
                 BinOp::Add => asm.add(d, mem)?,
                 BinOp::Sub => asm.sub(d, mem)?,
@@ -5017,7 +5315,7 @@ fn emit_binop_stack_mem(
         return Ok(true);
     }
 
-    if lhs == stack_vreg && op.is_commutative() {
+    if lhs == memory_vreg && op.is_commutative() {
         let other = rhs;
         if narrow32 {
             let d = preg_to_reg32(resolve(assignment, dst));
@@ -5025,7 +5323,7 @@ fn emit_binop_stack_mem(
             if d != o {
                 asm.mov(d, o)?;
             }
-            let mem = dword_ptr(mem_operand(BaseReg::StackFrame, stack_offset));
+            let mem = dword_ptr(memory);
             match op {
                 BinOp::Add => asm.add(d, mem)?,
                 BinOp::Mul => asm.imul_2(d, mem)?,
@@ -5040,7 +5338,7 @@ fn emit_binop_stack_mem(
             if d != o {
                 asm.mov(d, o)?;
             }
-            let mem = qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset));
+            let mem = qword_ptr(memory);
             match op {
                 BinOp::Add => asm.add(d, mem)?,
                 BinOp::Mul => asm.imul_2(d, mem)?,
@@ -5067,6 +5365,11 @@ fn emit_binop_rr_64(
     let d = preg_to_reg64(resolve(assignment, dst));
     let l = preg_to_reg64(resolve(assignment, lhs));
     let r = preg_to_reg64(resolve(assignment, rhs));
+
+    if matches!(op, BinOp::Add) && d != l && d != r {
+        asm.lea(d, ptr(l + r))?;
+        return Ok(());
+    }
 
     let (eff_l, eff_r) = if d == r && d != l {
         if op.is_commutative() {
@@ -5110,6 +5413,11 @@ fn emit_binop_rr_32(
     let l = preg_to_reg32(lp);
     let r = preg_to_reg32(rp);
 
+    if matches!(op, BinOp::Add) && d != l && d != r {
+        asm.lea(d, ptr(preg_to_reg64(lp) + preg_to_reg64(rp)))?;
+        return Ok(());
+    }
+
     let (eff_l, eff_r) = if d == r && d != l {
         if op.is_commutative() {
             (r, l)
@@ -5138,19 +5446,19 @@ fn emit_binop_rr_32(
     Ok(())
 }
 
-fn emit_select_stack_mem(
+fn emit_select_memory(
     asm: &mut CodeAssembler,
     assignment: &AssignmentMap,
     dst: VReg,
     cond: VReg,
     true_val: VReg,
     false_val: VReg,
-    stack_vreg: VReg,
-    stack_offset: i32,
+    memory_vreg: VReg,
+    memory: AsmMemoryOperand,
 ) -> Result<bool, IcedError> {
     let d = preg_to_reg64(resolve(assignment, dst));
-    if cond == stack_vreg {
-        asm.cmp(qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)), 0)?;
+    if cond == memory_vreg {
+        asm.cmp(qword_ptr(memory), 0)?;
         let tv = preg_to_reg64(resolve(assignment, true_val));
         let fv = preg_to_reg64(resolve(assignment, false_val));
         if d == tv {
@@ -5166,20 +5474,20 @@ fn emit_select_stack_mem(
 
     let c = preg_to_reg64(resolve(assignment, cond));
     asm.test(c, c)?;
-    if true_val == stack_vreg {
+    if true_val == memory_vreg {
         let fv = preg_to_reg64(resolve(assignment, false_val));
         if d != fv {
             asm.mov(d, fv)?;
         }
-        asm.cmovne(d, qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+        asm.cmovne(d, qword_ptr(memory))?;
         return Ok(true);
     }
-    if false_val == stack_vreg {
+    if false_val == memory_vreg {
         let tv = preg_to_reg64(resolve(assignment, true_val));
         if d != tv {
             asm.mov(d, tv)?;
         }
-        asm.cmove(d, qword_ptr(mem_operand(BaseReg::StackFrame, stack_offset)))?;
+        asm.cmove(d, qword_ptr(memory))?;
         return Ok(true);
     }
 
@@ -7251,7 +7559,122 @@ mod shift_encoding_tests {
     }
 
     #[test]
+    fn folded_state_load_comparisons_preserve_zero_extension_and_signedness() {
+        for size in [OpSize::S8, OpSize::S16, OpSize::S32, OpSize::S64] {
+            for kind in [
+                CmpKind::Eq,
+                CmpKind::Ne,
+                CmpKind::LtU,
+                CmpKind::LeU,
+                CmpKind::GtU,
+                CmpKind::GeU,
+                CmpKind::LtS,
+                CmpKind::LeS,
+                CmpKind::GtS,
+                CmpKind::GeS,
+            ] {
+                for imm in [-1, 0, 1, 127, 128, 255, 32767, 65535, i32::MAX] {
+                    let mut vregs = VRegAllocator::new();
+                    let input = vregs.alloc();
+                    let result = vregs.alloc();
+                    let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 2]);
+                    let mut block = MBlock::new(BlockId(0));
+                    block.push(MInst::Load {
+                        dst: input,
+                        base: BaseReg::SimState,
+                        offset: 0,
+                        size,
+                    });
+                    block.push(MInst::CmpImm {
+                        dst: result,
+                        lhs: input,
+                        imm,
+                        kind,
+                    });
+                    block.push(MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 8,
+                        src: result,
+                        size: OpSize::S64,
+                    });
+                    block.push(MInst::Return);
+                    function.push_block(block);
+                    let allocation = regalloc::run_regalloc(&mut function).unwrap();
+                    let emitted = emit(
+                        &function,
+                        &allocation.assignment,
+                        allocation.spill_frame_size,
+                    )
+                    .unwrap();
+                    let jit = JitCode::new(&emitted.code).unwrap();
+                    for value in [
+                        0,
+                        1,
+                        127,
+                        128,
+                        255,
+                        256,
+                        32767,
+                        32768,
+                        65535,
+                        65536,
+                        u32::MAX as u64,
+                        1 << 63,
+                        u64::MAX,
+                    ] {
+                        let mut state = [0xa5u8; 16];
+                        state[..8].copy_from_slice(&value.to_le_bytes());
+                        let lhs = value & (u64::MAX >> (64 - size.bytes() * 8));
+                        let rhs = imm as u64;
+                        let expected = match kind {
+                            CmpKind::Eq => lhs == rhs,
+                            CmpKind::Ne => lhs != rhs,
+                            CmpKind::LtU => lhs < rhs,
+                            CmpKind::LeU => lhs <= rhs,
+                            CmpKind::GtU => lhs > rhs,
+                            CmpKind::GeU => lhs >= rhs,
+                            CmpKind::LtS => (lhs as i64) < (rhs as i64),
+                            CmpKind::LeS => (lhs as i64) <= (rhs as i64),
+                            CmpKind::GtS => (lhs as i64) > (rhs as i64),
+                            CmpKind::GeS => (lhs as i64) >= (rhs as i64),
+                        };
+                        assert_eq!(unsafe { jit.call(&mut state) }, 0);
+                        assert_eq!(
+                            u64::from_le_bytes(state[8..].try_into().unwrap()),
+                            u64::from(expected),
+                            "{size:?} {kind:?}: {value:#x} vs {imm}"
+                        );
+                    }
+                    if size == OpSize::S64
+                        || (imm >= 0 && (imm as u64) <= u64::MAX >> (64 - size.bytes() * 8))
+                    {
+                        let decoder = Decoder::new(64, &emitted.code, DecoderOptions::NONE);
+                        assert!(
+                            decoder
+                                .into_iter()
+                                .any(|inst| inst.mnemonic() == Mnemonic::Cmp
+                                    && inst.op0_kind() == iced_x86::OpKind::Memory)
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
     fn sparse_worklist_clobbers_are_allocated_and_saved_once_per_function() {
+        check_sparse_worklist_clobbers(X86Features::detect());
+    }
+
+    #[test]
+    fn sparse_worklist_clobbers_exclude_the_reserved_state_base() {
+        check_sparse_worklist_clobbers(X86Features::for_test_with_state_base(
+            false,
+            StateBaseStrategy::R15,
+        ));
+    }
+
+    fn check_sparse_worklist_clobbers(features: X86Features) {
         const INPUT: usize = 0;
         const OUTPUT: usize = 8;
         const ACTIVE_BITS: usize = 16;
@@ -7259,6 +7682,7 @@ mod shift_encoding_tests {
         let mut vregs = VRegAllocator::new();
         let live_through = vregs.alloc();
         let mut func = MFunction::new(vregs, vec![SpillDesc::transient()]);
+        func.target_features = features;
         let descriptor = func.intern_constant_table(vec![0; SparseCommitDescriptor::WORDS]);
         let mut entry = MBlock::new(BlockId(0));
         entry.push(MInst::Load {
@@ -7315,6 +7739,202 @@ mod shift_encoding_tests {
             u64::from_le_bytes(state[OUTPUT..OUTPUT + 8].try_into().unwrap()),
             0x0123_4567_89ab_cdef
         );
+    }
+
+    #[test]
+    fn sparse_worklist_mixed_regions_preserve_dirty_chunks_and_inactive_values() {
+        // Cross active-word boundaries and the specialization budget, with
+        // every scalar copy width, two/four-state planes, and larger regions.
+        for capacity in [1usize, 66, 130, 300] {
+            let active_offset = capacity * 128;
+            let mut state = vec![0xa5u8; active_offset + capacity.div_ceil(64) * 8];
+            state[active_offset..].fill(0);
+            let mut table = Vec::new();
+            let mut expected = state.clone();
+            for index in 0..capacity {
+                let base = index * 128;
+                let width = if index % 9 == 8 { 13 } else { index % 9 + 1 };
+                let planes = if index % 2 == 0 { 2 } else { 1 };
+                let active = index % 3 != 1;
+                let dirty = if index % 11 == 0 {
+                    0u64
+                } else {
+                    2 | u64::from(index % 5 != 0)
+                };
+                let summary = u64::from(index % 7 != 0);
+                table.extend(
+                    SparseCommitDescriptor {
+                        src_offset: (base + 32) as u64,
+                        dst_offset: base as u64,
+                        byte_size: width as u64,
+                        dirty_words_offset: (base + 64) as u64,
+                        dirty_word_count: 1,
+                        summary_words_offset: (base + 72) as u64,
+                        summary_word_count: 1,
+                        four_state: (planes - 1) as u64,
+                    }
+                    .words(),
+                );
+                for byte in 0..width * planes {
+                    state[base + 32 + byte] = (index ^ byte) as u8;
+                }
+                state[base + 64..base + 72].copy_from_slice(&dirty.to_le_bytes());
+                state[base + 72..base + 80].copy_from_slice(&summary.to_le_bytes());
+                if active {
+                    state[active_offset + index / 8] |= 1 << (index % 8);
+                }
+                expected[base..base + 128].copy_from_slice(&state[base..base + 128]);
+                if !active {
+                    continue;
+                }
+                expected[base + 72..base + 80].fill(0);
+                if width <= 8 || summary != 0 {
+                    expected[base + 64..base + 72].fill(0);
+                    for plane in 0..planes {
+                        for byte in 0..width {
+                            if (width <= 8 && dirty != 0)
+                                || (width > 8 && dirty & (1 << (byte / 8)) != 0)
+                            {
+                                expected[base + plane * width + byte] =
+                                    state[base + 32 + plane * width + byte];
+                            }
+                        }
+                    }
+                }
+            }
+            // A checkpoint may contain set padding bits; they cannot visit a
+            // descriptor beyond the table, and must still be cleared.
+            if !capacity.is_multiple_of(64) {
+                *state.last_mut().unwrap() |= 0x80;
+            }
+            let mut func = MFunction::new(VRegAllocator::new(), Vec::new());
+            let descriptor_table = func.intern_constant_table(table);
+            let mut block = MBlock::new(BlockId(0));
+            block.push(MInst::SparseCommitWorklist {
+                descriptor_table,
+                active_bits_offset: active_offset as i32,
+                active_capacity: capacity,
+            });
+            block.push(MInst::Return);
+            func.push_block(block);
+            let emitted = emit(&func, &AssignmentMap::default(), 0).unwrap();
+            let jit = JitCode::new(&emitted.code).unwrap();
+            assert_eq!(unsafe { jit.call(&mut state) }, 0);
+            assert_eq!(state, expected, "capacity {capacity}");
+            assert_eq!(unsafe { jit.call(&mut state) }, 0);
+            assert_eq!(
+                state, expected,
+                "inactive second commit, capacity {capacity}"
+            );
+        }
+    }
+
+    #[test]
+    fn sparse_worklist_keeps_order_when_regions_alias() {
+        // The large region produces the small region's source. Reordering the
+        // small copy ahead of the large one would observe the old value.
+        let mut func = MFunction::new(VRegAllocator::new(), Vec::new());
+        let mut table = SparseCommitDescriptor {
+            src_offset: 0,
+            dst_offset: 16,
+            byte_size: 16,
+            dirty_words_offset: 64,
+            dirty_word_count: 1,
+            summary_words_offset: 72,
+            summary_word_count: 1,
+            four_state: 0,
+        }
+        .words()
+        .to_vec();
+        table.extend(
+            SparseCommitDescriptor {
+                src_offset: 16,
+                dst_offset: 32,
+                byte_size: 8,
+                dirty_words_offset: 80,
+                dirty_word_count: 1,
+                summary_words_offset: 88,
+                summary_word_count: 1,
+                four_state: 0,
+            }
+            .words(),
+        );
+        let descriptor_table = func.intern_constant_table(table);
+        let mut block = MBlock::new(BlockId(0));
+        block.push(MInst::SparseCommitWorklist {
+            descriptor_table,
+            active_bits_offset: 96,
+            active_capacity: 2,
+        });
+        block.push(MInst::Return);
+        func.push_block(block);
+        let emitted = emit(&func, &AssignmentMap::default(), 0).unwrap();
+        let jit = JitCode::new(&emitted.code).unwrap();
+        let mut state = [0u8; 104];
+        state[..8].copy_from_slice(&0x1234_5678_9abc_def0u64.to_le_bytes());
+        for offset in [64, 72, 80, 88] {
+            state[offset] = 1;
+        }
+        state[96] = 3;
+        assert_eq!(unsafe { jit.call(&mut state) }, 0);
+        assert_eq!(&state[32..40], &state[..8]);
+        assert!(state[64..].iter().all(|&byte| byte == 0));
+    }
+
+    #[test]
+    fn sparse_worklist_fixed_dirty_word_handles_bit_63_and_partial_planes() {
+        for bytes in [9usize, 13, 63, 64, 65, 504, 511, 512, 513] {
+            for four_state in [false, true] {
+                let planes = if four_state { 2 } else { 1 };
+                let dirty_word_count = bytes.div_ceil(512);
+                let mut state = vec![0xa5u8; 4144];
+                for byte in 0..bytes * planes {
+                    state[2048 + byte] = (byte ^ (byte >> 8)) as u8;
+                }
+                let dirty = 1u64 | (1 << 31) | (1 << 63);
+                state[4096..4104].copy_from_slice(&dirty.to_le_bytes());
+                state[4104..4112].copy_from_slice(&1u64.to_le_bytes());
+                state[4120..4128].copy_from_slice(&3u64.to_le_bytes());
+                state[4128..4136].copy_from_slice(&1u64.to_le_bytes());
+                let mut expected = state.clone();
+                for plane in 0..planes {
+                    for byte in 0..bytes {
+                        if [0, 31, 63, 64].contains(&(byte / 8)) {
+                            expected[plane * bytes + byte] = state[2048 + plane * bytes + byte];
+                        }
+                    }
+                }
+                expected[4096..4096 + dirty_word_count * 8].fill(0);
+                expected[4120..4136].fill(0);
+                let mut func = MFunction::new(VRegAllocator::new(), Vec::new());
+                let descriptor_table = func.intern_constant_table(
+                    SparseCommitDescriptor {
+                        src_offset: 2048,
+                        dst_offset: 0,
+                        byte_size: bytes as u64,
+                        dirty_words_offset: 4096,
+                        dirty_word_count: dirty_word_count as u64,
+                        summary_words_offset: 4120,
+                        summary_word_count: 1,
+                        four_state: u64::from(four_state),
+                    }
+                    .words()
+                    .to_vec(),
+                );
+                let mut block = MBlock::new(BlockId(0));
+                block.push(MInst::SparseCommitWorklist {
+                    descriptor_table,
+                    active_bits_offset: 4128,
+                    active_capacity: 1,
+                });
+                block.push(MInst::Return);
+                func.push_block(block);
+                let emitted = emit(&func, &AssignmentMap::default(), 0).unwrap();
+                let jit = JitCode::new(&emitted.code).unwrap();
+                assert_eq!(unsafe { jit.call(&mut state) }, 0);
+                assert_eq!(state, expected, "bytes {bytes}, four_state {four_state}");
+            }
+        }
     }
 
     #[test]
@@ -7705,8 +8325,8 @@ mod shift_encoding_tests {
         let mut table_leas = 0;
         while decoder.can_decode() {
             let instruction = decoder.decode();
-            if instruction.mnemonic() == Mnemonic::Lea {
-                assert_eq!(instruction.memory_base(), Register::RIP);
+            if instruction.mnemonic() == Mnemonic::Lea && instruction.memory_base() == Register::RIP
+            {
                 table_leas += 1;
             }
             if instruction.mnemonic() == Mnemonic::Ret {
@@ -8074,6 +8694,289 @@ mod shift_encoding_tests {
                     actual, expected,
                     "kind={kind:?} base={base_value} rhs={rhs_value}"
                 );
+            }
+        }
+    }
+    #[test]
+    fn scaled_lea_preserves_shift_overflow_and_register_aliases() {
+        use crate::native::{features::X86Features, jit_mem::JitCode};
+        for source in [PhysReg::RAX, PhysReg::R12] {
+            for destination in [source, PhysReg::RCX] {
+                for imm in 0..64u8 {
+                    let mut vregs = VRegAllocator::new();
+                    let input = vregs.alloc();
+                    let output = vregs.alloc();
+                    let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 2]);
+                    function.target_features = X86Features::for_test(false);
+                    let mut block = MBlock::new(BlockId(0));
+                    block.push(MInst::Load {
+                        dst: input,
+                        base: BaseReg::SimState,
+                        offset: 0,
+                        size: OpSize::S64,
+                    });
+                    // Keep the load separate from the shift's memory fold.
+                    block.push(MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 16,
+                        src: input,
+                        size: OpSize::S64,
+                    });
+                    block.push(MInst::ShlImm {
+                        dst: output,
+                        src: input,
+                        imm,
+                    });
+                    block.push(MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 8,
+                        src: output,
+                        size: OpSize::S64,
+                    });
+                    block.push(MInst::Return);
+                    function.push_block(block);
+                    let mut assignment = AssignmentMap::default();
+                    assignment.set(input, source);
+                    assignment.set(output, destination);
+                    let emitted = emit(&function, &assignment, 0).unwrap();
+                    let jit = JitCode::new(&emitted.code).unwrap();
+                    for value in [0u64, 1, 0xffff_ffff, 1 << 32, 1 << 63, u64::MAX] {
+                        let mut state = vec![0u8; emitted.required_state_size.max(24) as usize];
+                        state[..8].copy_from_slice(&value.to_le_bytes());
+                        assert_eq!(unsafe { jit.call(&mut state) }, 0);
+                        assert_eq!(
+                            u64::from_le_bytes(state[8..16].try_into().unwrap()),
+                            value << imm
+                        );
+                        assert_eq!(u64::from_le_bytes(state[16..24].try_into().unwrap()), value);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn lea_arithmetic_preserves_register_aliases_and_word_widths() {
+        use crate::native::{features::X86Features, jit_mem::JitCode};
+        for word32 in [false, true] {
+            for destination in [PhysReg::RAX, PhysReg::RCX, PhysReg::RDX] {
+                for immediate in [
+                    None,
+                    Some(i32::MIN),
+                    Some(-1),
+                    Some(0),
+                    Some(1),
+                    Some(i32::MAX),
+                ] {
+                    if word32 && immediate.is_some() {
+                        continue;
+                    }
+                    let mut vregs = VRegAllocator::new();
+                    for _ in 0..3 {
+                        vregs.alloc();
+                    }
+                    let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 3]);
+                    function.target_features = X86Features::for_test(false);
+                    let mut block = MBlock::new(BlockId(0));
+                    block.push(MInst::Load {
+                        dst: VReg(0),
+                        base: BaseReg::SimState,
+                        offset: 0,
+                        size: OpSize::S64,
+                    });
+                    block.push(MInst::Load {
+                        dst: VReg(1),
+                        base: BaseReg::SimState,
+                        offset: 8,
+                        size: OpSize::S64,
+                    });
+                    block.push(MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 24,
+                        src: VReg(1),
+                        size: OpSize::S64,
+                    });
+                    block.push(if let Some(imm) = immediate {
+                        MInst::SubImm {
+                            dst: VReg(2),
+                            src: VReg(0),
+                            imm,
+                        }
+                    } else if word32 {
+                        MInst::Add32 {
+                            dst: VReg(2),
+                            lhs: VReg(0),
+                            rhs: VReg(1),
+                        }
+                    } else {
+                        MInst::Add {
+                            dst: VReg(2),
+                            lhs: VReg(0),
+                            rhs: VReg(1),
+                        }
+                    });
+                    block.push(MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 16,
+                        src: VReg(2),
+                        size: OpSize::S64,
+                    });
+                    block.push(MInst::Return);
+                    function.push_block(block);
+                    let mut assignment = AssignmentMap::default();
+                    assignment.set(VReg(0), PhysReg::RAX);
+                    assignment.set(VReg(1), PhysReg::RCX);
+                    assignment.set(VReg(2), destination);
+                    let emitted = emit(&function, &assignment, 0).unwrap();
+                    let jit = JitCode::new(&emitted.code).unwrap();
+                    let values = [
+                        0u64,
+                        1,
+                        0x7fff_ffff,
+                        0x8000_0000,
+                        0xffff_ffff,
+                        1 << 32,
+                        1 << 63,
+                        u64::MAX,
+                    ];
+                    for a in values {
+                        for b in values {
+                            let mut state = vec![0u8; emitted.required_state_size.max(24) as usize];
+                            state[..8].copy_from_slice(&a.to_le_bytes());
+                            state[8..16].copy_from_slice(&b.to_le_bytes());
+                            assert_eq!(unsafe { jit.call(&mut state) }, 0);
+                            let expected = if let Some(imm) = immediate {
+                                a.wrapping_sub(imm as u64)
+                            } else if word32 {
+                                u64::from((a as u32).wrapping_add(b as u32))
+                            } else {
+                                a.wrapping_add(b)
+                            };
+                            assert_eq!(
+                                u64::from_le_bytes(state[16..24].try_into().unwrap()),
+                                expected
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn bmi1_not_and_fusion_preserves_aliases_widths_and_image_requirements() {
+        use crate::native::features::{IMAGE_FEATURE_AVX, IMAGE_FEATURE_BMI1};
+        for bmi1 in [false, true] {
+            for word32 in [false, true] {
+                for shared in [false, true] {
+                    for destination in [PhysReg::RAX, PhysReg::RCX, PhysReg::RDX] {
+                        let mut vregs = VRegAllocator::new();
+                        for _ in 0..4 {
+                            vregs.alloc();
+                        }
+                        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 4]);
+                        function.target_features = X86Features::for_test(false).with_bmi1(bmi1);
+                        let mut block = MBlock::new(BlockId(0));
+                        block.push(MInst::Load {
+                            dst: VReg(0),
+                            base: BaseReg::SimState,
+                            offset: 0,
+                            size: OpSize::S64,
+                        });
+                        block.push(MInst::Load {
+                            dst: VReg(1),
+                            base: BaseReg::SimState,
+                            offset: 8,
+                            size: OpSize::S64,
+                        });
+                        block.push(MInst::BitNot {
+                            dst: VReg(2),
+                            src: VReg(0),
+                        });
+                        block.push(if word32 {
+                            MInst::And32 {
+                                dst: VReg(3),
+                                lhs: VReg(2),
+                                rhs: VReg(1),
+                            }
+                        } else {
+                            MInst::And {
+                                dst: VReg(3),
+                                lhs: VReg(2),
+                                rhs: VReg(1),
+                            }
+                        });
+                        block.push(MInst::Store {
+                            base: BaseReg::SimState,
+                            offset: 16,
+                            src: VReg(3),
+                            size: OpSize::S64,
+                        });
+                        if shared {
+                            block.push(MInst::Store {
+                                base: BaseReg::SimState,
+                                offset: 24,
+                                src: VReg(2),
+                                size: OpSize::S64,
+                            });
+                        }
+                        block.push(MInst::Return);
+                        function.push_block(block);
+                        let mut assignment = AssignmentMap::default();
+                        for (value, register) in
+                            [PhysReg::RAX, PhysReg::RCX, PhysReg::R8, destination]
+                                .into_iter()
+                                .enumerate()
+                        {
+                            assignment.set(VReg(value as u32), register);
+                        }
+                        let emitted = emit(&function, &assignment, 0).unwrap();
+                        let instructions = Decoder::new(64, &emitted.code, DecoderOptions::NONE)
+                            .into_iter()
+                            .collect::<Vec<_>>();
+                        let fused = bmi1 && !shared;
+                        assert_eq!(
+                            instructions
+                                .iter()
+                                .any(|inst| inst.mnemonic() == Mnemonic::Andn),
+                            fused
+                        );
+                        assert_eq!(
+                            emitted.required_image_features & IMAGE_FEATURE_BMI1 != 0,
+                            fused
+                        );
+                        assert_eq!(emitted.required_image_features & IMAGE_FEATURE_AVX, 0);
+                        if bmi1 && !std::arch::is_x86_feature_detected!("bmi1") {
+                            continue;
+                        }
+                        let jit = JitCode::new(&emitted.code).unwrap();
+                        let values = [0u64, 1, 2, 1 << 31, 1 << 32, 1 << 63, u64::MAX];
+                        for lhs in values {
+                            for rhs in values {
+                                let mut state =
+                                    vec![0u8; emitted.required_state_size.max(32) as usize];
+                                state[..8].copy_from_slice(&lhs.to_le_bytes());
+                                state[8..16].copy_from_slice(&rhs.to_le_bytes());
+                                assert_eq!(unsafe { jit.call(&mut state) }, 0);
+                                let mask = if word32 {
+                                    u64::from(u32::MAX)
+                                } else {
+                                    u64::MAX
+                                };
+                                assert_eq!(
+                                    u64::from_le_bytes(state[16..24].try_into().unwrap()),
+                                    !lhs & rhs & mask
+                                );
+                                if shared {
+                                    assert_eq!(
+                                        u64::from_le_bytes(state[24..32].try_into().unwrap()),
+                                        !lhs
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/crates/celox-backend-x86/src/backend/native/features.rs
+++ b/crates/celox-backend-x86/src/backend/native/features.rs
@@ -39,6 +39,7 @@ pub(crate) enum StateBaseStrategy {
 /// boundaries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct X86Features {
+    bmi1: bool,
     bmi2: bool,
     avx: bool,
     popcnt: bool,
@@ -47,6 +48,10 @@ pub(crate) struct X86Features {
 
 impl X86Features {
     pub(crate) fn detect() -> Self {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        let bmi1 = std::arch::is_x86_feature_detected!("bmi1");
+        #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+        let bmi1 = false;
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         let bmi2 = std::arch::is_x86_feature_detected!("bmi2");
         #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
@@ -61,11 +66,22 @@ impl X86Features {
         let popcnt = false;
 
         Self {
+            bmi1,
             bmi2,
             avx,
             popcnt,
             state_base: detect_state_base_strategy(),
         }
+    }
+
+    pub(crate) const fn bmi1(self) -> bool {
+        self.bmi1
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn with_bmi1(mut self, enabled: bool) -> Self {
+        self.bmi1 = enabled;
+        self
     }
 
     pub(crate) const fn bmi2(self) -> bool {
@@ -111,6 +127,7 @@ impl X86Features {
     #[cfg(test)]
     pub(crate) const fn for_test_with_avx(bmi2: bool, avx: bool) -> Self {
         Self {
+            bmi1: false,
             bmi2,
             avx,
             popcnt: false,
@@ -124,6 +141,7 @@ impl X86Features {
         state_base: StateBaseStrategy,
     ) -> Self {
         Self {
+            bmi1: false,
             bmi2,
             avx: false,
             popcnt: false,
@@ -138,6 +156,7 @@ pub fn detected_image_feature_bits() -> u8 {
 }
 
 pub(crate) const IMAGE_FEATURE_BMI2: u8 = 1 << 0;
+pub(crate) const IMAGE_FEATURE_BMI1: u8 = 1 << 5;
 pub(crate) const IMAGE_FEATURE_AVX: u8 = 1 << 1;
 pub(crate) const IMAGE_FEATURE_POPCNT: u8 = 1 << 4;
 
@@ -147,7 +166,8 @@ pub(crate) fn emitted_image_feature_bits(
     uses_avx: bool,
     uses_popcnt: bool,
 ) -> u8 {
-    let mut bits = image_feature_bits(features);
+    // Emission adds BMI1 only when a late NOT/AND pair actually fuses.
+    let mut bits = image_feature_bits(features) & !IMAGE_FEATURE_BMI1;
     if !uses_bmi2 {
         bits &= !IMAGE_FEATURE_BMI2;
     }
@@ -167,6 +187,9 @@ fn image_feature_bits(features: X86Features) -> u8 {
     const GS_STATE_BASE: u8 = 1 << 3;
 
     let mut bits = 0;
+    if features.bmi1() {
+        bits |= IMAGE_FEATURE_BMI1;
+    }
     if features.bmi2() {
         bits |= IMAGE_FEATURE_BMI2;
     }

--- a/crates/celox-backend-x86/src/backend/native/isel.rs
+++ b/crates/celox-backend-x86/src/backend/native/isel.rs
@@ -1852,7 +1852,10 @@ impl<'a> ISelContext<'a> {
     ) -> Option<OpSize> {
         if let Some(array) = self.layout.unpacked_arrays.get(&addr.absolute_addr()) {
             if width_bits == array.element_width && bit_offset.is_multiple_of(array.element_width) {
-                return Self::exact_storage_access_size(width_bits);
+                let size = Self::op_size_for_width(width_bits);
+                return ((1..=64).contains(&width_bits)
+                    && size.bytes() as usize <= array.element_stride)
+                    .then_some(size);
             }
             // A complete unpacked array is not one contiguous scalar object
             // in element-strided mode. It must be gathered/scattered element
@@ -1910,7 +1913,9 @@ impl<'a> ISelContext<'a> {
                 dynamic_bit_offset: None,
                 ..
             } if *element_width == array.element_width => {
-                Self::exact_storage_access_size(width_bits)
+                let size = Self::op_size_for_width(width_bits);
+                ((1..=64).contains(&width_bits) && size.bytes() as usize <= array.element_stride)
+                    .then_some(size)
             }
             _ => None,
         }
@@ -4552,6 +4557,111 @@ fn direct_element_byte_offset(
     }
 }
 
+/// Read a scalar array element once in its native slot, then extract a field.
+/// Using the same containing load for every field lets value numbering share
+/// tag and flag reads without loading beyond the allocated element stride.
+fn try_emit_scalar_element_load(
+    ctx: &mut ISelContext,
+    block: &mut MBlock,
+    dst: RegisterId,
+    addr: &RegionedAbsoluteAddr,
+    offset: &SIROffset,
+    width: usize,
+) -> bool {
+    let SIROffset::Element {
+        index,
+        element_width,
+        bit_offset,
+        dynamic_bit_offset,
+    } = offset
+    else {
+        return false;
+    };
+    let Some(array) = ctx.layout.unpacked_arrays.get(&addr.absolute_addr()) else {
+        return false;
+    };
+    let size = ISelContext::op_size_for_width(array.element_width);
+    let dynamic_bits = if let Some(value) = dynamic_bit_offset {
+        let Some(&bits) = ctx.consts.get(value) else {
+            return false;
+        };
+        let Ok(bits) = usize::try_from(bits) else {
+            return false;
+        };
+        bits
+    } else {
+        0
+    };
+    let Some(field_bit) = bit_offset.checked_add(dynamic_bits) else {
+        return false;
+    };
+    if !(1..=64).contains(&array.element_width)
+        || *element_width != array.element_width
+        || width == 0
+        || field_bit
+            .checked_add(width)
+            .is_none_or(|end| end > array.element_width)
+        || size.bytes() as usize > array.element_stride
+    {
+        return false;
+    }
+    let base_offset = SIROffset::Element {
+        index: *index,
+        element_width: *element_width,
+        bit_offset: 0,
+        dynamic_bit_offset: None,
+    };
+    let Some(byte_index) = direct_element_byte_offset(ctx, block, addr, &base_offset) else {
+        return false;
+    };
+    let planes = if ctx.is_4state_var(addr) { 2 } else { 1 };
+    for plane in 0..planes {
+        let base = if plane == 0 {
+            ctx.byte_offset(addr, 0)
+        } else {
+            ctx.mask_byte_offset(addr, 0)
+        };
+        let value = if plane == 0 {
+            ctx.reg_map.get(dst)
+        } else {
+            let value = ctx.alloc_vreg(SpillDesc::transient());
+            ctx.set_mask(dst, value);
+            value
+        };
+        let raw = ctx.alloc_vreg(SpillDesc::transient());
+        block.push(MInst::LoadIndexed {
+            dst: raw,
+            base: BaseReg::SimState,
+            offset: base,
+            index: byte_index,
+            scale: 1,
+            size,
+            alias_range: MemoryAliasRange::new(base, ctx.layout.plane_size(&addr.absolute_addr())),
+        });
+        let shifted = if field_bit == 0 {
+            raw
+        } else {
+            let shifted = ctx.alloc_vreg(SpillDesc::transient());
+            block.push(MInst::ShrImm {
+                dst: shifted,
+                src: raw,
+                imm: field_bit as u8,
+            });
+            shifted
+        };
+        ctx.emit_and_imm(block, value, shifted, mask_for_width(width));
+    }
+    if ctx.four_state && planes == 1 {
+        let zero = ctx.alloc_vreg(SpillDesc::remat(0));
+        block.push(MInst::LoadImm {
+            dst: zero,
+            value: 0,
+        });
+        ctx.set_mask(dst, zero);
+    }
+    true
+}
+
 fn memory_offset_low_zero_bits(
     ctx: &ISelContext,
     addr: &RegionedAbsoluteAddr,
@@ -6321,6 +6431,9 @@ fn lower_instruction(
                 }
             }
             let vreg = ctx.reg_map.get(*dst);
+            if try_emit_scalar_element_load(ctx, block, *dst, addr, offset, *width_bits) {
+                return;
+            }
 
             match offset {
                 SIROffset::Static(bit_off)
@@ -15944,6 +16057,135 @@ mod tests {
         assert_eq!(&state[DIRTY..DIRTY + 8], &[0; 8]);
         assert_eq!(&state[SUMMARY..SUMMARY + 8], &[0; 8]);
         assert_eq!(&state[ACTIVE_BITS..ACTIVE_BITS + 8], &[0; 8]);
+    }
+
+    #[test]
+    fn whole_sparse_zero_overwrite_clears_padded_single_chunk_arrays() {
+        const SPARSE: usize = 32;
+        const DIRTY: usize = 64;
+        const SUMMARY: usize = 72;
+        const ACTIVE: usize = 88;
+        const STATE_SIZE: usize = 104;
+        for (element_width, element_count) in [(1, 2), (1, 4), (3, 4), (7, 8)] {
+            for four_state in [false, true] {
+                let absolute = AbsoluteAddr {
+                    instance_id: InstanceId(0),
+                    var_id: VarId::default(),
+                };
+                let sparse = RegionedAbsoluteAddr::from_absolute_addr(
+                    crate::SPARSE_WORKING_REGION,
+                    absolute,
+                );
+                let stable = RegionedAbsoluteAddr::from_absolute_addr(STABLE_REGION, absolute);
+                let width = element_width * element_count;
+                let zero = RegisterId(0);
+                let unit = ExecutionUnit {
+                    entry_block_id: SirBlockId(0),
+                    blocks: [(
+                        SirBlockId(0),
+                        BasicBlock {
+                            id: SirBlockId(0),
+                            params: vec![],
+                            instructions: vec![
+                                SIRInstruction::Imm(zero, SIRValue::new(0u8)),
+                                SIRInstruction::Store(
+                                    sparse,
+                                    SIROffset::PackedElements {
+                                        bit_offset: 0,
+                                        element_width,
+                                    },
+                                    width,
+                                    zero,
+                                    vec![],
+                                    vec![],
+                                ),
+                                SIRInstruction::Commit(
+                                    sparse,
+                                    stable,
+                                    SIROffset::Static(0),
+                                    width,
+                                    vec![],
+                                ),
+                            ],
+                            terminator: SIRTerminator::Return,
+                        },
+                    )]
+                    .into_iter()
+                    .collect(),
+                    register_map: [(zero, RegisterType::Logic { width })]
+                        .into_iter()
+                        .collect(),
+                };
+                unit.verify();
+                let mut layout = empty_layout();
+                layout.mode = MemoryLayoutMode::ElementStrided;
+                layout.four_state = four_state;
+                layout.offsets.insert(absolute, 0);
+                layout.widths.insert(absolute, width);
+                layout.is_4states.insert(absolute, four_state);
+                layout.unpacked_arrays.insert(
+                    absolute,
+                    celox_state_layout::UnpackedArrayLayout {
+                        element_width,
+                        element_count,
+                        element_stride: 1,
+                        plane_size: element_count,
+                    },
+                );
+                layout.total_size = SPARSE;
+                layout.working_base_offset = SPARSE;
+                layout.sparse_base_offset = SPARSE;
+                layout.sparse_offsets.insert(absolute, 0);
+                layout.sparse_layouts.insert(
+                    absolute,
+                    celox_state_layout::SparseWorkingLayout {
+                        active_index: 0,
+                        chunk_count: 1,
+                        dirty_words_offset: DIRTY,
+                        dirty_word_count: 1,
+                        summary_words_offset: SUMMARY,
+                        summary_word_count: 1,
+                    },
+                );
+                layout.sparse_active_bits_offset = ACTIVE;
+                layout.sparse_active_capacity = 1;
+                layout.merged_total_size = STATE_SIZE;
+                layout.triggered_bits_offset = STATE_SIZE;
+                layout.scratch_base_offset = STATE_SIZE;
+                let mut function = lower_execution_unit(&unit, &layout, four_state);
+                function.verify();
+                mir_legalize::legalize(&mut function);
+                mir_opt::optimize(&mut function);
+                let allocation = regalloc::run_regalloc(&mut function).unwrap();
+                mir_opt::post_regalloc_peephole(&mut function, &allocation.assignment);
+                function.verify();
+                let emitted = emit::emit(
+                    &function,
+                    &allocation.assignment,
+                    allocation.spill_frame_size,
+                )
+                .unwrap();
+                let jit = JitCode::new(&emitted.code).unwrap();
+                let mut state = [0xffu8; STATE_SIZE];
+                state[DIRTY..DIRTY + 8].fill(0);
+                state[SUMMARY..SUMMARY + 8].fill(0);
+                state[ACTIVE..ACTIVE + 8].fill(0);
+                assert_eq!(unsafe { jit.call(&mut state) }, 0);
+                let physical_size = element_count * if four_state { 2 } else { 1 };
+                for byte in &state[..physical_size] {
+                    assert_eq!(
+                        *byte & ((1 << element_width) - 1) as u8,
+                        0,
+                        "width={element_width}, count={element_count}, four_state={four_state}"
+                    );
+                }
+                assert_eq!(state[physical_size], 0xff);
+                assert_eq!(state[SPARSE + physical_size], 0xff);
+                assert_eq!(&state[DIRTY..DIRTY + 8], &[0; 8]);
+                assert_eq!(&state[SUMMARY..SUMMARY + 8], &[0; 8]);
+                assert_eq!(&state[ACTIVE..ACTIVE + 8], &[0; 8]);
+            }
+        }
     }
 
     #[test]

--- a/crates/celox-backend-x86/src/backend/native/isel.rs
+++ b/crates/celox-backend-x86/src/backend/native/isel.rs
@@ -6554,12 +6554,27 @@ fn lower_instruction(
                         && let Some(load_size) =
                             ctx.full_static_load_size(addr, *bit_off, *width_bits)
                     {
+                        // A padded slot is wider than its logical element.
+                        // Mask the raw load before claiming a known bit width.
+                        let padded_element = ctx
+                            .layout
+                            .unpacked_arrays
+                            .contains_key(&addr.absolute_addr())
+                            && ISelContext::access_size_has_padding(load_size, *width_bits);
+                        let raw = if padded_element {
+                            ctx.alloc_vreg(SpillDesc::transient())
+                        } else {
+                            vreg
+                        };
                         block.push(MInst::Load {
-                            dst: vreg,
+                            dst: raw,
                             base: BaseReg::SimState,
                             offset: byte_off,
                             size: load_size,
                         });
+                        if padded_element {
+                            ctx.emit_and_imm(block, vreg, raw, mask_for_width(*width_bits));
+                        }
                         ctx.known_bits.insert(vreg, *width_bits);
                     } else if intra_byte == 0 && OpSize::from_bits(*width_bits).is_some() {
                         // Word-aligned, native size: single load.
@@ -15755,6 +15770,151 @@ mod tests {
                 .count()
                 >= 2
         );
+    }
+
+    #[test]
+    fn static_padded_element_loads_mask_padding_before_concat() {
+        let array_abs = AbsoluteAddr {
+            instance_id: InstanceId(0),
+            var_id: VarId(0),
+        };
+        let output_abs = AbsoluteAddr {
+            var_id: VarId(1),
+            ..array_abs
+        };
+        let array = RegionedAbsoluteAddr::from_absolute_addr(STABLE_REGION, array_abs);
+        let output = RegionedAbsoluteAddr::from_absolute_addr(STABLE_REGION, output_abs);
+        let low = RegisterId(0);
+        let high = RegisterId(1);
+        let result = RegisterId(2);
+        for width in [24usize, 1, 3, 7, 9, 15, 17, 31, 33, 40, 48, 51, 57, 63] {
+            for four_state in [false, true] {
+                let stride = width.div_ceil(8).next_power_of_two();
+                let plane_size = stride * 2;
+                let result_width = width * 2;
+                let unit = ExecutionUnit {
+                    entry_block_id: SirBlockId(0),
+                    blocks: [(
+                        SirBlockId(0),
+                        BasicBlock {
+                            id: SirBlockId(0),
+                            params: vec![],
+                            instructions: vec![
+                                SIRInstruction::Load(low, array, SIROffset::Static(0), width),
+                                SIRInstruction::Load(high, array, SIROffset::Static(width), width),
+                                SIRInstruction::Concat(result, vec![high, low]),
+                                SIRInstruction::Store(
+                                    output,
+                                    SIROffset::Static(0),
+                                    result_width,
+                                    result,
+                                    vec![],
+                                    vec![],
+                                ),
+                            ],
+                            terminator: SIRTerminator::Return,
+                        },
+                    )]
+                    .into_iter()
+                    .collect(),
+                    register_map: [(low, width), (high, width), (result, result_width)]
+                        .into_iter()
+                        .map(|(register, width)| {
+                            (
+                                register,
+                                if four_state {
+                                    RegisterType::Logic { width }
+                                } else {
+                                    RegisterType::Bit {
+                                        width,
+                                        signed: false,
+                                    }
+                                },
+                            )
+                        })
+                        .collect(),
+                };
+                let mut layout = empty_layout();
+                layout.four_state = four_state;
+                layout.mode = MemoryLayoutMode::ElementStrided;
+                layout.offsets = [(array_abs, 0), (output_abs, 32)].into_iter().collect();
+                layout.widths = [(array_abs, result_width), (output_abs, result_width)]
+                    .into_iter()
+                    .collect();
+                layout.is_4states = [(array_abs, four_state), (output_abs, four_state)]
+                    .into_iter()
+                    .collect();
+                layout.unpacked_arrays.insert(
+                    array_abs,
+                    celox_state_layout::UnpackedArrayLayout {
+                        element_width: width,
+                        element_count: 2,
+                        element_stride: stride,
+                        plane_size,
+                    },
+                );
+                layout.total_size = 80;
+                layout.working_base_offset = 80;
+                layout.sparse_base_offset = 80;
+                layout.merged_total_size = 80;
+                layout.triggered_bits_offset = 80;
+                layout.scratch_base_offset = 80;
+
+                let mut function = lower_execution_unit(&unit, &layout, four_state);
+                mir_legalize::legalize(&mut function);
+                mir_opt::optimize(&mut function);
+                let allocation = regalloc::run_regalloc(&mut function).unwrap();
+                mir_opt::post_regalloc_peephole(&mut function, &allocation.assignment);
+                function.verify();
+                let emitted = emit::emit(
+                    &function,
+                    &allocation.assignment,
+                    allocation.spill_frame_size,
+                )
+                .unwrap();
+                let jit = JitCode::new(&emitted.code).unwrap();
+
+                let mut state = vec![0xa5u8; 80];
+                let element_mask = mask_for_width(width);
+                let result_mask = (BigUint::from(1u8) << result_width) - 1u8;
+                let planes = [
+                    [0x1234_5678_0012_3456u64, 0x5543_2100_0065_4321],
+                    [0x0001_0204_0008_1020, 0x0102_0400_0810_2000],
+                ];
+                for (plane, values) in
+                    planes
+                        .iter()
+                        .enumerate()
+                        .take(if four_state { 2 } else { 1 })
+                {
+                    for (element, value) in values.iter().enumerate() {
+                        let padded = value | !element_mask;
+                        let start = plane * plane_size + element * stride;
+                        state[start..start + stride]
+                            .copy_from_slice(&padded.to_le_bytes()[..stride]);
+                    }
+                }
+                assert_eq!(unsafe { jit.call(&mut state) }, 0);
+                for (plane, values) in
+                    planes
+                        .iter()
+                        .enumerate()
+                        .take(if four_state { 2 } else { 1 })
+                {
+                    let start = 32 + plane * result_width.div_ceil(8);
+                    let actual =
+                        BigUint::from_bytes_le(&state[start..start + result_width.div_ceil(8)])
+                            & &result_mask;
+                    let expected = (BigUint::from(values[1] & element_mask) << width)
+                        | BigUint::from(values[0] & element_mask);
+                    assert_eq!(
+                        actual, expected,
+                        "width={width}, four_state={four_state}, plane={plane}"
+                    );
+                }
+                assert_eq!(&state[64..], &[0xa5; 16]);
+            }
+        }
     }
 
     #[test]

--- a/crates/celox-backend-x86/src/backend/native/mir_opt.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt.rs
@@ -10,6 +10,16 @@ use super::mir::*;
 use super::regalloc::assignment::{AssignmentMap, PhysReg, clobbers};
 use crate::{HashMap, HashSet};
 
+mod bitmap_worklist;
+mod boolean;
+mod branch_merge;
+mod circular_scan;
+mod counted_loop;
+mod exclusive_loop;
+mod known_bits;
+mod loop_guard;
+#[cfg(test)]
+mod memory_forward_tests;
 mod pipeline;
 pub use pipeline::{optimize, optimize_with_diagnostics};
 
@@ -253,13 +263,11 @@ pub(crate) fn fold_direct_immediate_stores(func: &mut MFunction) -> usize {
     folded
 }
 
-/// Fold a proven power-of-two byte index into the x86 memory operand.
-///
-/// This pass does not infer an RTL range or replace a bit-offset expression.
-/// It only rewrites an already selected 64-bit `ShlImm` whose sole use is an
-/// indexed load. x86 effective-address scaling and the original shift both
-/// use modulo-64-bit arithmetic, so the rewrite preserves wrapping exactly.
-fn fold_scaled_indexed_loads(func: &mut MFunction) {
+/// Fold single-use byte displacements and power-of-two indexes into x86
+/// memory operands. The offset must remain an encodable signed displacement;
+/// scaling preserves the original modulo-64-bit address arithmetic. The alias
+/// range still describes the entire original object.
+fn fold_indexed_load_addresses(func: &mut MFunction) {
     let mut use_counts = HashMap::<VReg, usize>::default();
     for block in &func.blocks {
         for phi in &block.phis {
@@ -276,16 +284,35 @@ fn fold_scaled_indexed_loads(func: &mut MFunction) {
 
     for block in &mut func.blocks {
         let mut shifts = HashMap::<VReg, (VReg, u8)>::default();
+        let mut displacements = HashMap::<VReg, (VReg, i32)>::default();
         for inst in &mut block.insts {
+            if let MInst::AddImm { dst, src, imm } = inst {
+                displacements.insert(*dst, (*src, *imm));
+                continue;
+            }
             if let MInst::ShlImm { dst, src, imm } = inst {
                 if (1..=3).contains(imm) {
                     shifts.insert(*dst, (*src, *imm));
                 }
                 continue;
             }
-            let MInst::LoadIndexed { index, scale, .. } = inst else {
+            let MInst::LoadIndexed {
+                offset,
+                index,
+                scale,
+                ..
+            } = inst
+            else {
                 continue;
             };
+            if use_counts.get(index).copied() == Some(1)
+                && let Some(&(source, displacement)) = displacements.get(index)
+                && let Some(displacement) = displacement.checked_mul(i32::from(*scale))
+                && let Some(adjusted) = offset.checked_add(displacement)
+            {
+                *index = source;
+                *offset = adjusted;
+            }
             if *scale != 1 || use_counts.get(index).copied() != Some(1) {
                 continue;
             }
@@ -1205,9 +1232,11 @@ fn fold_imm_use(inst: &MInst, imm_vreg: VReg, value: u64) -> Option<MInst> {
             base,
             offset,
             index,
+            scale,
             size,
             ..
         } if *index == imm_vreg => sign_extended_i32(value)
+            .and_then(|index| index.checked_mul(i32::from(*scale)))
             .and_then(|index| offset.checked_add(index))
             .map(|offset| MInst::Load {
                 dst: *dst,
@@ -2081,7 +2110,7 @@ fn redundant_mask_eliminate(func: &mut MFunction) {
 }
 
 #[derive(Clone, Copy)]
-enum PossibleOneDefinition {
+enum ValueDefinition {
     Phi { block: usize, phi: usize },
     Instruction { block: usize, instruction: usize },
 }
@@ -2094,7 +2123,7 @@ enum PossibleOneDefinition {
 /// when a backedge fact actually improves.
 fn global_possible_one_bits(func: &MFunction, constants: &HashMap<VReg, u64>) -> Vec<u64> {
     let value_count = func.vregs.count() as usize;
-    let mut definitions = vec![None::<PossibleOneDefinition>; value_count];
+    let mut definitions = vec![None::<ValueDefinition>; value_count];
     let mut users = vec![Vec::<VReg>::new(); value_count];
     let mut queue = VecDeque::new();
     let mut queued = vec![false; value_count];
@@ -2102,7 +2131,7 @@ fn global_possible_one_bits(func: &MFunction, constants: &HashMap<VReg, u64>) ->
     for (block_index, block) in func.blocks.iter().enumerate() {
         for (phi_index, phi) in block.phis.iter().enumerate() {
             let destination = phi.dst.0 as usize;
-            definitions[destination] = Some(PossibleOneDefinition::Phi {
+            definitions[destination] = Some(ValueDefinition::Phi {
                 block: block_index,
                 phi: phi_index,
             });
@@ -2117,7 +2146,7 @@ fn global_possible_one_bits(func: &MFunction, constants: &HashMap<VReg, u64>) ->
                 continue;
             };
             let destination = dst.0 as usize;
-            definitions[destination] = Some(PossibleOneDefinition::Instruction {
+            definitions[destination] = Some(ValueDefinition::Instruction {
                 block: block_index,
                 instruction: instruction_index,
             });
@@ -2137,12 +2166,12 @@ fn global_possible_one_bits(func: &MFunction, constants: &HashMap<VReg, u64>) ->
             continue;
         };
         let computed = match definition {
-            PossibleOneDefinition::Phi { block, phi } => func.blocks[block].phis[phi]
+            ValueDefinition::Phi { block, phi } => func.blocks[block].phis[phi]
                 .sources
                 .iter()
                 .map(|(_, source)| possible_bits(*source, &possible_ones, constants))
                 .fold(0, |possible, source| possible | source),
-            PossibleOneDefinition::Instruction { block, instruction } => compute_possible_one_bits(
+            ValueDefinition::Instruction { block, instruction } => compute_possible_one_bits(
                 &func.blocks[block].insts[instruction],
                 &possible_ones,
                 constants,
@@ -6830,6 +6859,101 @@ fn emit_partial_store_overlay(
 /// the direct bytes referenced by one block. Insert recovery additionally
 /// reuses one sparse whole-function possible-bit solve.
 fn promote_partial_store_round_trips(func: &mut MFunction) {
+    promote_partial_store_round_trips_impl(func, false);
+}
+
+fn forward_live_partial_stores(func: &mut MFunction) {
+    promote_partial_store_round_trips_impl(func, true);
+}
+
+fn discover_live_partial_stores(
+    block: &MBlock,
+) -> (Vec<PartialRoundTripPlan>, Vec<Option<PartialStoreEvent>>) {
+    let mut plans = Vec::new();
+    let mut stores = vec![None; block.insts.len()];
+    for (instruction, inst) in block.insts.iter().enumerate() {
+        let MInst::Load {
+            dst,
+            base: BaseReg::SimState,
+            offset,
+            size,
+        } = *inst
+        else {
+            continue;
+        };
+        if size == OpSize::S8 {
+            continue;
+        }
+        let load_slot = MemorySlot {
+            base: BaseReg::SimState,
+            offset,
+            size,
+        };
+        let start = i64::from(offset);
+        let end = start + i64::from(size.bytes());
+        let mut selected = Vec::new();
+        let mut covered = 0u16;
+        for previous in (instruction.saturating_sub(32)..instruction).rev() {
+            let write = &block.insts[previous];
+            let effects = memory_effect::writes(write);
+            if effects.unknown_memory()
+                == Some(memory_effect::UnknownMemory::Direct(BaseReg::SimState))
+            {
+                break;
+            }
+            if !effects.ranges().any(|range| {
+                range.base == BaseReg::SimState
+                    && range.offset < end
+                    && range.end().is_none_or(|limit| start < limit)
+            }) {
+                continue;
+            }
+            let MInst::Store {
+                base,
+                offset,
+                src,
+                size,
+            } = *write
+            else {
+                break;
+            };
+            let slot = MemorySlot { base, offset, size };
+            if size.bytes() >= load_slot.size.bytes() || !contained_slot(slot, load_slot) {
+                break;
+            }
+            let mask = ((1u16 << size.bytes()) - 1) << (offset - load_slot.offset);
+            if mask & covered != 0 {
+                break;
+            }
+            covered |= mask;
+            selected.push(previous);
+            stores[previous] = Some(PartialStoreEvent {
+                slot,
+                source: src,
+                insert: None,
+                prior_events: [None; 8],
+                prior_writes: [None; 8],
+            });
+            if selected.len() == 2 {
+                break;
+            }
+        }
+        if selected.is_empty() {
+            continue;
+        }
+        selected.reverse();
+        plans.push(PartialRoundTripPlan {
+            load_instruction: instruction,
+            insertion_instruction: selected[0],
+            load_slot,
+            destination: dst,
+            stores: selected,
+        });
+    }
+    (plans, stores)
+}
+
+fn promote_partial_store_round_trips_impl(func: &mut MFunction, retain_stores: bool) {
     let constants = func
         .blocks
         .iter()
@@ -6853,14 +6977,22 @@ fn promote_partial_store_round_trips(func: &mut MFunction) {
         .collect::<HashSet<_>>();
     let (vregs, spill_descs, blocks) = (&mut func.vregs, &mut func.spill_descs, &mut func.blocks);
     for block in blocks {
-        let (plans, store_events) = discover_partial_round_trips(
-            block,
-            spill_descs,
-            &defined_values,
-            &possible_ones,
-            &constants,
-        );
-        let plans = retain_dead_partial_store_plans(block, plans);
+        let (plans, store_events) = if retain_stores {
+            discover_live_partial_stores(block)
+        } else {
+            discover_partial_round_trips(
+                block,
+                spill_descs,
+                &defined_values,
+                &possible_ones,
+                &constants,
+            )
+        };
+        let plans = if retain_stores {
+            plans
+        } else {
+            retain_dead_partial_store_plans(block, plans)
+        };
         if plans.is_empty() {
             continue;
         }
@@ -6900,7 +7032,9 @@ fn promote_partial_store_round_trips(func: &mut MFunction) {
                 &stores,
             );
             replacements.insert(plan.load_instruction, replacement);
-            removals.extend(plan.stores);
+            if !retain_stores {
+                removals.extend(plan.stores);
+            }
             spill_descs[plan.destination.0 as usize] = SpillDesc::transient();
         }
 
@@ -6953,7 +7087,17 @@ fn forward_local_store_loads(func: &mut MFunction) {
                     size,
                 } => {
                     if let Some(src) = available.get(base, offset, size) {
-                        rewritten.push(MInst::Mov { dst, src });
+                        emit_partial_load_forward(
+                            &mut rewritten,
+                            vregs,
+                            spill_descs,
+                            dst,
+                            src,
+                            offset,
+                            size,
+                            offset,
+                            size,
+                        );
                         continue;
                     }
                     if let Some((covering_slot, src)) =
@@ -6980,30 +7124,22 @@ fn forward_local_store_loads(func: &mut MFunction) {
                         size,
                     });
                 }
-                MInst::LoadIndexed { .. }
-                | MInst::LoadPtrIndexed { .. }
-                | MInst::StoreIndexed { .. }
-                | MInst::OrStoreIndexed { .. }
-                | MInst::StorePtrIndexed { .. }
-                | MInst::ReleaseStorePtrIndexed { .. } => {
-                    available.clear();
-                    rewritten.push(inst);
+                other => {
+                    let writes = memory_effect::writes(&other);
+                    if let Some(memory_effect::UnknownMemory::Direct(base)) =
+                        writes.unknown_memory()
+                    {
+                        available.invalidate_base(base);
+                    }
+                    for range in writes.ranges() {
+                        if let Some(end) = range.end() {
+                            available.invalidate_range(range.base, range.offset, end);
+                        } else {
+                            available.invalidate_base(range.base);
+                        }
+                    }
+                    rewritten.push(other);
                 }
-                MInst::MemCopy {
-                    src_offset,
-                    dst_offset,
-                    byte_len,
-                } => {
-                    // The source is read but unchanged. Only values cached for
-                    // the written destination range become stale.
-                    available.invalidate_byte_range(BaseReg::SimState, dst_offset, byte_len);
-                    rewritten.push(MInst::MemCopy {
-                        src_offset,
-                        dst_offset,
-                        byte_len,
-                    });
-                }
-                other => rewritten.push(other),
             }
         }
 
@@ -7020,6 +7156,7 @@ struct AvailableStores {
 }
 
 impl AvailableStores {
+    #[cfg(test)]
     fn clear(&mut self) {
         self.slots.clear();
     }
@@ -7043,6 +7180,7 @@ impl AvailableStores {
         self.invalidate_range(base, start, end);
     }
 
+    #[cfg(test)]
     fn invalidate_byte_range(&mut self, base: BaseReg, offset: i32, byte_len: usize) {
         let Some((start, end)) = byte_range(offset, byte_len) else {
             self.invalidate_base(base);
@@ -7318,11 +7456,58 @@ fn invalidate_stores_observed_by(
 pub(super) fn eliminate_redundant_local_stores(func: &mut MFunction) {
     for block in &mut func.blocks {
         let mut later_stores = LaterDirectStores::default();
+        let mut indexed_stores =
+            Vec::<(BaseReg, i32, VReg, OpSize, Option<MemoryAliasRange>)>::new();
         let mut invalidation_scratch = Vec::new();
         let mut reversed = Vec::with_capacity(block.insts.len());
 
         for inst in block.insts.drain(..).rev() {
             invalidate_stores_observed_by(&mut later_stores, &inst, &mut invalidation_scratch);
+            let reads = memory_effect::reads(&inst);
+            indexed_stores.retain(|&(base, _, _, _, envelope)| {
+                if reads.unknown_memory() == Some(memory_effect::UnknownMemory::Direct(base)) {
+                    return false;
+                }
+                !reads.ranges().any(|read| {
+                    read.base == base
+                        && envelope.is_none_or(|envelope| {
+                            read.end()
+                                .is_none_or(|end| i64::from(envelope.offset()) < end)
+                                && read.offset < envelope.end()
+                        })
+                })
+            });
+            if let MInst::StoreIndexed {
+                base,
+                offset,
+                index,
+                size,
+                alias_range,
+                ..
+            } = &inst
+            {
+                if indexed_stores.iter().any(
+                    |&(later_base, later_offset, later_index, later_size, later_envelope)| {
+                        (
+                            later_base,
+                            later_offset,
+                            later_index,
+                            later_size,
+                            later_envelope,
+                        ) == (*base, *offset, *index, *size, *alias_range)
+                    },
+                ) {
+                    continue;
+                }
+                // SSA index identity and the same semantic envelope prove an
+                // exact overwrite. Reads invalidate through that envelope;
+                // intervening writes cannot observe the discarded value.
+                // Bound compile-time work for unusually long store-only blocks.
+                if indexed_stores.len() == 64 {
+                    indexed_stores.remove(0);
+                }
+                indexed_stores.push((*base, *offset, *index, *size, *alias_range));
+            }
             if let MInst::Store {
                 base, offset, size, ..
             } = &inst
@@ -8120,6 +8305,91 @@ mod tests {
                 ..
             }
         )));
+    }
+
+    #[test]
+    fn forwards_live_partial_stores_without_losing_later_observers() {
+        use crate::native::{emit, jit_mem::JitCode, mir_legalize, regalloc};
+        fn compile(mut function: MFunction) -> (JitCode, usize) {
+            mir_legalize::legalize(&mut function);
+            let allocation = regalloc::run_regalloc(&mut function).unwrap();
+            let emitted = emit::emit(
+                &function,
+                &allocation.assignment,
+                allocation.spill_frame_size,
+            )
+            .unwrap();
+            (
+                JitCode::new(&emitted.code).unwrap(),
+                emitted.required_state_size.max(128) as usize,
+            )
+        }
+        for provenance in [false, true] {
+            for barrier in [false, true] {
+                let mut original = partial_store_round_trip(true, false);
+                if !provenance {
+                    original.spill_descs[3].state_insert = None;
+                }
+                if barrier {
+                    original.blocks[0].insts.insert(
+                        5,
+                        MInst::MemFill {
+                            dst_offset: 101,
+                            byte_len: 1,
+                            value: 0xa5,
+                        },
+                    );
+                }
+                original.blocks[0].push(MInst::Store {
+                    base: BaseReg::SimState,
+                    offset: 0,
+                    src: VReg(4),
+                    size: OpSize::S64,
+                });
+                original.blocks[0].push(MInst::Store {
+                    base: BaseReg::SimState,
+                    offset: 8,
+                    src: VReg(5),
+                    size: OpSize::S64,
+                });
+                original.blocks[0].push(MInst::Return);
+                let mut optimized = original.clone();
+                forward_live_partial_stores(&mut optimized);
+                optimized.verify();
+                assert_eq!(
+                    optimized.blocks[0]
+                        .insts
+                        .iter()
+                        .filter(|inst| matches!(
+                            inst,
+                            MInst::Store {
+                                offset: 100,
+                                size: OpSize::S8,
+                                ..
+                            }
+                        ))
+                        .count(),
+                    1
+                );
+                assert_eq!(
+                    optimized.blocks[0]
+                        .insts
+                        .iter()
+                        .any(|inst| matches!(inst, MInst::Load { dst: VReg(4), .. })),
+                    barrier
+                );
+                let (before, before_size) = compile(original);
+                let (after, after_size) = compile(optimized);
+                for value in [0u64, 1, 0x0123_4567_89ab_cdef, u64::MAX] {
+                    let mut left = vec![0u8; before_size.max(after_size)];
+                    left[100..108].copy_from_slice(&value.to_le_bytes());
+                    let mut right = left.clone();
+                    assert_eq!(unsafe { before.call(&mut left) }, 0);
+                    assert_eq!(unsafe { after.call(&mut right) }, 0);
+                    assert_eq!(&left[..128], &right[..128]);
+                }
+            }
+        }
     }
 
     #[test]
@@ -12143,6 +12413,115 @@ mod tests {
     }
 
     #[test]
+    fn folded_indexed_load_executes_the_original_address_and_keeps_its_alias_range() {
+        use crate::native::{emit, jit_mem::JitCode, regalloc};
+        let alias_range = MemoryAliasRange::new(32, 160);
+        let mut func = make_func(
+            vec![
+                MInst::Load {
+                    dst: VReg(0),
+                    base: BaseReg::SimState,
+                    offset: 0,
+                    size: OpSize::S64,
+                },
+                MInst::ShlImm {
+                    dst: VReg(1),
+                    src: VReg(0),
+                    imm: 2,
+                },
+                MInst::AddImm {
+                    dst: VReg(2),
+                    src: VReg(1),
+                    imm: 3,
+                },
+                MInst::LoadIndexed {
+                    dst: VReg(3),
+                    base: BaseReg::SimState,
+                    offset: 32,
+                    index: VReg(2),
+                    scale: 1,
+                    size: OpSize::S64,
+                    alias_range,
+                },
+                MInst::Store {
+                    base: BaseReg::SimState,
+                    offset: 8,
+                    src: VReg(3),
+                    size: OpSize::S64,
+                },
+                MInst::Return,
+            ],
+            4,
+        );
+        fold_indexed_load_addresses(&mut func);
+        assert!(
+            matches!(func.blocks[0].insts[3], MInst::LoadIndexed { offset: 35, index: VReg(0), scale: 4, alias_range: range, .. } if range == alias_range)
+        );
+        dead_code_eliminate(&mut func);
+        let allocation = regalloc::run_regalloc(&mut func).unwrap();
+        let emitted =
+            emit::emit(&func, &allocation.assignment, allocation.spill_frame_size).unwrap();
+        let jit = JitCode::new(&emitted.code).unwrap();
+        for index in 0..32u64 {
+            let mut state = [0u8; 192];
+            for (offset, byte) in state.iter_mut().enumerate().skip(32) {
+                *byte = offset as u8 ^ 0x5a;
+            }
+            state[..8].copy_from_slice(&index.to_le_bytes());
+            let address = 32 + (index as usize * 4 + 3);
+            let expected = u64::from_le_bytes(state[address..address + 8].try_into().unwrap());
+            assert_eq!(unsafe { jit.call(&mut state) }, 0);
+            assert_eq!(
+                u64::from_le_bytes(state[8..16].try_into().unwrap()),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn indexed_load_displacement_overflow_keeps_the_full_width_addition() {
+        for (offset, displacement, scale) in [(i32::MAX, 1, 1), (i32::MIN, -1, 1), (0, i32::MAX, 8)]
+        {
+            let mut func = make_func(
+                vec![
+                    MInst::Load {
+                        dst: VReg(0),
+                        base: BaseReg::SimState,
+                        offset: 0,
+                        size: OpSize::S64,
+                    },
+                    MInst::AddImm {
+                        dst: VReg(1),
+                        src: VReg(0),
+                        imm: displacement,
+                    },
+                    MInst::LoadIndexed {
+                        dst: VReg(2),
+                        base: BaseReg::SimState,
+                        offset,
+                        index: VReg(1),
+                        scale,
+                        size: OpSize::S64,
+                        alias_range: None,
+                    },
+                    MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 8,
+                        src: VReg(2),
+                        size: OpSize::S64,
+                    },
+                    MInst::Return,
+                ],
+                3,
+            );
+            fold_indexed_load_addresses(&mut func);
+            assert!(
+                matches!(func.blocks[0].insts[2], MInst::LoadIndexed { index: VReg(1), offset: original, .. } if original == offset)
+            );
+        }
+    }
+
+    #[test]
     fn forwards_exact_store_to_load_in_block() {
         let mut func = make_func(
             vec![
@@ -12162,10 +12541,9 @@ mod tests {
                     offset: 16,
                     size: OpSize::S8,
                 },
-                MInst::AddImm {
+                MInst::LoadImm {
                     dst: VReg(2),
-                    src: VReg(1),
-                    imm: 1,
+                    value: 0x56,
                 },
                 MInst::Store {
                     base: BaseReg::SimState,
@@ -12182,22 +12560,15 @@ mod tests {
 
         let insts = &func.blocks[0].insts;
         assert!(
-            insts.iter().any(|inst| matches!(
-                inst,
-                MInst::LoadImm {
-                    dst: VReg(1),
-                    value: 85,
-                }
-            )),
+            !insts.iter().any(|inst| matches!(inst, MInst::Load { .. })),
             "{insts:#?}"
         );
         assert!(
             insts.iter().any(|inst| matches!(
                 inst,
-                MInst::AddImm {
+                MInst::LoadImm {
                     dst: VReg(2),
-                    src: VReg(1),
-                    imm: 1,
+                    value: 0x56,
                 }
             )),
             "{insts:#?}"
@@ -12226,7 +12597,8 @@ mod tests {
     }
 
     #[test]
-    fn does_not_forward_across_overlapping_store() {
+    fn preserves_overlapping_store_when_forwarding_later_load() {
+        use crate::native::{emit, jit_mem::JitCode, regalloc};
         let mut func = make_func(
             vec![
                 MInst::LoadImm {
@@ -12268,31 +12640,18 @@ mod tests {
 
         optimize(&mut func);
 
-        let insts = &func.blocks[0].insts;
-        assert!(
-            insts.iter().any(|inst| matches!(
-                inst,
-                MInst::Load {
-                    dst: VReg(2),
-                    base: BaseReg::SimState,
-                    offset: 16,
-                    size: OpSize::S16,
-                }
-            )),
-            "{insts:#?}"
-        );
-        assert!(
-            insts.iter().any(|inst| matches!(
-                inst,
-                MInst::Store {
-                    base: BaseReg::SimState,
-                    offset: 32,
-                    src: VReg(2),
-                    size: OpSize::S16,
-                }
-            )),
-            "{insts:#?}"
-        );
+        let allocation = regalloc::run_regalloc(&mut func).unwrap();
+        let emitted =
+            emit::emit(&func, &allocation.assignment, allocation.spill_frame_size).unwrap();
+        let jit = JitCode::new(&emitted.code).unwrap();
+        let mut state = vec![0xa5u8; emitted.required_state_size.max(48) as usize];
+        assert_eq!(unsafe { jit.call(&mut state) }, 0);
+        // The later byte replaces the high byte of 0x1122. Reusing that old
+        // whole value would lose the overlapping store.
+        assert_eq!(&state[16..18], &[0x22, 0x33]);
+        assert_eq!(&state[32..34], &[0x22, 0x33]);
+        assert_eq!(state[18], 0xa5);
+        assert_eq!(state[34], 0xa5);
     }
 
     #[test]
@@ -12409,9 +12768,11 @@ mod tests {
                     src: VReg(0),
                     size: OpSize::S8,
                 },
-                MInst::LoadImm {
+                MInst::Load {
                     dst: VReg(1),
-                    value: 0,
+                    base: BaseReg::SimState,
+                    offset: 0,
+                    size: OpSize::S64,
                 },
                 MInst::LoadIndexed {
                     dst: VReg(2),
@@ -12808,13 +13169,33 @@ mod tests {
         optimize(&mut func);
 
         assert!(
-            func.blocks[0]
-                .insts
-                .iter()
-                .any(|inst| matches!(inst, MInst::Or { dst: VReg(9), .. })),
+            func.blocks[0].insts.iter().any(|inst| matches!(
+                inst,
+                MInst::Or { dst: VReg(9), .. } | MInst::Or32 { dst: VReg(9), .. }
+            )),
             "{:#?}",
             func.blocks[0].insts
         );
+    }
+
+    #[test]
+    fn constant_index_folding_preserves_scale_and_rejects_displacement_overflow() {
+        for scale in [1, 2, 4, 8] {
+            let instruction = MInst::LoadIndexed {
+                dst: VReg(1),
+                base: BaseReg::SimState,
+                offset: 64,
+                index: VReg(0),
+                scale,
+                size: OpSize::S64,
+                alias_range: MemoryAliasRange::new(0, 128),
+            };
+            for index in [-2i32, 0, 3] {
+                assert!(matches!(fold_imm_use(&instruction, VReg(0), index as u64),
+                    Some(MInst::Load { offset, .. }) if offset == 64 + index * i32::from(scale)));
+            }
+            assert!(fold_imm_use(&instruction, VReg(0), i32::MAX as u64).is_none());
+        }
     }
 
     #[test]

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/bitmap_worklist.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/bitmap_worklist.rs
@@ -1,0 +1,459 @@
+//! Skip empty lanes in a counted loop guarded by an invariant bitmap.
+
+use super::*;
+
+#[cfg(test)]
+pub(super) mod tests;
+
+struct Plan {
+    header: BlockId,
+    entry: BlockId,
+    latch: BlockId,
+    exit: BlockId,
+    index: VReg,
+    width: u32,
+    words: Vec<VReg>,
+    blocks: HashSet<BlockId>,
+    outputs: HashMap<VReg, VReg>,
+}
+
+struct Analysis<'a> {
+    func: &'a MFunction,
+    positions: HashMap<BlockId, usize>,
+    definitions: Vec<Option<&'a MInst>>,
+    definition_blocks: Vec<Option<BlockId>>,
+    zeros: Vec<u64>,
+}
+
+impl Analysis<'_> {
+    fn block(&self, id: BlockId) -> &MBlock {
+        &self.func.blocks[self.positions[&id]]
+    }
+    fn definition(&self, value: VReg) -> Option<&MInst> {
+        self.definitions[value.0 as usize]
+    }
+    fn constant(&self, value: VReg) -> Option<u64> {
+        match self.definition(value)? {
+            MInst::LoadImm { value, .. } => Some(*value),
+            _ => None,
+        }
+    }
+    fn words(&self, condition: VReg, index: VReg, blocks: &HashSet<BlockId>) -> Vec<VReg> {
+        let mut pending = vec![condition];
+        let mut visited = HashSet::default();
+        let mut words = BTreeSet::new();
+        while let Some(value) = pending.pop() {
+            if !visited.insert(value) {
+                continue;
+            }
+            match self.definition(value) {
+                Some(MInst::And { lhs, rhs, .. } | MInst::And32 { lhs, rhs, .. }) => {
+                    pending.extend([*lhs, *rhs])
+                }
+                Some(MInst::AndImm { src, imm, .. }) if imm & 1 != 0 => pending.push(*src),
+                Some(MInst::AndImm32 { src, imm, .. }) if imm & 1 != 0 => pending.push(*src),
+                Some(MInst::Mov { src, .. } | MInst::Mov32 { src, .. }) => pending.push(*src),
+                Some(MInst::Shr { lhs, rhs, .. })
+                    if *rhs == index
+                        && self.definition_blocks[lhs.0 as usize]
+                            .is_some_and(|block| !blocks.contains(&block)) =>
+                {
+                    words.insert(*lhs);
+                }
+                _ => {}
+            }
+        }
+        words.into_iter().collect()
+    }
+    fn skip_aliases(
+        &self,
+        header: BlockId,
+        first: BlockId,
+        latch: BlockId,
+        condition: VReg,
+        blocks: &HashSet<BlockId>,
+    ) -> Option<HashMap<VReg, VReg>> {
+        let mut aliases = HashMap::default();
+        let mut visited = HashSet::default();
+        let mut predecessor = header;
+        let mut next = first;
+        loop {
+            if !blocks.contains(&next) || next == header || !visited.insert(next) {
+                return None;
+            }
+            let block = self.block(next);
+            for phi in &block.phis {
+                let source = phi
+                    .sources
+                    .iter()
+                    .find_map(|&(pred, source)| (pred == predecessor).then_some(source))?;
+                aliases.insert(phi.dst, resolve(source, &aliases));
+            }
+            if next == latch {
+                return Some(aliases);
+            }
+            for inst in &block.insts[..block.insts.len() - 1] {
+                if !loop_guard::movable(inst)
+                    || memory_effect::reads(inst).has_effect()
+                    || memory_effect::writes(inst).has_effect()
+                {
+                    return None;
+                }
+                if let MInst::Mov { dst, src } = *inst {
+                    aliases.insert(dst, resolve(src, &aliases));
+                }
+            }
+            let target = match *block.terminator()? {
+                MInst::Jump { target } => target,
+                MInst::Branch {
+                    cond,
+                    true_bb,
+                    false_bb,
+                } => {
+                    let cond = resolve(cond, &aliases);
+                    let value = if cond == condition {
+                        0
+                    } else {
+                        self.constant(cond)?
+                    };
+                    if value != 0 { true_bb } else { false_bb }
+                }
+                _ => return None,
+            };
+            predecessor = next;
+            next = target;
+        }
+    }
+    fn plan(&self, region: &celox_analysis::cfg::NaturalLoop) -> Option<Plan> {
+        let header = &self.func.blocks[region.header];
+        let blocks = region
+            .blocks
+            .iter()
+            .map(|&block| self.func.blocks[block].id)
+            .collect::<HashSet<_>>();
+        let exits = region
+            .blocks
+            .iter()
+            .flat_map(|&position| {
+                self.func.blocks[position]
+                    .successors()
+                    .into_iter()
+                    .filter(|target| !blocks.contains(target))
+                    .map(move |target| (self.func.blocks[position].id, target))
+            })
+            .collect::<Vec<_>>();
+        let &[(latch, exit)] = exits.as_slice() else {
+            return None;
+        };
+        let &MInst::Branch {
+            cond: loop_condition,
+            true_bb,
+            false_bb,
+        } = self.block(latch).terminator()?
+        else {
+            return None;
+        };
+        let &MInst::CmpImm {
+            lhs: next_index,
+            imm,
+            kind,
+            ..
+        } = self.definition(loop_condition)?
+        else {
+            return None;
+        };
+        if !(8..=64).contains(&imm)
+            || !matches!(
+                (kind, true_bb == header.id, false_bb == header.id),
+                (CmpKind::Ne, true, false) | (CmpKind::Eq, false, true)
+            )
+        {
+            return None;
+        }
+        let index_phi = header
+            .phis
+            .iter()
+            .find(|phi| phi.sources.len() == 2 && phi.sources.contains(&(latch, next_index)))?;
+        let &(entry, initial) = index_phi
+            .sources
+            .iter()
+            .find(|(pred, _)| !blocks.contains(pred))?;
+        if self.constant(initial) != Some(0)
+            || !matches!(self.block(entry).terminator(), Some(MInst::Jump { target }) if *target == header.id)
+        {
+            return None;
+        }
+        let (mask, _) = counted_loop::step(next_index, index_phi.dst, true, &self.definitions)?;
+        if imm as u64 > mask {
+            return None;
+        }
+        let &MInst::Branch {
+            cond: predicate,
+            false_bb: skip,
+            ..
+        } = header.terminator()?
+        else {
+            return None;
+        };
+        if self.zeros[predicate.0 as usize] & !1 != !1 {
+            return None;
+        }
+        let words = self.words(predicate, index_phi.dst, &blocks);
+        if words.is_empty() {
+            return None;
+        }
+        let aliases = self.skip_aliases(header.id, skip, latch, predicate, &blocks)?;
+        let mut outputs = HashMap::default();
+        for phi in &header.phis {
+            if phi.dst == index_phi.dst {
+                continue;
+            }
+            if phi.sources.len() != 2 || !phi.sources.iter().any(|&(pred, _)| pred == entry) {
+                return None;
+            }
+            let source = phi
+                .sources
+                .iter()
+                .find_map(|&(pred, source)| (pred == latch).then_some(source))?;
+            if resolve(source, &aliases) != phi.dst || source == phi.dst {
+                return None;
+            }
+            outputs.insert(source, phi.dst);
+        }
+        for block in &self.func.blocks {
+            if blocks.contains(&block.id) {
+                if block.insts.iter().any(|inst| {
+                    !matches!(inst, MInst::Branch { .. } | MInst::Jump { .. })
+                        && !loop_guard::movable(inst)
+                }) {
+                    return None;
+                }
+            } else if block
+                .insts
+                .iter()
+                .flat_map(MInst::uses)
+                .chain(
+                    block
+                        .phis
+                        .iter()
+                        .flat_map(|phi| phi.sources.iter().map(|&(_, source)| source)),
+                )
+                .any(|value| {
+                    self.definition_blocks[value.0 as usize]
+                        .is_some_and(|block| blocks.contains(&block))
+                        && !outputs.contains_key(&value)
+                })
+            {
+                return None;
+            }
+        }
+        Some(Plan {
+            header: header.id,
+            entry,
+            latch,
+            exit,
+            index: index_phi.dst,
+            width: imm as u32,
+            words,
+            blocks,
+            outputs,
+        })
+    }
+}
+
+fn resolve(mut value: VReg, aliases: &HashMap<VReg, VReg>) -> VReg {
+    while let Some(&next) = aliases.get(&value) {
+        if value == next {
+            break;
+        }
+        value = next;
+    }
+    value
+}
+
+fn temporary(func: &mut MFunction) -> VReg {
+    let dst = func.vregs.alloc();
+    func.spill_descs.push(SpillDesc::transient());
+    dst
+}
+
+fn find_plan(func: &MFunction) -> Option<Plan> {
+    let positions = func
+        .blocks
+        .iter()
+        .enumerate()
+        .map(|(position, block)| (block.id, position))
+        .collect::<HashMap<_, _>>();
+    let successors = func
+        .blocks
+        .iter()
+        .map(|block| {
+            block
+                .successors()
+                .into_iter()
+                .map(|target| positions[&target])
+                .collect()
+        })
+        .collect();
+    let cfg =
+        celox_analysis::cfg::ForwardControlFlowGraph::analyze_structure(successors, 0).ok()?;
+    let mut definitions = vec![None; func.vregs.count() as usize];
+    let mut definition_blocks = vec![None; definitions.len()];
+    for block in &func.blocks {
+        for phi in &block.phis {
+            definition_blocks[phi.dst.0 as usize] = Some(block.id);
+        }
+        for inst in &block.insts {
+            if let Some(dst) = inst.def() {
+                definitions[dst.0 as usize] = Some(inst);
+                definition_blocks[dst.0 as usize] = Some(block.id);
+            }
+        }
+    }
+    let analysis = Analysis {
+        func,
+        positions,
+        definitions,
+        definition_blocks,
+        zeros: known_bits::known_zeros(func),
+    };
+    cfg.loops.iter().find_map(|region| analysis.plan(region))
+}
+
+pub(super) fn run(func: &mut MFunction) {
+    // Reanalyze after each rewrite so adjacent or nested loops cannot retain
+    // stale phi sources from an earlier rewrite.
+    for _ in 0..64 {
+        let Some(plan) = find_plan(func) else { break };
+        let Some(id) = func
+            .blocks
+            .iter()
+            .map(|block| block.id.0)
+            .max()
+            .and_then(|id| id.checked_add(1))
+            .map(BlockId)
+        else {
+            break;
+        };
+        let mut setup = Vec::new();
+        let mut bitmap = plan.words[0];
+        for &word in &plan.words[1..] {
+            let dst = temporary(func);
+            setup.push(MInst::And {
+                dst,
+                lhs: bitmap,
+                rhs: word,
+            });
+            bitmap = dst;
+        }
+        if plan.width < 64 {
+            let mask = (1u64 << plan.width) - 1;
+            let dst = temporary(func);
+            if plan.width <= 32 {
+                setup.push(MInst::AndImm32 {
+                    dst,
+                    src: bitmap,
+                    imm: mask as u32,
+                });
+            } else {
+                let constant = temporary(func);
+                setup.push(MInst::LoadImm {
+                    dst: constant,
+                    value: mask,
+                });
+                setup.push(MInst::And {
+                    dst,
+                    lhs: bitmap,
+                    rhs: constant,
+                });
+            }
+            bitmap = dst;
+        }
+        let pending = temporary(func);
+        let decremented = temporary(func);
+        let remaining = temporary(func);
+        let nonzero = temporary(func);
+        let mut guard = MBlock::new(id);
+        let header = func
+            .blocks
+            .iter_mut()
+            .find(|block| block.id == plan.header)
+            .unwrap();
+        guard.phis = std::mem::take(&mut header.phis)
+            .into_iter()
+            .filter(|phi| phi.dst != plan.index)
+            .collect();
+        guard.phis.push(PhiNode {
+            dst: pending,
+            sources: vec![(plan.entry, bitmap), (plan.latch, remaining)],
+        });
+        guard.push(MInst::CmpImm {
+            dst: nonzero,
+            lhs: pending,
+            imm: 0,
+            kind: CmpKind::Ne,
+        });
+        guard.push(MInst::Branch {
+            cond: nonzero,
+            true_bb: plan.header,
+            false_bb: plan.exit,
+        });
+        header.insts.insert(
+            0,
+            MInst::Bsf {
+                dst: plan.index,
+                src: pending,
+            },
+        );
+        func.spill_descs[plan.index.0 as usize] = SpillDesc::transient();
+        let entry = func
+            .blocks
+            .iter_mut()
+            .find(|block| block.id == plan.entry)
+            .unwrap();
+        entry.insts.pop();
+        entry.insts.extend(setup);
+        entry.push(MInst::Jump { target: id });
+        let latch = func
+            .blocks
+            .iter_mut()
+            .find(|block| block.id == plan.latch)
+            .unwrap();
+        latch.insts.pop();
+        latch.push(MInst::SubImm {
+            dst: decremented,
+            src: pending,
+            imm: 1,
+        });
+        latch.push(MInst::And {
+            dst: remaining,
+            lhs: pending,
+            rhs: decremented,
+        });
+        latch.push(MInst::Jump { target: id });
+        for block in &mut func.blocks {
+            if plan.blocks.contains(&block.id) {
+                continue;
+            }
+            for inst in &mut block.insts {
+                rewrite_uses(inst, &plan.outputs);
+            }
+            for phi in &mut block.phis {
+                for (pred, source) in &mut phi.sources {
+                    if let Some(&replacement) = plan.outputs.get(source) {
+                        *source = replacement;
+                    }
+                    if block.id == plan.exit && *pred == plan.latch {
+                        *pred = id;
+                    }
+                }
+            }
+        }
+        let position = func
+            .blocks
+            .iter()
+            .position(|block| block.id == plan.header)
+            .unwrap();
+        func.blocks.insert(position, guard);
+    }
+}

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/bitmap_worklist/tests.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/bitmap_worklist/tests.rs
@@ -1,0 +1,203 @@
+use super::*;
+use crate::native::{emit, jit_mem::JitCode, mir_legalize, regalloc};
+
+pub(crate) fn shared_condition_fixture(width: u32) -> MFunction {
+    let mut function = circular_scan::tests::fixture(width, 0);
+    for _ in 0..2 {
+        function.vregs.alloc();
+        function.spill_descs.push(SpillDesc::transient());
+    }
+    let mut comparisons = std::mem::take(&mut function.blocks[2].insts);
+    comparisons.pop();
+    let header = &mut function.blocks[1];
+    header.insts.pop();
+    header.insts.extend(comparisons);
+    header.push(MInst::And32 {
+        dst: VReg(28),
+        lhs: VReg(16),
+        rhs: VReg(25),
+    });
+    header.push(MInst::Branch {
+        cond: VReg(28),
+        true_bb: BlockId(3),
+        false_bb: BlockId(4),
+    });
+    header.phis.push(PhiNode {
+        dst: VReg(31),
+        sources: vec![(BlockId(0), VReg(0)), (BlockId(5), VReg(30))],
+    });
+    for position in [3, 4] {
+        function.blocks[position].insts = vec![MInst::Jump { target: BlockId(7) }];
+    }
+    let mut join = MBlock::new(BlockId(7));
+    join.phis = std::mem::take(&mut function.blocks[5].phis);
+    join.push(MInst::Branch {
+        cond: VReg(28),
+        true_bb: BlockId(8),
+        false_bb: BlockId(9),
+    });
+    let mut update = MBlock::new(BlockId(8));
+    update.push(MInst::LoadIndexed {
+        dst: VReg(29),
+        base: BaseReg::SimState,
+        offset: 128,
+        index: VReg(7),
+        scale: 8,
+        size: OpSize::S64,
+        alias_range: MemoryAliasRange::new(128, width as usize * 8),
+    });
+    update.push(MInst::Jump { target: BlockId(5) });
+    let mut skip = MBlock::new(BlockId(9));
+    skip.push(MInst::Jump { target: BlockId(5) });
+    function.blocks[5].phis.push(PhiNode {
+        dst: VReg(30),
+        sources: vec![(BlockId(8), VReg(29)), (BlockId(9), VReg(31))],
+    });
+    function.blocks[6].insts.insert(
+        0,
+        MInst::Store {
+            base: BaseReg::SimState,
+            offset: 56,
+            src: VReg(30),
+            size: OpSize::S64,
+        },
+    );
+    function.blocks.retain(|block| block.id != BlockId(2));
+    function.blocks.extend([join, update, skip]);
+    function
+}
+
+fn compile(mut function: MFunction) -> (JitCode, usize) {
+    mir_legalize::legalize(&mut function);
+    let allocation = regalloc::run_regalloc(&mut function).unwrap();
+    let emitted = emit::emit(
+        &function,
+        &allocation.assignment,
+        allocation.spill_frame_size,
+    )
+    .unwrap();
+    (
+        JitCode::new(&emitted.code).unwrap(),
+        emitted.required_state_size.max(768) as usize,
+    )
+}
+
+#[test]
+fn bitmap_worklists_preserve_empty_full_and_sparse_candidates_and_payloads() {
+    for width in [8u32, 9, 16, 32, 48, 64] {
+        for shared in [false, true] {
+            let original = if shared {
+                shared_condition_fixture(width)
+            } else {
+                circular_scan::tests::fixture(width, 0)
+            };
+            original.verify();
+            let mut optimized = original.clone();
+            run(&mut optimized);
+            optimized.verify();
+            assert_eq!(
+                optimized.blocks.len(),
+                original.blocks.len() + 1,
+                "width={width} shared={shared}"
+            );
+            let (before, before_size) = compile(original);
+            let (after, after_size) = compile(optimized);
+            for input in [
+                0u64,
+                1,
+                0xaaaa_aaaa_5555_5555,
+                0x0123_4567_89ab_cdef,
+                u64::MAX,
+            ]
+            .into_iter()
+            .chain((0..64).map(|bit| 1u64 << bit))
+            {
+                for guard in [0u64, 1, 2, 3, 1 << 32, u64::MAX] {
+                    for origin in [
+                        0u64,
+                        1,
+                        u64::from(width - 1),
+                        u64::from(width),
+                        63,
+                        64,
+                        u64::MAX,
+                    ] {
+                        let a = input;
+                        let b = if guard & 2 == 0 {
+                            u64::MAX
+                        } else {
+                            input.rotate_left(1)
+                        };
+                        let c = input.rotate_left(3);
+                        let mut expected = None;
+                        for index in 0..width {
+                            if (((a >> index) & (b >> index)) & ((c >> index) | guard)) & 1 != 0 {
+                                let distance =
+                                    u64::from(index).wrapping_sub(origin) & u64::from(width - 1);
+                                if expected.is_none_or(|(old, _)| distance < old) {
+                                    expected = Some((distance, index));
+                                }
+                            }
+                        }
+                        let mut left = vec![0u8; before_size.max(after_size)];
+                        for (offset, value) in [(0, a), (8, b), (16, c), (24, guard), (32, origin)]
+                        {
+                            left[offset..offset + 8].copy_from_slice(&value.to_le_bytes());
+                        }
+                        for index in 0..width as usize {
+                            left[128 + index * 8..136 + index * 8]
+                                .copy_from_slice(&(index as u64 * 7 + 5).to_le_bytes());
+                        }
+                        let mut right = left.clone();
+                        assert_eq!(unsafe { before.call(&mut left) }, 0);
+                        assert_eq!(unsafe { after.call(&mut right) }, 0);
+                        assert_eq!(
+                            &left[..768],
+                            &right[..768],
+                            "width={width} shared={shared} input={input:#x} guard={guard:#x} origin={origin}"
+                        );
+                        assert_eq!(&right[40..48], &u64::from(expected.is_some()).to_le_bytes());
+                        assert_eq!(
+                            &right[48..56],
+                            &expected.map_or(0, |(distance, _)| distance).to_le_bytes()
+                        );
+                        if shared {
+                            assert_eq!(
+                                &right[56..64],
+                                &expected
+                                    .map_or(0, |(_, index)| u64::from(index) * 7 + 5)
+                                    .to_le_bytes()
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn bitmap_worklists_keep_observable_skips_and_exported_iteration_indices() {
+    for blocker in [1, 3] {
+        let mut function = circular_scan::tests::fixture(32, blocker);
+        let original = format!("{function:?}");
+        run(&mut function);
+        function.verify();
+        assert_eq!(format!("{function:?}"), original);
+    }
+    let mut function = shared_condition_fixture(32);
+    function
+        .blocks
+        .iter_mut()
+        .find(|block| block.id == BlockId(7))
+        .unwrap()
+        .insts[0] = MInst::Branch {
+        cond: VReg(5),
+        true_bb: BlockId(8),
+        false_bb: BlockId(9),
+    };
+    let original = format!("{function:?}");
+    run(&mut function);
+    function.verify();
+    assert_eq!(format!("{function:?}"), original);
+}

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/boolean.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/boolean.rs
@@ -1,0 +1,1162 @@
+//! Share the zero test across a conjunction of zero comparisons.
+
+use super::*;
+
+/// Shorten private chains without duplicating any shared subexpression. Fold
+/// complemented leaves with De Morgan's law so an ANDN chain becomes an OR
+/// tree followed by one ANDN, instead of losing the target's NOT/AND fusion.
+pub(super) fn balance_private_bitwise_trees(func: &mut MFunction) {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    struct Operation {
+        and: bool,
+        word32: bool,
+    }
+    fn operands(inst: &MInst) -> Option<(Operation, VReg, VReg)> {
+        let (and, word32, lhs, rhs) = match *inst {
+            MInst::And { lhs, rhs, .. } => (true, false, lhs, rhs),
+            MInst::And32 { lhs, rhs, .. } => (true, true, lhs, rhs),
+            MInst::Or { lhs, rhs, .. } => (false, false, lhs, rhs),
+            MInst::Or32 { lhs, rhs, .. } => (false, true, lhs, rhs),
+            _ => return None,
+        };
+        Some((Operation { and, word32 }, lhs, rhs))
+    }
+    fn instruction(op: Operation, dst: VReg, lhs: VReg, rhs: VReg) -> MInst {
+        match (op.and, op.word32) {
+            (true, false) => MInst::And { dst, lhs, rhs },
+            (true, true) => MInst::And32 { dst, lhs, rhs },
+            (false, false) => MInst::Or { dst, lhs, rhs },
+            (false, true) => MInst::Or32 { dst, lhs, rhs },
+        }
+    }
+    fn tree(
+        block: &mut MBlock,
+        op: Operation,
+        values: &[VReg],
+        vregs: &mut VRegAllocator,
+        descs: &mut Vec<SpillDesc>,
+    ) -> VReg {
+        if values.len() == 1 {
+            return values[0];
+        }
+        let middle = values.len() / 2;
+        let lhs = tree(block, op, &values[..middle], vregs, descs);
+        let rhs = tree(block, op, &values[middle..], vregs, descs);
+        let dst = alloc_transient_vreg(vregs, descs);
+        block.push(instruction(op, dst, lhs, rhs));
+        dst
+    }
+    let mut definitions = vec![None; func.vregs.count() as usize];
+    let mut users = vec![Vec::new(); definitions.len()];
+    for (bi, block) in func.blocks.iter().enumerate() {
+        for phi in &block.phis {
+            for &(_, source) in &phi.sources {
+                users[source.0 as usize].push(None);
+            }
+        }
+        for inst in &block.insts {
+            if let Some(dst) = inst.def() {
+                definitions[dst.0 as usize] = Some((bi, inst.clone()));
+            }
+            for source in inst.uses() {
+                users[source.0 as usize].push(inst.def());
+            }
+        }
+    }
+    for (bi, block) in func.blocks.iter_mut().enumerate() {
+        let original = std::mem::take(&mut block.insts);
+        for inst in original {
+            let Some((op, lhs, rhs)) = operands(&inst) else {
+                block.push(inst);
+                continue;
+            };
+            let dst = inst.def().unwrap();
+            if let [Some(user)] = users[dst.0 as usize].as_slice()
+                && let Some((owner, parent)) = &definitions[user.0 as usize]
+                && *owner == bi
+                && operands(parent).is_some_and(|(parent_op, _, _)| parent_op == op)
+            {
+                block.push(inst);
+                continue;
+            }
+            let mut stack = vec![(rhs, 1usize), (lhs, 1usize)];
+            let mut positive = Vec::new();
+            let mut negative = Vec::new();
+            let mut depth = 0;
+            while let Some((value, level)) = stack.pop() {
+                depth = depth.max(level);
+                if users[value.0 as usize].len() == 1
+                    && let Some((owner, definition)) = &definitions[value.0 as usize]
+                    && *owner == bi
+                {
+                    if let Some((child_op, a, b)) = operands(definition)
+                        && child_op == op
+                    {
+                        stack.extend([(b, level + 1), (a, level + 1)]);
+                        continue;
+                    }
+                    if let MInst::BitNot { src, .. } = *definition {
+                        negative.push(src);
+                        continue;
+                    }
+                }
+                positive.push(value);
+            }
+            let count = positive.len() + negative.len();
+            if count < 6
+                || (negative.len() < 2 && depth <= count.next_power_of_two().ilog2() as usize)
+            {
+                block.push(inst);
+                continue;
+            }
+            let vregs = &mut func.vregs;
+            let descs = &mut func.spill_descs;
+            let positive = (!positive.is_empty()).then(|| tree(block, op, &positive, vregs, descs));
+            let result = if negative.is_empty() {
+                positive.unwrap()
+            } else {
+                let negative = tree(
+                    block,
+                    Operation { and: !op.and, ..op },
+                    &negative,
+                    vregs,
+                    descs,
+                );
+                let inverted = alloc_transient_vreg(vregs, descs);
+                block.push(MInst::BitNot {
+                    dst: inverted,
+                    src: negative,
+                });
+                if let Some(positive) = positive {
+                    block.push(instruction(op, dst, inverted, positive));
+                    continue;
+                }
+                inverted
+            };
+            block.push(if op.word32 {
+                MInst::Mov32 { dst, src: result }
+            } else {
+                MInst::Mov { dst, src: result }
+            });
+        }
+    }
+}
+
+/// With normalized booleans, `other & (condition == 0)` is an ANDN. Keep
+/// comparisons which have other users, or whose inputs are wider truth values.
+pub(super) fn fold_inverted_conjunctions(func: &mut MFunction) {
+    if !func.target_features.bmi1() {
+        return;
+    }
+    let zeros = known_bits::known_zeros(func);
+    let mut definitions = vec![None; func.vregs.count() as usize];
+    let mut uses = vec![0usize; definitions.len()];
+    for block in &func.blocks {
+        for phi in &block.phis {
+            for &(_, source) in &phi.sources {
+                uses[source.0 as usize] += 1;
+            }
+        }
+        for inst in &block.insts {
+            if let Some(dst) = inst.def() {
+                definitions[dst.0 as usize] = Some(inst.clone());
+            }
+            for source in inst.uses() {
+                uses[source.0 as usize] += 1;
+            }
+        }
+    }
+    let is_boolean = |value: VReg| zeros[value.0 as usize] & !1 == !1;
+    for block in &mut func.blocks {
+        let original = std::mem::take(&mut block.insts);
+        for mut inst in original {
+            if let MInst::And { dst, lhs, rhs } | MInst::And32 { dst, lhs, rhs } = inst {
+                for (comparison, other) in [(lhs, rhs), (rhs, lhs)] {
+                    if uses[comparison.0 as usize] != 1 || !is_boolean(other) {
+                        continue;
+                    }
+                    if let Some(MInst::CmpImm {
+                        lhs: condition,
+                        imm: 0,
+                        kind: CmpKind::Eq,
+                        ..
+                    }) = definitions[comparison.0 as usize]
+                        && is_boolean(condition)
+                    {
+                        let inverted = func.vregs.alloc();
+                        func.spill_descs.push(SpillDesc::transient());
+                        block.push(MInst::BitNot {
+                            dst: inverted,
+                            src: condition,
+                        });
+                        inst = MInst::And32 {
+                            dst,
+                            lhs: inverted,
+                            rhs: other,
+                        };
+                        break;
+                    }
+                }
+            }
+            block.push(inst);
+        }
+    }
+}
+
+/// Recover a scalar choice from `b ^ ((a ^ b) & -condition)`. The mask may
+/// truncate a packed field only when the arms cannot differ outside that field.
+pub(super) fn fold_masked_selects(func: &mut MFunction) {
+    let zeros = known_bits::known_zeros(func);
+    let mut definitions = vec![None; func.vregs.count() as usize];
+    for block in &func.blocks {
+        for inst in &block.insts {
+            if let Some(dst) = inst.def() {
+                definitions[dst.0 as usize] = Some(inst.clone());
+            }
+        }
+    }
+    let definition = |value: VReg| definitions[value.0 as usize].as_ref();
+    let constant = |value: VReg| match definition(value) {
+        Some(MInst::LoadImm { value, .. }) => Some(*value),
+        _ => None,
+    };
+    for block in &mut func.blocks {
+        let original = std::mem::take(&mut block.insts);
+        for inst in original {
+            let (dst, lhs, rhs, word32) = match inst {
+                MInst::Xor { dst, lhs, rhs } => (dst, lhs, rhs, false),
+                MInst::Xor32 { dst, lhs, rhs } => (dst, lhs, rhs, true),
+                _ => {
+                    block.push(inst);
+                    continue;
+                }
+            };
+            let mut replacement = None;
+            for (false_val, masked) in [(lhs, rhs), (rhs, lhs)] {
+                let (first, second, and_mask) = match definition(masked) {
+                    Some(MInst::And { lhs, rhs, .. }) => (*lhs, *rhs, u64::MAX),
+                    Some(MInst::And32 { lhs, rhs, .. }) => (*lhs, *rhs, u64::from(u32::MAX)),
+                    _ => continue,
+                };
+                for (difference, mut mask_value) in [(first, second), (second, first)] {
+                    let (a, b, xor_mask) = match definition(difference) {
+                        Some(MInst::Xor { lhs, rhs, .. }) => (*lhs, *rhs, u64::MAX),
+                        Some(MInst::Xor32 { lhs, rhs, .. }) => (*lhs, *rhs, u64::from(u32::MAX)),
+                        _ => continue,
+                    };
+                    let true_val = if a == false_val {
+                        b
+                    } else if b == false_val {
+                        a
+                    } else {
+                        continue;
+                    };
+                    let mut mask = and_mask & xor_mask;
+                    let condition = loop {
+                        match definition(mask_value) {
+                            Some(MInst::AndImm { src, imm, .. }) => {
+                                mask &= imm;
+                                mask_value = *src;
+                            }
+                            Some(MInst::AndImm32 { src, imm, .. }) => {
+                                mask &= u64::from(*imm);
+                                mask_value = *src;
+                            }
+                            Some(MInst::And { lhs, rhs, .. } | MInst::And32 { lhs, rhs, .. }) => {
+                                if matches!(definition(mask_value), Some(MInst::And32 { .. })) {
+                                    mask &= u64::from(u32::MAX);
+                                }
+                                if let Some(value) = constant(*lhs) {
+                                    mask &= value;
+                                    mask_value = *rhs;
+                                } else if let Some(value) = constant(*rhs) {
+                                    mask &= value;
+                                    mask_value = *lhs;
+                                } else {
+                                    break None;
+                                }
+                            }
+                            Some(MInst::Neg { src, .. }) => break Some(*src),
+                            Some(MInst::Sub { lhs, rhs, .. } | MInst::Sub32 { lhs, rhs, .. })
+                                if constant(*lhs) == Some(0) =>
+                            {
+                                if matches!(definition(mask_value), Some(MInst::Sub32 { .. })) {
+                                    mask &= u64::from(u32::MAX);
+                                }
+                                break Some(*rhs);
+                            }
+                            _ => break None,
+                        }
+                    };
+                    let Some(cond) = condition else {
+                        continue;
+                    };
+                    let demanded = if word32 {
+                        u64::from(u32::MAX)
+                    } else {
+                        u64::MAX
+                    };
+                    if zeros[cond.0 as usize] & !1 == !1
+                        && demanded & !mask & !(zeros[a.0 as usize] & zeros[b.0 as usize]) == 0
+                    {
+                        replacement = Some((cond, true_val, false_val));
+                        break;
+                    }
+                }
+                if replacement.is_some() {
+                    break;
+                }
+            }
+            if let Some((cond, true_val, false_val)) = replacement {
+                let result = if word32 {
+                    let value = func.vregs.alloc();
+                    func.spill_descs.push(SpillDesc::transient());
+                    value
+                } else {
+                    dst
+                };
+                block.push(MInst::Select {
+                    dst: result,
+                    cond,
+                    true_val,
+                    false_val,
+                });
+                if word32 {
+                    block.push(MInst::Mov32 { dst, src: result });
+                }
+            } else {
+                block.push(inst);
+            }
+        }
+    }
+}
+
+fn tested_bits(mut value: VReg, definitions: &[Option<MInst>]) -> (VReg, u64) {
+    let mut mask = u64::MAX;
+    loop {
+        match &definitions[value.0 as usize] {
+            Some(MInst::AndImm { src, imm, .. }) => {
+                mask &= imm;
+                value = *src;
+            }
+            Some(MInst::AndImm32 { src, imm, .. }) => {
+                mask &= u64::from(*imm);
+                value = *src;
+            }
+            Some(MInst::And { lhs, rhs, .. } | MInst::And32 { lhs, rhs, .. }) => {
+                let pair =
+                    [(*lhs, *rhs), (*rhs, *lhs)]
+                        .into_iter()
+                        .find_map(|(source, constant)| {
+                            if let Some(MInst::LoadImm { value, .. }) =
+                                definitions[constant.0 as usize]
+                            {
+                                Some((source, value))
+                            } else {
+                                None
+                            }
+                        });
+                let Some((source, constant)) = pair else {
+                    return (value, mask);
+                };
+                if matches!(definitions[value.0 as usize], Some(MInst::And32 { .. })) {
+                    mask &= u64::from(u32::MAX);
+                }
+                mask &= constant;
+                value = source;
+            }
+            Some(MInst::ShrImm { src, imm, .. }) => {
+                mask = mask.checked_shl(u32::from(*imm)).unwrap_or(0);
+                value = *src;
+            }
+            Some(MInst::ShlImm { src, imm, .. }) => {
+                mask = mask.checked_shr(u32::from(*imm)).unwrap_or(0);
+                value = *src;
+            }
+            Some(MInst::Mov { src, .. }) => value = *src,
+            Some(MInst::Mov32 { src, .. }) => {
+                mask &= u64::from(u32::MAX);
+                value = *src;
+            }
+            _ => return (value, mask),
+        }
+    }
+}
+
+pub(super) fn fold_zero_conjunctions(func: &mut MFunction) {
+    let mut definitions = vec![None; func.vregs.count() as usize];
+    let mut users = vec![Vec::new(); func.vregs.count() as usize];
+    for block in &func.blocks {
+        for phi in &block.phis {
+            for &(_, value) in &phi.sources {
+                users[value.0 as usize].push(None);
+            }
+        }
+        for inst in &block.insts {
+            if let Some(dst) = inst.def() {
+                definitions[dst.0 as usize] = Some(inst.clone());
+            }
+            for value in inst.uses() {
+                users[value.0 as usize].push(inst.def());
+            }
+        }
+    }
+    let and_operands = |value: VReg| match &definitions[value.0 as usize] {
+        Some(MInst::And { lhs, rhs, .. } | MInst::And32 { lhs, rhs, .. }) => Some((*lhs, *rhs)),
+        _ => None,
+    };
+    for block in &mut func.blocks {
+        let original = std::mem::take(&mut block.insts);
+        for inst in original {
+            let Some(dst) = inst.def() else {
+                block.push(inst);
+                continue;
+            };
+            let Some((lhs, rhs)) = and_operands(dst) else {
+                block.push(inst);
+                continue;
+            };
+            // Visit only roots of private AND trees. Shared subtrees remain
+            // leaves, bounding the total walk by the original instruction count.
+            if let [Some(user)] = users[dst.0 as usize].as_slice()
+                && and_operands(*user).is_some()
+            {
+                block.push(inst);
+                continue;
+            }
+            let mut stack = vec![rhs, lhs];
+            let mut tested = Vec::new();
+            let mut other = Vec::new();
+            while let Some(value) = stack.pop() {
+                if users[value.0 as usize].len() == 1 {
+                    if let Some((lhs, rhs)) = and_operands(value) {
+                        stack.extend([rhs, lhs]);
+                        continue;
+                    }
+                    if let Some(MInst::CmpImm {
+                        lhs,
+                        imm: 0,
+                        kind: CmpKind::Eq,
+                        ..
+                    }) = definitions[value.0 as usize]
+                    {
+                        tested.push(lhs);
+                        continue;
+                    }
+                }
+                other.push(value);
+            }
+            if tested.len() < 2 {
+                block.push(inst);
+                continue;
+            }
+            let mut groups = Vec::<(VReg, u64)>::new();
+            let mut group_indices = HashMap::<VReg, usize>::default();
+            for value in tested {
+                let (source, mask) = tested_bits(value, &definitions);
+                if let Some(&index) = group_indices.get(&source) {
+                    groups[index].1 |= mask;
+                } else {
+                    group_indices.insert(source, groups.len());
+                    groups.push((source, mask));
+                }
+            }
+            let mut tested = Vec::new();
+            for (source, mask) in groups {
+                let value = if mask == u64::MAX {
+                    source
+                } else {
+                    let value = func.vregs.alloc();
+                    func.spill_descs.push(SpillDesc::transient());
+                    if i32::try_from(mask as i64).is_ok() {
+                        block.push(MInst::AndImm {
+                            dst: value,
+                            src: source,
+                            imm: mask,
+                        });
+                    } else if let Ok(mask) = u32::try_from(mask) {
+                        block.push(MInst::AndImm32 {
+                            dst: value,
+                            src: source,
+                            imm: mask,
+                        });
+                    } else {
+                        let constant = func.vregs.alloc();
+                        func.spill_descs.push(SpillDesc::remat(mask));
+                        block.push(MInst::LoadImm {
+                            dst: constant,
+                            value: mask,
+                        });
+                        block.push(MInst::And {
+                            dst: value,
+                            lhs: source,
+                            rhs: constant,
+                        });
+                    }
+                    value
+                };
+                tested.push(value);
+            }
+            let mut combined = tested[0];
+            for value in tested.into_iter().skip(1) {
+                let next = func.vregs.alloc();
+                func.spill_descs.push(SpillDesc::transient());
+                block.push(MInst::Or {
+                    dst: next,
+                    lhs: combined,
+                    rhs: value,
+                });
+                combined = next;
+            }
+            let comparison = if other.is_empty() {
+                dst
+            } else {
+                let value = func.vregs.alloc();
+                func.spill_descs.push(SpillDesc::transient());
+                value
+            };
+            block.push(MInst::CmpImm {
+                dst: comparison,
+                lhs: combined,
+                imm: 0,
+                kind: CmpKind::Eq,
+            });
+            let mut combined = comparison;
+            let count = other.len();
+            for (position, value) in other.into_iter().enumerate() {
+                let next = if position + 1 == count {
+                    dst
+                } else {
+                    let value = func.vregs.alloc();
+                    func.spill_descs.push(SpillDesc::transient());
+                    value
+                };
+                // One conjunct is a normalized comparison, so only bit zero
+                // of every other conjunct can influence the result.
+                block.push(MInst::And32 {
+                    dst: next,
+                    lhs: combined,
+                    rhs: value,
+                });
+                combined = next;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::{emit, jit_mem::JitCode, mir_legalize, regalloc};
+
+    fn conjunction(shared: bool) -> MFunction {
+        let mut vregs = VRegAllocator::new();
+        for _ in 0..12 {
+            vregs.alloc();
+        }
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 12]);
+        let mut block = MBlock::new(BlockId(0));
+        for index in 0..4 {
+            block.push(MInst::Load {
+                dst: VReg(index),
+                base: BaseReg::SimState,
+                offset: index as i32 * 8,
+                size: OpSize::S64,
+            });
+        }
+        for index in 0..3 {
+            block.push(MInst::CmpImm {
+                dst: VReg(4 + index),
+                lhs: VReg(index),
+                imm: 0,
+                kind: CmpKind::Eq,
+            });
+        }
+        block.push(MInst::And {
+            dst: VReg(7),
+            lhs: VReg(4),
+            rhs: VReg(3),
+        });
+        block.push(MInst::And32 {
+            dst: VReg(8),
+            lhs: VReg(7),
+            rhs: VReg(5),
+        });
+        block.push(MInst::And {
+            dst: VReg(9),
+            lhs: VReg(8),
+            rhs: VReg(6),
+        });
+        block.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 32,
+            src: VReg(9),
+            size: OpSize::S64,
+        });
+        if shared {
+            block.push(MInst::Store {
+                base: BaseReg::SimState,
+                offset: 40,
+                src: VReg(5),
+                size: OpSize::S64,
+            });
+        }
+        block.push(MInst::Return);
+        function.push_block(block);
+        function
+    }
+
+    fn compile(mut function: MFunction) -> (JitCode, usize) {
+        mir_legalize::legalize(&mut function);
+        let allocation = regalloc::run_regalloc(&mut function).unwrap();
+        let code = emit::emit(
+            &function,
+            &allocation.assignment,
+            allocation.spill_frame_size,
+        )
+        .unwrap();
+        (
+            JitCode::new(&code.code).unwrap(),
+            code.required_state_size.max(48) as usize,
+        )
+    }
+
+    #[test]
+    fn balanced_bitwise_trees_preserve_width_complements_and_shared_values() {
+        for count in [5usize, 6, 7, 12, 33] {
+            for is_and in [false, true] {
+                for word32 in [false, true] {
+                    for complement in 0..3 {
+                        for shared in [false, true] {
+                            let mut vregs = VRegAllocator::new();
+                            for _ in 0..count * 3 {
+                                vregs.alloc();
+                            }
+                            let mut function =
+                                MFunction::new(vregs, vec![SpillDesc::transient(); count * 3]);
+                            let mut block = MBlock::new(BlockId(0));
+                            let negated = |i: usize| {
+                                complement == 2 || (complement == 1 && !i.is_multiple_of(3))
+                            };
+                            let mut leaves = Vec::new();
+                            for index in 0..count {
+                                let input = VReg(index as u32);
+                                block.push(MInst::Load {
+                                    dst: input,
+                                    base: BaseReg::SimState,
+                                    offset: index as i32 * 8,
+                                    size: OpSize::S64,
+                                });
+                                leaves.push(if negated(index) {
+                                    let dst = VReg((count + index) as u32);
+                                    block.push(MInst::BitNot { dst, src: input });
+                                    dst
+                                } else {
+                                    input
+                                });
+                            }
+                            let mut result = leaves[0];
+                            for (index, &rhs) in leaves.iter().enumerate().skip(1) {
+                                let dst = VReg((count * 2 + index) as u32);
+                                let lhs = result;
+                                block.push(match (is_and, word32) {
+                                    (false, false) => MInst::Or { dst, lhs, rhs },
+                                    (false, true) => MInst::Or32 { dst, lhs, rhs },
+                                    (true, false) => MInst::And { dst, lhs, rhs },
+                                    (true, true) => MInst::And32 { dst, lhs, rhs },
+                                });
+                                if shared && index == 2 {
+                                    block.push(MInst::Store {
+                                        base: BaseReg::SimState,
+                                        offset: (count * 8 + 8) as i32,
+                                        src: dst,
+                                        size: OpSize::S64,
+                                    });
+                                }
+                                result = dst;
+                            }
+                            block.push(MInst::Store {
+                                base: BaseReg::SimState,
+                                offset: count as i32 * 8,
+                                src: result,
+                                size: OpSize::S64,
+                            });
+                            block.push(MInst::Return);
+                            function.push_block(block);
+                            let mut optimized = function.clone();
+                            balance_private_bitwise_trees(&mut optimized);
+                            copy_propagate(&mut optimized);
+                            dead_code_eliminate(&mut optimized);
+                            optimized.verify();
+                            let (before, before_size) = compile(function);
+                            let (after, after_size) = compile(optimized);
+                            for sample in 0..128 {
+                                let mut left = vec![0xa5u8; before_size.max(after_size)];
+                                let mut expected = if is_and { u64::MAX } else { 0 };
+                                for lane in 0..count {
+                                    let value = if lane == sample % count {
+                                        if sample < 64 {
+                                            1u64 << sample
+                                        } else {
+                                            !(1u64 << (sample - 64))
+                                        }
+                                    } else if is_and {
+                                        u64::MAX
+                                    } else {
+                                        0
+                                    };
+                                    expected = if is_and {
+                                        expected & value
+                                    } else {
+                                        expected | value
+                                    };
+                                    let input = if negated(lane) { !value } else { value };
+                                    left[lane * 8..lane * 8 + 8]
+                                        .copy_from_slice(&input.to_le_bytes());
+                                }
+                                if word32 {
+                                    expected &= u64::from(u32::MAX);
+                                }
+                                let mut right = left.clone();
+                                assert_eq!(unsafe { before.call(&mut left) }, 0);
+                                assert_eq!(unsafe { after.call(&mut right) }, 0);
+                                assert_eq!(
+                                    &left[..count * 8 + 16],
+                                    &right[..count * 8 + 16],
+                                    "count={count} and={is_and} word32={word32} complement={complement} shared={shared} sample={sample}"
+                                );
+                                assert_eq!(
+                                    u64::from_le_bytes(
+                                        right[count * 8..count * 8 + 8].try_into().unwrap()
+                                    ),
+                                    expected
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn zero_conjunctions_preserve_arbitrary_bits_and_shared_comparisons() {
+        for shared in [false, true] {
+            let original = conjunction(shared);
+            let mut optimized = original.clone();
+            fold_zero_conjunctions(&mut optimized);
+            dead_code_eliminate(&mut optimized);
+            optimized.verify();
+            let compares = optimized
+                .blocks
+                .iter()
+                .flat_map(|block| &block.insts)
+                .filter(|inst| matches!(inst, MInst::CmpImm { .. }))
+                .count();
+            assert_eq!(compares, if shared { 2 } else { 1 });
+            let (before, before_size) = compile(original);
+            let (after, after_size) = compile(optimized);
+            let values = [0u64, 1, 2, 3, 1 << 32, 1 << 63, u64::MAX];
+            for a in values {
+                for b in values {
+                    for c in values {
+                        for guard in values {
+                            let mut left = vec![0u8; before_size.max(after_size)];
+                            for (index, value) in [a, b, c, guard].into_iter().enumerate() {
+                                left[index * 8..index * 8 + 8]
+                                    .copy_from_slice(&value.to_le_bytes());
+                            }
+                            let mut right = left.clone();
+                            assert_eq!(unsafe { before.call(&mut left) }, 0);
+                            assert_eq!(unsafe { after.call(&mut right) }, 0);
+                            assert_eq!(
+                                &left[32..48],
+                                &right[32..48],
+                                "{a:#x}, {b:#x}, {c:#x}, {guard:#x}"
+                            );
+                            assert_eq!(
+                                u64::from_le_bytes(right[32..40].try_into().unwrap()),
+                                u64::from(a == 0 && b == 0 && c == 0) & guard
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn masked_selects_preserve_condition_truth_and_truncated_masks() {
+        for word32 in [false, true] {
+            for normalized in [false, true] {
+                for mask in [0x3ff, 0x3fff_ffff_ffff_ffff, u64::MAX] {
+                    for bounded in [false, true] {
+                        let mut vregs = VRegAllocator::new();
+                        for _ in 0..14 {
+                            vregs.alloc();
+                        }
+                        let mut original = MFunction::new(vregs, vec![SpillDesc::transient(); 14]);
+                        let mut block = MBlock::new(BlockId(0));
+                        for index in 0..3 {
+                            block.push(MInst::Load {
+                                dst: VReg(index),
+                                base: BaseReg::SimState,
+                                offset: index as i32 * 8,
+                                size: OpSize::S64,
+                            });
+                        }
+                        block.push(MInst::LoadImm {
+                            dst: VReg(3),
+                            value: 0,
+                        });
+                        block.push(MInst::LoadImm {
+                            dst: VReg(4),
+                            value: mask,
+                        });
+                        block.push(if normalized {
+                            MInst::AndImm {
+                                dst: VReg(5),
+                                src: VReg(0),
+                                imm: 1,
+                            }
+                        } else {
+                            MInst::Mov {
+                                dst: VReg(5),
+                                src: VReg(0),
+                            }
+                        });
+                        for (dst, src) in [(VReg(6), VReg(1)), (VReg(7), VReg(2))] {
+                            block.push(if bounded {
+                                MInst::And {
+                                    dst,
+                                    lhs: src,
+                                    rhs: VReg(4),
+                                }
+                            } else {
+                                MInst::Mov { dst, src }
+                            });
+                        }
+                        block.push(MInst::Sub {
+                            dst: VReg(8),
+                            lhs: VReg(3),
+                            rhs: VReg(5),
+                        });
+                        block.push(MInst::And {
+                            dst: VReg(9),
+                            lhs: VReg(8),
+                            rhs: VReg(4),
+                        });
+                        block.push(MInst::Xor {
+                            dst: VReg(10),
+                            lhs: VReg(6),
+                            rhs: VReg(7),
+                        });
+                        block.push(MInst::And {
+                            dst: VReg(11),
+                            lhs: VReg(10),
+                            rhs: VReg(9),
+                        });
+                        block.push(if word32 {
+                            MInst::Xor32 {
+                                dst: VReg(12),
+                                lhs: VReg(7),
+                                rhs: VReg(11),
+                            }
+                        } else {
+                            MInst::Xor {
+                                dst: VReg(12),
+                                lhs: VReg(7),
+                                rhs: VReg(11),
+                            }
+                        });
+                        block.push(MInst::Store {
+                            base: BaseReg::SimState,
+                            offset: 32,
+                            src: VReg(12),
+                            size: OpSize::S64,
+                        });
+                        // The mask is also observed: folding must preserve shared producers.
+                        block.push(MInst::Store {
+                            base: BaseReg::SimState,
+                            offset: 40,
+                            src: VReg(9),
+                            size: OpSize::S64,
+                        });
+                        block.push(MInst::Return);
+                        original.push_block(block);
+                        let mut optimized = original.clone();
+                        fold_masked_selects(&mut optimized);
+                        dead_code_eliminate(&mut optimized);
+                        optimized.verify();
+                        let expected_fold = normalized
+                            && (bounded
+                                || mask == u64::MAX
+                                || (word32 && mask & u64::from(u32::MAX) == u64::from(u32::MAX)));
+                        assert_eq!(
+                            optimized.blocks[0]
+                                .insts
+                                .iter()
+                                .any(|inst| matches!(inst, MInst::Select { .. })),
+                            expected_fold
+                        );
+                        let (before, before_size) = compile(original);
+                        let (after, after_size) = compile(optimized);
+                        let values = [0u64, 1, 2, 3, 1 << 31, 1 << 32, 1 << 63, u64::MAX];
+                        for a in values {
+                            for b in values {
+                                for condition in values {
+                                    let mut left = vec![0u8; before_size.max(after_size)];
+                                    for (index, value) in [condition, a, b].into_iter().enumerate()
+                                    {
+                                        left[index * 8..index * 8 + 8]
+                                            .copy_from_slice(&value.to_le_bytes());
+                                    }
+                                    let mut right = left.clone();
+                                    assert_eq!(unsafe { before.call(&mut left) }, 0);
+                                    assert_eq!(unsafe { after.call(&mut right) }, 0);
+                                    assert_eq!(
+                                        &left[32..48],
+                                        &right[32..48],
+                                        "word32={word32}, normalized={normalized}, mask={mask:#x}, bounded={bounded}, condition={condition:#x}, a={a:#x}, b={b:#x}"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn zero_conjunctions_preserve_shifted_and_truncated_fields() {
+        for (left_shift, right_shift, mask) in [
+            (0, 0, u64::MAX),
+            (3, 9, 0x1fff_ffff),
+            (31, 32, 0x8000_0000_ffff_0000),
+            (32, 1, 0xffff_ffff),
+            (63, 63, u64::MAX),
+        ] {
+            let mut vregs = VRegAllocator::new();
+            for _ in 0..15 {
+                vregs.alloc();
+            }
+            let mut original = MFunction::new(vregs, vec![SpillDesc::transient(); 15]);
+            let mut block = MBlock::new(BlockId(0));
+            block.push(MInst::Load {
+                dst: VReg(0),
+                base: BaseReg::SimState,
+                offset: 0,
+                size: OpSize::S64,
+            });
+            block.push(MInst::Load {
+                dst: VReg(1),
+                base: BaseReg::SimState,
+                offset: 8,
+                size: OpSize::S64,
+            });
+            block.push(MInst::LoadImm {
+                dst: VReg(2),
+                value: mask,
+            });
+            block.push(MInst::ShlImm {
+                dst: VReg(3),
+                src: VReg(0),
+                imm: left_shift,
+            });
+            block.push(MInst::And32 {
+                dst: VReg(4),
+                lhs: VReg(3),
+                rhs: VReg(2),
+            });
+            block.push(MInst::ShrImm {
+                dst: VReg(5),
+                src: VReg(0),
+                imm: right_shift,
+            });
+            block.push(MInst::And {
+                dst: VReg(6),
+                lhs: VReg(5),
+                rhs: VReg(2),
+            });
+            block.push(MInst::Mov32 {
+                dst: VReg(7),
+                src: VReg(0),
+            });
+            block.push(MInst::AndImm32 {
+                dst: VReg(8),
+                src: VReg(7),
+                imm: 0x8000_0000,
+            });
+            for (dst, lhs) in [(9, 4), (10, 6), (11, 8)] {
+                block.push(MInst::CmpImm {
+                    dst: VReg(dst),
+                    lhs: VReg(lhs),
+                    imm: 0,
+                    kind: CmpKind::Eq,
+                });
+            }
+            block.push(MInst::And {
+                dst: VReg(12),
+                lhs: VReg(9),
+                rhs: VReg(10),
+            });
+            block.push(MInst::And32 {
+                dst: VReg(13),
+                lhs: VReg(12),
+                rhs: VReg(11),
+            });
+            block.push(MInst::And {
+                dst: VReg(14),
+                lhs: VReg(13),
+                rhs: VReg(1),
+            });
+            block.push(MInst::Store {
+                base: BaseReg::SimState,
+                offset: 32,
+                src: VReg(14),
+                size: OpSize::S64,
+            });
+            block.push(MInst::Return);
+            original.push_block(block);
+            let mut optimized = original.clone();
+            fold_zero_conjunctions(&mut optimized);
+            dead_code_eliminate(&mut optimized);
+            optimized.verify();
+            let (before, before_size) = compile(original);
+            let (after, after_size) = compile(optimized);
+            let inputs = [0u64, u64::MAX]
+                .into_iter()
+                .chain((0..64).flat_map(|bit| [1 << bit, !(1 << bit)]));
+            for value in inputs {
+                for guard in [0u64, 1, 2, u64::MAX] {
+                    let mut state = vec![0u8; before_size.max(after_size)];
+                    state[..8].copy_from_slice(&value.to_le_bytes());
+                    state[8..16].copy_from_slice(&guard.to_le_bytes());
+                    let mut actual = state.clone();
+                    assert_eq!(unsafe { before.call(&mut state) }, 0);
+                    assert_eq!(unsafe { after.call(&mut actual) }, 0);
+                    assert_eq!(
+                        &state[32..40],
+                        &actual[32..40],
+                        "left={left_shift}, right={right_shift}, mask={mask:#x}, value={value:#x}, guard={guard:#x}"
+                    );
+                    let expected = u64::from(
+                        ((value << left_shift) as u32 & mask as u32) == 0
+                            && ((value >> right_shift) & mask) == 0
+                            && value & 0x8000_0000 == 0,
+                    ) & guard;
+                    assert_eq!(
+                        u64::from_le_bytes(actual[32..40].try_into().unwrap()),
+                        expected
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn inverted_conjunctions_preserve_boolean_and_wide_truth_values() {
+        use crate::native::features::X86Features;
+        if !std::arch::is_x86_feature_detected!("bmi1") {
+            return;
+        }
+        for bounded in [false, true] {
+            for shared in [false, true] {
+                for bmi1 in [false, true] {
+                    let mut vregs = VRegAllocator::new();
+                    for _ in 0..7 {
+                        vregs.alloc();
+                    }
+                    let mut original = MFunction::new(vregs, vec![SpillDesc::transient(); 7]);
+                    original.target_features = X86Features::for_test(false).with_bmi1(bmi1);
+                    let mut block = MBlock::new(BlockId(0));
+                    block.push(MInst::Load {
+                        dst: VReg(0),
+                        base: BaseReg::SimState,
+                        offset: 0,
+                        size: OpSize::S64,
+                    });
+                    block.push(MInst::Load {
+                        dst: VReg(1),
+                        base: BaseReg::SimState,
+                        offset: 8,
+                        size: OpSize::S64,
+                    });
+                    block.push(if bounded {
+                        MInst::AndImm {
+                            dst: VReg(2),
+                            src: VReg(0),
+                            imm: 1,
+                        }
+                    } else {
+                        MInst::Mov {
+                            dst: VReg(2),
+                            src: VReg(0),
+                        }
+                    });
+                    block.push(MInst::AndImm {
+                        dst: VReg(3),
+                        src: VReg(1),
+                        imm: 1,
+                    });
+                    block.push(MInst::CmpImm {
+                        dst: VReg(4),
+                        lhs: VReg(2),
+                        imm: 0,
+                        kind: CmpKind::Eq,
+                    });
+                    block.push(MInst::And {
+                        dst: VReg(5),
+                        lhs: VReg(3),
+                        rhs: VReg(4),
+                    });
+                    block.push(MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 32,
+                        src: VReg(5),
+                        size: OpSize::S64,
+                    });
+                    if shared {
+                        block.push(MInst::Store {
+                            base: BaseReg::SimState,
+                            offset: 40,
+                            src: VReg(4),
+                            size: OpSize::S64,
+                        });
+                    }
+                    block.push(MInst::Return);
+                    original.push_block(block);
+                    let mut optimized = original.clone();
+                    fold_inverted_conjunctions(&mut optimized);
+                    dead_code_eliminate(&mut optimized);
+                    optimized.verify();
+                    assert_eq!(
+                        optimized.blocks[0]
+                            .insts
+                            .iter()
+                            .any(|inst| matches!(inst, MInst::BitNot { .. })),
+                        bounded && !shared && bmi1
+                    );
+                    let (before, before_size) = compile(original);
+                    let (after, after_size) = compile(optimized);
+                    for a in [0u64, 1, 2, 3, 1 << 32, 1 << 63, u64::MAX] {
+                        for b in [0u64, 1, 2, 3, 1 << 63, u64::MAX] {
+                            let mut left = vec![0u8; before_size.max(after_size)];
+                            left[..8].copy_from_slice(&a.to_le_bytes());
+                            left[8..16].copy_from_slice(&b.to_le_bytes());
+                            let mut right = left.clone();
+                            assert_eq!(unsafe { before.call(&mut left) }, 0);
+                            assert_eq!(unsafe { after.call(&mut right) }, 0);
+                            assert_eq!(
+                                &left[32..48],
+                                &right[32..48],
+                                "bounded={bounded}, shared={shared}, bmi1={bmi1}, a={a:#x}, b={b:#x}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/branch_merge.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/branch_merge.rs
@@ -1,0 +1,176 @@
+//! Merge adjacent diamonds that branch on the same SSA condition.
+//!
+//! Move the first diamond's phi nodes to the second diamond's merge, resolving
+//! their uses in each arm. This avoids materializing and testing the condition
+//! twice while preserving each arm's memory operations and their order.
+
+use super::*;
+
+#[cfg(test)]
+mod tests;
+
+struct Plan {
+    parent: BlockId,
+    edges: [BlockId; 2],
+    join: BlockId,
+    bodies: [BlockId; 2],
+    tail: BlockId,
+    aliases: [HashMap<VReg, VReg>; 2],
+}
+
+fn find_plan(func: &MFunction) -> Option<Plan> {
+    let blocks = func
+        .blocks
+        .iter()
+        .map(|block| (block.id, block))
+        .collect::<HashMap<_, _>>();
+    let mut predecessors = HashMap::<BlockId, BTreeSet<BlockId>>::default();
+    for block in &func.blocks {
+        for target in block.successors() {
+            predecessors.entry(target).or_default().insert(block.id);
+        }
+    }
+    let has_predecessors = |block, expected: &[BlockId]| {
+        predecessors.get(&block).is_some_and(|actual| {
+            actual.len() == expected.len() && expected.iter().all(|pred| actual.contains(pred))
+        })
+    };
+    let jump = |id| match blocks[&id].terminator() {
+        Some(MInst::Jump { target }) => Some(*target),
+        _ => None,
+    };
+    func.blocks.iter().find_map(|parent| {
+        let &MInst::Branch {
+            cond,
+            true_bb,
+            false_bb,
+        } = parent.terminator()?
+        else {
+            return None;
+        };
+        let edges = [true_bb, false_bb];
+        if edges.iter().any(|edge| {
+            let block = blocks[edge];
+            !has_predecessors(*edge, &[parent.id])
+                || !block.phis.is_empty()
+                || block.insts.len() != 1
+        }) {
+            return None;
+        }
+        let join = jump(edges[0])?;
+        if jump(edges[1])? != join || !has_predecessors(join, &edges) {
+            return None;
+        }
+        let block = blocks[&join];
+        let &[
+            MInst::Branch {
+                cond: next,
+                true_bb,
+                false_bb,
+            },
+        ] = block.insts.as_slice()
+        else {
+            return None;
+        };
+        if next != cond {
+            return None;
+        }
+        let bodies = [true_bb, false_bb];
+        if bodies.iter().any(|body| !has_predecessors(*body, &[join])) {
+            return None;
+        }
+        let tail = jump(bodies[0])?;
+        if jump(bodies[1])? != tail || !has_predecessors(tail, &bodies) {
+            return None;
+        }
+        if [
+            parent.id, edges[0], edges[1], join, bodies[0], bodies[1], tail,
+        ]
+        .into_iter()
+        .collect::<HashSet<_>>()
+        .len()
+            != 7
+        {
+            return None;
+        }
+        let mut aliases = [HashMap::default(), HashMap::default()];
+        for phi in &block.phis {
+            if phi.sources.len() != 2 {
+                return None;
+            }
+            for (arm, edge) in edges.into_iter().enumerate() {
+                let source = phi
+                    .sources
+                    .iter()
+                    .find_map(|&(pred, source)| (pred == edge).then_some(source))?;
+                aliases[arm].insert(phi.dst, source);
+            }
+        }
+        Some(Plan {
+            parent: parent.id,
+            edges,
+            join,
+            bodies,
+            tail,
+            aliases,
+        })
+    })
+}
+
+pub(super) fn run(func: &mut MFunction) {
+    for _ in 0..256 {
+        let Some(plan) = find_plan(func) else { break };
+        let mut moved = Vec::new();
+        for block in &mut func.blocks {
+            if block.id == plan.parent {
+                let Some(MInst::Branch {
+                    true_bb, false_bb, ..
+                }) = block.insts.last_mut()
+                else {
+                    unreachable!()
+                };
+                *true_bb = plan.bodies[0];
+                *false_bb = plan.bodies[1];
+            }
+            if block.id == plan.join {
+                moved = std::mem::take(&mut block.phis);
+                for phi in &mut moved {
+                    for (pred, _) in &mut phi.sources {
+                        *pred = plan.bodies[usize::from(*pred == plan.edges[1])];
+                    }
+                }
+            }
+            if let Some(arm) = plan.bodies.iter().position(|&body| body == block.id) {
+                for inst in &mut block.insts {
+                    rewrite_uses(inst, &plan.aliases[arm]);
+                }
+                for phi in &mut block.phis {
+                    for (pred, source) in &mut phi.sources {
+                        *pred = plan.parent;
+                        if let Some(&replacement) = plan.aliases[arm].get(source) {
+                            *source = replacement;
+                        }
+                    }
+                }
+            }
+            if block.id == plan.tail {
+                for phi in &mut block.phis {
+                    for (pred, source) in &mut phi.sources {
+                        let arm = usize::from(*pred == plan.bodies[1]);
+                        if let Some(&replacement) = plan.aliases[arm].get(source) {
+                            *source = replacement;
+                        }
+                    }
+                }
+            }
+        }
+        func.blocks
+            .iter_mut()
+            .find(|block| block.id == plan.tail)
+            .unwrap()
+            .phis
+            .extend(moved);
+        func.blocks
+            .retain(|block| block.id != plan.join && !plan.edges.contains(&block.id));
+    }
+}

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/branch_merge/tests.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/branch_merge/tests.rs
@@ -1,0 +1,185 @@
+use super::*;
+use crate::native::{emit, jit_mem::JitCode, mir_legalize, regalloc};
+
+fn compile(mut function: MFunction) -> (JitCode, usize) {
+    mir_legalize::legalize(&mut function);
+    let allocation = regalloc::run_regalloc(&mut function).unwrap();
+    let emitted = emit::emit(
+        &function,
+        &allocation.assignment,
+        allocation.spill_frame_size,
+    )
+    .unwrap();
+    (
+        JitCode::new(&emitted.code).unwrap(),
+        emitted.required_state_size.max(768) as usize,
+    )
+}
+
+#[test]
+fn repeated_diamonds_preserve_loop_phis_arm_effects_and_edge_values() {
+    for variant in 0..5 {
+        let mut original = bitmap_worklist::tests::shared_condition_fixture(32);
+        if variant == 1 {
+            bitmap_worklist::run(&mut original);
+        }
+        if variant == 2 {
+            for (body, offset) in [(BlockId(8), 64), (BlockId(9), 72)] {
+                let block = original
+                    .blocks
+                    .iter_mut()
+                    .find(|block| block.id == body)
+                    .unwrap();
+                block.insts.insert(
+                    0,
+                    MInst::Store {
+                        base: BaseReg::SimState,
+                        offset,
+                        src: VReg(21),
+                        size: OpSize::S64,
+                    },
+                );
+            }
+        }
+        if variant == 3 {
+            let value = original.vregs.alloc();
+            original.spill_descs.push(SpillDesc::transient());
+            let block = original
+                .blocks
+                .iter_mut()
+                .find(|block| block.id == BlockId(8))
+                .unwrap();
+            block.phis.push(PhiNode {
+                dst: value,
+                sources: vec![(BlockId(7), VReg(21))],
+            });
+            block.insts.insert(
+                0,
+                MInst::Store {
+                    base: BaseReg::SimState,
+                    offset: 64,
+                    src: value,
+                    size: OpSize::S64,
+                },
+            );
+            let block = original
+                .blocks
+                .iter_mut()
+                .find(|block| block.id == BlockId(5))
+                .unwrap();
+            block.phis[0].sources[1].1 = VReg(21);
+        }
+        if variant == 4 {
+            let block = original
+                .blocks
+                .iter_mut()
+                .find(|block| block.id == BlockId(7))
+                .unwrap();
+            if let MInst::Branch {
+                true_bb, false_bb, ..
+            } = &mut block.insts[0]
+            {
+                std::mem::swap(true_bb, false_bb);
+            }
+        }
+        original.verify();
+        let mut optimized = original.clone();
+        run(&mut optimized);
+        optimized.verify();
+        assert_eq!(
+            optimized.blocks.len() + 3,
+            original.blocks.len(),
+            "variant={variant}"
+        );
+        let (before, before_size) = compile(original);
+        let (after, after_size) = compile(optimized);
+        for input in [
+            0u64,
+            1,
+            0x5555_5555_aaaa_aaaa,
+            0x0123_4567_89ab_cdef,
+            u64::MAX,
+        ]
+        .into_iter()
+        .chain((0..64).map(|bit| 1u64 << bit))
+        {
+            for guard in [0u64, 1, 2, 3, 1 << 32, u64::MAX] {
+                for origin in [0u64, 1, 15, 31, 32, 63, u64::MAX] {
+                    let mut left = vec![0u8; before_size.max(after_size)];
+                    for (offset, value) in [
+                        (0, input),
+                        (8, input.rotate_right(1) | 1),
+                        (16, input.rotate_left(3)),
+                        (24, guard),
+                        (32, origin),
+                    ] {
+                        left[offset..offset + 8].copy_from_slice(&value.to_le_bytes());
+                    }
+                    for index in 0..32usize {
+                        left[128 + index * 8..136 + index * 8]
+                            .copy_from_slice(&(index as u64 * 7 + 5).to_le_bytes());
+                    }
+                    let mut right = left.clone();
+                    assert_eq!(unsafe { before.call(&mut left) }, 0);
+                    assert_eq!(unsafe { after.call(&mut right) }, 0);
+                    assert_eq!(
+                        &left[..768],
+                        &right[..768],
+                        "variant={variant} input={input:#x} guard={guard:#x} origin={origin}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn repeated_diamonds_keep_distinct_conditions_and_observable_first_arms() {
+    for blocker in 0..4 {
+        let mut function = bitmap_worklist::tests::shared_condition_fixture(32);
+        let id = if blocker == 0 || blocker == 2 {
+            BlockId(7)
+        } else {
+            BlockId(3)
+        };
+        let block = function
+            .blocks
+            .iter_mut()
+            .find(|block| block.id == id)
+            .unwrap();
+        match blocker {
+            0 => {
+                if let MInst::Branch { cond, .. } = &mut block.insts[0] {
+                    *cond = VReg(5);
+                }
+            }
+            1 => block.insts.insert(
+                0,
+                MInst::MemFill {
+                    dst_offset: 64,
+                    byte_len: 1,
+                    value: 5,
+                },
+            ),
+            2 => block.insts.insert(
+                0,
+                MInst::Load {
+                    dst: VReg(26),
+                    base: BaseReg::SimState,
+                    offset: 64,
+                    size: OpSize::S64,
+                },
+            ),
+            3 => block.phis.push(PhiNode {
+                dst: VReg(26),
+                sources: vec![(BlockId(1), VReg(5))],
+            }),
+            _ => unreachable!(),
+        }
+        function.verify();
+        let before = format!("{function:?}");
+        run(&mut function);
+        function.verify();
+        assert_eq!(format!("{function:?}"), before, "blocker={blocker}");
+    }
+}

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/circular_scan.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/circular_scan.rs
@@ -1,0 +1,513 @@
+//! Replace a pure circular minimum-distance bitmap scan with a rotated BSF.
+
+use super::*;
+
+#[cfg(test)]
+pub(super) mod tests;
+
+enum Bitmap {
+    Word(VReg),
+    Broadcast(VReg),
+    Constant(bool),
+    And(Box<Self>, Box<Self>),
+    Or(Box<Self>, Box<Self>),
+    Xor(Box<Self>, Box<Self>),
+    Not(Box<Self>),
+}
+
+struct Scan {
+    entry: BlockId,
+    latch: BlockId,
+    exit: BlockId,
+    blocks: HashSet<BlockId>,
+    found: VReg,
+    distance: VReg,
+    origin: VReg,
+    width: u32,
+    bitmap: Bitmap,
+}
+
+struct Matcher<'a> {
+    func: &'a MFunction,
+    positions: HashMap<BlockId, usize>,
+    definitions: Vec<Option<&'a MInst>>,
+    definition_blocks: Vec<Option<BlockId>>,
+    zeros: Vec<u64>,
+}
+
+impl Matcher<'_> {
+    fn definition(&self, value: VReg) -> Option<&MInst> {
+        self.definitions[value.0 as usize]
+    }
+    fn constant(&self, value: VReg) -> Option<u64> {
+        match self.definition(value)? {
+            MInst::LoadImm { value, .. } => Some(*value),
+            _ => None,
+        }
+    }
+    fn block(&self, id: BlockId) -> &MBlock {
+        &self.func.blocks[self.positions[&id]]
+    }
+    fn branch(&self, id: BlockId) -> Option<(VReg, BlockId, BlockId)> {
+        match *self.block(id).terminator()? {
+            MInst::Branch {
+                cond,
+                true_bb,
+                false_bb,
+            } => Some((cond, true_bb, false_bb)),
+            _ => None,
+        }
+    }
+    fn invariant(&self, value: VReg, blocks: &HashSet<BlockId>) -> bool {
+        self.definition_blocks[value.0 as usize].is_some_and(|block| !blocks.contains(&block))
+    }
+    fn bitmap(
+        &self,
+        value: VReg,
+        index: VReg,
+        blocks: &HashSet<BlockId>,
+        budget: &mut usize,
+    ) -> Option<Bitmap> {
+        *budget = budget.checked_sub(1)?;
+        if self.invariant(value, blocks) {
+            return Some(
+                self.constant(value)
+                    .map_or(Bitmap::Broadcast(value), |constant| {
+                        Bitmap::Constant(constant & 1 != 0)
+                    }),
+            );
+        }
+        let recurse =
+            |value, budget: &mut usize| self.bitmap(value, index, blocks, budget).map(Box::new);
+        Some(match *self.definition(value)? {
+            MInst::Shr { lhs, rhs, .. } if rhs == index && self.invariant(lhs, blocks) => {
+                Bitmap::Word(lhs)
+            }
+            MInst::AndImm { src, imm, .. } => {
+                if imm & 1 == 0 {
+                    Bitmap::Constant(false)
+                } else {
+                    *recurse(src, budget)?
+                }
+            }
+            MInst::AndImm32 { src, imm, .. } => {
+                if imm & 1 == 0 {
+                    Bitmap::Constant(false)
+                } else {
+                    *recurse(src, budget)?
+                }
+            }
+            MInst::And { lhs, rhs, .. } | MInst::And32 { lhs, rhs, .. } => {
+                Bitmap::And(recurse(lhs, budget)?, recurse(rhs, budget)?)
+            }
+            MInst::Or { lhs, rhs, .. } | MInst::Or32 { lhs, rhs, .. } => {
+                Bitmap::Or(recurse(lhs, budget)?, recurse(rhs, budget)?)
+            }
+            MInst::Xor { lhs, rhs, .. } | MInst::Xor32 { lhs, rhs, .. } => {
+                Bitmap::Xor(recurse(lhs, budget)?, recurse(rhs, budget)?)
+            }
+            MInst::BitNot { src, .. } => Bitmap::Not(recurse(src, budget)?),
+            MInst::CmpImm {
+                lhs, imm: 0, kind, ..
+            } if self.zeros[lhs.0 as usize] & !1 == !1 => match kind {
+                CmpKind::Eq => Bitmap::Not(recurse(lhs, budget)?),
+                CmpKind::Ne => *recurse(lhs, budget)?,
+                _ => return None,
+            },
+            _ => return None,
+        })
+    }
+    fn incoming(&self, phi: &PhiNode, predecessor: BlockId) -> Option<VReg> {
+        (phi.sources.len() == 2).then_some(())?;
+        phi.sources
+            .iter()
+            .find_map(|&(pred, value)| (pred == predecessor).then_some(value))
+    }
+    fn header_phi(
+        &self,
+        header: &MBlock,
+        entry: BlockId,
+        latch: BlockId,
+        next: VReg,
+    ) -> Option<VReg> {
+        header.phis.iter().find_map(|phi| {
+            (self.incoming(phi, latch) == Some(next)
+                && self
+                    .incoming(phi, entry)
+                    .and_then(|value| self.constant(value))
+                    == Some(0))
+            .then_some(phi.dst)
+        })
+    }
+    fn match_scan(&self, region: &celox_analysis::cfg::NaturalLoop) -> Option<Scan> {
+        // Require a header, candidate comparison, update/skip edges and latch.
+        if region.blocks.len() != 5 {
+            return None;
+        }
+        let header = &self.func.blocks[region.header];
+        let blocks = region
+            .blocks
+            .iter()
+            .map(|&position| self.func.blocks[position].id)
+            .collect::<HashSet<_>>();
+        let exits = region
+            .blocks
+            .iter()
+            .flat_map(|&position| {
+                self.func.blocks[position]
+                    .successors()
+                    .into_iter()
+                    .filter(|target| !blocks.contains(target))
+                    .map(move |target| (self.func.blocks[position].id, target))
+            })
+            .collect::<Vec<_>>();
+        let &[(latch, exit)] = exits.as_slice() else {
+            return None;
+        };
+        let (condition, taken, untaken) = self.branch(latch)?;
+        let MInst::CmpImm {
+            lhs: next_index,
+            imm,
+            kind,
+            ..
+        } = *self.definition(condition)?
+        else {
+            return None;
+        };
+        if !(8..=32).contains(&imm)
+            || !(imm as u32).is_power_of_two()
+            || !matches!(
+                (kind, taken == header.id, untaken == header.id),
+                (CmpKind::Ne, true, false) | (CmpKind::Eq, false, true)
+            )
+        {
+            return None;
+        }
+        let width = imm as u32;
+        let index_phi = header
+            .phis
+            .iter()
+            .find(|phi| self.incoming(phi, latch) == Some(next_index))?;
+        let &(entry, initial_index) = index_phi
+            .sources
+            .iter()
+            .find(|(pred, _)| !blocks.contains(pred))?;
+        if self.constant(initial_index) != Some(0)
+            || !matches!(self.block(entry).terminator(), Some(MInst::Jump { target }) if *target == header.id)
+        {
+            return None;
+        }
+        let (index_mask, _) =
+            counted_loop::step(next_index, index_phi.dst, true, &self.definitions)?;
+        if u64::from(width) > index_mask {
+            return None;
+        }
+        let (predicate, choose, skip) = self.branch(header.id)?;
+        let (improves, update, alternate_skip) = self.branch(choose)?;
+        if alternate_skip != skip
+            || [choose, skip, update, latch]
+                .into_iter()
+                .collect::<HashSet<_>>()
+                .len()
+                != 4
+            || [choose, skip, update, latch]
+                .iter()
+                .any(|block| !blocks.contains(block))
+        {
+            return None;
+        }
+        for edge in [skip, update] {
+            let block = self.block(edge);
+            if !block.phis.is_empty()
+                || !matches!(block.insts.as_slice(), [MInst::Jump { target }] if *target == latch)
+            {
+                return None;
+            }
+        }
+        let latch_block = self.block(latch);
+        let found_phi = latch_block.phis.iter().find(|phi| {
+            self.incoming(phi, update)
+                .and_then(|value| self.constant(value))
+                == Some(1)
+                && self.incoming(phi, skip) == self.header_phi(header, entry, latch, phi.dst)
+        })?;
+        let found = self.incoming(found_phi, skip)?;
+        let (empty, better) = match *self.definition(improves)? {
+            MInst::Or { lhs, rhs, .. } | MInst::Or32 { lhs, rhs, .. } => (lhs, rhs),
+            _ => return None,
+        };
+        let (delta, old_distance) = [(empty, better), (better, empty)].into_iter().find_map(|(empty, better)| {
+            if !matches!(self.definition(empty), Some(MInst::CmpImm { lhs, imm: 0, kind: CmpKind::Eq, .. }) if *lhs == found) { return None; }
+            match self.definition(better)? { MInst::Cmp { lhs, rhs, kind: CmpKind::LtU, .. } => Some((*lhs, *rhs)), _ => None }
+        })?;
+        let distance_phi = latch_block.phis.iter().find(|phi| {
+            self.incoming(phi, update) == Some(delta)
+                && self.incoming(phi, skip) == Some(old_distance)
+                && self.header_phi(header, entry, latch, phi.dst) == Some(old_distance)
+        })?;
+        let difference = match *self.definition(delta)? {
+            MInst::AndImm { src, imm, .. } if imm == u64::from(width - 1) => src,
+            MInst::AndImm32 { src, imm, .. } if imm == width - 1 => src,
+            _ => return None,
+        };
+        let origin = match *self.definition(difference)? {
+            MInst::Sub { lhs, rhs, .. } | MInst::Sub32 { lhs, rhs, .. }
+                if lhs == index_phi.dst && self.invariant(rhs, &blocks) =>
+            {
+                rhs
+            }
+            _ => return None,
+        };
+        if self.zeros[predicate.0 as usize] & !1 != !1 {
+            return None;
+        }
+        let bitmap = self.bitmap(predicate, index_phi.dst, &blocks, &mut 128)?;
+        let outputs = [found_phi.dst, distance_phi.dst];
+        for block in &self.func.blocks {
+            if blocks.contains(&block.id) {
+                if block.insts.iter().any(|inst| {
+                    !matches!(inst, MInst::Branch { .. } | MInst::Jump { .. })
+                        && (!loop_guard::movable(inst)
+                            || memory_effect::reads(inst).has_effect()
+                            || memory_effect::writes(inst).has_effect())
+                }) {
+                    return None;
+                }
+            } else if block
+                .insts
+                .iter()
+                .flat_map(MInst::uses)
+                .chain(
+                    block
+                        .phis
+                        .iter()
+                        .flat_map(|phi| phi.sources.iter().map(|&(_, source)| source)),
+                )
+                .any(|value| {
+                    self.definition_blocks[value.0 as usize]
+                        .is_some_and(|block| blocks.contains(&block))
+                        && !outputs.contains(&value)
+                })
+            {
+                return None;
+            }
+        }
+        Some(Scan {
+            entry,
+            latch,
+            exit,
+            blocks,
+            found: found_phi.dst,
+            distance: distance_phi.dst,
+            origin,
+            width,
+            bitmap,
+        })
+    }
+}
+
+fn temporary(func: &mut MFunction) -> VReg {
+    let value = func.vregs.alloc();
+    func.spill_descs.push(SpillDesc::transient());
+    value
+}
+
+fn constant(func: &mut MFunction, instructions: &mut Vec<MInst>, value: u64) -> VReg {
+    let dst = temporary(func);
+    func.spill_descs[dst.0 as usize] = SpillDesc::remat(value);
+    instructions.push(MInst::LoadImm { dst, value });
+    dst
+}
+
+fn emit_bitmap(bitmap: &Bitmap, func: &mut MFunction, instructions: &mut Vec<MInst>) -> VReg {
+    if let Bitmap::Word(value) = *bitmap {
+        return value;
+    }
+    if let Bitmap::Constant(value) = *bitmap {
+        return constant(func, instructions, if value { u64::MAX } else { 0 });
+    }
+    let dst = temporary(func);
+    let instruction = match bitmap {
+        Bitmap::Word(_) | Bitmap::Constant(_) => unreachable!(),
+        Bitmap::Broadcast(value) => {
+            let bit = temporary(func);
+            instructions.push(MInst::AndImm32 {
+                dst: bit,
+                src: *value,
+                imm: 1,
+            });
+            MInst::Neg { dst, src: bit }
+        }
+        Bitmap::Not(value) => MInst::BitNot {
+            dst,
+            src: emit_bitmap(value, func, instructions),
+        },
+        Bitmap::And(lhs, rhs) | Bitmap::Or(lhs, rhs) | Bitmap::Xor(lhs, rhs) => {
+            let lhs = emit_bitmap(lhs, func, instructions);
+            let rhs = emit_bitmap(rhs, func, instructions);
+            match bitmap {
+                Bitmap::And(..) => MInst::And { dst, lhs, rhs },
+                Bitmap::Or(..) => MInst::Or { dst, lhs, rhs },
+                _ => MInst::Xor { dst, lhs, rhs },
+            }
+        }
+    };
+    instructions.push(instruction);
+    dst
+}
+
+pub(super) fn run(func: &mut MFunction) {
+    let positions = func
+        .blocks
+        .iter()
+        .enumerate()
+        .map(|(position, block)| (block.id, position))
+        .collect::<HashMap<_, _>>();
+    let successors = func
+        .blocks
+        .iter()
+        .map(|block| {
+            block
+                .successors()
+                .into_iter()
+                .map(|target| positions[&target])
+                .collect()
+        })
+        .collect();
+    let Ok(cfg) = celox_analysis::cfg::ForwardControlFlowGraph::analyze_structure(successors, 0)
+    else {
+        return;
+    };
+    let mut definitions = vec![None; func.vregs.count() as usize];
+    let mut definition_blocks = vec![None; definitions.len()];
+    for block in &func.blocks {
+        for phi in &block.phis {
+            definition_blocks[phi.dst.0 as usize] = Some(block.id);
+        }
+        for inst in &block.insts {
+            if let Some(dst) = inst.def() {
+                definitions[dst.0 as usize] = Some(inst);
+                definition_blocks[dst.0 as usize] = Some(block.id);
+            }
+        }
+    }
+    let matcher = Matcher {
+        func,
+        positions,
+        definitions,
+        definition_blocks,
+        zeros: known_bits::known_zeros(func),
+    };
+    let mut claimed = HashSet::default();
+    let plans = cfg
+        .loops
+        .iter()
+        .filter_map(|region| matcher.match_scan(region))
+        .filter(|plan| {
+            if plan.blocks.iter().any(|block| claimed.contains(block))
+                || claimed.contains(&plan.entry)
+            {
+                return false;
+            }
+            claimed.extend(plan.blocks.iter().copied());
+            true
+        })
+        .collect::<Vec<_>>();
+    for plan in plans {
+        let mut instructions = Vec::new();
+        let bitmap = emit_bitmap(&plan.bitmap, func, &mut instructions);
+        let bounded = temporary(func);
+        let mask = ((1u64 << plan.width) - 1) as u32;
+        instructions.push(MInst::AndImm32 {
+            dst: bounded,
+            src: bitmap,
+            imm: mask,
+        });
+        let origin = temporary(func);
+        instructions.push(MInst::AndImm32 {
+            dst: origin,
+            src: plan.origin,
+            imm: plan.width - 1,
+        });
+        let width = constant(func, &mut instructions, u64::from(plan.width));
+        let complement = temporary(func);
+        instructions.push(MInst::Sub {
+            dst: complement,
+            lhs: width,
+            rhs: origin,
+        });
+        let right = temporary(func);
+        instructions.push(MInst::Shr {
+            dst: right,
+            lhs: bounded,
+            rhs: origin,
+        });
+        let left = temporary(func);
+        instructions.push(MInst::Shl {
+            dst: left,
+            lhs: bounded,
+            rhs: complement,
+        });
+        let combined = temporary(func);
+        instructions.push(MInst::Or {
+            dst: combined,
+            lhs: right,
+            rhs: left,
+        });
+        let rotated = temporary(func);
+        instructions.push(MInst::AndImm32 {
+            dst: rotated,
+            src: combined,
+            imm: mask,
+        });
+        let sentinel = constant(func, &mut instructions, 1u64 << plan.width);
+        let nonzero = temporary(func);
+        instructions.push(MInst::Or {
+            dst: nonzero,
+            lhs: rotated,
+            rhs: sentinel,
+        });
+        let distance = temporary(func);
+        instructions.push(MInst::Bsf {
+            dst: distance,
+            src: nonzero,
+        });
+        instructions.push(MInst::CmpImm {
+            dst: plan.found,
+            lhs: rotated,
+            imm: 0,
+            kind: CmpKind::Ne,
+        });
+        let zero = constant(func, &mut instructions, 0);
+        instructions.push(MInst::Select {
+            dst: plan.distance,
+            cond: plan.found,
+            true_val: distance,
+            false_val: zero,
+        });
+        func.spill_descs[plan.found.0 as usize] = SpillDesc::transient();
+        func.spill_descs[plan.distance.0 as usize] = SpillDesc::transient();
+        let entry = func
+            .blocks
+            .iter_mut()
+            .find(|block| block.id == plan.entry)
+            .unwrap();
+        entry.insts.pop();
+        entry.insts.extend(instructions);
+        entry.push(MInst::Jump { target: plan.exit });
+        func.blocks.retain(|block| !plan.blocks.contains(&block.id));
+        for phi in &mut func
+            .blocks
+            .iter_mut()
+            .find(|block| block.id == plan.exit)
+            .unwrap()
+            .phis
+        {
+            for (predecessor, _) in &mut phi.sources {
+                if *predecessor == plan.latch {
+                    *predecessor = plan.entry;
+                }
+            }
+        }
+    }
+}

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/circular_scan/tests.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/circular_scan/tests.rs
@@ -1,0 +1,291 @@
+use super::*;
+use crate::native::{emit, jit_mem::JitCode, mir_legalize, regalloc};
+
+pub(crate) fn fixture(width: u32, blocker: u8) -> MFunction {
+    let mut vregs = VRegAllocator::new();
+    for _ in 0..30 {
+        vregs.alloc();
+    }
+    let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 30]);
+    let mut entry = MBlock::new(BlockId(0));
+    for (dst, value) in [(VReg(0), 0), (VReg(1), 1)] {
+        entry.push(MInst::LoadImm { dst, value });
+    }
+    for (dst, offset) in [
+        (VReg(2), 0),
+        (VReg(3), 8),
+        (VReg(4), 16),
+        (VReg(5), 24),
+        (VReg(6), 32),
+    ] {
+        entry.push(MInst::Load {
+            dst,
+            base: BaseReg::SimState,
+            offset,
+            size: OpSize::S64,
+        });
+    }
+    entry.push(MInst::Jump { target: BlockId(1) });
+    let mut header = MBlock::new(BlockId(1));
+    for (dst, next) in [
+        (VReg(7), VReg(22)),
+        (VReg(8), VReg(20)),
+        (VReg(9), VReg(21)),
+    ] {
+        header.phis.push(PhiNode {
+            dst,
+            sources: vec![(BlockId(0), VReg(0)), (BlockId(5), next)],
+        });
+    }
+    for (dst, lhs) in [
+        (VReg(10), VReg(2)),
+        (VReg(11), VReg(3)),
+        (VReg(12), VReg(4)),
+    ] {
+        header.push(MInst::Shr {
+            dst,
+            lhs,
+            rhs: VReg(7),
+        });
+    }
+    header.push(MInst::And32 {
+        dst: VReg(13),
+        lhs: VReg(10),
+        rhs: VReg(11),
+    });
+    header.push(MInst::Or32 {
+        dst: VReg(14),
+        lhs: VReg(12),
+        rhs: VReg(5),
+    });
+    header.push(MInst::And32 {
+        dst: VReg(15),
+        lhs: VReg(13),
+        rhs: VReg(14),
+    });
+    header.push(MInst::AndImm32 {
+        dst: VReg(16),
+        src: VReg(15),
+        imm: 1,
+    });
+    header.push(MInst::Branch {
+        cond: VReg(16),
+        true_bb: BlockId(2),
+        false_bb: BlockId(4),
+    });
+    let mut choose = MBlock::new(BlockId(2));
+    choose.push(MInst::Sub32 {
+        dst: VReg(17),
+        lhs: VReg(7),
+        rhs: VReg(6),
+    });
+    choose.push(MInst::AndImm32 {
+        dst: VReg(18),
+        src: VReg(17),
+        imm: if blocker == 2 { width - 2 } else { width - 1 },
+    });
+    choose.push(MInst::CmpImm {
+        dst: VReg(19),
+        lhs: VReg(8),
+        imm: 0,
+        kind: CmpKind::Eq,
+    });
+    choose.push(MInst::Cmp {
+        dst: VReg(24),
+        lhs: VReg(18),
+        rhs: VReg(9),
+        kind: CmpKind::LtU,
+    });
+    choose.push(MInst::Or32 {
+        dst: VReg(25),
+        lhs: VReg(19),
+        rhs: VReg(24),
+    });
+    choose.push(MInst::Branch {
+        cond: VReg(25),
+        true_bb: BlockId(3),
+        false_bb: BlockId(4),
+    });
+    let mut update = MBlock::new(BlockId(3));
+    if blocker == 1 {
+        update.push(MInst::MemFill {
+            dst_offset: 64,
+            byte_len: 1,
+            value: 0x55,
+        });
+    }
+    update.push(MInst::Jump { target: BlockId(5) });
+    let mut skip = MBlock::new(BlockId(4));
+    skip.push(MInst::Jump { target: BlockId(5) });
+    let mut latch = MBlock::new(BlockId(5));
+    latch.phis.push(PhiNode {
+        dst: VReg(20),
+        sources: vec![(BlockId(3), VReg(1)), (BlockId(4), VReg(8))],
+    });
+    latch.phis.push(PhiNode {
+        dst: VReg(21),
+        sources: vec![(BlockId(3), VReg(18)), (BlockId(4), VReg(9))],
+    });
+    latch.push(MInst::Add32 {
+        dst: VReg(22),
+        lhs: VReg(7),
+        rhs: VReg(1),
+    });
+    latch.push(MInst::CmpImm {
+        dst: VReg(23),
+        lhs: VReg(22),
+        imm: width as i32,
+        kind: CmpKind::Ne,
+    });
+    latch.push(MInst::Branch {
+        cond: VReg(23),
+        true_bb: BlockId(1),
+        false_bb: BlockId(6),
+    });
+    let mut exit = MBlock::new(BlockId(6));
+    for (offset, src) in [(40, VReg(20)), (48, VReg(21))] {
+        exit.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset,
+            src,
+            size: OpSize::S64,
+        });
+    }
+    if blocker == 3 {
+        exit.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 56,
+            src: VReg(22),
+            size: OpSize::S64,
+        });
+    }
+    exit.push(MInst::Return);
+    function.blocks = vec![entry, header, choose, update, skip, latch, exit];
+    function
+}
+
+fn compile(mut function: MFunction) -> (JitCode, usize) {
+    mir_legalize::legalize(&mut function);
+    let allocation = regalloc::run_regalloc(&mut function).unwrap();
+    let emitted = emit::emit(
+        &function,
+        &allocation.assignment,
+        allocation.spill_frame_size,
+    )
+    .unwrap();
+    (
+        JitCode::new(&emitted.code).unwrap(),
+        emitted.required_state_size.max(72) as usize,
+    )
+}
+
+#[test]
+fn circular_bitmap_scans_preserve_empty_sets_wrapping_origins_and_distances() {
+    for (width, variant) in [8u32, 16, 32]
+        .into_iter()
+        .flat_map(|width| (0..4).map(move |variant| (width, variant)))
+    {
+        let mut original = fixture(width, 0);
+        for inst in &mut original.blocks[1].insts {
+            if variant == 1 && inst.def() == Some(VReg(13)) {
+                *inst = MInst::Xor32 {
+                    dst: VReg(13),
+                    lhs: VReg(10),
+                    rhs: VReg(11),
+                };
+            }
+            if variant == 2 && inst.def() == Some(VReg(14)) {
+                *inst = MInst::BitNot {
+                    dst: VReg(14),
+                    src: VReg(12),
+                };
+            }
+        }
+        if variant == 3 {
+            original.blocks[6].phis.push(PhiNode {
+                dst: VReg(26),
+                sources: vec![(BlockId(5), VReg(20))],
+            });
+            original.blocks[6].phis.push(PhiNode {
+                dst: VReg(27),
+                sources: vec![(BlockId(5), VReg(21))],
+            });
+            for inst in &mut original.blocks[6].insts {
+                inst.rewrite_use(VReg(20), VReg(26));
+                inst.rewrite_use(VReg(21), VReg(27));
+            }
+        }
+        original.verify();
+        let mut optimized = original.clone();
+        run(&mut optimized);
+        optimized.verify();
+        assert_eq!(optimized.blocks.len(), 2);
+        let (before, before_size) = compile(original);
+        let (after, after_size) = compile(optimized);
+        let inputs = [
+            0u64,
+            1,
+            0xaaaa_aaaa_5555_5555,
+            0x0123_4567_89ab_cdef,
+            u64::MAX,
+        ];
+        for input in inputs.into_iter().chain((0..64).map(|bit| 1u64 << bit)) {
+            for guard in [0u64, 1, 2, 3, 1 << 32, u64::MAX] {
+                for origin in (0..=width as u64).chain([63, 64, 255, u64::MAX]) {
+                    let a = input;
+                    let b = if guard & 2 == 0 {
+                        u64::MAX
+                    } else {
+                        input.rotate_left(1)
+                    };
+                    let c = input.rotate_left(3);
+                    let mut expected = None;
+                    for index in 0..width {
+                        let core = if variant == 1 {
+                            (a >> index) ^ (b >> index)
+                        } else {
+                            (a >> index) & (b >> index)
+                        };
+                        let gate = if variant == 2 {
+                            !(c >> index)
+                        } else {
+                            (c >> index) | guard
+                        };
+                        if (core & gate) & 1 != 0 {
+                            let distance =
+                                (u64::from(index).wrapping_sub(origin)) & u64::from(width - 1);
+                            expected =
+                                Some(expected.map_or(distance, |old: u64| old.min(distance)));
+                        }
+                    }
+                    let mut left = vec![0u8; before_size.max(after_size)];
+                    for (offset, value) in [(0, a), (8, b), (16, c), (24, guard), (32, origin)] {
+                        left[offset..offset + 8].copy_from_slice(&value.to_le_bytes());
+                    }
+                    let mut right = left.clone();
+                    assert_eq!(unsafe { before.call(&mut left) }, 0);
+                    assert_eq!(unsafe { after.call(&mut right) }, 0);
+                    assert_eq!(
+                        &left[..72],
+                        &right[..72],
+                        "width={width} input={input:#x} guard={guard:#x} origin={origin}"
+                    );
+                    assert_eq!(&right[40..48], &u64::from(expected.is_some()).to_le_bytes());
+                    assert_eq!(&right[48..56], &expected.unwrap_or(0).to_le_bytes());
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn circular_bitmap_scans_keep_side_effects_non_circular_masks_and_other_outputs() {
+    for blocker in 1..=3 {
+        let mut function = fixture(32, blocker);
+        let before = format!("{function:?}");
+        function.verify();
+        run(&mut function);
+        function.verify();
+        assert_eq!(format!("{function:?}"), before);
+    }
+}

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/counted_loop.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/counted_loop.rs
@@ -1,0 +1,709 @@
+//! Reuse a loop's increasing index for a redundant decreasing trip counter.
+
+use super::*;
+
+pub(super) fn step(
+    value: VReg,
+    source: VReg,
+    increasing: bool,
+    definitions: &[Option<&MInst>],
+) -> Option<(u64, Vec<VReg>)> {
+    let mut value = value;
+    let mut mask = u64::MAX;
+    let mut chain = Vec::new();
+    for _ in 0..8 {
+        chain.push(value);
+        let inst = *definitions.get(value.0 as usize)?.as_ref()?;
+        let constant_one = |value: VReg| {
+            matches!(
+                definitions[value.0 as usize],
+                Some(MInst::LoadImm { value: 1, .. })
+            )
+        };
+        match *inst {
+            MInst::Mov { src, .. } => value = src,
+            MInst::Mov32 { src, .. } => {
+                mask &= u32::MAX as u64;
+                value = src;
+            }
+            MInst::AndImm { src, imm, .. } => {
+                mask &= imm;
+                value = src;
+            }
+            MInst::AndImm32 { src, imm, .. } => {
+                mask &= u64::from(imm);
+                value = src;
+            }
+            MInst::AddImm { src, imm: 1, .. } if increasing && src == source => break,
+            MInst::SubImm { src, imm: 1, .. } if !increasing && src == source => break,
+            MInst::Add { lhs, rhs, .. } | MInst::Add32 { lhs, rhs, .. }
+                if increasing
+                    && (lhs == source && constant_one(rhs)
+                        || rhs == source && constant_one(lhs)) =>
+            {
+                if matches!(inst, MInst::Add32 { .. }) {
+                    mask &= u32::MAX as u64;
+                }
+                break;
+            }
+            MInst::Sub { lhs, rhs, .. } | MInst::Sub32 { lhs, rhs, .. }
+                if !increasing && lhs == source && constant_one(rhs) =>
+            {
+                if matches!(inst, MInst::Sub32 { .. }) {
+                    mask &= u32::MAX as u64;
+                }
+                break;
+            }
+            _ => return None,
+        }
+    }
+    // A truncation must preserve a contiguous low part. Confirm that the walk
+    // ended on the arithmetic operation, rather than exhausting its budget.
+    if value != *chain.last()? || mask == 0 || mask & mask.wrapping_add(1) != 0 {
+        return None;
+    }
+    Some((mask, chain))
+}
+
+/// A zero-based, unit-step phi cannot reach its limit on a backedge guarded by
+/// `next != limit`. Seed that inductive invariant before the bit-fact solve.
+pub(super) fn index_zeros(func: &MFunction) -> Vec<(VReg, u64)> {
+    let mut definitions = vec![None; func.vregs.count() as usize];
+    let positions = func
+        .blocks
+        .iter()
+        .enumerate()
+        .map(|(index, block)| (block.id, index))
+        .collect::<HashMap<_, _>>();
+    for block in &func.blocks {
+        for inst in &block.insts {
+            if let Some(dst) = inst.def() {
+                definitions[dst.0 as usize] = Some(inst);
+            }
+        }
+    }
+    let mut facts = Vec::new();
+    for header in &func.blocks {
+        for phi in &header.phis {
+            if phi.sources.len() != 2 {
+                continue;
+            }
+            let Some(&(entry, _)) = phi.sources.iter().find(|(_, source)| {
+                matches!(
+                    definitions[source.0 as usize],
+                    Some(MInst::LoadImm { value: 0, .. })
+                )
+            }) else {
+                continue;
+            };
+            let Some(&(latch, next)) = phi.sources.iter().find(|(pred, _)| *pred != entry) else {
+                continue;
+            };
+            let Some((mask, _)) = step(next, phi.dst, true, &definitions) else {
+                continue;
+            };
+            let Some(&MInst::Branch {
+                cond,
+                true_bb,
+                false_bb,
+            }) = func.blocks[positions[&latch]].terminator()
+            else {
+                continue;
+            };
+            let Some(MInst::CmpImm { lhs, imm, kind, .. }) = definitions[cond.0 as usize] else {
+                continue;
+            };
+            if *lhs != next
+                || *imm <= 0
+                || *imm as u64 > mask
+                || !matches!(
+                    (*kind, true_bb == header.id, false_bb == header.id),
+                    (CmpKind::Ne, true, false) | (CmpKind::Eq, false, true)
+                )
+            {
+                continue;
+            }
+            let maximum = (*imm - 1) as u64;
+            facts.push((
+                phi.dst,
+                u64::MAX
+                    .checked_shl(64 - maximum.leading_zeros())
+                    .unwrap_or(0),
+            ));
+        }
+    }
+    facts
+}
+
+/// A load at a loop header is executed on entry. Move it to a unique jumping
+/// predecessor when no loop write can change any of its physical bytes.
+pub(super) fn hoist_invariant_loads(func: &mut MFunction) {
+    let positions = func
+        .blocks
+        .iter()
+        .enumerate()
+        .map(|(index, block)| (block.id, index))
+        .collect::<HashMap<_, _>>();
+    let successors = func
+        .blocks
+        .iter()
+        .map(|block| {
+            block
+                .successors()
+                .into_iter()
+                .map(|target| positions[&target])
+                .collect()
+        })
+        .collect();
+    let Ok(cfg) = celox_analysis::cfg::ForwardControlFlowGraph::analyze_structure(successors, 0)
+    else {
+        return;
+    };
+    for region in &cfg.loops {
+        let mut entries = cfg.predecessors[region.header]
+            .iter()
+            .copied()
+            .filter(|pred| !region.blocks.contains(pred));
+        let Some(entry) = entries.next() else {
+            continue;
+        };
+        if entries.next().is_some()
+            || !matches!(func.blocks[entry].terminator(), Some(MInst::Jump { target }) if *target == func.blocks[region.header].id)
+        {
+            continue;
+        }
+        let writes = region
+            .blocks
+            .iter()
+            .flat_map(|&block| func.blocks[block].insts.iter().map(memory_effect::writes))
+            .filter(|effect| effect.has_effect())
+            .collect::<Vec<_>>();
+        let mut moved = Vec::new();
+        func.blocks[region.header].insts.retain(|inst| {
+            let MInst::Load {
+                base, offset, size, ..
+            } = *inst
+            else {
+                return true;
+            };
+            // State memory is valid for the whole native invocation. Stack
+            // lifetime and runtime-owned pointer accesses stay at their sites.
+            if base != BaseReg::SimState {
+                return true;
+            }
+            let start = i64::from(offset);
+            let end = start + i64::from(size.bytes());
+            if writes.iter().any(|effect| {
+                effect.unknown_memory() == Some(memory_effect::UnknownMemory::Direct(base))
+                    || effect.ranges().any(|range| {
+                        range.base == base
+                            && range.offset < end
+                            && range.end().is_none_or(|limit| start < limit)
+                    })
+            }) {
+                return true;
+            }
+            moved.push(inst.clone());
+            false
+        });
+        let at = func.blocks[entry].insts.len() - 1;
+        func.blocks[entry].insts.splice(at..at, moved);
+    }
+}
+
+pub(super) fn run(func: &mut MFunction) {
+    let positions = func
+        .blocks
+        .iter()
+        .enumerate()
+        .map(|(index, block)| (block.id, index))
+        .collect::<HashMap<_, _>>();
+    let successors = func
+        .blocks
+        .iter()
+        .map(|block| {
+            block
+                .successors()
+                .into_iter()
+                .map(|target| positions[&target])
+                .collect()
+        })
+        .collect();
+    let Ok(cfg) = celox_analysis::cfg::ForwardControlFlowGraph::analyze_structure(successors, 0)
+    else {
+        return;
+    };
+    let mut definitions = vec![None; func.vregs.count() as usize];
+    let mut uses = vec![0usize; definitions.len()];
+    for block in &func.blocks {
+        for phi in &block.phis {
+            for &(_, source) in &phi.sources {
+                uses[source.0 as usize] += 1;
+            }
+        }
+        for inst in &block.insts {
+            for source in inst.uses() {
+                uses[source.0 as usize] += 1;
+            }
+            if let Some(dst) = inst.def() {
+                definitions[dst.0 as usize] = Some(inst);
+            }
+        }
+    }
+    let constant = |value: VReg| match definitions[value.0 as usize] {
+        Some(MInst::LoadImm { value, .. }) => Some(*value),
+        _ => None,
+    };
+    let mut plans = Vec::new();
+    for region in &cfg.loops {
+        let header = &func.blocks[region.header];
+        for counter in &header.phis {
+            if counter.sources.len() != 2 {
+                continue;
+            }
+            let Some(&(latch, next)) = counter
+                .sources
+                .iter()
+                .find(|(pred, _)| region.blocks.contains(&positions[pred]))
+            else {
+                continue;
+            };
+            let Some(&(entry, initial)) = counter
+                .sources
+                .iter()
+                .find(|(pred, _)| !region.blocks.contains(&positions[pred]))
+            else {
+                continue;
+            };
+            let Some(trips) =
+                constant(initial).filter(|trips| (1..=i32::MAX as u64).contains(trips))
+            else {
+                continue;
+            };
+            let Some((counter_mask, mut chain)) = step(next, counter.dst, false, &definitions)
+            else {
+                continue;
+            };
+            if trips > counter_mask {
+                continue;
+            }
+            let latch_index = positions[&latch];
+            let Some(&MInst::Branch {
+                cond,
+                true_bb,
+                false_bb,
+            }) = func.blocks[latch_index].terminator()
+            else {
+                continue;
+            };
+            if true_bb == false_bb || uses[cond.0 as usize] != 1 {
+                continue;
+            }
+            let kind = match definitions[cond.0 as usize] {
+                Some(MInst::CmpImm {
+                    lhs, imm: 0, kind, ..
+                }) if *lhs == next => *kind,
+                Some(MInst::Cmp { lhs, rhs, kind, .. })
+                    if *lhs == next && constant(*rhs) == Some(0)
+                        || *rhs == next && constant(*lhs) == Some(0) =>
+                {
+                    *kind
+                }
+                _ => continue,
+            };
+            if !matches!(
+                (kind, true_bb == header.id, false_bb == header.id),
+                (CmpKind::Ne, true, false) | (CmpKind::Eq, false, true)
+            ) {
+                continue;
+            }
+            for index in &header.phis {
+                if index.sources.len() != 2
+                    || !index
+                        .sources
+                        .iter()
+                        .any(|&(pred, source)| pred == entry && constant(source) == Some(0))
+                {
+                    continue;
+                }
+                let Some(&(_, next_index)) = index.sources.iter().find(|&&(pred, _)| pred == latch)
+                else {
+                    continue;
+                };
+                let Some((index_mask, _)) = step(next_index, index.dst, true, &definitions) else {
+                    continue;
+                };
+                if trips > index_mask {
+                    continue;
+                }
+                chain.push(counter.dst);
+                plans.push((latch_index, cond, next_index, trips as i32, kind, chain));
+                break;
+            }
+        }
+    }
+    for (latch, condition, next_index, trips, kind, chain) in plans {
+        for block in &mut func.blocks {
+            block.insts.retain(|inst| inst.def() != Some(condition));
+        }
+        let before_branch = func.blocks[latch].insts.len() - 1;
+        func.blocks[latch].insts.insert(
+            before_branch,
+            MInst::CmpImm {
+                dst: condition,
+                lhs: next_index,
+                imm: trips,
+                kind,
+            },
+        );
+        // The old induction variable is a dead SSA cycle. Ordinary local DCE
+        // cannot collect it, so remove it only if its entire use set is private.
+        let private = func.blocks.iter().all(|block| {
+            block.phis.iter().all(|phi| {
+                chain.contains(&phi.dst)
+                    || phi
+                        .sources
+                        .iter()
+                        .all(|(_, source)| !chain.contains(source))
+            }) && block.insts.iter().all(|inst| {
+                inst.def().is_some_and(|dst| chain.contains(&dst))
+                    || inst
+                        .uses()
+                        .into_iter()
+                        .all(|source| !chain.contains(&source))
+            })
+        });
+        if private {
+            for block in &mut func.blocks {
+                block.phis.retain(|phi| !chain.contains(&phi.dst));
+                block
+                    .insts
+                    .retain(|inst| inst.def().is_none_or(|dst| !chain.contains(&dst)));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::{emit, jit_mem::JitCode, mir_legalize, regalloc};
+
+    fn fixture(
+        trips: u64,
+        mask: u64,
+        index_mask: u64,
+        reversed: bool,
+        observed: bool,
+    ) -> MFunction {
+        let mut vregs = VRegAllocator::new();
+        for _ in 0..14 {
+            vregs.alloc();
+        }
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 14]);
+        let mut entry = MBlock::new(BlockId(0));
+        for (dst, value) in [(VReg(0), 0), (VReg(1), trips), (VReg(2), 1)] {
+            entry.push(MInst::LoadImm { dst, value });
+        }
+        entry.push(MInst::Jump { target: BlockId(1) });
+        let mut header = MBlock::new(BlockId(1));
+        for (dst, first, next) in [
+            (VReg(3), VReg(1), VReg(7)),
+            (VReg(4), VReg(0), VReg(9)),
+            (VReg(5), VReg(0), VReg(10)),
+        ] {
+            header.phis.push(PhiNode {
+                dst,
+                sources: vec![(BlockId(0), first), (BlockId(2), next)],
+            });
+        }
+        header.push(MInst::Add {
+            dst: VReg(10),
+            lhs: VReg(5),
+            rhs: VReg(4),
+        });
+        if observed {
+            header.push(MInst::Store {
+                base: BaseReg::SimState,
+                offset: 16,
+                src: VReg(3),
+                size: OpSize::S64,
+            });
+        }
+        header.push(MInst::Jump { target: BlockId(2) });
+        let mut latch = MBlock::new(BlockId(2));
+        latch.push(MInst::Sub32 {
+            dst: VReg(6),
+            lhs: VReg(3),
+            rhs: VReg(2),
+        });
+        latch.push(MInst::AndImm {
+            dst: VReg(7),
+            src: VReg(6),
+            imm: mask,
+        });
+        latch.push(MInst::Add32 {
+            dst: VReg(8),
+            lhs: VReg(4),
+            rhs: VReg(2),
+        });
+        latch.push(MInst::AndImm {
+            dst: VReg(9),
+            src: VReg(8),
+            imm: index_mask,
+        });
+        latch.push(MInst::CmpImm {
+            dst: VReg(11),
+            lhs: VReg(7),
+            imm: 0,
+            kind: if reversed { CmpKind::Eq } else { CmpKind::Ne },
+        });
+        latch.push(MInst::Branch {
+            cond: VReg(11),
+            true_bb: BlockId(if reversed { 3 } else { 1 }),
+            false_bb: BlockId(if reversed { 1 } else { 3 }),
+        });
+        let mut exit = MBlock::new(BlockId(3));
+        for (offset, src) in [(0, VReg(10)), (8, VReg(9))] {
+            exit.push(MInst::Store {
+                base: BaseReg::SimState,
+                offset,
+                src,
+                size: OpSize::S64,
+            });
+        }
+        exit.push(MInst::Return);
+        function.blocks = vec![entry, header, latch, exit];
+        function
+    }
+
+    #[test]
+    fn reuses_index_without_changing_trip_counts_or_observed_counters() {
+        for trips in [1u64, 2, 7, 8, 31, 32, 63] {
+            for reversed in [false, true] {
+                for observed in [false, true] {
+                    let mut function = fixture(trips, 63, u32::MAX as u64, reversed, observed);
+                    run(&mut function);
+                    function.verify();
+                    assert_eq!(
+                        function.blocks[1].phis.iter().any(|phi| phi.dst == VReg(3)),
+                        observed
+                    );
+                    assert!(function.blocks[2].insts.iter().any(|inst| matches!(inst, MInst::CmpImm { lhs: VReg(9), imm, .. } if *imm == trips as i32)));
+                    mir_legalize::legalize(&mut function);
+                    let allocation = regalloc::run_regalloc(&mut function).unwrap();
+                    let emitted = emit::emit(
+                        &function,
+                        &allocation.assignment,
+                        allocation.spill_frame_size,
+                    )
+                    .unwrap();
+                    let jit = JitCode::new(&emitted.code).unwrap();
+                    let mut state = vec![0u8; emitted.required_state_size.max(24) as usize];
+                    assert_eq!(unsafe { jit.call(&mut state) }, 0);
+                    assert_eq!(&state[..8], &(trips * (trips - 1) / 2).to_le_bytes());
+                    assert_eq!(&state[8..16], &trips.to_le_bytes());
+                    assert_eq!(&state[16..24], &u64::from(observed).to_le_bytes());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_wrapping_and_noncontiguous_counters() {
+        for (trips, mask, index_mask) in [
+            (0, 63, 63),
+            (64, 63, 255),
+            (32, 63, 31),
+            (8, 61, 63),
+            (8, 63, 61),
+        ] {
+            let mut function = fixture(trips, mask, index_mask, false, false);
+            let before = format!("{function:?}");
+            run(&mut function);
+            function.verify();
+            assert_eq!(format!("{function:?}"), before);
+        }
+    }
+
+    #[test]
+    fn places_the_exit_test_after_the_index_update_and_keeps_shared_tests() {
+        let mut function = fixture(32, 63, 255, false, false);
+        let condition = function.blocks[2].insts.remove(4);
+        function.blocks[2].insts.insert(2, condition);
+        function.verify();
+        let mut shared = function.clone();
+        shared.blocks[3].insts.insert(
+            0,
+            MInst::Store {
+                base: BaseReg::SimState,
+                offset: 24,
+                src: VReg(11),
+                size: OpSize::S64,
+            },
+        );
+        let unchanged = format!("{shared:?}");
+        run(&mut shared);
+        shared.verify();
+        assert_eq!(format!("{shared:?}"), unchanged);
+        run(&mut function);
+        function.verify();
+        assert!(matches!(
+            function.blocks[2].insts[function.blocks[2].insts.len() - 2],
+            MInst::CmpImm {
+                lhs: VReg(9),
+                imm: 32,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn packed_loop_loads_respect_bounds_consumers_and_loop_writes() {
+        for trips in [9u64, 16, 17, 32, 33, 64] {
+            for effect in 0..8 {
+                let mut function = fixture(trips, 127, 255, false, false);
+                let mut allocate = || {
+                    let value = function.vregs.alloc();
+                    function.spill_descs.push(SpillDesc::transient());
+                    value
+                };
+                let byte = allocate();
+                let bit = allocate();
+                let raw = allocate();
+                let shifted = allocate();
+                let selected = allocate();
+                let size = if trips <= 16 {
+                    2
+                } else if trips <= 32 {
+                    4
+                } else {
+                    8
+                };
+                let envelope_size = if effect == 7 {
+                    trips.div_ceil(8) as usize
+                } else {
+                    size
+                };
+                let header = &mut function.blocks[1];
+                header.insts[0] = MInst::Add {
+                    dst: VReg(10),
+                    lhs: VReg(5),
+                    rhs: selected,
+                };
+                header.insts.splice(
+                    0..0,
+                    [
+                        MInst::ShrImm {
+                            dst: byte,
+                            src: VReg(4),
+                            imm: 3,
+                        },
+                        MInst::AndImm32 {
+                            dst: bit,
+                            src: VReg(4),
+                            imm: 7,
+                        },
+                        MInst::LoadIndexed {
+                            dst: raw,
+                            base: BaseReg::SimState,
+                            offset: 64,
+                            index: byte,
+                            scale: 1,
+                            size: OpSize::S8,
+                            alias_range: MemoryAliasRange::new(64, envelope_size),
+                        },
+                        MInst::Shr {
+                            dst: shifted,
+                            lhs: raw,
+                            rhs: bit,
+                        },
+                        MInst::AndImm32 {
+                            dst: selected,
+                            src: shifted,
+                            imm: if effect == 6 { 255 } else { 1 },
+                        },
+                    ],
+                );
+                if effect == 5 {
+                    let at = header.insts.len() - 1;
+                    header.insts.insert(
+                        at,
+                        MInst::Store {
+                            base: BaseReg::SimState,
+                            offset: 24,
+                            src: raw,
+                            size: OpSize::S64,
+                        },
+                    );
+                }
+                let write = match effect {
+                    1 | 2 => Some(MInst::MemFill {
+                        dst_offset: if effect == 1 { 64 } else { 96 },
+                        byte_len: 1,
+                        value: 0,
+                    }),
+                    3 | 4 => Some(MInst::StoreIndexed {
+                        base: BaseReg::SimState,
+                        offset: if effect == 3 { 64 } else { 96 },
+                        index: VReg(0),
+                        src: VReg(0),
+                        size: OpSize::S8,
+                        alias_range: if effect == 3 {
+                            None
+                        } else {
+                            MemoryAliasRange::new(96, 1)
+                        },
+                    }),
+                    _ => None,
+                };
+                if let Some(write) = write {
+                    function.blocks[2].insts.insert(0, write);
+                }
+                run(&mut function);
+                known_bits::fold_packed_bit_loads(&mut function);
+                hoist_invariant_loads(&mut function);
+                function.verify();
+                let widened = !matches!(effect, 5 | 6) && envelope_size == size;
+                let hoisted = widened && !matches!(effect, 1 | 3);
+                assert_eq!(
+                    function.blocks[0]
+                        .insts
+                        .iter()
+                        .any(|inst| matches!(inst, MInst::Load { offset: 64, .. })),
+                    hoisted,
+                    "trips={trips} effect={effect}"
+                );
+                mir_legalize::legalize(&mut function);
+                let allocation = regalloc::run_regalloc(&mut function).unwrap();
+                let emitted = emit::emit(
+                    &function,
+                    &allocation.assignment,
+                    allocation.spill_frame_size,
+                )
+                .unwrap();
+                let jit = JitCode::new(&emitted.code).unwrap();
+                for input in [0u64, 1, 0x0123_4567_89ab_cdef, 1 << 63, u64::MAX] {
+                    let mut state = vec![0u8; emitted.required_state_size.max(104) as usize];
+                    state[64..72].copy_from_slice(&input.to_le_bytes());
+                    let mut bytes = input.to_le_bytes();
+                    let mut sum = 0u64;
+                    for index in 0..trips as usize {
+                        sum += u64::from(bytes[index / 8] >> (index % 8))
+                            & if effect == 6 { 255 } else { 1 };
+                        if matches!(effect, 1 | 3) {
+                            bytes[0] = 0;
+                        }
+                    }
+                    assert_eq!(unsafe { jit.call(&mut state) }, 0);
+                    assert_eq!(
+                        &state[..8],
+                        &sum.to_le_bytes(),
+                        "trips={trips} effect={effect} input={input:#x}"
+                    );
+                    assert_eq!(&state[64..72], &bytes);
+                }
+            }
+        }
+    }
+}

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/exclusive_loop.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/exclusive_loop.rs
@@ -1,0 +1,356 @@
+//! Dispatch mutually exclusive loop predicates before computing their operands.
+//!
+//! `(key == A && p) || (key == B && q)` needs only the predicate selected by
+//! `key`. A result phi preserves every use of the original condition.
+
+use super::*;
+
+#[cfg(test)]
+mod tests;
+
+struct Case {
+    comparison: MInst,
+    predicate: VReg,
+    instructions: Vec<usize>,
+}
+
+struct Plan {
+    guard: Option<VReg>,
+    cases: Vec<Case>,
+    removed: HashSet<usize>,
+}
+
+fn and_operands(inst: &MInst) -> Option<(VReg, VReg)> {
+    match *inst {
+        MInst::And { lhs, rhs, .. } | MInst::And32 { lhs, rhs, .. } => Some((lhs, rhs)),
+        _ => None,
+    }
+}
+
+fn or_operands(inst: &MInst) -> Option<(VReg, VReg)> {
+    match *inst {
+        MInst::Or { lhs, rhs, .. } | MInst::Or32 { lhs, rhs, .. } => Some((lhs, rhs)),
+        _ => None,
+    }
+}
+
+fn plan(block: &MBlock, cond: VReg, uses: &[usize]) -> Option<Plan> {
+    // The result moves to the join. A use earlier in this block would then
+    // precede its definition, even if that use has no memory side effects.
+    if block.insts[..block.insts.len() - 1]
+        .iter()
+        .any(|inst| inst.uses().contains(&cond))
+    {
+        return None;
+    }
+    let definitions = block
+        .insts
+        .iter()
+        .enumerate()
+        .filter_map(|(position, inst)| inst.def().map(|dst| (dst, position)))
+        .collect::<HashMap<_, _>>();
+    let definition = |value: VReg| {
+        definitions
+            .get(&value)
+            .map(|&position| &block.insts[position])
+    };
+    let root = definition(cond)?;
+    let (guard, disjunction) = if or_operands(root).is_some() {
+        (None, cond)
+    } else {
+        let (lhs, rhs) = and_operands(root)?;
+        [(lhs, rhs), (rhs, lhs)]
+            .into_iter()
+            .find_map(|(guard, disjunction)| {
+                or_operands(definition(disjunction)?)
+                    .is_some()
+                    .then_some((Some(guard), disjunction))
+            })?
+    };
+    let mut removed = HashSet::default();
+    removed.insert(definitions[&cond]);
+    let mut pending = vec![disjunction];
+    let mut terms = Vec::new();
+    while let Some(value) = pending.pop() {
+        if value != cond && uses[value.0 as usize] != 1 {
+            return None;
+        }
+        let position = *definitions.get(&value)?;
+        if let Some((lhs, rhs)) = or_operands(&block.insts[position]) {
+            removed.insert(position);
+            pending.extend([rhs, lhs]);
+        } else {
+            let (lhs, rhs) = and_operands(&block.insts[position])?;
+            removed.insert(position);
+            terms.push((lhs, rhs));
+        }
+        if pending.len() + terms.len() > 8 {
+            return None;
+        }
+    }
+    if terms.len() < 2 {
+        return None;
+    }
+    let equality = |value: VReg| {
+        if uses[value.0 as usize] != 1 {
+            return None;
+        }
+        match *definition(value)? {
+            MInst::CmpImm {
+                lhs,
+                imm,
+                kind: CmpKind::Eq,
+                ..
+            } => Some((lhs, imm)),
+            _ => None,
+        }
+    };
+    // An AND can have an equality on both sides. Try either selector from the
+    // first term, then require that selector and distinct constants throughout.
+    for first_guard in [terms[0].0, terms[0].1] {
+        let Some((selector, _)) = equality(first_guard) else {
+            continue;
+        };
+        let mut values = HashSet::default();
+        let mut cases = Vec::new();
+        let mut selected = removed.clone();
+        let mut cost = 0usize;
+        for &(lhs, rhs) in &terms {
+            let pair = [(lhs, rhs), (rhs, lhs)]
+                .into_iter()
+                .find_map(|(comparison, predicate)| {
+                    let (key, value) = equality(comparison)?;
+                    (key == selector).then_some((comparison, predicate, value))
+                });
+            let Some((comparison, predicate, value)) = pair else {
+                break;
+            };
+            if !values.insert(value) {
+                break;
+            }
+            let instructions = loop_guard::private_operand(block, predicate, uses);
+            let Some(&predicate_position) = definitions.get(&predicate) else {
+                break;
+            };
+            if !instructions.contains(&predicate_position) {
+                break;
+            }
+            cost += instructions
+                .iter()
+                .filter(|&&position| {
+                    !matches!(
+                        block.insts[position],
+                        MInst::LoadImm { .. } | MInst::Mov { .. } | MInst::Mov32 { .. }
+                    )
+                })
+                .count();
+            if instructions
+                .iter()
+                .any(|position| selected.contains(position))
+            {
+                break;
+            }
+            selected.extend(instructions.iter().copied());
+            selected.insert(definitions[&comparison]);
+            cases.push(Case {
+                comparison: definition(comparison)?.clone(),
+                predicate,
+                instructions,
+            });
+        }
+        if cases.len() != terms.len() || cost < 10 {
+            continue;
+        }
+        let first = cases
+            .iter()
+            .flat_map(|case| case.instructions.iter().copied())
+            .min()?;
+        if block.insts[first..block.insts.len() - 1]
+            .iter()
+            .any(|inst| !loop_guard::movable(inst))
+        {
+            continue;
+        }
+        return Some(Plan {
+            guard,
+            cases,
+            removed: selected,
+        });
+    }
+    None
+}
+
+pub(super) fn run(func: &mut MFunction) {
+    let positions = func
+        .blocks
+        .iter()
+        .enumerate()
+        .map(|(index, block)| (block.id, index))
+        .collect::<HashMap<_, _>>();
+    let successors = func
+        .blocks
+        .iter()
+        .map(|block| {
+            block
+                .successors()
+                .into_iter()
+                .map(|target| positions[&target])
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    let Ok(cfg) = celox_analysis::cfg::ForwardControlFlowGraph::analyze_structure(successors, 0)
+    else {
+        return;
+    };
+    let headers = cfg
+        .loops
+        .iter()
+        .map(|region| func.blocks[region.header].id)
+        .collect::<HashSet<_>>();
+    let zeros = known_bits::known_zeros(func);
+    let mut uses = vec![0usize; func.vregs.count() as usize];
+    for block in &func.blocks {
+        for phi in &block.phis {
+            for &(_, source) in &phi.sources {
+                uses[source.0 as usize] += 1;
+            }
+        }
+        for inst in &block.insts {
+            for source in inst.uses() {
+                uses[source.0 as usize] += 1;
+            }
+        }
+    }
+    let Some(mut next_id) = func
+        .blocks
+        .iter()
+        .map(|block| block.id.0)
+        .max()
+        .and_then(|id| id.checked_add(1))
+    else {
+        return;
+    };
+    let original_count = func.blocks.len();
+    for position in 0..original_count {
+        let block = &func.blocks[position];
+        if !headers.contains(&block.id) {
+            continue;
+        }
+        let Some(&MInst::Branch {
+            cond,
+            true_bb,
+            false_bb,
+        }) = block.terminator()
+        else {
+            continue;
+        };
+        if true_bb == false_bb {
+            continue;
+        }
+        let Some(plan) = plan(block, cond, &uses) else {
+            continue;
+        };
+        let count = plan.cases.len() as u32;
+        let Some(end_id) = next_id.checked_add(count * 2 + 1) else {
+            return;
+        };
+        let dispatch = (0..count)
+            .map(|offset| BlockId(next_id + offset))
+            .collect::<Vec<_>>();
+        let bodies = (0..count)
+            .map(|offset| BlockId(next_id + count + offset))
+            .collect::<Vec<_>>();
+        let join_id = BlockId(next_id + count * 2);
+        next_id = end_id;
+        let original_id = block.id;
+        let original = std::mem::take(&mut func.blocks[position].insts);
+        let zero = func.vregs.alloc();
+        func.spill_descs.push(SpillDesc::remat(0));
+        let header = &mut func.blocks[position];
+        for (index, inst) in original.iter().enumerate().take(original.len() - 1) {
+            if !plan.removed.contains(&index) {
+                header.push(inst.clone());
+            }
+        }
+        header.push(MInst::LoadImm {
+            dst: zero,
+            value: 0,
+        });
+        if let Some(mut guard) = plan.guard {
+            // Each equality masks its predicate to bit zero. The outer
+            // bitwise guard also observes only that bit, not nonzero truth.
+            if zeros[guard.0 as usize] & !1 != !1 {
+                let normalized = func.vregs.alloc();
+                func.spill_descs.push(SpillDesc::transient());
+                header.push(MInst::AndImm32 {
+                    dst: normalized,
+                    src: guard,
+                    imm: 1,
+                });
+                guard = normalized;
+            }
+            header.push(MInst::Branch {
+                cond: guard,
+                true_bb: dispatch[0],
+                false_bb: join_id,
+            });
+        } else {
+            header.push(MInst::Jump {
+                target: dispatch[0],
+            });
+        }
+        let mut sources = vec![(*dispatch.last().unwrap(), zero)];
+        if plan.guard.is_some() {
+            sources.push((original_id, zero));
+        }
+        for (index, case) in plan.cases.into_iter().enumerate() {
+            let mut decision = MBlock::new(dispatch[index]);
+            let condition = case.comparison.def().unwrap();
+            decision.push(case.comparison);
+            decision.push(MInst::Branch {
+                cond: condition,
+                true_bb: bodies[index],
+                false_bb: dispatch.get(index + 1).copied().unwrap_or(join_id),
+            });
+            let mut body = MBlock::new(bodies[index]);
+            for instruction in case.instructions {
+                body.push(original[instruction].clone());
+            }
+            let predicate = if zeros[case.predicate.0 as usize] & !1 == !1 {
+                case.predicate
+            } else {
+                let normalized = func.vregs.alloc();
+                func.spill_descs.push(SpillDesc::transient());
+                body.push(MInst::AndImm32 {
+                    dst: normalized,
+                    src: case.predicate,
+                    imm: 1,
+                });
+                normalized
+            };
+            body.push(MInst::Jump { target: join_id });
+            sources.push((body.id, predicate));
+            func.push_block(decision);
+            func.push_block(body);
+        }
+        let mut join = MBlock::new(join_id);
+        join.phis.push(PhiNode { dst: cond, sources });
+        join.push(MInst::Branch {
+            cond,
+            true_bb,
+            false_bb,
+        });
+        for successor in &mut func.blocks {
+            if successor.id == true_bb || successor.id == false_bb {
+                for phi in &mut successor.phis {
+                    for (predecessor, _) in &mut phi.sources {
+                        if *predecessor == original_id {
+                            *predecessor = join_id;
+                        }
+                    }
+                }
+            }
+        }
+        func.push_block(join);
+    }
+}

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/exclusive_loop/tests.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/exclusive_loop/tests.rs
@@ -1,0 +1,295 @@
+use super::*;
+use crate::native::{emit, jit_mem::JitCode, mir_legalize, regalloc};
+
+fn fixture(guarded: bool, blocker: u8) -> MFunction {
+    let mut vregs = VRegAllocator::new();
+    for _ in 0..80 {
+        vregs.alloc();
+    }
+    let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 80]);
+    let mut entry = MBlock::new(BlockId(0));
+    entry.push(MInst::LoadImm {
+        dst: VReg(0),
+        value: 0,
+    });
+    entry.push(MInst::Jump { target: BlockId(1) });
+    let mut header = MBlock::new(BlockId(1));
+    header.phis.push(PhiNode {
+        dst: VReg(2),
+        sources: vec![(BlockId(0), VReg(0)), (BlockId(4), VReg(65))],
+    });
+    header.phis.push(PhiNode {
+        dst: VReg(3),
+        sources: vec![(BlockId(0), VReg(0)), (BlockId(4), VReg(66))],
+    });
+    header.push(MInst::Load {
+        dst: VReg(4),
+        base: BaseReg::SimState,
+        offset: 0,
+        size: OpSize::S64,
+    });
+    header.push(MInst::Load {
+        dst: VReg(5),
+        base: BaseReg::SimState,
+        offset: 8,
+        size: OpSize::S64,
+    });
+    header.push(MInst::AndImm {
+        dst: VReg(6),
+        src: VReg(5),
+        imm: 1,
+    });
+    for case in 0..3 {
+        let start = 10 + case * 12;
+        header.push(MInst::CmpImm {
+            dst: VReg(start),
+            lhs: VReg(4),
+            imm: if blocker == 3 && case == 1 {
+                0
+            } else {
+                case as i32
+            },
+            kind: CmpKind::Eq,
+        });
+        header.push(MInst::Load {
+            dst: VReg(start + 1),
+            base: BaseReg::SimState,
+            offset: 32 + case as i32 * 8,
+            size: OpSize::S64,
+        });
+        for step in 2..=5 {
+            header.push(MInst::AddImm {
+                dst: VReg(start + step),
+                src: VReg(start + step - 1),
+                imm: 1,
+            });
+        }
+        header.push(MInst::CmpImm {
+            dst: VReg(start + 10),
+            lhs: VReg(start + 5),
+            imm: case as i32 + 7,
+            kind: CmpKind::Eq,
+        });
+        header.push(MInst::And32 {
+            dst: VReg(start + 11),
+            lhs: VReg(start),
+            rhs: VReg(start + 10),
+        });
+    }
+    header.push(MInst::Or32 {
+        dst: VReg(60),
+        lhs: VReg(21),
+        rhs: VReg(33),
+    });
+    header.push(MInst::Or {
+        dst: VReg(61),
+        lhs: VReg(60),
+        rhs: VReg(45),
+    });
+    if blocker == 1 {
+        header.push(MInst::MemFill {
+            dst_offset: 32,
+            byte_len: 8,
+            value: 0xa5,
+        });
+    }
+    let cond = if guarded {
+        header.push(MInst::And32 {
+            dst: VReg(62),
+            lhs: VReg(6),
+            rhs: VReg(61),
+        });
+        VReg(62)
+    } else {
+        VReg(61)
+    };
+    if blocker == 4 {
+        header.push(MInst::AddImm {
+            dst: VReg(68),
+            src: cond,
+            imm: 10,
+        });
+    }
+    header.push(MInst::Branch {
+        cond,
+        true_bb: BlockId(2),
+        false_bb: BlockId(3),
+    });
+    let mut hit = MBlock::new(BlockId(2));
+    hit.push(MInst::AddImm {
+        dst: VReg(64),
+        src: VReg(2),
+        imm: 1,
+    });
+    hit.push(MInst::Jump { target: BlockId(4) });
+    let mut miss = MBlock::new(BlockId(3));
+    miss.push(MInst::Jump { target: BlockId(4) });
+    let mut latch = MBlock::new(BlockId(4));
+    latch.phis.push(PhiNode {
+        dst: VReg(65),
+        sources: vec![(BlockId(2), VReg(64)), (BlockId(3), VReg(2))],
+    });
+    latch.push(MInst::AddImm {
+        dst: VReg(66),
+        src: VReg(3),
+        imm: 1,
+    });
+    latch.push(MInst::CmpImm {
+        dst: VReg(67),
+        lhs: VReg(66),
+        imm: 4,
+        kind: CmpKind::LtU,
+    });
+    latch.push(MInst::Branch {
+        cond: VReg(67),
+        true_bb: BlockId(1),
+        false_bb: BlockId(5),
+    });
+    let mut exit = MBlock::new(BlockId(5));
+    exit.push(MInst::Store {
+        base: BaseReg::SimState,
+        offset: 80,
+        src: VReg(65),
+        size: OpSize::S64,
+    });
+    exit.push(MInst::Store {
+        base: BaseReg::SimState,
+        offset: 88,
+        src: cond,
+        size: OpSize::S64,
+    });
+    if blocker == 2 {
+        exit.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 72,
+            src: VReg(20),
+            size: OpSize::S64,
+        });
+    }
+    if blocker == 4 {
+        exit.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 72,
+            src: VReg(68),
+            size: OpSize::S64,
+        });
+    }
+    exit.push(MInst::Return);
+    function.blocks = vec![entry, header, hit, miss, latch, exit];
+    function
+}
+
+fn compile(mut function: MFunction) -> (JitCode, usize) {
+    mir_legalize::legalize(&mut function);
+    let allocation = regalloc::run_regalloc(&mut function).unwrap();
+    let code = emit::emit(
+        &function,
+        &allocation.assignment,
+        allocation.spill_frame_size,
+    )
+    .unwrap();
+    (
+        JitCode::new(&code.code).unwrap(),
+        code.required_state_size.max(96) as usize,
+    )
+}
+
+#[test]
+fn exclusive_dispatch_preserves_low_bit_of_wide_predicates_and_guards() {
+    for guarded in [false, true] {
+        let mut original = fixture(guarded, 0);
+        for inst in &mut original.blocks[1].insts {
+            match *inst {
+                MInst::AndImm {
+                    dst: VReg(6), src, ..
+                } => {
+                    *inst = MInst::Mov { dst: VReg(6), src };
+                }
+                MInst::CmpImm { dst, lhs, .. } if [20, 32, 44].contains(&dst.0) => {
+                    *inst = MInst::Mov { dst, src: lhs };
+                }
+                _ => {}
+            }
+        }
+        original.verify();
+        let mut optimized = original.clone();
+        run(&mut optimized);
+        optimized.verify();
+        assert_eq!(optimized.blocks.len(), 13);
+        let (before, before_size) = compile(original);
+        let (after, after_size) = compile(optimized);
+        for key in [0u64, 1, 2, 3, u64::MAX] {
+            for guard in [0u64, 1, 2, 3, 1 << 32, 1 << 63, u64::MAX] {
+                for input in [0u64, 1, 2, 3, 1 << 32, 1 << 63, u64::MAX] {
+                    let mut left = vec![0u8; before_size.max(after_size)];
+                    left[..8].copy_from_slice(&key.to_le_bytes());
+                    left[8..16].copy_from_slice(&guard.to_le_bytes());
+                    for lane in 0..3usize {
+                        left[32 + lane * 8..40 + lane * 8]
+                            .copy_from_slice(&input.wrapping_add(lane as u64).to_le_bytes());
+                    }
+                    let mut right = left.clone();
+                    assert_eq!(unsafe { before.call(&mut left) }, 0);
+                    assert_eq!(unsafe { after.call(&mut right) }, 0);
+                    assert_eq!(
+                        &left[..96],
+                        &right[..96],
+                        "guarded={guarded} key={key} guard={guard} input={input}"
+                    );
+                    let expected = u64::from(
+                        key < 3
+                            && input.wrapping_add(key).wrapping_add(4) & 1 != 0
+                            && (!guarded || guard & 1 != 0),
+                    );
+                    assert_eq!(
+                        u64::from_le_bytes(right[80..88].try_into().unwrap()),
+                        expected * 4
+                    );
+                    assert_eq!(
+                        u64::from_le_bytes(right[88..96].try_into().unwrap()),
+                        expected
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn exclusive_dispatch_preserves_shared_results_and_rejects_unsafe_trees() {
+    for guarded in [false, true] {
+        for blocker in 0..5 {
+            let original = fixture(guarded, blocker);
+            original.verify();
+            let mut optimized = original.clone();
+            run(&mut optimized);
+            optimized.verify();
+            assert_eq!(optimized.blocks.len(), if blocker == 0 { 13 } else { 6 });
+            let (before, before_size) = compile(original);
+            let (after, after_size) = compile(optimized);
+            for key in [0u64, 1, 2, 3, u64::MAX] {
+                for guard in [0u64, 1, 2, 3] {
+                    for matches in 0..8 {
+                        let mut left = vec![0u8; before_size.max(after_size)];
+                        left[..8].copy_from_slice(&key.to_le_bytes());
+                        left[8..16].copy_from_slice(&guard.to_le_bytes());
+                        for lane in 0..3usize {
+                            let value =
+                                lane as u64 + if matches & (1 << lane) != 0 { 3 } else { 4 };
+                            left[32 + lane * 8..40 + lane * 8]
+                                .copy_from_slice(&value.to_le_bytes());
+                        }
+                        let mut right = left.clone();
+                        assert_eq!(unsafe { before.call(&mut left) }, 0);
+                        assert_eq!(unsafe { after.call(&mut right) }, 0);
+                        assert_eq!(
+                            &left[..96],
+                            &right[..96],
+                            "guarded={guarded}, blocker={blocker}, key={key}, guard={guard}, matches={matches}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/known_bits.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/known_bits.rs
@@ -1,0 +1,1944 @@
+//! Bit facts for machine-width SSA arithmetic, including packed array offsets.
+
+use super::*;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct KnownBits {
+    zero: u64,
+    one: u64,
+}
+
+impl KnownBits {
+    fn constant(value: u64) -> Self {
+        Self {
+            zero: !value,
+            one: value,
+        }
+    }
+
+    fn value(self) -> Option<u64> {
+        (self.zero | self.one == u64::MAX).then_some(self.one)
+    }
+
+    fn truth(self) -> Option<bool> {
+        if self.one != 0 {
+            Some(true)
+        } else {
+            (self.zero == u64::MAX).then_some(false)
+        }
+    }
+
+    fn compare(self, other: Self, kind: CmpKind) -> Self {
+        if let (Some(lhs), Some(rhs)) = (self.value(), other.value()) {
+            let value = match kind {
+                CmpKind::Eq => lhs == rhs,
+                CmpKind::Ne => lhs != rhs,
+                CmpKind::LtU => lhs < rhs,
+                CmpKind::LeU => lhs <= rhs,
+                CmpKind::GtU => lhs > rhs,
+                CmpKind::GeU => lhs >= rhs,
+                CmpKind::LtS => (lhs as i64) < (rhs as i64),
+                CmpKind::LeS => (lhs as i64) <= (rhs as i64),
+                CmpKind::GtS => (lhs as i64) > (rhs as i64),
+                CmpKind::GeS => (lhs as i64) >= (rhs as i64),
+            };
+            return Self::constant(u64::from(value));
+        }
+        if (self.zero & other.one) | (self.one & other.zero) != 0 {
+            match kind {
+                CmpKind::Eq => return Self::constant(0),
+                CmpKind::Ne => return Self::constant(1),
+                _ => {}
+            }
+        }
+        let signed = matches!(
+            kind,
+            CmpKind::LtS | CmpKind::LeS | CmpKind::GtS | CmpKind::GeS
+        );
+        // Flipping the sign bit converts signed order to unsigned order,
+        // including a range whose sign is not known yet.
+        let (left, right) = if signed {
+            let sign = Self::constant(1 << 63);
+            (self.xor(sign), other.xor(sign))
+        } else {
+            (self, other)
+        };
+        let (min_left, max_left) = (left.one, !left.zero);
+        let (min_right, max_right) = (right.one, !right.zero);
+        let value = match kind {
+            CmpKind::LtU | CmpKind::LtS if max_left < min_right => Some(true),
+            CmpKind::LtU | CmpKind::LtS if min_left >= max_right => Some(false),
+            CmpKind::LeU | CmpKind::LeS if max_left <= min_right => Some(true),
+            CmpKind::LeU | CmpKind::LeS if min_left > max_right => Some(false),
+            CmpKind::GtU | CmpKind::GtS if min_left > max_right => Some(true),
+            CmpKind::GtU | CmpKind::GtS if max_left <= min_right => Some(false),
+            CmpKind::GeU | CmpKind::GeS if min_left >= max_right => Some(true),
+            CmpKind::GeU | CmpKind::GeS if max_left < min_right => Some(false),
+            _ => None,
+        };
+        if let Some(value) = value {
+            return Self::constant(u64::from(value));
+        }
+        Self::default().truncate(1)
+    }
+
+    fn truncate(self, mask: u64) -> Self {
+        Self {
+            zero: self.zero | !mask,
+            one: self.one & mask,
+        }
+    }
+
+    fn join(self, other: Self) -> Self {
+        Self {
+            zero: self.zero & other.zero,
+            one: self.one & other.one,
+        }
+    }
+
+    fn not(self) -> Self {
+        Self {
+            zero: self.one,
+            one: self.zero,
+        }
+    }
+
+    fn and(self, other: Self) -> Self {
+        Self {
+            zero: self.zero | other.zero,
+            one: self.one & other.one,
+        }
+    }
+
+    fn or(self, other: Self) -> Self {
+        Self {
+            zero: self.zero & other.zero,
+            one: self.one | other.one,
+        }
+    }
+
+    fn xor(self, other: Self) -> Self {
+        Self {
+            zero: (self.zero & other.zero) | (self.one & other.one),
+            one: (self.zero & other.one) | (self.one & other.zero),
+        }
+    }
+
+    fn add(self, other: Self) -> Self {
+        // A carry is monotone in the lower input bits. Evaluate the minimum
+        // and maximum inputs to find which carry-in bits are fixed, then XOR
+        // those with the fixed operand bits. This also preserves u64 wrapping.
+        let min_sum = self.one.wrapping_add(other.one);
+        let max_sum = (!self.zero).wrapping_add(!other.zero);
+        let min_carry = min_sum ^ self.one ^ other.one;
+        let max_carry = max_sum ^ !self.zero ^ !other.zero;
+        let known = (self.zero | self.one) & (other.zero | other.one) & !(min_carry ^ max_carry);
+        Self {
+            zero: !min_sum & known,
+            one: min_sum & known,
+        }
+    }
+
+    fn mul(self, other: Self) -> Self {
+        // Split each operand into a fixed low part and an unknown multiple
+        // of a power of two. All three terms involving an unknown part are
+        // multiples of 2^known_low, even when multiplication wraps.
+        let left_unknown = (!(self.zero | self.one)).trailing_zeros();
+        let right_unknown = (!(other.zero | other.one)).trailing_zeros();
+        let known_low = (left_unknown + other.one.trailing_zeros())
+            .min(right_unknown + self.one.trailing_zeros())
+            .min(left_unknown + right_unknown)
+            .min(64);
+        let low_mask = u64::MAX.checked_shr(64 - known_low).unwrap_or(0);
+        let product = self.one.wrapping_mul(other.one);
+        let mut zero = !product & low_mask;
+        if let Some(max) = (!self.zero).checked_mul(!other.zero) {
+            zero |= u64::MAX.checked_shl(64 - max.leading_zeros()).unwrap_or(0);
+        }
+        Self {
+            zero,
+            one: product & low_mask,
+        }
+    }
+
+    fn shl(self, shift: u8) -> Self {
+        Self {
+            zero: !(!self.zero).checked_shl(u32::from(shift)).unwrap_or(0),
+            one: self.one.checked_shl(u32::from(shift)).unwrap_or(0),
+        }
+    }
+
+    fn shr(self, shift: u8) -> Self {
+        Self {
+            zero: !(!self.zero).checked_shr(u32::from(shift)).unwrap_or(0),
+            one: self.one.checked_shr(u32::from(shift)).unwrap_or(0),
+        }
+    }
+}
+
+fn comparison_selection(inst: &MInst, bits: impl Fn(VReg) -> KnownBits) -> Option<VReg> {
+    let (condition, true_val, false_val) = match *inst {
+        MInst::CmpSelect {
+            lhs,
+            rhs,
+            kind,
+            true_val,
+            false_val,
+            ..
+        } => (
+            bits(lhs).compare(bits(rhs), kind).truth(),
+            true_val,
+            false_val,
+        ),
+        MInst::CmpImmSelect {
+            lhs,
+            imm,
+            kind,
+            true_val,
+            false_val,
+            ..
+        } => (
+            bits(lhs)
+                .compare(KnownBits::constant(imm as u64), kind)
+                .truth(),
+            true_val,
+            false_val,
+        ),
+        MInst::GuardedCmpSelect {
+            guard,
+            lhs,
+            rhs,
+            kind,
+            true_val,
+            false_val,
+            ..
+        } => {
+            let condition = match (
+                bits(guard).truth(),
+                bits(lhs).compare(bits(rhs), kind).truth(),
+            ) {
+                (Some(false), _) | (_, Some(false)) => Some(false),
+                (Some(true), Some(true)) => Some(true),
+                _ => None,
+            };
+            (condition, true_val, false_val)
+        }
+        _ => return None,
+    };
+    condition.map(|condition| if condition { true_val } else { false_val })
+}
+
+fn instruction_bits(inst: &MInst, facts: &[KnownBits]) -> KnownBits {
+    let bits = |value: VReg| facts[value.0 as usize];
+    let low32 = u64::from(u32::MAX);
+    match inst {
+        MInst::LoadImm { value, .. } => KnownBits::constant(*value),
+        MInst::Load { size, .. }
+        | MInst::LoadIndexed { size, .. }
+        | MInst::LoadPtr { size, .. }
+        | MInst::LoadPtrIndexed { size, .. } => {
+            KnownBits::default().truncate(machine_width_mask(*size))
+        }
+        MInst::Mov { src, .. } => bits(*src),
+        MInst::Mov32 { src, .. } => bits(*src).truncate(low32),
+        MInst::BitNot { src, .. } => bits(*src).not(),
+        MInst::And { lhs, rhs, .. } => bits(*lhs).and(bits(*rhs)),
+        MInst::And32 { lhs, rhs, .. } => bits(*lhs).and(bits(*rhs)).truncate(low32),
+        MInst::AndImm { src, imm, .. } => bits(*src).and(KnownBits::constant(*imm)),
+        MInst::AndImm32 { src, imm, .. } => bits(*src).and(KnownBits::constant(u64::from(*imm))),
+        MInst::Or { lhs, rhs, .. } => bits(*lhs).or(bits(*rhs)),
+        MInst::Or32 { lhs, rhs, .. } => bits(*lhs).or(bits(*rhs)).truncate(low32),
+        MInst::OrImm { src, imm, .. } => bits(*src).or(KnownBits::constant(*imm)),
+        MInst::Xor { lhs, rhs, .. } => bits(*lhs).xor(bits(*rhs)),
+        MInst::Xor32 { lhs, rhs, .. } => bits(*lhs).xor(bits(*rhs)).truncate(low32),
+        MInst::Add { lhs, rhs, .. } => bits(*lhs).add(bits(*rhs)),
+        MInst::Add32 { lhs, rhs, .. } => bits(*lhs).add(bits(*rhs)).truncate(low32),
+        MInst::AddImm { src, imm, .. } => bits(*src).add(KnownBits::constant(*imm as u64)),
+        MInst::Sub { lhs, rhs, .. } => bits(*lhs).add(bits(*rhs).not()).add(KnownBits::constant(1)),
+        MInst::Sub32 { lhs, rhs, .. } => bits(*lhs)
+            .add(bits(*rhs).not())
+            .add(KnownBits::constant(1))
+            .truncate(low32),
+        MInst::SubImm { src, imm, .. } => {
+            bits(*src).add(KnownBits::constant((*imm as u64).wrapping_neg()))
+        }
+        MInst::Mul { lhs, rhs, .. } => bits(*lhs).mul(bits(*rhs)),
+        MInst::Mul32 { lhs, rhs, .. } => bits(*lhs).mul(bits(*rhs)).truncate(low32),
+        MInst::ShrImm { src, imm, .. } => bits(*src).shr(*imm),
+        MInst::ShlImm { src, imm, .. } => bits(*src).shl(*imm),
+        MInst::Cmp { lhs, rhs, kind, .. } => bits(*lhs).compare(bits(*rhs), *kind),
+        MInst::CmpImm { lhs, imm, kind, .. } => {
+            bits(*lhs).compare(KnownBits::constant(*imm as u64), *kind)
+        }
+        MInst::Shl { lhs, rhs, .. } => {
+            if bits(*lhs).value() == Some(0) {
+                return KnownBits::constant(0);
+            }
+            bits(*rhs).value().map_or_else(KnownBits::default, |shift| {
+                bits(*lhs).shl(shift.min(64) as u8)
+            })
+        }
+        MInst::Shr { lhs, rhs, .. } => {
+            if bits(*lhs).value() == Some(0) {
+                return KnownBits::constant(0);
+            }
+            bits(*rhs).value().map_or_else(KnownBits::default, |shift| {
+                bits(*lhs).shr(shift.min(64) as u8)
+            })
+        }
+        MInst::Popcnt { .. } => KnownBits::default().truncate(0x7f),
+        MInst::BsrOr { zero_value, .. } => {
+            KnownBits::default().truncate(0x3f | u64::from(*zero_value))
+        }
+        MInst::Select {
+            cond,
+            true_val,
+            false_val,
+            ..
+        } => match bits(*cond).truth() {
+            Some(true) => bits(*true_val),
+            Some(false) => bits(*false_val),
+            None => bits(*true_val).join(bits(*false_val)),
+        },
+        MInst::CmpSelect {
+            true_val,
+            false_val,
+            ..
+        }
+        | MInst::CmpImmSelect {
+            true_val,
+            false_val,
+            ..
+        }
+        | MInst::GuardedCmpSelect {
+            true_val,
+            false_val,
+            ..
+        } => comparison_selection(inst, bits)
+            .map_or_else(|| bits(*true_val).join(bits(*false_val)), bits),
+        _ => KnownBits::default(),
+    }
+}
+
+/// Start with unknown bits and refine along SSA uses, revisiting a loop only
+/// when one of its inputs improves. Phi joins retain facts shared by every
+/// incoming edge; they never assume a constant from just the entry edge.
+pub(super) fn known_zeros(func: &MFunction) -> Vec<u64> {
+    analyze(func).into_iter().map(|bits| bits.zero).collect()
+}
+
+fn analyze(func: &MFunction) -> Vec<KnownBits> {
+    let value_count = func.vregs.count() as usize;
+    let mut definitions = vec![None::<ValueDefinition>; value_count];
+    let mut users = vec![Vec::<VReg>::new(); value_count];
+    let mut queue = VecDeque::new();
+    let mut queued = vec![false; value_count];
+    for (block, body) in func.blocks.iter().enumerate() {
+        for (phi, row) in body.phis.iter().enumerate() {
+            definitions[row.dst.0 as usize] = Some(ValueDefinition::Phi { block, phi });
+            queue.push_back(row.dst);
+            queued[row.dst.0 as usize] = true;
+            for &(_, source) in &row.sources {
+                users[source.0 as usize].push(row.dst);
+            }
+        }
+        for (instruction, inst) in body.insts.iter().enumerate() {
+            let Some(dst) = inst.def() else { continue };
+            definitions[dst.0 as usize] = Some(ValueDefinition::Instruction { block, instruction });
+            queue.push_back(dst);
+            queued[dst.0 as usize] = true;
+            for source in inst.uses() {
+                users[source.0 as usize].push(dst);
+            }
+        }
+    }
+    let mut facts = vec![KnownBits::default(); value_count];
+    for (index, zero) in counted_loop::index_zeros(func) {
+        facts[index.0 as usize].zero = zero;
+    }
+    while let Some(value) = queue.pop_front() {
+        let index = value.0 as usize;
+        queued[index] = false;
+        let computed = match definitions[index] {
+            Some(ValueDefinition::Phi { block, phi }) => func.blocks[block].phis[phi]
+                .sources
+                .iter()
+                .map(|(_, source)| facts[source.0 as usize])
+                .reduce(KnownBits::join)
+                .unwrap_or_default(),
+            Some(ValueDefinition::Instruction { block, instruction }) => {
+                instruction_bits(&func.blocks[block].insts[instruction], &facts)
+            }
+            None => continue,
+        };
+        let improved = KnownBits {
+            zero: facts[index].zero | computed.zero,
+            one: facts[index].one | computed.one,
+        };
+        debug_assert_eq!(improved.zero & improved.one, 0);
+        if facts[index] == improved {
+            continue;
+        }
+        facts[index] = improved;
+        for &user in &users[index] {
+            if !queued[user.0 as usize] {
+                queued[user.0 as usize] = true;
+                queue.push_back(user);
+            }
+        }
+    }
+    facts
+}
+
+/// Resolve fixed portions of dynamic bit addresses before allocation. For
+/// example, `(index * 288 + 163) & 7` is always 3, so it needs neither an
+/// address-dependent mask nor a variable shift in the generated code. Move
+/// byte-address arithmetic ahead of a right shift only when the bit facts
+/// prove that the original multiply/add/left shift cannot wrap.
+pub(super) fn fold(func: &mut MFunction) {
+    let facts = analyze(func);
+    let definitions = func
+        .blocks
+        .iter()
+        .flat_map(|block| &block.insts)
+        .filter_map(|inst| match inst {
+            MInst::ShlImm { .. } | MInst::AddImm { .. } | MInst::Mul { .. } => {
+                Some((inst.def().unwrap(), inst.clone()))
+            }
+            _ => None,
+        })
+        .collect::<HashMap<_, _>>();
+    for block in &mut func.blocks {
+        let original = std::mem::take(&mut block.insts);
+        for mut inst in original {
+            if let Some(dst) = inst.def()
+                && let Some(value) = facts[dst.0 as usize].value()
+            {
+                inst = MInst::LoadImm { dst, value };
+            } else if let Some(src) = comparison_selection(&inst, |value| facts[value.0 as usize]) {
+                inst = MInst::Mov {
+                    dst: inst.def().unwrap(),
+                    src,
+                };
+            } else if let MInst::CmpImm {
+                dst,
+                lhs,
+                imm,
+                kind,
+            } = inst
+                && ((kind == CmpKind::Ne && imm == 0) || (kind == CmpKind::Eq && imm == 1))
+                && facts[lhs.0 as usize].zero & !1 == !1
+            {
+                inst = MInst::Mov { dst, src: lhs };
+            } else if let MInst::Select {
+                dst,
+                cond,
+                true_val,
+                false_val,
+            } = inst
+            {
+                let condition = facts[cond.0 as usize];
+                let true_bits = facts[true_val.0 as usize];
+                let false_bits = facts[false_val.0 as usize];
+                let is_boolean = |bits: KnownBits| bits.zero & !1 == !1;
+                if let Some(condition) = condition.truth() {
+                    inst = MInst::Mov {
+                        dst,
+                        src: if condition { true_val } else { false_val },
+                    };
+                } else if true_bits.value() == Some(0) && false_bits.value() == Some(1) {
+                    inst = MInst::CmpImm {
+                        dst,
+                        lhs: cond,
+                        imm: 0,
+                        kind: CmpKind::Eq,
+                    };
+                } else if true_bits.value() == Some(1) && false_bits.value() == Some(0) {
+                    inst = if is_boolean(condition) {
+                        MInst::Mov { dst, src: cond }
+                    } else {
+                        MInst::CmpImm {
+                            dst,
+                            lhs: cond,
+                            imm: 0,
+                            kind: CmpKind::Ne,
+                        }
+                    };
+                } else if false_bits.value() == Some(0)
+                    && is_boolean(condition)
+                    && is_boolean(true_bits)
+                {
+                    inst = MInst::And32 {
+                        dst,
+                        lhs: cond,
+                        rhs: true_val,
+                    };
+                } else if true_bits.value() == Some(1)
+                    && is_boolean(condition)
+                    && is_boolean(false_bits)
+                {
+                    inst = MInst::Or32 {
+                        dst,
+                        lhs: cond,
+                        rhs: false_val,
+                    };
+                } else if true_bits.value() == Some(0) && is_boolean(false_bits) {
+                    let inverted = func.vregs.alloc();
+                    func.spill_descs.push(SpillDesc::transient());
+                    if func.target_features.bmi1() && is_boolean(condition) {
+                        block.push(MInst::BitNot {
+                            dst: inverted,
+                            src: cond,
+                        });
+                    } else {
+                        block.push(MInst::CmpImm {
+                            dst: inverted,
+                            lhs: cond,
+                            imm: 0,
+                            kind: CmpKind::Eq,
+                        });
+                    }
+                    inst = MInst::And32 {
+                        dst,
+                        lhs: inverted,
+                        rhs: false_val,
+                    };
+                }
+            } else if let MInst::ShrImm {
+                dst,
+                src,
+                imm: shift @ 1..=63,
+            } = inst
+            {
+                match definitions.get(&src) {
+                    Some(MInst::ShlImm { src, imm, .. })
+                        if *imm < 64 && !facts[src.0 as usize].zero <= (u64::MAX >> imm) =>
+                    {
+                        inst = if *imm >= shift {
+                            MInst::ShlImm {
+                                dst,
+                                src: *src,
+                                imm: *imm - shift,
+                            }
+                        } else {
+                            MInst::ShrImm {
+                                dst,
+                                src: *src,
+                                imm: shift - *imm,
+                            }
+                        };
+                    }
+                    Some(MInst::AddImm { src, imm, .. })
+                        if *imm >= 0
+                            && facts[src.0 as usize].zero.trailing_ones() >= u32::from(shift)
+                            && (!facts[src.0 as usize].zero)
+                                .checked_add(*imm as u64)
+                                .is_some() =>
+                    {
+                        let shifted = func.vregs.alloc();
+                        func.spill_descs.push(SpillDesc::transient());
+                        block.push(MInst::ShrImm {
+                            dst: shifted,
+                            src: *src,
+                            imm: shift,
+                        });
+                        inst = MInst::AddImm {
+                            dst,
+                            src: shifted,
+                            imm: ((*imm as u64) >> shift) as i32,
+                        };
+                    }
+                    Some(MInst::Mul { lhs, rhs, .. }) => {
+                        for (source, factor) in [(*lhs, *rhs), (*rhs, *lhs)] {
+                            if let Some(factor) = facts[factor.0 as usize].value()
+                                && factor.trailing_zeros() >= u32::from(shift)
+                                && (!facts[source.0 as usize].zero)
+                                    .checked_mul(factor)
+                                    .is_some()
+                            {
+                                let scale = func.vregs.alloc();
+                                func.spill_descs.push(SpillDesc::remat(factor >> shift));
+                                block.push(MInst::LoadImm {
+                                    dst: scale,
+                                    value: factor >> shift,
+                                });
+                                inst = MInst::Mul {
+                                    dst,
+                                    lhs: source,
+                                    rhs: scale,
+                                };
+                                break;
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            block.push(inst);
+        }
+    }
+}
+
+/// Propagate the bits observed by stores and predicates backwards through SSA.
+/// Packed struct reconstruction often computes a whole word only to extract
+/// one field. Preserve every demanded bit, but allow dead fields to disappear
+/// before they acquire registers and spill homes.
+fn demand_masks(func: &MFunction, facts: &[KnownBits]) -> Vec<u64> {
+    let mut definitions = vec![None; facts.len()];
+    let mut demanded = vec![0u64; facts.len()];
+    let mut work = VecDeque::new();
+    let add = |value: VReg, mask: u64, demanded: &mut [u64], work: &mut VecDeque<VReg>| {
+        let old = demanded[value.0 as usize];
+        if mask & !old != 0 {
+            demanded[value.0 as usize] |= mask;
+            work.push_back(value);
+        }
+    };
+    for (block, body) in func.blocks.iter().enumerate() {
+        for (phi, row) in body.phis.iter().enumerate() {
+            definitions[row.dst.0 as usize] = Some(ValueDefinition::Phi { block, phi });
+        }
+        for (instruction, inst) in body.insts.iter().enumerate() {
+            if let Some(dst) = inst.def() {
+                definitions[dst.0 as usize] =
+                    Some(ValueDefinition::Instruction { block, instruction });
+            } else {
+                for source in inst.uses() {
+                    let mask = match inst {
+                        MInst::Store { src, size, .. } if source == *src => {
+                            machine_width_mask(*size)
+                        }
+                        _ => u64::MAX,
+                    };
+                    add(source, mask, &mut demanded, &mut work);
+                }
+            }
+        }
+    }
+    while let Some(value) = work.pop_front() {
+        let mask = demanded[value.0 as usize];
+        let mut use_bits = |source, bits| add(source, bits, &mut demanded, &mut work);
+        let Some(definition) = definitions[value.0 as usize] else {
+            continue;
+        };
+        let inst = match definition {
+            ValueDefinition::Phi { block, phi } => {
+                for &(_, source) in &func.blocks[block].phis[phi].sources {
+                    use_bits(source, mask);
+                }
+                continue;
+            }
+            ValueDefinition::Instruction { block, instruction } => {
+                &func.blocks[block].insts[instruction]
+            }
+        };
+        match *inst {
+            MInst::Mov { src, .. } | MInst::BitNot { src, .. } => use_bits(src, mask),
+            MInst::OrImm { src, imm, .. } => use_bits(src, mask & !imm),
+            MInst::Mov32 { src, .. } => use_bits(src, mask & u64::from(u32::MAX)),
+            MInst::AndImm { src, imm, .. } => use_bits(src, mask & imm),
+            MInst::AndImm32 { src, imm, .. } => use_bits(src, mask & u64::from(imm)),
+            MInst::ShlImm { src, imm, .. } => {
+                use_bits(src, mask.checked_shr(u32::from(imm)).unwrap_or(0))
+            }
+            MInst::ShrImm { src, imm, .. } => {
+                use_bits(src, mask.checked_shl(u32::from(imm)).unwrap_or(0))
+            }
+            MInst::And { lhs, rhs, .. }
+            | MInst::And32 { lhs, rhs, .. }
+            | MInst::Or { lhs, rhs, .. }
+            | MInst::Or32 { lhs, rhs, .. }
+            | MInst::Xor { lhs, rhs, .. }
+            | MInst::Xor32 { lhs, rhs, .. } => {
+                let mask = if matches!(
+                    inst,
+                    MInst::And32 { .. } | MInst::Or32 { .. } | MInst::Xor32 { .. }
+                ) {
+                    mask & u64::from(u32::MAX)
+                } else {
+                    mask
+                };
+                let (left, right) = match inst {
+                    MInst::And { .. } | MInst::And32 { .. } => {
+                        (facts[lhs.0 as usize].zero, facts[rhs.0 as usize].zero)
+                    }
+                    MInst::Or { .. } | MInst::Or32 { .. } => {
+                        (facts[lhs.0 as usize].one, facts[rhs.0 as usize].one)
+                    }
+                    _ => (0, 0),
+                };
+                // A controlling zero (AND) or one (OR) makes the opposite
+                // input irrelevant. If both sides control a bit, retain the
+                // right side: dropping both would let later rewrites change
+                // the originally constant output bit.
+                use_bits(lhs, mask & !right);
+                use_bits(rhs, mask & (!left | right));
+            }
+            MInst::Add { lhs, rhs, .. }
+            | MInst::Sub { lhs, rhs, .. }
+            | MInst::Mul { lhs, rhs, .. }
+            | MInst::Add32 { lhs, rhs, .. }
+            | MInst::Sub32 { lhs, rhs, .. }
+            | MInst::Mul32 { lhs, rhs, .. } => {
+                let mask = if matches!(
+                    inst,
+                    MInst::Add32 { .. } | MInst::Sub32 { .. } | MInst::Mul32 { .. }
+                ) {
+                    mask & u64::from(u32::MAX)
+                } else {
+                    mask
+                };
+                // Every lower bit can contribute a carry, borrow, or product
+                // term to the highest observed result bit.
+                let inputs = u64::MAX.checked_shr(mask.leading_zeros()).unwrap_or(0);
+                use_bits(lhs, inputs);
+                use_bits(rhs, inputs);
+            }
+            MInst::Select {
+                cond,
+                true_val,
+                false_val,
+                ..
+            } => {
+                use_bits(cond, u64::MAX);
+                use_bits(true_val, mask);
+                use_bits(false_val, mask);
+            }
+            MInst::CmpSelect {
+                lhs,
+                rhs,
+                true_val,
+                false_val,
+                ..
+            } => {
+                use_bits(lhs, u64::MAX);
+                use_bits(rhs, u64::MAX);
+                use_bits(true_val, mask);
+                use_bits(false_val, mask);
+            }
+            MInst::CmpImmSelect {
+                lhs,
+                true_val,
+                false_val,
+                ..
+            } => {
+                use_bits(lhs, u64::MAX);
+                use_bits(true_val, mask);
+                use_bits(false_val, mask);
+            }
+            MInst::GuardedCmpSelect {
+                guard,
+                lhs,
+                rhs,
+                true_val,
+                false_val,
+                ..
+            } => {
+                use_bits(guard, u64::MAX);
+                use_bits(lhs, u64::MAX);
+                use_bits(rhs, u64::MAX);
+                use_bits(true_val, mask);
+                use_bits(false_val, mask);
+            }
+            _ => {
+                for source in inst.uses() {
+                    use_bits(source, u64::MAX);
+                }
+            }
+        }
+    }
+    demanded
+}
+
+/// Read a bounded packed bitmap as one word, rather than computing a byte
+/// address and a second shift count for every tested bit. Only the observed
+/// low bit is equivalent; no wider consumer may see the new high bits.
+pub(super) fn fold_packed_bit_loads(func: &mut MFunction) {
+    let facts = analyze(func);
+    let demanded = demand_masks(func, &facts);
+    let mut definitions = vec![None; facts.len()];
+    let mut uses = vec![0usize; facts.len()];
+    for block in &func.blocks {
+        for phi in &block.phis {
+            for &(_, source) in &phi.sources {
+                uses[source.0 as usize] += 1;
+            }
+        }
+        for inst in &block.insts {
+            if let Some(dst) = inst.def() {
+                definitions[dst.0 as usize] = Some(inst);
+            }
+            for source in inst.uses() {
+                uses[source.0 as usize] += 1;
+            }
+        }
+    }
+    let mut replacements = HashMap::default();
+    for block in &func.blocks {
+        for inst in &block.insts {
+            let MInst::Shr { dst, lhs, rhs } = *inst else {
+                continue;
+            };
+            if demanded[dst.0 as usize] != 1 || uses[lhs.0 as usize] != 1 {
+                continue;
+            }
+            let Some(&MInst::LoadIndexed {
+                base,
+                offset,
+                index,
+                scale: 1,
+                size: OpSize::S8,
+                alias_range: Some(envelope),
+                ..
+            }) = definitions[lhs.0 as usize]
+            else {
+                continue;
+            };
+            let Some(&MInst::ShrImm {
+                src: bit, imm: 3, ..
+            }) = definitions[index.0 as usize]
+            else {
+                continue;
+            };
+            if !matches!(definitions[rhs.0 as usize], Some(MInst::AndImm { src, imm: 7, .. } | MInst::AndImm32 { src, imm: 7, .. }) if *src == bit)
+            {
+                continue;
+            }
+            let maximum = !facts[bit.0 as usize].zero;
+            let size = match maximum {
+                8..=15 => OpSize::S16,
+                16..=31 => OpSize::S32,
+                32..=63 => OpSize::S64,
+                _ => continue,
+            };
+            if offset != envelope.offset() || size.bytes() as usize > envelope.byte_len() {
+                continue;
+            }
+            replacements.insert(
+                lhs,
+                MInst::Load {
+                    dst: lhs,
+                    base,
+                    offset,
+                    size,
+                },
+            );
+            replacements.insert(dst, MInst::Shr { dst, lhs, rhs: bit });
+        }
+    }
+    for block in &mut func.blocks {
+        for inst in &mut block.insts {
+            if let Some(replacement) = inst.def().and_then(|dst| replacements.remove(&dst)) {
+                if let MInst::Load { dst, .. } = replacement {
+                    func.spill_descs[dst.0 as usize] = SpillDesc::transient();
+                }
+                *inst = replacement;
+            }
+        }
+    }
+}
+
+pub(super) fn fold_demanded(func: &mut MFunction) {
+    let facts = analyze(func);
+    let demanded = demand_masks(func, &facts);
+    for block in &mut func.blocks {
+        for inst in &mut block.insts {
+            let Some(dst) = inst.def() else { continue };
+            let mask = demanded[dst.0 as usize];
+            let fact = facts[dst.0 as usize];
+            if mask != 0 && mask & !(fact.zero | fact.one) == 0 {
+                *inst = MInst::LoadImm {
+                    dst,
+                    value: fact.one & mask,
+                };
+                continue;
+            }
+            let copy = match *inst {
+                MInst::AndImm { src, imm, .. } if mask & !imm == 0 => Some(src),
+                MInst::AndImm32 { src, imm, .. } if mask & !u64::from(imm) == 0 => Some(src),
+                MInst::Mov32 { src, .. } if mask & !u64::from(u32::MAX) == 0 => Some(src),
+                MInst::OrImm { src, imm, .. } if mask & imm == 0 => Some(src),
+                MInst::Or { lhs, rhs, .. }
+                | MInst::Xor { lhs, rhs, .. }
+                | MInst::Or32 { lhs, rhs, .. }
+                | MInst::Xor32 { lhs, rhs, .. } => {
+                    let word_mask = if matches!(inst, MInst::Or32 { .. } | MInst::Xor32 { .. }) {
+                        u64::from(u32::MAX)
+                    } else {
+                        u64::MAX
+                    };
+                    if mask & !word_mask != 0 {
+                        None
+                    } else if mask & !facts[lhs.0 as usize].zero == 0 {
+                        Some(rhs)
+                    } else if mask & !facts[rhs.0 as usize].zero == 0 {
+                        Some(lhs)
+                    } else {
+                        None
+                    }
+                }
+                MInst::And { lhs, rhs, .. } | MInst::And32 { lhs, rhs, .. } => {
+                    if matches!(inst, MInst::And32 { .. }) && mask & !u64::from(u32::MAX) != 0 {
+                        None
+                    } else if mask & !facts[lhs.0 as usize].one == 0 {
+                        Some(rhs)
+                    } else if mask & !facts[rhs.0 as usize].one == 0 {
+                        Some(lhs)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
+            if let Some(src) = copy {
+                *inst = MInst::Mov { dst, src };
+            } else if mask & !u64::from(u32::MAX) == 0
+                || fact.zero & !u64::from(u32::MAX) == !u64::from(u32::MAX)
+            {
+                *inst = match *inst {
+                    MInst::And { dst, lhs, rhs } => MInst::And32 { dst, lhs, rhs },
+                    MInst::Or { dst, lhs, rhs } => MInst::Or32 { dst, lhs, rhs },
+                    MInst::Xor { dst, lhs, rhs } => MInst::Xor32 { dst, lhs, rhs },
+                    MInst::Add { dst, lhs, rhs } => MInst::Add32 { dst, lhs, rhs },
+                    MInst::Sub { dst, lhs, rhs } => MInst::Sub32 { dst, lhs, rhs },
+                    MInst::Mul { dst, lhs, rhs } => MInst::Mul32 { dst, lhs, rhs },
+                    MInst::AndImm { dst, src, imm } => MInst::AndImm32 {
+                        dst,
+                        src,
+                        imm: imm as u32,
+                    },
+                    _ => continue,
+                };
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn boolean_selects_preserve_nonzero_truth_and_full_width_arms() {
+        use crate::native::{
+            emit, features::X86Features, jit_mem::JitCode, mir_legalize, regalloc,
+        };
+        fn compile(mut function: MFunction) -> (JitCode, usize) {
+            mir_legalize::legalize(&mut function);
+            let allocation = regalloc::run_regalloc(&mut function).unwrap();
+            let emitted = emit::emit(
+                &function,
+                &allocation.assignment,
+                allocation.spill_frame_size,
+            )
+            .unwrap();
+            (
+                JitCode::new(&emitted.code).unwrap(),
+                emitted.required_state_size.max(128) as usize,
+            )
+        }
+        for normalized in [false, true] {
+            for bmi1 in [false, true] {
+                if bmi1 && !std::arch::is_x86_feature_detected!("bmi1") {
+                    continue;
+                }
+                let mut vregs = VRegAllocator::new();
+                for _ in 0..24 {
+                    vregs.alloc();
+                }
+                let mut original = MFunction::new(vregs, vec![SpillDesc::transient(); 24]);
+                original.target_features = X86Features::for_test(false).with_bmi1(bmi1);
+                let mut block = MBlock::new(BlockId(0));
+                for index in 0..3 {
+                    block.push(MInst::Load {
+                        dst: VReg(index),
+                        base: BaseReg::SimState,
+                        offset: index as i32 * 8,
+                        size: OpSize::S64,
+                    });
+                }
+                block.push(MInst::LoadImm {
+                    dst: VReg(3),
+                    value: 0,
+                });
+                block.push(MInst::LoadImm {
+                    dst: VReg(4),
+                    value: 1,
+                });
+                block.push(if normalized {
+                    MInst::AndImm {
+                        dst: VReg(5),
+                        src: VReg(0),
+                        imm: 1,
+                    }
+                } else {
+                    MInst::Mov {
+                        dst: VReg(5),
+                        src: VReg(0),
+                    }
+                });
+                block.push(MInst::AndImm {
+                    dst: VReg(6),
+                    src: VReg(1),
+                    imm: 1,
+                });
+                block.push(MInst::AndImm {
+                    dst: VReg(7),
+                    src: VReg(2),
+                    imm: 1,
+                });
+                let arms = [
+                    (3, 4),
+                    (4, 3),
+                    (6, 3),
+                    (4, 7),
+                    (3, 7),
+                    (6, 7),
+                    (1, 3),
+                    (4, 2),
+                    (3, 2),
+                ];
+                for (index, (a, b)) in arms.into_iter().enumerate() {
+                    let dst = VReg(8 + index as u32);
+                    block.push(MInst::Select {
+                        dst,
+                        cond: VReg(5),
+                        true_val: VReg(a),
+                        false_val: VReg(b),
+                    });
+                    block.push(MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 32 + index as i32 * 8,
+                        src: dst,
+                        size: OpSize::S64,
+                    });
+                }
+                block.push(MInst::Shl {
+                    dst: VReg(20),
+                    lhs: VReg(3),
+                    rhs: VReg(0),
+                });
+                block.push(MInst::Shr {
+                    dst: VReg(21),
+                    lhs: VReg(3),
+                    rhs: VReg(0),
+                });
+                block.push(MInst::Store {
+                    base: BaseReg::SimState,
+                    offset: 104,
+                    src: VReg(20),
+                    size: OpSize::S64,
+                });
+                block.push(MInst::Store {
+                    base: BaseReg::SimState,
+                    offset: 112,
+                    src: VReg(21),
+                    size: OpSize::S64,
+                });
+                block.push(MInst::Return);
+                original.push_block(block);
+                let mut optimized = original.clone();
+                fold(&mut optimized);
+                copy_propagate(&mut optimized);
+                dead_code_eliminate(&mut optimized);
+                optimized.verify();
+                let (before, before_size) = compile(original);
+                let (after, after_size) = compile(optimized);
+                let values = [
+                    0u64,
+                    1,
+                    2,
+                    3,
+                    31,
+                    32,
+                    63,
+                    64,
+                    65,
+                    1 << 32,
+                    1 << 63,
+                    u64::MAX,
+                ];
+                for condition in values {
+                    for a in values {
+                        for b in values {
+                            let mut left = vec![0u8; before_size.max(after_size)];
+                            for (index, value) in [condition, a, b].into_iter().enumerate() {
+                                left[index * 8..index * 8 + 8]
+                                    .copy_from_slice(&value.to_le_bytes());
+                            }
+                            let mut right = left.clone();
+                            assert_eq!(unsafe { before.call(&mut left) }, 0);
+                            assert_eq!(unsafe { after.call(&mut right) }, 0);
+                            assert_eq!(
+                                &left[32..120],
+                                &right[32..120],
+                                "normalized={normalized}, bmi1={bmi1}, condition={condition:#x}, a={a:#x}, b={b:#x}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn contains(facts: KnownBits, value: u64) -> bool {
+        facts.zero & value == 0 && facts.one & value == facts.one
+    }
+
+    #[test]
+    fn demanded_bits_keep_a_controlling_operand_when_both_sides_agree() {
+        use crate::native::{emit, jit_mem::JitCode, mir_legalize, regalloc};
+        let masks = [0, 1, 0xff00, 0x8000_0001, 0xffff_0000_ffff_0000, u64::MAX];
+        for is_or in [false, true] {
+            for word32 in [false, true] {
+                for left_mask in masks {
+                    for right_mask in masks {
+                        let mut vregs = VRegAllocator::new();
+                        for _ in 0..7 {
+                            vregs.alloc();
+                        }
+                        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 7]);
+                        let mut block = MBlock::new(BlockId(0));
+                        for index in 0..2 {
+                            block.push(MInst::Load {
+                                dst: VReg(index),
+                                base: BaseReg::SimState,
+                                offset: index as i32 * 8,
+                                size: OpSize::S64,
+                            });
+                        }
+                        for (index, value) in [(2, left_mask), (3, right_mask)] {
+                            block.push(MInst::LoadImm {
+                                dst: VReg(index),
+                                value,
+                            });
+                        }
+                        for (dst, lhs, rhs) in [
+                            (VReg(4), VReg(0), VReg(2)),
+                            (VReg(5), VReg(1), VReg(3)),
+                            (VReg(6), VReg(4), VReg(5)),
+                        ] {
+                            block.push(match (is_or, word32) {
+                                (false, false) => MInst::And { dst, lhs, rhs },
+                                (false, true) => MInst::And32 { dst, lhs, rhs },
+                                (true, false) => MInst::Or { dst, lhs, rhs },
+                                (true, true) => MInst::Or32 { dst, lhs, rhs },
+                            });
+                        }
+                        block.push(MInst::Store {
+                            base: BaseReg::SimState,
+                            offset: 16,
+                            src: VReg(6),
+                            size: OpSize::S64,
+                        });
+                        block.push(MInst::Return);
+                        function.push_block(block);
+                        for _ in 0..2 {
+                            fold_demanded(&mut function);
+                            copy_propagate(&mut function);
+                            dead_code_eliminate(&mut function);
+                        }
+                        function.verify();
+                        mir_legalize::legalize(&mut function);
+                        let allocation = regalloc::run_regalloc(&mut function).unwrap();
+                        let emitted = emit::emit(
+                            &function,
+                            &allocation.assignment,
+                            allocation.spill_frame_size,
+                        )
+                        .unwrap();
+                        let jit = JitCode::new(&emitted.code).unwrap();
+                        for bit in 0..64 {
+                            for inverted in [false, true] {
+                                let left = if inverted {
+                                    !(1u64 << bit)
+                                } else {
+                                    1u64 << bit
+                                };
+                                let right = left.rotate_left(17);
+                                let mut expected = if is_or {
+                                    left | left_mask | right | right_mask
+                                } else {
+                                    left & left_mask & right & right_mask
+                                };
+                                if word32 {
+                                    expected &= u64::from(u32::MAX);
+                                }
+                                let mut state =
+                                    vec![0u8; emitted.required_state_size.max(24) as usize];
+                                state[..8].copy_from_slice(&left.to_le_bytes());
+                                state[8..16].copy_from_slice(&right.to_le_bytes());
+                                assert_eq!(unsafe { jit.call(&mut state) }, 0);
+                                assert_eq!(
+                                    u64::from_le_bytes(state[16..24].try_into().unwrap()),
+                                    expected,
+                                    "or={is_or} word32={word32} left_mask={left_mask:#x} right_mask={right_mask:#x} bit={bit} inverted={inverted}"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn demanded_bits_preserve_generated_word_and_field_extractions() {
+        use crate::native::{emit, jit_mem::JitCode, mir_legalize, regalloc};
+        fn compile(mut function: MFunction, simplify: bool) -> JitCode {
+            mir_legalize::legalize(&mut function);
+            if simplify {
+                for _ in 0..2 {
+                    fold_demanded(&mut function);
+                    copy_propagate(&mut function);
+                    dead_code_eliminate(&mut function);
+                }
+                refresh_constant_spill_descs(&mut function);
+            }
+            function.verify();
+            let allocation = regalloc::run_regalloc(&mut function).unwrap();
+            let emitted = emit::emit(
+                &function,
+                &allocation.assignment,
+                allocation.spill_frame_size,
+            )
+            .unwrap();
+            JitCode::new(&emitted.code).unwrap()
+        }
+        fn random(seed: &mut u64) -> u64 {
+            *seed ^= *seed << 13;
+            *seed ^= *seed >> 7;
+            *seed ^= *seed << 17;
+            *seed
+        }
+        for case in 1..=24 {
+            let mut seed = case;
+            let mut vregs = VRegAllocator::new();
+            for _ in 0..40 {
+                vregs.alloc();
+            }
+            let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 40]);
+            let mut block = MBlock::new(BlockId(0));
+            for index in 0..3 {
+                block.push(MInst::Load {
+                    dst: VReg(index),
+                    base: BaseReg::SimState,
+                    offset: index as i32 * 8,
+                    size: OpSize::S64,
+                });
+            }
+            block.push(MInst::LoadImm {
+                dst: VReg(3),
+                value: u64::MAX,
+            });
+            for index in 4..32 {
+                let dst = VReg(index);
+                let lhs = VReg((random(&mut seed) % u64::from(index)) as u32);
+                let rhs = VReg((random(&mut seed) % u64::from(index)) as u32);
+                let shift = [0, 1, 7, 8, 15, 31, 32, 62, 63][(random(&mut seed) % 9) as usize];
+                block.push(match index % 13 {
+                    0 => MInst::And { dst, lhs, rhs },
+                    1 => MInst::And32 { dst, lhs, rhs },
+                    2 => MInst::Or { dst, lhs, rhs },
+                    3 => MInst::Or32 { dst, lhs, rhs },
+                    4 => MInst::Xor { dst, lhs, rhs },
+                    5 => MInst::Xor32 { dst, lhs, rhs },
+                    6 => MInst::ShlImm {
+                        dst,
+                        src: lhs,
+                        imm: shift,
+                    },
+                    7 => MInst::ShrImm {
+                        dst,
+                        src: lhs,
+                        imm: shift,
+                    },
+                    8 => MInst::AndImm32 {
+                        dst,
+                        src: lhs,
+                        imm: 0xff00_ff00,
+                    },
+                    9 => MInst::Mov32 { dst, src: lhs },
+                    10 => MInst::BitNot { dst, src: lhs },
+                    11 => MInst::Select {
+                        dst,
+                        cond: VReg(2),
+                        true_val: lhs,
+                        false_val: rhs,
+                    },
+                    _ => MInst::Add { dst, lhs, rhs },
+                });
+            }
+            // Observe different fields of shared graphs, and retain a complete
+            // 64-bit use so narrowing a second use cannot discard its upper bits.
+            for index in 0..8 {
+                block.push(MInst::ShrImm {
+                    dst: VReg(32 + index),
+                    src: VReg(31 - index / 2),
+                    imm: (index * 8) as u8,
+                });
+                block.push(MInst::Store {
+                    base: BaseReg::SimState,
+                    offset: 24 + index as i32 * 8,
+                    src: VReg(32 + index),
+                    size: [OpSize::S8, OpSize::S16, OpSize::S32, OpSize::S64][index as usize % 4],
+                });
+            }
+            block.push(MInst::Return);
+            function.push_block(block);
+            let reference = compile(function.clone(), false);
+            let optimized = compile(function, true);
+            for sample in 0..128 {
+                let mut expected = [0xa5u8; 88];
+                for lane in 0..3 {
+                    let value = if sample < 64 {
+                        1u64 << sample
+                    } else {
+                        random(&mut seed)
+                    };
+                    expected[lane * 8..lane * 8 + 8].copy_from_slice(&value.to_le_bytes());
+                }
+                if sample % 2 == 0 {
+                    expected[16..24].fill(0);
+                }
+                let mut actual = expected;
+                assert_eq!(unsafe { reference.call(&mut expected) }, 0);
+                assert_eq!(unsafe { optimized.call(&mut actual) }, 0);
+                assert_eq!(actual, expected, "case={case}, sample={sample}");
+            }
+        }
+    }
+
+    #[test]
+    fn demanded_bits_remove_unused_packed_fields() {
+        let mut vregs = VRegAllocator::new();
+        for _ in 0..6 {
+            vregs.alloc();
+        }
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 6]);
+        let mut block = MBlock::new(BlockId(0));
+        for index in 0..2 {
+            block.push(MInst::Load {
+                dst: VReg(index),
+                base: BaseReg::SimState,
+                offset: index as i32 * 8,
+                size: OpSize::S8,
+            });
+        }
+        block.push(MInst::ShlImm {
+            dst: VReg(2),
+            src: VReg(1),
+            imm: 8,
+        });
+        block.push(MInst::Or {
+            dst: VReg(3),
+            lhs: VReg(0),
+            rhs: VReg(2),
+        });
+        block.push(MInst::ShlImm {
+            dst: VReg(4),
+            src: VReg(3),
+            imm: 16,
+        });
+        block.push(MInst::ShrImm {
+            dst: VReg(5),
+            src: VReg(4),
+            imm: 16,
+        });
+        block.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 16,
+            src: VReg(5),
+            size: OpSize::S8,
+        });
+        block.push(MInst::Return);
+        function.push_block(block);
+        fold_demanded(&mut function);
+        copy_propagate(&mut function);
+        dead_code_eliminate(&mut function);
+        function.verify();
+        assert!(
+            !function.blocks[0]
+                .insts
+                .iter()
+                .any(|inst| matches!(inst, MInst::Load { offset: 8, .. } | MInst::Or { .. }))
+        );
+    }
+
+    #[test]
+    fn demanded_bits_reach_a_fixed_point_through_loop_phis() {
+        use crate::native::{emit, jit_mem::JitCode, regalloc};
+        let mut vregs = VRegAllocator::new();
+        for _ in 0..9 {
+            vregs.alloc();
+        }
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 9]);
+        let mut entry = MBlock::new(BlockId(0));
+        entry.push(MInst::Load {
+            dst: VReg(0),
+            base: BaseReg::SimState,
+            offset: 0,
+            size: OpSize::S64,
+        });
+        entry.push(MInst::Load {
+            dst: VReg(1),
+            base: BaseReg::SimState,
+            offset: 8,
+            size: OpSize::S8,
+        });
+        entry.push(MInst::Jump { target: BlockId(1) });
+        let mut header = MBlock::new(BlockId(1));
+        header.phis.push(PhiNode {
+            dst: VReg(2),
+            sources: vec![(BlockId(0), VReg(0)), (BlockId(2), VReg(7))],
+        });
+        header.phis.push(PhiNode {
+            dst: VReg(3),
+            sources: vec![(BlockId(0), VReg(1)), (BlockId(2), VReg(8))],
+        });
+        header.push(MInst::Branch {
+            cond: VReg(3),
+            true_bb: BlockId(2),
+            false_bb: BlockId(3),
+        });
+        let mut body = MBlock::new(BlockId(2));
+        body.push(MInst::ShlImm {
+            dst: VReg(5),
+            src: VReg(2),
+            imm: 8,
+        });
+        body.push(MInst::ShrImm {
+            dst: VReg(6),
+            src: VReg(2),
+            imm: 56,
+        });
+        body.push(MInst::Or {
+            dst: VReg(7),
+            lhs: VReg(5),
+            rhs: VReg(6),
+        });
+        body.push(MInst::SubImm {
+            dst: VReg(8),
+            src: VReg(3),
+            imm: 1,
+        });
+        body.push(MInst::Jump { target: BlockId(1) });
+        let mut exit = MBlock::new(BlockId(3));
+        exit.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 9,
+            src: VReg(2),
+            size: OpSize::S8,
+        });
+        exit.push(MInst::Return);
+        for block in [entry, header, exit, body] {
+            function.push_block(block);
+        }
+        fold_demanded(&mut function);
+        copy_propagate(&mut function);
+        dead_code_eliminate(&mut function);
+        function.verify();
+        let allocation = regalloc::run_regalloc(&mut function).unwrap();
+        let emitted = emit::emit(
+            &function,
+            &allocation.assignment,
+            allocation.spill_frame_size,
+        )
+        .unwrap();
+        let jit = JitCode::new(&emitted.code).unwrap();
+        let input = 0x0123_4567_89ab_cdefu64;
+        for rotations in 0..=16 {
+            let mut state = [0u8; 16];
+            state[..8].copy_from_slice(&input.to_le_bytes());
+            state[8] = rotations;
+            assert_eq!(unsafe { jit.call(&mut state) }, 0);
+            assert_eq!(state[9], input.rotate_left(u32::from(rotations) * 8) as u8);
+        }
+    }
+
+    #[test]
+    fn arithmetic_facts_cover_all_concrete_inputs_including_wrapping() {
+        // Exhaust every four-bit abstract input (zero, one, or unknown per
+        // bit). Move it across the 32/64-bit boundaries and exercise carries
+        // into and out of the fixed surrounding bits as well.
+        for shift in [0, 30, 60] {
+            for surrounding in [0, 0xaaaa_aaaa_aaaa_aaaa, u64::MAX] {
+                let inputs = (0..81)
+                    .map(|mut pattern| {
+                        let mut facts = KnownBits::constant(surrounding & !(15u64 << shift));
+                        for bit in shift..shift + 4 {
+                            match pattern % 3 {
+                                0 => facts.zero &= !(1 << bit),
+                                1 => {}
+                                2 => {
+                                    facts.zero &= !(1 << bit);
+                                    facts.one |= 1 << bit;
+                                }
+                                _ => unreachable!(),
+                            }
+                            pattern /= 3;
+                        }
+                        let values = (0..16)
+                            .map(|bits| (surrounding & !(15u64 << shift)) | (bits << shift))
+                            .filter(|&value| contains(facts, value))
+                            .collect::<Vec<_>>();
+                        (facts, values)
+                    })
+                    .collect::<Vec<_>>();
+                for (left, left_values) in &inputs {
+                    for (right, right_values) in &inputs {
+                        let sum = left.add(*right);
+                        let difference = left.add(right.not()).add(KnownBits::constant(1));
+                        let product = left.mul(*right);
+                        for &a in left_values {
+                            for &b in right_values {
+                                for (facts, value) in [
+                                    (sum, a.wrapping_add(b)),
+                                    (difference, a.wrapping_sub(b)),
+                                    (product, a.wrapping_mul(b)),
+                                    (left.and(*right), a & b),
+                                    (left.or(*right), a | b),
+                                    (left.xor(*right), a ^ b),
+                                ] {
+                                    assert_eq!(facts.zero & facts.one, 0);
+                                    assert!(
+                                        contains(facts, value),
+                                        "{left:?} {right:?} => {facts:?}, actual {value:#x}"
+                                    );
+                                    assert!(contains(
+                                        facts.truncate(u64::from(u32::MAX)),
+                                        value & u64::from(u32::MAX)
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_high_bits_do_not_hide_fixed_array_offset_bits() {
+        let index = KnownBits::default();
+        for stride in [8, 32, 288, 512, 1u64 << 63] {
+            for offset in [0, 9, 18, 163, u64::MAX] {
+                let address = index
+                    .mul(KnownBits::constant(stride))
+                    .add(KnownBits::constant(offset));
+                assert_eq!(
+                    address.and(KnownBits::constant(7)).value(),
+                    Some(offset & 7)
+                );
+                for index in [0, 1, 15, u64::MAX, u64::MAX / stride] {
+                    assert!(contains(
+                        address,
+                        index.wrapping_mul(stride).wrapping_add(offset)
+                    ));
+                }
+            }
+        }
+        // An odd stride can change every bit of the address.
+        assert_eq!(
+            index
+                .mul(KnownBits::constant(7))
+                .add(KnownBits::constant(163)),
+            KnownBits::default()
+        );
+    }
+
+    #[test]
+    fn immediate_shifts_preserve_fixed_bits_at_machine_boundaries() {
+        for value in [0, 1, 0x8000_0000_ffff_ffff, u64::MAX] {
+            for shift in [0, 1, 31, 32, 63, 64, 255] {
+                let facts = KnownBits::constant(value);
+                assert_eq!(
+                    facts.shl(shift).value(),
+                    Some(value.checked_shl(u32::from(shift)).unwrap_or(0))
+                );
+                assert_eq!(
+                    facts.shr(shift).value(),
+                    Some(value.checked_shr(u32::from(shift)).unwrap_or(0))
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn late_address_bits_fold_comparisons_and_selects_without_losing_wrapping() {
+        use crate::native::{emit, jit_mem::JitCode, mir_legalize, regalloc};
+
+        let mut vregs = VRegAllocator::new();
+        for _ in 0..10 {
+            vregs.alloc();
+        }
+        let mut func = MFunction::new(vregs, vec![SpillDesc::transient(); 10]);
+        let mut entry = MBlock::new(BlockId(0));
+        entry.push(MInst::Load {
+            dst: VReg(0),
+            base: BaseReg::SimState,
+            offset: 0,
+            size: OpSize::S64,
+        });
+        entry.push(MInst::LoadImm {
+            dst: VReg(1),
+            value: 288,
+        });
+        entry.push(MInst::Mul {
+            dst: VReg(2),
+            lhs: VReg(0),
+            rhs: VReg(1),
+        });
+        entry.push(MInst::AddImm {
+            dst: VReg(3),
+            src: VReg(2),
+            imm: 163,
+        });
+        entry.push(MInst::AndImm {
+            dst: VReg(4),
+            src: VReg(3),
+            imm: 7,
+        });
+        entry.push(MInst::Jump { target: BlockId(1) });
+        let mut body = MBlock::new(BlockId(1));
+        body.push(MInst::CmpImm {
+            dst: VReg(5),
+            lhs: VReg(4),
+            imm: 3,
+            kind: CmpKind::Eq,
+        });
+        body.push(MInst::Load {
+            dst: VReg(6),
+            base: BaseReg::SimState,
+            offset: 8,
+            size: OpSize::S64,
+        });
+        body.push(MInst::LoadImm {
+            dst: VReg(7),
+            value: 0xdead_beef,
+        });
+        body.push(MInst::Select {
+            dst: VReg(8),
+            cond: VReg(5),
+            true_val: VReg(6),
+            false_val: VReg(7),
+        });
+        body.push(MInst::Shl {
+            dst: VReg(9),
+            lhs: VReg(6),
+            rhs: VReg(4),
+        });
+        body.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 16,
+            src: VReg(8),
+            size: OpSize::S64,
+        });
+        body.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 24,
+            src: VReg(9),
+            size: OpSize::S64,
+        });
+        body.push(MInst::Return);
+        func.blocks = vec![entry, body];
+        fold(&mut func);
+        assert!(
+            !func
+                .blocks
+                .iter()
+                .flat_map(|b| &b.insts)
+                .any(|inst| matches!(inst, MInst::CmpImm { .. } | MInst::Select { .. }))
+        );
+        mir_legalize::legalize(&mut func);
+        optimize(&mut func);
+        let ra = regalloc::run_regalloc(&mut func).unwrap();
+        post_regalloc_peephole(&mut func, &ra.assignment);
+        let emitted = emit::emit(&func, &ra.assignment, ra.spill_frame_size).unwrap();
+        let jit = JitCode::new(&emitted.code).unwrap();
+        for input in [0u64, 1, u64::MAX / 288, 1 << 63, u64::MAX] {
+            for value in [0u64, 7, 0xdead_beef, u64::MAX] {
+                let mut state = vec![0u8; emitted.required_state_size.max(32) as usize];
+                state[..8].copy_from_slice(&input.to_le_bytes());
+                state[8..16].copy_from_slice(&value.to_le_bytes());
+                assert_eq!(unsafe { jit.call(&mut state) }, 0);
+                assert_eq!(u64::from_le_bytes(state[16..24].try_into().unwrap()), value);
+                assert_eq!(
+                    u64::from_le_bytes(state[24..32].try_into().unwrap()),
+                    value << 3
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn comparison_bounds_preserve_unknown_signs_and_overlapping_ranges() {
+        let mut cases = Vec::new();
+        for free in [1u64, 7, 0xff, 0xf000_0000, 1 << 63, (1 << 63) | 7] {
+            for fixed in [0u64, u64::MAX, 1 << 31, 1 << 63] {
+                let fixed = fixed & !free;
+                let facts = KnownBits {
+                    zero: !(fixed | free),
+                    one: fixed,
+                };
+                let mut values = vec![fixed, fixed | free];
+                for bit in 0..64 {
+                    if free & (1 << bit) != 0 {
+                        values.push(fixed | (1 << bit));
+                        values.push(fixed | (free & !(1 << bit)));
+                    }
+                }
+                cases.push((facts, values));
+            }
+        }
+        for (left, lhs_values) in &cases {
+            for (right, rhs_values) in &cases {
+                for kind in [
+                    CmpKind::Eq,
+                    CmpKind::Ne,
+                    CmpKind::LtU,
+                    CmpKind::LeU,
+                    CmpKind::GtU,
+                    CmpKind::GeU,
+                    CmpKind::LtS,
+                    CmpKind::LeS,
+                    CmpKind::GtS,
+                    CmpKind::GeS,
+                ] {
+                    let result = left.compare(*right, kind);
+                    for &lhs in lhs_values {
+                        for &rhs in rhs_values {
+                            let value = match kind {
+                                CmpKind::Eq => lhs == rhs,
+                                CmpKind::Ne => lhs != rhs,
+                                CmpKind::LtU => lhs < rhs,
+                                CmpKind::LeU => lhs <= rhs,
+                                CmpKind::GtU => lhs > rhs,
+                                CmpKind::GeU => lhs >= rhs,
+                                CmpKind::LtS => (lhs as i64) < (rhs as i64),
+                                CmpKind::LeS => (lhs as i64) <= (rhs as i64),
+                                CmpKind::GtS => (lhs as i64) > (rhs as i64),
+                                CmpKind::GeS => (lhs as i64) >= (rhs as i64),
+                            };
+                            assert!(
+                                contains(result, u64::from(value)),
+                                "kind={kind:?} lhs={lhs:#x} rhs={rhs:#x}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn comparison_facts_preserve_signedness_and_unknown_bits() {
+        for lhs in [0u64, 1, 1 << 31, 1 << 63, u64::MAX] {
+            for rhs in [0u64, 1, 1 << 31, 1 << 63, u64::MAX] {
+                for (kind, expected) in [
+                    (CmpKind::Eq, lhs == rhs),
+                    (CmpKind::Ne, lhs != rhs),
+                    (CmpKind::LtU, lhs < rhs),
+                    (CmpKind::LeU, lhs <= rhs),
+                    (CmpKind::GtU, lhs > rhs),
+                    (CmpKind::GeU, lhs >= rhs),
+                    (CmpKind::LtS, (lhs as i64) < (rhs as i64)),
+                    (CmpKind::LeS, (lhs as i64) <= (rhs as i64)),
+                    (CmpKind::GtS, (lhs as i64) > (rhs as i64)),
+                    (CmpKind::GeS, (lhs as i64) >= (rhs as i64)),
+                ] {
+                    assert_eq!(
+                        KnownBits::constant(lhs)
+                            .compare(KnownBits::constant(rhs), kind)
+                            .value(),
+                        Some(u64::from(expected))
+                    );
+                }
+            }
+        }
+        let low_clear = KnownBits { zero: 1, one: 0 };
+        let low_set = KnownBits { zero: 0, one: 1 };
+        assert_eq!(low_clear.compare(low_set, CmpKind::Eq).value(), Some(0));
+        assert_eq!(low_clear.compare(low_set, CmpKind::Ne).value(), Some(1));
+        assert_eq!(low_clear.compare(low_set, CmpKind::LtU).value(), None);
+        assert_eq!(low_clear.truth(), None);
+        assert_eq!(low_set.truth(), Some(true));
+    }
+
+    #[test]
+    fn optimized_array_address_arithmetic_executes_with_wrapping_and_narrow_inputs() {
+        use crate::native::{emit, jit_mem::JitCode, mir_legalize, regalloc};
+
+        for size in [OpSize::S32, OpSize::S64] {
+            for factor in [0u64, 7, 8, 32, 288, 1 << 63] {
+                for addend in [0i32, 9, 163, -9] {
+                    let mut vregs = VRegAllocator::new();
+                    for _ in 0..8 {
+                        vregs.alloc();
+                    }
+                    let mut func = MFunction::new(vregs, vec![SpillDesc::transient(); 8]);
+                    let mut block = MBlock::new(BlockId(0));
+                    block.push(MInst::Load {
+                        dst: VReg(0),
+                        base: BaseReg::SimState,
+                        offset: 0,
+                        size,
+                    });
+                    block.push(MInst::LoadImm {
+                        dst: VReg(1),
+                        value: factor,
+                    });
+                    block.push(MInst::Mul {
+                        dst: VReg(2),
+                        lhs: VReg(0),
+                        rhs: VReg(1),
+                    });
+                    block.push(MInst::AddImm {
+                        dst: VReg(3),
+                        src: VReg(2),
+                        imm: addend,
+                    });
+                    block.push(MInst::ShrImm {
+                        dst: VReg(4),
+                        src: VReg(3),
+                        imm: 3,
+                    });
+                    block.push(MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 8,
+                        src: VReg(4),
+                        size: OpSize::S64,
+                    });
+                    block.push(MInst::AndImm {
+                        dst: VReg(5),
+                        src: VReg(3),
+                        imm: 7,
+                    });
+                    block.push(MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 16,
+                        src: VReg(5),
+                        size: OpSize::S64,
+                    });
+                    block.push(MInst::LoadImm {
+                        dst: VReg(6),
+                        value: 0xfedc_ba98_7654_3210,
+                    });
+                    block.push(MInst::Shr {
+                        dst: VReg(7),
+                        lhs: VReg(6),
+                        rhs: VReg(5),
+                    });
+                    block.push(MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 24,
+                        src: VReg(7),
+                        size: OpSize::S64,
+                    });
+                    block.push(MInst::Return);
+                    func.push_block(block);
+                    mir_legalize::legalize(&mut func);
+                    optimize(&mut func);
+                    let allocation = regalloc::run_regalloc(&mut func).unwrap();
+                    let emitted =
+                        emit::emit(&func, &allocation.assignment, allocation.spill_frame_size)
+                            .unwrap();
+                    let jit = JitCode::new(&emitted.code).unwrap();
+                    for input in [0u64, 1, 15, u32::MAX as u64, u64::MAX / 32, u64::MAX] {
+                        let mut state = [0u8; 32];
+                        state[..8].copy_from_slice(&input.to_le_bytes());
+                        let source = input & machine_width_mask(size);
+                        let address = source.wrapping_mul(factor).wrapping_add(addend as u64);
+                        assert_eq!(unsafe { jit.call(&mut state) }, 0);
+                        for (offset, expected) in [
+                            (8, address >> 3),
+                            (16, address & 7),
+                            (24, 0xfedc_ba98_7654_3210 >> (address & 7)),
+                        ] {
+                            assert_eq!(
+                                u64::from_le_bytes(state[offset..offset + 8].try_into().unwrap()),
+                                expected,
+                                "{size:?}: ({input:#x} * {factor:#x} + {addend}), output {offset}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn folds_fixed_offset_bits_across_blocks_but_keeps_distinct_phi_inputs() {
+        let mut vregs = VRegAllocator::new();
+        for _ in 0..8 {
+            vregs.alloc();
+        }
+        let mut func = MFunction::new(vregs, vec![SpillDesc::transient(); 8]);
+        let mut entry = MBlock::new(BlockId(0));
+        entry.push(MInst::Load {
+            dst: VReg(0),
+            base: BaseReg::SimState,
+            offset: 0,
+            size: OpSize::S64,
+        });
+        entry.push(MInst::LoadImm {
+            dst: VReg(1),
+            value: 288,
+        });
+        entry.push(MInst::Mul {
+            dst: VReg(2),
+            lhs: VReg(0),
+            rhs: VReg(1),
+        });
+        entry.push(MInst::Branch {
+            cond: VReg(0),
+            true_bb: BlockId(1),
+            false_bb: BlockId(2),
+        });
+        let mut left = MBlock::new(BlockId(1));
+        left.push(MInst::AddImm {
+            dst: VReg(3),
+            src: VReg(2),
+            imm: 163,
+        });
+        left.push(MInst::AndImm {
+            dst: VReg(4),
+            src: VReg(3),
+            imm: 7,
+        });
+        left.push(MInst::Jump { target: BlockId(3) });
+        let mut right = MBlock::new(BlockId(2));
+        right.push(MInst::LoadImm {
+            dst: VReg(5),
+            value: 5,
+        });
+        right.push(MInst::Jump { target: BlockId(3) });
+        let mut exit = MBlock::new(BlockId(3));
+        exit.phis.push(PhiNode {
+            dst: VReg(6),
+            sources: vec![(BlockId(1), VReg(4)), (BlockId(2), VReg(5))],
+        });
+        exit.push(MInst::AndImm {
+            dst: VReg(7),
+            src: VReg(6),
+            imm: 1,
+        });
+        exit.push(MInst::Return);
+        // Deliberately visit the consumer before the defining predecessor.
+        for block in [entry, exit, left, right] {
+            func.push_block(block);
+        }
+        let facts = analyze(&func);
+        assert_eq!(facts[4].value(), Some(3));
+        assert_eq!(facts[6].value(), None);
+        assert_eq!(facts[7].value(), Some(1));
+        fold(&mut func);
+        assert!(matches!(
+            func.blocks[2].insts[1],
+            MInst::LoadImm {
+                dst: VReg(4),
+                value: 3
+            }
+        ));
+    }
+}

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/loop_guard.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/loop_guard.rs
@@ -1,0 +1,438 @@
+//! Defer an expensive, private boolean operand until its guard passes.
+
+use super::*;
+
+pub(super) fn movable(inst: &MInst) -> bool {
+    matches!(
+        inst,
+        MInst::LoadImm { .. }
+            | MInst::Mov { .. }
+            | MInst::Mov32 { .. }
+            | MInst::Load {
+                base: BaseReg::SimState,
+                ..
+            }
+            | MInst::LoadIndexed {
+                base: BaseReg::SimState,
+                ..
+            }
+            | MInst::Add { .. }
+            | MInst::Add32 { .. }
+            | MInst::AddImm { .. }
+            | MInst::Sub { .. }
+            | MInst::Sub32 { .. }
+            | MInst::SubImm { .. }
+            | MInst::Mul { .. }
+            | MInst::Mul32 { .. }
+            | MInst::And { .. }
+            | MInst::And32 { .. }
+            | MInst::AndImm { .. }
+            | MInst::AndImm32 { .. }
+            | MInst::Or { .. }
+            | MInst::Or32 { .. }
+            | MInst::OrImm { .. }
+            | MInst::Xor { .. }
+            | MInst::Xor32 { .. }
+            | MInst::BitNot { .. }
+            | MInst::Neg { .. }
+            | MInst::Shl { .. }
+            | MInst::ShlImm { .. }
+            | MInst::Shr { .. }
+            | MInst::ShrImm { .. }
+            | MInst::Sar { .. }
+            | MInst::SarImm { .. }
+            | MInst::Cmp { .. }
+            | MInst::CmpImm { .. }
+            | MInst::Select { .. }
+            | MInst::CmpSelect { .. }
+            | MInst::CmpImmSelect { .. }
+    )
+}
+
+pub(super) fn private_operand(block: &MBlock, operand: VReg, uses: &[usize]) -> Vec<usize> {
+    let mut needed = HashMap::<VReg, usize>::default();
+    needed.insert(operand, 1);
+    let mut selected = Vec::new();
+    for (position, inst) in block.insts.iter().enumerate().rev() {
+        let Some(dst) = inst.def() else { continue };
+        if needed.get(&dst).copied() != Some(uses[dst.0 as usize]) || !movable(inst) {
+            continue;
+        }
+        selected.push(position);
+        for source in inst.uses() {
+            *needed.entry(source).or_default() += 1;
+        }
+    }
+    selected.reverse();
+    selected
+}
+
+pub(super) fn run(func: &mut MFunction) {
+    let facts = known_bits::known_zeros(func);
+    let positions = func
+        .blocks
+        .iter()
+        .enumerate()
+        .map(|(index, block)| (block.id, index))
+        .collect::<HashMap<_, _>>();
+    let successors = func
+        .blocks
+        .iter()
+        .map(|block| {
+            block
+                .successors()
+                .into_iter()
+                .map(|target| positions[&target])
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let Ok(cfg) = celox_analysis::cfg::ForwardControlFlowGraph::analyze(successors, 0) else {
+        return;
+    };
+    let mut headers = HashSet::default();
+    for (predecessor, block) in func.blocks.iter().enumerate() {
+        for target in block.successors() {
+            if cfg.dominators.dominates(positions[&target], predecessor) {
+                headers.insert(target);
+            }
+        }
+    }
+    let mut uses = vec![0usize; func.vregs.count() as usize];
+    for block in &func.blocks {
+        for phi in &block.phis {
+            for &(_, source) in &phi.sources {
+                uses[source.0 as usize] += 1;
+            }
+        }
+        for inst in &block.insts {
+            for source in inst.uses() {
+                uses[source.0 as usize] += 1;
+            }
+        }
+    }
+    let Some(mut next_id) = func
+        .blocks
+        .iter()
+        .map(|block| block.id.0)
+        .max()
+        .and_then(|id| id.checked_add(1))
+    else {
+        return;
+    };
+    let mut index = 0;
+    while index < func.blocks.len() {
+        let block = &func.blocks[index];
+        index += 1;
+        if !headers.contains(&block.id) {
+            continue;
+        }
+        let Some(&MInst::Branch {
+            cond,
+            true_bb,
+            false_bb,
+        }) = block.terminator()
+        else {
+            continue;
+        };
+        if true_bb == false_bb || uses[cond.0 as usize] != 1 {
+            continue;
+        }
+        let Some((condition_position, condition)) = block
+            .insts
+            .iter()
+            .enumerate()
+            .find(|(_, inst)| inst.def() == Some(cond))
+        else {
+            continue;
+        };
+        let (lhs, rhs, is_and) = match condition {
+            MInst::And { lhs, rhs, .. } | MInst::And32 { lhs, rhs, .. } => (*lhs, *rhs, true),
+            MInst::Or { lhs, rhs, .. } | MInst::Or32 { lhs, rhs, .. } => (*lhs, *rhs, false),
+            _ => continue,
+        };
+        if lhs == rhs
+            || (!is_and
+                && [lhs, rhs]
+                    .iter()
+                    .any(|source| !facts[source.0 as usize] & !1 != 0))
+        {
+            continue;
+        }
+        let mut best = None;
+        for (guard, delayed) in [(lhs, rhs), (rhs, lhs)] {
+            let selected = private_operand(block, delayed, &uses);
+            let cost = selected
+                .iter()
+                .filter(|&&position| {
+                    !matches!(
+                        block.insts[position],
+                        MInst::LoadImm { .. } | MInst::Mov { .. } | MInst::Mov32 { .. }
+                    )
+                })
+                .count();
+            if cost < 6 {
+                continue;
+            }
+            let first = selected[0];
+            // Loads must not pass a write, call, or other observable operation.
+            if block.insts[first..block.insts.len() - 1]
+                .iter()
+                .any(|inst| !movable(inst))
+            {
+                continue;
+            }
+            if best
+                .as_ref()
+                .is_none_or(|(_, _, _, previous)| cost > *previous)
+            {
+                best = Some((guard, delayed, selected, cost));
+            }
+        }
+        let Some((guard, delayed, selected, _)) = best else {
+            continue;
+        };
+        let Some(following_id) = next_id.checked_add(1) else {
+            return;
+        };
+        let new_id = BlockId(next_id);
+        next_id = following_id;
+        let old_id = block.id;
+        let deferred_condition = block.insts[condition_position].clone();
+        let bypass = if is_and { false_bb } else { true_bb };
+        let block = &mut func.blocks[index - 1];
+        let original = std::mem::take(&mut block.insts);
+        let mut deferred = MBlock::new(new_id);
+        let mut positions = selected.into_iter().peekable();
+        let last = original.len() - 1;
+        for (position, inst) in original.into_iter().enumerate() {
+            if positions.peek() == Some(&position) {
+                positions.next();
+                deferred.push(inst);
+            } else if position != condition_position && position != last {
+                block.push(inst);
+            }
+        }
+        block.push(MInst::Branch {
+            cond: guard,
+            true_bb: if is_and { new_id } else { true_bb },
+            false_bb: if is_and { false_bb } else { new_id },
+        });
+        if is_and {
+            deferred.push(deferred_condition);
+        }
+        deferred.push(MInst::Branch {
+            cond: if is_and { cond } else { delayed },
+            true_bb,
+            false_bb,
+        });
+        for successor in &mut func.blocks {
+            if successor.id != true_bb && successor.id != false_bb {
+                continue;
+            }
+            for phi in &mut successor.phis {
+                if let Some(row) = phi.sources.iter_mut().find(|(pred, _)| *pred == old_id) {
+                    if successor.id == bypass {
+                        let source = row.1;
+                        phi.sources.push((new_id, source));
+                    } else {
+                        row.0 = new_id;
+                    }
+                }
+            }
+        }
+        func.push_block(deferred);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::{emit, jit_mem::JitCode, mir_legalize, regalloc};
+
+    fn fixture(is_and: bool, word32: bool, barrier: u8) -> MFunction {
+        let mut vregs = VRegAllocator::new();
+        for _ in 0..32 {
+            vregs.alloc();
+        }
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 32]);
+        let mut entry = MBlock::new(BlockId(0));
+        entry.push(MInst::LoadImm {
+            dst: VReg(0),
+            value: 0,
+        });
+        entry.push(MInst::Jump { target: BlockId(1) });
+        let mut header = MBlock::new(BlockId(1));
+        header.phis.push(PhiNode {
+            dst: VReg(1),
+            sources: vec![(BlockId(0), VReg(0)), (BlockId(4), VReg(25))],
+        });
+        header.phis.push(PhiNode {
+            dst: VReg(2),
+            sources: vec![(BlockId(0), VReg(0)), (BlockId(4), VReg(24))],
+        });
+        header.push(MInst::Load {
+            dst: VReg(3),
+            base: BaseReg::SimState,
+            offset: 0,
+            size: OpSize::S64,
+        });
+        let guard = if is_and {
+            VReg(3)
+        } else {
+            header.push(MInst::AndImm {
+                dst: VReg(4),
+                src: VReg(3),
+                imm: 1,
+            });
+            VReg(4)
+        };
+        header.push(MInst::Load {
+            dst: VReg(5),
+            base: BaseReg::SimState,
+            offset: 8,
+            size: OpSize::S64,
+        });
+        for next in 6..20 {
+            header.push(MInst::AddImm {
+                dst: VReg(next),
+                src: VReg(next - 1),
+                imm: next as i32,
+            });
+        }
+        header.push(MInst::AndImm {
+            dst: VReg(20),
+            src: VReg(19),
+            imm: if is_and { 3 } else { 1 },
+        });
+        if barrier == 1 {
+            header.push(MInst::MemFill {
+                dst_offset: 8,
+                byte_len: 8,
+                value: 0xa5,
+            });
+        }
+        header.push(match (is_and, word32) {
+            (true, false) => MInst::And {
+                dst: VReg(21),
+                lhs: guard,
+                rhs: VReg(20),
+            },
+            (true, true) => MInst::And32 {
+                dst: VReg(21),
+                lhs: guard,
+                rhs: VReg(20),
+            },
+            (false, false) => MInst::Or {
+                dst: VReg(21),
+                lhs: guard,
+                rhs: VReg(20),
+            },
+            (false, true) => MInst::Or32 {
+                dst: VReg(21),
+                lhs: guard,
+                rhs: VReg(20),
+            },
+        });
+        header.push(MInst::Branch {
+            cond: VReg(21),
+            true_bb: BlockId(2),
+            false_bb: BlockId(3),
+        });
+        let mut hit = MBlock::new(BlockId(2));
+        hit.push(MInst::AddImm {
+            dst: VReg(23),
+            src: VReg(2),
+            imm: 1,
+        });
+        if barrier == 2 {
+            hit.push(MInst::Store {
+                base: BaseReg::SimState,
+                offset: 24,
+                src: VReg(20),
+                size: OpSize::S64,
+            });
+        }
+        hit.push(MInst::Jump { target: BlockId(4) });
+        let mut miss = MBlock::new(BlockId(3));
+        miss.push(MInst::Jump { target: BlockId(4) });
+        let mut latch = MBlock::new(BlockId(4));
+        latch.phis.push(PhiNode {
+            dst: VReg(24),
+            sources: vec![(BlockId(2), VReg(23)), (BlockId(3), VReg(2))],
+        });
+        latch.push(MInst::AddImm {
+            dst: VReg(25),
+            src: VReg(1),
+            imm: 1,
+        });
+        latch.push(MInst::CmpImm {
+            dst: VReg(26),
+            lhs: VReg(25),
+            imm: 4,
+            kind: CmpKind::LtU,
+        });
+        latch.push(MInst::Branch {
+            cond: VReg(26),
+            true_bb: BlockId(1),
+            false_bb: BlockId(5),
+        });
+        let mut exit = MBlock::new(BlockId(5));
+        exit.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 16,
+            src: VReg(24),
+            size: OpSize::S64,
+        });
+        exit.push(MInst::Return);
+        function.blocks = vec![entry, header, hit, miss, latch, exit];
+        function
+    }
+
+    fn compile(mut function: MFunction) -> (JitCode, usize) {
+        mir_legalize::legalize(&mut function);
+        let allocation = regalloc::run_regalloc(&mut function).unwrap();
+        let code = emit::emit(
+            &function,
+            &allocation.assignment,
+            allocation.spill_frame_size,
+        )
+        .unwrap();
+        (
+            JitCode::new(&code.code).unwrap(),
+            code.required_state_size.max(32) as usize,
+        )
+    }
+
+    #[test]
+    fn guarded_loops_preserve_bitwise_conditions_phis_and_memory_order() {
+        for is_and in [false, true] {
+            for word32 in [false, true] {
+                for barrier in 0..3 {
+                    let original = fixture(is_and, word32, barrier);
+                    original.verify();
+                    let mut optimized = original.clone();
+                    run(&mut optimized);
+                    optimized.verify();
+                    assert_eq!(optimized.blocks.len(), if barrier == 0 { 7 } else { 6 });
+                    let (before, before_size) = compile(original);
+                    let (after, after_size) = compile(optimized);
+                    for guard in [0u64, 1, 2, 3, 1 << 32, 1 << 63, u64::MAX] {
+                        for seed in [0u64, 1, 2, 3, 0xdead_beef, u64::MAX] {
+                            let mut left = vec![0u8; before_size.max(after_size)];
+                            left[..8].copy_from_slice(&guard.to_le_bytes());
+                            left[8..16].copy_from_slice(&seed.to_le_bytes());
+                            let mut right = left.clone();
+                            assert_eq!(unsafe { before.call(&mut left) }, 0);
+                            assert_eq!(unsafe { after.call(&mut right) }, 0);
+                            assert_eq!(
+                                &left[..32],
+                                &right[..32],
+                                "and={is_and}, word32={word32}, barrier={barrier}, guard={guard:#x}, seed={seed:#x}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/memory_forward_tests.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/memory_forward_tests.rs
@@ -1,0 +1,399 @@
+use super::*;
+use crate::native::{emit, jit_mem::JitCode, mir_legalize, regalloc};
+
+#[test]
+fn indexed_dead_stores_preserve_intervening_observers() {
+    for size in [OpSize::S8, OpSize::S16, OpSize::S32, OpSize::S64] {
+        for bounded in [false, true] {
+            for effect in 0..12 {
+                let mut vregs = VRegAllocator::new();
+                for _ in 0..6 {
+                    vregs.alloc();
+                }
+                let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 6]);
+                let mut block = MBlock::new(BlockId(0));
+                for (dst, offset) in [(VReg(0), 0), (VReg(1), 8), (VReg(2), 16)] {
+                    block.push(MInst::Load {
+                        dst,
+                        base: BaseReg::SimState,
+                        offset,
+                        size: OpSize::S64,
+                    });
+                }
+                block.push(MInst::LoadImm {
+                    dst: VReg(3),
+                    value: 0,
+                });
+                let envelope = bounded.then(|| MemoryAliasRange::new(64, 32).unwrap());
+                block.push(MInst::StoreIndexed {
+                    base: BaseReg::SimState,
+                    offset: 64,
+                    index: VReg(1),
+                    src: VReg(0),
+                    size,
+                    alias_range: if effect == 11 {
+                        MemoryAliasRange::new(64, 40)
+                    } else {
+                        envelope
+                    },
+                });
+                match effect {
+                    1 | 2 => block.push(MInst::Load {
+                        dst: VReg(4),
+                        base: BaseReg::SimState,
+                        offset: if effect == 1 { 96 } else { 64 },
+                        size: OpSize::S64,
+                    }),
+                    3..=5 => block.push(MInst::LoadIndexed {
+                        dst: VReg(4),
+                        base: BaseReg::SimState,
+                        offset: if effect == 3 { 96 } else { 64 },
+                        index: VReg(1),
+                        scale: 1,
+                        size,
+                        alias_range: match effect {
+                            3 => MemoryAliasRange::new(96, 32),
+                            4 => envelope,
+                            _ => None,
+                        },
+                    }),
+                    6 => block.push(MInst::OrStoreIndexed {
+                        base: BaseReg::SimState,
+                        offset: 64,
+                        index: VReg(1),
+                        src: VReg(0),
+                        size,
+                        alias_range: envelope,
+                    }),
+                    7 => block.push(MInst::MemCopy {
+                        dst_offset: 128,
+                        src_offset: 64,
+                        byte_len: 32,
+                    }),
+                    8 => block.push(MInst::MemFill {
+                        dst_offset: 64,
+                        byte_len: 32,
+                        value: 0xa5,
+                    }),
+                    _ => {}
+                }
+                if (1..=5).contains(&effect) {
+                    block.push(MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 32,
+                        src: VReg(4),
+                        size: OpSize::S64,
+                    });
+                }
+                block.push(MInst::StoreIndexed {
+                    base: BaseReg::SimState,
+                    offset: 64,
+                    index: if effect == 9 { VReg(2) } else { VReg(1) },
+                    src: VReg(3),
+                    size: if effect == 10 && size != OpSize::S8 {
+                        OpSize::S8
+                    } else {
+                        size
+                    },
+                    alias_range: envelope,
+                });
+                block.push(MInst::Return);
+                function.push_block(block);
+                let mut optimized = function.clone();
+                eliminate_redundant_local_stores(&mut optimized);
+                dead_code_eliminate(&mut optimized);
+                optimized.verify();
+                let removed = matches!(effect, 0 | 8)
+                    || bounded && matches!(effect, 1 | 3)
+                    || effect == 10 && size == OpSize::S8;
+                assert_eq!(
+                    optimized.blocks[0]
+                        .insts
+                        .iter()
+                        .filter(|inst| matches!(inst, MInst::StoreIndexed { .. }))
+                        .count(),
+                    if removed { 1 } else { 2 },
+                    "size={size:?} bounded={bounded} effect={effect}"
+                );
+                let compile = |mut function: MFunction| {
+                    mir_legalize::legalize(&mut function);
+                    let allocation = regalloc::run_regalloc(&mut function).unwrap();
+                    let emitted = emit::emit(
+                        &function,
+                        &allocation.assignment,
+                        allocation.spill_frame_size,
+                    )
+                    .unwrap();
+                    (
+                        JitCode::new(&emitted.code).unwrap(),
+                        emitted.required_state_size.max(160) as usize,
+                    )
+                };
+                let (before, before_size) = compile(function);
+                let (after, after_size) = compile(optimized);
+                for input in [0u64, 1, 0x0123_4567_89ab_cdef, u64::MAX] {
+                    for index in [0u64, 1, 8, 16] {
+                        let mut left = vec![0x69u8; before_size.max(after_size)];
+                        left[..8].copy_from_slice(&input.to_le_bytes());
+                        left[8..16].copy_from_slice(&index.to_le_bytes());
+                        left[16..24].copy_from_slice(&(16 - index).to_le_bytes());
+                        let mut right = left.clone();
+                        assert_eq!(unsafe { before.call(&mut left) }, 0);
+                        assert_eq!(unsafe { after.call(&mut right) }, 0);
+                        assert_eq!(
+                            &left[..160],
+                            &right[..160],
+                            "size={size:?} bounded={bounded} effect={effect} input={input:#x} index={index}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn live_partial_forwarding_preserves_bytes_across_widths_and_aliases() {
+    for wide in [OpSize::S16, OpSize::S32, OpSize::S64] {
+        for narrow in [OpSize::S8, OpSize::S16, OpSize::S32] {
+            if narrow.bytes() >= wide.bytes() {
+                continue;
+            }
+            for displacement in 0..=wide.bytes() - narrow.bytes() {
+                for effect in 0..5 {
+                    let mut vregs = VRegAllocator::new();
+                    for _ in 0..5 {
+                        vregs.alloc();
+                    }
+                    let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 5]);
+                    let mut block = MBlock::new(BlockId(0));
+                    block.push(MInst::Load {
+                        dst: VReg(0),
+                        base: BaseReg::SimState,
+                        offset: 0,
+                        size: OpSize::S64,
+                    });
+                    block.push(MInst::LoadImm {
+                        dst: VReg(1),
+                        value: 0,
+                    });
+                    block.push(MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 64 + displacement as i32,
+                        src: VReg(0),
+                        size: narrow,
+                    });
+                    // Reading the bytes before the final observation must not
+                    // make a forwarded store disappear from observable state.
+                    block.push(MInst::Load {
+                        dst: VReg(2),
+                        base: BaseReg::SimState,
+                        offset: 64,
+                        size: wide,
+                    });
+                    let (offset, alias_range) = match effect {
+                        1 | 4 => (80, MemoryAliasRange::new(80, 8)),
+                        _ => (64, None),
+                    };
+                    match effect {
+                        1 | 2 => block.push(MInst::MemFill {
+                            dst_offset: offset,
+                            byte_len: 1,
+                            value: 0xa5,
+                        }),
+                        3 | 4 => block.push(MInst::StoreIndexed {
+                            base: BaseReg::SimState,
+                            offset,
+                            index: VReg(1),
+                            src: VReg(0),
+                            size: OpSize::S8,
+                            alias_range,
+                        }),
+                        _ => {}
+                    }
+                    block.push(MInst::Load {
+                        dst: VReg(3),
+                        base: BaseReg::SimState,
+                        offset: 64,
+                        size: wide,
+                    });
+                    for (source, offset) in [(VReg(2), 16), (VReg(3), 24)] {
+                        block.push(MInst::Store {
+                            base: BaseReg::SimState,
+                            offset,
+                            src: source,
+                            size: OpSize::S64,
+                        });
+                    }
+                    block.push(MInst::Return);
+                    function.push_block(block);
+                    forward_live_partial_stores(&mut function);
+                    known_bits::fold(&mut function);
+                    for _ in 0..2 {
+                        known_bits::fold_demanded(&mut function);
+                        algebraic_simplify(&mut function);
+                        copy_propagate(&mut function);
+                        dead_code_eliminate(&mut function);
+                    }
+                    function.verify();
+                    mir_legalize::legalize(&mut function);
+                    let allocation = regalloc::run_regalloc(&mut function).unwrap();
+                    let emitted = emit::emit(
+                        &function,
+                        &allocation.assignment,
+                        allocation.spill_frame_size,
+                    )
+                    .unwrap();
+                    let jit = JitCode::new(&emitted.code).unwrap();
+                    for input in [0u64, 1, 0x0123_4567_89ab_cdef, u64::MAX] {
+                        let mut state = vec![0x69u8; emitted.required_state_size.max(96) as usize];
+                        state[..8].copy_from_slice(&input.to_le_bytes());
+                        let mut expected = state.clone();
+                        let start = 64 + displacement as usize;
+                        expected[start..start + narrow.bytes() as usize]
+                            .copy_from_slice(&input.to_le_bytes()[..narrow.bytes() as usize]);
+                        let observed = |state: &[u8]| {
+                            let mut bytes = [0u8; 8];
+                            bytes[..wide.bytes() as usize]
+                                .copy_from_slice(&state[64..64 + wide.bytes() as usize]);
+                            bytes
+                        };
+                        let first = observed(&expected);
+                        match effect {
+                            1 | 2 => expected[offset as usize] = 0xa5,
+                            3 | 4 => expected[offset as usize] = input as u8,
+                            _ => {}
+                        }
+                        let second = observed(&expected);
+                        expected[16..24].copy_from_slice(&first);
+                        expected[24..32].copy_from_slice(&second);
+                        assert_eq!(unsafe { jit.call(&mut state) }, 0);
+                        assert_eq!(
+                            &state[..96],
+                            &expected[..96],
+                            "wide={wide:?} narrow={narrow:?} displacement={displacement} effect={effect} input={input:#x}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn local_forwarding_preserves_narrow_values_and_physical_write_effects() {
+    for size in [OpSize::S8, OpSize::S16, OpSize::S32, OpSize::S64] {
+        for effect in 0..5 {
+            let mut vregs = VRegAllocator::new();
+            for _ in 0..5 {
+                vregs.alloc();
+            }
+            let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 5]);
+            let mut block = MBlock::new(BlockId(0));
+            block.push(MInst::Load {
+                dst: VReg(0),
+                base: BaseReg::SimState,
+                offset: 0,
+                size: OpSize::S64,
+            });
+            block.push(MInst::LoadImm {
+                dst: VReg(1),
+                value: 0x9876_dead_bacd_a321,
+            });
+            block.push(MInst::LoadImm {
+                dst: VReg(2),
+                value: 0,
+            });
+            block.push(MInst::Store {
+                base: BaseReg::SimState,
+                offset: 8,
+                src: VReg(0),
+                size,
+            });
+            let observer = match effect {
+                0 => MInst::LoadIndexed {
+                    dst: VReg(4),
+                    base: BaseReg::SimState,
+                    offset: 24,
+                    index: VReg(2),
+                    scale: 1,
+                    size: OpSize::S64,
+                    alias_range: MemoryAliasRange::new(24, 8),
+                },
+                1..=3 => MInst::StoreIndexed {
+                    base: BaseReg::SimState,
+                    offset: if effect == 1 { 24 } else { 8 },
+                    index: VReg(2),
+                    src: VReg(1),
+                    size,
+                    alias_range: match effect {
+                        1 => MemoryAliasRange::new(24, 8),
+                        2 => MemoryAliasRange::new(8, 8),
+                        _ => None,
+                    },
+                },
+                _ => MInst::MemFill {
+                    dst_offset: 8,
+                    byte_len: 8,
+                    value: 0xa5,
+                },
+            };
+            block.push(observer);
+            block.push(MInst::Load {
+                dst: VReg(3),
+                base: BaseReg::SimState,
+                offset: 8,
+                size,
+            });
+            block.push(MInst::Store {
+                base: BaseReg::SimState,
+                offset: 32,
+                src: VReg(3),
+                size: OpSize::S64,
+            });
+            if effect == 0 {
+                block.push(MInst::Store {
+                    base: BaseReg::SimState,
+                    offset: 40,
+                    src: VReg(4),
+                    size: OpSize::S64,
+                });
+            }
+            block.push(MInst::Return);
+            function.push_block(block);
+            forward_local_store_loads(&mut function);
+            function.verify();
+            assert_eq!(
+                function.blocks[0]
+                    .insts
+                    .iter()
+                    .any(|inst| matches!(inst, MInst::Load { dst: VReg(3), .. })),
+                effect >= 2
+            );
+            mir_legalize::legalize(&mut function);
+            let allocation = regalloc::run_regalloc(&mut function).unwrap();
+            let code = emit::emit(
+                &function,
+                &allocation.assignment,
+                allocation.spill_frame_size,
+            )
+            .unwrap();
+            let jit = JitCode::new(&code.code).unwrap();
+            for input in [0u64, 1, 0x1234_5678_9abc_def0, u64::MAX] {
+                let mut state = vec![0u8; code.required_state_size.max(48) as usize];
+                state[..8].copy_from_slice(&input.to_le_bytes());
+                assert_eq!(unsafe { jit.call(&mut state) }, 0);
+                let expected = match effect {
+                    0 | 1 => input,
+                    2 | 3 => 0x9876_dead_bacd_a321,
+                    _ => 0xa5a5_a5a5_a5a5_a5a5,
+                } & machine_width_mask(size);
+                assert_eq!(
+                    u64::from_le_bytes(state[32..40].try_into().unwrap()),
+                    expected,
+                    "size={size:?}, effect={effect}, input={input:#x}"
+                );
+            }
+        }
+    }
+}

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/pipeline.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/pipeline.rs
@@ -64,12 +64,19 @@ fn run_high_pressure_pipeline(runner: &mut PassRunner<'_>) {
             "promote_partial_store_round_trips",
             promote_partial_store_round_trips,
         );
+        if iteration == 0 {
+            runner.run(
+                "early_forward_live_partial_stores",
+                forward_live_partial_stores,
+            );
+        }
         runner.run("forward_local_store_loads", forward_local_store_loads);
         runner.run(
             "eliminate_redundant_local_stores",
             eliminate_redundant_local_stores,
         );
         runner.run("algebraic_simplify", algebraic_simplify);
+        runner.run("fold_known_bits", known_bits::fold);
         runner.run("redundant_mask_eliminate", redundant_mask_eliminate);
         runner.run("fold_bit_toggle_insert", fold_bit_toggle_insert);
         // Expose target-rematerializable one-source operations to the final
@@ -79,12 +86,14 @@ fn run_high_pressure_pipeline(runner: &mut PassRunner<'_>) {
         // the carry/rematerialize choice to allocation.
         if iteration == 1 {
             runner.run("pre_gvn_lower_to_imm_forms", lower_to_imm_forms);
+            runner.run("pre_gvn_fold_known_bits", known_bits::fold);
             runner.run("post_imm_fold_proven_comparisons", fold_proven_comparisons);
         }
         runner.run("global_gvn", global_gvn);
         runner.run("dead_code_eliminate", dead_code_eliminate);
     }
     runner.run("fold_boolean_normalizations", fold_boolean_normalizations);
+    runner.run("fold_known_bits", known_bits::fold);
     runner.run("redundant_mask_eliminate", redundant_mask_eliminate);
     runner.run("copy_propagate", copy_propagate);
     runner.run("dead_code_eliminate", dead_code_eliminate);
@@ -116,6 +125,7 @@ fn run_low_pressure_pipeline(runner: &mut PassRunner<'_>) {
         eliminate_redundant_local_stores,
     );
     runner.run("algebraic_simplify", algebraic_simplify);
+    runner.run("fold_known_bits", known_bits::fold);
     runner.run("redundant_mask_eliminate", redundant_mask_eliminate);
     runner.run("fold_bit_toggle_insert", fold_bit_toggle_insert);
     runner.run("eliminate_redundant_or_terms", eliminate_redundant_or_terms);
@@ -126,6 +136,7 @@ fn run_low_pressure_pipeline(runner: &mut PassRunner<'_>) {
     runner.run("lower_to_imm_forms", lower_to_imm_forms);
     runner.run("post_imm_fold_proven_comparisons", fold_proven_comparisons);
     runner.run("fold_boolean_normalizations", fold_boolean_normalizations);
+    runner.run("fold_known_bits", known_bits::fold);
     runner.run("redundant_mask_eliminate", redundant_mask_eliminate);
     runner.run("copy_propagate", copy_propagate);
     runner.run("dead_code_eliminate", dead_code_eliminate);
@@ -161,6 +172,8 @@ fn run_final_pipeline(runner: &mut PassRunner<'_>) {
     runner.run("final_copy_propagate", copy_propagate);
     runner.run("final_constant_fold", constant_fold);
     runner.run("final_lower_to_imm_forms", lower_to_imm_forms);
+    runner.run("fold_masked_selects", boolean::fold_masked_selects);
+    runner.run("fold_zero_conjunctions", boolean::fold_zero_conjunctions);
     runner.run(
         "fold_reconstructed_bit_partitions",
         fold_reconstructed_bit_partitions,
@@ -169,20 +182,60 @@ fn run_final_pipeline(runner: &mut PassRunner<'_>) {
         "fold_relocated_bit_copy_groups",
         fold_relocated_bit_copy_groups,
     );
+    for _ in 0..2 {
+        runner.run("fold_demanded_bits", known_bits::fold_demanded);
+        runner.run("demanded_copy_propagate", copy_propagate);
+        runner.run("demanded_dead_code_eliminate", dead_code_eliminate);
+    }
     runner.run("post_lower_algebraic_simplify", algebraic_simplify);
     runner.run("post_lower_copy_propagate", copy_propagate);
     runner.run(
         "fold_contiguous_memory_copies",
         fold_contiguous_memory_copies,
     );
-    runner.run("fold_scaled_indexed_loads", fold_scaled_indexed_loads);
+    runner.run("fold_indexed_load_addresses", fold_indexed_load_addresses);
     runner.run(
         "fold_late_serial_and_immediates",
         fold_late_serial_and_immediates,
     );
     runner.run("final_dead_code_eliminate", dead_code_eliminate);
+    runner.run("reuse_loop_trip_counters", counted_loop::run);
+    runner.run("fold_packed_bit_loads", known_bits::fold_packed_bit_loads);
+    runner.run(
+        "hoist_invariant_loop_loads",
+        counted_loop::hoist_invariant_loads,
+    );
+    runner.run("fold_circular_bitmap_scans", circular_scan::run);
+    runner.run("skip_empty_bitmap_lanes", bitmap_worklist::run);
+    runner.run("dispatch_exclusive_loop_predicates", exclusive_loop::run);
+    runner.run("guard_expensive_loop_predicates", loop_guard::run);
+    runner.run("merge_repeated_branch_diamonds", branch_merge::run);
+    runner.run(
+        "fold_inverted_conjunctions",
+        boolean::fold_inverted_conjunctions,
+    );
     runner.run("simplify_cfg", simplify_cfg);
+    runner.run("forward_live_partial_stores", forward_live_partial_stores);
+    runner.run("post_forward_known_bits", known_bits::fold);
+    for _ in 0..2 {
+        runner.run("post_forward_demanded_bits", known_bits::fold_demanded);
+        runner.run("post_forward_algebraic_simplify", algebraic_simplify);
+        runner.run("post_forward_copy_propagate", copy_propagate);
+        runner.run("post_forward_dead_code_eliminate", dead_code_eliminate);
+    }
+    runner.run("post_cfg_global_gvn", global_gvn);
+    runner.run("post_cfg_copy_propagate", copy_propagate);
+    runner.run(
+        "post_cfg_eliminate_redundant_local_stores",
+        eliminate_redundant_local_stores,
+    );
     runner.run("post_cfg_dead_code_eliminate", dead_code_eliminate);
+    runner.run(
+        "balance_private_bitwise_trees",
+        boolean::balance_private_bitwise_trees,
+    );
+    runner.run("balanced_copy_propagate", copy_propagate);
+    runner.run("balanced_dead_code_eliminate", dead_code_eliminate);
     // CFG simplification concatenates linear blocks. Re-place constants only
     // after that concatenation, otherwise a block-local constant can acquire a
     // very long artificial live range in the merged block.

--- a/crates/celox-backend-x86/src/backend/native/regalloc/assignment.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/assignment.rs
@@ -176,6 +176,20 @@ pub fn clobbers(inst: &MInst) -> &'static [PhysReg] {
     }
 }
 
+/// Reserved state-base registers do not consume allocator capacity. The
+/// worklist caches the same state pointer in R15 on both target strategies;
+/// only the segment-base strategy makes R15 an allocatable value to evict.
+pub(super) fn allocatable_clobber_count(inst: &MInst, func: &MFunction) -> usize {
+    clobbers(inst)
+        .iter()
+        .filter(|&&register| {
+            register != PhysReg::R15
+                || func.target_features.state_base()
+                    != crate::native::features::StateBaseStrategy::R15
+        })
+        .count()
+}
+
 /// Returns true if the instruction is a register-register shift (needs RCX).
 pub fn is_reg_shift(inst: &MInst) -> bool {
     matches!(

--- a/crates/celox-backend-x86/src/backend/native/regalloc/pressure.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/pressure.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use crate::native::mir::{BlockId, MFunction, VReg};
 
 use super::analysis::AnalysisResult;
-use super::assignment::{RegConstraint, clobbers, use_constraints};
+use super::assignment::{RegConstraint, use_constraints};
 
 #[derive(Debug)]
 pub(super) struct PressureError {
@@ -93,7 +93,7 @@ pub(super) fn verify(
                 )?;
             }
 
-            let clobbered = clobbers(inst).len();
+            let clobbered = super::assignment::allocatable_clobber_count(inst, func);
             if clobbered != 0 {
                 let live_through = live_before.intersection(&live_after).count();
                 check(

--- a/crates/celox-backend-x86/src/backend/native/regalloc/spill_plan.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/spill_plan.rs
@@ -6,7 +6,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use crate::HashMap;
 use crate::native::mir::{BlockId, MFunction, MInst, PackedStateHome, VReg};
 
-use super::assignment::clobbers;
 use super::cfg::NormalizedCfg;
 use super::next_use::{NextUseAnalysis, NextUseDistance};
 use super::reload::{EdgeUse, PlanningRecipes, PointUse, ReloadRecipeAnalysis, ResolvedRecipe};
@@ -1713,7 +1712,7 @@ impl<'a> BlockTransitionPlanner<'a> {
         future_uses: &impl FutureUses,
     ) -> Result<(), SpillPlanError> {
         let block_id = self.func.blocks[self.block].id;
-        let clobbered = clobbers(inst).len();
+        let clobbered = super::assignment::allocatable_clobber_count(inst, self.func);
         if clobbered > self.registers {
             return Err(SpillPlanError::new(
                 "SPILL_PLAN.CLOBBER_CAPACITY",

--- a/crates/celox-backend-x86/src/backend/native/sparse_write_state.rs
+++ b/crates/celox-backend-x86/src/backend/native/sparse_write_state.rs
@@ -180,8 +180,13 @@ fn finish_zero_fill_group(
             .get(&object)
             .is_some_and(|sparse| sparse.chunk_count > 1)
     };
-    // A single native chunk already has a cheaper dedicated lowering.
-    if logical_width == 0 || !multiple_native_chunks || candidates.is_empty() {
+    let padded_array = layout
+        .unpacked_arrays
+        .get(&object)
+        .is_some_and(|array| array.element_stride * 8 != array.element_width);
+    // A contiguous single chunk has a cheap scalar store. A padded array
+    // would otherwise expand into a read/modify/write for every element.
+    if logical_width == 0 || (!multiple_native_chunks && !padded_array) || candidates.is_empty() {
         return;
     }
 

--- a/crates/celox-sir/src/lib.rs
+++ b/crates/celox-sir/src/lib.rs
@@ -816,6 +816,16 @@ pub fn collect_exact_zero_registers<A>(
                 continue;
             };
             if expanded {
+                // Repeated zero bits may have been lowered to a mux between
+                // all ones and all zeros. An exact-zero condition selects
+                // only the else arm, even in four-state execution.
+                if let SIRInstruction::Mux(_, condition, _, else_value) = instruction
+                    && result.get(condition) == Some(&true)
+                {
+                    result.insert(register, result.get(else_value) == Some(&true));
+                    visiting.remove(&register);
+                    continue;
+                }
                 let mut all_zero = true;
                 let count = visit_exact_zero_dependencies(instruction, |dependency| {
                     all_zero &= result.get(&dependency) == Some(&true);
@@ -846,6 +856,10 @@ pub fn collect_exact_zero_registers<A>(
                 work.pop();
                 result.insert(register, false);
                 visiting.remove(&register);
+            } else if let SIRInstruction::Mux(_, condition, ..) = instruction
+                && !result.contains_key(condition)
+            {
+                work.push((*condition, false));
             }
         }
     }
@@ -853,6 +867,51 @@ pub fn collect_exact_zero_registers<A>(
         .into_iter()
         .filter_map(|(register, zero)| zero.then_some(register))
         .collect()
+}
+
+#[cfg(test)]
+mod exact_zero_tests {
+    use super::*;
+
+    #[test]
+    fn zero_mux_condition_selects_else_without_assuming_unknown_conditions() {
+        let r = RegisterId;
+        let unit = ExecutionUnit::<()> {
+            entry_block_id: BlockId(0),
+            blocks: [(
+                BlockId(0),
+                BasicBlock {
+                    id: BlockId(0),
+                    params: vec![],
+                    instructions: vec![
+                        SIRInstruction::Imm(r(0), SIRValue::new(0u8)),
+                        SIRInstruction::Imm(r(1), SIRValue::new(1u8)),
+                        SIRInstruction::Imm(
+                            r(2),
+                            SIRValue {
+                                payload: 1u8.into(),
+                                mask: 1u8.into(),
+                            },
+                        ),
+                        SIRInstruction::Mux(r(3), r(0), r(1), r(0)),
+                        SIRInstruction::Mux(r(4), r(1), r(0), r(1)),
+                        SIRInstruction::Mux(r(5), r(2), r(1), r(0)),
+                        SIRInstruction::Mux(r(6), r(2), r(0), r(0)),
+                        SIRInstruction::Mux(r(7), r(3), r(1), r(0)),
+                    ],
+                    terminator: SIRTerminator::Return,
+                },
+            )]
+            .into_iter()
+            .collect(),
+            register_map: (0..8)
+                .map(|id| (r(id), RegisterType::Logic { width: 1 }))
+                .collect(),
+        };
+        unit.verify();
+        let zeros = collect_exact_zero_registers(&unit, [r(3), r(4), r(5), r(6), r(7)]);
+        assert_eq!(zeros, [r(0), r(3), r(6), r(7)].into_iter().collect());
+    }
 }
 
 #[cfg(test)]

--- a/crates/celox/src/backend/memory_layout.rs
+++ b/crates/celox/src/backend/memory_layout.rs
@@ -71,7 +71,9 @@ fn declared_strided_array_layouts(
         }
         let element_width = metadata.width / element_count;
         let element_bytes = get_byte_size(element_width);
-        let element_stride = element_bytes;
+        // Native scalar accesses and x86 scaled addressing use power-of-two
+        // widths. Padding also keeps a partial last byte inside its element.
+        let element_stride = element_bytes.next_power_of_two();
         layouts.insert(
             address,
             UnpackedArrayLayout {
@@ -93,7 +95,7 @@ fn supports_strided_access(
     layout: UnpackedArrayLayout,
     offset: &SIROffset,
     width: usize,
-    whole_object_transfer: bool,
+    bulk_transfer: bool,
 ) -> bool {
     match offset {
         SIROffset::Element {
@@ -108,23 +110,27 @@ fn supports_strided_access(
         }
         SIROffset::Static(start) => {
             let physically_contiguous = layout.element_stride * 8 == layout.element_width;
-            let whole = *start == 0 && width == layout.element_width * layout.element_count;
+            let bounded_transfer = start
+                .checked_add(width)
+                .is_some_and(|end| end <= layout.element_width * layout.element_count);
             let single_element = start
                 .checked_add(width.saturating_sub(1))
                 .is_some_and(|end| *start / layout.element_width == end / layout.element_width);
-            physically_contiguous || single_element || (whole_object_transfer && whole)
+            physically_contiguous || single_element || (bulk_transfer && bounded_transfer)
         }
         SIROffset::PackedElements {
             bit_offset,
             element_width,
         } => {
-            let whole = *bit_offset == 0 && width == layout.element_width * layout.element_count;
+            let bounded_transfer = bit_offset
+                .checked_add(width)
+                .is_some_and(|end| end <= layout.element_width * layout.element_count);
             *element_width == layout.element_width
                 && ((layout.element_stride * 8 == layout.element_width
                     && bit_offset
                         .checked_add(width)
                         .is_some_and(|end| end <= layout.element_width * layout.element_count))
-                    || (whole_object_transfer && whole))
+                    || (bulk_transfer && bounded_transfer))
         }
         SIROffset::Dynamic(_) => false,
     }
@@ -150,12 +156,12 @@ pub(crate) fn collect_strided_array_layouts(
         let mut check = |addr: &crate::ir::RegionedAbsoluteAddr,
                          offset: &SIROffset,
                          width: usize,
-                         whole_object_transfer: bool| {
+                         bulk_transfer: bool| {
             let abs = addr.absolute_addr();
             let Some(layout) = candidates.get(&abs).copied() else {
                 return;
             };
-            if !supports_strided_access(layout, offset, width, whole_object_transfer) {
+            if !supports_strided_access(layout, offset, width, bulk_transfer) {
                 candidates.remove(&abs);
             }
         };
@@ -188,6 +194,9 @@ pub(crate) fn collect_strided_array_layouts(
         .chain(program.sir.eval_only_ffs.values().flatten())
         .chain(program.sir.apply_ffs.values().flatten())
     {
+        // Zero resets may be coalesced or split at native word boundaries.
+        // Strided access expansion handles each logical range, and the native
+        // zero-fill planner can combine a complete reset into a physical fill.
         let mut zero_roots = eu
             .blocks
             .values()
@@ -197,8 +206,8 @@ pub(crate) fn collect_strided_array_layouts(
                     if matches!(
                         address.region,
                         STABLE_REGION | crate::ir::SPARSE_WORKING_REGION
-                    ) && offset.constant_bit_offset() == Some(0)
-                        && *width > 64 =>
+                    ) && offset.constant_bit_offset().is_some()
+                        && *width != 0 =>
                 {
                     Some(*source)
                 }
@@ -259,7 +268,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn padded_array_accepts_only_semantic_whole_object_transfers() {
+    fn padded_array_accepts_only_semantic_bulk_transfers() {
         let layout = UnpackedArrayLayout {
             element_width: 51,
             element_count: 4096,
@@ -280,10 +289,22 @@ mod tests {
             whole_width,
             true,
         ));
-        assert!(!supports_strided_access(
+        assert!(supports_strided_access(
             layout,
             &SIROffset::Static(51),
             whole_width - 51,
+            true,
+        ));
+        assert!(!supports_strided_access(
+            layout,
+            &SIROffset::Static(51),
+            whole_width,
+            true,
+        ));
+        assert!(!supports_strided_access(
+            layout,
+            &SIROffset::Static(usize::MAX),
+            whole_width,
             true,
         ));
     }
@@ -330,13 +351,22 @@ mod tests {
             32,
             true,
         ));
-        assert!(!supports_strided_access(
+        assert!(supports_strided_access(
             padded,
             &SIROffset::PackedElements {
                 bit_offset: 1,
                 element_width: 1,
             },
             31,
+            true,
+        ));
+        assert!(!supports_strided_access(
+            padded,
+            &SIROffset::PackedElements {
+                bit_offset: 1,
+                element_width: 1,
+            },
+            32,
             true,
         ));
     }

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -40,11 +40,13 @@ const NATIVE_FEATURE_AVX: u8 = 1 << 1;
 const NATIVE_FEATURE_FS_STATE_BASE: u8 = 1 << 2;
 const NATIVE_FEATURE_GS_STATE_BASE: u8 = 1 << 3;
 const NATIVE_FEATURE_POPCNT: u8 = 1 << 4;
+const NATIVE_FEATURE_BMI1: u8 = 1 << 5;
 const KNOWN_NATIVE_FEATURES: u8 = NATIVE_FEATURE_BMI2
     | NATIVE_FEATURE_AVX
     | NATIVE_FEATURE_FS_STATE_BASE
     | NATIVE_FEATURE_GS_STATE_BASE
-    | NATIVE_FEATURE_POPCNT;
+    | NATIVE_FEATURE_POPCNT
+    | NATIVE_FEATURE_BMI1;
 
 fn current_native_feature_bits() -> u8 {
     #[cfg(any(
@@ -65,6 +67,9 @@ fn current_native_feature_bits() -> u8 {
 
 fn format_native_feature_bits(bits: u8) -> String {
     let mut names = Vec::new();
+    if bits & NATIVE_FEATURE_BMI1 != 0 {
+        names.push("BMI1");
+    }
     if bits & NATIVE_FEATURE_BMI2 != 0 {
         names.push("BMI2");
     }

--- a/crates/celox/tests/native_exec.rs
+++ b/crates/celox/tests/native_exec.rs
@@ -7,6 +7,111 @@
 use celox::{MemoryLayout, MemoryLayoutMode, OptimizedSir, Simulator, SimulatorBuilder};
 
 #[test]
+fn zero_reset_keeps_narrow_arrays_strided_and_preserves_dynamic_ff_writes() {
+    for width in [1, 3, 7, 8, 17, 24, 33, 51, 57] {
+        for four_state in [false, true] {
+            for opt_level in [celox::OptLevel::O0, celox::OptLevel::O2] {
+                let code = format!(
+                    r#"
+                    module Top (
+                        clk: input clock, clear: input logic, write: input logic,
+                        index: input logic<3>, probe: input logic<3>,
+                        d: input logic<{width}>, q: output logic<{width}>,
+                        old: output logic<{width}>, low: output logic, high: output logic,
+                    ) {{
+                        var lanes: logic<{width}> [8];
+                        always_ff (clk) {{
+                            old = lanes[index];
+                            if clear {{
+                                for i in 0..8 {{ lanes[i] = '0; }}
+                            }} else if write {{
+                                lanes[index] = d;
+                            }}
+                        }}
+                        assign q = lanes[probe];
+                        assign low = q[0];
+                        assign high = q[{high_bit}];
+                    }}
+                    "#,
+                    high_bit = width - 1,
+                );
+                let result = SimulatorBuilder::new(&code, "Top")
+                    .four_state(four_state)
+                    .opt_level(opt_level)
+                    .trace_post_optimized_sir()
+                    .build_with_trace();
+                let mut sim = result.res.unwrap();
+                let program = result.trace.post_optimized_sir.unwrap();
+                let layout =
+                    MemoryLayout::build(&program, four_state, MemoryLayoutMode::ElementStrided);
+                let address = program.get_addr(&[], &["lanes"]).unwrap();
+                assert!(
+                    layout.unpacked_arrays.contains_key(&address),
+                    "zero reset must permit strided storage: width={width}, four_state={four_state}, opt={opt_level:?}"
+                );
+
+                let clk = sim.event("clk");
+                let clear = sim.signal("clear");
+                let write = sim.signal("write");
+                let index = sim.signal("index");
+                let probe = sim.signal("probe");
+                let d = sim.signal("d");
+                let q = sim.signal("q");
+                let old = sim.signal("old");
+                let low = sim.signal("low");
+                let high = sim.signal("high");
+                let full = (1u64 << width) - 1;
+                // Reset again after dirty writes, including unknown bits, so
+                // the whole-object fill must clear every physical lane/plane.
+                for round in 0..2 {
+                    sim.modify(|io| io.set(clear, 1u8)).unwrap();
+                    sim.tick(clk).unwrap();
+                    let mut expected = [(0u64, 0u64); 8];
+                    for lane in 0..8 {
+                        sim.modify(|io| io.set(probe, lane as u8)).unwrap();
+                        assert_eq!(sim.get_four_state(q), (0u8.into(), 0u8.into()));
+                    }
+                    sim.modify(|io| {
+                        io.set(clear, 0u8);
+                        io.set(write, 1u8);
+                    })
+                    .unwrap();
+                    for lane in [7, 0, 4, 2, 6, 1, 5, 3, 7] {
+                        let mask = if four_state {
+                            ((lane as u64 ^ round) | ((lane as u64 & 1) << (width - 1))) & full
+                        } else {
+                            0
+                        };
+                        let value = ((full ^ lane as u64 ^ round) | mask) & full;
+                        sim.modify(|io| {
+                            io.set(index, lane as u8);
+                            io.set_four_state(d, value.into(), mask.into());
+                        })
+                        .unwrap();
+                        sim.tick(clk).unwrap();
+                        let (old_value, old_mask) = expected[lane];
+                        assert_eq!(sim.get_four_state(old), (old_value.into(), old_mask.into()));
+                        expected[lane] = (value, mask);
+                        for (lane, &(value, mask)) in expected.iter().enumerate() {
+                            sim.modify(|io| io.set(probe, lane as u8)).unwrap();
+                            assert_eq!(sim.get_four_state(q), (value.into(), mask.into()));
+                            assert_eq!(
+                                sim.get_four_state(low),
+                                ((value & 1).into(), (mask & 1).into())
+                            );
+                            assert_eq!(
+                                sim.get_four_state(high),
+                                ((value >> (width - 1)).into(), (mask >> (width - 1)).into())
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
 fn native_compilation_can_be_initialized_later() {
     let code = r#"
         module Top (o: output logic<8>) {

--- a/crates/celox/tests/native_exec.rs
+++ b/crates/celox/tests/native_exec.rs
@@ -278,7 +278,8 @@ fn compile_and_run_inner(
     let emit_result = {
         use celox::native_backend::emit;
 
-        emit::emit_prepared_eu(eu, &layout, false, "native_exec", false, None).expect("emit failed")
+        emit::emit_prepared_eu(eu, &layout, false, "native_exec", false, None, || false)
+            .expect("emit failed")
     };
 
     if debug {
@@ -740,6 +741,7 @@ fn test_debug_let_bitslice_write() {
             "native_exec_debug",
             false,
             None,
+            || false,
         )
         .expect("emit failed");
         println!(


### PR DESCRIPTION
Restore the x86 Heliodor optimizations with correct padded array accesses on both native backends. ARM64 treated aggregate loads and stores as contiguous memory even when logical elements occupied separate padded slots, corrupting state during Linux boot. Both backends also need to remove padding bits from static element loads before concatenation or recording a known bit width.

This reapplies #764, reverted in #766, with these correctness fixes:

- Split ARM64 static and packed aggregate accesses at element boundaries before instruction selection and sparse-write planning.
- Mask padding in ARM64 and x86 static scalar element loads. Without the x86 mask, concatenating two 24-bit elements with nonzero slot padding produces `0x6543ff123456` instead of `0x654321123456`.
- Execute an ARM64 regression covering 88 combinations of widths, two/four-state values, partial/packed accesses, and stable/sparse FF storage, plus an x86 regression with 28 width/state combinations and deliberately nonzero padding.
- Run the existing `native_exec` suite in ARM64 CI, including array resets and dynamic FF writes. Update its two ARM64 helpers for the current cancellation callback argument.

## Performance

Remeasured after the x86 padding fix: Ryzen 7 9800X3D, WSL2 x86_64, CPU 12 affinity, release/LTO runners, native O2/two-state versus Veryl 0.21.0 synchronous AOT-C/GCC 13.3. Each trial compiles from source; execution timing excludes compilation.

| Pair | Celox execution (s) | veryl-cc execution (s) |
| --- | ---: | ---: |
| 1 | 16.201157 | 15.898168 |
| 2 | 15.624636 | 16.277854 |
| 3 | 15.391261 | 15.264241 |
| 4 | 17.123511 | 16.471446 |
| 5 | 16.085284 | 15.985855 |
| **Median** | **16.085284** | **15.985855** |

Celox's median is **0.62% longer** in this run. All ten Linux boots pass with `cy=87cda0 x3=aa pass=1`. The runners alternate order between pairs; no trial was excluded under the preselected SMT-utilization and wall/CPU-time criteria.

## Validation

- Actual AArch64 binaries under QEMU 8.2.2/Cortex-A53: **32 backend tests and 156 facade/integration tests pass**, with one existing ignored test.
- Compile the pinned Heliodor source with the AArch64 runner, then execute its native image under QEMU: **Linux boot passes**, `cy=87cda0 x3=aa pass=1`. Heliodor revision `a78d04730cf2b37c616e039b4a5bd437c1cfd355`, `heliodor-dev` profile, native O2/two-state.
- The ARM64 fix also passes [Linux boot on ubuntu-24.04-arm](https://github.com/celox-sim/celox/actions/runs/34089677329/job/101640602430) and the ARM64 backend CI suite.
- After the x86 mask fix: **545 x86 backend tests and 95 facade/integration tests pass**, with five existing ignored tests. The ARM64 backend also passed 31 code-generation tests on the x86 host.
- Clippy with warnings denied on host and AArch64, workspace checks, formatting, whitespace checks, and pre-push checks pass.

```sh
cargo test --locked --offline -p celox-backend-arm64 --target aarch64-unknown-linux-gnu
cargo test --locked --offline -p celox --target aarch64-unknown-linux-gnu \
  --profile heliodor-dev --lib --test native_exec --test ff_narrow_arrays --test nba_dynamic_array
cargo test --locked --offline -p celox-backend-x86 --lib
cargo test --locked --offline -p celox --test native_exec \
  --test native_boundary_hardening --test ff_narrow_arrays --test four_state_expression_semantics
cargo test --locked --offline -p celox-backend-arm64
cargo clippy --locked --offline -p celox-backend-arm64 \
  --target aarch64-unknown-linux-gnu --all-targets --no-deps -- -D warnings
cargo clippy --locked --offline -p celox-backend-x86 -p celox --all-targets --no-deps -- -D warnings
cargo check --workspace --locked --offline
cargo fmt --all -- --check
git diff --check
```
