### PR TITLE
test(veryl): cover FF index and select read dependencies

### DIFF
--- a/crates/celox/tests/ff_event_snapshot.rs
+++ b/crates/celox/tests/ff_event_snapshot.rs
@@ -140,6 +140,138 @@ fn acyclic_shared_clock_array_samples_the_previous_input_pair(sim) {
 }
 
 all_backends! {
+fn ff_read_array_uses_previous_index(sim) {
+    // Veryl 0.21.0 misses reads used only in indices/selects during FF
+    // classification. Re-enable its reference run when read tracking is fixed.
+    @ignore_on(veryl);
+    @setup {
+        let source = r#"
+            module Top (
+                clk: input clock, rst_n: input reset_async_low,
+                addr: input logic<2>, q: output logic<8>,
+            ) {
+                var addr_q: logic<2>;
+                var mem: logic<8> [4];
+                assign mem[0] = 8'h10;
+                assign mem[1] = 8'h11;
+                assign mem[2] = 8'h12;
+                assign mem[3] = 8'h13;
+
+                always_ff (clk) { addr_q = addr; }
+                // Separate reset groups exercise dependency-based FF scheduling.
+                always_ff (clk, rst_n) {
+                    if_reset { q = 0; }
+                    else { q = mem[addr_q]; }
+                }
+            }
+        "#;
+    }
+    @build SimulatorBuilder::new(source, "Top");
+    let clk = sim.event("clk");
+    let rst = sim.signal("rst_n");
+    let addr = sim.signal("addr");
+    let q = sim.signal("q");
+
+    // Seed addr_q without relying on its initial value. It must only be read
+    // as an index: a counter's self-read could mask missing index dependencies.
+    sim.modify(|io| { io.set(rst, 0u8); io.set(addr, 0u8); }).unwrap();
+    sim.tick(clk).unwrap();
+    sim.modify(|io| io.set(rst, 1u8)).unwrap();
+    for (next_addr, expected) in [(3u8, 0x10u8), (1, 0x13), (2, 0x11), (0, 0x12)] {
+        sim.modify(|io| io.set(addr, next_addr)).unwrap();
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get(q), expected.into(), "new addr input {next_addr}");
+    }
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(q), 0x10u8.into());
+}
+
+fn ff_read_bit_select_uses_previous_index(sim) {
+    // Veryl 0.21.0 misses bit-select index reads during FF classification.
+    // The SV frontend rejects this dynamic bit-select in always_ff lowering.
+    @ignore_on(veryl, sv);
+    @setup {
+        let source = r#"
+            module Top (
+                clk: input clock, rst_n: input reset_async_low,
+                index: input logic<2>, q: output logic,
+            ) {
+                var index_q: logic<2>;
+                var bits: logic<4>;
+                assign bits = 4'b1010;
+
+                always_ff (clk) { index_q = index; }
+                // Separate reset groups exercise dependency-based FF scheduling.
+                always_ff (clk, rst_n) {
+                    if_reset { q = 0; }
+                    else { q = bits[index_q]; }
+                }
+            }
+        "#;
+    }
+    @build SimulatorBuilder::new(source, "Top");
+    let clk = sim.event("clk");
+    let rst = sim.signal("rst_n");
+    let index = sim.signal("index");
+    let q = sim.signal("q");
+
+    sim.modify(|io| { io.set(rst, 0u8); io.set(index, 0u8); }).unwrap();
+    sim.tick(clk).unwrap();
+    sim.modify(|io| io.set(rst, 1u8)).unwrap();
+    for (next_index, expected) in [(3u8, 0u8), (0, 1), (1, 0), (2, 1)] {
+        sim.modify(|io| io.set(index, next_index)).unwrap();
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get(q), expected.into(), "new bit index {next_index}");
+    }
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(q), 0u8.into());
+}
+
+fn ff_read_part_select_uses_previous_index(sim) {
+    // Veryl 0.21.0 misses part-select index reads during FF classification.
+    // The SV frontend does not support indexed part-selects yet.
+    @ignore_on(veryl, sv);
+    @setup {
+        let source = r#"
+            module Top (
+                clk: input clock, rst_n: input reset_async_low,
+                index: input logic<2>, q: output logic<8>,
+            ) {
+                var index_q: logic<2>;
+                var word: logic<32>;
+                assign word = 32'h44332211;
+
+                always_ff (clk) { index_q = index; }
+                // Separate reset groups exercise dependency-based FF scheduling.
+                always_ff (clk, rst_n) {
+                    if_reset { q = 0; }
+                    else { q = word[index_q * 8+:8]; }
+                }
+            }
+        "#;
+    }
+    @build SimulatorBuilder::new(source, "Top");
+    let clk = sim.event("clk");
+    let rst = sim.signal("rst_n");
+    let index = sim.signal("index");
+    let q = sim.signal("q");
+
+    // Keep bit and part selects in separate designs: either read could
+    // otherwise order the whole reader group before the writer group.
+    sim.modify(|io| { io.set(rst, 0u8); io.set(index, 0u8); }).unwrap();
+    sim.tick(clk).unwrap();
+    sim.modify(|io| io.set(rst, 1u8)).unwrap();
+    for (next_index, expected) in [(2u8, 0x11u8), (1, 0x33), (3, 0x22), (0, 0x44)] {
+        sim.modify(|io| io.set(index, next_index)).unwrap();
+        sim.tick(clk).unwrap();
+        assert_eq!(sim.get(q), expected.into(), "new byte index {next_index}");
+    }
+    sim.tick(clk).unwrap();
+    assert_eq!(sim.get(q), 0x11u8.into());
+}
+}
+
+all_backends! {
 fn reset_groups_sample_the_same_pre_edge_state(sim) {
     @setup {
         let source = r#"


### PR DESCRIPTION
## Summary

Add regression tests ensuring that registers used only as array indices, bit-select positions, or indexed part-select positions are read from the pre-edge state by another `always_ff` block. Input-driven index registers and separate reset groups make missing read dependencies observable, with each access form tested independently across all four Celox execution backends.

Keep the three Veryl 0.21.0 reference runs ignored because its FF classification misses these reads. Also skip the two SV select variants because their lowering is unsupported.

## Validation

- `cargo test -p celox --test ff_event_snapshot --features systemverilog --locked --offline`: 30 passed, 6 ignored (including one existing exclusion).
- `cargo fmt --all -- --check`
- `cargo clippy --locked --offline -p celox --test ff_event_snapshot --features systemverilog --no-deps -- -D warnings`
- Temporarily omitted index/select read tracking: all 12 new Celox backend cases failed as expected. Restored the implementation after checking.
- Explicitly ran the three ignored Veryl reference cases and confirmed the expected failures.
