### PR TITLE
fix(simulator): type top-level parameter overrides before elaboration

### DIFF
--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -1,7 +1,10 @@
 use std::path::{Path, PathBuf};
 
-use veryl_analyzer::conv::utils::get_component;
-use veryl_analyzer::ir::{Comptime, Expression, Signature, VarPath};
+use veryl_analyzer::conv::utils::{TypePosition, eval_const_assign, eval_expr, get_component};
+use veryl_analyzer::ir::{
+    AssignDestination, Comptime, Expression, Signature, VarId, VarIndex, VarPath, VarSelect,
+};
+use veryl_analyzer::symbol::{Affiliation, ClockDomain, SymbolKind};
 use veryl_analyzer::value::Value;
 use veryl_analyzer::{Analyzer, AnalyzerError, Context, attribute_table, ir::Ir, symbol_table};
 use veryl_metadata::{ClockType, Component, ComponentBackendKind, Metadata, ResetType};
@@ -139,18 +142,81 @@ fn elaborate_parameterized_top(
         )
     })?;
 
-    let mut signature = Signature::new(symbol.found.id);
-    let mut override_map = fxhash::FxHashMap::default();
-    let token = veryl_parser::token_range::TokenRange::default();
-    for (name, value) in param_overrides {
-        let name_id = resource_table::insert_str(name);
-        let path = VarPath::new(name_id);
-        let value = Value::new(*value, 64, false);
-        let comptime = Comptime::create_value(value.clone(), token);
-        let expr = Expression::create_value(value, token);
-        signature.add_parameter(name_id, comptime.value.clone());
-        override_map.insert(path, (comptime, expr));
-    }
+    let SymbolKind::Module(property) = &symbol.found.kind else {
+        unreachable!();
+    };
+    let values: fxhash::FxHashMap<_, _> = param_overrides
+        .iter()
+        .map(|(name, value)| (resource_table::insert_str(name), *value))
+        .collect();
+
+    // push_override expects expressions that have already been evaluated in
+    // the formal parameter type (as get_overridden_params does for HDL insts).
+    // Resolve the header in declaration order so dependent widths/defaults see
+    // earlier overrides, independently of the order of builder.param() calls.
+    let mut header = Context::default();
+    header.inherit(context);
+    header.push_affiliation(Affiliation::Module);
+    header.push_namespace(symbol.found.inner_namespace());
+    let overrides = (|| {
+        let mut signature = Signature::new(symbol.found.id);
+        let mut override_map = fxhash::FxHashMap::default();
+        for parameter in &property.parameters {
+            let property = parameter.property();
+            let token = property.token.into();
+            let invalid = || {
+                ParserError::illegal_context(
+                    "top-level parameter override",
+                    format!(
+                        "unable to evaluate parameter `{}` of top module `{top}`",
+                        parameter.name
+                    ),
+                    Some(&token),
+                )
+            };
+            let r#type = property
+                .r#type
+                .to_ir_type(&mut header, TypePosition::Variable)
+                .map_err(|_| invalid())?;
+            let path = VarPath::new(parameter.name);
+            let mut expr = if let Some(value) = values.get(&parameter.name) {
+                let width = r#type.total_width().ok_or_else(invalid)?;
+                let mut value = Value::new(*value, 64, false)
+                    .expand(width, false)
+                    .into_owned();
+                value.trunc(width);
+                value.set_signed(r#type.signed);
+                let mut comptime = Comptime::create_value(value.clone(), token);
+                comptime.r#type = r#type.clone();
+                let expr = Expression::create_value(value, token);
+                signature.add_parameter(parameter.name, comptime.value.clone());
+                override_map.insert(path.clone(), (comptime.clone(), expr.clone()));
+                (comptime, expr)
+            } else {
+                eval_expr(
+                    &mut header,
+                    Some(r#type.clone()),
+                    property.value.as_ref().ok_or_else(invalid)?,
+                    false,
+                )
+                .map_err(|_| invalid())?
+            };
+            let dst = AssignDestination {
+                id: VarId::default(),
+                path,
+                index: VarIndex::default(),
+                select: VarSelect::default(),
+                comptime: Comptime::from_type(r#type, ClockDomain::None, token),
+                token,
+            };
+            eval_const_assign(&mut header, (&property.kind).into(), &dst, &mut expr)
+                .map_err(|_| invalid())?;
+        }
+        Ok::<_, ParserError>((signature, override_map))
+    })();
+    header.pop_namespace();
+    context.inherit(&mut header);
+    let (signature, override_map) = overrides?;
 
     context.push_override(override_map);
     let component = get_component(context, &signature, top_token).map_err(|_| {

--- a/crates/celox/tests/param_override_width.rs
+++ b/crates/celox/tests/param_override_width.rs
@@ -1,0 +1,168 @@
+use celox::SimulatorBuilder;
+
+struct Case {
+    name: &'static str,
+    parameters: &'static str,
+    expression: &'static str,
+    overrides: &'static [(&'static str, u64)],
+    expected: u64,
+}
+
+fn cases() -> Vec<Case> {
+    vec![
+        Case {
+            name: "bit default",
+            parameters: "param P: bit = 1",
+            expression: "{P repeat 64}",
+            overrides: &[],
+            expected: u64::MAX,
+        },
+        Case {
+            name: "bit zero",
+            parameters: "param P: bit = 1",
+            expression: "{P repeat 64}",
+            overrides: &[("P", 0)],
+            expected: 0,
+        },
+        Case {
+            name: "bit one",
+            parameters: "param P: bit = 0",
+            expression: "{P repeat 64}",
+            overrides: &[("P", 1)],
+            expected: u64::MAX,
+        },
+        Case {
+            name: "bit truncation",
+            parameters: "param P: bit = 0",
+            expression: "{P repeat 64}",
+            overrides: &[("P", 3)],
+            expected: u64::MAX,
+        },
+        Case {
+            name: "nibble",
+            parameters: "param P: bit<4> = 0",
+            expression: "{P repeat 16}",
+            overrides: &[("P", 0xa)],
+            expected: 0xaaaa_aaaa_aaaa_aaaa,
+        },
+        Case {
+            name: "nibble truncation",
+            parameters: "param P: logic<4> = 0",
+            expression: "{P repeat 16}",
+            overrides: &[("P", 0x1f)],
+            expected: u64::MAX,
+        },
+        Case {
+            name: "u32",
+            parameters: "param P: u32 = 0",
+            expression: "{P repeat 2}",
+            overrides: &[("P", 0xa123_4567)],
+            expected: 0xa123_4567_a123_4567,
+        },
+        Case {
+            name: "u64 high bit",
+            parameters: "param P: u64 = 0",
+            expression: "P",
+            overrides: &[("P", 0x8000_0000_0000_0001)],
+            expected: 0x8000_0000_0000_0001,
+        },
+        Case {
+            name: "signed extension",
+            parameters: "param P: signed logic<8> = 0",
+            expression: "P",
+            overrides: &[("P", 0xff)],
+            expected: u64::MAX,
+        },
+        Case {
+            name: "signed comparison",
+            parameters: "param P: i32 = 0",
+            expression: "if P <: 0 ? 64'd7 : 64'd9",
+            overrides: &[("P", 0xffff_fff8)],
+            expected: 7,
+        },
+        Case {
+            name: "signed division",
+            parameters: "param P: i32 = 0",
+            expression: "P / 2",
+            overrides: &[("P", 0xffff_fff8)],
+            expected: (-4_i64) as u64,
+        },
+        Case {
+            name: "dependent width",
+            parameters: "param W: u32 = 4, param P: bit<W> = 0",
+            expression: "{P repeat 8}",
+            overrides: &[("W", 8), ("P", 0xa5)],
+            expected: 0xa5a5_a5a5_a5a5_a5a5,
+        },
+        Case {
+            name: "reverse builder order",
+            parameters: "param W: u32 = 4, param P: bit<W> = 0",
+            expression: "{P repeat 8}",
+            overrides: &[("P", 0xa5), ("W", 8)],
+            expected: 0xa5a5_a5a5_a5a5_a5a5,
+        },
+        Case {
+            name: "dependent default",
+            parameters: "param W: u32 = 4, param P: bit<W> = '1",
+            expression: "{P repeat 8}",
+            overrides: &[("W", 8)],
+            expected: u64::MAX,
+        },
+        Case {
+            name: "truncated dependency",
+            parameters: "param F: bit = 0, param W: u32 = F + 3, param P: bit<W> = 0",
+            expression: "{P repeat 16}",
+            overrides: &[("P", 0xa), ("F", 3)],
+            expected: 0xaaaa_aaaa_aaaa_aaaa,
+        },
+        Case {
+            name: "declared signed const",
+            parameters: "param P: i32 = 0",
+            expression: "P / 2",
+            overrides: &[],
+            expected: 0,
+        },
+    ]
+}
+
+macro_rules! check_backend {
+    ($test:ident, $build:ident) => {
+        #[test]
+        fn $test() {
+            for case in cases() {
+                let source = format!(
+                    "module Top #({}) (a: input logic<64>, o: output logic<64>) {{ let value: logic<64> = {}; assign o = a ^ value; }}",
+                    case.parameters, case.expression,
+                );
+                let mut builder = SimulatorBuilder::new(&source, "Top");
+                for &(name, value) in case.overrides {
+                    builder = builder.param(name, value);
+                }
+                let mut sim = builder.$build().unwrap();
+                let a = sim.signal("a");
+                let o = sim.signal("o");
+                for input in [0_u64, 1, u64::MAX, 0x0123_4567_89ab_cdef, 1 << 63] {
+                    sim.modify(|io| io.set(a, input)).unwrap();
+                    assert_eq!(sim.get(o), (input ^ case.expected).into(), "{}", case.name);
+                }
+            }
+
+            // A u64 API value must zero-extend to a wider declared parameter.
+            let mut sim = SimulatorBuilder::new(
+                "module Top #(param P: bit<96> = 0) (a: input logic<64>, o: output logic<192>) { assign o = {P repeat 2} ^ {128'd0, a}; }",
+                "Top",
+            ).param("P", u64::MAX).$build().unwrap();
+            let a = sim.signal("a");
+            let o = sim.signal("o");
+            for input in [0_u64, 1, u64::MAX, 0x0123_4567_89ab_cdef, 1 << 63] {
+                sim.modify(|io| io.set(a, input)).unwrap();
+                assert_eq!(sim.get(o).to_u64_digits(), vec![u64::MAX ^ input, 0xffff_ffff_0000_0000, 0xffff_ffff]);
+            }
+        }
+    };
+}
+
+check_backend!(native_parameter_width, build_native);
+check_backend!(cranelift_parameter_width, build_cranelift);
+check_backend!(wasm_parameter_width, build_wasm);
+check_backend!(interpreter_parameter_width, build_interpreter);


### PR DESCRIPTION
Top-level `SimulatorBuilder::param()` currently creates an unsigned 64-bit `Comptime` for every override, even when the formal parameter is a single `bit`. For `param ENABLE: bit = 0`, setting `.param("ENABLE", 1)` makes `{ENABLE repeat 64}` produce `0x0000000000000001` instead of `0xffffffffffffffff`.

Resolve formal types and defaults in declaration order, fit each u64 API value to the declared width and signedness, and use the same normalized value in the specialization signature and override map. This also handles dependent widths, reversed builder call order, narrow-value truncation, wide parameters, and child/default scope. The change runs during elaboration and does not alter per-clock execution.

The regression covers 17 programs and five inputs on native, Cranelift, WASM, and interpreter: 340 comparisons. This PR changes only the Celox caller and its tests and requires no Veryl analyzer patch.

Validation on the PR commit with the repository's unmodified Veryl analyzer 0.21.0 dependency:

- `cargo test --locked --offline -p celox --test param_override --test param_override_width -- --nocapture` — 52 passed (48 existing + 4 new)
- `cargo fmt --all -- --check` — passed
- `cargo clippy --locked --offline -p celox --test param_override --test param_override_width --no-deps -- -D warnings` — passed
