### PR TITLE
perf(vcd)!: track writes and specialize waveform output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,7 @@ dependencies = [
  "thiserror 2.0.20",
  "toml 1.1.5+spec-1.1.0",
  "tracing",
+ "vcd",
  "veryl-analyzer",
  "veryl-component-sys",
  "veryl-emitter",
@@ -713,6 +714,7 @@ dependencies = [
  "num-bigint",
  "serde",
  "tempfile",
+ "vcd",
 ]
 
 [[package]]

--- a/benches/verilator/bench_vcd.cpp
+++ b/benches/verilator/bench_vcd.cpp
@@ -1,0 +1,116 @@
+// Same scalar counters and sampling points as crates/celox/benches/vcd.rs.
+// The comparison runner generates VTop and vcd_fixture.h for each signal count.
+#include "VTop.h"
+#include "vcd_fixture.h"
+#include "verilated.h"
+#if VM_TRACE
+#include "verilated_vcd_c.h"
+#endif
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#if VM_TRACE
+class CountingFile final : public VerilatedVcdFile {
+public:
+    uint64_t bytes = 0;
+    ssize_t write(const char* data, ssize_t size) override {
+        const auto written = VerilatedVcdFile::write(data, size);
+        if (written > 0) bytes += static_cast<uint64_t>(written);
+        return written;
+    }
+};
+#endif
+
+int main(int argc, char** argv) {
+    try {
+        if (argc != 5) throw std::runtime_error("expected MODE CASE STEPS OUTPUT");
+        const std::string mode = argv[1];
+        const std::string workload = argv[2];
+        const uint64_t steps = std::stoull(argv[3]);
+        const unsigned active = workload == "idle" ? 0
+            : workload == "sparse" ? std::max(1U, kSignals / 100)
+            : workload == "dense" ? kSignals
+            : throw std::runtime_error("unknown workload");
+#if VM_TRACE
+        if (mode != "instrumented" && mode != "vcd")
+            throw std::runtime_error("trace build expects instrumented or vcd");
+#else
+        if (mode != "off") throw std::runtime_error("untraced build expects off");
+#endif
+        auto context = std::make_unique<VerilatedContext>();
+        context->threads(1);
+#if VM_TRACE
+        context->traceEverOn(true);
+#endif
+        auto top = std::make_unique<VTop>(context.get());
+        top->clk = 0;
+        top->rst = 0;
+        set_enables(*top, 0);
+        top->eval();
+        top->clk = 1;
+        top->eval();  // Assert the active-low reset on a clock edge.
+        top->clk = 0;
+        top->rst = 1;
+        set_enables(*top, active);
+        top->eval();
+        top->clk = 1;
+        top->eval();  // One untimed enabled tick, matching Celox's setup.
+        top->clk = 0;
+        top->eval();  // Celox's explicit tick leaves the clock signal at zero.
+
+        uint64_t initial_bytes = 0;
+        uint64_t bytes = 0;
+#if VM_TRACE
+        CountingFile sink;
+        std::unique_ptr<VerilatedVcdC> trace;
+        if (mode == "vcd") {
+            trace = std::make_unique<VerilatedVcdC>(&sink);
+            top->trace(trace.get(), 1);
+            trace->open(argv[4]);
+            if (!trace->isOpen()) throw std::runtime_error("cannot open trace output");
+            trace->dump(uint64_t{0});
+            trace->flush();
+            initial_bytes = sink.bytes;
+        }
+#endif
+        const auto start = std::chrono::steady_clock::now();
+        for (uint64_t step = 1; step <= steps; ++step) {
+            top->clk = 0;
+            top->eval();
+#if VM_TRACE
+            if (trace) trace->dump(step * 2);
+#endif
+            top->clk = 1;
+            top->eval();
+#if VM_TRACE
+            if (trace) trace->dump(step * 2 + 1);
+#endif
+        }
+#if VM_TRACE
+        if (trace) trace->flush();
+#endif
+        const auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now() - start).count();
+#if VM_TRACE
+        bytes = sink.bytes - initial_bytes;
+#endif
+        // Observe every counter after timing, including in the non-tracing build.
+        // This also checks that the sparse enable configuration actually ran.
+        verify_counters(*top, active, steps + 1);
+        std::cout << "mode,case,signals,steps,elapsed_ns,bytes\n"
+                  << mode << ',' << workload << ',' << kSignals << ',' << steps
+                  << ',' << elapsed << ',' << bytes << '\n';
+        top->final();
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << error.what() << '\n';
+        return 1;
+    }
+}

--- a/crates/celox-backend-arm64/src/isel.rs
+++ b/crates/celox-backend-arm64/src/isel.rs
@@ -302,8 +302,36 @@ pub fn lower_execution_unit_with_diagnostics(
         let mut lookup_emit_cache = DenseLookupEmitCache::default();
         let sir_defs = collect_sir_defs(sir_block);
 
+        // Waveform observers share Store/Commit notification sites with clock
+        // triggers. Mark before specialized store/commit lowering can absorb a
+        // run (packed stores and sparse worklists included). Repeated writes
+        // in this basic block need only one notification per physical group.
+        let mut trace_marks = HashSet::default();
         // Lower instructions
         for (inst_idx, inst) in sir_block.instructions.iter().enumerate() {
+            let target = match inst {
+                SIRInstruction::Store(addr, _, width, _, _, _)
+                | SIRInstruction::Commit(_, addr, _, width, _)
+                    if *width != 0 =>
+                {
+                    Some(addr)
+                }
+                _ => None,
+            };
+            if let Some(offsets) = target.and_then(|addr| layout.trace_notification_offsets(addr)) {
+                for offset in offsets {
+                    if trace_marks.insert(offset) {
+                        let one = ctx.alloc_vreg(SpillDesc::remat(1));
+                        mblock.push(MInst::LoadImm { dst: one, value: 1 });
+                        mblock.push(MInst::Store {
+                            base: BaseReg::SimState,
+                            offset: offset as i32,
+                            src: one,
+                            size: OpSize::S8,
+                        });
+                    }
+                }
+            }
             if branch_table_plan.is_some_and(|plan| plan.skip_indices.contains(&inst_idx)) {
                 continue;
             }
@@ -13123,6 +13151,7 @@ mod tests {
         let plane_size = width.div_ceil(8);
         let total_size = plane_size * if four_state { 2 } else { 1 };
         MemoryLayout {
+            trace: None,
             four_state,
             mode: MemoryLayoutMode::Packed,
             unpacked_arrays: HashMap::default(),

--- a/crates/celox-backend-cranelift/src/translator/core.rs
+++ b/crates/celox-backend-cranelift/src/translator/core.rs
@@ -283,6 +283,25 @@ impl SIRTranslator {
         state: &mut TranslationState,
         inst: &SIRInstruction<RegionedAbsoluteAddr>,
     ) {
+        let target = match inst {
+            SIRInstruction::Store(addr, _, width, _, _, _)
+            | SIRInstruction::Commit(_, addr, _, width, _)
+                if *width != 0 =>
+            {
+                Some(addr)
+            }
+            _ => None,
+        };
+        if let Some(offsets) = target.and_then(|addr| self.layout.trace_notification_offsets(addr))
+        {
+            let one = state.builder.ins().iconst(types::I8, 1);
+            for offset in offsets {
+                state
+                    .builder
+                    .ins()
+                    .store(MemFlags::trusted(), one, state.mem_ptr, offset as i32);
+            }
+        }
         match inst {
             SIRInstruction::Imm(dst, val) => {
                 self.translate_imm_inst(state, dst, val);

--- a/crates/celox-backend-wasm/src/lib.rs
+++ b/crates/celox-backend-wasm/src/lib.rs
@@ -437,6 +437,26 @@ fn compile_instruction(
     locals: &mut LocalAllocator,
     instrs: &mut Vec<Instruction<'static>>,
 ) {
+    let target = match inst {
+        SIRInstruction::Store(addr, _, width, _, _, _)
+        | SIRInstruction::Commit(_, addr, _, width, _)
+            if *width != 0 =>
+        {
+            Some(addr)
+        }
+        _ => None,
+    };
+    if let Some(offsets) = target.and_then(|addr| layout.trace_notification_offsets(addr)) {
+        for offset in offsets {
+            instrs.push(Instruction::I32Const(offset as i32));
+            instrs.push(Instruction::I32Const(1));
+            instrs.push(Instruction::I32Store8(wasm_encoder::MemArg {
+                offset: 0,
+                align: 0,
+                memory_index: 0,
+            }));
+        }
+    }
     match inst {
         SIRInstruction::Imm(dst, val) => {
             compile_imm(dst, val, unit, four_state, &*locals, instrs);
@@ -5918,6 +5938,7 @@ mod bit_count_tests {
         let working_base_offset = (total_size + 7) & !7;
 
         MemoryLayout {
+            trace: None,
             four_state,
             mode: MemoryLayoutMode::Packed,
             unpacked_arrays: HashMap::default(),

--- a/crates/celox-backend-x86/src/backend/native/isel.rs
+++ b/crates/celox-backend-x86/src/backend/native/isel.rs
@@ -1183,8 +1183,36 @@ pub fn lower_execution_unit_with_diagnostics(
         let mut packed_field_load_cache = PackedFieldLoadCache::default();
         let sir_defs = collect_sir_defs(sir_block);
 
+        // Waveform observers share Store/Commit notification sites with clock
+        // triggers. Mark before specialized store/commit lowering can absorb a
+        // run (packed stores and sparse worklists included). Repeated writes
+        // in this basic block need only one notification per physical group.
+        let mut trace_marks = HashSet::default();
         // Lower instructions
         for (inst_idx, inst) in sir_block.instructions.iter().enumerate() {
+            let target = match inst {
+                SIRInstruction::Store(addr, _, width, _, _, _)
+                | SIRInstruction::Commit(_, addr, _, width, _)
+                    if *width != 0 =>
+                {
+                    Some(addr)
+                }
+                _ => None,
+            };
+            if let Some(offsets) = target.and_then(|addr| layout.trace_notification_offsets(addr)) {
+                for offset in offsets {
+                    if trace_marks.insert(offset) {
+                        let one = ctx.alloc_vreg(SpillDesc::remat(1));
+                        mblock.push(MInst::LoadImm { dst: one, value: 1 });
+                        mblock.push(MInst::Store {
+                            base: BaseReg::SimState,
+                            offset: offset as i32,
+                            src: one,
+                            size: OpSize::S8,
+                        });
+                    }
+                }
+            }
             if branch_table_plan.is_some_and(|plan| plan.skip_indices.contains(&inst_idx)) {
                 continue;
             }
@@ -14331,6 +14359,7 @@ mod tests {
 
     fn empty_layout() -> MemoryLayout {
         MemoryLayout {
+            trace: None,
             four_state: false,
             mode: MemoryLayoutMode::Packed,
             unpacked_arrays: HashMap::default(),
@@ -17371,6 +17400,7 @@ mod tests {
         eu.verify();
 
         let layout = MemoryLayout {
+            trace: None,
             four_state: false,
             mode: MemoryLayoutMode::Packed,
             unpacked_arrays: HashMap::default(),
@@ -17747,6 +17777,7 @@ mod tests {
         };
         eu.verify();
         let layout = MemoryLayout {
+            trace: None,
             four_state,
             mode: MemoryLayoutMode::Packed,
             unpacked_arrays: HashMap::default(),
@@ -17982,6 +18013,7 @@ mod tests {
         };
         eu.verify();
         let layout = MemoryLayout {
+            trace: None,
             four_state: false,
             mode: MemoryLayoutMode::Packed,
             unpacked_arrays: HashMap::default(),
@@ -18126,6 +18158,7 @@ mod tests {
         eu.verify();
 
         let layout = MemoryLayout {
+            trace: None,
             four_state: false,
             mode: MemoryLayoutMode::Packed,
             unpacked_arrays: HashMap::default(),
@@ -18865,6 +18898,7 @@ mod tests {
         fixture.eu.verify();
 
         let layout = MemoryLayout {
+            trace: None,
             four_state: false,
             mode: MemoryLayoutMode::Packed,
             unpacked_arrays: HashMap::default(),
@@ -19080,6 +19114,7 @@ mod tests {
         eu.verify();
 
         let layout = MemoryLayout {
+            trace: None,
             four_state,
             mode: MemoryLayoutMode::Packed,
             unpacked_arrays: HashMap::default(),
@@ -19306,6 +19341,7 @@ mod tests {
         eu.verify();
 
         let layout = MemoryLayout {
+            trace: None,
             four_state: false,
             mode: MemoryLayoutMode::Packed,
             unpacked_arrays: HashMap::default(),
@@ -19481,6 +19517,7 @@ mod tests {
         eu.verify();
 
         let layout = MemoryLayout {
+            trace: None,
             four_state: false,
             mode: MemoryLayoutMode::Packed,
             unpacked_arrays: HashMap::default(),

--- a/crates/celox-backend-x86/src/backend/native/sparse_write_state.rs
+++ b/crates/celox-backend-x86/src/backend/native/sparse_write_state.rs
@@ -1466,6 +1466,7 @@ mod tests {
             })
             .collect();
         MemoryLayout {
+            trace: None,
             four_state: false,
             mode: MemoryLayoutMode::Packed,
             unpacked_arrays: HashMap::default(),

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -621,7 +621,10 @@ fn apply_options<'a, T>(
     builder = builder.four_state(opts.four_state);
     builder = builder.optimize_options(opts.optimize_options.clone());
     builder = builder.cranelift_options(opts.cranelift_options);
-    // VCD is handled separately after build — not passed to SimulatorBuilder
+    // VCD changes the layout and generated stores, so enable it before building.
+    if let Some(path) = opts.vcd.as_deref() {
+        builder = builder.vcd(path);
+    }
     for (from, to) in &opts.false_loops {
         builder = builder.false_loop(from.clone(), to.clone());
     }
@@ -680,6 +683,7 @@ struct CacheKey {
     sources: Vec<(String, String)>,
     top: String,
     four_state: bool,
+    vcd_tracking: bool,
     sir_optimization: SirOptimizationCacheKey,
     cranelift_opt_level: u8,
     regalloc_algorithm: u8,
@@ -753,6 +757,7 @@ fn build_cache_key(
         sources: sorted_sources,
         top: top.to_string(),
         four_state: opts.four_state,
+        vcd_tracking: opts.vcd.is_some(),
         sir_optimization: SirOptimizationCacheKey::from(&opts.optimize_options),
         cranelift_opt_level: opts.cranelift_options.opt_level as u8,
         regalloc_algorithm: opts.cranelift_options.regalloc_algorithm as u8,
@@ -879,13 +884,6 @@ impl HandleBackend {
                 let event = backend.id_to_event_slice()[event_id];
                 backend.eval_apply_ff_at(event)
             }
-        }
-    }
-
-    fn memory_as_ptr(&self) -> (*const u8, usize) {
-        match self {
-            Self::Default(backend) => backend.memory_as_ptr(),
-            Self::Tiered(backend) => backend.memory_as_ptr(),
         }
     }
 
@@ -1171,13 +1169,7 @@ impl NativeSimulatorHandle {
             .iter()
             .map(|(s, p)| (s.as_str(), p.as_path()))
             .collect();
-        let mut builder = apply_options(celox::Simulator::from_sources(source_refs, &top), &opts);
-        // Forward VCD before building: tiered layout selection must know that
-        // recording was requested so it picks the packed layout the VCD
-        // descriptors require (see `build_and_cache_tiered`).
-        if let Some(path) = opts.vcd.as_deref() {
-            builder = builder.vcd(path);
-        }
+        let builder = apply_options(celox::Simulator::from_sources(source_refs, &top), &opts);
         let sim = builder
             .build_tiered()
             .map_err(|e| Error::from_reason(format!("{}", e)))?;
@@ -1207,16 +1199,10 @@ impl NativeSimulatorHandle {
             .map(|(s, p)| (s.as_str(), p.as_path()))
             .collect();
 
-        let mut builder = apply_options(
+        let builder = apply_options(
             celox::Simulator::from_sources(source_refs, &top).with_metadata(metadata),
             &opts,
         );
-        // Forward VCD before building: tiered layout selection must know that
-        // recording was requested so it picks the packed layout the VCD
-        // descriptors require (see `build_and_cache_tiered`).
-        if let Some(path) = opts.vcd.as_deref() {
-            builder = builder.vcd(path);
-        }
         let sim = builder
             .build_tiered()
             .map_err(|e| Error::from_reason(format!("{}", e)))?;
@@ -1386,14 +1372,18 @@ impl NativeSimulatorHandle {
     pub fn dump(&mut self, timestamp: f64) -> Result<()> {
         let b = self
             .backend
-            .as_ref()
+            .as_mut()
             .ok_or_else(|| Error::from_reason("Simulator has been disposed"))?;
         if let Some(ref mut writer) = self.vcd_writer {
-            let (ptr, size) = b.memory_as_ptr();
-            let memory = unsafe { std::slice::from_raw_parts(ptr, size) };
-            writer
-                .dump(timestamp as u64, memory)
-                .map_err(|e| Error::from_reason(format!("VCD write error: {}", e)))?;
+            match b {
+                HandleBackend::Default(backend) => {
+                    writer.dump_backend(timestamp as u64, backend, &[])
+                }
+                HandleBackend::Tiered(backend) => {
+                    writer.dump_backend(timestamp as u64, backend.as_mut(), &[])
+                }
+            }
+            .map_err(|e| Error::from_reason(format!("VCD write error: {}", e)))?;
         }
         Ok(())
     }
@@ -1463,10 +1453,7 @@ impl NativeSimulationHandle {
             .iter()
             .map(|(s, p)| (s.as_str(), p.as_path()))
             .collect();
-        let mut builder = apply_options(celox::Simulation::from_sources(source_refs, &top), &opts);
-        if let Some(path) = &opts.vcd {
-            builder = builder.vcd(path);
-        }
+        let builder = apply_options(celox::Simulation::from_sources(source_refs, &top), &opts);
         let sim = builder
             .build()
             .map_err(|e| Error::from_reason(format!("{}", e)))?;
@@ -1510,10 +1497,7 @@ impl NativeSimulationHandle {
         let opts = parse_options(&options)?;
         let artifact = celox::FrontendArtifact::from_json(&artifact_json)
             .map_err(|error| Error::from_reason(error.to_string()))?;
-        let mut builder = apply_options(celox::Simulation::from_frontend(artifact), &opts);
-        if let Some(path) = &opts.vcd {
-            builder = builder.vcd(path);
-        }
+        let builder = apply_options(celox::Simulation::from_frontend(artifact), &opts);
         let sim = builder
             .build()
             .map_err(|error| Error::from_reason(error.to_string()))?;
@@ -1562,13 +1546,10 @@ impl NativeSimulationHandle {
             .map(|(s, p)| (s.as_str(), p.as_path()))
             .collect();
 
-        let mut builder = apply_options(
+        let builder = apply_options(
             celox::Simulation::from_sources(source_refs, &top).with_metadata(metadata),
             &opts,
         );
-        if let Some(path) = &opts.vcd {
-            builder = builder.vcd(path);
-        }
         let sim = builder
             .build()
             .map_err(|e| Error::from_reason(format!("{}", e)))?;
@@ -3327,6 +3308,76 @@ mod tests {
     }
 
     #[test]
+    fn native_handle_dumps_consume_activity_until_memory_is_exposed() {
+        let source = "module Top (
+            clk: input clock, q: output logic<64>,
+            a: input logic<512>, b: input logic<512>, c: input logic<512>,
+        ) { always_ff (clk) { q += 1; } }";
+        let dir = tempfile::tempdir().unwrap();
+        // Warm the uninstrumented cache first. A traced build must not reuse it.
+        NativeSimulatorHandle::new(napi_sources(source), "Top".into(), None)
+            .unwrap()
+            .dispose()
+            .unwrap();
+        for mode in ["fresh", "cached", "tiered"] {
+            let path = dir.path().join(format!("{mode}.vcd"));
+            let options = Some(NapiOptions {
+                vcd: Some(path.to_str().unwrap().to_owned()),
+                four_state: None,
+                opt_level: None,
+                pass_overrides: None,
+                optimize: None,
+                optimize_options: None,
+                cranelift_opt_level: None,
+                regalloc_algorithm: None,
+                enable_alias_analysis: None,
+                enable_verifier: None,
+                false_loops: None,
+                true_loops: None,
+                clock_type: None,
+                reset_type: None,
+                extra_source: None,
+                parameters: None,
+                dead_store_policy: None,
+            });
+            let mut handle = if mode == "tiered" {
+                NativeSimulatorHandle::new_tiered(napi_sources(source), "Top".into(), options)
+            } else {
+                NativeSimulatorHandle::new(napi_sources(source), "Top".into(), options)
+            }
+            .unwrap();
+            handle.dump(0.0).unwrap();
+            let initial = handle.vcd_writer.as_ref().unwrap().statistics();
+            assert!(initial.comparisons > 0);
+            handle.dump(1.0).unwrap();
+            assert_eq!(
+                handle.vcd_writer.as_ref().unwrap().statistics().comparisons,
+                initial.comparisons,
+                "{mode}: idle dumps must not rescan memory"
+            );
+            handle.tick(0).unwrap();
+            handle.dump(2.0).unwrap();
+            let changed = handle.vcd_writer.as_ref().unwrap().statistics();
+            assert!(changed.changes > initial.changes);
+            assert!(changed.comparisons - initial.comparisons < initial.comparisons);
+            handle.dump(3.0).unwrap();
+            assert_eq!(
+                handle.vcd_writer.as_ref().unwrap().statistics().comparisons,
+                changed.comparisons
+            );
+            // shared_memory() obtains its pointer through this same dispatch.
+            handle.backend.as_mut().unwrap().memory_as_mut_ptr();
+            handle.dump(4.0).unwrap();
+            assert_eq!(
+                handle.vcd_writer.as_ref().unwrap().statistics().comparisons,
+                changed.comparisons + initial.comparisons
+            );
+            handle.dispose().unwrap();
+            assert!(std::fs::read_to_string(path).unwrap().contains("\nb1 "));
+        }
+    }
+
+    #[test]
     fn standard_event_metadata_is_dense_and_valid_ids_still_work() {
         let mut simulator =
             NativeSimulatorHandle::new(napi_sources(TWO_EVENTS_SOURCE), "Top".into(), None)
@@ -3593,13 +3644,18 @@ mod tests {
     }
 
     #[test]
-    fn non_compilation_options_ignored() {
+    fn vcd_paths_share_compiled_code_but_tracing_modes_do_not() {
         let src = make_sources(&[("module Top {}", "a.veryl")]);
         let mut o1 = default_opts();
         let mut o2 = default_opts();
-        // VCD path doesn't affect compilation
+        // VCD instrumentation affects compilation, but its destination does not.
         o1.common.vcd = None;
         o2.common.vcd = Some("/tmp/dump.vcd".into());
+        assert_ne!(
+            build_cache_key(&src, "Top", &o1, None),
+            build_cache_key(&src, "Top", &o2, None),
+        );
+        o1.common.vcd = Some("/tmp/another.vcd".into());
         assert_eq!(
             build_cache_key(&src, "Top", &o1, None),
             build_cache_key(&src, "Top", &o2, None),

--- a/crates/celox-napi/src/lib.rs
+++ b/crates/celox-napi/src/lib.rs
@@ -1416,9 +1416,14 @@ impl NativeSimulatorHandle {
 
     /// Invalidate this handle and release its simulator resources.
     #[napi]
-    pub fn dispose(&mut self) {
+    pub fn dispose(&mut self) -> Result<()> {
         self.backend = None;
-        self.vcd_writer = None;
+        if let Some(mut writer) = self.vcd_writer.take() {
+            writer
+                .flush()
+                .map_err(|e| Error::from_reason(format!("VCD flush error: {e}")))?;
+        }
+        Ok(())
     }
 }
 
@@ -1746,8 +1751,12 @@ impl NativeSimulationHandle {
 
     /// Invalidate this handle.
     #[napi]
-    pub fn dispose(&mut self) {
-        self.sim = None;
+    pub fn dispose(&mut self) -> Result<()> {
+        if let Some(mut sim) = self.sim.take() {
+            sim.flush_vcd()
+                .map_err(|e| Error::from_reason(format!("VCD flush error: {e}")))?;
+        }
+        Ok(())
     }
 }
 
@@ -3293,7 +3302,7 @@ mod tests {
     fn disposed_errors_take_precedence_over_event_validation() {
         let mut simulator =
             NativeSimulatorHandle::new(napi_sources(NO_EVENTS_SOURCE), "Top".into(), None).unwrap();
-        simulator.dispose();
+        simulator.dispose().unwrap();
         assert_eq!(
             simulator.tick(0).unwrap_err().reason,
             "Simulator has been disposed"
@@ -3306,7 +3315,7 @@ mod tests {
         let mut simulation =
             NativeSimulationHandle::new(napi_sources(NO_EVENTS_SOURCE), "Top".into(), None)
                 .unwrap();
-        simulation.dispose();
+        simulation.dispose().unwrap();
         assert_eq!(
             simulation.add_clock(0, 10.0, 0.0).unwrap_err().reason,
             "Simulation has been disposed"

--- a/crates/celox-runtime/Cargo.toml
+++ b/crates/celox-runtime/Cargo.toml
@@ -21,6 +21,11 @@ serde = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true
+vcd = "0.7"
+
+[[bench]]
+name = "vcd"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/celox-runtime/benches/vcd.rs
+++ b/crates/celox-runtime/benches/vcd.rs
@@ -1,7 +1,7 @@
 //! See docs/internals/vcd-performance.md for controls and interpretation.
 use celox_runtime::{VcdSignalDesc, VcdWriter};
 use celox_state_layout::{
-    LayoutInput, LayoutSource, MemoryLayout, MemoryLayoutMode, StateObjectLayout,
+    LayoutInput, LayoutSource, MemoryLayout, MemoryLayoutMode, StateObjectLayout, TraceLayout,
 };
 use std::{hint::black_box, io::Write, time::Instant};
 
@@ -61,6 +61,58 @@ fn setting(name: &str) -> Result<String, std::env::VarError> {
 fn number(name: &str, default: usize) -> usize {
     setting(name).map_or(default, |x| x.parse().unwrap())
 }
+
+struct Stimulus {
+    width: usize,
+    scattered: bool,
+    same: bool,
+    mask_only: bool,
+    notify: bool,
+}
+
+impl Stimulus {
+    // Keep the timed input updates in a separate function so changes to the
+    // collector do not alter register allocation in this per-signal loop.
+    #[inline(never)]
+    fn apply(
+        &self,
+        step: usize,
+        count: usize,
+        descs: &[VcdSignalDesc],
+        memory: &mut [u8],
+        trace: &TraceLayout,
+    ) {
+        for j in 0..count {
+            let index = if self.scattered {
+                (j * descs.len() / count + step) % descs.len()
+            } else {
+                j
+            };
+            let home = descs[index].offset;
+            let bit = step % self.width.saturating_sub(1).max(1);
+            let at = home
+                + bit / 8
+                + if self.mask_only {
+                    self.width.div_ceil(8)
+                } else {
+                    0
+                };
+            let next = if self.same {
+                memory[at]
+            } else {
+                memory[at] ^ (1 << (bit % 8))
+            };
+            memory[at] = black_box(next);
+            if self.notify {
+                // Same two byte notifications emitted at generated stores.
+                unsafe {
+                    trace.mark_home(memory.as_mut_ptr(), home);
+                }
+            }
+        }
+    }
+}
+
 fn main() {
     let signals = number("VCD_SIGNALS", 16_384);
     let steps = number("VCD_STEPS", 1_000);
@@ -106,6 +158,13 @@ fn main() {
         if case.as_ref().is_some_and(|case| case != name) || (name == "mask_only" && !four_state) {
             continue;
         }
+        let stimulus = Stimulus {
+            width,
+            scattered,
+            same,
+            mask_only: name == "mask_only",
+            notify: mode != "scan",
+        };
         for repeat in 0..repeats {
             let mut memory = vec![0; layout.merged_total_size];
             for (i, desc) in descs.iter().enumerate() {
@@ -129,27 +188,8 @@ fn main() {
                 } else {
                     count
                 };
-                for j in 0..count {
-                    let index = if scattered {
-                        (j * signals / count + step) % signals
-                    } else {
-                        j
-                    };
-                    let home = descs[index].offset;
-                    let bit = step % width.saturating_sub(1).max(1);
-                    let at = home + bit / 8 + if name == "mask_only" { size } else { 0 };
-                    let next = if same {
-                        memory[at]
-                    } else {
-                        memory[at] ^ (1 << (bit % 8))
-                    };
-                    memory[at] = black_box(next);
-                    if mode != "scan" {
-                        // Same two byte notifications emitted at generated stores.
-                        unsafe {
-                            trace.mark_home(memory.as_mut_ptr(), home);
-                        }
-                    }
+                if count != 0 {
+                    stimulus.apply(step, count, &descs, &mut memory, trace);
                 }
                 if mode != "scan" {
                     trace.take(&mut memory, &mut activity);

--- a/crates/celox-runtime/benches/vcd.rs
+++ b/crates/celox-runtime/benches/vcd.rs
@@ -1,0 +1,181 @@
+//! See docs/internals/vcd-performance.md for controls and interpretation.
+use celox_runtime::{VcdSignalDesc, VcdWriter};
+use celox_state_layout::{
+    LayoutInput, LayoutSource, MemoryLayout, MemoryLayoutMode, StateObjectLayout,
+};
+use std::{hint::black_box, io::Write, time::Instant};
+
+struct Fixture {
+    signals: usize,
+    width: usize,
+    four_state: bool,
+}
+impl LayoutSource<usize> for Fixture {
+    fn layout_input(&self, _: MemoryLayoutMode) -> LayoutInput<usize> {
+        LayoutInput {
+            state_objects: (0..self.signals)
+                .map(|address| StateObjectLayout {
+                    address,
+                    width: self.width,
+                    is_4state: self.four_state,
+                })
+                .collect(),
+            working_addresses: vec![],
+            sparse_addresses: vec![],
+            unpacked_arrays: Default::default(),
+            requirements: Default::default(),
+            ff_referenced_addresses: Default::default(),
+            num_events: 0,
+            runtime_event_sites: vec![],
+        }
+    }
+}
+struct Sink {
+    file: Option<std::fs::File>,
+    bytes: u64,
+}
+impl Write for Sink {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        // Observe the actual encoded buffer even in the no-I/O measurement.
+        black_box(bytes);
+        let count = if let Some(file) = self.file.as_mut() {
+            file.write(bytes)?
+        } else {
+            bytes.len()
+        };
+        self.bytes += count as u64;
+        Ok(count)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        if let Some(file) = self.file.as_mut() {
+            file.flush()?;
+        }
+        Ok(())
+    }
+}
+// Standalone benchmark configuration is read at this executable's boundary.
+#[allow(clippy::disallowed_methods)]
+fn setting(name: &str) -> Result<String, std::env::VarError> {
+    std::env::var(name)
+}
+fn number(name: &str, default: usize) -> usize {
+    setting(name).map_or(default, |x| x.parse().unwrap())
+}
+fn main() {
+    let signals = number("VCD_SIGNALS", 16_384);
+    let steps = number("VCD_STEPS", 1_000);
+    let repeats = number("VCD_REPEATS", 3);
+    let width = number("VCD_WIDTH", 64);
+    let four_state = number("VCD_FOUR_STATE", 0) != 0;
+    let mode = setting("VCD_MODE").unwrap_or_else(|_| "dirty".into());
+    assert!(["dirty", "scan", "collect"].contains(&mode.as_str()));
+    assert!(signals > 0 && width > 0 && repeats > 0);
+    let output = setting("VCD_OUTPUT").unwrap_or_else(|_| "count".into());
+    let case = setting("VCD_CASE").ok();
+    let fixture = Fixture {
+        signals,
+        width,
+        four_state,
+    };
+    let mut layout = MemoryLayout::build(&fixture, four_state, MemoryLayoutMode::Packed);
+    // Same physical layout for every measurement, including full scanning.
+    layout.enable_trace();
+    let trace = layout.trace.as_ref().unwrap();
+    let descs: Vec<_> = (0..signals)
+        .map(|i| VcdSignalDesc {
+            scope: "top".into(),
+            name: format!("s{i}"),
+            offset: layout.offsets[&i],
+            width,
+            is_4state: four_state,
+        })
+        .collect();
+    let size = width.div_ceil(8);
+    println!(
+        "mode,case,signals,width,four_state,steps,repeat,elapsed_ns,comparisons,changes,bytes"
+    );
+    for (name, count, scattered, same) in [
+        ("idle", 0, false, false),
+        ("sparse_clustered", (signals / 1000).max(1), false, false),
+        ("sparse_scattered", (signals / 1000).max(1), true, false),
+        ("same_value", (signals / 1000).max(1), true, true),
+        ("dense", signals, false, false),
+        ("burst", signals, false, false),
+        ("mask_only", (signals / 1000).max(1), true, false),
+    ] {
+        if case.as_ref().is_some_and(|case| case != name) || (name == "mask_only" && !four_state) {
+            continue;
+        }
+        for repeat in 0..repeats {
+            let mut memory = vec![0; layout.merged_total_size];
+            for (i, desc) in descs.iter().enumerate() {
+                memory[desc.offset] = i as u8;
+                memory[desc.offset + size - 1] |= 1 << ((width - 1) % 8);
+            }
+            let sink = Sink {
+                file: (output != "count").then(|| std::fs::File::create(&output).unwrap()),
+                bytes: 0,
+            };
+            let mut writer = VcdWriter::from_writer(sink, &descs);
+            writer.dump(0, &memory).unwrap();
+            writer.flush().unwrap();
+            let initial_bytes = writer.get_ref().bytes;
+            let initial_stats = writer.statistics();
+            let mut activity = Vec::with_capacity(trace.group_count);
+            let start = Instant::now();
+            for step in 1..=steps {
+                let count = if name == "burst" && step % 100 != 0 {
+                    0
+                } else {
+                    count
+                };
+                for j in 0..count {
+                    let index = if scattered {
+                        (j * signals / count + step) % signals
+                    } else {
+                        j
+                    };
+                    let home = descs[index].offset;
+                    let bit = step % width.saturating_sub(1).max(1);
+                    let at = home + bit / 8 + if name == "mask_only" { size } else { 0 };
+                    let next = if same {
+                        memory[at]
+                    } else {
+                        memory[at] ^ (1 << (bit % 8))
+                    };
+                    memory[at] = black_box(next);
+                    if mode != "scan" {
+                        // Same two byte notifications emitted at generated stores.
+                        unsafe {
+                            trace.mark_home(memory.as_mut_ptr(), home);
+                        }
+                    }
+                }
+                if mode != "scan" {
+                    trace.take(&mut memory, &mut activity);
+                }
+                if mode == "collect" {
+                    black_box(&activity);
+                } else {
+                    writer
+                        .dump_with_activity(
+                            step as u64,
+                            black_box(&memory),
+                            &[],
+                            (mode == "dirty").then_some(&activity),
+                        )
+                        .unwrap();
+                }
+            }
+            writer.flush().unwrap();
+            let elapsed = start.elapsed().as_nanos();
+            let stats = writer.statistics();
+            println!(
+                "{mode},{name},{signals},{width},{four_state},{steps},{repeat},{elapsed},{},{},{}",
+                stats.comparisons - initial_stats.comparisons,
+                stats.changes - initial_stats.changes,
+                writer.get_ref().bytes - initial_bytes
+            );
+        }
+    }
+}

--- a/crates/celox-runtime/src/backend.rs
+++ b/crates/celox-runtime/src/backend.rs
@@ -108,4 +108,44 @@ pub trait SimBackend {
     fn clear_triggered_bits(&mut self);
     fn mark_triggered_bit(&mut self, id: usize);
     fn get_triggered_bits(&self) -> bit_set::BitSet;
+
+    /// Consume waveform activity independently of clock trigger processing.
+    /// Returns false when full scanning is required (including raw host views).
+    fn take_vcd_activity(&mut self, groups: &mut Vec<usize>) -> bool {
+        groups.clear();
+        let Some(trace) = self.layout().trace.as_ref() else {
+            return false;
+        };
+        let (ptr, size) = self.memory_as_ptr();
+        // SAFETY: &mut self excludes execution/host access during consumption;
+        // the backend memory contract exposes this same writable state image.
+        let memory = unsafe { std::slice::from_raw_parts_mut(ptr.cast_mut(), size) };
+        trace.take(memory, groups)
+    }
+
+    /// Called by host setters, which share the generated-store notification ABI.
+    fn mark_vcd_signal(&mut self, signal: SignalRef) {
+        if let Some(trace) = self.layout().trace.as_ref() {
+            let len = signal.array_layout.map_or_else(
+                || celox_state_layout::get_byte_size(signal.width),
+                |array| array.plane_size,
+            );
+            let (ptr, _) = self.memory_as_ptr();
+            // SAFETY: layout homes and metadata fit in the writable state image.
+            unsafe {
+                trace.mark_range(ptr.cast_mut(), signal.offset, len);
+            }
+        }
+    }
+
+    /// Raw mutable views can outlive this call and bypass every store observer.
+    fn disable_vcd_tracking(&mut self) {
+        if let Some(trace) = self.layout().trace.as_ref() {
+            let (ptr, _) = self.memory_as_ptr();
+            // SAFETY: &mut self excludes execution; the offset is layout-owned.
+            unsafe {
+                *ptr.cast_mut().add(trace.untracked_offset) = 1;
+            }
+        }
+    }
 }

--- a/crates/celox-runtime/src/backend.rs
+++ b/crates/celox-runtime/src/backend.rs
@@ -79,6 +79,8 @@ pub trait SimBackend {
 
     // ── memory / layout ─────────────────────────────────────────
     fn memory_as_ptr(&self) -> (*const u8, usize);
+    /// Exposing a retained writable view must permanently disable sparse VCD
+    /// tracking in backend-owned state outside the returned memory range.
     fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize);
     /// Return an opaque owner that keeps the memory allocation alive.
     ///
@@ -109,10 +111,19 @@ pub trait SimBackend {
     fn mark_triggered_bit(&mut self, id: usize);
     fn get_triggered_bits(&self) -> bit_set::BitSet;
 
+    /// Opt into generated write notifications only while no raw mutable view
+    /// has escaped. The default keeps other backend implementations correct.
+    fn vcd_tracking_enabled(&self) -> bool {
+        false
+    }
+
     /// Consume waveform activity independently of clock trigger processing.
     /// Returns false when full scanning is required (including raw host views).
     fn take_vcd_activity(&mut self, groups: &mut Vec<usize>) -> bool {
         groups.clear();
+        if !self.vcd_tracking_enabled() {
+            return false;
+        }
         let Some(trace) = self.layout().trace.as_ref() else {
             return false;
         };
@@ -120,7 +131,8 @@ pub trait SimBackend {
         // SAFETY: &mut self excludes execution/host access during consumption;
         // the backend memory contract exposes this same writable state image.
         let memory = unsafe { std::slice::from_raw_parts_mut(ptr.cast_mut(), size) };
-        trace.take(memory, groups)
+        trace.take(memory, groups);
+        true
     }
 
     /// Called by host setters, which share the generated-store notification ABI.
@@ -134,17 +146,6 @@ pub trait SimBackend {
             // SAFETY: layout homes and metadata fit in the writable state image.
             unsafe {
                 trace.mark_range(ptr.cast_mut(), signal.offset, len);
-            }
-        }
-    }
-
-    /// Raw mutable views can outlive this call and bypass every store observer.
-    fn disable_vcd_tracking(&mut self) {
-        if let Some(trace) = self.layout().trace.as_ref() {
-            let (ptr, _) = self.memory_as_ptr();
-            // SAFETY: &mut self excludes execution; the offset is layout-owned.
-            unsafe {
-                *ptr.cast_mut().add(trace.untracked_offset) = 1;
             }
         }
     }

--- a/crates/celox-runtime/src/lib.rs
+++ b/crates/celox-runtime/src/lib.rs
@@ -17,7 +17,7 @@ pub use reflection::{
 };
 pub use simulation::{EventInfo, SimulationExecutor, SimulationState};
 pub use testbench::bind_testbench_program;
-pub use vcd::{VcdExternalSignalDesc, VcdSignalDesc, VcdWriter};
+pub use vcd::{VcdExternalSignalDesc, VcdSignalDesc, VcdStatistics, VcdWriter};
 
 pub type AbsoluteAddr = celox_design::StateAddr;
 pub type MemoryLayout = celox_state_layout::MemoryLayout<AbsoluteAddr>;

--- a/crates/celox-runtime/src/vcd.rs
+++ b/crates/celox-runtime/src/vcd.rs
@@ -567,7 +567,7 @@ fn encode_u64(out: &mut [MaybeUninit<u8>], value: u64) -> usize {
     use std::arch::x86_64::*;
 
     let bits = (64 - value.leading_zeros() as usize).max(1);
-    let mut remaining = value << (64 - bits);
+    let remaining = value << (64 - bits);
     let out = &mut out[..65];
     out[0].write(b'b');
     // SAFETY: SSE2 is enabled for this target. Each unaligned store initializes
@@ -575,23 +575,37 @@ fn encode_u64(out: &mut [MaybeUninit<u8>], value: u64) -> usize {
     // digits are published; any extra initialized bytes remain outside len.
     unsafe {
         let masks = _mm_set1_epi64x(0x0102_0408_1020_4080);
-        for chunk in out[1..]
-            .as_chunks_mut::<16>()
-            .0
-            .iter_mut()
-            .take(bits.div_ceil(16))
-        {
-            // Repeat each of the next two bytes eight times, then select one
-            // bit per lane in most-significant-bit-first order.
-            let word = _mm_set1_epi16((remaining >> 48) as i16);
-            let bytes = _mm_packus_epi16(
-                _mm_srli_epi16::<8>(word),
-                _mm_and_si128(word, _mm_set1_epi16(0xff)),
-            );
-            let zero = _mm_cmpeq_epi8(_mm_and_si128(bytes, masks), _mm_setzero_si128());
-            let ascii = _mm_add_epi8(_mm_set1_epi8(b'1' as i8), zero);
+        // Duplicate all eight input bytes once. Each chunk then selects two
+        // adjacent bytes and repeats each eight times, high byte first.
+        let word = _mm_cvtsi64_si128(remaining as i64);
+        let pairs = _mm_unpacklo_epi8(word, word);
+        let chunks = out[1..].as_chunks_mut::<16>().0;
+        let emit = |chunk: &mut [MaybeUninit<u8>; 16], bytes| {
+            let ones = _mm_cmpeq_epi8(_mm_and_si128(bytes, masks), masks);
+            let ascii = _mm_sub_epi8(_mm_set1_epi8(b'0' as i8), ones);
             _mm_storeu_si128(chunk.as_mut_ptr().cast(), ascii);
-            remaining <<= 16;
+        };
+        emit(
+            &mut chunks[0],
+            _mm_shuffle_epi32::<0xfa>(_mm_shufflehi_epi16::<0xaf>(pairs)),
+        );
+        if bits > 16 {
+            emit(
+                &mut chunks[1],
+                _mm_shuffle_epi32::<0xfa>(_mm_shufflehi_epi16::<0x05>(pairs)),
+            );
+        }
+        if bits > 32 {
+            emit(
+                &mut chunks[2],
+                _mm_shuffle_epi32::<0x50>(_mm_shufflelo_epi16::<0xaf>(pairs)),
+            );
+        }
+        if bits > 48 {
+            emit(
+                &mut chunks[3],
+                _mm_shuffle_epi32::<0x50>(_mm_shufflelo_epi16::<0x05>(pairs)),
+            );
         }
     }
     1 + bits

--- a/crates/celox-runtime/src/vcd.rs
+++ b/crates/celox-runtime/src/vcd.rs
@@ -118,9 +118,13 @@ pub struct VcdWriter<W: Write = File> {
 
 struct VcdOutput<W: Write> {
     writer: BufWriter<W>,
-    /// Complete value records accumulated for a bulk write. Successful dumps
-    /// always hand the tail to BufWriter so flush and Drop own pending output.
+    /// Complete records accepted by the encoder. Retained on I/O errors because
+    /// the trace plan already caches their values. Headers and timestamps also
+    /// use this queue, and are drained before any value records are appended.
+    /// Successful dumps hand the tail to BufWriter so Drop owns pending output.
     encoded: Vec<u8>,
+    /// Bytes already accepted by BufWriter, including short writes before an error.
+    written: usize,
     encoded_changes: u64,
     stats: VcdStatistics,
 }
@@ -153,6 +157,7 @@ impl<W: Write> VcdWriter<W> {
             output: VcdOutput {
                 writer: BufWriter::with_capacity(256 * 1024, writer),
                 encoded: Vec::new(),
+                written: 0,
                 encoded_changes: 0,
                 stats: VcdStatistics::default(),
             },
@@ -170,6 +175,7 @@ impl<W: Write> VcdWriter<W> {
 
     /// Publish buffered output, also reporting errors that Drop cannot report.
     pub fn flush(&mut self) -> std::io::Result<()> {
+        self.output.write_encoded()?;
         self.output.writer.flush()
     }
 
@@ -265,17 +271,17 @@ impl<W: Write> VcdWriter<W> {
 
     #[cold]
     fn write_header(&mut self) -> std::io::Result<()> {
-        writeln!(self.output.writer, "$date")?;
+        writeln!(self.output.encoded, "$date")?;
         writeln!(
-            self.output.writer,
+            self.output.encoded,
             "  {}",
             chrono::Local::now().format("%Y-%m-%d %H:%M:%S")
         )?;
-        writeln!(self.output.writer, "$end")?;
-        writeln!(self.output.writer, "$version")?;
-        writeln!(self.output.writer, "  celox")?;
-        writeln!(self.output.writer, "$end")?;
-        writeln!(self.output.writer, "$timescale 1ns $end")?;
+        writeln!(self.output.encoded, "$end")?;
+        writeln!(self.output.encoded, "$version")?;
+        writeln!(self.output.encoded, "  celox")?;
+        writeln!(self.output.encoded, "$end")?;
+        writeln!(self.output.encoded, "$timescale 1ns $end")?;
 
         let mut scope_order = Vec::<String>::new();
         let mut scope_groups = Vec::<Vec<usize>>::new();
@@ -292,24 +298,24 @@ impl<W: Write> VcdWriter<W> {
         }
         let mut next_id = 0;
         for (scope, group) in scope_order.iter().zip(scope_groups) {
-            writeln!(self.output.writer, "$scope module {} $end", scope)?;
+            writeln!(self.output.encoded, "$scope module {} $end", scope)?;
             for signal_index in group {
                 let signal = &mut self.headers[signal_index];
                 let id = Self::generate_vcd_id(next_id);
                 *self.plan.suffix(signal_index) = VcdRecordSuffix::new(signal.width, &id);
                 next_id += 1;
                 writeln!(
-                    self.output.writer,
+                    self.output.encoded,
                     "$var wire {} {} {} $end",
                     signal.width, id, signal.name
                 )?;
             }
-            writeln!(self.output.writer, "$upscope $end")?;
+            writeln!(self.output.encoded, "$upscope $end")?;
         }
-        writeln!(self.output.writer, "$enddefinitions $end")?;
-        writeln!(self.output.writer, "$dumpvars")?;
-        writeln!(self.output.writer, "$end")?;
-        if let Some(max_record) = self
+        writeln!(self.output.encoded, "$enddefinitions $end")?;
+        writeln!(self.output.encoded, "$dumpvars")?;
+        writeln!(self.output.encoded, "$end")?;
+        let record_capacity = self
             .headers
             .iter()
             .enumerate()
@@ -319,16 +325,22 @@ impl<W: Write> VcdWriter<W> {
                     + self.plan.suffix(index).capacity()
             })
             .max()
-        {
+            .map(|max_record| self.output.writer.capacity() + max_record);
+        if let Some(capacity) = record_capacity {
             // A block can cross the writer's capacity by one complete record.
             // Include the short suffix's padding, even for scalar-only traces.
             // Integer SIMD stores also fit within the full declared width.
             // Reserve here so record encoding never needs to grow the Vec.
             self.output
                 .encoded
-                .reserve(self.output.writer.capacity() + max_record);
+                .reserve(capacity.saturating_sub(self.output.encoded.len()));
         }
         self.header_written = true;
+        self.output.write_encoded()?;
+        if let Some(capacity) = record_capacity {
+            // A large header must not permanently enlarge the value buffer.
+            self.output.encoded.shrink_to(capacity);
+        }
         Ok(())
     }
 
@@ -384,16 +396,18 @@ impl<W: Write> VcdWriter<W> {
         activity: Option<&[usize]>,
     ) -> std::io::Result<()> {
         self.validate_external_count(external.len())?;
+        // Finish the previous attempt before starting a new timestamp or
+        // consulting caches that include its queued value records.
+        self.output.write_encoded()?;
         let first_dump = !self.initial_values_written;
         if !self.header_written {
             self.write_header()?;
         }
         if timestamp > self.timestamp || timestamp == 0 {
-            writeln!(self.output.writer, "#{}", timestamp)?;
+            writeln!(self.output.encoded, "#{}", timestamp)?;
             self.timestamp = timestamp;
+            self.output.write_encoded()?;
         }
-        self.output.encoded.clear();
-        self.output.encoded_changes = 0;
         self.selected.clear();
         // Dense activity is cheaper to walk directly in registration order.
         let sparse = activity
@@ -448,17 +462,42 @@ impl<W: Write> VcdOutput<W> {
         Ok(())
     }
 
+    #[inline]
     fn write_encoded(&mut self) -> std::io::Result<()> {
         if !self.encoded.is_empty() {
             // Full blocks bypass BufWriter's internal copy. A dump's final
             // partial block stays buffered with the timestamps and header.
-            self.writer.write_all(&self.encoded)?;
-            self.stats.changes += self.encoded_changes;
-            self.stats.value_bytes += self.encoded.len() as u64;
+            // Unlike write_all, retain progress if a later short write fails.
+            let remaining = &self.encoded[self.written..];
+            match self.writer.write(remaining) {
+                Ok(count) if count == remaining.len() => {}
+                result => self.finish_short_write(result)?,
+            }
+            if self.encoded_changes != 0 {
+                self.stats.changes += self.encoded_changes;
+                self.stats.value_bytes += self.encoded.len() as u64;
+            }
             self.encoded.clear();
+            self.written = 0;
             self.encoded_changes = 0;
         }
         Ok(())
+    }
+
+    #[cold]
+    fn finish_short_write(&mut self, mut result: std::io::Result<usize>) -> std::io::Result<()> {
+        loop {
+            match result {
+                Ok(0) => return Err(std::io::ErrorKind::WriteZero.into()),
+                Ok(count) => self.written += count,
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(error) => return Err(error),
+            }
+            if self.written == self.encoded.len() {
+                return Ok(());
+            }
+            result = self.writer.write(&self.encoded[self.written..]);
+        }
     }
 }
 
@@ -1161,11 +1200,16 @@ mod encoding_tests {
             .dump_with_activity(2, &[0; 200], &[], Some(&[]))
             .unwrap();
         assert!(writer.initial_values_written);
-        assert_eq!(writer.statistics().changes, 4);
+        // Finish the accepted record at its original time, then repeat the
+        // incomplete initial snapshot in full at the retry's timestamp.
+        assert_eq!(writer.statistics().changes, 5);
         assert_eq!(writer.statistics().comparisons, 5);
         assert_eq!(
             changes(&writer.into_inner().unwrap().bytes),
-            vec![(2, "0".into()); 4]
+            [(1, "0".into())]
+                .into_iter()
+                .chain(vec![(2, "0".into()); 4])
+                .collect::<Vec<_>>()
         );
     }
 
@@ -1307,6 +1351,137 @@ mod encoding_tests {
 
         fn flush(&mut self) -> std::io::Result<()> {
             Ok(())
+        }
+    }
+
+    #[test]
+    fn failed_value_blocks_resume_without_losing_cached_transitions() {
+        for width in [1usize, 64, 9, 65, 256 * 1024 + 17] {
+            for four_state in [false, true] {
+                for capacity in [1, 64] {
+                    for accepted in [0, 1, 31] {
+                        let count = if width > 1024 { 2 } else { 80 };
+                        let stride = width.div_ceil(8) * if four_state { 2 } else { 1 };
+                        let descs = (0..count)
+                            .map(|index| VcdSignalDesc {
+                                scope: "top".into(),
+                                name: format!("s{index}"),
+                                offset: index * stride,
+                                width,
+                                is_4state: four_state,
+                            })
+                            .collect::<Vec<_>>();
+                        let mut memory = vec![0; count * stride];
+                        let mut writer = VcdWriter::from_writer(ShortWrites::default(), &descs);
+                        writer.output.writer =
+                            BufWriter::with_capacity(capacity, ShortWrites::default());
+                        let mut reference = VcdWriter::from_writer(Vec::new(), &descs);
+                        writer.dump(0, &memory).unwrap();
+                        writer.flush().unwrap();
+                        reference.dump(0, &memory).unwrap();
+
+                        // Fail before accepting a value block, or after a short
+                        // prefix of it. A block may contain several cache updates.
+                        let limit = writer.get_ref().bytes.len() + b"#1\n".len() + accepted;
+                        writer.output.writer.get_mut().fail_after = Some(limit);
+                        memory.fill(0xff);
+                        for _ in 0..2 {
+                            assert_eq!(
+                                writer.dump(1, &memory).unwrap_err().kind(),
+                                std::io::ErrorKind::BrokenPipe
+                            );
+                        }
+                        writer.output.writer.get_mut().fail_after = None;
+                        writer.dump(1, &memory).unwrap();
+                        reference.dump(1, &memory).unwrap();
+                        // Also check that recovery leaves the caches current.
+                        writer.dump(2, &memory).unwrap();
+                        reference.dump(2, &memory).unwrap();
+                        assert_eq!(writer.statistics().changes, reference.statistics().changes);
+                        assert_eq!(
+                            writer.statistics().value_bytes,
+                            reference.statistics().value_bytes
+                        );
+                        assert_eq!(
+                            changes(&writer.into_inner().unwrap().bytes),
+                            changes(&reference.into_inner().unwrap()),
+                            "width={width}, four_state={four_state}, capacity={capacity}, accepted={accepted}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn pending_value_records_finish_before_the_next_timestamp() {
+        for flush_first in [false, true] {
+            let descs = (0..4)
+                .map(|index| VcdSignalDesc {
+                    scope: "top".into(),
+                    name: format!("s{index}"),
+                    offset: index * 8,
+                    width: 64,
+                    is_4state: false,
+                })
+                .collect::<Vec<_>>();
+            let mut writer = VcdWriter::from_writer(ShortWrites::default(), &descs);
+            // Keep the unwritten suffix larger than BufWriter's capacity so it
+            // cannot accept another record before surfacing the injected error.
+            writer.output.writer = BufWriter::with_capacity(1, ShortWrites::default());
+            writer.dump(0, &[0; 32]).unwrap();
+            writer.flush().unwrap();
+            let limit = writer.get_ref().bytes.len() + b"#1\n".len() + 7;
+            writer.output.writer.get_mut().fail_after = Some(limit);
+            assert!(writer.dump(1, &[0xff; 32]).is_err());
+            writer.output.writer.get_mut().fail_after = None;
+            if flush_first {
+                writer.flush().unwrap();
+            }
+            // The memory has changed again since the failed attempt. The old
+            // queued record must finish at #1, followed by the new value at #2.
+            writer.dump(2, &[0; 32]).unwrap();
+            let mut expected = vec![(0, "0".to_owned()); 4];
+            expected.extend([(1, "1".repeat(64)), (2, "0".into())]);
+            assert_eq!(changes(&writer.into_inner().unwrap().bytes), expected);
+        }
+    }
+
+    #[test]
+    fn header_and_timestamp_resume_after_partial_writes() {
+        let desc = VcdSignalDesc {
+            scope: "top".into(),
+            name: "q".into(),
+            offset: 0,
+            width: 64,
+            is_4state: false,
+        };
+        for accepted in [0, 1, 17] {
+            let mut writer =
+                VcdWriter::from_writer(ShortWrites::default(), std::slice::from_ref(&desc));
+            writer.output.writer = BufWriter::with_capacity(
+                1,
+                ShortWrites {
+                    fail_after: Some(accepted),
+                    ..Default::default()
+                },
+            );
+            assert!(writer.dump(0, &[0; 8]).is_err());
+            writer.output.writer.get_mut().fail_after = None;
+            writer.dump(0, &[0; 8]).unwrap();
+            writer.flush().unwrap();
+            let limit = writer.get_ref().bytes.len() + 2;
+            writer.output.writer.get_mut().fail_after = Some(limit);
+            assert!(writer.dump(123, &[1; 8]).is_err());
+            writer.output.writer.get_mut().fail_after = None;
+            writer.dump(123, &[1; 8]).unwrap();
+            assert_eq!(
+                changes(&writer.into_inner().unwrap().bytes),
+                [
+                    (0, "0".to_owned()),
+                    (123, format!("{:b}", u64::from_le_bytes([1; 8])))
+                ],
+            );
         }
     }
 

--- a/crates/celox-runtime/src/vcd.rs
+++ b/crates/celox-runtime/src/vcd.rs
@@ -108,6 +108,7 @@ pub struct VcdWriter<W: Write = File> {
     plan: TracePlan,
     groups: fxhash::FxHashMap<usize, Vec<usize>>,
     selected: Vec<usize>,
+    /// Consumed groups retained after a failed dump; empty after success.
     activity: Vec<usize>,
     timestamp: u64,
     header_written: bool,
@@ -191,12 +192,27 @@ impl<W: Write> VcdWriter<W> {
         // Reject recoverable input errors before consuming pending writes.
         self.validate_external_count(external.len())?;
         let mut activity = std::mem::take(&mut self.activity);
-        let tracked = backend.take_vcd_activity(&mut activity);
+        let tracked = if activity.is_empty() {
+            backend.take_vcd_activity(&mut activity)
+        } else {
+            // Consumption clears its destination. Keep failed-dump activity
+            // and merge writes made since that attempt, including duplicates.
+            // Only this retry path needs a second allocation.
+            let mut new_activity = Vec::new();
+            let tracked = backend.take_vcd_activity(&mut new_activity);
+            activity.extend(new_activity);
+            activity.sort_unstable();
+            activity.dedup();
+            tracked
+        };
         let (ptr, size) = backend.memory_as_ptr();
         // SAFETY: the backend owns the image and cannot run during this dump.
         let memory = unsafe { std::slice::from_raw_parts(ptr, size) };
         let result =
             self.dump_with_activity(timestamp, memory, external, tracked.then_some(&activity));
+        if result.is_ok() {
+            activity.clear();
+        }
         self.activity = activity;
         result
     }

--- a/crates/celox-runtime/src/vcd.rs
+++ b/crates/celox-runtime/src/vcd.rs
@@ -2,6 +2,7 @@ use celox_state_layout::{TRACE_GROUP_BYTES, get_byte_size};
 use num_bigint::BigUint;
 use std::fs::File;
 use std::io::{BufWriter, Write};
+use std::mem::MaybeUninit;
 use std::path::Path;
 
 /// Describes a signal for VCD recording.
@@ -42,12 +43,65 @@ enum VcdWriterSource {
 }
 
 struct VcdWriterSignal {
-    vcd_id: String,
+    suffix: VcdRecordSuffix,
     scope: String,
     name: String,
     width: usize,
     source: VcdWriterSource,
     previous_offset: usize,
+}
+
+/// Finalized with the header: an optional space, the ID, and a newline.
+/// Most IDs fit in one fixed-size copy; retain arbitrary-length IDs as well.
+enum VcdRecordSuffix {
+    Inline { bytes: [u8; 8], len: u8 },
+    Long(Box<[u8]>),
+}
+
+impl VcdRecordSuffix {
+    fn new(width: usize, id: &str) -> Self {
+        let prefix = usize::from(width != 1);
+        let len = prefix + id.len() + 1;
+        if len <= 8 {
+            let mut bytes = [b' '; 8];
+            bytes[prefix..len - 1].copy_from_slice(id.as_bytes());
+            bytes[len - 1] = b'\n';
+            Self::Inline {
+                bytes,
+                len: len as u8,
+            }
+        } else {
+            let mut bytes = Vec::with_capacity(len);
+            if prefix != 0 {
+                bytes.push(b' ');
+            }
+            bytes.extend_from_slice(id.as_bytes());
+            bytes.push(b'\n');
+            Self::Long(bytes.into_boxed_slice())
+        }
+    }
+
+    fn capacity(&self) -> usize {
+        match self {
+            Self::Inline { .. } => 8,
+            Self::Long(bytes) => bytes.len(),
+        }
+    }
+
+    /// Initializes the returned number of bytes, plus padding for short IDs.
+    #[inline]
+    fn encode(&self, out: &mut [MaybeUninit<u8>]) -> usize {
+        match self {
+            Self::Inline { bytes, len } => {
+                copy_encoded(out, bytes);
+                *len as usize
+            }
+            Self::Long(bytes) => {
+                copy_encoded(out, bytes);
+                bytes.len()
+            }
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -94,7 +148,7 @@ impl<W: Write> VcdWriter<W> {
                 let group = desc.offset / TRACE_GROUP_BYTES;
                 groups.entry(group).or_default().push(index);
                 VcdWriterSignal {
-                    vcd_id: String::new(),
+                    suffix: VcdRecordSuffix::new(desc.width, ""),
                     scope: desc.scope.clone(),
                     name: desc.name.clone(),
                     width: desc.width,
@@ -199,7 +253,7 @@ impl<W: Write> VcdWriter<W> {
             let index = self.external_count;
             self.external_count += 1;
             self.signals.push(VcdWriterSignal {
-                vcd_id: String::new(),
+                suffix: VcdRecordSuffix::new(desc.width, ""),
                 scope: desc.scope.clone(),
                 name: desc.name.clone(),
                 width: desc.width,
@@ -245,12 +299,13 @@ impl<W: Write> VcdWriter<W> {
             writeln!(self.writer, "$scope module {} $end", scope)?;
             for signal_index in group {
                 let signal = &mut self.signals[signal_index];
-                signal.vcd_id = Self::generate_vcd_id(next_id);
+                let id = Self::generate_vcd_id(next_id);
+                signal.suffix = VcdRecordSuffix::new(signal.width, &id);
                 next_id += 1;
                 writeln!(
                     self.writer,
                     "$var wire {} {} {} $end",
-                    signal.width, signal.vcd_id, signal.name
+                    signal.width, id, signal.name
                 )?;
             }
             writeln!(self.writer, "$upscope $end")?;
@@ -261,11 +316,15 @@ impl<W: Write> VcdWriter<W> {
         if let Some(max_record) = self
             .signals
             .iter()
-            .map(|signal| signal.width + signal.vcd_id.len() + 3)
+            .map(|signal| {
+                signal.width.max(1) + usize::from(signal.width != 1) + signal.suffix.capacity()
+            })
             .max()
         {
             // A block can cross the writer's capacity by one complete record.
-            // Reserve both here, once IDs and external signals are finalized.
+            // Include the short suffix's padding, even for scalar-only traces.
+            // Integer SIMD stores also fit within the full declared width.
+            // Reserve here so record encoding never needs to grow the Vec.
             self.encoded.reserve(self.writer.capacity() + max_record);
         }
         self.header_written = true;
@@ -359,7 +418,7 @@ impl<W: Write> VcdWriter<W> {
             };
             let sig = &self.signals[i];
             self.stats.comparisons += 1;
-            match sig.source {
+            let value_len = match sig.source {
                 VcdWriterSource::Memory { .. } | VcdWriterSource::External { .. } => {
                     let size = get_byte_size(sig.width);
                     // The memory path borrows bytes directly. External component values
@@ -403,11 +462,11 @@ impl<W: Write> VcdWriter<W> {
                     }
                     self.initialized[i] = true;
                     encode_value(
-                        &mut self.encoded,
+                        self.encoded.spare_capacity_mut(),
                         sig.width,
                         &old[..size],
                         if track_mask { &old[size..] } else { &[] },
-                    );
+                    )
                 }
                 VcdWriterSource::MemoryBit { offset } => {
                     let value = memory[offset] & 1;
@@ -417,7 +476,8 @@ impl<W: Write> VcdWriter<W> {
                     }
                     *old = value;
                     self.initialized[i] = true;
-                    self.encoded.push(b'0' + value);
+                    self.encoded.spare_capacity_mut()[0].write(b'0' + value);
+                    1
                 }
                 VcdWriterSource::Memory64 { offset } => {
                     let value: [u8; 8] = memory[offset..offset + 8].try_into().unwrap();
@@ -431,14 +491,19 @@ impl<W: Write> VcdWriter<W> {
                     }
                     *old = value;
                     self.initialized[i] = true;
-                    encode_u64(&mut self.encoded, u64::from_le_bytes(value));
+                    encode_u64(self.encoded.spare_capacity_mut(), u64::from_le_bytes(value))
                 }
+            };
+            let suffix_len = sig
+                .suffix
+                .encode(&mut self.encoded.spare_capacity_mut()[value_len..]);
+            // SAFETY: the encoders initialize their returned lengths in checked
+            // slices of spare capacity. Publish only the complete record, once;
+            // any SIMD/suffix padding stays outside the Vec's visible length.
+            unsafe {
+                self.encoded
+                    .set_len(self.encoded.len() + value_len + suffix_len);
             }
-            if sig.width != 1 {
-                self.encoded.push(b' ');
-            }
-            self.encoded.extend_from_slice(sig.vcd_id.as_bytes());
-            self.encoded.push(b'\n');
             self.encoded_changes += 1;
             if self.encoded.len() >= self.writer.capacity() {
                 self.write_encoded()?;
@@ -498,20 +563,19 @@ fn copy_plane(dst: &mut [u8], src: &[u8], width: usize) {
 
 #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
 #[inline]
-fn encode_u64(out: &mut Vec<u8>, value: u64) {
+fn encode_u64(out: &mut [MaybeUninit<u8>], value: u64) -> usize {
     use std::arch::x86_64::*;
 
     let bits = (64 - value.leading_zeros() as usize).max(1);
     let mut remaining = value << (64 - bits);
-    out.push(b'b');
-    out.reserve(64);
-    let start = out.len();
+    let out = &mut out[..65];
+    out[0].write(b'b');
     // SAFETY: SSE2 is enabled for this target. Each unaligned store initializes
     // exactly one 16-byte chunk of reserved capacity. Only the significant
     // digits are published; any extra initialized bytes remain outside len.
     unsafe {
         let masks = _mm_set1_epi64x(0x0102_0408_1020_4080);
-        for chunk in out.spare_capacity_mut()[..64]
+        for chunk in out[1..]
             .as_chunks_mut::<16>()
             .0
             .iter_mut()
@@ -529,19 +593,22 @@ fn encode_u64(out: &mut Vec<u8>, value: u64) {
             _mm_storeu_si128(chunk.as_mut_ptr().cast(), ascii);
             remaining <<= 16;
         }
-        out.set_len(start + bits);
     }
+    1 + bits
 }
 
 #[cfg(not(all(target_arch = "x86_64", target_feature = "sse2")))]
 #[inline]
-fn encode_u64(out: &mut Vec<u8>, value: u64) {
-    encode_value(out, 64, &value.to_le_bytes(), &[]);
+fn encode_u64(out: &mut [MaybeUninit<u8>], value: u64) -> usize {
+    encode_value(out, 64, &value.to_le_bytes(), &[])
 }
 
-fn encode_value(out: &mut Vec<u8>, width: usize, value: &[u8], mask: &[u8]) {
+/// Initializes and returns the value's encoded length. The caller reserves a
+/// full-width record, including any SIMD and suffix padding, before encoding.
+fn encode_value(out: &mut [MaybeUninit<u8>], width: usize, value: &[u8], mask: &[u8]) -> usize {
+    let prefix = usize::from(width != 1);
     if width != 1 {
-        out.push(b'b');
+        out[0].write(b'b');
     }
     let four_state = mask.iter().any(|&byte| byte != 0);
     let bits = if four_state {
@@ -552,25 +619,42 @@ fn encode_value(out: &mut Vec<u8>, width: usize, value: &[u8], mask: &[u8]) {
             .rposition(|&byte| byte != 0)
             .map_or(1, |i| i * 8 + (8 - value[i].leading_zeros() as usize))
     };
-    out.reserve(bits);
+    let out = &mut out[prefix..prefix + bits];
     if !four_state {
         let bytes = bits.div_ceil(8);
         let high = value.get(bytes - 1).copied().unwrap_or(0);
-        out.extend_from_slice(&BINARY[high as usize][8 - (bits - (bytes - 1) * 8)..]);
-        for &byte in value[..bytes - 1].iter().rev() {
-            out.extend_from_slice(&BINARY[byte as usize]);
+        let high_bits = bits - (bytes - 1) * 8;
+        copy_encoded(out, &BINARY[high as usize][8 - high_bits..]);
+        for (chunk, &byte) in out[high_bits..]
+            .as_chunks_mut::<8>()
+            .0
+            .iter_mut()
+            .zip(value[..bytes - 1].iter().rev())
+        {
+            copy_encoded(chunk, &BINARY[byte as usize]);
         }
-        return;
+        return prefix + bits;
     }
-    for bit in (0..bits).rev() {
+    for (dst, bit) in out.iter_mut().zip((0..bits).rev()) {
         let v = value.get(bit / 8).copied().unwrap_or(0) >> (bit % 8) & 1;
         let m = mask.get(bit / 8).copied().unwrap_or(0) >> (bit % 8) & 1;
-        out.push(match (m, v) {
+        dst.write(match (m, v) {
             (0, 0) => b'0',
             (0, _) => b'1',
             (_, 0) => b'z',
             _ => b'x',
         });
+    }
+    prefix + bits
+}
+
+#[inline]
+fn copy_encoded(out: &mut [MaybeUninit<u8>], bytes: &[u8]) {
+    let out = &mut out[..bytes.len()];
+    // SAFETY: the checked destination has enough capacity and the borrowed
+    // source cannot overlap it. This initializes exactly bytes.len() bytes.
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), out.as_mut_ptr().cast(), bytes.len());
     }
 }
 
@@ -672,13 +756,150 @@ mod encoding_tests {
             let mut actual = vec![b'#'; prefix];
             let mut expected = actual.clone();
             for &value in &values {
-                encode_u64(&mut actual, value);
+                actual.reserve(65);
+                let len = encode_u64(actual.spare_capacity_mut(), value);
+                // SAFETY: encode_u64 initialized len bytes of spare capacity.
+                unsafe { actual.set_len(actual.len() + len) };
                 expected.extend_from_slice(format!("b{value:b}").as_bytes());
                 assert_eq!(actual, expected, "prefix={prefix} value={value:#x}");
                 if actual.len() > 4096 {
                     actual.truncate(prefix);
                     expected.truncate(prefix);
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn record_suffixes_preserve_ids_and_never_publish_padding() {
+        for (number, expected) in [(0, "!"), (93, "~"), (94, "!!"), (8929, "~~"), (8930, "!!!")] {
+            assert_eq!(VcdWriter::<Vec<u8>>::generate_vcd_id(number), expected);
+        }
+        // Test both sides of the inline boundary without allocating the huge
+        // signal set needed to reach long IDs through normal registration.
+        for id in [
+            "!",
+            "~",
+            "!!",
+            "~~~",
+            "abcdef",
+            "abcdefg",
+            "abcdefgh",
+            "abcdefghi",
+            "abcdefghijklmnop",
+        ] {
+            for width in [1, 64] {
+                let suffix = VcdRecordSuffix::new(width, id);
+                let expected_suffix = format!("{}{id}\n", if width == 1 { "" } else { " " });
+                for prefix in 0..16 {
+                    let mut guarded = [MaybeUninit::new(b'#'); 64];
+                    let end = prefix + suffix.capacity();
+                    let len = suffix.encode(&mut guarded[prefix..end]);
+                    // SAFETY: all guard bytes started initialized, and encoding
+                    // only overwrites them with initialized suffix bytes.
+                    let actual = guarded.map(|byte| unsafe { byte.assume_init() });
+                    assert_eq!(&actual[..prefix], vec![b'#'; prefix]);
+                    assert_eq!(&actual[prefix..prefix + len], expected_suffix.as_bytes());
+                    assert!(actual[end..].iter().all(|&byte| byte == b'#'));
+
+                    let mut records = vec![b'#'; prefix];
+                    let mut expected = records.clone();
+                    for value in [0u64, 1, 1 << 63, u64::MAX, 0] {
+                        let value_capacity = if width == 1 { 1 } else { 65 };
+                        records.reserve(value_capacity + suffix.capacity());
+                        // Bound the spare slice to exactly the reserved record
+                        // space, including fixed-store padding. Later records
+                        // must overwrite that padding at the visible length.
+                        let out =
+                            &mut records.spare_capacity_mut()[..value_capacity + suffix.capacity()];
+                        let value_len = if width == 1 {
+                            out[0].write(b'0' + (value & 1) as u8);
+                            1
+                        } else {
+                            encode_u64(out, value)
+                        };
+                        let suffix_len = suffix.encode(&mut out[value_len..]);
+                        // SAFETY: both encoders initialized their returned lengths.
+                        unsafe { records.set_len(records.len() + value_len + suffix_len) };
+                        let value_text = if width == 1 {
+                            (value & 1).to_string()
+                        } else {
+                            format!("b{value:b}")
+                        };
+                        expected.extend_from_slice(value_text.as_bytes());
+                        expected.extend_from_slice(expected_suffix.as_bytes());
+                        assert_eq!(records, expected, "id={id} width={width} prefix={prefix}");
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn complete_records_cross_small_blocks_with_scalar_and_mixed_widths() {
+        for scalar_only in [true, false] {
+            let descs = (0..100)
+                .map(|i| VcdSignalDesc {
+                    scope: format!("scope{}", i % 2),
+                    name: format!("s{i}"),
+                    offset: i * 8,
+                    width: if scalar_only { 1 } else { [1, 9, 64][i % 3] },
+                    is_4state: false,
+                })
+                .collect::<Vec<_>>();
+            for capacity in [1, 3, 7, 8, 9, 16, 64, 71, 72, 73] {
+                let mut writer = VcdWriter::from_writer(Vec::new(), &descs);
+                writer.writer = BufWriter::with_capacity(capacity, Vec::new());
+                for (time, value) in [0xff, 0, 0, 0xff].into_iter().enumerate() {
+                    writer.dump(time as u64, &[value; 800]).unwrap();
+                }
+                assert_eq!(writer.statistics().changes, 300);
+                let bytes = writer.into_inner().unwrap();
+                let mut parser = vcd::Parser::new(bytes.as_slice());
+                let header = parser.parse_header().unwrap();
+                let mut names = fxhash::FxHashMap::default();
+                for item in header.items {
+                    if let vcd::ScopeItem::Scope(scope) = item {
+                        for item in scope.items {
+                            if let vcd::ScopeItem::Var(var) = item {
+                                names.insert(var.code, var.reference);
+                            }
+                        }
+                    }
+                }
+                assert_eq!(names.len(), descs.len());
+                let mut time = 0;
+                let actual = parser
+                    .filter_map(|command| {
+                        let (id, value) = match command.unwrap() {
+                            vcd::Command::Timestamp(t) => {
+                                time = t;
+                                return None;
+                            }
+                            vcd::Command::ChangeScalar(id, value) => (id, value.to_string()),
+                            vcd::Command::ChangeVector(id, value) => (id, value.to_string()),
+                            _ => return None,
+                        };
+                        Some((time, names[&id].clone(), value))
+                    })
+                    .collect::<Vec<_>>();
+                let expected = [0, 1, 3]
+                    .into_iter()
+                    .flat_map(|time| {
+                        descs.iter().map(move |desc| {
+                            let value = if time == 1 {
+                                "0".into()
+                            } else {
+                                "1".repeat(desc.width)
+                            };
+                            (time, desc.name.clone(), value)
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                assert_eq!(
+                    actual, expected,
+                    "scalar_only={scalar_only} capacity={capacity}"
+                );
             }
         }
     }

--- a/crates/celox-runtime/src/vcd.rs
+++ b/crates/celox-runtime/src/vcd.rs
@@ -1,4 +1,4 @@
-use celox_state_layout::get_byte_size;
+use celox_state_layout::{TRACE_GROUP_BYTES, get_byte_size};
 use num_bigint::BigUint;
 use std::fs::File;
 use std::io::{BufWriter, Write};
@@ -36,6 +36,9 @@ pub struct VcdExternalSignalDesc {
 enum VcdWriterSource {
     Memory { offset: usize, is_4state: bool },
     External { index: usize },
+    // Classify once so the dump loop can use a fixed-width load and store.
+    MemoryBit { offset: usize },
+    Memory64 { offset: usize },
 }
 
 struct VcdWriterSignal {
@@ -44,45 +47,125 @@ struct VcdWriterSignal {
     name: String,
     width: usize,
     source: VcdWriterSource,
+    previous_offset: usize,
 }
 
-pub struct VcdWriter {
-    writer: BufWriter<File>,
+#[derive(Clone, Copy, Debug, Default)]
+pub struct VcdStatistics {
+    pub comparisons: u64,
+    pub changes: u64,
+    pub value_bytes: u64,
+}
+
+pub struct VcdWriter<W: Write = File> {
+    writer: BufWriter<W>,
     signals: Vec<VcdWriterSignal>,
-    last_values: Vec<Option<(BigUint, BigUint)>>,
+    previous: Vec<u8>,
+    initialized: Vec<bool>,
+    groups: fxhash::FxHashMap<usize, Vec<usize>>,
+    selected: Vec<usize>,
+    activity: Vec<usize>,
+    /// Complete value records accumulated for a bulk write. Successful dumps
+    /// always hand the tail to BufWriter so flush and Drop own pending output.
+    encoded: Vec<u8>,
+    encoded_changes: u64,
+    stats: VcdStatistics,
     timestamp: u64,
     header_written: bool,
     external_count: usize,
 }
 
-impl VcdWriter {
+impl VcdWriter<File> {
     pub fn new<P: AsRef<Path>>(path: P, descs: &[VcdSignalDesc]) -> std::io::Result<Self> {
-        let file = File::create(path)?;
-        let writer = BufWriter::new(file);
+        Ok(Self::from_writer(File::create(path)?, descs))
+    }
+}
+
+impl<W: Write> VcdWriter<W> {
+    pub fn from_writer(writer: W, descs: &[VcdSignalDesc]) -> Self {
+        let mut previous = Vec::new();
+        let mut groups: fxhash::FxHashMap<usize, Vec<usize>> = Default::default();
         let signals = descs
             .iter()
-            .map(|desc| VcdWriterSignal {
-                vcd_id: String::new(),
-                scope: desc.scope.clone(),
-                name: desc.name.clone(),
-                width: desc.width,
-                source: VcdWriterSource::Memory {
-                    offset: desc.offset,
-                    is_4state: desc.is_4state,
-                },
+            .enumerate()
+            .map(|(index, desc)| {
+                let previous_offset = previous.len();
+                previous.resize(previous.len() + get_byte_size(desc.width) * 2, 0);
+                let group = desc.offset / TRACE_GROUP_BYTES;
+                groups.entry(group).or_default().push(index);
+                VcdWriterSignal {
+                    vcd_id: String::new(),
+                    scope: desc.scope.clone(),
+                    name: desc.name.clone(),
+                    width: desc.width,
+                    source: match (desc.width, desc.is_4state) {
+                        (1, false) => VcdWriterSource::MemoryBit {
+                            offset: desc.offset,
+                        },
+                        (64, false) => VcdWriterSource::Memory64 {
+                            offset: desc.offset,
+                        },
+                        _ => VcdWriterSource::Memory {
+                            offset: desc.offset,
+                            is_4state: desc.is_4state,
+                        },
+                    },
+                    previous_offset,
+                }
             })
             .collect::<Vec<_>>();
-
-        let last_values = vec![None; signals.len()];
-
-        Ok(Self {
-            writer,
+        Self {
+            writer: BufWriter::with_capacity(256 * 1024, writer),
+            initialized: vec![false; signals.len()],
             signals,
-            last_values,
+            previous,
+            groups,
+            selected: Vec::new(),
+            activity: Vec::new(),
+            encoded: Vec::new(),
+            encoded_changes: 0,
+            stats: VcdStatistics::default(),
             timestamp: 0,
             header_written: false,
             external_count: 0,
-        })
+        }
+    }
+
+    /// Publish buffered output, also reporting errors that Drop cannot report.
+    pub fn flush(&mut self) -> std::io::Result<()> {
+        self.writer.flush()
+    }
+
+    pub fn statistics(&self) -> VcdStatistics {
+        self.stats
+    }
+    pub fn get_ref(&self) -> &W {
+        self.writer.get_ref()
+    }
+
+    /// Dump as the backend's sole incremental waveform observer. Multiple
+    /// writers must consume activity once and share it through
+    /// `dump_with_activity`, since each consumption clears the pending flags.
+    pub fn dump_backend<B: crate::backend::SimBackend>(
+        &mut self,
+        timestamp: u64,
+        backend: &mut B,
+        external: &[(BigUint, BigUint)],
+    ) -> std::io::Result<()> {
+        let mut activity = std::mem::take(&mut self.activity);
+        let tracked = backend.take_vcd_activity(&mut activity);
+        let (ptr, size) = backend.memory_as_ptr();
+        // SAFETY: the backend owns the image and cannot run during this dump.
+        let memory = unsafe { std::slice::from_raw_parts(ptr, size) };
+        let result =
+            self.dump_with_activity(timestamp, memory, external, tracked.then_some(&activity));
+        self.activity = activity;
+        result
+    }
+
+    pub fn into_inner(mut self) -> std::io::Result<W> {
+        self.flush()?;
+        self.writer.into_inner().map_err(|error| error.into_error())
     }
 
     /// Adds externally supplied signals before the first dump. VCD headers
@@ -121,16 +204,17 @@ impl VcdWriter {
                 name: desc.name.clone(),
                 width: desc.width,
                 source: VcdWriterSource::External { index },
+                previous_offset: self.previous.len(),
             });
-            self.last_values.push(None);
+            self.previous
+                .resize(self.previous.len() + get_byte_size(desc.width) * 2, 0);
+            self.initialized.push(false);
         }
         Ok(())
     }
 
+    #[cold]
     fn write_header(&mut self) -> std::io::Result<()> {
-        if self.header_written {
-            return Ok(());
-        }
         writeln!(self.writer, "$date")?;
         writeln!(
             self.writer,
@@ -174,6 +258,16 @@ impl VcdWriter {
         writeln!(self.writer, "$enddefinitions $end")?;
         writeln!(self.writer, "$dumpvars")?;
         writeln!(self.writer, "$end")?;
+        if let Some(max_record) = self
+            .signals
+            .iter()
+            .map(|signal| signal.width + signal.vcd_id.len() + 3)
+            .max()
+        {
+            // A block can cross the writer's capacity by one complete record.
+            // Reserve both here, once IDs and external signals are finalized.
+            self.encoded.reserve(self.writer.capacity() + max_record);
+        }
         self.header_written = true;
         Ok(())
     }
@@ -192,39 +286,29 @@ impl VcdWriter {
         id.chars().rev().collect()
     }
 
-    /// Read a value from the JIT memory at the given offset and width.
-    fn read_value(memory: &[u8], offset: usize, width: usize) -> BigUint {
-        let byte_size = get_byte_size(width);
-        let slice = &memory[offset..offset + byte_size];
-        let mut val = BigUint::from_bytes_le(slice);
-        let extra_bits = byte_size * 8 - width;
-        if extra_bits > 0 {
-            let mask = (BigUint::from(1u32) << width) - 1u32;
-            val &= mask;
-        }
-        val
-    }
-
-    fn mask_to_width(mut value: BigUint, width: usize) -> BigUint {
-        if value.bits() > width as u64 {
-            value &= (BigUint::from(1u8) << width) - 1u8;
-        }
-        value
-    }
-
-    /// Dump all changed signals at the given timestamp.
-    ///
-    /// `memory` is the raw JIT memory (stable region or full buffer).
+    /// Full-scan reference path, also suitable for uninstrumented/raw memory.
     pub fn dump(&mut self, timestamp: u64, memory: &[u8]) -> std::io::Result<()> {
         self.dump_with_external(timestamp, memory, &[])
     }
 
-    /// Dump memory-backed signals and external values in registration order.
     pub fn dump_with_external(
         &mut self,
         timestamp: u64,
         memory: &[u8],
         external: &[(BigUint, BigUint)],
+    ) -> std::io::Result<()> {
+        self.dump_with_activity(timestamp, memory, external, None)
+    }
+
+    /// `activity` contains unique physical group IDs consumed from TraceLayout.
+    /// None requests a full scan. Initial values and external signals are always
+    /// observed, including when no generated store has executed.
+    pub fn dump_with_activity(
+        &mut self,
+        timestamp: u64,
+        memory: &[u8],
+        external: &[(BigUint, BigUint)],
+        activity: Option<&[usize]>,
     ) -> std::io::Result<()> {
         if external.len() != self.external_count {
             return Err(std::io::Error::new(
@@ -236,99 +320,273 @@ impl VcdWriter {
                 ),
             ));
         }
-        self.write_header()?;
+        let first_dump = !self.header_written;
+        if first_dump {
+            self.write_header()?;
+        }
         if timestamp > self.timestamp || timestamp == 0 {
             writeln!(self.writer, "#{}", timestamp)?;
             self.timestamp = timestamp;
         }
-
-        for (i, sig) in self.signals.iter().enumerate() {
-            let (current_val, current_mask, is_4state) = match sig.source {
-                VcdWriterSource::Memory { offset, is_4state } => {
-                    let byte_size = get_byte_size(sig.width);
-                    let value = Self::read_value(memory, offset, sig.width);
-                    let mask = if is_4state {
-                        Self::read_value(memory, offset + byte_size, sig.width)
-                    } else {
-                        BigUint::from(0u32)
+        self.encoded.clear();
+        self.encoded_changes = 0;
+        self.selected.clear();
+        // Dense activity is cheaper to walk directly in registration order.
+        let sparse = activity
+            .filter(|activity| !first_dump && activity.len() < self.groups.len().div_ceil(2));
+        if let Some(activity) = sparse {
+            for &group in activity {
+                if let Some(indices) = self.groups.get(&group) {
+                    self.selected.extend_from_slice(indices);
+                }
+            }
+            self.selected
+                .extend(self.signals.len() - self.external_count..self.signals.len());
+            // Preserve registration order even when homes are laid out differently.
+            self.selected.sort_unstable();
+            self.selected.dedup();
+        }
+        let count = if sparse.is_some() {
+            self.selected.len()
+        } else {
+            self.signals.len()
+        };
+        for index in 0..count {
+            let i = if sparse.is_some() {
+                self.selected[index]
+            } else {
+                index
+            };
+            let sig = &self.signals[i];
+            self.stats.comparisons += 1;
+            match sig.source {
+                VcdWriterSource::Memory { .. } | VcdWriterSource::External { .. } => {
+                    let size = get_byte_size(sig.width);
+                    // The memory path borrows bytes directly. External component values
+                    // retain their existing BigUint ABI and are converted only here.
+                    let external_bytes;
+                    let (value, mask, track_mask): (&[u8], &[u8], bool) = match sig.source {
+                        VcdWriterSource::MemoryBit { .. } | VcdWriterSource::Memory64 { .. } => {
+                            unreachable!()
+                        }
+                        VcdWriterSource::Memory { offset, is_4state } => (
+                            &memory[offset..offset + size],
+                            if is_4state {
+                                &memory[offset + size..offset + size * 2]
+                            } else {
+                                &[]
+                            },
+                            is_4state,
+                        ),
+                        VcdWriterSource::External { index } => {
+                            external_bytes = (
+                                external[index].0.to_bytes_le(),
+                                external[index].1.to_bytes_le(),
+                            );
+                            (&external_bytes.0, &external_bytes.1, true)
+                        }
                     };
-                    (value, mask, is_4state)
-                }
-                VcdWriterSource::External { index } => {
-                    let (value, mask) = &external[index];
-                    let value = Self::mask_to_width(value.clone(), sig.width);
-                    let mask = Self::mask_to_width(mask.clone(), sig.width);
-                    let is_4state = mask != BigUint::default();
-                    (value, mask, is_4state)
-                }
-            };
-
-            let prev = &self.last_values[i];
-            let changed = match prev {
-                Some((pv, pm)) => pv != &current_val || pm != &current_mask,
-                None => true,
-            };
-
-            if changed {
-                if is_4state && current_mask != BigUint::from(0u32) {
-                    Self::write_four_state_value(
-                        &mut self.writer,
+                    let old =
+                        &mut self.previous[sig.previous_offset..sig.previous_offset + size * 2];
+                    if self.initialized[i]
+                        && plane_equal(&old[..size], value, sig.width)
+                        && (!track_mask || plane_equal(&old[size..], mask, sig.width))
+                    {
+                        continue;
+                    }
+                    copy_plane(&mut old[..size], value, sig.width);
+                    // A two-state memory signal's previous mask stays zero for the
+                    // writer's lifetime. External values can change between X/Z and
+                    // known values, so their masks always participate.
+                    if track_mask {
+                        copy_plane(&mut old[size..], mask, sig.width);
+                    }
+                    self.initialized[i] = true;
+                    encode_value(
+                        &mut self.encoded,
                         sig.width,
-                        &current_val,
-                        &current_mask,
-                        &sig.vcd_id,
-                    )?;
-                } else if sig.width == 1 {
-                    writeln!(self.writer, "{}{}", current_val, sig.vcd_id)?;
-                } else {
-                    writeln!(
-                        self.writer,
-                        "b{} {}",
-                        current_val.to_str_radix(2),
-                        sig.vcd_id
-                    )?;
+                        &old[..size],
+                        if track_mask { &old[size..] } else { &[] },
+                    );
                 }
-                self.last_values[i] = Some((current_val, current_mask));
+                VcdWriterSource::MemoryBit { offset } => {
+                    let value = memory[offset] & 1;
+                    let old = &mut self.previous[sig.previous_offset];
+                    if self.initialized[i] && *old == value {
+                        continue;
+                    }
+                    *old = value;
+                    self.initialized[i] = true;
+                    self.encoded.push(b'0' + value);
+                }
+                VcdWriterSource::Memory64 { offset } => {
+                    let value: [u8; 8] = memory[offset..offset + 8].try_into().unwrap();
+                    let old: &mut [u8; 8] = (&mut self.previous
+                        [sig.previous_offset..sig.previous_offset + 8])
+                        .try_into()
+                        .unwrap();
+                    if self.initialized[i] && u64::from_ne_bytes(*old) == u64::from_ne_bytes(value)
+                    {
+                        continue;
+                    }
+                    *old = value;
+                    self.initialized[i] = true;
+                    encode_u64(&mut self.encoded, u64::from_le_bytes(value));
+                }
+            }
+            if sig.width != 1 {
+                self.encoded.push(b' ');
+            }
+            self.encoded.extend_from_slice(sig.vcd_id.as_bytes());
+            self.encoded.push(b'\n');
+            self.encoded_changes += 1;
+            if self.encoded.len() >= self.writer.capacity() {
+                self.write_encoded()?;
             }
         }
-        self.writer.flush()?;
+        self.write_encoded()
+    }
+
+    fn write_encoded(&mut self) -> std::io::Result<()> {
+        if !self.encoded.is_empty() {
+            // Full blocks bypass BufWriter's internal copy. A dump's final
+            // partial block stays buffered with the timestamps and header.
+            self.writer.write_all(&self.encoded)?;
+            self.stats.changes += self.encoded_changes;
+            self.stats.value_bytes += self.encoded.len() as u64;
+            self.encoded.clear();
+            self.encoded_changes = 0;
+        }
         Ok(())
     }
+}
 
-    fn write_four_state_value(
-        writer: &mut BufWriter<File>,
-        width: usize,
-        value: &BigUint,
-        mask: &BigUint,
-        vcd_id: &str,
-    ) -> std::io::Result<()> {
-        if width == 1 {
-            let m = mask.bit(0);
-            let v = value.bit(0);
-            let ch = match (m, v) {
-                (false, false) => '0',
-                (false, true) => '1',
-                (true, false) => 'z',
-                (true, true) => 'x',
-            };
-            writeln!(writer, "{}{}", ch, vcd_id)
-        } else {
-            write!(writer, "b")?;
-            for i in (0..width).rev() {
-                let m = mask.bit(i as u64);
-                let v = value.bit(i as u64);
-                let ch = match (m, v) {
-                    (false, false) => '0',
-                    (false, true) => '1',
-                    (true, false) => 'z',
-                    (true, true) => 'x',
-                };
-                write!(writer, "{}", ch)?;
-            }
-            writeln!(writer, " {}", vcd_id)
-        }
+fn last_mask(width: usize) -> u8 {
+    if width.is_multiple_of(8) {
+        0xff
+    } else {
+        ((1u16 << (width % 8)) - 1) as u8
     }
 }
+
+fn plane_equal(old: &[u8], value: &[u8], width: usize) -> bool {
+    let Some((&last, prefix)) = old.split_last() else {
+        return true;
+    };
+    if value.len() >= old.len() {
+        prefix == &value[..prefix.len()] && last == value[prefix.len()] & last_mask(width)
+    } else {
+        old.iter().enumerate().all(|(i, &byte)| {
+            byte == value.get(i).copied().unwrap_or(0)
+                & if i + 1 == old.len() {
+                    last_mask(width)
+                } else {
+                    0xff
+                }
+        })
+    }
+}
+
+fn copy_plane(dst: &mut [u8], src: &[u8], width: usize) {
+    let len = dst.len().min(src.len());
+    dst[..len].copy_from_slice(&src[..len]);
+    dst[len..].fill(0);
+    if let Some(last) = dst.last_mut() {
+        *last &= last_mask(width);
+    }
+}
+
+#[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+#[inline]
+fn encode_u64(out: &mut Vec<u8>, value: u64) {
+    use std::arch::x86_64::*;
+
+    let bits = (64 - value.leading_zeros() as usize).max(1);
+    let mut remaining = value << (64 - bits);
+    out.push(b'b');
+    out.reserve(64);
+    let start = out.len();
+    // SAFETY: SSE2 is enabled for this target. Each unaligned store initializes
+    // exactly one 16-byte chunk of reserved capacity. Only the significant
+    // digits are published; any extra initialized bytes remain outside len.
+    unsafe {
+        let masks = _mm_set1_epi64x(0x0102_0408_1020_4080);
+        for chunk in out.spare_capacity_mut()[..64]
+            .as_chunks_mut::<16>()
+            .0
+            .iter_mut()
+            .take(bits.div_ceil(16))
+        {
+            // Repeat each of the next two bytes eight times, then select one
+            // bit per lane in most-significant-bit-first order.
+            let word = _mm_set1_epi16((remaining >> 48) as i16);
+            let bytes = _mm_packus_epi16(
+                _mm_srli_epi16::<8>(word),
+                _mm_and_si128(word, _mm_set1_epi16(0xff)),
+            );
+            let zero = _mm_cmpeq_epi8(_mm_and_si128(bytes, masks), _mm_setzero_si128());
+            let ascii = _mm_add_epi8(_mm_set1_epi8(b'1' as i8), zero);
+            _mm_storeu_si128(chunk.as_mut_ptr().cast(), ascii);
+            remaining <<= 16;
+        }
+        out.set_len(start + bits);
+    }
+}
+
+#[cfg(not(all(target_arch = "x86_64", target_feature = "sse2")))]
+#[inline]
+fn encode_u64(out: &mut Vec<u8>, value: u64) {
+    encode_value(out, 64, &value.to_le_bytes(), &[]);
+}
+
+fn encode_value(out: &mut Vec<u8>, width: usize, value: &[u8], mask: &[u8]) {
+    if width != 1 {
+        out.push(b'b');
+    }
+    let four_state = mask.iter().any(|&byte| byte != 0);
+    let bits = if four_state {
+        width
+    } else {
+        value
+            .iter()
+            .rposition(|&byte| byte != 0)
+            .map_or(1, |i| i * 8 + (8 - value[i].leading_zeros() as usize))
+    };
+    out.reserve(bits);
+    if !four_state {
+        let bytes = bits.div_ceil(8);
+        let high = value.get(bytes - 1).copied().unwrap_or(0);
+        out.extend_from_slice(&BINARY[high as usize][8 - (bits - (bytes - 1) * 8)..]);
+        for &byte in value[..bytes - 1].iter().rev() {
+            out.extend_from_slice(&BINARY[byte as usize]);
+        }
+        return;
+    }
+    for bit in (0..bits).rev() {
+        let v = value.get(bit / 8).copied().unwrap_or(0) >> (bit % 8) & 1;
+        let m = mask.get(bit / 8).copied().unwrap_or(0) >> (bit % 8) & 1;
+        out.push(match (m, v) {
+            (0, 0) => b'0',
+            (0, _) => b'1',
+            (_, 0) => b'z',
+            _ => b'x',
+        });
+    }
+}
+
+const BINARY: [[u8; 8]; 256] = {
+    let mut table = [[b'0'; 8]; 256];
+    let mut byte = 0;
+    while byte < 256 {
+        let mut bit = 0;
+        while bit < 8 {
+            table[byte][bit] += ((byte >> (7 - bit)) & 1) as u8;
+            bit += 1;
+        }
+        byte += 1;
+    }
+    table
+};
 
 #[cfg(test)]
 mod tests {
@@ -357,9 +615,419 @@ mod tests {
         writer
             .dump_with_external(1, &[], &[(BigUint::from(0xffu8), BigUint::default())])
             .unwrap();
+        writer
+            .dump_with_external(2, &[], &[(BigUint::default(), BigUint::from(0xffu8))])
+            .unwrap();
+        writer
+            .dump_with_external(3, &[], &[(BigUint::default(), BigUint::default())])
+            .unwrap();
 
+        writer.flush().unwrap();
         let dump = std::fs::read_to_string(path).unwrap();
         assert!(!dump.contains("b111111111"), "{dump}");
         assert_eq!(dump.matches("b11111111 !").count(), 1, "{dump}");
+        assert_eq!(dump.matches("bzzzzzzzz !").count(), 1, "{dump}");
+        assert_eq!(dump.matches("b0 !").count(), 1, "{dump}");
+    }
+}
+
+#[cfg(test)]
+mod encoding_tests {
+    use super::*;
+
+    fn changes(bytes: &[u8]) -> Vec<(u64, String)> {
+        let mut parser = vcd::Parser::new(bytes);
+        parser.parse_header().unwrap();
+        let mut time = 0;
+        parser
+            .filter_map(|command| match command.unwrap() {
+                vcd::Command::Timestamp(t) => {
+                    time = t;
+                    None
+                }
+                vcd::Command::ChangeScalar(_, value) => Some((time, value.to_string())),
+                vcd::Command::ChangeVector(_, value) => Some((time, value.to_string())),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn integer_encoding_matches_binary_format_at_every_bit_length() {
+        let mut values = vec![0, u64::MAX, 0x0123_4567_89ab_cdef, 0xaaaa_5555_aaaa_5555];
+        let mut random = 0x8314_40be_9d6a_2785u64;
+        for bit in 0..64 {
+            let mask = u64::MAX >> (63 - bit);
+            values.extend([1 << bit, mask]);
+            for _ in 0..32 {
+                random ^= random << 13;
+                random ^= random >> 7;
+                random ^= random << 17;
+                values.push((random & mask) | (1 << bit));
+            }
+        }
+        // Exercise unaligned output, capacity growth, and reuse of spare bytes
+        // after truncation, checking that neither prefixes nor lengths change.
+        for prefix in [0, 1, 15, 16, 63] {
+            let mut actual = vec![b'#'; prefix];
+            let mut expected = actual.clone();
+            for &value in &values {
+                encode_u64(&mut actual, value);
+                expected.extend_from_slice(format!("b{value:b}").as_bytes());
+                assert_eq!(actual, expected, "prefix={prefix} value={value:#x}");
+                if actual.len() > 4096 {
+                    actual.truncate(prefix);
+                    expected.truncate(prefix);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn integer_memory_at_unaligned_buffer_end_preserves_changes_and_aliases() {
+        for offset in 1..=8 {
+            let descs = [
+                VcdSignalDesc {
+                    scope: "top".into(),
+                    name: "prefix".into(),
+                    offset: 0,
+                    width: 7,
+                    is_4state: false,
+                },
+                VcdSignalDesc {
+                    scope: "top".into(),
+                    name: "q".into(),
+                    offset,
+                    width: 64,
+                    is_4state: false,
+                },
+                VcdSignalDesc {
+                    scope: "top".into(),
+                    name: "alias".into(),
+                    offset,
+                    width: 64,
+                    is_4state: false,
+                },
+            ];
+            let mut writer = VcdWriter::from_writer(Vec::new(), &descs);
+            // Both previous values follow a 7-bit signal, so their cached
+            // offsets are unaligned too. No padding follows the memory value.
+            let mut memory = vec![0; offset + 8];
+            memory[0] = 0x45;
+            let mut expected = vec![(0, format!("{:b}", memory[0]))];
+            for (step, value) in std::iter::once(0u64)
+                .chain((0..64).map(|bit| 1 << bit))
+                .chain([u64::MAX, 0])
+                .enumerate()
+            {
+                let time = (step * 2) as u64;
+                memory[offset..].copy_from_slice(&value.to_le_bytes());
+                writer.dump(time, &memory).unwrap();
+                writer.dump(time + 1, &memory).unwrap();
+                expected.extend(std::iter::repeat_n((time, format!("{value:b}")), 2));
+            }
+            assert_eq!(writer.statistics().changes, expected.len() as u64);
+            assert_eq!(
+                changes(&writer.into_inner().unwrap()),
+                expected,
+                "offset={offset}"
+            );
+        }
+    }
+
+    #[test]
+    fn emitted_values_match_independent_biguint_oracle() {
+        for width in [1, 7, 8, 9, 31, 32, 63, 64, 65, 257, 1024] {
+            for four_state in [false, true] {
+                let desc = VcdSignalDesc {
+                    scope: "top".into(),
+                    name: "q".into(),
+                    offset: 0,
+                    width,
+                    is_4state: four_state,
+                };
+                let mut writer = VcdWriter::from_writer(Vec::new(), &[desc]);
+                let size = width.div_ceil(8);
+                let mut memory = vec![0; size * 2];
+                let limit = (BigUint::from(1u8) << width) - 1u8;
+                let mut expected = vec![];
+                let mut previous = None;
+                let mut random = 0x8314_40be_9d6a_2785u64;
+                for step in 0..96u64 {
+                    if step % 4 != 1 {
+                        for byte in &mut memory {
+                            random ^= random << 13;
+                            random ^= random >> 7;
+                            random ^= random << 17;
+                            *byte = random as u8;
+                        }
+                    }
+                    if step % 3 == 0 {
+                        memory[size..].fill(0);
+                    }
+                    if step % 8 == 0 {
+                        memory[..size].fill(0);
+                    }
+                    // Deliberately include nonzero padding above the declared width.
+                    let value = BigUint::from_bytes_le(&memory[..size]) & &limit;
+                    let mask = if four_state {
+                        BigUint::from_bytes_le(&memory[size..]) & &limit
+                    } else {
+                        BigUint::default()
+                    };
+                    let state = (value.clone(), mask.clone());
+                    if previous.as_ref() != Some(&state) {
+                        let text = if mask == BigUint::default() {
+                            value.to_str_radix(2)
+                        } else {
+                            (0..width)
+                                .rev()
+                                .map(|bit| match (mask.bit(bit as u64), value.bit(bit as u64)) {
+                                    (false, false) => '0',
+                                    (false, true) => '1',
+                                    (true, false) => 'z',
+                                    (true, true) => 'x',
+                                })
+                                .collect()
+                        };
+                        expected.push((step / 2, text));
+                        previous = Some(state);
+                    }
+                    writer.dump(step / 2, &memory).unwrap();
+                }
+                assert_eq!(
+                    changes(&writer.into_inner().unwrap()),
+                    expected,
+                    "width={width} four_state={four_state}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sparse_selection_preserves_aliases_initial_values_and_registration_order() {
+        let descs = [128, 0, 129, 0, 512, 640, 768, 896, 1024, 1152]
+            .into_iter()
+            .enumerate()
+            .map(|(index, offset)| VcdSignalDesc {
+                scope: "top".into(),
+                name: format!("s{index}"),
+                offset,
+                width: 8,
+                is_4state: false,
+            })
+            .collect::<Vec<_>>();
+        let mut sparse = VcdWriter::from_writer(Vec::new(), &descs);
+        let mut full = VcdWriter::from_writer(Vec::new(), &descs);
+        let mut memory = vec![0; 1153];
+        for time in 0..5 {
+            memory[0] = time as u8;
+            memory[129] = (time * 3) as u8;
+            // First sample ignores an empty candidate set; later sets arrive unsorted.
+            let groups = if time == 0 { &[][..] } else { &[2, 0, 2][..] };
+            sparse
+                .dump_with_activity(time, &memory, &[], Some(groups))
+                .unwrap();
+            full.dump(time, &memory).unwrap();
+        }
+        assert!(sparse.statistics().comparisons < full.statistics().comparisons);
+        let parse = |bytes: Vec<u8>| {
+            let mut parser = vcd::Parser::new(bytes.as_slice());
+            parser.parse_header().unwrap();
+            parser.map(Result::unwrap).collect::<Vec<_>>()
+        };
+        assert_eq!(
+            parse(sparse.into_inner().unwrap()),
+            parse(full.into_inner().unwrap())
+        );
+    }
+
+    #[test]
+    fn padding_and_mask_only_changes_have_exact_semantics() {
+        let desc = VcdSignalDesc {
+            scope: "top".into(),
+            name: "q".into(),
+            offset: 0,
+            width: 1,
+            is_4state: true,
+        };
+        let mut writer = VcdWriter::from_writer(Vec::new(), &[desc]);
+        for (time, bytes) in [[0, 0], [0xfe, 0xfe], [0, 1], [1, 1], [1, 0]]
+            .iter()
+            .enumerate()
+        {
+            writer.dump(time as u64, bytes).unwrap();
+        }
+        assert_eq!(
+            changes(&writer.into_inner().unwrap()),
+            [(0, "0"), (2, "z"), (3, "x"), (4, "1")].map(|(t, s)| (t, s.to_string()))
+        );
+    }
+
+    #[derive(Default)]
+    struct ShortWrites {
+        bytes: Vec<u8>,
+        calls: usize,
+        fail_after: Option<usize>,
+    }
+
+    impl Write for ShortWrites {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.calls += 1;
+            if self.calls.is_multiple_of(7) {
+                return Err(std::io::ErrorKind::Interrupted.into());
+            }
+            let remaining = self
+                .fail_after
+                .unwrap_or(usize::MAX)
+                .saturating_sub(self.bytes.len());
+            if remaining == 0 && !bytes.is_empty() {
+                return Err(std::io::ErrorKind::BrokenPipe.into());
+            }
+            let len = bytes.len().min(113).min(remaining);
+            self.bytes.extend_from_slice(&bytes[..len]);
+            Ok(len)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn blocks_and_oversized_records_survive_short_writes_and_drop() {
+        let mut offset = 0;
+        let descs = (0..1025)
+            .map(|i| {
+                let width = if i == 1024 {
+                    256 * 1024 + 17
+                } else {
+                    [1, 9, 65, 1024][i % 4]
+                };
+                let is_4state = i % 3 == 0 || i == 1024;
+                let desc = VcdSignalDesc {
+                    scope: "top".into(),
+                    name: format!("s{i}"),
+                    offset,
+                    width,
+                    is_4state,
+                };
+                offset += width.div_ceil(8) * if is_4state { 2 } else { 1 };
+                desc
+            })
+            .collect::<Vec<_>>();
+        let mut memory = vec![0xff; offset];
+        let mut sink = ShortWrites::default();
+        let mut expected = Vec::new();
+        let stats = {
+            let mut writer = VcdWriter::from_writer(&mut sink, &descs);
+            writer
+                .add_external_signals(&[VcdExternalSignalDesc {
+                    scope: "component".into(),
+                    name: "state".into(),
+                    width: 9,
+                }])
+                .unwrap();
+            for time in 0..4 {
+                if time == 1 {
+                    memory.fill(0);
+                } else if time == 3 {
+                    for desc in &descs {
+                        let size = desc.width.div_ceil(8);
+                        if desc.is_4state {
+                            memory[desc.offset + size..desc.offset + size * 2].fill(0xff);
+                        } else {
+                            memory[desc.offset..desc.offset + size].fill(0xff);
+                        }
+                    }
+                }
+                let external = match time {
+                    0 => (BigUint::from(0x1ffu16), BigUint::from(0x1ffu16)),
+                    3 => (BigUint::default(), BigUint::from(0x1ffu16)),
+                    _ => (BigUint::default(), BigUint::default()),
+                };
+                writer
+                    .dump_with_external(time, &memory, &[external])
+                    .unwrap();
+                if time != 2 {
+                    for desc in &descs {
+                        let value = if time == 1 {
+                            "0".into()
+                        } else if desc.is_4state {
+                            if time == 0 { "x" } else { "z" }.repeat(desc.width)
+                        } else {
+                            "1".repeat(desc.width)
+                        };
+                        expected.push((time, value));
+                    }
+                    expected.push((
+                        time,
+                        match time {
+                            0 => "x".repeat(9),
+                            3 => "z".repeat(9),
+                            _ => "0".into(),
+                        },
+                    ));
+                }
+            }
+            // Leave the final partial block buffered and exercise Drop.
+            writer.statistics()
+        };
+        assert_eq!(changes(&sink.bytes), expected);
+        let text = std::str::from_utf8(&sink.bytes).unwrap();
+        assert!(text.contains("\n#2\n#3\n"));
+        assert_eq!(stats.changes, expected.len() as u64);
+        let values = text.split_once("$dumpvars\n$end\n").unwrap().1;
+        assert_eq!(
+            stats.value_bytes,
+            values
+                .lines()
+                .filter(|line| !line.starts_with('#'))
+                .map(|line| (line.len() + 1) as u64)
+                .sum::<u64>()
+        );
+    }
+
+    #[test]
+    fn block_and_tail_io_errors_are_reported() {
+        for (width, fail_after, fails_during_dump) in
+            [(64, 16, false), (512 * 1024, 256 * 1024 + 13, true)]
+        {
+            let desc = VcdSignalDesc {
+                scope: "top".into(),
+                name: "q".into(),
+                offset: 0,
+                width,
+                is_4state: false,
+            };
+            let mut sink = ShortWrites {
+                fail_after: Some(fail_after),
+                ..Default::default()
+            };
+            {
+                let mut writer = VcdWriter::from_writer(&mut sink, &[desc]);
+                let dump = writer.dump(0, &vec![0xff; width.div_ceil(8)]);
+                assert_eq!(dump.is_err(), fails_during_dump);
+                let error = dump.and_then(|()| writer.flush()).unwrap_err();
+                assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
+            }
+            assert_eq!(sink.bytes.len(), fail_after);
+        }
+    }
+
+    #[test]
+    fn explicit_flush_reports_sink_failure() {
+        struct BadFlush;
+        impl Write for BadFlush {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Err(std::io::Error::other("flush failed"))
+            }
+        }
+        let mut writer = VcdWriter::from_writer(BadFlush, &[]);
+        writer.dump(0, &[]).unwrap();
+        assert_eq!(writer.flush().unwrap_err().to_string(), "flush failed");
     }
 }

--- a/crates/celox-runtime/src/vcd.rs
+++ b/crates/celox-runtime/src/vcd.rs
@@ -188,6 +188,8 @@ impl<W: Write> VcdWriter<W> {
         backend: &mut B,
         external: &[(BigUint, BigUint)],
     ) -> std::io::Result<()> {
+        // Reject recoverable input errors before consuming pending writes.
+        self.validate_external_count(external.len())?;
         let mut activity = std::mem::take(&mut self.activity);
         let tracked = backend.take_vcd_activity(&mut activity);
         let (ptr, size) = backend.memory_as_ptr();
@@ -342,6 +344,19 @@ impl<W: Write> VcdWriter<W> {
         self.dump_with_activity(timestamp, memory, external, None)
     }
 
+    fn validate_external_count(&self, count: usize) -> std::io::Result<()> {
+        if count != self.external_count {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "expected {} external VCD values, got {count}",
+                    self.external_count
+                ),
+            ));
+        }
+        Ok(())
+    }
+
     /// `activity` contains unique physical group IDs consumed from TraceLayout.
     /// None requests a full scan. Initial values and external signals are always
     /// observed, including when no generated store has executed.
@@ -352,16 +367,7 @@ impl<W: Write> VcdWriter<W> {
         external: &[(BigUint, BigUint)],
         activity: Option<&[usize]>,
     ) -> std::io::Result<()> {
-        if external.len() != self.external_count {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!(
-                    "expected {} external VCD values, got {}",
-                    self.external_count,
-                    external.len()
-                ),
-            ));
-        }
+        self.validate_external_count(external.len())?;
         let first_dump = !self.initial_values_written;
         if !self.header_written {
             self.write_header()?;

--- a/crates/celox-runtime/src/vcd.rs
+++ b/crates/celox-runtime/src/vcd.rs
@@ -1,5 +1,8 @@
-use celox_state_layout::{TRACE_GROUP_BYTES, get_byte_size};
+mod plan;
+
+use celox_state_layout::TRACE_GROUP_BYTES;
 use num_bigint::BigUint;
+use plan::TracePlan;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::mem::MaybeUninit;
@@ -33,22 +36,10 @@ pub struct VcdExternalSignalDesc {
     pub width: usize,
 }
 
-#[derive(Clone, Copy)]
-enum VcdWriterSource {
-    Memory { offset: usize, is_4state: bool },
-    External { index: usize },
-    // Classify once so the dump loop can use a fixed-width load and store.
-    MemoryBit { offset: usize },
-    Memory64 { offset: usize },
-}
-
-struct VcdWriterSignal {
-    suffix: VcdRecordSuffix,
+struct VcdHeaderSignal {
     scope: String,
     name: String,
     width: usize,
-    source: VcdWriterSource,
-    previous_offset: usize,
 }
 
 /// Finalized with the header: an optional space, the ID, and a newline.
@@ -112,21 +103,25 @@ pub struct VcdStatistics {
 }
 
 pub struct VcdWriter<W: Write = File> {
-    writer: BufWriter<W>,
-    signals: Vec<VcdWriterSignal>,
-    previous: Vec<u8>,
-    initialized: Vec<bool>,
+    output: VcdOutput<W>,
+    headers: Vec<VcdHeaderSignal>,
+    plan: TracePlan,
     groups: fxhash::FxHashMap<usize, Vec<usize>>,
     selected: Vec<usize>,
     activity: Vec<usize>,
+    timestamp: u64,
+    header_written: bool,
+    initial_values_written: bool,
+    external_count: usize,
+}
+
+struct VcdOutput<W: Write> {
+    writer: BufWriter<W>,
     /// Complete value records accumulated for a bulk write. Successful dumps
     /// always hand the tail to BufWriter so flush and Drop own pending output.
     encoded: Vec<u8>,
     encoded_changes: u64,
     stats: VcdStatistics,
-    timestamp: u64,
-    header_written: bool,
-    external_count: usize,
 }
 
 impl VcdWriter<File> {
@@ -137,64 +132,51 @@ impl VcdWriter<File> {
 
 impl<W: Write> VcdWriter<W> {
     pub fn from_writer(writer: W, descs: &[VcdSignalDesc]) -> Self {
-        let mut previous = Vec::new();
+        let mut plan = TracePlan::default();
         let mut groups: fxhash::FxHashMap<usize, Vec<usize>> = Default::default();
-        let signals = descs
+        let headers = descs
             .iter()
             .enumerate()
             .map(|(index, desc)| {
-                let previous_offset = previous.len();
-                previous.resize(previous.len() + get_byte_size(desc.width) * 2, 0);
+                plan.add_memory(desc);
                 let group = desc.offset / TRACE_GROUP_BYTES;
                 groups.entry(group).or_default().push(index);
-                VcdWriterSignal {
-                    suffix: VcdRecordSuffix::new(desc.width, ""),
+                VcdHeaderSignal {
                     scope: desc.scope.clone(),
                     name: desc.name.clone(),
                     width: desc.width,
-                    source: match (desc.width, desc.is_4state) {
-                        (1, false) => VcdWriterSource::MemoryBit {
-                            offset: desc.offset,
-                        },
-                        (64, false) => VcdWriterSource::Memory64 {
-                            offset: desc.offset,
-                        },
-                        _ => VcdWriterSource::Memory {
-                            offset: desc.offset,
-                            is_4state: desc.is_4state,
-                        },
-                    },
-                    previous_offset,
                 }
             })
             .collect::<Vec<_>>();
         Self {
-            writer: BufWriter::with_capacity(256 * 1024, writer),
-            initialized: vec![false; signals.len()],
-            signals,
-            previous,
+            output: VcdOutput {
+                writer: BufWriter::with_capacity(256 * 1024, writer),
+                encoded: Vec::new(),
+                encoded_changes: 0,
+                stats: VcdStatistics::default(),
+            },
+            headers,
+            plan,
             groups,
             selected: Vec::new(),
             activity: Vec::new(),
-            encoded: Vec::new(),
-            encoded_changes: 0,
-            stats: VcdStatistics::default(),
             timestamp: 0,
             header_written: false,
+            initial_values_written: false,
             external_count: 0,
         }
     }
 
     /// Publish buffered output, also reporting errors that Drop cannot report.
     pub fn flush(&mut self) -> std::io::Result<()> {
-        self.writer.flush()
+        self.output.writer.flush()
     }
 
     pub fn statistics(&self) -> VcdStatistics {
-        self.stats
+        self.output.stats
     }
     pub fn get_ref(&self) -> &W {
-        self.writer.get_ref()
+        self.output.writer.get_ref()
     }
 
     /// Dump as the backend's sole incremental waveform observer. Multiple
@@ -219,7 +201,10 @@ impl<W: Write> VcdWriter<W> {
 
     pub fn into_inner(mut self) -> std::io::Result<W> {
         self.flush()?;
-        self.writer.into_inner().map_err(|error| error.into_error())
+        self.output
+            .writer
+            .into_inner()
+            .map_err(|error| error.into_error())
     }
 
     /// Adds externally supplied signals before the first dump. VCD headers
@@ -229,10 +214,8 @@ impl<W: Write> VcdWriter<W> {
             return Ok(());
         }
         if self.external_count != 0 {
-            let existing = self
-                .signals
+            let existing = self.headers[self.headers.len() - self.external_count..]
                 .iter()
-                .filter(|signal| matches!(signal.source, VcdWriterSource::External { .. }))
                 .zip(descs)
                 .all(|(signal, desc)| {
                     signal.scope == desc.scope
@@ -252,39 +235,34 @@ impl<W: Write> VcdWriter<W> {
         for desc in descs {
             let index = self.external_count;
             self.external_count += 1;
-            self.signals.push(VcdWriterSignal {
-                suffix: VcdRecordSuffix::new(desc.width, ""),
+            self.headers.push(VcdHeaderSignal {
                 scope: desc.scope.clone(),
                 name: desc.name.clone(),
                 width: desc.width,
-                source: VcdWriterSource::External { index },
-                previous_offset: self.previous.len(),
             });
-            self.previous
-                .resize(self.previous.len() + get_byte_size(desc.width) * 2, 0);
-            self.initialized.push(false);
+            self.plan.add_external(index, desc.width);
         }
         Ok(())
     }
 
     #[cold]
     fn write_header(&mut self) -> std::io::Result<()> {
-        writeln!(self.writer, "$date")?;
+        writeln!(self.output.writer, "$date")?;
         writeln!(
-            self.writer,
+            self.output.writer,
             "  {}",
             chrono::Local::now().format("%Y-%m-%d %H:%M:%S")
         )?;
-        writeln!(self.writer, "$end")?;
-        writeln!(self.writer, "$version")?;
-        writeln!(self.writer, "  celox")?;
-        writeln!(self.writer, "$end")?;
-        writeln!(self.writer, "$timescale 1ns $end")?;
+        writeln!(self.output.writer, "$end")?;
+        writeln!(self.output.writer, "$version")?;
+        writeln!(self.output.writer, "  celox")?;
+        writeln!(self.output.writer, "$end")?;
+        writeln!(self.output.writer, "$timescale 1ns $end")?;
 
         let mut scope_order = Vec::<String>::new();
         let mut scope_groups = Vec::<Vec<usize>>::new();
         let mut scope_idx = fxhash::FxHashMap::<String, usize>::default();
-        for (signal_index, signal) in self.signals.iter().enumerate() {
+        for (signal_index, signal) in self.headers.iter().enumerate() {
             if let Some(index) = scope_idx.get(&signal.scope).copied() {
                 scope_groups[index].push(signal_index);
             } else {
@@ -296,28 +274,31 @@ impl<W: Write> VcdWriter<W> {
         }
         let mut next_id = 0;
         for (scope, group) in scope_order.iter().zip(scope_groups) {
-            writeln!(self.writer, "$scope module {} $end", scope)?;
+            writeln!(self.output.writer, "$scope module {} $end", scope)?;
             for signal_index in group {
-                let signal = &mut self.signals[signal_index];
+                let signal = &mut self.headers[signal_index];
                 let id = Self::generate_vcd_id(next_id);
-                signal.suffix = VcdRecordSuffix::new(signal.width, &id);
+                *self.plan.suffix(signal_index) = VcdRecordSuffix::new(signal.width, &id);
                 next_id += 1;
                 writeln!(
-                    self.writer,
+                    self.output.writer,
                     "$var wire {} {} {} $end",
                     signal.width, id, signal.name
                 )?;
             }
-            writeln!(self.writer, "$upscope $end")?;
+            writeln!(self.output.writer, "$upscope $end")?;
         }
-        writeln!(self.writer, "$enddefinitions $end")?;
-        writeln!(self.writer, "$dumpvars")?;
-        writeln!(self.writer, "$end")?;
+        writeln!(self.output.writer, "$enddefinitions $end")?;
+        writeln!(self.output.writer, "$dumpvars")?;
+        writeln!(self.output.writer, "$end")?;
         if let Some(max_record) = self
-            .signals
+            .headers
             .iter()
-            .map(|signal| {
-                signal.width.max(1) + usize::from(signal.width != 1) + signal.suffix.capacity()
+            .enumerate()
+            .map(|(index, signal)| {
+                signal.width.max(1)
+                    + usize::from(signal.width != 1)
+                    + self.plan.suffix(index).capacity()
             })
             .max()
         {
@@ -325,7 +306,9 @@ impl<W: Write> VcdWriter<W> {
             // Include the short suffix's padding, even for scalar-only traces.
             // Integer SIMD stores also fit within the full declared width.
             // Reserve here so record encoding never needs to grow the Vec.
-            self.encoded.reserve(self.writer.capacity() + max_record);
+            self.output
+                .encoded
+                .reserve(self.output.writer.capacity() + max_record);
         }
         self.header_written = true;
         Ok(())
@@ -379,16 +362,16 @@ impl<W: Write> VcdWriter<W> {
                 ),
             ));
         }
-        let first_dump = !self.header_written;
-        if first_dump {
+        let first_dump = !self.initial_values_written;
+        if !self.header_written {
             self.write_header()?;
         }
         if timestamp > self.timestamp || timestamp == 0 {
-            writeln!(self.writer, "#{}", timestamp)?;
+            writeln!(self.output.writer, "#{}", timestamp)?;
             self.timestamp = timestamp;
         }
-        self.encoded.clear();
-        self.encoded_changes = 0;
+        self.output.encoded.clear();
+        self.output.encoded_changes = 0;
         self.selected.clear();
         // Dense activity is cheaper to walk directly in registration order.
         let sparse = activity
@@ -400,116 +383,47 @@ impl<W: Write> VcdWriter<W> {
                 }
             }
             self.selected
-                .extend(self.signals.len() - self.external_count..self.signals.len());
+                .extend(self.headers.len() - self.external_count..self.headers.len());
             // Preserve registration order even when homes are laid out differently.
             self.selected.sort_unstable();
             self.selected.dedup();
+            if self.selected.is_empty() {
+                return Ok(());
+            }
         }
-        let count = if sparse.is_some() {
-            self.selected.len()
+        if first_dump {
+            self.plan
+                .dump::<true, W>(memory, external, None, &mut self.output)?;
+            self.initial_values_written = true;
         } else {
-            self.signals.len()
-        };
-        for index in 0..count {
-            let i = if sparse.is_some() {
-                self.selected[index]
-            } else {
-                index
-            };
-            let sig = &self.signals[i];
-            self.stats.comparisons += 1;
-            let value_len = match sig.source {
-                VcdWriterSource::Memory { .. } | VcdWriterSource::External { .. } => {
-                    let size = get_byte_size(sig.width);
-                    // The memory path borrows bytes directly. External component values
-                    // retain their existing BigUint ABI and are converted only here.
-                    let external_bytes;
-                    let (value, mask, track_mask): (&[u8], &[u8], bool) = match sig.source {
-                        VcdWriterSource::MemoryBit { .. } | VcdWriterSource::Memory64 { .. } => {
-                            unreachable!()
-                        }
-                        VcdWriterSource::Memory { offset, is_4state } => (
-                            &memory[offset..offset + size],
-                            if is_4state {
-                                &memory[offset + size..offset + size * 2]
-                            } else {
-                                &[]
-                            },
-                            is_4state,
-                        ),
-                        VcdWriterSource::External { index } => {
-                            external_bytes = (
-                                external[index].0.to_bytes_le(),
-                                external[index].1.to_bytes_le(),
-                            );
-                            (&external_bytes.0, &external_bytes.1, true)
-                        }
-                    };
-                    let old =
-                        &mut self.previous[sig.previous_offset..sig.previous_offset + size * 2];
-                    if self.initialized[i]
-                        && plane_equal(&old[..size], value, sig.width)
-                        && (!track_mask || plane_equal(&old[size..], mask, sig.width))
-                    {
-                        continue;
-                    }
-                    copy_plane(&mut old[..size], value, sig.width);
-                    // A two-state memory signal's previous mask stays zero for the
-                    // writer's lifetime. External values can change between X/Z and
-                    // known values, so their masks always participate.
-                    if track_mask {
-                        copy_plane(&mut old[size..], mask, sig.width);
-                    }
-                    self.initialized[i] = true;
-                    encode_value(
-                        self.encoded.spare_capacity_mut(),
-                        sig.width,
-                        &old[..size],
-                        if track_mask { &old[size..] } else { &[] },
-                    )
-                }
-                VcdWriterSource::MemoryBit { offset } => {
-                    let value = memory[offset] & 1;
-                    let old = &mut self.previous[sig.previous_offset];
-                    if self.initialized[i] && *old == value {
-                        continue;
-                    }
-                    *old = value;
-                    self.initialized[i] = true;
-                    self.encoded.spare_capacity_mut()[0].write(b'0' + value);
-                    1
-                }
-                VcdWriterSource::Memory64 { offset } => {
-                    let value: [u8; 8] = memory[offset..offset + 8].try_into().unwrap();
-                    let old: &mut [u8; 8] = (&mut self.previous
-                        [sig.previous_offset..sig.previous_offset + 8])
-                        .try_into()
-                        .unwrap();
-                    if self.initialized[i] && u64::from_ne_bytes(*old) == u64::from_ne_bytes(value)
-                    {
-                        continue;
-                    }
-                    *old = value;
-                    self.initialized[i] = true;
-                    encode_u64(self.encoded.spare_capacity_mut(), u64::from_le_bytes(value))
-                }
-            };
-            let suffix_len = sig
-                .suffix
-                .encode(&mut self.encoded.spare_capacity_mut()[value_len..]);
-            // SAFETY: the encoders initialize their returned lengths in checked
-            // slices of spare capacity. Publish only the complete record, once;
-            // any SIMD/suffix padding stays outside the Vec's visible length.
-            unsafe {
-                self.encoded
-                    .set_len(self.encoded.len() + value_len + suffix_len);
-            }
-            self.encoded_changes += 1;
-            if self.encoded.len() >= self.writer.capacity() {
-                self.write_encoded()?;
-            }
+            self.plan.dump::<false, W>(
+                memory,
+                external,
+                sparse.map(|_| self.selected.as_slice()),
+                &mut self.output,
+            )?;
         }
-        self.write_encoded()
+        Ok(())
+    }
+}
+
+impl<W: Write> VcdOutput<W> {
+    // Keep suffix publication with the value encoder so SIMD constants and
+    // output state can stay in registers between records.
+    #[inline(always)]
+    fn finish_record(&mut self, value_len: usize, suffix: &VcdRecordSuffix) -> std::io::Result<()> {
+        let suffix_len = suffix.encode(&mut self.encoded.spare_capacity_mut()[value_len..]);
+        // SAFETY: both encoders initialize their returned lengths in checked
+        // spare capacity. SIMD/suffix padding stays outside the visible length.
+        unsafe {
+            self.encoded
+                .set_len(self.encoded.len() + value_len + suffix_len);
+        }
+        self.encoded_changes += 1;
+        if self.encoded.len() >= self.writer.capacity() {
+            self.write_encoded()?;
+        }
+        Ok(())
     }
 
     fn write_encoded(&mut self) -> std::io::Result<()> {
@@ -863,7 +777,7 @@ mod encoding_tests {
                 .collect::<Vec<_>>();
             for capacity in [1, 3, 7, 8, 9, 16, 64, 71, 72, 73] {
                 let mut writer = VcdWriter::from_writer(Vec::new(), &descs);
-                writer.writer = BufWriter::with_capacity(capacity, Vec::new());
+                writer.output.writer = BufWriter::with_capacity(capacity, Vec::new());
                 for (time, value) in [0xff, 0, 0, 0xff].into_iter().enumerate() {
                     writer.dump(time as u64, &[value; 800]).unwrap();
                 }
@@ -1036,6 +950,251 @@ mod encoding_tests {
                     "width={width} four_state={four_state}"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn typed_sparse_runs_preserve_aliases_external_values_and_order() {
+        let descs = [
+            (512, 64, false),
+            (0, 1, false),
+            (128, 64, false),
+            (256, 64, true),
+            (512, 64, false),
+            (640, 1, false),
+            (768, 33, true),
+            (896, 64, false),
+            (0, 1, false),
+            (1024, 9, false),
+            (1152, 64, false),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(index, (offset, width, is_4state))| VcdSignalDesc {
+            scope: format!("scope{}", index % 2),
+            name: format!("s{index}"),
+            offset,
+            width,
+            is_4state,
+        })
+        .collect::<Vec<_>>();
+        let external_descs = [1, 64, 65]
+            .into_iter()
+            .enumerate()
+            .map(|(index, width)| VcdExternalSignalDesc {
+                scope: "component".into(),
+                name: format!("e{index}"),
+                width,
+            })
+            .collect::<Vec<_>>();
+        let mut sparse = VcdWriter::from_writer(Vec::new(), &descs);
+        let mut full = VcdWriter::from_writer(Vec::new(), &descs);
+        sparse.add_external_signals(&external_descs).unwrap();
+        full.add_external_signals(&external_descs).unwrap();
+        let mut memory = vec![0; 1216];
+        for (step, groups) in [
+            vec![],
+            vec![8, 0, 8],
+            vec![4, 2],
+            vec![12, 10],
+            vec![16, 14],
+            vec![18, 0],
+            vec![],
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            for &group in &groups {
+                for (index, byte) in memory[group * 64..][..64].iter_mut().enumerate() {
+                    *byte = (step * 19 + index) as u8;
+                }
+            }
+            let external = external_descs
+                .iter()
+                .map(|desc| {
+                    (
+                        (BigUint::from(step) << desc.width.saturating_sub(1))
+                            + BigUint::from(step % 2),
+                        BigUint::from(step % 3) << desc.width.saturating_sub(1),
+                    )
+                })
+                .collect::<Vec<_>>();
+            sparse
+                .dump_with_activity((step / 2) as u64, &memory, &external, Some(&groups))
+                .unwrap();
+            full.dump_with_external((step / 2) as u64, &memory, &external)
+                .unwrap();
+        }
+        // Re-registering the same external descriptors remains idempotent.
+        sparse.add_external_signals(&external_descs).unwrap();
+        assert!(sparse.statistics().comparisons < full.statistics().comparisons);
+        let parse = |bytes: Vec<u8>| {
+            let mut parser = vcd::Parser::new(bytes.as_slice());
+            parser.parse_header().unwrap();
+            parser.map(Result::unwrap).collect::<Vec<_>>()
+        };
+        assert_eq!(
+            parse(sparse.into_inner().unwrap()),
+            parse(full.into_inner().unwrap())
+        );
+    }
+
+    #[test]
+    fn typed_plan_checks_each_dump_and_only_requires_selected_memory() {
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+        let descs = [
+            (0, 64, false),
+            (64, 1, false),
+            (128, 64, false),
+            (192, 64, true),
+            (256, 65, false),
+            (320, 64, false),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(index, (offset, width, is_4state))| VcdSignalDesc {
+            scope: "top".into(),
+            name: format!("s{index}"),
+            offset,
+            width,
+            is_4state,
+        })
+        .collect::<Vec<_>>();
+        let mut writer = VcdWriter::from_writer(Vec::new(), &descs);
+        writer
+            .dump_with_activity(0, &[0; 328], &[], Some(&[]))
+            .unwrap();
+        writer.dump_with_activity(1, &[], &[], Some(&[])).unwrap();
+        writer
+            .dump_with_activity(2, &[1; 8], &[], Some(&[0]))
+            .unwrap();
+        writer
+            .dump_with_activity(3, &[1; 65], &[], Some(&[1]))
+            .unwrap();
+        assert_eq!(writer.statistics().comparisons, 8);
+        for (group, short_len) in [(0, 7), (1, 64), (2, 135), (3, 207), (4, 264)] {
+            assert!(
+                catch_unwind(AssertUnwindSafe(|| {
+                    writer
+                        .dump_with_activity(4, &vec![0; short_len], &[], Some(&[group]))
+                        .unwrap();
+                }))
+                .is_err()
+            );
+        }
+        assert!(catch_unwind(AssertUnwindSafe(|| writer.dump(5, &[0; 327]).unwrap())).is_err());
+        let overflowing = VcdSignalDesc {
+            offset: usize::MAX,
+            ..descs[0].clone()
+        };
+        assert!(catch_unwind(|| VcdWriter::from_writer(Vec::new(), &[overflowing])).is_err());
+    }
+
+    #[test]
+    fn initial_snapshot_is_retried_after_a_record_write_error() {
+        #[derive(Default)]
+        struct FailRecordOnce {
+            bytes: Vec<u8>,
+            fail: bool,
+        }
+        impl Write for FailRecordOnce {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                if self.fail
+                    && self.bytes.last() == Some(&b'\n')
+                    && matches!(bytes.first(), Some(b'0' | b'1' | b'b'))
+                {
+                    self.fail = false;
+                    return Err(std::io::ErrorKind::BrokenPipe.into());
+                }
+                self.bytes.extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        let descs = [64, 1, 9, 64]
+            .into_iter()
+            .enumerate()
+            .map(|(index, width)| VcdSignalDesc {
+                scope: "top".into(),
+                name: format!("s{index}"),
+                offset: index * 64,
+                width,
+                is_4state: false,
+            })
+            .collect::<Vec<_>>();
+        let mut writer = VcdWriter::from_writer(FailRecordOnce::default(), &descs);
+        writer.output.writer = BufWriter::with_capacity(1, FailRecordOnce::default());
+        writer.write_header().unwrap();
+        writer.flush().unwrap();
+        writer.output.writer.get_mut().fail = true;
+        assert!(
+            writer
+                .dump_with_activity(1, &[0; 200], &[], Some(&[]))
+                .is_err()
+        );
+        assert!(!writer.initial_values_written);
+        writer
+            .dump_with_activity(2, &[0; 200], &[], Some(&[]))
+            .unwrap();
+        assert!(writer.initial_values_written);
+        assert_eq!(writer.statistics().changes, 4);
+        assert_eq!(writer.statistics().comparisons, 5);
+        assert_eq!(
+            changes(&writer.into_inner().unwrap().bytes),
+            vec![(2, "0".into()); 4]
+        );
+    }
+
+    #[test]
+    fn comparison_statistics_count_the_visited_prefix_on_io_error() {
+        #[derive(Default)]
+        struct FailAfterRecord {
+            bytes: Vec<u8>,
+            remaining: Option<usize>,
+        }
+        impl Write for FailAfterRecord {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                if self.bytes.last() == Some(&b'\n')
+                    && matches!(bytes.first(), Some(b'0' | b'1' | b'b'))
+                    && let Some(remaining) = &mut self.remaining
+                {
+                    if *remaining == 0 {
+                        self.remaining = None;
+                        return Err(std::io::ErrorKind::BrokenPipe.into());
+                    }
+                    *remaining -= 1;
+                }
+                self.bytes.extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        for width in [1, 64, 9] {
+            let descs = (0..8)
+                .map(|index| VcdSignalDesc {
+                    scope: "top".into(),
+                    name: format!("s{index}"),
+                    offset: index * 16,
+                    width,
+                    is_4state: false,
+                })
+                .collect::<Vec<_>>();
+            let mut writer = VcdWriter::from_writer(FailAfterRecord::default(), &descs);
+            writer.output.writer = BufWriter::with_capacity(1, FailAfterRecord::default());
+            let mut memory = [0; 128];
+            writer.dump(0, &memory).unwrap();
+            writer.flush().unwrap();
+            memory[0] = 1;
+            memory[4 * 16] = 1;
+            writer.output.writer.get_mut().remaining = Some(1);
+            assert!(writer.dump(1, &memory).is_err());
+            // Visit indices 0 through 4, including the three unchanged values.
+            assert_eq!(writer.statistics().comparisons, 8 + 5, "width={width}");
+            assert_eq!(writer.statistics().changes, 8 + 1, "width={width}");
         }
     }
 

--- a/crates/celox-runtime/src/vcd/plan.rs
+++ b/crates/celox-runtime/src/vcd/plan.rs
@@ -28,6 +28,7 @@ struct Run {
 struct FixedSignal {
     suffix: VcdRecordSuffix,
     offset: usize,
+    /// Last encoded value; VcdOutput retains its record until the write succeeds.
     previous: u64,
 }
 
@@ -50,6 +51,7 @@ pub(super) struct TracePlan {
     bits: Vec<FixedSignal>,
     words: Vec<FixedSignal>,
     generic: Vec<GenericSignal>,
+    /// Includes values queued in VcdOutput, even after a partial write fails.
     previous: Vec<u8>,
     memory_required: usize,
 }

--- a/crates/celox-runtime/src/vcd/plan.rs
+++ b/crates/celox-runtime/src/vcd/plan.rs
@@ -1,0 +1,339 @@
+//! Registration-order runs for the hot waveform comparison loop.
+use super::{
+    VcdOutput, VcdRecordSuffix, VcdSignalDesc, copy_plane, encode_u64, encode_value, plane_equal,
+};
+use num_bigint::BigUint;
+use std::io::Write;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    Bit,
+    Word,
+    Generic,
+}
+
+#[derive(Clone, Copy)]
+struct Entry {
+    kind: Kind,
+    index: usize,
+}
+
+#[derive(Clone, Copy)]
+struct Run {
+    kind: Kind,
+    start: usize,
+    end: usize,
+}
+
+struct FixedSignal {
+    suffix: VcdRecordSuffix,
+    offset: usize,
+    previous: u64,
+}
+
+enum GenericSource {
+    Memory { offset: usize, is_4state: bool },
+    External { index: usize },
+}
+
+struct GenericSignal {
+    suffix: VcdRecordSuffix,
+    source: GenericSource,
+    width: usize,
+    previous_offset: usize,
+}
+
+#[derive(Default)]
+pub(super) struct TracePlan {
+    entries: Vec<Entry>,
+    runs: Vec<Run>,
+    bits: Vec<FixedSignal>,
+    words: Vec<FixedSignal>,
+    generic: Vec<GenericSignal>,
+    previous: Vec<u8>,
+    memory_required: usize,
+}
+
+impl TracePlan {
+    pub(super) fn add_memory(&mut self, desc: &VcdSignalDesc) {
+        let size = desc.width.div_ceil(8);
+        let end = size
+            .checked_mul(if desc.is_4state { 2 } else { 1 })
+            .and_then(|size| desc.offset.checked_add(size))
+            .expect("VCD signal memory range overflows");
+        self.memory_required = self.memory_required.max(end);
+        let suffix = VcdRecordSuffix::new(desc.width, "");
+        let entry = match (desc.width, desc.is_4state) {
+            (1 | 64, false) => {
+                let (kind, signals) = if desc.width == 1 {
+                    (Kind::Bit, &mut self.bits)
+                } else {
+                    (Kind::Word, &mut self.words)
+                };
+                let index = signals.len();
+                signals.push(FixedSignal {
+                    suffix,
+                    offset: desc.offset,
+                    previous: 0,
+                });
+                Entry { kind, index }
+            }
+            _ => {
+                let index = self.generic.len();
+                self.generic.push(GenericSignal {
+                    suffix,
+                    source: GenericSource::Memory {
+                        offset: desc.offset,
+                        is_4state: desc.is_4state,
+                    },
+                    width: desc.width,
+                    previous_offset: self.previous.len(),
+                });
+                self.previous.resize(self.previous.len() + size * 2, 0);
+                Entry {
+                    kind: Kind::Generic,
+                    index,
+                }
+            }
+        };
+        self.push(entry);
+    }
+
+    pub(super) fn add_external(&mut self, index: usize, width: usize) {
+        let entry = Entry {
+            kind: Kind::Generic,
+            index: self.generic.len(),
+        };
+        self.generic.push(GenericSignal {
+            suffix: VcdRecordSuffix::new(width, ""),
+            source: GenericSource::External { index },
+            width,
+            previous_offset: self.previous.len(),
+        });
+        self.previous
+            .resize(self.previous.len() + width.div_ceil(8) * 2, 0);
+        self.push(entry);
+    }
+
+    fn push(&mut self, entry: Entry) {
+        self.entries.push(entry);
+        if let Some(run) = self.runs.last_mut()
+            && run.kind == entry.kind
+            && run.end == entry.index
+        {
+            run.end += 1;
+        } else {
+            self.runs.push(Run {
+                kind: entry.kind,
+                start: entry.index,
+                end: entry.index + 1,
+            });
+        }
+    }
+
+    pub(super) fn suffix(&mut self, index: usize) -> &mut VcdRecordSuffix {
+        let entry = self.entries[index];
+        match entry.kind {
+            Kind::Bit => &mut self.bits[entry.index].suffix,
+            Kind::Word => &mut self.words[entry.index].suffix,
+            Kind::Generic => &mut self.generic[entry.index].suffix,
+        }
+    }
+
+    fn memory_end(&self, entry: Entry) -> usize {
+        // Memory ranges were checked for overflow at registration.
+        match entry.kind {
+            Kind::Bit => self.bits[entry.index].offset + 1,
+            Kind::Word => self.words[entry.index].offset + 8,
+            Kind::Generic => {
+                let signal = &self.generic[entry.index];
+                match signal.source {
+                    GenericSource::Memory { offset, is_4state } => {
+                        offset + signal.width.div_ceil(8) * if is_4state { 2 } else { 1 }
+                    }
+                    GenericSource::External { .. } => 0,
+                }
+            }
+        }
+    }
+
+    pub(super) fn dump<const INITIAL: bool, W: Write>(
+        &mut self,
+        memory: &[u8],
+        external: &[(BigUint, BigUint)],
+        selected: Option<&[usize]>,
+        output: &mut VcdOutput<W>,
+    ) -> std::io::Result<()> {
+        // Validate once per dump. A sparse caller may supply a shorter slice
+        // that still covers every selected signal; preserve that contract.
+        if memory.len() < self.memory_required {
+            if let Some(selected) = selected {
+                for &index in selected {
+                    assert!(
+                        self.memory_end(self.entries[index]) <= memory.len(),
+                        "VCD memory does not cover a selected signal"
+                    );
+                }
+            } else {
+                panic!("VCD memory does not cover all signals");
+            }
+        }
+        if let Some(selected) = selected {
+            // Sparse indices can break a long typed run into many short ones.
+            // Visit each entry once instead of first rebuilding those runs.
+            for &index in selected {
+                let entry = self.entries[index];
+                let run = Run {
+                    kind: entry.kind,
+                    start: entry.index,
+                    end: entry.index + 1,
+                };
+                // SAFETY: all selected memory ranges were validated above.
+                unsafe {
+                    self.write_run::<INITIAL, W>(run, memory, external, output)?;
+                }
+            }
+        } else if self.runs.len() > self.entries.len() / 2 {
+            // Alternating types form many tiny runs. Visit their entries
+            // directly so each specialized loop has a known length of one.
+            for index in 0..self.entries.len() {
+                let entry = self.entries[index];
+                let run = Run {
+                    kind: entry.kind,
+                    start: entry.index,
+                    end: entry.index + 1,
+                };
+                // SAFETY: the complete memory range was validated above.
+                unsafe {
+                    self.write_run::<INITIAL, W>(run, memory, external, output)?;
+                }
+            }
+        } else {
+            for index in 0..self.runs.len() {
+                // SAFETY: the complete memory range was validated above.
+                unsafe {
+                    self.write_run::<INITIAL, W>(self.runs[index], memory, external, output)?;
+                }
+            }
+        }
+        output.write_encoded()
+    }
+
+    /// Every signal in the run must fit in memory.
+    // Runs can contain a single signal when types alternate. Keep dispatch in
+    // the caller so these runs do not pay for a function prologue per signal.
+    #[inline(always)]
+    unsafe fn write_run<const INITIAL: bool, W: Write>(
+        &mut self,
+        run: Run,
+        memory: &[u8],
+        external: &[(BigUint, BigUint)],
+        output: &mut VcdOutput<W>,
+    ) -> std::io::Result<()> {
+        match run.kind {
+            // SAFETY: the caller validated the selected memory ranges.
+            Kind::Bit => unsafe {
+                write_fixed::<INITIAL, true, W>(&mut self.bits[run.start..run.end], memory, output)
+            },
+            // SAFETY: the caller validated the selected memory ranges.
+            Kind::Word => unsafe {
+                write_fixed::<INITIAL, false, W>(
+                    &mut self.words[run.start..run.end],
+                    memory,
+                    output,
+                )
+            },
+            Kind::Generic => {
+                let signals = &self.generic[run.start..run.end];
+                for (index, signal) in signals.iter().enumerate() {
+                    let size = signal.width.div_ceil(8);
+                    let external_bytes;
+                    let (value, mask, track_mask): (&[u8], &[u8], bool) = match signal.source {
+                        GenericSource::Memory { offset, is_4state } => (
+                            &memory[offset..offset + size],
+                            if is_4state {
+                                &memory[offset + size..offset + size * 2]
+                            } else {
+                                &[]
+                            },
+                            is_4state,
+                        ),
+                        GenericSource::External { index } => {
+                            external_bytes = (
+                                external[index].0.to_bytes_le(),
+                                external[index].1.to_bytes_le(),
+                            );
+                            (&external_bytes.0, &external_bytes.1, true)
+                        }
+                    };
+                    let old = &mut self.previous
+                        [signal.previous_offset..signal.previous_offset + size * 2];
+                    if !INITIAL
+                        && plane_equal(&old[..size], value, signal.width)
+                        && (!track_mask || plane_equal(&old[size..], mask, signal.width))
+                    {
+                        continue;
+                    }
+                    copy_plane(&mut old[..size], value, signal.width);
+                    if track_mask {
+                        copy_plane(&mut old[size..], mask, signal.width);
+                    }
+                    let len = encode_value(
+                        output.encoded.spare_capacity_mut(),
+                        signal.width,
+                        &old[..size],
+                        if track_mask { &old[size..] } else { &[] },
+                    );
+                    if let Err(error) = output.finish_record(len, &signal.suffix) {
+                        output.stats.comparisons += index as u64 + 1;
+                        return Err(error);
+                    }
+                }
+                output.stats.comparisons += signals.len() as u64;
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Every signal's one/eight-byte input must fit in memory. Checked by TracePlan.
+#[inline(always)]
+unsafe fn write_fixed<const INITIAL: bool, const BIT: bool, W: Write>(
+    signals: &mut [FixedSignal],
+    memory: &[u8],
+    output: &mut VcdOutput<W>,
+) -> std::io::Result<()> {
+    for (index, signal) in signals.iter_mut().enumerate() {
+        let value = if BIT {
+            // SAFETY: the plan validated this one-byte range for this dump.
+            u64::from(unsafe { *memory.as_ptr().add(signal.offset) } & 1)
+        } else {
+            // SAFETY: the plan validated all eight bytes; homes may be unaligned.
+            u64::from_le(unsafe {
+                memory
+                    .as_ptr()
+                    .add(signal.offset)
+                    .cast::<u64>()
+                    .read_unaligned()
+            })
+        };
+        if !INITIAL && value == signal.previous {
+            continue;
+        }
+        signal.previous = value;
+        let len = if BIT {
+            output.encoded.spare_capacity_mut()[0].write(b'0' + value as u8);
+            1
+        } else {
+            encode_u64(output.encoded.spare_capacity_mut(), value)
+        };
+        if let Err(error) = output.finish_record(len, &signal.suffix) {
+            output.stats.comparisons += index as u64 + 1;
+            return Err(error);
+        }
+    }
+    // Count a completed run once, avoiding a memory RMW dependency on every
+    // comparison. The error path above counts exactly the visited prefix.
+    output.stats.comparisons += signals.len() as u64;
+    Ok(())
+}

--- a/crates/celox-state-layout/src/lib.rs
+++ b/crates/celox-state-layout/src/lib.rs
@@ -11,6 +11,9 @@ use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use serde::{Deserialize, Serialize};
 use std::hash::Hash;
 
+mod trace;
+pub use trace::{TRACE_GROUP_BYTES, TraceLayout};
+
 pub const RUNTIME_EVENT_CAPACITY: usize = 1024;
 pub const RUNTIME_EVENT_WRITING: u64 = u64::MAX;
 pub const STATE_HEADER_SIZE: usize = 32;
@@ -139,6 +142,8 @@ pub trait LayoutSource<A> {
     deserialize = "A: Deserialize<'de> + Eq + Hash"
 ))]
 pub struct MemoryLayout<A> {
+    /// Present only in builds that record waveforms.
+    pub trace: Option<TraceLayout>,
     pub four_state: bool,
     pub mode: MemoryLayoutMode,
     /// Stable region offsets. Includes all declared state objects.
@@ -367,6 +372,7 @@ where
         }
 
         Self {
+            trace: None,
             four_state,
             mode,
             offsets,
@@ -400,6 +406,41 @@ where
         self.scratch_size = scratch_size;
         self.merged_total_size = align_up(self.scratch_base_offset + scratch_size, 8);
         self
+    }
+
+    /// Reserve observer activity after scheduler metadata and before backend
+    /// scratch. Stable/working addresses and clock-trigger offsets stay fixed.
+    pub fn enable_trace(&mut self) {
+        if self.trace.is_some() {
+            return;
+        }
+        assert_eq!(
+            self.scratch_size, 0,
+            "trace must be enabled before backend planning"
+        );
+        let homes = self
+            .offsets
+            .iter()
+            .map(|(address, &offset)| {
+                let planes = if self.four_state { 2 } else { 1 };
+                (offset, offset + self.plane_size(address) * planes)
+            })
+            .collect();
+        let trace = TraceLayout::new(self.scratch_base_offset, self.total_size, homes);
+        self.scratch_base_offset = align_up(trace.end_offset(), 8);
+        self.merged_total_size = self.scratch_base_offset;
+        self.trace = Some(trace);
+    }
+
+    pub fn trace_notification_offsets<R: RegionedAddress<A>>(
+        &self,
+        address: &R,
+    ) -> Option<[usize; 2]> {
+        if address.region() != STABLE_REGION {
+            return None;
+        }
+        let trace = self.trace.as_ref()?;
+        Some(trace.notification_offsets(self.offsets[&address.absolute_address()]))
     }
 
     pub fn plane_size(&self, address: &A) -> usize {

--- a/crates/celox-state-layout/src/trace.rs
+++ b/crates/celox-state-layout/src/trace.rs
@@ -1,0 +1,164 @@
+//! Write activity shared by generated code and waveform observers.
+//!
+//! An object is assigned by its stable home, so aliases share notifications
+//! and partial/dynamic stores also notify observers of the complete object.
+use serde::{Deserialize, Serialize};
+
+pub const TRACE_GROUP_BYTES: usize = 64;
+const GROUPS_PER_SUMMARY: usize = 64;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TraceLayout {
+    pub flags_offset: usize,
+    pub group_count: usize,
+    pub summary_offset: usize,
+    pub summary_count: usize,
+    /// Nonzero after a mutable raw view escapes. Such views can change without
+    /// any generated notification, so observers must keep scanning all values.
+    pub untracked_offset: usize,
+    /// Disjoint physical homes, including both planes and element padding.
+    homes: Vec<(usize, usize)>,
+}
+
+impl TraceLayout {
+    pub(crate) fn new(offset: usize, stable_size: usize, mut homes: Vec<(usize, usize)>) -> Self {
+        homes.sort_unstable();
+        let mut merged: Vec<(usize, usize)> = Vec::new();
+        for (start, end) in homes {
+            if let Some(last) = merged.last_mut()
+                && last.0 == start
+            {
+                last.1 = last.1.max(end);
+            } else {
+                merged.push((start, end));
+            }
+        }
+        let group_count = stable_size.div_ceil(TRACE_GROUP_BYTES);
+        let summary_count = group_count.div_ceil(GROUPS_PER_SUMMARY);
+        Self {
+            flags_offset: offset,
+            group_count,
+            summary_offset: offset + group_count,
+            summary_count,
+            untracked_offset: offset + group_count + summary_count,
+            homes: merged,
+        }
+    }
+
+    pub fn end_offset(&self) -> usize {
+        self.untracked_offset + 1
+    }
+
+    pub fn validate(
+        &self,
+        stable_size: usize,
+        metadata_start: usize,
+        scratch_start: usize,
+    ) -> bool {
+        self.group_count == stable_size.div_ceil(TRACE_GROUP_BYTES)
+            && self.summary_count == self.group_count.div_ceil(GROUPS_PER_SUMMARY)
+            && self.flags_offset >= metadata_start
+            && self.flags_offset.checked_add(self.group_count) == Some(self.summary_offset)
+            && self.summary_offset.checked_add(self.summary_count) == Some(self.untracked_offset)
+            && self.untracked_offset < scratch_start
+            && self
+                .homes
+                .iter()
+                .all(|&(start, end)| start <= end && end <= stable_size)
+            && self.homes.windows(2).all(|homes| homes[0].1 <= homes[1].0)
+    }
+
+    /// Two byte stores suffice: no read/modify/write in generated hot paths.
+    pub fn notification_offsets(&self, stable_home: usize) -> [usize; 2] {
+        let group = stable_home / TRACE_GROUP_BYTES;
+        [
+            self.flags_offset + group,
+            self.summary_offset + group / GROUPS_PER_SUMMARY,
+        ]
+    }
+
+    /// # Safety
+    /// `memory` must exclusively reference the complete writable state image.
+    pub unsafe fn mark_home(&self, memory: *mut u8, home: usize) {
+        for offset in self.notification_offsets(home) {
+            unsafe {
+                *memory.add(offset) = 1;
+            }
+        }
+    }
+
+    /// Mark host writes, including an element view into a larger array.
+    /// # Safety
+    /// `memory` must exclusively reference the complete writable state image.
+    pub unsafe fn mark_range(&self, memory: *mut u8, offset: usize, len: usize) {
+        if len == 0 {
+            return;
+        }
+        let first = self
+            .homes
+            .partition_point(|&(start, _)| start <= offset)
+            .saturating_sub(1);
+        for &(start, end) in &self.homes[first..] {
+            if start >= offset.saturating_add(len) {
+                break;
+            }
+            if end > offset {
+                unsafe {
+                    self.mark_home(memory, start);
+                }
+            }
+        }
+    }
+
+    /// Consume only nonempty groups. Clock trigger clearing never touches this
+    /// region. The caller owns the reusable result allocation.
+    pub fn take(&self, memory: &mut [u8], groups: &mut Vec<usize>) -> bool {
+        groups.clear();
+        let tracked = memory[self.untracked_offset] == 0;
+        for summary in 0..self.summary_count {
+            if memory[self.summary_offset + summary] == 0 {
+                continue;
+            }
+            memory[self.summary_offset + summary] = 0;
+            let start = summary * GROUPS_PER_SUMMARY;
+            let end = (start + GROUPS_PER_SUMMARY).min(self.group_count);
+            for group in start..end {
+                let flag = &mut memory[self.flags_offset + group];
+                if *flag != 0 {
+                    *flag = 0;
+                    groups.push(group);
+                }
+            }
+        }
+        tracked
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aliases_partial_writes_and_separate_consumers() {
+        let trace = TraceLayout::new(
+            8192,
+            8192,
+            vec![(0, 512), (0, 64), (512, 520), (4096, 4104)],
+        );
+        let mut memory = vec![0; trace.end_offset()];
+        // A partial write near the end of an array notifies its stable home.
+        unsafe {
+            trace.mark_range(memory.as_mut_ptr(), 500, 2);
+            trace.mark_range(memory.as_mut_ptr(), 510, 4);
+            trace.mark_home(memory.as_mut_ptr(), 4096);
+        }
+        let mut groups = vec![];
+        assert!(trace.take(&mut memory, &mut groups));
+        assert_eq!(groups, [0, 8, 64]);
+        assert!(trace.take(&mut memory, &mut groups));
+        assert!(groups.is_empty());
+        memory[trace.untracked_offset] = 1;
+        assert!(!trace.take(&mut memory, &mut groups));
+        assert!(!trace.take(&mut memory, &mut groups));
+    }
+}

--- a/crates/celox-state-layout/src/trace.rs
+++ b/crates/celox-state-layout/src/trace.rs
@@ -115,28 +115,142 @@ impl TraceLayout {
     pub fn take(&self, memory: &mut [u8], groups: &mut Vec<usize>) -> bool {
         groups.clear();
         let tracked = memory[self.untracked_offset] == 0;
-        for summary in 0..self.summary_count {
-            if memory[self.summary_offset + summary] == 0 {
-                continue;
-            }
-            memory[self.summary_offset + summary] = 0;
+        let (prefix, summaries) = memory.split_at_mut(self.summary_offset);
+        let flags = &mut prefix[self.flags_offset..][..self.group_count];
+        take_nonzero(&mut summaries[..self.summary_count], |summary| {
             let start = summary * GROUPS_PER_SUMMARY;
-            let end = (start + GROUPS_PER_SUMMARY).min(self.group_count);
-            for group in start..end {
-                let flag = &mut memory[self.flags_offset + group];
-                if *flag != 0 {
-                    *flag = 0;
-                    groups.push(group);
-                }
-            }
-        }
+            let flags = &mut flags[start..];
+            let len = flags.len().min(GROUPS_PER_SUMMARY);
+            take_nonzero(&mut flags[..len], |index| groups.push(start + index));
+        });
         tracked
+    }
+}
+
+/// Clear and visit nonzero bytes in address order. Notifications stay byte
+/// stores, while the consumer skips eight empty bytes with one word test.
+fn take_nonzero(bytes: &mut [u8], mut visit: impl FnMut(usize)) {
+    let (words, tail) = bytes.as_chunks_mut::<8>();
+    for (index, bytes) in words.iter_mut().enumerate() {
+        // A safe unaligned load; little endian keeps bit order in address order
+        // even on big-endian hosts.
+        let word = u64::from_le_bytes(*bytes);
+        if word == 0 {
+            continue;
+        }
+        bytes.fill(0);
+        // Set exactly the high bit of each nonzero byte, including flags other
+        // than 1. Adding 0x7f to the low seven bits cannot carry between bytes.
+        const LOW_BITS: u64 = 0x7f7f_7f7f_7f7f_7f7f;
+        let mut active = (((word & LOW_BITS) + LOW_BITS) | word) & !LOW_BITS;
+        while active != 0 {
+            visit(index * 8 + active.trailing_zeros() as usize / 8);
+            active &= active - 1;
+        }
+    }
+    let base = words.len() * 8;
+    for (index, byte) in tail.iter_mut().enumerate() {
+        if *byte != 0 {
+            *byte = 0;
+            visit(base + index);
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn nonzero_bytes_preserve_address_order() {
+        for alignment in 0..8 {
+            // Exercise every possible byte value, including adjacent zero and
+            // nonzero bytes, word boundaries, and short tails.
+            for len in 0..=512 {
+                let mut bytes = vec![0xa5; alignment + len + 8];
+                for (index, byte) in bytes[alignment..][..len].iter_mut().enumerate() {
+                    *byte = if index % 2 == 0 { (index / 2) as u8 } else { 0 };
+                }
+                let expected: Vec<_> = bytes[alignment..][..len]
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, &byte)| (byte != 0).then_some(index))
+                    .collect();
+                let mut actual = vec![];
+                take_nonzero(&mut bytes[alignment..][..len], |index| actual.push(index));
+                assert_eq!(actual, expected);
+                assert!(bytes[..alignment].iter().all(|&byte| byte == 0xa5));
+                assert!(bytes[alignment..][..len].iter().all(|&byte| byte == 0));
+                assert!(bytes[alignment + len..].iter().all(|&byte| byte == 0xa5));
+            }
+        }
+    }
+
+    #[test]
+    fn activity_boundaries_match_scalar_collection() {
+        for group_count in [
+            0, 1, 7, 8, 9, 63, 64, 65, 127, 128, 447, 448, 449, 511, 512, 513, 575, 576, 577, 1024,
+        ] {
+            for alignment in 0..8 {
+                // Include partial stable groups and unaligned metadata.
+                let stable_size = (group_count * TRACE_GROUP_BYTES).saturating_sub(3);
+                let trace = TraceLayout::new(stable_size + alignment, stable_size, vec![]);
+                assert_eq!(trace.group_count, group_count);
+                for pattern in 0..5 {
+                    let mut memory = vec![0xa5; trace.end_offset() + 8];
+                    memory[trace.flags_offset..trace.end_offset()].fill(0);
+                    for group in 0..group_count {
+                        let flag = match pattern {
+                            0 => 0,
+                            1 => 1,
+                            2 => u8::from(group % 2 == 0),
+                            3 => {
+                                u8::from(group == 0 || group + 1 == group_count || group % 64 == 0)
+                            }
+                            _ => [0, 2, 0, 0x80, 0, 0xff, 1][group % 7],
+                        };
+                        memory[trace.flags_offset + group] = flag;
+                        if flag != 0 {
+                            memory[trace.summary_offset + group / GROUPS_PER_SUMMARY] = flag;
+                        }
+                    }
+                    // Both an empty marked summary and an unmarked summary with
+                    // stale flags must retain the scalar collector's behavior.
+                    if trace.summary_count > 1 && matches!(pattern, 0 | 4) {
+                        memory[trace.summary_offset] = 0xff;
+                        memory[trace.summary_offset + 1] = 0;
+                    }
+                    memory[trace.untracked_offset] = (pattern % 2) as u8;
+                    let mut expected_memory = memory.clone();
+                    let mut expected_groups = vec![];
+                    for summary in 0..trace.summary_count {
+                        if expected_memory[trace.summary_offset + summary] == 0 {
+                            continue;
+                        }
+                        expected_memory[trace.summary_offset + summary] = 0;
+                        for group in 0..group_count {
+                            if group / GROUPS_PER_SUMMARY == summary
+                                && expected_memory[trace.flags_offset + group] != 0
+                            {
+                                expected_memory[trace.flags_offset + group] = 0;
+                                expected_groups.push(group);
+                            }
+                        }
+                    }
+                    let mut groups = vec![usize::MAX];
+                    assert_eq!(trace.take(&mut memory, &mut groups), pattern % 2 == 0);
+                    assert_eq!(groups, expected_groups);
+                    // This also checks untouched state/clock bytes and the byte
+                    // immediately following the last (possibly partial) group.
+                    assert_eq!(memory, expected_memory);
+                    groups.push(usize::MAX);
+                    assert_eq!(trace.take(&mut memory, &mut groups), pattern % 2 == 0);
+                    assert!(groups.is_empty());
+                    assert_eq!(memory, expected_memory);
+                }
+            }
+        }
+    }
 
     #[test]
     fn aliases_partial_writes_and_separate_consumers() {

--- a/crates/celox-state-layout/src/trace.rs
+++ b/crates/celox-state-layout/src/trace.rs
@@ -13,9 +13,6 @@ pub struct TraceLayout {
     pub group_count: usize,
     pub summary_offset: usize,
     pub summary_count: usize,
-    /// Nonzero after a mutable raw view escapes. Such views can change without
-    /// any generated notification, so observers must keep scanning all values.
-    pub untracked_offset: usize,
     /// Disjoint physical homes, including both planes and element padding.
     homes: Vec<(usize, usize)>,
 }
@@ -40,13 +37,12 @@ impl TraceLayout {
             group_count,
             summary_offset: offset + group_count,
             summary_count,
-            untracked_offset: offset + group_count + summary_count,
             homes: merged,
         }
     }
 
     pub fn end_offset(&self) -> usize {
-        self.untracked_offset + 1
+        self.summary_offset + self.summary_count
     }
 
     pub fn validate(
@@ -59,8 +55,10 @@ impl TraceLayout {
             && self.summary_count == self.group_count.div_ceil(GROUPS_PER_SUMMARY)
             && self.flags_offset >= metadata_start
             && self.flags_offset.checked_add(self.group_count) == Some(self.summary_offset)
-            && self.summary_offset.checked_add(self.summary_count) == Some(self.untracked_offset)
-            && self.untracked_offset < scratch_start
+            && self
+                .summary_offset
+                .checked_add(self.summary_count)
+                .is_some_and(|end| end <= scratch_start)
             && self
                 .homes
                 .iter()
@@ -112,9 +110,8 @@ impl TraceLayout {
 
     /// Consume only nonempty groups. Clock trigger clearing never touches this
     /// region. The caller owns the reusable result allocation.
-    pub fn take(&self, memory: &mut [u8], groups: &mut Vec<usize>) -> bool {
+    pub fn take(&self, memory: &mut [u8], groups: &mut Vec<usize>) {
         groups.clear();
-        let tracked = memory[self.untracked_offset] == 0;
         let (prefix, summaries) = memory.split_at_mut(self.summary_offset);
         let flags = &mut prefix[self.flags_offset..][..self.group_count];
         take_nonzero(&mut summaries[..self.summary_count], |summary| {
@@ -123,7 +120,6 @@ impl TraceLayout {
             let len = flags.len().min(GROUPS_PER_SUMMARY);
             take_nonzero(&mut flags[..len], |index| groups.push(start + index));
         });
-        tracked
     }
 }
 
@@ -220,7 +216,6 @@ mod tests {
                         memory[trace.summary_offset] = 0xff;
                         memory[trace.summary_offset + 1] = 0;
                     }
-                    memory[trace.untracked_offset] = (pattern % 2) as u8;
                     let mut expected_memory = memory.clone();
                     let mut expected_groups = vec![];
                     for summary in 0..trace.summary_count {
@@ -238,13 +233,13 @@ mod tests {
                         }
                     }
                     let mut groups = vec![usize::MAX];
-                    assert_eq!(trace.take(&mut memory, &mut groups), pattern % 2 == 0);
+                    trace.take(&mut memory, &mut groups);
                     assert_eq!(groups, expected_groups);
                     // This also checks untouched state/clock bytes and the byte
                     // immediately following the last (possibly partial) group.
                     assert_eq!(memory, expected_memory);
                     groups.push(usize::MAX);
-                    assert_eq!(trace.take(&mut memory, &mut groups), pattern % 2 == 0);
+                    trace.take(&mut memory, &mut groups);
                     assert!(groups.is_empty());
                     assert_eq!(memory, expected_memory);
                 }
@@ -267,12 +262,9 @@ mod tests {
             trace.mark_home(memory.as_mut_ptr(), 4096);
         }
         let mut groups = vec![];
-        assert!(trace.take(&mut memory, &mut groups));
+        trace.take(&mut memory, &mut groups);
         assert_eq!(groups, [0, 8, 64]);
-        assert!(trace.take(&mut memory, &mut groups));
+        trace.take(&mut memory, &mut groups);
         assert!(groups.is_empty());
-        memory[trace.untracked_offset] = 1;
-        assert!(!trace.take(&mut memory, &mut groups));
-        assert!(!trace.take(&mut memory, &mut groups));
     }
 }

--- a/crates/celox-testbench/src/vm.rs
+++ b/crates/celox-testbench/src/vm.rs
@@ -88,12 +88,23 @@ impl CompiledExpr {
     /// signals on a single stack.  The common case (all ≤64-bit operands)
     /// stays in the `TestbenchValue::U64` variant and never allocates.
     fn eval(&self, memory: *mut u8) -> TestbenchValue {
+        self.eval_value_with_write_observer(memory, |_, _| {})
+    }
+
+    /// Evaluate with a notification for each executed memory write. Expression
+    /// function calls can store arguments and results; ordinary reads do not
+    /// notify the observer or require a retained mutable view of the image.
+    pub fn eval_value_with_write_observer(
+        &self,
+        memory: *mut u8,
+        mut on_write: impl FnMut(usize, usize),
+    ) -> TestbenchValue {
         let mut stack: Vec<TestbenchValue> = Vec::with_capacity(16);
         let mut pc: usize = 0;
         let ops = self.bytecode.ops();
 
         while pc < ops.len() {
-            self.exec_at(ops, &mut pc, &mut stack, memory);
+            self.exec_at(ops, &mut pc, &mut stack, memory, &mut on_write);
         }
         stack.pop().unwrap_or_else(|| {
             debug_assert!(false, "testbench bytecode: stack empty after evaluation");
@@ -110,6 +121,7 @@ impl CompiledExpr {
         pc: &mut usize,
         stack: &mut Vec<TestbenchValue>,
         memory: *mut u8,
+        on_write: &mut impl FnMut(usize, usize),
     ) {
         match &ops[*pc] {
             TbOpcode::ConstU64(v) => {
@@ -246,14 +258,14 @@ impl CompiledExpr {
                 if !cond.is_zero() {
                     let then_end = *pc + then_len;
                     while *pc < then_end {
-                        self.exec_at(ops, pc, stack, memory);
+                        self.exec_at(ops, pc, stack, memory, on_write);
                     }
                     *pc += else_len; // skip else block
                 } else {
                     *pc += then_len; // skip then block
                     let else_end = *pc + else_len;
                     while *pc < else_end {
-                        self.exec_at(ops, pc, stack, memory);
+                        self.exec_at(ops, pc, stack, memory, on_write);
                     }
                 }
             }
@@ -314,6 +326,7 @@ impl CompiledExpr {
                 unsafe {
                     std::ptr::copy_nonoverlapping(bytes.as_ptr(), memory.add(*location), n);
                 }
+                on_write(*location, n);
                 *pc += 1;
             }
         }

--- a/crates/celox/Cargo.toml
+++ b/crates/celox/Cargo.toml
@@ -90,6 +90,11 @@ tempfile.workspace = true
 veryl-std = { workspace = true }
 veryl-emitter = { workspace = true }
 veryl-simulator = { workspace = true }
+vcd = "0.7"
+
+[[bench]]
+name = "vcd"
+harness = false
 
 [[bench]]
 name = "simulation"

--- a/crates/celox/benches/vcd.rs
+++ b/crates/celox/benches/vcd.rs
@@ -1,0 +1,141 @@
+//! End-to-end cost of compiled write notifications and waveform output.
+use celox::{SimBackend, Simulator, SimulatorBuilder};
+use std::{fmt::Write, time::Instant};
+
+// Standalone benchmark configuration is read at this executable's boundary.
+#[allow(clippy::disallowed_methods)]
+fn setting(name: &str) -> Result<String, std::env::VarError> {
+    std::env::var(name)
+}
+fn number(name: &str, default: usize) -> usize {
+    setting(name).map_or(default, |x| x.parse().unwrap())
+}
+fn run<B: SimBackend>(
+    mut sim: Simulator<B>,
+    mode: &str,
+    case: &str,
+    active: usize,
+    signals: usize,
+    steps: usize,
+    repeat: usize,
+) {
+    let clk = sim.event("clk");
+    let clock_signal = sim.signal("clk");
+    sim.set(sim.signal("rst"), 0u8);
+    sim.tick(clk).unwrap();
+    sim.set(sim.signal("rst"), 1u8);
+    for i in 0..signals {
+        sim.set(sim.signal(&format!("en{i}")), u8::from(i < active));
+    }
+    sim.tick(clk).unwrap();
+    if mode == "scan" {
+        // Force the safe reference path while keeping identical generated code.
+        let _ = sim.memory_as_mut_ptr();
+    }
+    if mode == "dirty" || mode == "scan" {
+        sim.dump(0);
+        sim.flush_vcd().unwrap();
+    }
+    let initial = sim.vcd_statistics().unwrap_or_default();
+    let start = Instant::now();
+    for step in 1..=steps {
+        sim.set(clock_signal, 0u8);
+        sim.eval_comb().unwrap();
+        if mode == "dirty" || mode == "scan" {
+            sim.dump((step * 2) as u64);
+        }
+        sim.set(clock_signal, 1u8);
+        sim.tick(clk).unwrap();
+        if mode == "dirty" || mode == "scan" {
+            sim.dump((step * 2 + 1) as u64);
+        }
+    }
+    sim.flush_vcd().unwrap();
+    let elapsed = start.elapsed().as_nanos();
+    let stats = sim.vcd_statistics().unwrap_or_default();
+    std::hint::black_box(sim.get_as::<u64>(sim.signal("q0")));
+    println!(
+        "{mode},{case},{signals},{steps},{repeat},{elapsed},{},{},{}",
+        stats.comparisons - initial.comparisons,
+        stats.changes - initial.changes,
+        stats.value_bytes - initial.value_bytes
+    );
+}
+fn main() {
+    let signals = number("VCD_SIGNALS", 256);
+    let steps = number("VCD_STEPS", 10_000);
+    let repeats = number("VCD_REPEATS", 3);
+    // Keep all 64 value bits significant when comparing encoders that do not
+    // abbreviate leading zeros (for example Verilator's VCD writer).
+    let high_bit = if number("VCD_FULL_WIDTH", 0) == 0 {
+        0
+    } else {
+        1u64 << 63
+    };
+    let backend = setting("VCD_BACKEND").unwrap_or_else(|_| "native".into());
+    let output = setting("VCD_OUTPUT").unwrap_or_else(|_| "/dev/null".into());
+    let selected_mode = setting("VCD_MODE").ok();
+    let selected_case = setting("VCD_CASE").ok();
+    let mut code = String::from("module Top (clk: input clock, rst: input reset,");
+    for i in 0..signals {
+        write!(code, "en{i}: input logic, q{i}: output logic<64>,").unwrap();
+    }
+    code.push_str(") {");
+    for i in 0..signals {
+        write!(code, "always_ff (clk, rst) {{ if_reset {{ q{i} = 64'd{}; }} else if en{i} {{ q{i} += 64'd{}; }} }}", high_bit | (i as u64 + 1), i * 2 + 1).unwrap();
+    }
+    code.push('}');
+    println!("mode,case,signals,steps,repeat,elapsed_ns,comparisons,changes,value_bytes");
+    for (case, active) in [
+        ("idle", 0),
+        ("sparse", (signals / 100).max(1)),
+        ("dense", signals),
+    ] {
+        if selected_case.as_ref().is_some_and(|name| name != case) {
+            continue;
+        }
+        for mode in ["off", "instrumented", "scan", "dirty"] {
+            if selected_mode.as_ref().is_some_and(|name| name != mode) {
+                continue;
+            }
+            for repeat in 0..repeats {
+                let builder = SimulatorBuilder::new(&code, "Top");
+                let builder = if mode == "off" {
+                    builder
+                } else {
+                    builder.vcd(&output)
+                };
+                match backend.as_str() {
+                    "native" => run(
+                        builder.build().unwrap(),
+                        mode,
+                        case,
+                        active,
+                        signals,
+                        steps,
+                        repeat,
+                    ),
+                    "cranelift" => run(
+                        builder.build_cranelift().unwrap(),
+                        mode,
+                        case,
+                        active,
+                        signals,
+                        steps,
+                        repeat,
+                    ),
+                    "interpreter" => run(
+                        builder.build_interpreter().unwrap(),
+                        mode,
+                        case,
+                        active,
+                        signals,
+                        steps,
+                        repeat,
+                    ),
+                    other => panic!("unknown VCD_BACKEND: {other}"),
+                }
+            }
+        }
+    }
+}

--- a/crates/celox/src/backend/interp.rs
+++ b/crates/celox/src/backend/interp.rs
@@ -718,6 +718,16 @@ impl InterpMachine<RegionedAbsoluteAddr> for Machine<'_> {
         bits: usize,
         value: &SIRValue,
     ) -> Result<(), InterpError> {
+        if bits != 0
+            && let Some(offsets) = self.layout.trace_notification_offsets(addr)
+        {
+            for offset in offsets {
+                // SAFETY: notification offsets belong to the complete state image.
+                unsafe {
+                    *self.byte_mut(offset) = 1;
+                }
+            }
+        }
         let object = self.object_offset(addr)?;
         let absolute_addr_ref = addr.absolute_addr();
         let bit_offset =
@@ -748,6 +758,16 @@ impl InterpMachine<RegionedAbsoluteAddr> for Machine<'_> {
         bits: usize,
         value: u64,
     ) -> Result<(), InterpError> {
+        if bits != 0
+            && let Some(offsets) = self.layout.trace_notification_offsets(addr)
+        {
+            for offset in offsets {
+                // SAFETY: notification offsets belong to the complete state image.
+                unsafe {
+                    *self.byte_mut(offset) = 1;
+                }
+            }
+        }
         debug_assert!(bits <= 64);
         let object = self.object_offset(addr)?;
         let absolute = addr.absolute_addr();
@@ -796,6 +816,16 @@ impl InterpMachine<RegionedAbsoluteAddr> for Machine<'_> {
         access: ResolvedAccess<'_>,
         bits: usize,
     ) -> Result<(), InterpError> {
+        if bits != 0
+            && let Some(offsets) = self.layout.trace_notification_offsets(dst)
+        {
+            for offset in offsets {
+                // SAFETY: notification offsets belong to the complete state image.
+                unsafe {
+                    *self.byte_mut(offset) = 1;
+                }
+            }
+        }
         if src.region == SPARSE_WORKING_REGION {
             return self.commit_sparse_object(src);
         }
@@ -1575,6 +1605,7 @@ impl SimBackend for InterpBackend {
     }
 
     fn set<T: Copy>(&mut self, signal: SignalRef, value: T) {
+        celox_runtime::backend::SimBackend::mark_vcd_signal(self, signal);
         let allocated_size = get_byte_size(signal.width);
         let provided_size = std::mem::size_of::<T>();
         let clear_mask = self.four_state && signal.is_4state;
@@ -1620,6 +1651,7 @@ impl SimBackend for InterpBackend {
     }
 
     fn set_wide(&mut self, signal: SignalRef, value: BigUint) {
+        celox_runtime::backend::SimBackend::mark_vcd_signal(self, signal);
         if let Some(ref arr) = signal.array_layout {
             let base = self.memory.as_mut_ptr() as *mut u8;
             unsafe {
@@ -1652,6 +1684,7 @@ impl SimBackend for InterpBackend {
     }
 
     fn set_four_state(&mut self, signal: SignalRef, value: BigUint, mask: BigUint) {
+        celox_runtime::backend::SimBackend::mark_vcd_signal(self, signal);
         if let Some(ref arr) = signal.array_layout {
             let base = self.memory.as_mut_ptr() as *mut u8;
             unsafe {
@@ -1810,6 +1843,7 @@ impl SimBackend for InterpBackend {
     }
 
     fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize) {
+        celox_runtime::backend::SimBackend::disable_vcd_tracking(self);
         (
             self.memory.as_mut_ptr() as *mut u8,
             self.layout.merged_total_size,

--- a/crates/celox/src/backend/interp.rs
+++ b/crates/celox/src/backend/interp.rs
@@ -1843,15 +1843,18 @@ impl SimBackend for InterpBackend {
     }
 
     fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize) {
-        celox_runtime::backend::SimBackend::disable_vcd_tracking(self);
         (
-            self.memory.as_mut_ptr() as *mut u8,
+            self.memory.expose_mut_ptr() as *mut u8,
             self.layout.merged_total_size,
         )
     }
 
     fn memory_owner(&self) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
         Some(self.memory.owner())
+    }
+
+    fn vcd_tracking_enabled(&self) -> bool {
+        self.memory.vcd_tracking_enabled()
     }
 
     fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize) {

--- a/crates/celox/src/backend/memory_image.rs
+++ b/crates/celox/src/backend/memory_image.rs
@@ -47,6 +47,9 @@ impl MemoryAllocation {
 pub(crate) struct MemoryImage {
     allocation: Arc<MemoryAllocation>,
     logical_words: usize,
+    // Keep this outside the exposed allocation: restoring or clearing the
+    // whole state image must not forget an escaped writable pointer.
+    raw_view_exposed: bool,
 }
 
 impl MemoryImage {
@@ -54,6 +57,7 @@ impl MemoryImage {
         Self {
             allocation: Arc::new(MemoryAllocation::zeroed(logical_words)),
             logical_words,
+            raw_view_exposed: false,
         }
     }
 
@@ -63,6 +67,15 @@ impl MemoryImage {
 
     pub(crate) fn as_mut_ptr(&mut self) -> *mut u64 {
         self.allocation.as_mut_ptr()
+    }
+
+    pub(crate) fn expose_mut_ptr(&mut self) -> *mut u64 {
+        self.raw_view_exposed = true;
+        self.as_mut_ptr()
+    }
+
+    pub(crate) fn vcd_tracking_enabled(&self) -> bool {
+        !self.raw_view_exposed
     }
 
     #[cfg(test)]

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -2685,12 +2685,18 @@ impl super::super::SimBackend for NativeBackend {
     }
 
     fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize) {
-        celox_runtime::backend::SimBackend::disable_vcd_tracking(self);
-        (self.mem_mut_ptr(), self.memory.len_words() * 8)
+        (
+            self.memory.expose_mut_ptr().cast(),
+            self.memory.len_words() * 8,
+        )
     }
 
     fn memory_owner(&self) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
         Some(self.memory.owner())
+    }
+
+    fn vcd_tracking_enabled(&self) -> bool {
+        self.memory.vcd_tracking_enabled()
     }
 
     fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize) {

--- a/crates/celox/src/backend/native/backend.rs
+++ b/crates/celox/src/backend/native/backend.rs
@@ -495,6 +495,20 @@ impl NativeProgramImage {
             .merged_total_size
             .checked_add(self.layout.triggered_bits_total_size)
             .ok_or_else(|| "semantic memory size overflows".to_string())?;
+        if let Some(trace) = &self.layout.trace {
+            let metadata_start = self
+                .layout
+                .triggered_bits_offset
+                .checked_add(self.layout.triggered_bits_total_size)
+                .ok_or_else(|| "trace metadata offset overflows".to_string())?;
+            if !trace.validate(
+                self.layout.total_size,
+                metadata_start,
+                self.layout.scratch_base_offset,
+            ) {
+                return Err("invalid waveform activity layout".into());
+            }
+        }
         if self.native_memory_size < semantic_size {
             return Err("native memory is smaller than the semantic state".into());
         }
@@ -2565,6 +2579,7 @@ impl super::super::SimBackend for NativeBackend {
     }
 
     fn set<T: Copy>(&mut self, signal: SignalRef, val: T) {
+        celox_runtime::backend::SimBackend::mark_vcd_signal(self, signal);
         let allocated_size = get_byte_size(signal.width);
         let provided_size = std::mem::size_of::<T>();
         let clear_mask = self.compiled.options.four_state && signal.is_4state;
@@ -2607,6 +2622,7 @@ impl super::super::SimBackend for NativeBackend {
     }
 
     fn set_wide(&mut self, signal: SignalRef, val: BigUint) {
+        celox_runtime::backend::SimBackend::mark_vcd_signal(self, signal);
         let clear_mask = self.compiled.options.four_state && signal.is_4state;
         self.write_signal_plane(signal, false, &val);
         if clear_mask {
@@ -2615,6 +2631,7 @@ impl super::super::SimBackend for NativeBackend {
     }
 
     fn set_four_state(&mut self, signal: SignalRef, val: BigUint, mask: BigUint) {
+        celox_runtime::backend::SimBackend::mark_vcd_signal(self, signal);
         let write_mask = self.compiled.options.four_state && signal.is_4state;
         self.write_signal_plane(signal, false, &val);
         if write_mask {
@@ -2668,6 +2685,7 @@ impl super::super::SimBackend for NativeBackend {
     }
 
     fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize) {
+        celox_runtime::backend::SimBackend::disable_vcd_tracking(self);
         (self.mem_mut_ptr(), self.memory.len_words() * 8)
     }
 

--- a/crates/celox/src/backend/native/image_file.rs
+++ b/crates/celox/src/backend/native/image_file.rs
@@ -6,7 +6,7 @@ use std::{fmt, path::Path};
 use super::backend::NativeProgramImage;
 
 const TRAILER_MAGIC: &[u8; 8] = b"CELOXNPI";
-const CONTAINER_VERSION: u16 = 4;
+const CONTAINER_VERSION: u16 = 5;
 const TRAILER_SIZE: usize = 32;
 const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
 const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -712,6 +712,7 @@ impl JitBackend {
 
     /// Set value for a variable using a pre-resolved [`SignalRef`].
     pub fn set<T: Copy>(&mut self, signal: SignalRef, value: T) {
+        celox_runtime::backend::SimBackend::mark_vcd_signal(self, signal);
         let allocated_size = get_byte_size(signal.width);
         let provided_size = std::mem::size_of::<T>();
         let clear_mask = self.shared.options.four_state && signal.is_4state;
@@ -744,6 +745,7 @@ impl JitBackend {
 
     /// Set value for a variable using a pre-resolved [`SignalRef`] and `BigUint`.
     pub fn set_wide(&mut self, signal: SignalRef, value: BigUint) {
+        celox_runtime::backend::SimBackend::mark_vcd_signal(self, signal);
         let allocated_size = get_byte_size(signal.width);
         let mut bytes = value.to_bytes_le();
 
@@ -826,6 +828,7 @@ impl JitBackend {
     /// - `(v=1, m=1)` → X (unknown)
     /// - `(v=0, m=1)` → Z (high-impedance)
     pub fn set_four_state(&mut self, signal: SignalRef, value: BigUint, mask: BigUint) {
+        celox_runtime::backend::SimBackend::mark_vcd_signal(self, signal);
         let allocated_size = get_byte_size(signal.width);
 
         let mut v_bytes = value.to_bytes_le();
@@ -931,6 +934,7 @@ impl JitBackend {
 
     /// Returns a mutable raw pointer to the JIT memory and its total size in bytes.
     pub fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize) {
+        celox_runtime::backend::SimBackend::disable_vcd_tracking(self);
         let size = self.shared.layout.merged_total_size;
         (self.memory.as_mut_ptr() as *mut u8, size)
     }

--- a/crates/celox/src/backend/runtime.rs
+++ b/crates/celox/src/backend/runtime.rs
@@ -934,9 +934,8 @@ impl JitBackend {
 
     /// Returns a mutable raw pointer to the JIT memory and its total size in bytes.
     pub fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize) {
-        celox_runtime::backend::SimBackend::disable_vcd_tracking(self);
         let size = self.shared.layout.merged_total_size;
-        (self.memory.as_mut_ptr() as *mut u8, size)
+        (self.memory.expose_mut_ptr() as *mut u8, size)
     }
 
     pub fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize) {
@@ -1120,6 +1119,10 @@ impl super::SimBackend for JitBackend {
 
     fn memory_owner(&self) -> Option<Arc<dyn std::any::Any + Send + Sync>> {
         Some(self.memory.owner())
+    }
+
+    fn vcd_tracking_enabled(&self) -> bool {
+        self.memory.vcd_tracking_enabled()
     }
 
     fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize) {

--- a/crates/celox/src/backend/tiered.rs
+++ b/crates/celox/src/backend/tiered.rs
@@ -194,13 +194,13 @@ impl CompiledTier {
 
     fn memory_base_mut(&mut self) -> *mut u8 {
         match self {
-            Self::Jit(jit) => jit.memory_as_mut_ptr().0,
+            Self::Jit(jit) => jit.memory_as_ptr().0.cast_mut(),
             #[cfg(any(
                 target_arch = "x86_64",
                 feature = "arm64-codegen",
                 target_arch = "aarch64"
             ))]
-            Self::Native(native) => native.memory_as_mut_ptr().0,
+            Self::Native(native) => native.memory_as_ptr().0.cast_mut(),
         }
     }
 
@@ -1876,6 +1876,67 @@ module Top (
         }
 
         assert_eq!(observed, reference_outputs(&inputs));
+    }
+
+    #[test]
+    fn waveform_activity_survives_promotion_before_dump() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("promotion.vcd");
+        let gate = Gate::closed();
+        let worker_gate = gate.0.clone();
+        let mut sim: Simulator<TieredBackend> = SimulatorBuilder::<Simulator>::new(PIPELINE, "Top")
+            .vcd(&path)
+            .build_tiered_with_compiler(move |laid_out, options, cancel| {
+                wait_for_gate_or_cancel(&worker_gate, cancel)?;
+                let image = NativeBackend::compile_image(laid_out, options)?;
+                let shared = unsafe { SharedNativeCode::from_image(image)? };
+                Ok(CompiledCode::Native(Arc::new(shared)))
+            })
+            .unwrap();
+        let descs = sim.build_vcd_descs(false);
+        let mut reference = crate::VcdWriter::from_writer(Vec::new(), &descs);
+        let dump = |sim: &mut Simulator<TieredBackend>,
+                    reference: &mut crate::VcdWriter<Vec<u8>>,
+                    time| {
+            sim.dump(time);
+            let (ptr, size) = sim.memory_as_ptr();
+            reference
+                .dump(time, unsafe { std::slice::from_raw_parts(ptr, size) })
+                .unwrap();
+        };
+        let clk = sim.event("clk");
+        let rst = sim.signal("rst");
+        let d = sim.signal("d");
+        sim.set(rst, 0u8);
+        sim.tick(clk).unwrap();
+        dump(&mut sim, &mut reference, 0);
+        sim.set(rst, 1u8);
+        sim.set(d, 0xa5u8);
+        sim.tick(clk).unwrap();
+        sim.tick(clk).unwrap();
+        assert!(!sim.is_compiled());
+        // Leave interpreted writes pending while the compiled tier is adopted.
+        gate.open();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        while !sim.is_compiled() && std::time::Instant::now() < deadline {
+            sim.tick(clk).unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+        assert!(sim.is_compiled(), "{:?}", sim.promotion_error());
+        dump(&mut sim, &mut reference, 1);
+        let before = sim.vcd_statistics().unwrap().comparisons;
+        dump(&mut sim, &mut reference, 2);
+        assert_eq!(sim.vcd_statistics().unwrap().comparisons, before);
+        sim.flush_vcd().unwrap();
+        let parse = |bytes: Vec<u8>| {
+            let mut parser = vcd::Parser::new(bytes.as_slice());
+            parser.parse_header().unwrap();
+            parser.map(Result::unwrap).collect::<Vec<_>>()
+        };
+        assert_eq!(
+            parse(std::fs::read(path).unwrap()),
+            parse(reference.into_inner().unwrap())
+        );
     }
 
     #[test]

--- a/crates/celox/src/backend/tiered.rs
+++ b/crates/celox/src/backend/tiered.rs
@@ -1284,6 +1284,20 @@ impl SimBackend for TieredBackend {
         }
     }
 
+    fn vcd_tracking_enabled(&self) -> bool {
+        match &self.phase {
+            Phase::Interpreting(Some(interp)) => interp.vcd_tracking_enabled(),
+            Phase::Compiled(CompiledTier::Jit(jit)) => jit.vcd_tracking_enabled(),
+            #[cfg(any(
+                target_arch = "x86_64",
+                feature = "arm64-codegen",
+                target_arch = "aarch64"
+            ))]
+            Phase::Compiled(CompiledTier::Native(native)) => native.vcd_tracking_enabled(),
+            Phase::Interpreting(None) => unreachable!("promoted backend left no interpreter"),
+        }
+    }
+
     fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize) {
         match &self.phase {
             Phase::Interpreting(Some(interp)) => interp.runtime_event_buffer_as_ptr(),
@@ -1880,63 +1894,86 @@ module Top (
 
     #[test]
     fn waveform_activity_survives_promotion_before_dump() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("promotion.vcd");
-        let gate = Gate::closed();
-        let worker_gate = gate.0.clone();
-        let mut sim: Simulator<TieredBackend> = SimulatorBuilder::<Simulator>::new(PIPELINE, "Top")
-            .vcd(&path)
-            .build_tiered_with_compiler(move |laid_out, options, cancel| {
-                wait_for_gate_or_cancel(&worker_gate, cancel)?;
-                let image = NativeBackend::compile_image(laid_out, options)?;
-                let shared = unsafe { SharedNativeCode::from_image(image)? };
-                Ok(CompiledCode::Native(Arc::new(shared)))
-            })
-            .unwrap();
-        let descs = sim.build_vcd_descs(false);
-        let mut reference = crate::VcdWriter::from_writer(Vec::new(), &descs);
-        let dump = |sim: &mut Simulator<TieredBackend>,
-                    reference: &mut crate::VcdWriter<Vec<u8>>,
-                    time| {
-            sim.dump(time);
-            let (ptr, size) = sim.memory_as_ptr();
-            reference
-                .dump(time, unsafe { std::slice::from_raw_parts(ptr, size) })
-                .unwrap();
-        };
-        let clk = sim.event("clk");
-        let rst = sim.signal("rst");
-        let d = sim.signal("d");
-        sim.set(rst, 0u8);
-        sim.tick(clk).unwrap();
-        dump(&mut sim, &mut reference, 0);
-        sim.set(rst, 1u8);
-        sim.set(d, 0xa5u8);
-        sim.tick(clk).unwrap();
-        sim.tick(clk).unwrap();
-        assert!(!sim.is_compiled());
-        // Leave interpreted writes pending while the compiled tier is adopted.
-        gate.open();
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
-        while !sim.is_compiled() && std::time::Instant::now() < deadline {
+        for expose_raw in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("promotion.vcd");
+            let gate = Gate::closed();
+            let worker_gate = gate.0.clone();
+            let mut sim: Simulator<TieredBackend> =
+                SimulatorBuilder::<Simulator>::new(PIPELINE, "Top")
+                    .vcd(&path)
+                    .build_tiered_with_compiler(move |laid_out, options, cancel| {
+                        wait_for_gate_or_cancel(&worker_gate, cancel)?;
+                        let image = NativeBackend::compile_image(laid_out, options)?;
+                        let shared = unsafe { SharedNativeCode::from_image(image)? };
+                        Ok(CompiledCode::Native(Arc::new(shared)))
+                    })
+                    .unwrap();
+            let descs = sim.build_vcd_descs(false);
+            let mut reference = crate::VcdWriter::from_writer(Vec::new(), &descs);
+            let dump = |sim: &mut Simulator<TieredBackend>,
+                        reference: &mut crate::VcdWriter<Vec<u8>>,
+                        time| {
+                sim.dump(time);
+                let (ptr, size) = sim.memory_as_ptr();
+                reference
+                    .dump(time, unsafe { std::slice::from_raw_parts(ptr, size) })
+                    .unwrap();
+            };
+            let clk = sim.event("clk");
+            let rst = sim.signal("rst");
+            let d = sim.signal("d");
+            sim.set(rst, 0u8);
             sim.tick(clk).unwrap();
-            std::thread::sleep(std::time::Duration::from_millis(1));
+            dump(&mut sim, &mut reference, 0);
+            let raw = expose_raw.then(|| {
+                let (ptr, size) = sim.memory_as_ptr();
+                // Snapshot before exposing a pointer, then restore the full image.
+                let snapshot = unsafe { std::slice::from_raw_parts(ptr, size) }.to_vec();
+                let (ptr, _) = sim.memory_as_mut_ptr();
+                unsafe {
+                    std::ptr::copy_nonoverlapping(snapshot.as_ptr(), ptr, size);
+                }
+                ptr
+            });
+            sim.set(rst, 1u8);
+            sim.set(d, 0xa5u8);
+            sim.tick(clk).unwrap();
+            sim.tick(clk).unwrap();
+            assert!(!sim.is_compiled());
+            // Leave interpreted writes pending while the compiled tier is adopted.
+            gate.open();
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+            while !sim.is_compiled() && std::time::Instant::now() < deadline {
+                sim.tick(clk).unwrap();
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            assert!(sim.is_compiled(), "{:?}", sim.promotion_error());
+            dump(&mut sim, &mut reference, 1);
+            let before = sim.vcd_statistics().unwrap().comparisons;
+            if let Some(raw) = raw {
+                // Reuse the pointer obtained while interpreting, without exposing
+                // a new pointer from the compiled backend or notifying a setter.
+                unsafe {
+                    *raw.add(d.offset) = 0x3c;
+                }
+            }
+            dump(&mut sim, &mut reference, 2);
+            assert_eq!(
+                sim.vcd_statistics().unwrap().comparisons,
+                before + if expose_raw { descs.len() as u64 } else { 0 }
+            );
+            sim.flush_vcd().unwrap();
+            let parse = |bytes: Vec<u8>| {
+                let mut parser = vcd::Parser::new(bytes.as_slice());
+                parser.parse_header().unwrap();
+                parser.map(Result::unwrap).collect::<Vec<_>>()
+            };
+            assert_eq!(
+                parse(std::fs::read(path).unwrap()),
+                parse(reference.into_inner().unwrap())
+            );
         }
-        assert!(sim.is_compiled(), "{:?}", sim.promotion_error());
-        dump(&mut sim, &mut reference, 1);
-        let before = sim.vcd_statistics().unwrap().comparisons;
-        dump(&mut sim, &mut reference, 2);
-        assert_eq!(sim.vcd_statistics().unwrap().comparisons, before);
-        sim.flush_vcd().unwrap();
-        let parse = |bytes: Vec<u8>| {
-            let mut parser = vcd::Parser::new(bytes.as_slice());
-            parser.parse_header().unwrap();
-            parser.map(Result::unwrap).collect::<Vec<_>>()
-        };
-        assert_eq!(
-            parse(std::fs::read(path).unwrap()),
-            parse(reference.into_inner().unwrap())
-        );
     }
 
     #[test]

--- a/crates/celox/src/backend/wasm_runtime.rs
+++ b/crates/celox/src/backend/wasm_runtime.rs
@@ -106,6 +106,9 @@ impl super::traits::SimBackend for WasmBackend {
     fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize) {
         WasmBackend::memory_as_mut_ptr(self)
     }
+    fn vcd_tracking_enabled(&self) -> bool {
+        !self.raw_view_exposed
+    }
     fn runtime_event_buffer_as_ptr(&self) -> (*const u8, usize) {
         WasmBackend::runtime_event_buffer_as_ptr(self)
     }
@@ -142,6 +145,7 @@ impl super::traits::SimBackend for WasmBackend {
 pub struct WasmBackend {
     store: Store<()>,
     memory: Memory,
+    raw_view_exposed: bool,
     comb_func: TypedFunc<(), i64>,
     event_funcs: HashMap<AbsoluteAddr, Vec<TypedFunc<(), i64>>>,
     eval_only_funcs: HashMap<AbsoluteAddr, Vec<TypedFunc<(), i64>>>,
@@ -373,6 +377,7 @@ impl WasmBackend {
         Ok(Self {
             store,
             memory,
+            raw_view_exposed: false,
             comb_func,
             event_funcs,
             eval_only_funcs,
@@ -574,7 +579,7 @@ impl WasmBackend {
     }
 
     pub fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize) {
-        celox_runtime::backend::SimBackend::disable_vcd_tracking(self);
+        self.raw_view_exposed = true;
         let data = self.memory.data_mut(&mut self.store);
         (data.as_mut_ptr(), self.layout.merged_total_size)
     }

--- a/crates/celox/src/backend/wasm_runtime.rs
+++ b/crates/celox/src/backend/wasm_runtime.rs
@@ -458,6 +458,7 @@ impl WasmBackend {
     }
 
     pub fn set<T: Copy>(&mut self, signal: SignalRef, value: T) {
+        celox_runtime::backend::SimBackend::mark_vcd_signal(self, signal);
         let allocated_size = get_byte_size(signal.width);
         let provided_size = std::mem::size_of::<T>();
         assert!(provided_size <= allocated_size);
@@ -481,6 +482,7 @@ impl WasmBackend {
     }
 
     pub fn set_wide(&mut self, signal: SignalRef, value: BigUint) {
+        celox_runtime::backend::SimBackend::mark_vcd_signal(self, signal);
         let allocated_size = get_byte_size(signal.width);
         let mut bytes = value.to_bytes_le();
         bytes.resize(allocated_size, 0u8);
@@ -497,6 +499,7 @@ impl WasmBackend {
     }
 
     pub fn set_four_state(&mut self, signal: SignalRef, value: BigUint, mask: BigUint) {
+        celox_runtime::backend::SimBackend::mark_vcd_signal(self, signal);
         let allocated_size = get_byte_size(signal.width);
         let mut v_bytes = value.to_bytes_le();
         v_bytes.resize(allocated_size, 0u8);
@@ -571,6 +574,7 @@ impl WasmBackend {
     }
 
     pub fn memory_as_mut_ptr(&mut self) -> (*mut u8, usize) {
+        celox_runtime::backend::SimBackend::disable_vcd_tracking(self);
         let data = self.memory.data_mut(&mut self.store);
         (data.as_mut_ptr(), self.layout.merged_total_size)
     }

--- a/crates/celox/src/component.rs
+++ b/crates/celox/src/component.rs
@@ -20,6 +20,7 @@ pub use injected::{
     InjectedPort, InjectedResult, InjectedValue,
 };
 
+use crate::testbench::eval_backend_expr;
 use crate::{EventHandle, SignalRef, SimBackend};
 
 /// Registers an in-process Veryl component implementation.
@@ -102,8 +103,7 @@ impl ComponentWrite {
             backend.set_four_state(self.target.signal, self.value, self.mask_xz);
             return;
         };
-        let (values, _) = backend.memory_as_mut_ptr();
-        let offset = selection.offset.eval_u64(values) as usize;
+        let offset = eval_backend_expr(backend, &selection.offset).to_u64() as usize;
         let width = selection
             .width
             .min(self.target.signal.width.saturating_sub(offset));
@@ -299,16 +299,15 @@ fn take_output_writes(component: &mut LiveComponent) -> Vec<ComponentWrite> {
 }
 
 fn stage_component_inputs<B: SimBackend>(component: &mut LiveComponent, backend: &mut B) {
-    let (values, _) = backend.memory_as_mut_ptr();
     for input in &component.inputs {
-        let value = input.expr.eval_value(values).to_biguint();
+        let value = eval_backend_expr(backend, &input.expr).to_biguint();
         let mask_xz = input
             .mask_source
             .as_ref()
             .map(|source| {
                 let (_, mut mask) = backend.get_four_state(source.signal);
                 if let Some(selection) = &source.selection {
-                    let offset = selection.offset.eval_u64(values) as usize;
+                    let offset = eval_backend_expr(backend, &selection.offset).to_u64() as usize;
                     mask >>= offset;
                     mask &= width_mask(selection.width);
                 }

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -509,6 +509,7 @@ pub struct LaidOutProgram {
 }
 
 impl LaidOutProgram {
+    #[cfg(feature = "host-runtime")]
     pub(crate) fn enable_vcd_tracking(&mut self) {
         self.layout.enable_trace();
     }

--- a/crates/celox/src/ir.rs
+++ b/crates/celox/src/ir.rs
@@ -509,6 +509,10 @@ pub struct LaidOutProgram {
 }
 
 impl LaidOutProgram {
+    pub(crate) fn enable_vcd_tracking(&mut self) {
+        self.layout.enable_trace();
+    }
+
     pub fn layout(&self) -> &crate::backend::MemoryLayout {
         &self.layout
     }

--- a/crates/celox/src/lib.rs
+++ b/crates/celox/src/lib.rs
@@ -85,7 +85,7 @@ mod host_api {
     };
     pub use crate::testbench::{AssertionResult, SourceLocation, TestResult, TestResultDetailed};
     pub use celox_macros::veryl_test;
-    pub use celox_runtime::{VcdSignalDesc, VcdWriter};
+    pub use celox_runtime::{VcdSignalDesc, VcdStatistics, VcdWriter};
 
     pub struct IOContext<'a, B: SimBackend = DefaultBackend> {
         pub(crate) backend: &'a mut B,

--- a/crates/celox/src/simulation.rs
+++ b/crates/celox/src/simulation.rs
@@ -202,6 +202,10 @@ impl<B: SimBackend> Simulation<B> {
         self.simulator.dump(timestamp);
     }
 
+    pub fn flush_vcd(&mut self) -> std::io::Result<()> {
+        self.simulator.flush_vcd()
+    }
+
     /// Resolves a signal path into a performance-optimized [`SignalRef`].
     pub fn signal(&self, path: &str) -> SignalRef {
         self.simulator.signal(path)

--- a/crates/celox/src/simulator.rs
+++ b/crates/celox/src/simulator.rs
@@ -661,7 +661,9 @@ mod host {
         ) {
             let value_byte_size = signal.width.div_ceil(8);
             let write_mask = self.backend.layout().four_state && signal.is_4state;
-            let (ptr, mem_len) = self.backend.memory_as_mut_ptr();
+            // Initial writes precede the first full dump; no mutable view escapes.
+            let (ptr, mem_len) = self.backend.memory_as_ptr();
+            let ptr = ptr.cast_mut();
             let mem = unsafe { std::slice::from_raw_parts_mut(ptr, mem_len) };
 
             for run in runs {
@@ -869,12 +871,22 @@ mod host {
             }
             let component_traces = self.components.trace_values();
             if let Some(ref mut writer) = self.vcd_writer {
-                let (ptr, size) = self.backend.memory_as_ptr();
-                let memory = unsafe { std::slice::from_raw_parts(ptr, size) };
                 writer
-                    .dump_with_external(timestamp, memory, &component_traces)
+                    .dump_backend(timestamp, &mut self.backend, &component_traces)
                     .unwrap();
             }
+        }
+
+        /// Make buffered waveform output visible and report write errors.
+        pub fn flush_vcd(&mut self) -> std::io::Result<()> {
+            if let Some(writer) = self.vcd_writer.as_mut() {
+                writer.flush()?;
+            }
+            Ok(())
+        }
+
+        pub fn vcd_statistics(&self) -> Option<celox_runtime::VcdStatistics> {
+            self.vcd_writer.as_ref().map(crate::VcdWriter::statistics)
         }
 
         /// Sets a signal value and marks combinational logic as dirty.

--- a/crates/celox/src/simulator/builder.rs
+++ b/crates/celox/src/simulator/builder.rs
@@ -1221,6 +1221,14 @@ mod host {
         sim.components.set_injected(injected_components);
         sim.diagnostics = options.diagnostics.clone();
         if let Some(path) = vcd_path {
+            if sim.layout().unpacked_arrays.values().any(|array| {
+                !array.element_width.is_multiple_of(8)
+                    || array.element_stride != array.element_width / 8
+            }) {
+                return Err(SimulatorError::from(crate::CodegenError::message(
+                    "VCD requires packed array storage; compile this native image with VCD enabled",
+                )));
+            }
             let descs = sim.build_vcd_descs(options.four_state);
             let vcd_writer = crate::VcdWriter::new(path, &descs)
                 .map_err(|_| SimulatorError::from(crate::RuntimeErrorCode::InternalError))?;
@@ -1925,6 +1933,13 @@ mod host {
             ),
             SimulatorError,
         > {
+            // VCD descriptors currently describe packed whole objects. Apply
+            // the same layout rule to every factory, including native images.
+            let layout_mode = if self.vcd_path.is_some() {
+                crate::backend::memory_layout::MemoryLayoutMode::Packed
+            } else {
+                layout_mode
+            };
             self.enforce_native_force_optimizer();
             let phase_timing = self.options.diagnostics.phase_timing;
             let compile_start = phase_timing.then(crate::timing::now);
@@ -1993,6 +2008,9 @@ mod host {
             let layout_start = phase_timing.then(crate::timing::now);
             let mut laid_out =
                 program.into_laid_out_with_mode(self.options.four_state, layout_mode);
+            if self.vcd_path.is_some() {
+                laid_out.enable_vcd_tracking();
+            }
             if let Some(start) = layout_start {
                 tracing::debug!("[phase-timing] build_layout: {:?}", start.elapsed());
             }
@@ -2469,6 +2487,11 @@ mod host {
                 all(target_arch = "aarch64", not(feature = "x86_64-codegen"))
             )))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::Packed;
+            let layout_mode = if self.vcd_path.is_some() {
+                crate::backend::memory_layout::MemoryLayoutMode::Packed
+            } else {
+                layout_mode
+            };
             let injected_manifests = self.injected_components.manifests();
             let program_res = if let Some(artifact) = &self.frontend_artifact {
                 if self.sources.is_empty() {
@@ -2530,6 +2553,9 @@ mod host {
             let sim_res = program_res.and_then(|(program, warnings)| {
                 let mut laid_out =
                     program.into_laid_out_with_mode(self.options.four_state, layout_mode);
+                if self.vcd_path.is_some() {
+                    laid_out.enable_vcd_tracking();
+                }
 
                 if self.options.dead_store_policy != DeadStorePolicy::Off {
                     run_dead_store_elimination(&mut laid_out, &self.live_signals, &self.options);
@@ -2676,6 +2702,11 @@ mod host {
                 all(target_arch = "aarch64", not(feature = "x86_64-codegen"))
             )))]
             let layout_mode = crate::backend::memory_layout::MemoryLayoutMode::Packed;
+            let layout_mode = if self.vcd_path.is_some() {
+                crate::backend::memory_layout::MemoryLayoutMode::Packed
+            } else {
+                layout_mode
+            };
             let (program, warnings) = if let Some(artifact) = &self.frontend_artifact {
                 compile_frontend_to_sir_with_layout_mode(
                     artifact,
@@ -2712,6 +2743,9 @@ mod host {
             };
             let mut laid_out =
                 program.into_laid_out_with_mode(self.options.four_state, layout_mode);
+            if self.vcd_path.is_some() {
+                laid_out.enable_vcd_tracking();
+            }
 
             if self.options.dead_store_policy != DeadStorePolicy::Off {
                 run_dead_store_elimination(&mut laid_out, &self.live_signals, &self.options);

--- a/crates/celox/src/testbench.rs
+++ b/crates/celox/src/testbench.rs
@@ -86,8 +86,38 @@ pub(crate) type TestbenchStatement<B> = ExecutableStatement<<B as SimBackend>::E
 
 pub(crate) type CompiledAssertArg = ExecutableArgument;
 
-fn format_assert_arg(arg: &CompiledAssertArg, memory: *mut u8, spec: Option<char>) -> String {
-    let value = arg.expr.eval_value(memory);
+fn eval_expr<B: SimBackend>(
+    sim: &mut Simulator<B>,
+    expr: &celox_testbench::CompiledExpr,
+) -> TbValue {
+    eval_backend_expr(&mut sim.backend, expr)
+}
+
+pub(crate) fn eval_backend_expr<B: SimBackend>(
+    backend: &mut B,
+    expr: &celox_testbench::CompiledExpr,
+) -> TbValue {
+    // This pointer is used only during evaluation, never exposed to a host.
+    // Observe VM stores explicitly instead of disabling tracking for reads.
+    let (memory, _) = backend.memory_as_ptr();
+    let trace = backend.layout().trace.as_ref();
+    expr.eval_value_with_write_observer(memory.cast_mut(), |offset, len| {
+        if let Some(trace) = trace {
+            // SAFETY: bound bytecode writes valid locations in this image, and
+            // the simulator cannot execute concurrently with this evaluation.
+            unsafe {
+                trace.mark_range(memory.cast_mut(), offset, len);
+            }
+        }
+    })
+}
+
+fn format_assert_arg<B: SimBackend>(
+    sim: &mut Simulator<B>,
+    arg: &CompiledAssertArg,
+    spec: Option<char>,
+) -> String {
+    let value = eval_expr(sim, &arg.expr);
     let value = value.to_biguint();
     format_display_arg(
         &DisplayFormatArg {
@@ -101,16 +131,16 @@ fn format_assert_arg(arg: &CompiledAssertArg, memory: *mut u8, spec: Option<char
     )
 }
 
-fn render_assert_message(
+fn render_assert_message<B: SimBackend>(
+    sim: &mut Simulator<B>,
     message: &Option<AssertMessage>,
-    memory: *mut u8,
     current_time: u64,
 ) -> Option<String> {
     match message {
         None => None,
         Some(AssertMessage::DynamicArgs(args)) => Some(
             args.iter()
-                .map(|arg| format_assert_arg(arg, memory, Some('x')))
+                .map(|arg| format_assert_arg(sim, arg, Some('x')))
                 .collect::<Vec<_>>()
                 .join(" "),
         ),
@@ -142,7 +172,7 @@ fn render_assert_message(
                             'h' | 'H' | 'x' | 'X' | 'd' | 'D' | 'i' | 'I' | 'o' | 'O' | 'b'
                             | 'B' | 'c' | 'C' | 's' | 'S' => {
                                 if let Some(arg) = args.get(arg_idx) {
-                                    rendered.push_str(&format_assert_arg(arg, memory, Some(spec)));
+                                    rendered.push_str(&format_assert_arg(sim, arg, Some(spec)));
                                 }
                                 arg_idx += 1;
                             }
@@ -185,8 +215,7 @@ fn sim_set_target<B: SimBackend>(
         return;
     };
 
-    let (ptr, _) = sim.memory_as_mut_ptr();
-    let offset = selection.offset.eval_u64(ptr) as usize;
+    let offset = eval_expr(sim, &selection.offset).to_u64() as usize;
     let width = selection
         .width
         .min(target.signal.width.saturating_sub(offset));
@@ -330,8 +359,7 @@ fn eval_clock_count<B: SimBackend>(
         ClockCount::Dynamic(expr) => {
             sim.eval_comb()
                 .map_err(|source| TestbenchEvaluationError::EvalComb { source })?;
-            let (ptr, _) = sim.memory_as_mut_ptr();
-            expr.eval_u64(ptr)
+            eval_expr(sim, expr).to_u64()
         }
     })
 }
@@ -351,8 +379,7 @@ fn eval_loop_bound<B: SimBackend>(
         } => {
             sim.eval_comb()
                 .map_err(|source| TestbenchEvaluationError::EvalComb { source })?;
-            let (ptr, _) = sim.memory_as_mut_ptr();
-            let value = expr.eval_value(ptr);
+            let value = eval_expr(sim, expr);
             if *signed {
                 decode_signed_loop_bound(value, *width)
             } else {
@@ -1179,11 +1206,10 @@ fn publish_tb_assert_event<B: SimBackend>(
     sim: &mut Simulator<B>,
     site_id: u32,
     message: &Option<AssertMessage>,
-    memory: *mut u8,
 ) {
     let args = assert_event_args(message)
         .iter()
-        .map(|arg| arg.expr.eval_value(memory).to_biguint())
+        .map(|arg| eval_expr(sim, &arg.expr).to_biguint())
         .collect::<Vec<_>>();
     let layout = sim.layout();
     let Some(site_layout) = layout
@@ -1471,10 +1497,9 @@ fn exec_one_detailed<B: SimBackend>(
             if let Err(e) = sim.eval_comb() {
                 return ExecResult::Fail(format!("eval_comb: {e}"));
             }
-            let (ptr, _) = sim.memory_as_mut_ptr();
-            let passed = expr.eval_bool(ptr);
+            let passed = !eval_expr(sim, expr).is_zero();
             if passed {
-                let rendered_message = render_assert_message(message, ptr, ctx.current_time);
+                let rendered_message = render_assert_message(sim, message, ctx.current_time);
                 ctx.assertions.push(AssertionResult {
                     passed,
                     message: rendered_message.clone(),
@@ -1482,10 +1507,10 @@ fn exec_one_detailed<B: SimBackend>(
                 });
                 ExecResult::Continue
             } else {
-                publish_tb_assert_event(sim, *site_id, message, ptr);
+                publish_tb_assert_event(sim, *site_id, message);
                 let rendered_message = drain_runtime_assertions(sim, ctx, location.as_ref())
                     .last_message
-                    .or_else(|| render_assert_message(message, ptr, ctx.current_time));
+                    .or_else(|| render_assert_message(sim, message, ctx.current_time));
                 if !continue_on_fail {
                     ExecResult::Fail(
                         rendered_message.unwrap_or_else(|| "assertion failed".to_string()),
@@ -1499,9 +1524,8 @@ fn exec_one_detailed<B: SimBackend>(
             if let Err(e) = sim.eval_comb() {
                 return ExecResult::Fail(format!("eval_comb: {e}"));
             }
-            let (ptr, _) = sim.memory_as_mut_ptr();
             let rendered =
-                render_assert_message(message, ptr, ctx.current_time).unwrap_or_default();
+                render_assert_message(sim, message, ctx.current_time).unwrap_or_default();
             forward_display(&rendered, *newline);
             ExecResult::Continue
         }
@@ -1513,8 +1537,7 @@ fn exec_one_detailed<B: SimBackend>(
             if let Err(e) = sim.eval_comb() {
                 return ExecResult::Fail(format!("eval_comb: {e}"));
             }
-            let (ptr, _) = sim.memory_as_mut_ptr();
-            if expr.eval_bool(ptr) {
+            if !eval_expr(sim, expr).is_zero() {
                 exec_detailed(sim, then_block, ctx)
             } else {
                 exec_detailed(sim, else_block, ctx)
@@ -1544,8 +1567,7 @@ fn exec_one_detailed<B: SimBackend>(
             if let Err(e) = sim.eval_comb() {
                 return ExecResult::Fail(format!("eval_comb: {e}"));
             }
-            let (ptr, _) = sim.memory_as_mut_ptr();
-            let val = expr.eval_value(ptr);
+            let val = eval_expr(sim, expr);
             sim_set_target(sim, dst, val);
             ExecResult::Continue
         }
@@ -1553,8 +1575,7 @@ fn exec_one_detailed<B: SimBackend>(
             if let Err(e) = sim.eval_comb() {
                 return ExecResult::Fail(format!("eval_comb: {e}"));
             }
-            let (ptr, _) = sim.memory_as_mut_ptr();
-            ctx.random.seed(handle, value.eval_u64(ptr));
+            ctx.random.seed(handle, eval_expr(sim, value).to_u64());
             ExecResult::Continue
         }
         GenericTestbenchStatement::RandomGet {
@@ -1585,9 +1606,8 @@ fn exec_one_detailed<B: SimBackend>(
             if let Err(e) = sim.eval_comb() {
                 return ExecResult::Fail(format!("eval_comb: {e}"));
             }
-            let (ptr, _) = sim.memory_as_mut_ptr();
-            let min = min.eval_u64(ptr);
-            let max = max.eval_u64(ptr);
+            let min = eval_expr(sim, min).to_u64();
+            let max = eval_expr(sim, max).to_u64();
             let value = ctx.random.get_range(handle, min, max, *width, *signed);
             if let Some(ret) = ret {
                 sim_set_random_target(sim, ret, value, *width, *signed);
@@ -1620,12 +1640,11 @@ fn exec_one_detailed<B: SimBackend>(
             {
                 return ExecResult::Fail(format!("eval_comb: {error}"));
             }
-            let (ptr, _) = sim.memory_as_mut_ptr();
             let host_args = args
                 .iter()
                 .map(|arg| {
                     crate::component::host_value_from_argument(
-                        arg.expr.eval_value(ptr),
+                        eval_expr(sim, &arg.expr),
                         arg.width,
                         arg.is_string,
                     )
@@ -1841,6 +1860,68 @@ mod tests {
             run_compiled_testbench(&mut sim, &tb),
             TestResult::Fail("continue failure".to_string()),
         );
+    }
+
+    #[test]
+    fn expression_evaluation_preserves_sparse_vcd_tracking() {
+        let code = r#"
+            #[test(t)]
+            module t {
+                var a: logic<8>;
+                var b: logic<8>;
+                initial {
+                    a = 1;
+                    b = a;
+                    if b == 1 {
+                        $assert(a == b);
+                        $display("a=%h", a);
+                    }
+                    $finish();
+                }
+            }
+        "#;
+        let dir = tempfile::tempdir().unwrap();
+        let mut sim = Simulator::builder(code, "t")
+            .vcd(dir.path().join("testbench.vcd"))
+            .build()
+            .unwrap();
+        let tb = compile_initial_testbench(&sim).unwrap();
+        sim.dump(0);
+        assert_eq!(run_compiled_testbench(&mut sim, &tb), TestResult::Pass);
+        sim.dump(1);
+        let before = sim.vcd_statistics().unwrap();
+        sim.dump(2);
+        assert_eq!(
+            sim.vcd_statistics().unwrap().comparisons,
+            before.comparisons
+        );
+    }
+
+    #[test]
+    fn expression_stores_notify_vcd_without_exposing_memory() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut sim = Simulator::builder("module Top (a: input logic<8>) {}", "Top")
+            .vcd(dir.path().join("expression.vcd"))
+            .build()
+            .unwrap();
+        let a = sim.signal("a");
+        let expr = celox_testbench::CompiledExpr::new(celox_testbench::ExprBytecode::new(vec![
+            celox_testbench::ExprOpcode::ConstU64(7),
+            celox_testbench::ExprOpcode::StoreU64 {
+                location: a.offset,
+                byte_size: 1,
+            },
+            celox_testbench::ExprOpcode::ConstU64(7),
+        ]));
+        sim.dump(0);
+        let before = sim.vcd_statistics().unwrap();
+        assert_eq!(eval_expr(&mut sim, &expr).to_u64(), 7);
+        assert_eq!(sim.get_as::<u8>(a), 7);
+        sim.dump(1);
+        let after = sim.vcd_statistics().unwrap();
+        assert_eq!(after.changes, before.changes + 1);
+        sim.dump(2);
+        assert_eq!(sim.vcd_statistics().unwrap().comparisons, after.comparisons);
     }
 
     #[test]

--- a/crates/celox/tests/injected_component.rs
+++ b/crates/celox/tests/injected_component.rs
@@ -100,10 +100,22 @@ fn injected_clocked_component_uses_component_scheduling() {
         )
         .unwrap();
 
-    let result = Simulator::builder(source, "InjectedComponentTb")
+    let dir = tempfile::tempdir().unwrap();
+    let mut sim = Simulator::builder(source, "InjectedComponentTb")
         .with_injected_components(components)
-        .run_test()
+        .vcd(dir.path().join("component.vcd"))
+        .build()
         .unwrap();
+    let tb = celox::testbench::compile_initial_testbench(&sim).unwrap();
+    let result = celox::testbench::run_compiled_testbench(&mut sim, &tb);
+    sim.dump(100);
+    let before = sim.vcd_statistics().unwrap().comparisons;
+    sim.dump(101);
+    assert_eq!(
+        sim.vcd_statistics().unwrap().comparisons,
+        before,
+        "staging component inputs must not expose a retained mutable view"
+    );
     assert_eq!(result, TestResult::Pass, "{result:?}");
     assert_eq!(
         *phases.lock().unwrap(),

--- a/crates/celox/tests/native_exec.rs
+++ b/crates/celox/tests/native_exec.rs
@@ -195,6 +195,7 @@ fn native_image_restores_four_state_mode_for_vcd() {
 
     sim.set_four_state(sim.signal("a"), 0xffu8.into(), 0xffu8.into());
     sim.dump(0);
+    sim.flush_vcd().unwrap();
     let dump = std::fs::read_to_string(vcd_path).unwrap();
     assert!(dump.contains("xxxxxxxx"), "{dump}");
 }
@@ -786,4 +787,71 @@ fn test_native_dynamic_index_pattern() {
         state[val_off] = 0x55;
     });
     assert_eq!(read_u32_at(&state, &sir, &layout, "z"), 0x04550201);
+}
+
+#[test]
+fn native_image_roundtrip_preserves_waveform_write_activity() {
+    let code = r#"module Top (a: input logic<8>, q: output logic<8>) { assign q = a + 1; }"#;
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("image.vcd");
+    let image = Simulator::builder(code, "Top")
+        .vcd(&path)
+        .compile_native()
+        .unwrap()
+        .into_program_image();
+    assert!(image.layout().trace.is_some());
+    let image =
+        celox::NativeProgramImage::from_container_bytes(&image.to_container_bytes().unwrap())
+            .unwrap();
+    let mut sim = Simulator::from_sources(Vec::new(), "Top")
+        .vcd(&path)
+        .build_native_from_image(image)
+        .unwrap();
+    sim.dump(0);
+    sim.set(sim.signal("a"), 41u8);
+    sim.dump(1);
+    assert_eq!(sim.get_as::<u8>(sim.signal("q")), 42);
+    let before = sim.vcd_statistics().unwrap();
+    sim.dump(2);
+    assert_eq!(
+        sim.vcd_statistics().unwrap().comparisons,
+        before.comparisons
+    );
+    assert!(before.changes >= 4);
+    sim.flush_vcd().unwrap();
+    let bytes = std::fs::read(path).unwrap();
+    let mut parser = vcd::Parser::new(bytes.as_slice());
+    parser.parse_header().unwrap();
+    assert!(parser.map(Result::unwrap).any(|command| {
+        matches!(command, vcd::Command::ChangeVector(_, ref value) if value.to_string() == "101010")
+    }));
+}
+
+#[test]
+fn tracing_an_imported_strided_image_requests_compatible_recompilation() {
+    let code = r#"
+        module Top (clk: input clock, d: input logic<3>, index: input logic<2>, q: output logic<3>) {
+            var mem: logic<3>[4];
+            always_ff (clk) { mem[index] = d; }
+            assign q = mem[index];
+        }
+    "#;
+    let image = Simulator::builder(code, "Top")
+        .compile_native()
+        .unwrap()
+        .into_program_image();
+    assert!(!image.layout().unpacked_arrays.is_empty());
+    let dir = tempfile::tempdir().unwrap();
+    let result = Simulator::from_sources(Vec::new(), "Top")
+        .vcd(dir.path().join("incompatible.vcd"))
+        .build_native_from_image(image);
+    let Err(error) = result else {
+        panic!("an incompatible waveform layout was accepted");
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("compile this native image with VCD enabled"),
+        "{error}"
+    );
 }

--- a/crates/celox/tests/vcd.rs
+++ b/crates/celox/tests/vcd.rs
@@ -455,6 +455,56 @@ mod activity {
     }
 
     #[test]
+    fn restoring_raw_memory_cannot_reenable_sparse_tracking() {
+        fn check<B: SimBackend>(mut sim: Simulator<B>, path: &std::path::Path) {
+            let a = sim.signal("a");
+            let descs = sim.build_vcd_descs(false);
+            let mut reference = VcdWriter::from_writer(Vec::new(), &descs);
+            sim.dump(0);
+            let (ptr, size) = sim.memory_as_ptr();
+            // SAFETY: the backend is idle and owns the complete state image.
+            let snapshot = unsafe { std::slice::from_raw_parts(ptr, size) }.to_vec();
+            reference.dump(0, &snapshot).unwrap();
+            let (raw, writable_size) = sim.memory_as_mut_ptr();
+            assert_eq!(size, writable_size);
+            // Restore every exposed byte, including activity metadata. Retain
+            // the same pointer for later unnotified writes, as a host may do.
+            unsafe {
+                std::ptr::copy_nonoverlapping(snapshot.as_ptr(), raw, writable_size);
+            }
+            for time in 1..4 {
+                unsafe {
+                    *raw.add(a.offset) = time as u8;
+                }
+                sim.dump(time);
+                reference
+                    .dump(time, unsafe { std::slice::from_raw_parts(raw, size) })
+                    .unwrap();
+            }
+            sim.flush_vcd().unwrap();
+            assert_eq!(
+                commands(&std::fs::read(path).unwrap()),
+                commands(&reference.into_inner().unwrap())
+            );
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("raw-restore.vcd");
+        let builder = || {
+            SimulatorBuilder::new(
+                "module Top (a: input logic<512>, b: input logic<512>, c: input logic<512>) {}",
+                "Top",
+            )
+            .vcd(&path)
+        };
+        check(builder().build().unwrap(), &path);
+        check(builder().build_cranelift().unwrap(), &path);
+        check(builder().build_interpreter().unwrap(), &path);
+        check(builder().build_wasm().unwrap(), &path);
+        check(builder().build_tiered().unwrap(), &path);
+    }
+
+    #[test]
     fn generated_notifications_match_full_scan_across_backends() {
         let dir = tempfile::tempdir().unwrap();
         for optimized in [false, true] {

--- a/crates/celox/tests/vcd.rs
+++ b/crates/celox/tests/vcd.rs
@@ -283,6 +283,109 @@ mod activity {
         );
     }
 
+    #[test]
+    fn timestamp_errors_preserve_backend_activity_for_retry() {
+        #[derive(Default)]
+        struct FailWrites {
+            bytes: Vec<u8>,
+            failures: std::cell::Cell<usize>,
+        }
+        impl std::io::Write for FailWrites {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                if let Some(remaining) = self.failures.get().checked_sub(1) {
+                    self.failures.set(remaining);
+                    return Err(std::io::ErrorKind::Other.into());
+                }
+                self.bytes.extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        for failures in [1, 3] {
+            for new_activity in [false, true] {
+                let dir = tempfile::tempdir().unwrap();
+                // Separate physical groups keep both the original write and a
+                // write between retries on the sparse comparison path.
+                let sim = SimulatorBuilder::new(
+                    "module Top (
+                        a: input logic<512>, b: input logic<512>,
+                        c: input logic<512>, d: input logic<512>,
+                        e: input logic<512>, f: input logic<512>,
+                    ) {}",
+                    "Top",
+                )
+                .vcd(dir.path().join("unused.vcd"))
+                .build_cranelift()
+                .unwrap();
+                let a = sim.signal("a");
+                let b = sim.signal("b");
+                let descs = sim.build_vcd_descs(false);
+                let mut backend = sim.into_backend();
+                let mut writer = VcdWriter::from_writer(FailWrites::default(), &descs);
+                let mut reference = VcdWriter::from_writer(Vec::new(), &descs);
+                writer.dump_backend(0, &mut backend, &[]).unwrap();
+                let (ptr, size) = backend.memory_as_ptr();
+                // SAFETY: backend owns this memory and is not mutated during the dump.
+                reference
+                    .dump(0, unsafe { std::slice::from_raw_parts(ptr, size) })
+                    .unwrap();
+                writer.flush().unwrap();
+                reference.flush().unwrap();
+
+                // Fill the 256 KiB output buffer exactly with timestamps. The
+                // next timestamp must flush it before accepting any new bytes,
+                // so a sink error occurs after consuming activity but before
+                // comparing or updating any cached signal values.
+                writer.dump_with_activity(10, &[], &[], Some(&[])).unwrap();
+                reference
+                    .dump_with_activity(10, &[], &[], Some(&[]))
+                    .unwrap();
+                for _ in 0..(256 * 1024 - 4) / 3 {
+                    writer.dump_with_activity(0, &[], &[], Some(&[])).unwrap();
+                    reference
+                        .dump_with_activity(0, &[], &[], Some(&[]))
+                        .unwrap();
+                }
+
+                backend.set_wide(a, BigUint::from(11u8));
+                writer.get_ref().failures.set(failures);
+                let before = writer.statistics().comparisons;
+                for attempt in 0..failures {
+                    let error = writer.dump_backend(20, &mut backend, &[]).unwrap_err();
+                    assert_eq!(error.kind(), std::io::ErrorKind::Other);
+                    assert_eq!(writer.statistics().comparisons, before);
+                    if new_activity {
+                        // Include repeated notifications as well as a different
+                        // group, without another write to the original group.
+                        backend.set_wide(b, BigUint::from(22 + attempt));
+                    }
+                }
+                writer.dump_backend(20, &mut backend, &[]).unwrap();
+                let (ptr, size) = backend.memory_as_ptr();
+                // SAFETY: backend owns this memory and is not mutated during the dump.
+                reference
+                    .dump(20, unsafe { std::slice::from_raw_parts(ptr, size) })
+                    .unwrap();
+                assert_eq!(
+                    writer.statistics().comparisons - before,
+                    1 + u64::from(new_activity),
+                    "retry must visit each pending group exactly once"
+                );
+                let after = writer.statistics().comparisons;
+                writer.dump_backend(20, &mut backend, &[]).unwrap();
+                assert_eq!(writer.statistics().comparisons, after);
+                assert_eq!(
+                    commands(&writer.into_inner().unwrap().bytes),
+                    commands(&reference.into_inner().unwrap()),
+                    "failures={failures}, new_activity={new_activity}"
+                );
+            }
+        }
+    }
+
     fn compare<B: SimBackend>(mut sim: Simulator<B>, path: &std::path::Path, four_state: bool) {
         assert!(sim.layout().trace.is_some());
         let descs = sim.build_vcd_descs(four_state);

--- a/crates/celox/tests/vcd.rs
+++ b/crates/celox/tests/vcd.rs
@@ -34,6 +34,7 @@ mod tests {
 
         sim.dump(0);
         sim.dump(10);
+        sim.flush_vcd().unwrap();
 
         assert!(Path::new(vcd_path).exists());
         let content = fs::read_to_string(vcd_path).unwrap();
@@ -110,6 +111,8 @@ mod tests {
         drive(&mut tiered);
         dump_at(&mut tiered, 10);
 
+        reference.flush_vcd().unwrap();
+        tiered.flush_vcd().unwrap();
         assert_eq!(without_date(reference_path), without_date(tiered_path));
 
         fs::remove_file(reference_path).unwrap();
@@ -191,5 +194,229 @@ mod tests {
             out.push('\n');
         }
         out
+    }
+}
+
+mod activity {
+    use celox::{SimBackend, Simulator, SimulatorBuilder, VcdWriter};
+    use num_bigint::BigUint;
+
+    const SOURCE: &str = r#"
+        module Top (
+            clk: input clock, rst: input reset,
+            enable: input logic, index: input logic<3>, data: input logic<65>,
+            q: output logic<65>, alias_out: output logic<65>, comb: output logic<65>,
+            read: output logic<9>,
+        ) {
+            var mem: logic<9>[8];
+            assign alias_out = data;
+            assign comb = data ^ (data << 1);
+            assign read = mem[index];
+            always_ff (clk, rst) {
+                if_reset {
+                    q = 0;
+                    mem = '0;
+                } else if enable {
+                    q = data;
+                    mem[index] = data[0+:9];
+                }
+            }
+        }
+    "#;
+
+    fn commands(bytes: &[u8]) -> Vec<vcd::Command> {
+        let mut parser = vcd::Parser::new(bytes);
+        parser.parse_header().unwrap();
+        parser.map(Result::unwrap).collect()
+    }
+
+    fn compare<B: SimBackend>(mut sim: Simulator<B>, path: &std::path::Path, four_state: bool) {
+        assert!(sim.layout().trace.is_some());
+        let descs = sim.build_vcd_descs(four_state);
+        let mut reference = VcdWriter::from_writer(Vec::new(), &descs);
+        let clk = sim.event("clk");
+        let rst = sim.signal("rst");
+        let data = sim.signal("data");
+        let index = sim.signal("index");
+        let enable = sim.signal("enable");
+        let dump = |sim: &mut Simulator<B>, reference: &mut VcdWriter<Vec<u8>>, time| {
+            sim.dump(time);
+            let (ptr, size) = sim.memory_as_ptr();
+            reference
+                .dump(time, unsafe { std::slice::from_raw_parts(ptr, size) })
+                .unwrap();
+        };
+        // Initial dump works even without any registered activity.
+        dump(&mut sim, &mut reference, 0);
+        sim.set(rst, 0u8);
+        sim.tick(clk).unwrap();
+        dump(&mut sim, &mut reference, 1);
+        sim.set(rst, 1u8);
+        for step in 2..34u64 {
+            let value = (BigUint::from(1u8) << (step as usize % 65)) | BigUint::from(step);
+            let mask = if four_state && step % 3 == 0 {
+                BigUint::from(0x155u16)
+            } else {
+                BigUint::default()
+            };
+            sim.modify(|io| {
+                io.set(index, (step % 8) as u8);
+                io.set(enable, u8::from(step % 4 != 0));
+                io.set_four_state(data, value.clone(), mask.clone());
+            })
+            .unwrap();
+            // Notifications must survive several clock/comb evaluations before dump.
+            sim.tick(clk).unwrap();
+            sim.tick(clk).unwrap();
+            dump(&mut sim, &mut reference, step);
+            let before = sim.vcd_statistics().unwrap().comparisons;
+            dump(&mut sim, &mut reference, step);
+            assert_eq!(
+                sim.vcd_statistics().unwrap().comparisons,
+                before,
+                "a second dump without writes must not rescan memory"
+            );
+        }
+        // Changes that return to the previous dump value are suppressed.
+        let old = sim.get(data);
+        sim.set_wide(data, &old ^ BigUint::from(1u8));
+        sim.set_wide(data, old);
+        dump(&mut sim, &mut reference, 35);
+        // A retained mutable pointer bypasses setters on more than one dump.
+        let (raw, _) = sim.memory_as_mut_ptr();
+        for time in 36..39 {
+            unsafe {
+                *raw.add(data.offset) ^= 1;
+            }
+            sim.modify(|_| {}).unwrap();
+            dump(&mut sim, &mut reference, time);
+        }
+        sim.flush_vcd().unwrap();
+        let actual = std::fs::read(path).unwrap();
+        let expected = reference.into_inner().unwrap();
+        assert!(!commands(&actual).is_empty());
+        assert_eq!(commands(&actual), commands(&expected));
+    }
+
+    #[test]
+    fn generated_notifications_match_full_scan_across_backends() {
+        let dir = tempfile::tempdir().unwrap();
+        for optimized in [false, true] {
+            for four_state in [false, true] {
+                let path = dir.path().join("wave.vcd");
+                let builder = || {
+                    SimulatorBuilder::new(SOURCE, "Top")
+                        .optimize(optimized)
+                        .four_state(four_state)
+                        .vcd(&path)
+                };
+                compare(builder().build().unwrap(), &path, four_state);
+                compare(builder().build_cranelift().unwrap(), &path, four_state);
+                compare(builder().build_interpreter().unwrap(), &path, four_state);
+                compare(builder().build_wasm().unwrap(), &path, four_state);
+                compare(builder().build_tiered().unwrap(), &path, four_state);
+            }
+        }
+    }
+
+    #[test]
+    fn clock_trigger_consumption_does_not_consume_waveform_activity() {
+        let code = r#"
+            module Top (clk: input clock, rst: input reset, div: output logic, q: output logic<8>) {
+                let gclk: '_ clock = clk;
+                always_ff (clk, rst) { if_reset { div = 0; } else { div = ~div; } }
+                always_ff (gclk, rst) { if_reset { q = 0; } else { q += 1; } }
+            }
+        "#;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cascade.vcd");
+        let mut sim = celox::Simulation::builder(code, "Top")
+            .vcd(&path)
+            .build()
+            .unwrap();
+        sim.add_clock("clk", 10, 10);
+        let rst = sim.signal("rst");
+        sim.modify(|io| io.set(rst, 0u8)).unwrap();
+        // The reference writer reads the same committed state after the scheduler.
+        let descs = ["clk", "rst", "div", "q"].map(|name| {
+            let signal = sim.signal(name);
+            celox::VcdSignalDesc {
+                scope: "reference".into(),
+                name: name.into(),
+                offset: signal.offset,
+                width: signal.width,
+                is_4state: false,
+            }
+        });
+        let mut reference = VcdWriter::from_writer(Vec::new(), &descs);
+        for step in 0..20 {
+            if step == 2 {
+                let rst = sim.signal("rst");
+                sim.modify(|io| io.set(rst, 1u8)).unwrap();
+            }
+            let time = sim.step().unwrap().unwrap();
+            sim.dump(time);
+            let (ptr, size) = sim.memory_as_ptr();
+            reference
+                .dump(time, unsafe { std::slice::from_raw_parts(ptr, size) })
+                .unwrap();
+        }
+        sim.flush_vcd().unwrap();
+        let bytes = std::fs::read(path).unwrap();
+        let actual = commands(&bytes);
+        let reference_bytes = reference.into_inner().unwrap();
+        let expected = commands(&reference_bytes);
+        // Match by declaration names, since the full design includes scopes and aliases.
+        fn values(bytes: &[u8], names: &[&str]) -> Vec<(u64, String, String)> {
+            let mut parser = vcd::Parser::new(bytes);
+            let header = parser.parse_header().unwrap();
+            fn vars(
+                items: &[vcd::ScopeItem],
+                out: &mut Vec<(vcd::IdCode, String)>,
+                names: &[&str],
+            ) {
+                for item in items {
+                    match item {
+                        vcd::ScopeItem::Var(var) if names.contains(&var.reference.as_str()) => {
+                            out.push((var.code, var.reference.clone()))
+                        }
+                        vcd::ScopeItem::Scope(scope) => vars(&scope.items, out, names),
+                        _ => {}
+                    }
+                }
+            }
+            let mut ids = vec![];
+            vars(&header.items, &mut ids, names);
+            let mut time = 0;
+            let mut out = vec![];
+            for command in parser.map(Result::unwrap) {
+                let pair = match command {
+                    vcd::Command::Timestamp(t) => {
+                        time = t;
+                        None
+                    }
+                    vcd::Command::ChangeScalar(id, value) => Some((id, value.to_string())),
+                    vcd::Command::ChangeVector(id, value) => Some((id, value.to_string())),
+                    _ => None,
+                };
+                if let Some((id, value)) = pair {
+                    for (_, name) in ids.iter().filter(|(code, _)| *code == id) {
+                        out.push((time, name.clone(), value.clone()));
+                    }
+                }
+            }
+            out.sort();
+            out
+        }
+        assert!(actual.len() > 20 && expected.len() > 20);
+        assert_eq!(
+            values(&bytes, &["clk", "rst", "div", "q"]),
+            values(&reference_bytes, &["clk", "rst", "div", "q"])
+        );
+        assert!(
+            values(&bytes, &["q"])
+                .iter()
+                .any(|(_, _, value)| value != "0")
+        );
     }
 }

--- a/crates/celox/tests/vcd.rs
+++ b/crates/celox/tests/vcd.rs
@@ -230,6 +230,59 @@ mod activity {
         parser.map(Result::unwrap).collect()
     }
 
+    #[test]
+    fn invalid_external_values_preserve_backend_activity_for_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        let sim = SimulatorBuilder::new(
+            "module Top (a: input logic<8>, q: output logic<8>) { assign q = a + 1; }",
+            "Top",
+        )
+        .vcd(dir.path().join("unused.vcd"))
+        .build_cranelift()
+        .unwrap();
+        let input = sim.signal("a");
+        let descs = sim.build_vcd_descs(false);
+        let mut backend = sim.into_backend();
+        let mut writer = VcdWriter::from_writer(Vec::new(), &descs);
+        let mut reference = VcdWriter::from_writer(Vec::new(), &descs);
+        let external_descs = [celox_runtime::VcdExternalSignalDesc {
+            scope: "component".into(),
+            name: "state".into(),
+            width: 8,
+        }];
+        writer.add_external_signals(&external_descs).unwrap();
+        reference.add_external_signals(&external_descs).unwrap();
+
+        for time in 0..3u64 {
+            backend.set(input, time as u8);
+            backend.eval_comb().unwrap();
+            let external = [(BigUint::from(time), BigUint::default())];
+            if time != 0 {
+                // Both missing and excess values are recoverable input errors.
+                // Retry without another memory write to expose lost activity.
+                let invalid = vec![external[0].clone(); if time == 1 { 0 } else { 2 }];
+                let before = writer.statistics();
+                let error = writer
+                    .dump_backend(time, &mut backend, &invalid)
+                    .unwrap_err();
+                assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+                assert_eq!(writer.statistics().comparisons, before.comparisons);
+            }
+            writer.dump_backend(time, &mut backend, &external).unwrap();
+            let (ptr, size) = backend.memory_as_ptr();
+            // SAFETY: backend owns this memory and is not mutated during the dump.
+            let memory = unsafe { std::slice::from_raw_parts(ptr, size) };
+            reference
+                .dump_with_external(time, memory, &external)
+                .unwrap();
+        }
+
+        assert_eq!(
+            commands(&writer.into_inner().unwrap()),
+            commands(&reference.into_inner().unwrap())
+        );
+    }
+
     fn compare<B: SimBackend>(mut sim: Simulator<B>, path: &std::path::Path, four_state: bool) {
         assert!(sim.layout().trace.is_some());
         let descs = sim.build_vcd_descs(four_state);

--- a/crates/celox/tests/wasm_regression.rs
+++ b/crates/celox/tests/wasm_regression.rs
@@ -1225,6 +1225,7 @@ fn wasm_reg_vcd_output() {
         dump_vcd(&wasm, &mut vcd_writer, i * 10);
     }
 
+    vcd_writer.flush().unwrap();
     // Verify VCD file was written
     let content = std::fs::read_to_string(&vcd_path).unwrap();
     assert!(

--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -59,7 +59,13 @@ pnpm bench
 
 # Verilator comparison (requires Verilator and a C++ toolchain)
 bash scripts/run-verilator-bench.sh
+
+# VCD comparison (also requires Python 3; validates matching waveforms)
+python3 scripts/compare-vcd-verilator.py
 ```
+
+The [VCD benchmark methodology and results](../internals/vcd-performance.md#verilator-comparison)
+cover idle, sparse, and dense recording, with tracing disabled and enabled.
 
 The CodSpeed workflow runs benchmarks on pull requests and `master`. Merge queue
 events preserve the workflow check without running CodSpeed because CodSpeed does

--- a/docs/guide/vcd.md
+++ b/docs/guide/vcd.md
@@ -26,8 +26,15 @@ sim.dispose();    // flushes and closes the file
 ```
 
 ::: warning
-The VCD file is not written until `dispose()` is called. Always call `dispose()` when you are done — or use a try/finally block.
+VCD output is buffered. Always call `dispose()` when you are done so the remaining bytes are written — or use a try/finally block.
 :::
+
+In Rust, call `Simulator::flush_vcd()` or `Simulation::flush_vcd()` to make
+buffered output visible before dropping the simulator and to handle write errors.
+Standalone `VcdWriter` instances provide `flush()` and `into_inner()`.
+
+The [VCD performance notes](../internals/vcd-performance.md) describe change
+tracking, shared-memory behavior, and reproducible benchmarks.
 
 ## With Time-Based Simulation
 

--- a/docs/internals/vcd-performance.md
+++ b/docs/internals/vcd-performance.md
@@ -1,0 +1,653 @@
+# VCD write activity and benchmarks
+
+VCD recording has three costs: discovering changes, encoding changed values,
+and writing the encoded bytes. The benchmarks report these separately from HDL
+compilation and initialization. Both benchmarks use deterministic stimulus and
+emit CSV; no timing threshold is a correctness test.
+
+## Write activity
+
+A VCD-enabled build reserves a `TraceLayout` between scheduler metadata and
+backend scratch. Native x86/AArch64, Cranelift, Wasm, and the interpreter notify
+this layout at Stable `Store` and `Commit` sites, alongside clock notifications.
+A write to a Working object becomes visible when it commits. Native instruction
+selection also covers combined packed stores and sparse commit worklists.
+
+Each physical object's stable home selects a 64-byte group. A notification sets
+one group byte and one summary byte covering 64 groups. Byte stores avoid an
+extra read/modify/write in generated code. Native lowering coalesces repeated
+notifications within a basic block. An observer skips unmarked summary groups,
+consumes the marked group bytes, and compares only their associated signals.
+Dense activity uses a direct scan. Aliases share the same home; a partial or
+dynamically indexed write notifies observers of the complete object. These are
+conservative write notifications: a notification does not imply a value change.
+
+Clock notification bits are consumed during scheduling. Waveform activity is
+consumed only at `dump`, so several commits or clock cascades between samples do
+not lose updates. Tier promotion carries the activity in the existing state
+allocation. The first dump always records every selected signal. Externally
+supplied component values retain their existing ABI and are compared every dump.
+
+Host setters use the same notification layout. Obtaining a mutable raw memory
+view permanently selects full scanning for that memory image, since a retained
+view can write at any later time without a setter notification. This includes
+JavaScript shared-memory views and components that receive writable raw memory.
+The buffered byte encoder still applies on these paths. Builds without VCD do
+not reserve activity storage or generate notification stores.
+
+The writer keeps previous value and mask planes as packed bytes. Padding above a
+signal's declared width is ignored. Four-state and external signals compare
+both planes; two-state memory signals compare only values because their previous
+mask stays zero for the writer's lifetime. Two-state memory signals of widths
+1 and 64 are classified when registering signals and use fixed-size integer
+comparisons and copies, including unaligned memory and previous-value offsets.
+The one-bit path emits its ASCII digit directly. On x86-64 with SSE2 enabled,
+the 64-bit path expands 16 bits at a time directly into spare output capacity;
+other targets retain the scalar lookup-table encoder. It publishes only the
+significant digits, preserving leading-zero abbreviation and the single digit
+for zero. Other widths and four-state/external values use the generic byte
+encoder; unknown bits retain VCD's `x`/`z` distinction. A changed vector
+emits its complete VCD value, even if
+only one bit changed. Values, IDs, and newlines are appended directly to a
+reusable output block. Blocks at least as large as the `BufWriter` capacity
+(256 KiB) bypass its internal copy; a dump's final partial block is handed to
+`BufWriter` before returning. Headers, timestamps, and value records therefore
+retain their order, including when a single record exceeds the block size.
+The block reserves capacity for 256 KiB plus the largest possible record at the
+first dump, adding roughly 256 KiB compared with a single-record buffer.
+Header construction stays in a separate cold function. The pending change
+count belongs to the output block, so unchanged-signal comparisons need not
+carry a separate local accumulator through the loop.
+
+`VcdWriter::flush`, `Simulator::flush_vcd`, or `Simulation::flush_vcd` explicitly
+publishes pending bytes and reports I/O errors. Dropping the writer flushes
+through `BufWriter`, but cannot report errors. JavaScript handles report flush
+failures from `dispose()`. These flushes do not request durable-storage `fsync`.
+
+VCD currently describes whole objects as packed memory. Factories compiling
+source with VCD therefore select the packed layout, including native image
+compilation. Imported images retain their layout: an uninstrumented image uses
+full scanning, and incompatible element-strided arrays produce a construction
+error requesting recompilation with VCD enabled.
+The waveform metadata changes the native image container version from 4 to 5;
+old containers must be regenerated.
+
+## Writer benchmark
+
+```sh
+VCD_MODE=scan cargo bench --locked -p celox-runtime --bench vcd
+VCD_MODE=dirty cargo bench --locked -p celox-runtime --bench vcd
+VCD_MODE=collect cargo bench --locked -p celox-runtime --bench vcd
+```
+
+`scan` compares every signal. `dirty` measures the production notifications,
+consumption, candidate selection, comparison, and encoder. `collect` measures
+mutation and activity collection without encoding. `VCD_OUTPUT=count` (default)
+consumes the actual encoded buffer and counts bytes without system calls;
+`VCD_OUTPUT=/dev/null` includes file writes but excludes storage latency. Set a
+local file path to include filesystem output. Each sample recreates the file.
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `VCD_SIGNALS` | 16384 | Independently declared signals |
+| `VCD_WIDTH` | 64 | Width per signal |
+| `VCD_FOUR_STATE` | 0 | Use value and mask planes when set to 1 |
+| `VCD_STEPS` | 1000 | Dumps after the initial snapshot |
+| `VCD_REPEATS` | 3 | Independent repetitions |
+| `VCD_CASE` | all | Run one case from the table below |
+
+| Case | Stimulus / purpose |
+| --- | --- |
+| `idle` | No writes after initialization; measures dependence on total state size |
+| `sparse_clustered` | Approximately 0.1% of signals updated in adjacent homes |
+| `sparse_scattered` | Same update count spread across homes, rotating each step |
+| `same_value` | Scattered writes of unchanged values; notification overhead with no output |
+| `dense` | Every signal changes; encoding throughput and dense fallback |
+| `burst` | Every signal changes once per 100 steps; activity bursts |
+| `mask_only` | Only mask bits change; enabled in four-state runs |
+
+Useful sweeps are 1024/16384/131072 signals and widths 1/9/64/65/256/1024.
+Clustered versus scattered updates quantify the extra comparisons caused by
+coarse groups. Initialization uses nonzero values and is followed by an explicit
+flush before timing. The timed region includes mutation and the final flush.
+CSV reports wall time, comparisons, changed signals, and actual emitted bytes;
+`scan` and `dirty` must have identical change counts and output byte counts.
+
+## End-to-end benchmark
+
+```sh
+cargo bench --locked -p celox --bench vcd
+VCD_BACKEND=cranelift cargo bench --locked -p celox --bench vcd
+```
+
+This benchmark compiles independent counters with individual enables and
+increments, avoiding accidental merging of identical counters. It samples both
+clock phases and explicitly settles combinational logic even with tracing off.
+Idle, approximately 1% enabled, and all-enabled workloads run in four modes:
+
+- `off`: VCD disabled, including write instrumentation.
+- `instrumented`: notifications enabled, no dumping; isolates simulation overhead.
+- `scan`: notifications enabled but full scanning forced through the raw-view fallback.
+- `dirty`: notifications and incremental dumping enabled.
+
+Defaults are `VCD_SIGNALS=256`, `VCD_STEPS=10000` full cycles,
+`VCD_REPEATS=3`, `VCD_BACKEND=native`, and `VCD_OUTPUT=/dev/null`.
+`VCD_MODE` and `VCD_CASE` select a single mode or workload; `interpreter` is also
+an available backend. `VCD_FULL_WIDTH=1` sets bit 63 in the reset values so all
+64 bits remain significant during the measured runs; the default is zero.
+Here `VCD_SIGNALS` counts counters; the default fixture
+records 514 signals including enables, clock, and reset. The idle case still
+toggles the clock. Construction, reset, initial configuration, and the initial
+waveform snapshot are excluded. Final flush is included. The scalar fixture has
+the same stable data layout in all modes. CSV value bytes exclude timestamps;
+the writer benchmark reports total bytes including timestamps.
+
+Measure compilation separately. Run timing samples without concurrent builds or
+tests, retain individual samples and compare medians, and record the revision,
+CPU, Rust version, backend, and output destination. For filesystem measurements,
+record the filesystem and use a sufficiently long run to expose sustained
+throughput. `/usr/bin/time -v` can separately record peak RSS.
+
+Heliodor is a useful subsequent macro workload, but its existing benchmark
+runner does not sample VCD. A comparable tracing run needs explicit matching
+signal sets, time units, reset/unknown-state semantics, and sampling points in
+both simulators. Prefer fixed idle/compute/memory-heavy windows to dumping an
+entire Linux boot. No Heliodor tracing performance claim follows from the
+microbenchmarks here.
+
+## Measured results
+
+These initial measurements predate output-block encoding.
+
+Measured on 2026-09-10 with the changes on `perf/vcd-change-tracking`, based on
+`f114181392ef23ed8fc2c4fb102f4041821999f7`. The host reports an AMD Ryzen 7 9800X3D
+under virtualized Linux; processes were pinned to CPU 0. Rust was 1.98.1, using
+the optimized bench profile with LTO. No builds or tests ran concurrently.
+The following are elapsed-time medians in milliseconds, writing to `/dev/null`.
+Both `scan` and `dirty` use the new byte encoder and buffering, so these ratios
+measure incremental observation against the full-scan control in this change.
+
+The writer used 16,384 64-bit two-state signals, 1,000 dumps, and five samples:
+
+| Case | Full scan (ms) | Incremental (ms) | Scan / incremental |
+| --- | ---: | ---: | ---: |
+| `idle` | 86.609 | 0.035 | 2507.78× |
+| `sparse_clustered` | 88.668 | 0.493 | 180.02× |
+| `sparse_scattered` | 90.366 | 1.926 | 46.92× |
+| `same_value` | 88.413 | 1.573 | 56.22× |
+| `dense` | 359.811 | 418.889 | 0.86× |
+| `burst` | 95.709 | 3.793 | 25.23× |
+
+Scattered sparse updates reduced comparisons from 16,384,000 to 127,988 while
+emitting the same 16,000 changes and 1,116,063 bytes. A completely idle writer
+performed no value comparisons; it still scanned the small summary and emitted
+timestamps. Fully dense updates were 16% slower in this measurement: notification
+and collection costs remain even when the writer chooses its dense scan. Dense
+samples varied from 359–418 ms for `scan` and 368–500 ms for `dirty`, so the
+precise regression needs more samples before treating it as stable.
+
+The compiled counter workload used 256 counters and 10,000 full cycles (20,000
+dumps), with five native samples and three Cranelift samples:
+
+| Backend | Case | Off (ms) | Instrumented (ms) | Full scan (ms) | Incremental (ms) | Scan / incremental |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| native | idle | 1.203 | 1.661 | 61.479 | 7.937 | 7.75× |
+| native | sparse | 1.262 | 1.799 | 60.563 | 9.317 | 6.50× |
+| native | dense | 1.439 | 2.111 | 97.848 | 73.100 | 1.34× |
+| Cranelift | idle | 1.006 | 1.759 | 59.625 | 33.659 | 1.77× |
+| Cranelift | sparse | 1.055 | 1.759 | 60.370 | 42.723 | 1.41× |
+| Cranelift | dense | 1.057 | 1.805 | 97.725 | 73.317 | 1.33× |
+
+Instrumentation has a measurable simulation cost before dumping: approximately
+0.46–0.67 ms per 10,000 cycles in the native fixture. Native sparse comparisons
+fell from 10,280,000 to 760,000. Cranelift sparse comparisons fell to 5,500,000;
+conservative notifications reflect executed stable writes, so unchanged values
+can still require comparison. Its sparse incremental samples ranged from
+35.992–43.867 ms. Dense end-to-end gains include skipping most comparisons on
+the low clock phase, unlike the writer's every-signal-every-dump dense case.
+
+Three-sample sweeps also covered 1,024 and 131,072 signals, giving 38.43× and
+43.57× for scattered sparse updates. Four-state mask-only updates at widths
+65/256/1024 took 2.071/4.827/19.038 ms incrementally, versus
+86.731/90.480/142.172 ms for full scans. All scan/incremental pairs had identical
+change and output-byte counts. Local ext4 file output for scattered updates
+also matched byte-for-byte after excluding the date header; that short run does
+not measure sustained storage throughput or durable writes.
+
+Individual CSV samples and the run manifest are saved locally under
+`target/vcd-benchmark-results/` (ignored build artifacts). Reproduce the main
+writer measurements with `VCD_OUTPUT=/dev/null VCD_REPEATS=5` and each of
+`VCD_MODE=scan`, `dirty`, and `collect`; use `VCD_REPEATS=5` for the native
+end-to-end benchmark and `VCD_BACKEND=cranelift VCD_REPEATS=3` for Cranelift.
+On Linux, prefix the command with `taskset -c <cpu>` to pin to an available CPU.
+
+## Hardware profiling on WSL
+
+This profile also predates output-block encoding.
+
+On the measured host, `/usr/bin/perf` was an Ubuntu launcher that could not find
+a binary under the running WSL kernel's version name. The already installed
+`/usr/lib/linux-tools-6.8.0-139/perf` (perf 6.8.12) successfully read hardware
+counters on kernel `6.18.33.2-microsoft-standard-WSL2`. A user-local symlink now
+makes that binary available through the normal `perf` command:
+
+```text
+~/.local/bin/perf -> /usr/lib/linux-tools-6.8.0-139/perf
+```
+
+No additional build or kernel setting change was needed. Check the actual
+binary and hardware access before collecting profiles:
+
+```sh
+command -v perf
+perf version
+perf stat -e cycles:u,instructions:u,branches:u,branch-misses:u -- true
+```
+
+The `:u` events count user-mode execution. Profile the compiled benchmark
+executable directly to exclude Cargo and compilation from the counters.
+
+A follow-up on 2026-09-10 used the same writer binary, CPU 0, `/dev/null`,
+16,384 64-bit two-state signals, and 1,000 dense steps. After one warm-up per
+mode, seven independent processes per mode ran in alternating order. All four
+events reported 100% running time, without multiplexing. These counters cover
+the entire process, including fixture construction and the initial snapshot;
+the benchmark's own elapsed time still excludes those phases.
+
+| Median | Full scan | Incremental |
+| --- | ---: | ---: |
+| Cycles | 3,024,609,647 | 3,033,034,066 |
+| Instructions | 9,216,358,029 | 9,348,346,641 |
+| Branch misses / branches | 0.0325% | 0.0340% |
+
+The incremental path executed 1.43% more instructions, with a 0.28% difference
+in median cycles. Wall time varied substantially: 785–1,096 ms for full scans
+and 894–1,683 ms for incremental dumps. The earlier 16% wall-time gap therefore
+does not establish a stable 16% execution-cost increase. Branch misprediction
+does not appear to dominate this dense workload. This measurement does not
+predict the cost of adding a new comparison or branch at every generated store.
+
+Cycle sampling also worked: `perf record -F 499 -e cycles:u --call-graph dwarf`
+on 5,000 incremental dense steps captured 2,053 samples with no reported loss.
+The largest self-time shares were `VcdWriter::dump_with_activity` (48.4%) and
+libc's `memmove` (38.5%), followed by the benchmark's `main` (7.7%) and
+`memcmp` (3.3%). The binary retains symbols but strips source debug
+information, so these results identify functions rather than source lines.
+
+Raw counter files, benchmark CSVs, a summary, the executable hash, and the
+sampling recording are in `target/vcd-perf-results/` (ignored build artifacts).
+
+## Output blocks and two-state comparison
+
+A subsequent comparison on 2026-09-10 measures output blocks and the two-state
+mask invariant described above. Both binaries already include activity tracking
+and the byte encoder; these are additional gains over the preceding
+implementation. The host, compiler, bench profile, and CPU affinity are the same
+as above. Five independent processes per binary ran in alternating before/after
+order, writing to `/dev/null`, without concurrent builds or tests. Timings below
+are medians; construction and the initial snapshot are excluded, and the final
+flush is included.
+
+The writer used 16,384 64-bit two-state signals and 1,000 dumps:
+
+| Mode | Case | Before (ms) | After (ms) | Time reduction |
+| --- | --- | ---: | ---: | ---: |
+| `dirty` | idle | 0.0343 | 0.0339 | approximately unchanged |
+| `dirty` | sparse_clustered | 0.481 | 0.371 | 22.8% |
+| `dirty` | sparse_scattered | 1.711 | 1.299 | 24.1% |
+| `dirty` | same_value | 1.490 | 1.029 | 31.0% |
+| `dirty` | dense | 415.414 | 305.684 | 26.4% |
+| `dirty` | burst | 3.925 | 2.892 | 26.3% |
+| `scan` | idle | 109.634 | 73.445 | 33.0% |
+| `scan` | dense | 418.216 | 309.759 | 25.9% |
+
+Longer sparse runs of 100,000 dumps also improved: clustered updates took
+48.856 to 42.377 ms (13.3% reduction), and scattered updates took 177.567 to
+134.241 ms (24.4%). The unchanged mask check is skipped only for two-state
+memory signals. External signals still compare masks when the current value
+is known, preserving transitions from `x` or `z` to zero.
+
+The native counter workload used 256 counters (514 traced signals) and 100,000
+full cycles, or 200,000 dumps:
+
+| Mode | Case | Before (ms) | After (ms) | Time reduction |
+| --- | --- | ---: | ---: | ---: |
+| `scan` | idle | 685.748 | 530.723 | 22.6% |
+| `scan` | sparse | 704.517 | 540.259 | 23.3% |
+| `scan` | dense | 1125.349 | 888.444 | 21.1% |
+| `dirty` | idle | 81.032 | 69.654 | 14.0% |
+| `dirty` | sparse | 112.928 | 85.270 | 24.5% |
+| `dirty` | dense | 892.650 | 641.617 | 28.1% |
+
+Hardware counters corroborate the dense writer gain. For the incremental
+1,000-dump workload, median cycles fell from 2,051,929,560 to 1,509,797,721
+(26.4%), and instructions from 9,348,339,330 to 7,214,076,419 (22.8%). These
+counters cover the whole process, including initialization, and all events
+reported 100% running time without multiplexing. A separate pair of cycle
+profiles at 499 Hz over 5,000 dense dumps captured 1,032 and 772 samples with
+no reported loss. Libc `memmove` self-time accounted for 56.2% before and 16.2%
+after. Sampling shares alone do not measure absolute time, but agree with the
+removal of the per-record copy into `BufWriter`.
+
+Four-state mask-only workloads remain sensitive to width. At 65 bits the
+median changed from 2.049 to 1.875 ms. At 1,024 bits it changed from 18.505 to
+18.970 ms; the ranges overlap (17.209–22.985 versus 18.726–23.918 ms), so this
+run establishes no improvement for that case. The output block adds roughly
+256 KiB per writer. These `/dev/null` measurements do not establish sustained
+filesystem throughput or gains for other simulation workloads.
+
+Every before/after pair had identical comparison, change, and output-byte
+counts. A separate dense file comparison matched byte-for-byte after excluding
+the date header. Saved binaries and source snapshots, SHA-256 hashes, individual
+CSV and counter samples, the comparison driver, and profiles are under
+`target/vcd-block-results/` (ignored build artifacts). The manifest records each
+command and environment. The existing benchmark commands reproduce the
+workloads; use `VCD_STEPS=100000` for the longer sparse and native runs.
+
+## Verilator comparison
+
+```sh
+python3 scripts/compare-vcd-verilator.py
+```
+
+This Linux runner builds the Celox native benchmark and equivalent SystemVerilog
+models, then checks their VCD output against an independent counter oracle before
+timing. It requires Verilator, GCC, Make, Python 3, and Cargo. Use `--verilator`
+for a Verilator executable outside `PATH`, `--celox` for an already built Celox
+benchmark, and `--output` for a separate results directory. Defaults are 256
+counters, 100,000 full cycles, five independent processes per combination, and
+the first available CPU. `--signals`, `--steps`, `--repeats`, and `--cpu` override
+those settings. `--check-only` builds and validates without collecting timings.
+`--reuse-builds` reruns validation and measurements using binaries checked
+against the preceding manifest, without recompiling the C++ models. Pass
+`--celox` with this option to replace the cached Celox executable. The runner
+sets a 64 MiB process and Rust worker stack (`--stack-mib`); the 4,096-counter
+fixture overflowed a frontend worker's default stack during construction.
+`--baseline-celox PATH` adds an earlier Celox executable to the same validation
+and rotating measurement order, avoiding comparisons made only across separate
+runs. Its input is snapshotted before replacing cached executables, so it may
+refer to the previous `celox-vcd` in the output directory. `--cases dense` and
+`--modes vcd` select a focused timing run; waveform validation still runs for
+every selected case and engine.
+
+Both engines run idle, approximately 1% enabled, and fully enabled cases, with
+VCD disabled, instrumentation only, and VCD output enabled. Verilator uses
+separate traced and untraced builds; the traced binary also supplies the
+instrumentation-only control. Celox uses its incremental native path. Both
+timers exclude construction, reset, one enabled setup tick, and the initial
+snapshot, and include both clock phases and the final flush. Samples alternate
+engine order, use one simulation thread pinned to one CPU, and write to
+`/dev/null`. Compilation finishes before the timing runs. Rust uses the bench
+profile with LTO; generated C++ and its runtime use GCC `-O3 -flto`, with
+`OPT_FAST`, `OPT_SLOW`, and `OPT_GLOBAL` all set to `-O3`.
+
+The verifier checks every signal's width and transitions over 20 cycles per
+combination (`--check-steps`), including initial values,
+active-low reset semantics, and nanosecond timestamps. It accepts differences
+in VCD identifiers, scopes, leading zeros, and empty timestamps, while rejecting
+missing signals or differing values. Verilator's extra top wrapper trace and
+parameter tracing are disabled to retain the same signal set. The C++ harness
+also checks every final counter outside the timed region, including in the
+untraced build.
+
+Two value patterns expose an encoding difference. `counter` uses the original
+small reset values. Celox abbreviates leading zero bits, whereas Verilator emits
+all 64 bits. `full_width` sets bit 63 so both writers emit all 64 value bits;
+identifier lengths can still differ. Verilator's sink counts actual writes;
+Celox's total adds timestamp lengths to its value-byte statistics. Headers and
+initial snapshots are excluded from these byte counts. Files, individual CSVs,
+commands, versions, executable hashes, and medians/ranges are retained in
+`target/vcd-verilator-results/` by default.
+
+### What Verilator generates
+
+The inspected version is Verilator 5.052 (tag `v5.052`, commit
+`ea338be98e1e838d3518809ce8899f85a009963c`). Its compiler groups signals by
+activity, inserts byte flags, and can choose unconditional comparison when the
+estimated comparisons are cheaper than testing the flags. This supports the
+same general design choice of conservative write activity followed by value
+comparison. Its groups follow generated execution dependencies, rather than
+Celox's physical memory homes.
+[Source: V3Trace.cpp](https://github.com/verilator/verilator/blob/v5.052/src/V3Trace.cpp).
+
+Generated trace calls specialize comparison by width: `chgBit`, `chgIData`, and
+`chgQData` compare native integers and emit only on a difference. The VCD writer
+encodes directly into its output buffer, keeps precomputed identifier/newline
+suffixes, and uses SIMD binary-to-ASCII conversion on x86. Its single-threaded
+path avoids a separate record buffer. These are useful candidates for further
+Celox optimization if profiles show comparison dispatch or encoding dominating.
+[Comparison source](https://github.com/verilator/verilator/blob/v5.052/include/verilated_trace.h),
+[encoding source](https://github.com/verilator/verilator/blob/v5.052/include/verilated_trace_imp.h),
+[output source](https://github.com/verilator/verilator/blob/v5.052/include/verilated_vcd_c.cpp).
+
+The counter fixture exposes every counter as a top-level output. In the inspected
+generated code, all these ports use unconditional change checks after a global
+activity guard. This fixture therefore tests a specialized comparison loop and
+encoding throughput; it does not establish how either engine's activity
+selection behaves on a large hierarchy with mostly quiet internal state.
+
+### Baseline measured against 5.052
+
+These measurements precede the integer and SIMD specialization below. They use
+the same Ryzen 7 9800X3D host under WSL, CPU 0, Rust 1.98.1,
+and GCC 13.3.0. Verilator was built from the release tag above in
+`target/verilator-v5.052/`; no system installation was needed. The standard
+Ubuntu package available on this host was 5.020 and was not used for this
+comparison. An additional Flex header needed for the source build was extracted
+from Ubuntu's `libfl-dev` package into `target/`.
+
+The commands below reproduce the two sizes after the local Verilator build:
+
+```sh
+python3 scripts/compare-vcd-verilator.py \
+  --verilator target/verilator-v5.052/bin/verilator
+python3 scripts/compare-vcd-verilator.py \
+  --verilator target/verilator-v5.052/bin/verilator \
+  --celox target/vcd-verilator-results/celox-vcd \
+  --output target/vcd-verilator-4096 \
+  --signals 4096 --steps 10000 --patterns full_width
+```
+
+For 256 counters (514 traced signals), 100,000 cycles, and the `full_width`
+pattern, median elapsed times in milliseconds were:
+
+| Case | Celox off | Verilator off | Celox instrumented | Verilator instrumented | Celox VCD | Verilator VCD |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| idle | 12.471 | 16.838 | 17.532 | 17.130 | 66.844 | 56.008 |
+| sparse | 12.410 | 16.866 | 17.177 | 16.523 | 81.114 | 62.141 |
+| dense | 15.306 | 18.024 | 22.075 | 17.911 | 637.877 | 146.975 |
+
+For 4,096 counters (8,194 traced signals), 10,000 cycles, and the same
+`full_width` pattern:
+
+| Case | Celox off | Verilator off | Celox instrumented | Verilator instrumented | Celox VCD | Verilator VCD |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| idle | 17.206 | 70.308 | 20.219 | 71.370 | 25.918 | 112.966 |
+| sparse | 17.029 | 69.355 | 19.809 | 82.345 | 38.855 | 115.628 |
+| dense | 22.115 | 63.130 | 33.676 | 63.986 | 942.670 | 294.993 |
+
+Thus Verilator was 4.34 times as fast in the smaller dense case and 3.20 times
+as fast in the larger dense case. Celox was 4.36 times as fast in the larger
+idle case and 2.98 times as fast in its sparse case. These ratios
+include simulation; the off and instrumented controls are necessary to assess
+the tracing contribution. For example, in the larger idle case, the difference
+between VCD and instrumented medians was about 5.7 ms for Celox and 41.6 ms for
+Verilator. Subtracting medians is an indication of additional cost, not a
+separately measured writer-only time.
+
+Output volume does not explain the dense gap. In the smaller `full_width`
+case Celox emitted 1,768,488,897 timed bytes and Verilator 1,765,488,894; in the
+larger case they emitted 2,826,428,895 and 2,837,328,892. For the smaller original
+`counter` pattern, Celox emitted fewer bytes (724,756,054 versus 1,765,488,894)
+but still took 703.325 ms versus 155.987 ms.
+
+Each table entry is the median of five processes. The smaller dense VCD
+`full_width` samples ranged from 626.880–669.425 ms for Celox and 144.569–186.808
+ms for Verilator; the larger dense samples ranged from 887.611–1,048.264 ms and
+287.609–321.733 ms. Some shorter controls varied much more under virtualization.
+All samples are retained. The first 256-counter run, before adopting the larger
+stack and cached-build runner options, remains in
+`target/vcd-verilator-results/initial-run/`; the tables use the subsequent full
+repeat under the final runner settings.
+
+A separate profile used 256 counters, the `full_width` dense pattern, and
+1,000,000 cycles at 499 Hz. Celox collected 3,443 cycle samples with 53.6% self
+time in `dump_with_activity`, 21.7% in libc `memcmp`, 12.6% in `memmove`, and
+3.6% in `memset`. The `memcmp` call chain came almost entirely from the VCD
+writer. Verilator collected 758 samples, with 62.8% in its specialized
+`fullQData` routine and 11.5% in the generated change-check function. Neither
+profile reported lost samples. These profiles cover the whole process, including
+construction, and sample shares are not absolute time comparisons.
+
+The measurements motivated retaining sparse activity selection while
+specializing integer comparisons, previous-value copies, and SIMD encoding
+directly into the output block, as measured below. Neither
+this top-level port fixture nor `/dev/null` establishes results for four-state
+simulation, storage throughput, or a mostly quiet internal hierarchy such as
+Heliodor. A hierarchy benchmark is still needed to compare dependency-based
+activity groups with physical-home groups on that workload.
+
+### Integer comparison and SIMD encoding
+
+The subsequent implementation specializes two-state memory signals of widths
+1 and 64. Registration selects the comparison path once; the 64-bit path uses
+unaligned-safe fixed-size loads/copies and SSE2 encoding into the output block.
+The generic cases share a match arm, avoiding a chain of separate integer-kind
+tests before their normal processing. There is no PGO or generated-code
+rewriting, and SSE2 selection is at compile time. AArch64 retains scalar
+encoding and was compile-checked; SIMD performance was measured only on x86-64.
+
+The writer comparison uses 16,384 signals, 1,000 dumps, CPU 0, `/dev/null`, one
+warm process and five measured processes per binary/case. Binary order rotates
+between samples. Construction and the first dump are outside the timer;
+stimulus, activity collection, encoding, and final flush are inside it. Every
+pair has identical comparison counts, change counts, and emitted byte counts.
+The baseline is the output-block writer used in the preceding Verilator tables.
+Median times in milliseconds:
+
+| Width / states | Mode | Case | Before | Integer + SIMD |
+| --- | --- | --- | ---: | ---: |
+| 64 / 2 | scan | idle | 65.241 | 23.011 |
+| 64 / 2 | scan | dense | 272.424 | 129.963 |
+| 64 / 2 | dirty | idle | 0.033 | 0.033 |
+| 64 / 2 | dirty | sparse scattered | 1.241 | 0.796 |
+| 64 / 2 | dirty | same-value writes | 1.009 | 0.663 |
+| 64 / 2 | dirty | dense | 276.351 | 132.233 |
+| 1 / 2 | dirty | dense | 190.196 | 93.093 |
+
+An intermediate three-way run separated the two optimizations: the 64-bit dense
+scan took 274.368 ms before, 211.782 ms with only integer comparison/copy, and
+129.732 ms after adding SSE2. These are separate samples from the final table,
+not additive estimates. The one-bit specialization was added after measuring
+a regression in one-bit workloads with only the 64-bit path enabled.
+
+The generic path is not uniformly faster. The final five-process series measured
+the following controls, also using 16,384 signals and 1,000 dumps:
+
+| Width / states | Dirty case | Before | Integer + SIMD |
+| --- | --- | ---: | ---: |
+| 32 / 2 | dense | 233.574 | 239.979 |
+| 63 / 2 | dense | 275.576 | 280.016 |
+| 65 / 2 | dense | 292.896 | 293.939 |
+| 256 / 2 | dense | 455.789 | 457.183 |
+| 64 / 4 | dense | 319.290 | 345.745 |
+| 64 / 4 | mask-only sparse | 2.043 | 2.253 |
+
+The two-state generic widths differed by 0.3–2.7%, and the four-state cases
+were 8–10% slower in that series. Short controls varied between runs; for
+example, a separate seven-process series with 5,000 mask-only dumps measured
+9.966 versus 10.164 ms. These results support the two-state integer optimization,
+not a four-state speedup or a general no-regression claim. Individual CSVs,
+intermediate binaries, source snapshots, and hashes are retained under
+`target/vcd-integer-results/`, with final writer measurements in
+`writer-final-simd-summary.json` and `writer-final-fallback-summary.json`.
+
+### Native results after integer specialization
+
+The final comparison also runs the saved pre-specialization Celox executable
+alongside the new executable and Verilator 5.052. It rotates all three engines
+within each repetition and validates all three waveforms against the same
+counter oracle. Both Celox versions emit exactly the same number of timed
+bytes. The `full_width` dense results below use five processes per engine,
+CPU 0, `/dev/null`, and the preceding compilation/initialization exclusions:
+
+| Counters | Full cycles | Celox before (ms) | Celox after (ms) | Verilator (ms) | Celox speedup |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 256 | 100,000 | 608.066 | 255.871 | 147.186 | 2.38x |
+| 4,096 | 10,000 | 933.196 | 388.599 | 292.175 | 2.40x |
+
+Celox's dense elapsed time fell by about 58%. Verilator remains 1.74 times as
+fast in the smaller case and 1.33 times as fast in the larger one. These are
+whole-simulation comparisons, including tracing. The 256-counter ranges were
+602.127–661.866 ms before, 249.008–284.738 ms after, and 140.793–152.421 ms for
+Verilator. The 4,096-counter ranges were 913.549–1,018.107 ms,
+368.478–434.953 ms, and 286.747–328.943 ms respectively.
+
+The full control run for 4,096 counters also retained the advantage on sparse
+activity. These are separate samples from the focused dense comparison above:
+
+| Case | Celox off | Verilator off | Celox instrumented | Verilator instrumented | Celox VCD | Verilator VCD |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| idle | 16.462 | 67.116 | 18.912 | 66.575 | 21.945 | 116.436 |
+| sparse | 16.576 | 65.826 | 18.636 | 69.502 | 30.188 | 118.378 |
+| dense | 20.432 | 64.008 | 31.612 | 64.943 | 373.489 | 320.014 |
+
+The host varied substantially during the earlier 256-counter runs: both
+engines' off/instrumented controls roughly doubled during one interval. The
+first three-way dense run had a baseline range of 1,367–2,392 ms and a new
+Celox range of 569–836 ms. That run is retained in `paired-256/`; the table uses
+one subsequent run restricted to dense `full_width`, retained in
+`paired-256-dense/`. The larger focused run is in `paired-4096/`, and the full
+control runs are in `verilator-256/` and `verilator-4096/`, all beneath
+`target/vcd-integer-results/`. Timing variability limits conclusions about
+small differences and the winner in the smaller sparse case. No samples were
+removed from a reported median.
+
+For the verified cached fixtures, the focused comparison can be repeated with:
+
+```sh
+python3 scripts/compare-vcd-verilator.py \
+  --verilator target/verilator-v5.052/bin/verilator \
+  --celox target/vcd-integer-results/e2e-final \
+  --baseline-celox target/vcd-integer-results/e2e-before \
+  --output target/vcd-integer-results/paired-256-dense \
+  --patterns full_width --cases dense --modes vcd --reuse-builds
+```
+
+Use `--signals 4096 --steps 10000` and `paired-4096` for the larger fixture.
+Omit `--reuse-builds` when populating a fresh output directory. The comparison
+script itself tests baseline caching when the input path is the executable
+being replaced, preventing an accidental comparison of two copies of the new
+binary.
+
+A final profile repeated the 256-counter `full_width` dense workload for
+1,000,000 cycles at 499 Hz. It collected 1,584 samples with none lost. `memcmp`
+fell from 21.7% of cycle samples in the earlier profile to 0.08%; the final
+profile had 69.3% self time in `dump_with_activity` and 11.9% in `memmove`.
+About 11.1 percentage points of the latter had the VCD writer as caller.
+This is consistent with removing generic comparison and previous-value copying
+for integer signals while retaining encoding and output copies. These profiles
+include construction, and sample shares are not absolute time measurements.
+The data, command, environment, and binary hash are retained as
+`profile-final.*` and `profile-manifest.json` in the same results directory.
+
+## Correctness
+
+`cargo test --locked -p celox-runtime -p celox-state-layout` checks byte encoding
+against an independent BigUint oracle, padding, mask-only transitions,
+registration order, aliases, activity consumption, and flush errors. It also
+checks integer formatting at every significant bit length, unaligned input and
+output, exact end-of-buffer loads, output capacity growth/reuse, and aliases of
+64-bit values with repeated unchanged samples. The output tests cover
+output-block boundaries, records larger than a block, short writes,
+interrupted writes, partial I/O failures, and the final tail flushed by Drop.
+`cargo test --locked -p celox --test vcd` compares parsed incremental output with
+full scans of the same committed state across native, Cranelift, interpreter,
+Wasm, and tiered backends, with optimization and four-state mode on and off. It
+also exercises multiple ticks per dump, repeated timestamps, dynamic array
+writes, retained raw views, and clock-trigger consumption.
+`PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/tests -p
+'test_compare_vcd_verilator.py'` checks that the external comparison rejects
+incorrect values, sample times, timescales, and signal sets while accepting
+equivalent VCD padding and empty timestamps. It also checks that replacing a
+cached executable preserves the original baseline when input/output paths alias.

--- a/docs/internals/vcd-performance.md
+++ b/docs/internals/vcd-performance.md
@@ -47,14 +47,20 @@ other targets retain the scalar lookup-table encoder. It publishes only the
 significant digits, preserving leading-zero abbreviation and the single digit
 for zero. Other widths and four-state/external values use the generic byte
 encoder; unknown bits retain VCD's `x`/`z` distinction. A changed vector
-emits its complete VCD value, even if
-only one bit changed. Values, IDs, and newlines are appended directly to a
-reusable output block. Blocks at least as large as the `BufWriter` capacity
+emits its complete VCD value, even if only one bit changed.
+Header construction precomputes each record's suffix: a space for vectors,
+the ID, and a newline. Suffixes of up to eight bytes are stored inline and
+copied with a fixed-size store; longer IDs retain a separate byte allocation.
+The encoders write directly into checked slices of the output block's spare
+capacity. The writer publishes the complete record with one Vec length update.
+Padding written by SIMD or the fixed-size suffix copy stays outside that length.
+Blocks at least as large as the `BufWriter` capacity
 (256 KiB) bypass its internal copy; a dump's final partial block is handed to
 `BufWriter` before returning. Headers, timestamps, and value records therefore
 retain their order, including when a single record exceeds the block size.
-The block reserves capacity for 256 KiB plus the largest possible record at the
-first dump, adding roughly 256 KiB compared with a single-record buffer.
+The block reserves capacity for 256 KiB plus the largest possible record,
+including fixed-store padding, at the first dump. No record grows the Vec;
+the allocation adds roughly 256 KiB compared with a single-record buffer.
 Header construction stays in a separate cold function. The pending change
 count belongs to the output block, so unchanged-signal comparisons need not
 carry a separate local accumulator through the loop.
@@ -631,6 +637,160 @@ include construction, and sample shares are not absolute time measurements.
 The data, command, environment, and binary hash are retained as
 `profile-final.*` and `profile-manifest.json` in the same results directory.
 
+### Complete-record output
+
+The next change uses commit `4c9a50735` (integer comparison and SSE2 encoding)
+as its baseline. It precomputes the space/ID/newline suffix, replaces short-ID
+copies with a fixed eight-byte store, and updates the output Vec length once
+per complete record. The encoding algorithm, significant-digit abbreviation,
+activity selection, and output-block/flush policy are retained. Checked spare
+capacity includes suffix padding even for scalar-only traces. Long suffixes
+use a separate byte slice. No generated-code rewriting, PGO, or additional
+instruction-set requirement is introduced.
+
+The writer comparison again uses 16,384 signals, 1,000 dumps, CPU 0,
+`/dev/null`, one warm process and five measured processes per binary/case,
+with alternating binary order. Comparison counts, change counts, and emitted
+byte counts match in every pair. Median times in milliseconds:
+
+| Width / states | Mode | Case | Before | Complete records |
+| --- | --- | --- | ---: | ---: |
+| 64 / 2 | scan | dense | 139.909 | 99.210 |
+| 64 / 2 | dirty | dense | 146.960 | 116.869 |
+| 1 / 2 | dirty | dense | 99.294 | 69.621 |
+| 32 / 2 | dirty | dense | 272.081 | 244.892 |
+| 63 / 2 | dirty | dense | 305.122 | 264.444 |
+| 65 / 2 | dirty | dense | 314.191 | 292.528 |
+| 256 / 2 | dirty | dense | 508.588 | 456.981 |
+| 64 / 4 | dirty | dense | 347.422 | 345.496 |
+
+An alternating three-process `perf stat` control on the 64-bit dirty dense
+case measured 4.149 billion instructions before versus 3.393 billion after,
+including process setup, an 18.2% reduction. The short-ID copy in the compiled
+writer is an inline fixed-size store. The SIMD algorithm remains unchanged.
+
+Short sparse samples were noisy, so a separate control increased their length
+to 100,000 dumps. This reproduced a regression in the standalone benchmark:
+
+| Width / states | Dirty case | Before (ms) | Complete records (ms) |
+| --- | --- | ---: | ---: |
+| 64 / 2 | idle | 3.907 | 3.794 |
+| 64 / 2 | sparse scattered | 91.127 | 100.434 |
+| 64 / 2 | same-value writes | 73.319 | 84.626 |
+| 64 / 4 | mask-only sparse | 220.271 | 239.759 |
+
+These regressions are retained rather than discarded. In three alternating
+hardware-counter samples, same-value instructions remained almost identical
+(2.170 versus 2.166 billion), while cycles increased. Profiles of 2,000,000
+same-value dumps locate most additional cycle samples in the benchmark main
+function's activity-collection loop; they do not establish a per-record writer
+regression. Both profiles reported no lost samples. A subsequent five-process
+`collect` control, which never calls the writer during the timed loop, also
+reproduced the difference: same-value writes took 32.527 versus 45.823 ms;
+sparse scattered writes took 32.565 versus 52.950 ms; mask-only writes took
+37.130 versus 47.515 ms. This establishes an effect outside the timed writer
+calls, without establishing its exact cause. Do not subtract these separate
+samples to estimate isolated writer cost. Use the native controls below to
+assess the effect on simulation.
+
+Raw samples, binary hashes and source snapshots are under
+`target/vcd-record-results/`. The writer tables are reproduced by
+`compare-writer.py`, `compare-writer.py --fallback`, `compare-controls.py`, and
+`compare-collection.py`
+in that directory. Their summaries retain all five samples per binary/case;
+no sample was removed from a reported median.
+
+### Native results after complete-record output
+
+The native comparison uses saved executables for `4c9a50735`, the record-output
+change, and the same Verilator 5.052 fixtures. It rotates engine order and runs
+five measured processes after a warm process per engine/mode. CPU 0,
+`/dev/null`, and the preceding construction/initial-snapshot exclusions apply.
+All three engines pass the 20-cycle waveform oracle. Old and new Celox also
+emit the same timed byte counts, and their validation waveform bodies match
+byte for byte after the header. At 256 counters and 100,000 full cycles,
+median elapsed times with VCD enabled are:
+
+| Pattern | Case | Celox before (ms) | Complete records (ms) | Verilator (ms) |
+| --- | --- | ---: | ---: | ---: |
+| counter | idle | 46.728 | 38.650 | 58.263 |
+| counter | sparse | 48.215 | 48.598 | 56.958 |
+| counter | dense | 250.238 | 186.323 | 146.935 |
+| full_width | idle | 38.162 | 38.495 | 57.582 |
+| full_width | sparse | 47.965 | 49.459 | 58.575 |
+| full_width | dense | 284.127 | 211.982 | 142.041 |
+
+Dense elapsed time fell by about 25% in both patterns. The `full_width` gap
+relative to Verilator narrowed from 2.00x to 1.49x in this paired run. Dense
+ranges were 253.461–311.118 ms before, 204.028–217.089 ms after, and
+140.161–157.244 ms for Verilator. Native sparse elapsed times differed by
+0.8–3.1%; individual ranges overlap. These results do not support a sparse
+speedup from record encoding.
+
+The no-output controls are also retained. For `full_width` dense, off took
+14.495 versus 14.656 ms, while instrumented-without-dumping took 21.034 versus
+28.829 ms. The latter regression also appeared in `counter` dense
+(21.685 versus 29.257 ms), with disjoint before/after sample ranges. A writer
+dump is not called during those timed loops; the cause remains unestablished.
+Do not attribute the entire before/after difference to encoding or claim that
+all controls are unchanged. The full matrix, ranges, commands, and binary
+hashes are retained in `target/vcd-record-results/paired-256/`.
+
+At 4,096 counters and 10,000 full cycles, five processes per engine give:
+
+| Full-width case | Celox before (ms) | Complete records (ms) | Verilator (ms) |
+| --- | ---: | ---: | ---: |
+| idle | 22.072 | 21.636 | 113.053 |
+| sparse | 29.795 | 28.660 | 113.871 |
+| dense | 403.500 | 292.690 | 319.673 |
+
+Dense elapsed time fell by 27.5%; new Celox took 8.4% less time than Verilator
+in this run. Dense ranges were 378.755–428.553 ms before, 279.528–298.023 ms
+after, and 301.363–334.930 ms for Verilator. Old and new Celox both emitted
+2,826,428,895 timed bytes; Verilator emitted 2,837,328,892 bytes. The larger
+fixture retains the sparse advantage. Results are in
+`target/vcd-record-results/paired-4096/`. These results concern this two-state
+counter fixture and `/dev/null`, not storage throughput or a general advantage
+over Verilator on other designs.
+
+The hardware-counter comparison runs 256 `full_width` dense counters for
+1,000,000 cycles, rotating all three engines over five processes each.
+`perf stat` counts user-space events for the whole process, including
+construction; each event was counted for 100% of its enabled time. Medians:
+
+| Engine | Instructions (billions) | Branches (billions) | Branch-miss rate |
+| --- | ---: | ---: | ---: |
+| Celox before | 70.391 | 13.218 | 0.061% |
+| Complete records | 59.274 | 10.126 | 0.082% |
+| Verilator | 30.073 | 2.949 | 0.176% |
+
+Celox's instruction count fell by 15.8%, but remains 1.97x Verilator's in
+this whole-process measurement. A 499 Hz profile of the new binary collected
+1,154 samples with none lost: 67.3% self time was in `dump_with_activity`
+and 5.7% in `memmove`. The earlier same-workload profile of the baseline
+had 69.3% and 11.9% respectively. Profile shares are not absolute time
+comparisons. Commands, environment, hashes, per-process counters, and the
+profile are retained in `stat-manifest.json`, `stat-summary.json`, and
+`profile-after.*` under `target/vcd-record-results/`.
+
+Repeat the verified cached native comparison with:
+
+```sh
+python3 scripts/compare-vcd-verilator.py \
+  --verilator target/verilator-v5.052/bin/verilator \
+  --celox target/vcd-record-results/e2e-after \
+  --baseline-celox target/vcd-record-results/e2e-before \
+  --output target/vcd-record-results/paired-256 \
+  --signals 256 --steps 100000 --repeats 5 \
+  --patterns counter full_width --reuse-builds
+```
+
+For the larger run use `--signals 4096 --steps 10000 --patterns full_width
+--modes vcd` and output directory `paired-4096`. Omit `--reuse-builds` for
+fresh Verilator fixtures. `binaries.json` links the saved executables to the
+runtime source snapshots; `output-equivalence.json` records the nine identical
+before/after validation waveform bodies and equal timed byte counts.
+
 ## Correctness
 
 `cargo test --locked -p celox-runtime -p celox-state-layout` checks byte encoding
@@ -638,7 +798,11 @@ against an independent BigUint oracle, padding, mask-only transitions,
 registration order, aliases, activity consumption, and flush errors. It also
 checks integer formatting at every significant bit length, unaligned input and
 output, exact end-of-buffer loads, output capacity growth/reuse, and aliases of
-64-bit values with repeated unchanged samples. The output tests cover
+64-bit values with repeated unchanged samples. Suffix tests cover ID carries,
+the inline/long boundary, adjacent records of different significant lengths,
+and bounds on fixed-store padding. Scalar-only and mixed-width traces cross
+small block sizes while retaining registration order and scope/ID mappings.
+The output tests cover
 output-block boundaries, records larger than a block, short writes,
 interrupted writes, partial I/O failures, and the final tail flushed by Drop.
 `cargo test --locked -p celox --test vcd` compares parsed incremental output with

--- a/docs/internals/vcd-performance.md
+++ b/docs/internals/vcd-performance.md
@@ -41,12 +41,25 @@ JavaScript shared-memory views and components that receive writable raw memory.
 The buffered byte encoder still applies on these paths. Builds without VCD do
 not reserve activity storage or generate notification stores.
 
-The writer keeps previous value and mask planes as packed bytes. Padding above a
-signal's declared width is ignored. Four-state and external signals compare
-both planes; two-state memory signals compare only values because their previous
-mask stays zero for the writer's lifetime. Two-state memory signals of widths
-1 and 64 are classified when registering signals and use fixed-size integer
-comparisons and copies, including unaligned memory and previous-value offsets.
+The writer builds a trace plan at registration. Consecutive two-state one-bit
+signals, two-state 64-bit signals, and generic signals form separate runs in
+registration order. Fixed-width runs keep each memory offset, previous integer,
+and precomputed suffix together; header names and scopes stay outside the hot
+records. The initial snapshot has a separate loop specialization. Long fixed-width
+runs dispatch once; their comparisons do not check per-signal type, initialization
+flags, or previous-value offsets. The writer validates memory coverage once per
+dump before unaligned fixed-width loads. A sparse dump with a shorter slice
+validates only the selected ranges, and no selected signals means no memory access.
+Sparse candidates use a one-signal specialization without changing their order
+or alias IDs, avoiding a second traversal to rebuild runs from scattered indices.
+When full-scan runs average fewer than two entries, the writer instead visits
+registration entries with a one-signal specialization. This avoids setting up
+a variable-length inner loop for every signal in an alternating-type trace.
+
+Generic signals keep previous value and mask planes as packed bytes. Padding
+above a signal's declared width is ignored. Four-state and external signals
+compare both planes; two-state memory signals compare only values because their
+previous mask stays zero for the writer's lifetime.
 The one-bit path emits its ASCII digit directly. On x86-64 with SSE2 enabled,
 the 64-bit path duplicates all input bytes once, then shuffles each required
 pair into 16 output digits directly in spare capacity. Other targets retain
@@ -69,8 +82,10 @@ The block reserves capacity for 256 KiB plus the largest possible record,
 including fixed-store padding, at the first dump. No record grows the Vec;
 the allocation adds roughly 256 KiB compared with a single-record buffer.
 Header construction stays in a separate cold function. The pending change
-count belongs to the output block, so unchanged-signal comparisons need not
-carry a separate local accumulator through the loop.
+count belongs to the output block. Comparison statistics update once per run;
+an I/O error records exactly the visited prefix, including unchanged values.
+The initial snapshot is complete only after its value records are handed to
+`BufWriter`; a failed initial dump retries a full snapshot on the next dump.
 
 `VcdWriter::flush`, `Simulator::flush_vcd`, or `Simulation::flush_vcd` explicitly
 publishes pending bytes and reports I/O errors. Dropping the writer flushes
@@ -1276,6 +1291,179 @@ python3 scripts/compare-vcd-verilator.py \
   --patterns counter full_width --reuse-builds
 ```
 
+### Typed trace plans
+
+This stage starts from `15f179813046fbaf2ca974686232cd16b0fb3d7c`.
+The preceding 256-counter full-width dense comparison was 1.36 times Verilator's
+elapsed time. Its whole-process profile used 53.158 billion instructions,
+versus Verilator's 30.073 billion, with only 0.088% of Celox's branches missed.
+Correctly predicted branches still execute their surrounding loads, indexing,
+and bookkeeping. The generated Verilator trace calls fixed-offset, typed
+comparison primitives; the old Celox writer revisited signal kind, initialization,
+previous-plane offsets, and slice bounds on every comparison. This stage targets
+that repeated work without changing the write-notification ABI or generated
+simulation code.
+
+Registration now builds separate bit, 64-bit, and generic record arrays, plus
+a registration-order map and consecutive runs. On this x86-64 build, a fixed
+record's hot stride is 40 bytes instead of 104, and includes its previous integer.
+That is a hot-record measurement: header strings, the registration map, and run
+storage still occupy separate allocations. Generic records retain packed
+previous value/mask planes. Initial values have a separate loop specialization.
+Each dump checks memory coverage before fixed-width reads; sparse callers may
+still supply a slice covering only their selected signals. The plan retains
+scope/ID assignments, registration order, aliases, and external-value behavior.
+
+Two details matter for the generated loop. Comparison statistics accumulate
+once per completed run; a returned I/O error counts the visited prefix, including
+unchanged signals. Value encoding and suffix publication stay in the same
+inlined loop, allowing SIMD constants to remain in registers across records.
+A plain inline hint did not accomplish this in the first experiment. An empty
+selection returns after timestamp handling, avoiding additional idle traversal.
+
+The first run-based candidate regressed on alternating types: a 16,384-signal
+`1,64` dense scan took 714 versus 494 ms, and a full idle scan took 1,244 versus
+540 ms. Each one-record run paid for a call and a variable-length inner loop.
+Inlining only the run dispatcher subsequently outlined the fixed-width helper
+and retained much of that cost. The next candidate also inlines the
+fixed-width loop; when average run length is below two, it walks registration
+entries with a known one-record length. This candidate still coalesces sparse
+selections and uses long runs where available.
+
+Alternating-width controls use the same fixture source and compiler options
+for both writers, with width read per descriptor by the isolated stimulus
+function. The following are five rotated process medians on CPU 0, `/dev/null`,
+16,384 signals, 5,000 dense dumps or 20,000 full-scan idle dumps. Instruction
+counts include process construction; timings exclude initialization and include
+the final flush. These standalone mixed-width timings are separate from the
+Cargo writer benchmark and linked native comparison.
+
+| Width pattern | Mode/case | Previous ms | Plan ms | Previous instructions B | Plan instructions B |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 1,64 | scan/dense | 506.558 | 448.520 | 12.177 | 10.294 |
+| 1,64 | dirty/dense | 564.828 | 463.015 | 12.919 | 11.036 |
+| 1,64 | scan/idle | 729.311 | 283.850 | 13.370 | 7.146 |
+| 1,9,64,65 | scan/dense | 1,281.307 | 1,238.415 | 22.117 | 21.053 |
+| 1,9,64,65 | dirty/dense | 1,100.067 | 1,062.876 | 22.902 | 21.839 |
+| 1,9,64,65 | scan/idle | 1,113.012 | 904.861 | 26.397 | 20.010 |
+
+Host timing variation remains substantial. The repeated instruction reductions
+are stronger evidence of removing work than any single elapsed-time ratio.
+Raw samples, rejected candidates, sources, and executables are retained under
+`target/vcd-plan-results/`; `v7-mixed-summary.json` records these mixed controls.
+The normal benchmark's stimulus remains exactly 278 instructions and 1,036 bytes
+in both builds after relocation normalization, so changing the trace plan did
+not change its per-signal input update loop.
+
+The first linked native comparison reached 1.009 times Verilator on full-width
+dense output (805.949 versus 798.525 ms; the previous writer took 1,124.583 ms).
+However, full-width idle rose from 205.309 to 217.424 ms and sparse from 260.209
+to 305.969 ms. Whole-process idle instructions increased from 9.830 to 10.550
+billion. This was not solely host timing noise and required a sparse-path fix.
+
+The actual clock home is byte 2,080. Its 64-byte group contains `clk`, `rst`,
+`en0` through `en29`, and `q252` through `q255`: 36 trace entries. Registration
+sorts names lexically, so `en10` is followed by `en100`, and most of the selected
+bit indices have gaps. Those 36 entries formed 25 runs. A uniform bit fixture
+did not reproduce the extra work because its selected indices were consecutive.
+The final sparse path visits each selected entry once with a known one-record
+length, removing both run reconstruction and dynamic loop setup at these gaps.
+
+The diagnostic exports the native fixture's real descriptors, initial memory,
+counter increments, and both half-cycle activity lists. A separate writer
+executable replays the same clock and counter updates with those activity lists;
+it excludes scheduling and activity collection. Five rotated process medians
+at one million full cycles give:
+
+| Native-layout replay | Previous ms | Coalescing candidate ms | Direct sparse ms | Previous instructions B | Direct sparse instructions B |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| idle | 218.716 | 263.995 | 174.662 | 5.541 | 4.178 |
+| sparse | 335.887 | 386.632 | 296.366 | 7.451 | 5.953 |
+| dense | 2,856.165 | 1,579.256 | 1,608.278 | 48.792 | 32.342 |
+
+The intermediate candidate and final sparse-path experiment are retained
+separately under `target/vcd-plan-results/` and
+`target/vcd-plan-sparse-results/`. The latter includes `capture-fixture.rs`,
+the three `native-*.json` fixtures, `replay.rs`, compiler commands, immutable
+executables, and `replay-summary.json`. All replay variants use the same input
+update function and fixture. Their comparison, change, and value-byte counts
+agree; replay elapsed times are not end-to-end simulation timings.
+
+The final library was rebuilt and linked into the native benchmark with the
+normal release/LTO settings. On the Ryzen 7 9800X3D/WSL host, the final paired
+comparison uses 256 counters, 500,000 full cycles, CPU 0, `/dev/null`, a 64 MiB
+stack, one warm process, and five rotated measured processes per engine/mode.
+Construction, reset, and the initial snapshot are excluded; the final flush is
+included. Both Verilator fixtures reuse binaries verified against the preceding
+manifest. The previous Celox executable is the unchanged `15f179813` baseline.
+
+| Pattern | VCD case | Previous ms | Final ms | Verilator ms | Final / Verilator |
+| --- | --- | ---: | ---: | ---: | ---: |
+| counter | idle | 214.647 | 199.438 | 298.732 | 0.668 |
+| counter | sparse | 281.895 | 251.754 | 318.834 | 0.790 |
+| counter | dense | 933.726 | 712.029 | 817.287 | 0.871 |
+| full_width | idle | 196.687 | 181.480 | 290.215 | 0.625 |
+| full_width | sparse | 262.491 | 227.740 | 308.605 | 0.738 |
+| full_width | dense | 1,055.644 | 788.720 | 815.000 | 0.968 |
+
+The full-width dense ratio is 1.295 before and 0.968 after in this comparison,
+a 25.3% reduction in Celox elapsed time. The previous 1.36 ratio came from an
+earlier run and should not be combined with these timings. Final dense samples
+range from 765.277 to 801.541 ms; Verilator ranges from 764.966 to 866.668 ms.
+These measurements support approximate parity on this fixture, not a stable
+3.2% lead across workloads. The two Celox versions emit exactly 8,842,888,899
+timed bytes in this case; Verilator emits 8,827,888,896. Counter-pattern output
+still benefits from leading-zero abbreviation and is a different volume control.
+
+Whole-process hardware counters at one million full-width cycles include
+construction, so their cycle ratios are not steady-state timing ratios. Five
+rotated repetitions of the old writer, intermediate candidate, final writer,
+and Verilator give these instruction medians:
+
+| Case | Previous B | Coalescing candidate B | Final B | Verilator B |
+| --- | ---: | ---: | ---: | ---: |
+| idle | 9.830 | 10.550 | 8.270 | 8.800 |
+| sparse | 11.785 | 12.530 | 10.103 | 8.966 |
+| dense | 53.158 | 36.933 | 35.535 | 30.073 |
+
+The final reductions from the previous writer are 15.9%, 14.3%, and 33.2%.
+The repeated instruction counts also verify that the sparse fix removes work
+from the real simulator. Timing variation remains visible in unchanged-code
+controls: full-width idle `off`, for example, moves from 63.195 to 67.221 ms.
+`off` and `instrumented` JIT captures remain byte-identical to the baseline;
+these control timings are not subtracted to estimate writer cost.
+
+The final writer-only checks cover 256 through 65,536 signals, widths 1/32/63/65/256,
+64-bit four-state values, mask-only changes, no changes, same-value stores, and
+sparse updates. All dense configurations reduce instructions relative to the
+previous writer; `collect` instruction counts change by less than 1%.
+Empty-selection instruction counts are within 0.2% of the previous writer in
+the 256/4,096/16,384/65,536 signal controls. Raw elapsed samples are retained,
+including controls whose medians increase despite similar instruction counts.
+
+Validation passes 15 runtime tests, 9 state-layout tests, 4 cross-backend VCD
+integration tests, formatting, Clippy on all runtime/state-layout targets, and
+the aarch64 runtime check. All 130 writer waveform/statistics comparisons pass.
+The native-layout replay matches both linked Celox executables byte-for-byte
+after the header, including comparison/change/value-byte counts, in all three
+cases. The three engines pass the waveform oracle at 256 and 4,096 counters;
+the larger native fixture is a correctness check only in this stage. Native
+old/new timed byte counts also agree in every measured case.
+
+Final artifacts and all commands are in `target/vcd-plan-sparse-results/`.
+`candidate-manifest.json`, `checks.json`, and `final-runs.json` record sources,
+executables, validation, and measurement commands. Reproduce the native matrix:
+
+```sh
+python3 scripts/compare-vcd-verilator.py \
+  --verilator target/verilator-v5.052/bin/verilator \
+  --celox target/vcd-plan-sparse-results/e2e-after \
+  --baseline-celox target/vcd-plan-sparse-results/e2e-before \
+  --output target/vcd-plan-sparse-results/paired-256 \
+  --signals 256 --steps 500000 --repeats 5 \
+  --patterns counter full_width --reuse-builds
+```
+
 ## Correctness
 
 `cargo test --locked -p celox-runtime -p celox-state-layout` checks byte encoding
@@ -1290,6 +1478,9 @@ small block sizes while retaining registration order and scope/ID mappings.
 The output tests cover
 output-block boundaries, records larger than a block, short writes,
 interrupted writes, partial I/O failures, and the final tail flushed by Drop.
+Trace-plan tests cover mixed typed/generic runs, external values, repeated
+timestamps, short selected-memory slices, rejected out-of-bounds ranges,
+initial-snapshot retries, and comparison counts at an I/O-error boundary.
 `cargo test --locked -p celox --test vcd` compares parsed incremental output with
 full scans of the same committed state across native, Cranelift, interpreter,
 Wasm, and tiered backends, with optimization and four-state mode on and off. It

--- a/docs/internals/vcd-performance.md
+++ b/docs/internals/vcd-performance.md
@@ -38,6 +38,13 @@ Host setters use the same notification layout. Obtaining a mutable raw memory
 view permanently selects full scanning for that memory image, since a retained
 view can write at any later time without a setter notification. This includes
 JavaScript shared-memory views and components that receive writable raw memory.
+The permanent fallback lives in backend-owned state outside the exposed image,
+so restoring or clearing every exposed byte cannot re-enable sparse tracking.
+Tier promotion transfers that state with the allocation. Internal testbench
+expression reads do not expose a retained view; VM stores notify the same trace
+groups as setters. Native JavaScript handles consume backend activity until a
+shared-memory view escapes, and their compiled-code cache distinguishes builds
+with and without VCD instrumentation.
 The buffered byte encoder still applies on these paths. Builds without VCD do
 not reserve activity storage or generate notification stores.
 
@@ -86,6 +93,11 @@ count belongs to the output block. Comparison statistics update once per run;
 an I/O error records exactly the visited prefix, including unchanged values.
 The initial snapshot is complete only after its value records are handed to
 `BufWriter`; a failed initial dump retries a full snapshot on the next dump.
+Cached values include complete records queued by the encoder. An I/O error
+retains that queue and the number of bytes already accepted, so the next dump
+or explicit flush resumes the unwritten suffix before emitting a new timestamp.
+This also covers partial header and timestamp writes. Backend activity consumed
+by a failed dump remains pending and is merged with writes made before retrying.
 
 `VcdWriter::flush`, `Simulator::flush_vcd`, or `Simulation::flush_vcd` explicitly
 publishes pending bytes and reports I/O errors. Dropping the writer flushes
@@ -400,8 +412,14 @@ counters, 100,000 full cycles, five independent processes per combination, and
 the first available CPU. `--signals`, `--steps`, `--repeats`, and `--cpu` override
 those settings. `--check-only` builds and validates without collecting timings.
 `--reuse-builds` reruns validation and measurements using binaries checked
-against the preceding manifest, without recompiling the C++ models. Pass
-`--celox` with this option to replace the cached Celox executable. The runner
+against the preceding manifest, without recompiling. Reuse requires identical
+runner/harness/benchmark sources, checkout state, compiler versions, build
+commands, compiler environment, and cached executable hashes. Old manifests
+without the complete build context are rejected. Timing options such as steps,
+repeats, cases, modes, and CPU may change; changing a build input or selecting a
+different `--celox` executable requires a fresh build without `--reuse-builds`.
+Reused Celox and baseline executables come from the verified snapshots, rather
+than copying the original input paths again. The runner
 sets a 64 MiB process and Rust worker stack (`--stack-mib`); the 4,096-counter
 fixture overflowed a frontend worker's default stack during construction.
 `--baseline-celox PATH` adds an earlier Celox executable to the same validation

--- a/docs/internals/vcd-performance.md
+++ b/docs/internals/vcd-performance.md
@@ -42,10 +42,11 @@ mask stays zero for the writer's lifetime. Two-state memory signals of widths
 1 and 64 are classified when registering signals and use fixed-size integer
 comparisons and copies, including unaligned memory and previous-value offsets.
 The one-bit path emits its ASCII digit directly. On x86-64 with SSE2 enabled,
-the 64-bit path expands 16 bits at a time directly into spare output capacity;
-other targets retain the scalar lookup-table encoder. It publishes only the
-significant digits, preserving leading-zero abbreviation and the single digit
-for zero. Other widths and four-state/external values use the generic byte
+the 64-bit path duplicates all input bytes once, then shuffles each required
+pair into 16 output digits directly in spare capacity. Other targets retain
+the scalar lookup-table encoder. It publishes only the significant digits,
+preserving leading-zero abbreviation and the single digit for zero.
+Other widths and four-state/external values use the generic byte
 encoder; unknown bits retain VCD's `x`/`z` distinction. A changed vector
 emits its complete VCD value, even if only one bit changed.
 Header construction precomputes each record's suffix: a space for vectors,
@@ -939,10 +940,163 @@ hot code even when the generated simulation image is identical. Benchmark
 candidate loop layouts across circuit sizes and sparse/dense patterns before
 adopting a padding policy. PGO can affect placement and inlining, but the
 0.082% dense branch-miss rate gives little evidence for prioritizing branch
-hints over removing work. The next implementation should isolate the SSE2
-conversion change, then repeat the existing waveform oracle and paired native
-matrix; the candidate improvements above have not yet been implemented or
-measured as production changes.
+hints over removing work. The following stage implements and measures the
+SSE2 conversion change in isolation; the trace-plan and buffer changes remain
+subsequent candidates.
+
+### Shared-byte SSE2 expansion
+
+This stage uses the complete-record implementation (`e45be5052`, documented
+in `32873bbae`) as the baseline. It duplicates the eight input bytes once and
+uses two immediate shuffles per required 16-digit group. Explicit groups let
+the compiler share the input expansion without a runtime shuffle selector.
+Leading-zero abbreviation, output bounds and padding, suffix publication,
+and the SSE2 requirement are retained. Signal selection, comparison, and
+buffering are outside this change.
+
+The first candidate replaced each 16-bit broadcast/pack with unpack/shuffle
+operations but repeated the input expansion. It reduced writer instructions
+by about 5%, while elapsed time was essentially unchanged (scan 490.325 to
+484.478 ms, dirty 505.512 to 515.641 ms). The shared expansion below was selected
+after a separate paired comparison. Both candidates and their raw samples
+are preserved; the first candidate's executable and summaries use the `v1-`
+prefix.
+
+The final writer comparison uses 16,384 two-state 64-bit signals, 5,000 dense
+dumps, CPU 0, `/dev/null`, one warm process and five alternating measured
+processes per binary/mode. Comparisons, changes, and bytes are equal in each
+pair: 81,920,000 comparisons and changes, and 5,689,308,893 timed bytes.
+Hardware counters cover the whole process and run for 100% of enabled time.
+
+| Mode | Before (ms) | Shared expansion (ms) | Before instructions (billions) | Shared-expansion instructions (billions) |
+| --- | ---: | ---: | ---: | ---: |
+| scan | 487.172 | 431.845 | 15.979 | 14.177 |
+| dirty | 510.597 | 467.532 | 16.639 | 14.837 |
+
+Elapsed time falls by 8.4–11.4%, with a 10.8–11.3% instruction reduction.
+
+The negative controls are retained. Their dump counts are longer because
+short idle/sparse samples are too small to assess reliably:
+
+| Mode / case | Dumps | Before (ms) | Shared expansion (ms) |
+| --- | ---: | ---: | ---: |
+| dirty / idle | 5,000,000 | 183.925 | 233.011 |
+| dirty / sparse_scattered | 100,000 | 101.930 | 90.917 |
+| dirty / same_value | 100,000 | 89.742 | 76.900 |
+| collect / same_value | 1,000,000 | 468.916 | 367.315 |
+
+Same-value and `collect` improvements occur without executing the changed
+encoder during timing. Conversely, idle regresses by 26.7% despite essentially
+unchanged whole-process instructions (about 5.52 billion each). These are not
+uniform encoder speedups. The generic-width/four-state matrix also retains
+its results: 32-bit dense takes 232.573 versus 242.213 ms; the other measured
+1/63/65/256-bit dense and 64-bit four-state cases range from a 4.8% decrease
+to a 1.5% increase in median time. All pairs retain equal comparisons, changes,
+and output bytes.
+
+A 100,000,000-dump idle profile reproduces the regression (3.772 versus
+4.545 seconds, no lost samples). Most additional cycle samples are in the
+benchmark's activity-summary loop. Its 85-byte body is identical except
+external branch displacements, but moves from `0x1df90` (offset 16 within a
+64-byte line) to `0x1df80` (offset 0). The latter placement makes the memory
+bounds comparison cross a line boundary. A diagnostic trampoline copies
+this unchanged body to controlled offsets in a page 1 MiB from the executable
+base; it adds entry/exit jumps and retains every inner-loop instruction.
+At 5,000,000 idle dumps, one warm process and five rotated measured processes
+per variant give:
+
+| Mode | Loop offset within line | Before (ms) | Shared expansion (ms) |
+| --- | ---: | ---: | ---: |
+| collect | 0 | 141.161 | 136.827 |
+| collect | 16 | 94.220 | 94.579 |
+| dirty | 0 | 221.398 | 231.388 |
+| dirty | 16 | 179.057 | 184.399 |
+
+Matching placement removes the isolated collection regression. The complete
+idle writer retains a 3.0–4.5% median difference under matching placement,
+compared with 26.7% in the unmodified executables. This confirms a substantial
+placement contribution, without identifying a specific frontend mechanism.
+Trampoline timings include their added jumps; the production change contains
+only the encoder improvement. The original idle regression remains a measured
+limitation of these built executables.
+
+The native benchmark is rebuilt and linked with the repository's bench/LTO
+profile. The following comparison rotates the baseline, shared expansion, and
+the same verified Verilator 5.052 executables over five measured processes
+after warming each variant. CPU 0, `/dev/null`, initial-snapshot exclusions,
+and the previous counter oracle apply. Dense medians:
+
+| Counters / pattern / cycles | Before (ms) | Shared expansion (ms) | Verilator (ms) |
+| --- | ---: | ---: | ---: |
+| 256 / counter / 100,000 | 183.688 | 177.787 | 164.883 |
+| 256 / full_width / 100,000 | 206.137 | 196.232 | 146.668 |
+| 4,096 / full_width / 10,000 | 298.556 | 286.959 | 334.363 |
+
+At 256 counters, dense elapsed time falls by 3.2% for short counters and 4.8%
+for full-width values. The full-width ratio to Verilator narrows from 1.41x to
+1.34x within this comparison. Its before range is 202.864–213.830 ms and after
+range 193.003–199.543 ms. Native sparse medians are nearly equal (counter:
+52.436 versus 52.529 ms; full-width: 51.486 versus 51.548 ms). Idle takes
+39.416 versus 41.562 ms for counter and 40.741 versus 40.587 ms for full-width;
+the before/after ranges overlap. These data do not establish a general idle
+or sparse improvement.
+
+The 4,096-counter matrix is much noisier: dense ranges are 287.173–321.475 ms
+before and 265.330–604.975 ms after. Sparse ranges are 28.854–141.769 and
+28.642–138.538 ms. Those samples remain in the reported medians; this matrix
+alone does not establish a reliable larger-fixture speedup. The stable
+256-counter result and retired-instruction reduction support this change.
+
+The dense no-output controls also vary: counter `off` takes 14.931 versus
+15.240 ms and `instrumented` takes 30.888 versus 29.981 ms; full-width takes
+15.729 versus 15.021 ms and 30.961 versus 29.459 ms respectively. Captured JIT
+images for both modes are byte-identical to the baseline, with the same hashes
+reported in the preceding investigation. Do not subtract separate controls
+to estimate isolated encoding time.
+
+At 256 full-width dense counters and 1,000,000 cycles, five rotated whole-process
+`perf stat` samples give:
+
+| Engine | Instructions (billions) | Branches (billions) | Cycles (billions) |
+| --- | ---: | ---: | ---: |
+| Complete-record baseline | 59.274 | 10.126 | 11.850 |
+| Shared expansion | 53.386 | 10.126 | 11.124 |
+| Verilator | 30.073 | 2.949 | 7.444 |
+
+Instructions fall by 9.9%; cycles fall by 6.1% in these medians. Branch counts
+are essentially unchanged. A 499 Hz profile of the final native executable
+has 1,105 samples with none lost: writer self time is 66.1%, with `memmove` at
+5.8%. Grouping instruction addresses puts approximately 27% of whole-process
+cycle samples in 64-bit encoding and 33% in signal-loop dispatch and
+scalar/integer comparison. These are sampling estimates, including possible
+skid, not isolated costs. The next target is the compact trace plan described
+above: reduce per-signal decisions and repeated metadata/indexing work.
+
+All three engines pass the waveform oracle; the nine old/new validation
+waveform bodies are also byte-identical, and all timed byte counts match.
+Validation includes the 11 runtime tests, 7 state-layout tests, 4 cross-backend
+VCD integration tests, formatting, Clippy for all runtime targets with warnings
+denied, and the aarch64 runtime check. The existing integer oracle covers every
+significant bit length, zero, random values, and unaligned output; record tests
+check that partial SIMD groups never publish their padding.
+
+Raw samples, commands, source/binary hashes, JIT captures, and profiles are in
+`target/vcd-shuffle-results/`. `compare-writer.py` accepts `dense`, `controls`,
+and `fallback`; `run-comparisons.py` records the paired native matrix and
+hardware-counter runs. `output-equivalence.json` records exact waveform and
+byte-count agreement. `profile-idle.py`, `relocate-idle-loop.c`, and
+`measure-idle-loop.py` retain the idle diagnosis; that shim is specific to the
+saved executable offsets. The comparison can be repeated with:
+
+```sh
+python3 scripts/compare-vcd-verilator.py \
+  --verilator target/verilator-v5.052/bin/verilator \
+  --celox target/vcd-shuffle-results/e2e-after \
+  --baseline-celox target/vcd-shuffle-results/e2e-before \
+  --output target/vcd-shuffle-results/paired-256 \
+  --signals 256 --steps 100000 --repeats 5 \
+  --patterns counter full_width --reuse-builds
+```
 
 ## Correctness
 

--- a/docs/internals/vcd-performance.md
+++ b/docs/internals/vcd-performance.md
@@ -18,6 +18,12 @@ one group byte and one summary byte covering 64 groups. Byte stores avoid an
 extra read/modify/write in generated code. Native lowering coalesces repeated
 notifications within a basic block. An observer skips unmarked summary groups,
 consumes the marked group bytes, and compares only their associated signals.
+The consumer reads each level eight bytes at a time. Empty words need one test;
+nonempty words become a mask of nonzero byte positions, visited in address order.
+It clears those words together and handles the remaining bytes separately.
+Safe slice loads support unaligned metadata without reading past the last flag.
+The mask exists only during collection; notification storage and generated
+stores retain their byte layout.
 Dense activity uses a direct scan. Aliases share the same home; a partial or
 dynamically indexed write notifies observers of the complete object. These are
 conservative write notifications: a notification does not imply a value change.
@@ -117,8 +123,21 @@ Useful sweeps are 1024/16384/131072 signals and widths 1/9/64/65/256/1024.
 Clustered versus scattered updates quantify the extra comparisons caused by
 coarse groups. Initialization uses nonzero values and is followed by an explicit
 flush before timing. The timed region includes mutation and the final flush.
+Mutation runs in a separate, non-inlined `Stimulus::apply` function. This keeps
+collector changes from also changing register allocation in the measurement's
+per-signal input loop. Case and notification settings are prepared before timing;
+the actual input writes and notifications remain timed. Rebuild both library
+versions with this same harness when comparing them.
 CSV reports wall time, comparisons, changed signals, and actual emitted bytes;
 `scan` and `dirty` must have identical change counts and output byte counts.
+
+Keep both `collect / idle` and `collect / same_value` as controls when changing
+the writer or collector. They expose collection costs without timed encoding;
+`dirty / idle` also includes timestamp output. Use millions of idle dumps and
+include small layouts with fewer than eight summary bytes, alongside larger
+layouts. Run timing executables serially, without overlapping builds or tests,
+and retain retired instructions as well as elapsed-time ranges: code placement
+can change elapsed time even when the executed work is unchanged.
 
 ## End-to-end benchmark
 
@@ -1095,6 +1114,165 @@ python3 scripts/compare-vcd-verilator.py \
   --baseline-celox target/vcd-shuffle-results/e2e-before \
   --output target/vcd-shuffle-results/paired-256 \
   --signals 256 --steps 100000 --repeats 5 \
+  --patterns counter full_width --reuse-builds
+```
+
+### Word-at-a-time activity collection
+
+The baseline for this stage is `5dafc4835`, including shared-byte SSE2 expansion.
+Instead of adjusting loop placement, the collector removes work from both
+levels of the activity hierarchy. It first obtains bounded, disjoint flag and
+summary slices, then tests eight bytes at once. Only nonempty summary words
+lead to flag ranges; only nonempty flag words lead to group enumeration.
+
+For a nonzero word, adding `0x7f` to each byte's low seven bits and ORing the
+original word sets a high bit exactly where that byte is nonzero. There are no
+carries between bytes. Clearing one low set bit per iteration visits those
+positions in ascending address order. The word is loaded as little endian so
+that order also holds on big-endian hosts. Short tails use byte loads. The
+implementation uses safe slices, has no new CPU-feature requirement, and accepts
+every nonzero flag value. It retains the notification ABI, raw-view fallback,
+registration order, and independent consumption of clock notifications.
+
+The selected implementation batches both levels with normal compiler inlining.
+A summary-only candidate reduced idle instructions but left most sparse flag
+scanning intact. An additional candidate prohibited inlining of `TraceLayout::take`;
+that did not remove the standalone dense instruction increase and added idle
+instructions, so it was not retained. Sources and executables for these trials
+are preserved as `v1`, `v2` (selected), and `v3` under
+`target/vcd-activity-results/`. No alignment directive or runtime code patch is
+part of this change.
+
+The original monolithic benchmark showed an additional 163.839 million
+instructions in `scan / dense` after the collector change: about two per input
+update, even though this mode never calls the collector. Disassembly shows
+additional loads in the stimulus loop. Its original three-way idle comparison
+is retained: complete records take 232.704 ms, shared SSE2 takes 279.659 ms,
+and word collection takes 137.913 ms at 16,384 signals and 5,000,000 dumps.
+Thus the large idle regression is removed even with the original harness.
+
+The final writer comparison rebuilds all three library versions with the
+isolated stimulus function. Its 278 instructions and 1,036-byte size agree in
+all three executables after normalizing link-time addresses. Placement can still
+vary. Across 130 correctness cases, the original stimulus, isolated stimulus,
+and new collector produce identical waveform bodies and statistics. Absolute
+timings and instruction counts from different harness revisions should not be
+compared directly.
+
+The following medians use CPU 0, `/dev/null`, 16,384 two-state 64-bit signals,
+one warm process and five rotated measured processes per variant. Counters
+cover the whole process, with no multiplexing. Builds and tests do not overlap
+timing runs.
+
+| Mode / case | Dumps | Complete records (ms) | Shared SSE2 baseline (ms) | Word collection (ms) |
+| --- | ---: | ---: | ---: | ---: |
+| dirty / idle | 5,000,000 | 209.895 | 190.694 | 126.135 |
+| collect / idle | 5,000,000 | 99.363 | 95.290 | 29.498 |
+| scan / dense | 5,000 | 534.144 | 484.899 | 483.634 |
+| dirty / dense | 5,000 | 555.172 | 504.650 | 480.768 |
+
+Idle collection instructions fall from 3.166 to 0.841 billion (73.4%); complete
+idle writer instructions fall from 5.530 to 3.200 billion (42.1%). The complete
+idle writer's before range is 188.992–234.011 ms and after range
+118.923–137.412 ms. This improvement removes executed work rather than relying
+only on favorable placement. Dense instruction counts are almost unchanged:
+`scan` is 12.375 billion in both versions, and `dirty` is 13.107 versus 13.102
+billion. The 4.7% dense median improvement is not a new encoding optimization;
+its elapsed-time ranges overlap. The previous SSE2 instruction reduction is
+retained under the same harness.
+
+Sparse controls, comparing shared SSE2 with word collection:
+
+| Mode / case | Dumps | Before (ms) | After (ms) | Before instructions (billions) | After instructions (billions) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| dirty / sparse_scattered | 100,000 | 109.105 | 68.232 | 2.160 | 1.453 |
+| dirty / same_value | 100,000 | 105.027 | 63.975 | 2.021 | 1.314 |
+| collect / same_value | 1,000,000 | 515.362 | 130.902 | 9.842 | 2.775 |
+
+The size sweep retains an important limitation. At 256 signals, there is only
+one summary byte, so a completely idle collector does not benefit from batching:
+5,000,000 `collect / idle` dumps take 14.742 versus 19.983 ms, an increase of
+about 1.05 ns per dump, with instructions rising from 0.366 to 0.521 billion.
+Complete `dirty / idle` takes 109.310 versus 112.490 ms. At 4,096 signals,
+complete idle takes 134.070 versus 119.515 ms; at 65,536 signals it takes
+409.415 versus 140.617 ms. Empty collection at 65,536 signals falls from
+11.572 to 1.747 billion instructions.
+
+Dense timing is not uniformly better across sizes: 256 signals take 491.849
+versus 508.344 ms, 4,096 take 460.039 versus 458.219 ms, and 65,536 take
+459.933 versus 482.440 ms, each with 81,920,000 input updates. All three pairs'
+elapsed-time ranges overlap, and their instruction counts differ by less than
+0.1%. The generic-width/four-state dense controls range from a 1.5% decrease
+to a 5.0% increase in median elapsed time, with overlapping ranges and nearly
+unchanged instructions. Four-state `mask_only` improves from 230.820 to
+190.531 ms. These controls remain in the raw results; this change is a sparse
+collection improvement, not a universal dense timing improvement.
+
+The native benchmark is rebuilt and linked with the bench/LTO profile. It
+uses the unchanged native harness, 256 counters, 500,000 full cycles, and five
+rotated measured processes after warming each engine. Verilator 5.052 uses
+the same verified cached executables as the preceding comparison. VCD medians:
+
+| Pattern / case | Shared SSE2 baseline (ms) | Word collection (ms) | Verilator (ms) |
+| --- | ---: | ---: | ---: |
+| counter / idle | 229.488 | 195.228 | 292.656 |
+| counter / sparse | 296.781 | 263.442 | 303.707 |
+| counter / dense | 987.490 | 992.998 | 792.315 |
+| full_width / idle | 225.576 | 221.236 | 293.164 |
+| full_width / sparse | 405.623 | 289.942 | 329.587 |
+| full_width / dense | 1,078.541 | 1,060.526 | 781.193 |
+
+Native dense is approximately preserved: counter changes by +0.6% and
+full-width by -1.7%, with overlapping ranges. The full-width ratio to Verilator
+is 1.38x versus 1.36x within this run; the dense gap remains. Idle and sparse
+medians improve, but their ranges overlap too. In particular, full-width sparse
+ranges are 269.614–433.173 versus 274.957–412.636 ms, so its large median
+decrease should not be treated as a stable 29% native speedup.
+
+Five rotated whole-process hardware-counter runs at 1,000,000 full-width cycles
+provide separate evidence of the work reduction:
+
+| Case | Before instructions (billions) | After instructions (billions) | Before cycles (billions) | After cycles (billions) |
+| --- | ---: | ---: | ---: | ---: |
+| idle | 10.266 | 9.830 | 3.114 | 2.841 |
+| dense | 53.386 | 53.158 | 11.356 | 11.195 |
+
+Native idle instructions fall by 4.2%; dense instructions fall by 0.4%.
+The final dense profile attributes 66.5% of whole-process samples to writer
+self time, 5.8% to `memmove`, and 1.8% to `TraceLayout::take`. This leaves
+the per-signal comparison/dispatch and output paths as the main targets for
+closing the dense Verilator gap.
+
+The `off` and `instrumented` controls are retained in the native results.
+Captured JIT images are byte-identical to the preceding stage in both modes,
+including the recorded hashes. No-output timings still vary (full-width dense
+`instrumented`: 148.837 versus 120.723 ms); they do not measure the new collector
+and must not be subtracted to estimate its cost.
+
+All three engines pass the waveform oracle at 256 and 4,096 counters. The nine
+old/new validation waveform bodies and all native timed byte counts agree.
+The larger native fixture is checked for correctness only in this stage;
+there is no new 4,096-counter native timing claim. Validation includes
+11 runtime tests, 9 state-layout tests, 4 cross-backend VCD integration tests,
+formatting, Clippy for all runtime/state-layout targets, and the aarch64 runtime
+check. The new tests cover zero-sized layouts, summary/word boundaries, partial
+tails, all byte values, unaligned metadata, stale result vectors, and untouched
+memory outside the consumed activity.
+
+Artifacts are in `target/vcd-activity-results/`. The selected library sources,
+original-harness binaries, native binaries, JIT captures, and profiles remain
+at that level. `isolated-writer/` contains the final writer comparison, all three
+rebuilt executables, source hashes, instruction-sequence comparison, and 130
+stimulus-equivalence checks. Its `compare-writer.py` accepts `regression`,
+`controls`, `scale`, and `fallback`. Reproduce the native comparison with:
+
+```sh
+python3 scripts/compare-vcd-verilator.py \
+  --verilator target/verilator-v5.052/bin/verilator \
+  --celox target/vcd-activity-results/e2e-after \
+  --baseline-celox target/vcd-activity-results/e2e-before \
+  --output target/vcd-activity-results/paired-256 \
+  --signals 256 --steps 500000 --repeats 5 \
   --patterns counter full_width --reuse-builds
 ```
 

--- a/docs/internals/vcd-performance.md
+++ b/docs/internals/vcd-performance.md
@@ -689,9 +689,9 @@ regression. Both profiles reported no lost samples. A subsequent five-process
 reproduced the difference: same-value writes took 32.527 versus 45.823 ms;
 sparse scattered writes took 32.565 versus 52.950 ms; mask-only writes took
 37.130 versus 47.515 ms. This establishes an effect outside the timed writer
-calls, without establishing its exact cause. Do not subtract these separate
-samples to estimate isolated writer cost. Use the native controls below to
-assess the effect on simulation.
+calls. The code-placement experiments below investigate its cause. Do not
+subtract these separate samples to estimate isolated writer cost. Use the
+native controls below to assess the effect on simulation.
 
 Raw samples, binary hashes and source snapshots are under
 `target/vcd-record-results/`. The writer tables are reproduced by
@@ -731,7 +731,9 @@ The no-output controls are also retained. For `full_width` dense, off took
 14.495 versus 14.656 ms, while instrumented-without-dumping took 21.034 versus
 28.829 ms. The latter regression also appeared in `counter` dense
 (21.685 versus 29.257 ms), with disjoint before/after sample ranges. A writer
-dump is not called during those timed loops; the cause remains unestablished.
+dump is not called during those timed loops. The code-placement experiments
+below reproduce and substantially reduce this regression without changing the
+emitted simulation instructions.
 Do not attribute the entire before/after difference to encoding or claim that
 all controls are unchanged. The full matrix, ranges, commands, and binary
 hashes are retained in `target/vcd-record-results/paired-256/`.
@@ -790,6 +792,157 @@ For the larger run use `--signals 4096 --steps 10000 --patterns full_width
 fresh Verilator fixtures. `binaries.json` links the saved executables to the
 runtime source snapshots; `output-equivalence.json` records the nine identical
 before/after validation waveform bodies and equal timed byte counts.
+
+### Investigation of the no-output regressions
+
+The complete-record implementation is committed as `e45be5052`. Follow-up
+experiments use the same saved baseline and optimized executables, CPU 0 on
+the Ryzen 7 9800X3D, and `/dev/null`. Builds and other benchmarks were excluded
+from timing runs. Code placement demonstrably affects both no-output controls;
+the particular CPU frontend mechanism remains unmeasured.
+
+First, an `mprotect` interposer captured the packed native JIT image before
+execution. The old and new executables emit byte-identical images in each mode:
+
+| Mode | Image bytes | SHA-256, identical before/after |
+| --- | ---: | --- |
+| off | 51,514 | `3400ee6c67fd55b389ceb4d3fb395811f870b7d80843b6103089b2a44d7a5174` |
+| instrumented | 63,165 | `03f7393ad9710a01a7466b5cdb65ae9b91e724727746a9f79f51d5bb5ca4a045` |
+
+A separate allocation interposer aligned the simulation state to either
+64 bytes or 4 KiB. The instrumented regression remained at both alignments.
+Whole-process instructions and branches were almost unchanged. Thus neither
+additional emitted JIT instructions nor state alignment alone explains it.
+
+Next, a diagnostic mapping interposer moved the entire instrumented image
+within its executable allocation, retaining its bytes and relative entry
+offsets. A five-process confirmation rotates all six version/placement
+combinations, after one warm process each. At 256 full-width dense counters
+and 5,000,000 cycles, medians are:
+
+| JIT start offset from page boundary | Before (ms) | Complete records (ms) | Before cycles (billions) | Complete-record cycles (billions) |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 1,096.909 | 1,511.675 | 6.345 | 8.337 |
+| 64 | 1,100.134 | 1,161.446 | 6.267 | 6.449 |
+| 4,096 | 1,098.994 | 1,550.816 | 6.264 | 8.412 |
+
+Elapsed times cover the simulation loop; hardware counters cover the whole
+process. All six variants retire approximately 16.364 billion instructions
+and 2.322 billion branches. Median branch misses range from 4.60 to 4.77 million;
+the extra cycles at offset zero do not accompany extra branch misses. Moving
+the image by 64 bytes reduces the elapsed-time regression from 37.8% to 5.6%.
+Moving by 4 KiB restores it. A 64-byte move preserves every instruction's
+position within a cache line, so individual loop alignment alone cannot
+explain this result. Interaction with other code through frontend caches or
+predictor indexing is a hypothesis consistent with these measurements.
+All six placements produce the same 20-cycle waveform body as the previously
+oracle-validated fixture. The initial three-process sweep also retains results
+for offsets 0, 16, 32, 48, and 64; none were discarded from their summaries.
+
+The standalone `collect` regression has a smaller reproducible example. Its
+hot `TraceLayout::take` loop has the same 36-byte instruction sequence after
+relocating branch destinations. In the baseline it starts at `0x1dec1`, offset
+1 within a 64-byte line; after the writer change it starts at `0x1e021`, offset
+33. In the latter position the flag comparison crosses the line boundary.
+A diagnostic trampoline places this loop at either offset in a page 1 MiB
+from the executable base. It retains all inner-loop instructions and adds
+jumps only on entry/exit. At 16,384 signals, 64 bits, 1,000,000 same-value dumps,
+one warm process and five rotated measured processes per variant give:
+
+| Mode | Loop offset within line | Before (ms) | Complete records (ms) | Before cycles (billions) | Complete-record cycles (billions) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| collect | 1 | 347.377 | 339.390 | 1.764 | 1.739 |
+| collect | 33 | 506.066 | 487.752 | 2.488 | 2.444 |
+| dirty | 1 | 752.042 | 730.221 | 3.737 | 3.630 |
+| dirty | 33 | 950.933 | 921.109 | 4.621 | 4.493 |
+
+At matching placement the original before/after regression disappears. Moving
+either version's loop by 32 bytes slows `collect` by 44–46% and `dirty` by
+about 26%, with the same work and effectively unchanged instruction counts
+within each binary/mode. Comparisons, changes, and bytes agree across variants.
+These trampoline times include their added jumps and are not directly
+comparable to the original benchmark's absolute times. An earlier trampoline
+64 MiB away also showed placement sensitivity but had noisier samples and a
+residual `collect` difference; those results remain in the raw records.
+
+AMD's [Zen 5 optimization guide, sections 2.8.2–2.8.3 and 2.9.1](https://docs.amd.com/v/u/en-US/58455_1.00)
+describes effects of loop/branch placement on prediction throughput and of
+Op Cache misses on instruction supply. This supports investigating frontend
+placement even when branch-miss counts remain low. The measurements above
+establish placement sensitivity, not a specific Op Cache conflict or loss of
+instruction fusion. Identifying that mechanism needs suitable frontend PMU
+events beyond the generic counters used here. The observed offsets are
+diagnostic interventions for these executables and this processor, rather
+than a generally validated JIT padding policy.
+
+Raw data and diagnostic sources are in the ignored directory
+`target/vcd-followup-results/`: `jit-captures.json`, `align-state-summary.json`,
+`shift-summary.json`, `shift-confirm-summary.json`, `loop-summary.json`, and
+`loop-near-summary.json`. The confirmation manifests record every command;
+summaries retain every measured sample, including outliers. `binaries.json`
+pins the executables. The C interposers are `capture-jit.c`, `align-state.c`,
+`shift-jit.c`, and `relocate-loop-near.c`; the latter two experiments are run
+by `measure-shift-confirm.py` and `measure-loop-near.py` after compiling each
+interposer with `gcc -O2 -Wall -Wextra -Werror -shared -fPIC`. Their fixed image
+size and instruction offsets apply only to the saved fixtures. The benchmark
+process receives `LD_PRELOAD` after `perf stat -- env`, so the diagnostic does
+not patch the profiler itself. `shift-confirm-validation.json` records the
+six identical validation waveforms.
+
+### Next steps toward Verilator
+
+The current 256-counter dense result needs a further 33.0% elapsed-time
+reduction to match Verilator in that run. The 4,096-counter result already
+has lower elapsed time, so both sizes remain necessary controls. The existing
+activity tracking still provides the sparse advantage.
+
+Grouping the new native profile's instruction addresses puts approximately
+34% of whole-process cycle samples in 64-bit encoding, 27% in signal-loop
+dispatch and scalar/integer comparisons, and 5% in suffix/output management.
+Separate `memmove` samples account for 5.7%. These are sampling estimates,
+including possible skid, rather than isolated costs or additive speedups.
+The address ranges are recorded in `writer-regions.json`.
+
+1. **Reduce 64-bit conversion instructions first.** The current SSE2 path
+   broadcasts words, shifts/masks them, and packs bytes before testing bits.
+   Verilator's [SSE2 conversion](https://github.com/verilator/verilator/blob/ea338be98e1e838d3518809ce8899f85a009963c/include/verilated_trace_imp.h#L474)
+   uses byte unpacking and shuffles instead. Compare that approach with the
+   current encoder while preserving leading-zero abbreviation, including
+   short counters, full-width data, and unaligned output. Test an AVX2 path
+   separately, selecting an entire encoding loop outside per-signal work.
+   The compared Verilator fixture uses `-O3 -flto` without `-march=native` or
+   `-mavx2`; its result does not require an AVX2 explanation. Even halving the
+   sampled conversion cost would imply only about 17% overall improvement,
+   so encoding alone is not an established solution to the remaining gap.
+
+2. **Move repeated signal decisions into trace construction.** Signal metadata
+   still has a 104-byte stride including names/scopes unused by normal dumps.
+   A compact trace plan can separate header data, precompute same-type runs,
+   and distinguish the initial snapshot from steady-state comparisons.
+   Validate memory coverage before the loop, preserving the public slice
+   bounds contract, and reduce repeated indexing checks. Verilator's
+   [typed comparison primitives](https://github.com/verilator/verilator/blob/ea338be98e1e838d3518809ce8899f85a009963c/include/verilated_trace.h#L398)
+   are called from generated fixed-offset code. Celox can first specialize
+   its trace plan without runtime code rewriting, retaining registration
+   order, aliases, external values, and the four-state fallback.
+
+3. **Revisit the remaining output-buffer copy after those changes.** Complete
+   records removed short-ID copy calls, while dump tails still pass through
+   `BufWriter`. Eliminating all sampled `memmove` time would save only about
+   5.7% in isolation. A single output buffer may also reduce surrounding
+   bookkeeping, but must retain timestamp ordering, flush/Drop behavior,
+   short-write handling, and I/O error propagation.
+
+Use instruction counts together with elapsed-time distributions, preserving
+`off`, `instrumented`, and `collect` controls. A source change can move unrelated
+hot code even when the generated simulation image is identical. Benchmark
+candidate loop layouts across circuit sizes and sparse/dense patterns before
+adopting a padding policy. PGO can affect placement and inlining, but the
+0.082% dense branch-miss rate gives little evidence for prioritizing branch
+hints over removing work. The next implementation should isolate the SSE2
+conversion change, then repeat the existing waveform oracle and paired native
+matrix; the candidate improvements above have not yet been implemented or
+measured as production changes.
 
 ## Correctness
 

--- a/docs/ja/benchmarks/index.md
+++ b/docs/ja/benchmarks/index.md
@@ -57,7 +57,13 @@ pnpm bench
 
 # Verilator 比較（Verilator と C++ ツールチェーンが必要）
 bash scripts/run-verilator-bench.sh
+
+# VCD 比較（Python 3 も必要。波形の一致を検証してから計測）
+python3 scripts/compare-vcd-verilator.py
 ```
+
+[VCD の測定条件と結果](../../internals/vcd-performance.md#verilator-comparison)には、
+idle・sparse・dense の各負荷で、記録なし／ありを比較した結果をまとめています。
 
 CodSpeed ワークフローは pull request と `master` でベンチマークを実行します。
 CodSpeed は `merge_group` event をサポートしていないため、merge queue では

--- a/docs/ja/guide/vcd.md
+++ b/docs/ja/guide/vcd.md
@@ -26,8 +26,12 @@ sim.dispose();    // ファイルをフラッシュして閉じる
 ```
 
 ::: warning
-VCD ファイルは `dispose()` を呼ぶまで書き出されません。終了時は必ず `dispose()` を呼ぶか、try/finally ブロックで確実に実行してください。
+VCD 出力はバッファリングされます。残りのデータを書き出すため、終了時は必ず `dispose()` を呼ぶか、try/finally ブロックで確実に実行してください。
 :::
+
+Rust では `Simulator::flush_vcd()` または `Simulation::flush_vcd()` を呼ぶと、
+シミュレータの破棄前に出力を反映し、書き込みエラーを処理できます。
+単独の `VcdWriter` では `flush()` と `into_inner()` を使用できます。
 
 ## タイムベースシミュレーションでの使い方
 

--- a/scripts/compare-vcd-verilator.py
+++ b/scripts/compare-vcd-verilator.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Build, validate, and time equivalent Celox/Verilator VCD workloads.
+
+Requires Python 3, Verilator, a C++ toolchain, and Cargo. All generated files and
+individual results live under --output. No builds run during timing samples.
+"""
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import re
+import resource
+import shutil
+import statistics
+import subprocess
+import tempfile
+import time
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "benches/verilator/bench_vcd.cpp"
+RUST_BENCH = ROOT / "crates/celox/benches/vcd.rs"
+CASES = ("idle", "sparse", "dense")
+MODES = ("off", "instrumented", "vcd")
+
+
+def positive(value):
+    number = int(value)
+    if number < 1:
+        raise argparse.ArgumentTypeError("must be positive")
+    return number
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def write_json(path, value):
+    path.write_text(json.dumps(value, indent=2) + "\n")
+
+
+def cache_celox_binaries(output, celox, baseline=None):
+    sources = {"celox": (celox, "celox-vcd")}
+    if baseline is not None:
+        sources["baseline_celox"] = (baseline, "celox-before")
+    # Snapshot every input before replacing a cached binary: the baseline can
+    # be the previous celox-vcd in this same output directory.
+    with tempfile.TemporaryDirectory(prefix="cache-", dir=output) as staging:
+        for source, name in sources.values():
+            shutil.copy2(source, Path(staging) / name)
+        for _, name in sources.values():
+            (Path(staging) / name).replace(output / name)
+    return {engine: output / name for engine, (_, name) in sources.items()}
+
+
+def generate_fixture(folder, signals, full_width, verify_only=False):
+    high_bit = (1 << 63) if full_width else 0
+    ports = ["input logic clk", "input logic rst"]
+    body = []
+    setters = []
+    checks = []
+    for i in range(signals):
+        initial = high_bit | (i + 1)
+        increment = i * 2 + 1
+        ports.extend((f"input logic en{i}", f"output logic [63:0] q{i}"))
+        body.append(
+            f"always_ff @(posedge clk or negedge rst) begin\n"
+            f"  if (!rst) q{i} <= 64'd{initial};\n"
+            f"  else if (en{i}) q{i} <= q{i} + 64'd{increment};\nend\n"
+        )
+        setters.append(f"    top.en{i} = {i} < active;")
+        checks.append(
+            f"    if (top.q{i} != (UINT64_C({initial}) + "
+            f"({i} < active ? ticks * UINT64_C({increment}) : 0)))\n"
+            f'        throw std::runtime_error("unexpected q{i}");'
+        )
+    verilog = (
+        "module Top (\n" + ",\n".join(ports) + ");\n"
+        "timeunit 1ns; timeprecision 1ns;\n" + "".join(body) + "endmodule\n"
+    )
+    header = (
+        "#pragma once\n#include <cstdint>\n#include <stdexcept>\n"
+        f"constexpr unsigned kSignals = {signals};\n"
+        "inline void set_enables(VTop& top, unsigned active) {\n"
+        + "\n".join(setters) + "\n}\n"
+        "inline void verify_counters(const VTop& top, unsigned active, uint64_t ticks) {\n"
+        + "\n".join(checks) + "\n}\n"
+    )
+    for name, text in (("Top.sv", verilog), ("vcd_fixture.h", header)):
+        path = folder / name
+        if verify_only:
+            if path.read_text() != text:
+                raise ValueError(f"{path} differs from this fixture; omit --reuse-builds")
+        else:
+            path.write_text(text)
+
+
+def read_waveform(path):
+    """Canonicalize this fixture's VCD by names/widths and actual transitions.
+
+    Identifier assignments, scopes, leading zeros, redundant records, and empty
+    timestamps may differ. Missing/extra signals and wrong values must fail.
+    """
+    widths = {}
+    identifiers = {}
+    values = {}
+    events = {}
+    timestamp = None
+    in_header = True
+    header = []
+    with path.open() as source:
+        for raw in source:
+            line = raw.strip()
+            if in_header:
+                header.append(line)
+                if line.startswith("$var "):
+                    fields = line.split()
+                    width, identifier, name = int(fields[2]), fields[3], fields[4]
+                    if name in widths or identifier in identifiers:
+                        raise ValueError(f"{path}: duplicate signal/identifier: {line}")
+                    widths[name] = width
+                    identifiers[identifier] = name
+                elif line.startswith("$enddefinitions"):
+                    in_header = False
+                continue
+            if not line or line.startswith("$"):
+                continue
+            if line.startswith("#"):
+                next_time = int(line[1:])
+                if timestamp is not None and next_time < timestamp:
+                    raise ValueError(f"{path}: timestamp went backwards")
+                timestamp = next_time
+                continue
+            if timestamp is None:
+                raise ValueError(f"{path}: value before first timestamp")
+            if line[0] in "bB":
+                bits, identifier = line[1:].split()
+            elif line[0] in "01xXzZ":
+                bits, identifier = line[0], line[1:]
+            else:
+                raise ValueError(f"{path}: unsupported value record: {line}")
+            name = identifiers[identifier]
+            if len(bits) > widths[name] or any(bit not in "01" for bit in bits):
+                raise ValueError(f"{path}: invalid two-state value: {line}")
+            value = int(bits, 2)
+            if values.get(name) != value:
+                key = (timestamp, name)
+                if key in events:
+                    raise ValueError(f"{path}: multiple transitions at {key}")
+                events[key] = value
+                values[name] = value
+    if in_header:
+        raise ValueError(f"{path}: missing VCD header")
+    scale = re.search(r"\$timescale\s+1\s*ns\s+\$end", " ".join(header))
+    if not scale:
+        raise ValueError(f"{path}: expected a 1 ns timescale")
+    return widths, events
+
+
+def expected_waveform(signals, steps, case, full_width):
+    active = 0 if case == "idle" else max(1, signals // 100) if case == "sparse" else signals
+    high_bit = (1 << 63) if full_width else 0
+    widths = {"clk": 1, "rst": 1}
+    events = {(0, "clk"): 0, (0, "rst"): 1}
+    for i in range(signals):
+        widths[f"en{i}"] = 1
+        widths[f"q{i}"] = 64
+        events[0, f"en{i}"] = int(i < active)
+        events[0, f"q{i}"] = (high_bit | (i + 1)) + (i * 2 + 1 if i < active else 0)
+    for step in range(1, steps + 1):
+        if step > 1:
+            events[step * 2, "clk"] = 0
+        events[step * 2 + 1, "clk"] = 1
+        for i in range(active):
+            events[step * 2 + 1, f"q{i}"] = (
+                (high_bit | (i + 1)) + (step + 1) * (i * 2 + 1)
+            ) & ((1 << 64) - 1)
+    return widths, events
+
+
+def validate_waveform(path, expected):
+    actual = read_waveform(path)
+    if actual[0] != expected[0]:
+        raise ValueError(f"{path}: traced signal names or widths differ from the fixture")
+    if actual[1] != expected[1]:
+        keys = sorted(actual[1].keys() | expected[1].keys())
+        for key in keys:
+            if actual[1].get(key) != expected[1].get(key):
+                raise ValueError(
+                    f"{path}: at {key}, got {actual[1].get(key)}, "
+                    f"expected {expected[1].get(key)}"
+                )
+    normalized = json.dumps(sorted(actual[1].items())).encode()
+    return {"signals": len(actual[0]), "transitions": len(actual[1]),
+            "normalized_sha256": hashlib.sha256(normalized).hexdigest(),
+            "file_bytes": path.stat().st_size}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--verilator", default=shutil.which("verilator"))
+    parser.add_argument("--celox", type=Path, help="existing celox --bench vcd executable; otherwise build it")
+    parser.add_argument("--baseline-celox", type=Path, help="also validate and time an earlier Celox benchmark")
+    parser.add_argument("--output", type=Path, default=ROOT / "target/vcd-verilator-results")
+    parser.add_argument("--signals", type=positive, default=256)
+    parser.add_argument("--steps", type=positive, default=100_000)
+    parser.add_argument("--repeats", type=positive, default=5)
+    parser.add_argument("--check-steps", type=positive, default=20)
+    parser.add_argument("--check-only", action="store_true", help="build and check waveforms without timing runs")
+    parser.add_argument("--reuse-builds", action="store_true", help="reuse binaries verified against an earlier manifest")
+    parser.add_argument("--stack-mib", type=positive, default=64, help="stack limit for this process and its children")
+    parser.add_argument("--cpu", type=int, default=min(os.sched_getaffinity(0)))
+    parser.add_argument("--jobs", type=positive, default=min(8, os.cpu_count() or 1))
+    parser.add_argument("--patterns", nargs="+", choices=("counter", "full_width"), default=["counter", "full_width"])
+    parser.add_argument("--cases", nargs="+", choices=CASES, default=list(CASES))
+    parser.add_argument("--modes", nargs="+", choices=MODES, default=list(MODES))
+    args = parser.parse_args()
+    if not args.verilator:
+        parser.error("Verilator is required; use --verilator /path/to/verilator")
+    verilator = str(Path(args.verilator).resolve())
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    previous = json.loads((output / "manifest.json").read_text()) if args.reuse_builds else None
+    _, hard_stack = resource.getrlimit(resource.RLIMIT_STACK)
+    resource.setrlimit(resource.RLIMIT_STACK, (args.stack_mib * 1024 * 1024, hard_stack))
+    environment = {key: value for key, value in os.environ.items() if not key.startswith("VCD_")}
+    # Large generated port lists also need more stack in frontend worker threads.
+    environment["RUST_MIN_STACK"] = str(args.stack_mib * 1024 * 1024)
+    manifest = {
+        "options": {key: str(value) if isinstance(value, Path) else value for key, value in vars(args).items()},
+        "kernel": os.uname().release,
+        "cpu": subprocess.check_output(["lscpu"], text=True),
+        "verilator": subprocess.check_output([verilator, "--version"], text=True).strip(),
+        "cxx": subprocess.check_output(["g++", "--version"], text=True).splitlines()[0],
+        "rustc": subprocess.check_output(["rustc", "--version"], text=True).strip(),
+        "git_head": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT, text=True).strip(),
+        "git_status": subprocess.check_output(["git", "status", "--porcelain"], cwd=ROOT, text=True),
+        "source_sha256": {str(path.relative_to(ROOT)): digest(path) for path in (HARNESS, RUST_BENCH, Path(__file__))},
+        "timing_scope": "steady-state execution and final flush; excludes construction, reset and initial snapshot",
+        "environment": {"RUST_MIN_STACK": environment["RUST_MIN_STACK"]},
+        "builds": [], "validation": {}, "binaries": {}, "runs": [],
+    }
+
+    def build(command, label):
+        start = time.monotonic_ns()
+        with (output / f"{label}.log").open("w") as log:
+            subprocess.run(command, cwd=ROOT, env=environment, stdout=log, stderr=subprocess.STDOUT, check=True)
+        manifest["builds"].append({"command": command, "elapsed_ns": time.monotonic_ns() - start})
+        write_json(output / "manifest.json", manifest)
+
+    if previous:
+        if previous["options"]["signals"] != args.signals or previous["verilator"] != manifest["verilator"]:
+            raise ValueError("cached build settings differ; omit --reuse-builds")
+        for source in (HARNESS, RUST_BENCH):
+            name = str(source.relative_to(ROOT))
+            if previous["source_sha256"][name] != digest(source):
+                raise ValueError(f"{name} changed; omit --reuse-builds")
+        for binary, expected_hash in previous["binaries"].items():
+            if digest(Path(binary)) != expected_hash:
+                raise ValueError(f"{binary} changed; omit --reuse-builds")
+        manifest["builds"] = previous["builds"]
+        manifest["reused_builds"] = True
+        celox = args.celox.resolve() if args.celox else output / "celox-vcd"
+    elif args.celox:
+        celox = args.celox.resolve()
+    else:
+        print("Building the Celox benchmark", flush=True)
+        build(["cargo", "bench", "--locked", "-p", "celox", "--bench", "vcd", "--no-run", "--message-format=json"], "build-celox")
+        artifacts = []
+        for line in (output / "build-celox.log").read_text().splitlines():
+            if line.startswith("{"):
+                record = json.loads(line)
+                if record.get("reason") == "compiler-artifact" and record["target"]["name"] == "vcd" and record.get("executable"):
+                    artifacts.append(record["executable"])
+        if len(artifacts) != 1:
+            raise ValueError("could not identify the Celox benchmark executable")
+        celox = Path(artifacts[0])
+    celox_engines = cache_celox_binaries(output, celox, args.baseline_celox)
+    for binary in celox_engines.values():
+        manifest["binaries"][str(binary)] = digest(binary)
+    engines = (*celox_engines, "verilator")
+    verilated = {}
+    for pattern in args.patterns:
+        folder = output / pattern
+        folder.mkdir(exist_ok=True)
+        generate_fixture(folder, args.signals, pattern == "full_width", verify_only=bool(previous))
+        for traced in (False, True):
+            label = f"{pattern}-{'traced' if traced else 'off'}"
+            obj = folder / ("obj_traced" if traced else "obj_off")
+            binary = obj / "VTop"
+            if previous:
+                if str(binary) not in previous["binaries"]:
+                    raise ValueError(f"no verified cached build for {binary}; omit --reuse-builds")
+                verilated[pattern, traced] = binary
+                manifest["binaries"][str(binary)] = digest(binary)
+                continue
+            print(f"Building Verilator {label}", flush=True)
+            command = [verilator, "--cc", "-O3", "--threads", "1", "--top-module", "Top",
+                       "--Mdir", str(obj), "--exe", str(HARNESS), str(folder / "Top.sv"),
+                       "-CFLAGS", f"-O3 -flto -I{folder}", "-LDFLAGS", "-flto"]
+            if traced:
+                command.extend(("--trace-vcd", "--no-trace-top", "--no-trace-params"))
+            build(command, f"generate-{label}")
+            build(["make", "-C", str(obj), "-f", "VTop.mk", f"-j{args.jobs}",
+                   "OPT_FAST=-O3", "OPT_SLOW=-O3", "OPT_GLOBAL=-O3"], f"build-{label}")
+            binary = obj / "VTop"
+            verilated[pattern, traced] = binary
+            manifest["binaries"][str(binary)] = digest(binary)
+            write_json(output / "manifest.json", manifest)
+    # Build first; only benchmark subprocesses inherit this affinity.
+    os.sched_setaffinity(0, {args.cpu})
+
+    def run(engine, mode, case, pattern, steps, destination, label):
+        full_width = pattern == "full_width"
+        options = {}
+        if engine in celox_engines:
+            options = {"VCD_BACKEND": "native", "VCD_SIGNALS": str(args.signals),
+                       "VCD_STEPS": str(steps), "VCD_REPEATS": "1", "VCD_CASE": case,
+                       "VCD_MODE": "dirty" if mode == "vcd" else mode,
+                       "VCD_FULL_WIDTH": str(int(full_width)), "VCD_OUTPUT": str(destination)}
+            command = [str(celox_engines[engine])]
+        else:
+            command = [str(verilated[pattern, mode != "off"]), mode, case, str(steps), str(destination)]
+        result = subprocess.run(command, env={**environment, **options}, capture_output=True, text=True)
+        (output / f"{label}.csv").write_text(result.stdout)
+        (output / f"{label}.log").write_text(result.stderr)
+        result.check_returncode()
+        rows = list(csv.DictReader(io.StringIO(result.stdout)))
+        if len(rows) != 1:
+            raise ValueError(f"{label}: expected one CSV result")
+        row = rows[0]
+        if (int(row["signals"]), int(row["steps"]), row["case"]) != (args.signals, steps, case):
+            raise ValueError(f"{label}: unexpected benchmark settings: {row}")
+        # Celox reports value-line bytes separately; its writer emits every
+        # requested timestamp, including the unchanged first low clock phase.
+        total_bytes = int(row.get("bytes", 0))
+        if engine in celox_engines and mode == "vcd":
+            total_bytes = int(row["value_bytes"]) + sum(len(str(t)) + 2 for t in range(2, steps * 2 + 2))
+        manifest["runs"].append({"label": label, "command": command, "environment": options})
+        return {"engine": engine, "mode": mode, "case": case, "pattern": pattern,
+                "elapsed_ns": int(row["elapsed_ns"]), "bytes": total_bytes}
+
+    print("Validating both waveforms against the counter oracle", flush=True)
+    for pattern in args.patterns:
+        for case in args.cases:
+            expected = expected_waveform(args.signals, args.check_steps, case, pattern == "full_width")
+            for engine in engines:
+                label = f"check-{pattern}-{case}-{engine}"
+                path = output / f"{label}.vcd"
+                run(engine, "vcd", case, pattern, args.check_steps, path, label)
+                manifest["validation"][label] = validate_waveform(path, expected)
+    write_json(output / "manifest.json", manifest)
+    if args.check_only:
+        print(f"All waveforms validated; results: {output}", flush=True)
+        return
+
+    samples = []
+    for pattern in args.patterns:
+        for case in args.cases:
+            # Warm both binaries/modes before collecting independent processes.
+            for mode in args.modes:
+                for engine in engines:
+                    run(engine, mode, case, pattern, args.steps, "/dev/null",
+                        f"warm-{pattern}-{case}-{mode}-{engine}")
+            for repeat in range(args.repeats):
+                start = repeat % len(engines)
+                engine_order = engines[start:] + engines[:start]
+                modes = args.modes if repeat % 2 == 0 else tuple(reversed(args.modes))
+                for mode in modes:
+                    for engine in engine_order:
+                        row = run(engine, mode, case, pattern, args.steps, "/dev/null",
+                                  f"sample-{pattern}-{case}-{mode}-{engine}-{repeat}")
+                        samples.append({**row, "repeat": repeat})
+            print(f"Measured {pattern} {case}", flush=True)
+            write_json(output / "samples.json", samples)
+            write_json(output / "manifest.json", manifest)
+
+    summary = []
+    for pattern in args.patterns:
+        for case in args.cases:
+            for mode in args.modes:
+                line = {"pattern": pattern, "case": case, "mode": mode}
+                for engine in engines:
+                    rows = [row for row in samples if (row["pattern"], row["case"], row["mode"], row["engine"]) == (pattern, case, mode, engine)]
+                    times = [row["elapsed_ns"] for row in rows]
+                    byte_counts = {row["bytes"] for row in rows}
+                    if len(byte_counts) != 1:
+                        raise ValueError(f"{engine} {pattern} {case}: output sizes changed between repetitions")
+                    line[engine] = {"median_ns": statistics.median(times), "min_ns": min(times),
+                                    "max_ns": max(times), "bytes": byte_counts.pop()}
+                line["celox_over_verilator"] = line["celox"]["median_ns"] / line["verilator"]["median_ns"]
+                baseline_text = ""
+                if "baseline_celox" in line:
+                    line["celox_over_baseline"] = line["celox"]["median_ns"] / line["baseline_celox"]["median_ns"]
+                    baseline_text = f'Baseline {line["baseline_celox"]["median_ns"] / 1e6:9.3f} ms, '
+                summary.append(line)
+                print(f"{pattern:10} {case:6} {mode:12} "
+                      + baseline_text +
+                      f'Celox {line["celox"]["median_ns"] / 1e6:9.3f} ms, '
+                      f'Verilator {line["verilator"]["median_ns"] / 1e6:9.3f} ms, '
+                      f'Celox/Verilator {line["celox_over_verilator"]:.3f}x', flush=True)
+    write_json(output / "summary.json", summary)
+    print(f"All waveforms validated; results: {output}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare-vcd-verilator.py
+++ b/scripts/compare-vcd-verilator.py
@@ -200,6 +200,68 @@ def validate_waveform(path, expected):
             "file_bytes": path.stat().st_size}
 
 
+def validate_reused_builds(previous, current):
+    # Compare the complete recorded build context, including the runner that
+    # selects flags. Timing-only options may change without relabeling a build.
+    for key in ("source_sha256", "verilator", "cxx", "rustc", "git_head",
+                "git_status", "git_diff_sha256", "environment", "build_commands"):
+        if key not in previous or previous[key] != current[key]:
+            raise ValueError(f"cached {key} differs; omit --reuse-builds")
+    for key in ("signals", "celox", "baseline_celox"):
+        if previous.get("options", {}).get(key) != current["options"][key]:
+            raise ValueError(f"cached {key} differs; omit --reuse-builds")
+    commands = [build["command"] for build in previous.get("builds", [])]
+    if commands != current["build_commands"] or not previous.get("binaries"):
+        raise ValueError("cached build history is incomplete or differs; omit --reuse-builds")
+    for binary, expected_hash in previous["binaries"].items():
+        if not Path(binary).is_file() or digest(Path(binary)) != expected_hash:
+            raise ValueError(f"{binary} changed; omit --reuse-builds")
+
+
+def plan_builds(args, verilator, output):
+    commands = {}
+    if not args.celox:
+        commands["build-celox"] = ["cargo", "bench", "--locked", "-p", "celox", "--bench", "vcd",
+                                   "--no-run", "--message-format=json"]
+    for pattern in args.patterns:
+        folder = output / pattern
+        for traced in (False, True):
+            label = f"{pattern}-{'traced' if traced else 'off'}"
+            obj = folder / ("obj_traced" if traced else "obj_off")
+            command = [verilator, "--cc", "-O3", "--threads", "1", "--top-module", "Top",
+                       "--Mdir", str(obj), "--exe", str(HARNESS), str(folder / "Top.sv"),
+                       "-CFLAGS", f"-O3 -flto -I{folder}", "-LDFLAGS", "-flto"]
+            if traced:
+                command.extend(("--trace-vcd", "--no-trace-top", "--no-trace-params"))
+            commands[f"generate-{label}"] = command
+            commands[f"build-{label}"] = ["make", "-C", str(obj), "-f", "VTop.mk", f"-j{args.jobs}",
+                                          "OPT_FAST=-O3", "OPT_SLOW=-O3", "OPT_GLOBAL=-O3"]
+    return commands
+
+
+def build_environment(environment):
+    names = {"RUST_MIN_STACK", "RUSTFLAGS", "CARGO_ENCODED_RUSTFLAGS", "CARGO_BUILD_RUSTFLAGS",
+             "RUSTC", "RUSTC_WRAPPER", "RUSTC_WORKSPACE_WRAPPER", "RUSTUP_TOOLCHAIN",
+             "CARGO_BUILD_TARGET", "CARGO_TARGET_DIR", "CC", "CXX", "AR", "CFLAGS", "CXXFLAGS",
+             "CPPFLAGS", "LDFLAGS", "MAKEFLAGS", "VERILATOR_ROOT", "VERILATOR_BIN"}
+    return {key: value for key, value in environment.items()
+            if key in names or key.startswith("CARGO_PROFILE_BENCH_")
+            or (key.startswith("CARGO_TARGET_") and key.endswith(("_RUSTFLAGS", "_LINKER", "_AR")))}
+
+
+def source_digests():
+    sources = {HARNESS, RUST_BENCH, Path(__file__).resolve()}
+    # The git diff below covers tracked edits. Include untracked build inputs
+    # too: changing their contents need not change `git status --porcelain`.
+    untracked = subprocess.check_output(
+        ["git", "ls-files", "--others", "--exclude-standard", "-z", "--",
+         "crates", "vendor", ".cargo", "benches/verilator", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml"],
+        cwd=ROOT,
+    )
+    sources.update(ROOT / os.fsdecode(path) for path in untracked.split(b"\0") if path)
+    return {str(path.relative_to(ROOT)): digest(path) for path in sorted(sources) if path.is_file()}
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--verilator", default=shutil.which("verilator"))
@@ -230,6 +292,7 @@ def main():
     environment = {key: value for key, value in os.environ.items() if not key.startswith("VCD_")}
     # Large generated port lists also need more stack in frontend worker threads.
     environment["RUST_MIN_STACK"] = str(args.stack_mib * 1024 * 1024)
+    planned = plan_builds(args, verilator, output)
     manifest = {
         "options": {key: str(value) if isinstance(value, Path) else value for key, value in vars(args).items()},
         "kernel": os.uname().release,
@@ -239,37 +302,40 @@ def main():
         "rustc": subprocess.check_output(["rustc", "--version"], text=True).strip(),
         "git_head": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT, text=True).strip(),
         "git_status": subprocess.check_output(["git", "status", "--porcelain"], cwd=ROOT, text=True),
-        "source_sha256": {str(path.relative_to(ROOT)): digest(path) for path in (HARNESS, RUST_BENCH, Path(__file__))},
+        "git_diff_sha256": hashlib.sha256(subprocess.check_output(
+            ["git", "diff", "HEAD", "--binary"], cwd=ROOT)).hexdigest(),
+        "source_sha256": source_digests(),
         "timing_scope": "steady-state execution and final flush; excludes construction, reset and initial snapshot",
-        "environment": {"RUST_MIN_STACK": environment["RUST_MIN_STACK"]},
+        "environment": build_environment(environment),
+        "build_commands": list(planned.values()),
         "builds": [], "validation": {}, "binaries": {}, "runs": [],
     }
 
-    def build(command, label):
+    def build(label):
+        command = planned[label]
         start = time.monotonic_ns()
         with (output / f"{label}.log").open("w") as log:
             subprocess.run(command, cwd=ROOT, env=environment, stdout=log, stderr=subprocess.STDOUT, check=True)
         manifest["builds"].append({"command": command, "elapsed_ns": time.monotonic_ns() - start})
         write_json(output / "manifest.json", manifest)
 
-    if previous:
-        if previous["options"]["signals"] != args.signals or previous["verilator"] != manifest["verilator"]:
-            raise ValueError("cached build settings differ; omit --reuse-builds")
-        for source in (HARNESS, RUST_BENCH):
-            name = str(source.relative_to(ROOT))
-            if previous["source_sha256"][name] != digest(source):
-                raise ValueError(f"{name} changed; omit --reuse-builds")
-        for binary, expected_hash in previous["binaries"].items():
-            if digest(Path(binary)) != expected_hash:
-                raise ValueError(f"{binary} changed; omit --reuse-builds")
+    if previous is not None:
+        validate_reused_builds(previous, manifest)
         manifest["builds"] = previous["builds"]
         manifest["reused_builds"] = True
-        celox = args.celox.resolve() if args.celox else output / "celox-vcd"
+        # Reuse the verified snapshots, including a baseline whose original
+        # source may have aliased celox-vcd before that file was replaced.
+        celox_engines = {"celox": output / "celox-vcd"}
+        if args.baseline_celox:
+            celox_engines["baseline_celox"] = output / "celox-before"
+        for binary in celox_engines.values():
+            if str(binary) not in previous["binaries"]:
+                raise ValueError(f"no verified cached build for {binary}; omit --reuse-builds")
     elif args.celox:
         celox = args.celox.resolve()
     else:
         print("Building the Celox benchmark", flush=True)
-        build(["cargo", "bench", "--locked", "-p", "celox", "--bench", "vcd", "--no-run", "--message-format=json"], "build-celox")
+        build("build-celox")
         artifacts = []
         for line in (output / "build-celox.log").read_text().splitlines():
             if line.startswith("{"):
@@ -279,7 +345,8 @@ def main():
         if len(artifacts) != 1:
             raise ValueError("could not identify the Celox benchmark executable")
         celox = Path(artifacts[0])
-    celox_engines = cache_celox_binaries(output, celox, args.baseline_celox)
+    if previous is None:
+        celox_engines = cache_celox_binaries(output, celox, args.baseline_celox)
     for binary in celox_engines.values():
         manifest["binaries"][str(binary)] = digest(binary)
     engines = (*celox_engines, "verilator")
@@ -287,26 +354,20 @@ def main():
     for pattern in args.patterns:
         folder = output / pattern
         folder.mkdir(exist_ok=True)
-        generate_fixture(folder, args.signals, pattern == "full_width", verify_only=bool(previous))
+        generate_fixture(folder, args.signals, pattern == "full_width", verify_only=previous is not None)
         for traced in (False, True):
             label = f"{pattern}-{'traced' if traced else 'off'}"
             obj = folder / ("obj_traced" if traced else "obj_off")
             binary = obj / "VTop"
-            if previous:
+            if previous is not None:
                 if str(binary) not in previous["binaries"]:
                     raise ValueError(f"no verified cached build for {binary}; omit --reuse-builds")
                 verilated[pattern, traced] = binary
                 manifest["binaries"][str(binary)] = digest(binary)
                 continue
             print(f"Building Verilator {label}", flush=True)
-            command = [verilator, "--cc", "-O3", "--threads", "1", "--top-module", "Top",
-                       "--Mdir", str(obj), "--exe", str(HARNESS), str(folder / "Top.sv"),
-                       "-CFLAGS", f"-O3 -flto -I{folder}", "-LDFLAGS", "-flto"]
-            if traced:
-                command.extend(("--trace-vcd", "--no-trace-top", "--no-trace-params"))
-            build(command, f"generate-{label}")
-            build(["make", "-C", str(obj), "-f", "VTop.mk", f"-j{args.jobs}",
-                   "OPT_FAST=-O3", "OPT_SLOW=-O3", "OPT_GLOBAL=-O3"], f"build-{label}")
+            build(f"generate-{label}")
+            build(f"build-{label}")
             binary = obj / "VTop"
             verilated[pattern, traced] = binary
             manifest["binaries"][str(binary)] = digest(binary)

--- a/scripts/tests/test_compare_vcd_verilator.py
+++ b/scripts/tests/test_compare_vcd_verilator.py
@@ -1,6 +1,7 @@
 """Guard against accepting unlike VCD workloads as a valid comparison."""
 
 import importlib.util
+import copy
 from pathlib import Path
 import tempfile
 import unittest
@@ -97,6 +98,91 @@ class WaveformComparisonTests(unittest.TestCase):
             )
             self.assertEqual(swapped["celox"].read_bytes(), b"before")
             self.assertEqual(swapped["baseline_celox"].read_bytes(), b"after")
+
+
+class BuildReuseTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        binary = Path(self.temporary.name) / "celox-vcd"
+        binary.write_bytes(b"cached executable")
+        self.binary = binary
+        self.manifest = {
+            "options": {"signals": 256, "celox": None, "baseline_celox": None, "steps": 100},
+            "source_sha256": {str(path.relative_to(BENCH.ROOT)): BENCH.digest(path)
+                              for path in (BENCH.HARNESS, BENCH.RUST_BENCH, SCRIPT)},
+            "rustc": "rustc version 1", "cxx": "g++ version 1", "verilator": "Verilator version 1",
+            "git_head": "revision", "git_status": "", "git_diff_sha256": "clean",
+            "environment": {"RUST_MIN_STACK": "67108864"},
+            "build_commands": [["cargo", "bench", "--locked"]],
+            "builds": [{"command": ["cargo", "bench", "--locked"], "elapsed_ns": 1}],
+            "binaries": {str(binary): BENCH.digest(binary)},
+        }
+
+    def test_unchanged_builds_allow_different_measurement_options(self):
+        current = copy.deepcopy(self.manifest)
+        current["options"].update(steps=1000, repeats=7, cpu=1, cases=["idle"])
+        BENCH.validate_reused_builds(self.manifest, current)
+
+    def test_changed_recorded_build_inputs_are_rejected(self):
+        for field in ("rustc", "cxx", "verilator", "git_head", "git_status", "git_diff_sha256"):
+            with self.subTest(field=field):
+                current = copy.deepcopy(self.manifest)
+                current[field] += " changed"
+                with self.assertRaisesRegex(ValueError, "omit --reuse-builds"):
+                    BENCH.validate_reused_builds(self.manifest, current)
+        for source in self.manifest["source_sha256"]:
+            with self.subTest(source=source):
+                current = copy.deepcopy(self.manifest)
+                current["source_sha256"][source] = "changed"
+                with self.assertRaisesRegex(ValueError, "omit --reuse-builds"):
+                    BENCH.validate_reused_builds(self.manifest, current)
+        for field, replacement in (("build_commands", [["cargo", "bench", "--release"]]),
+                                   ("environment", {"RUSTFLAGS": "-C target-cpu=native"})):
+            with self.subTest(field=field):
+                current = copy.deepcopy(self.manifest)
+                current[field] = replacement
+                with self.assertRaisesRegex(ValueError, "omit --reuse-builds"):
+                    BENCH.validate_reused_builds(self.manifest, current)
+
+    def test_changed_build_options_are_rejected(self):
+        for option, value in (("signals", 512), ("celox", "/another/binary"),
+                              ("baseline_celox", "/another/baseline")):
+            with self.subTest(option=option):
+                current = copy.deepcopy(self.manifest)
+                current["options"][option] = value
+                with self.assertRaisesRegex(ValueError, "omit --reuse-builds"):
+                    BENCH.validate_reused_builds(self.manifest, current)
+
+    def test_incomplete_or_changed_build_history_is_rejected(self):
+        for history in ([], [{"command": ["cargo", "bench", "--different-flags"]}]):
+            with self.subTest(history=history):
+                previous = copy.deepcopy(self.manifest)
+                previous["builds"] = history
+                with self.assertRaisesRegex(ValueError, "omit --reuse-builds"):
+                    BENCH.validate_reused_builds(previous, self.manifest)
+
+    def test_changed_cached_binary_is_rejected(self):
+        self.binary.write_bytes(b"different executable")
+        with self.assertRaisesRegex(ValueError, "omit --reuse-builds"):
+            BENCH.validate_reused_builds(self.manifest, self.manifest)
+
+    def test_old_manifests_and_missing_binaries_are_rejected(self):
+        previous = copy.deepcopy(self.manifest)
+        del previous["build_commands"]
+        with self.assertRaisesRegex(ValueError, "omit --reuse-builds"):
+            BENCH.validate_reused_builds(previous, self.manifest)
+        self.binary.unlink()
+        with self.assertRaisesRegex(ValueError, "omit --reuse-builds"):
+            BENCH.validate_reused_builds(self.manifest, self.manifest)
+
+    def test_compiler_environment_is_recorded_without_credentials(self):
+        environment = {"RUSTFLAGS": "-C target-cpu=native", "CXXFLAGS": "-O2",
+                       "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS": "-C opt-level=2",
+                       "CARGO_PROFILE_BENCH_LTO": "false", "RUST_MIN_STACK": "67108864",
+                       "CARGO_REGISTRY_TOKEN": "private", "UNRELATED_SECRET": "private"}
+        actual = BENCH.build_environment(environment)
+        self.assertEqual(actual, {key: value for key, value in environment.items() if value != "private"})
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_compare_vcd_verilator.py
+++ b/scripts/tests/test_compare_vcd_verilator.py
@@ -1,0 +1,103 @@
+"""Guard against accepting unlike VCD workloads as a valid comparison."""
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "compare-vcd-verilator.py"
+SPEC = importlib.util.spec_from_file_location("compare_vcd_verilator", SCRIPT)
+BENCH = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(BENCH)
+
+WAVEFORM = '''$timescale 1 ns $end
+$scope module Top $end
+$var wire 1 ! clk $end
+$var wire 1 " rst $end
+$var wire 1 # en0 $end
+$var wire 64 $ q0 [63:0] $end
+$upscope $end
+$enddefinitions $end
+#0
+0!
+1"
+1#
+b10 $
+#2
+0!
+#3
+1!
+b11 $
+'''
+
+
+class WaveformComparisonTests(unittest.TestCase):
+    def validate(self, text):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "wave.vcd"
+            path.write_text(text)
+            return BENCH.validate_waveform(
+                path, BENCH.expected_waveform(1, 1, "dense", False)
+            )
+
+    def test_equivalent_padding_and_redundant_records(self):
+        short = self.validate(WAVEFORM)
+        padded = self.validate(
+            WAVEFORM.replace("b10 $", "b00010 $").replace("b11 $", "b00011 $")
+        )
+        no_empty_step = self.validate(WAVEFORM.replace("#2\n0!\n", ""))
+        self.assertEqual(short["normalized_sha256"], padded["normalized_sha256"])
+        self.assertEqual(short["normalized_sha256"], no_empty_step["normalized_sha256"])
+
+    def test_mismatches_are_rejected(self):
+        for before, after in (
+            ("b10 $", "b1 $"),              # wrong initialization
+            ("#3\n1!", "#3"),              # missing clock edge
+            ("#3", "#4"),                  # wrong sample time
+            ("b11 $", "bxx $"),            # unknown value in two-state run
+            ("wire 64", "wire 63"),         # missing a traced bit
+            ("q0 [63:0]", "other [63:0]"),  # wrong signal set
+            ("1 ns", "1 ps"),              # unlike time scales
+            ("$upscope", '$var wire 1 % clk $end\n$upscope'),
+        ):
+            with self.subTest(before=before, after=after):
+                with self.assertRaises(ValueError):
+                    self.validate(WAVEFORM.replace(before, after))
+
+    def test_missing_header_is_rejected(self):
+        with self.assertRaises(ValueError):
+            self.validate("")
+
+    def test_cached_fixture_must_match_without_overwriting_it(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            folder = Path(temporary)
+            BENCH.generate_fixture(folder, 3, False)
+            original = (folder / "Top.sv").read_bytes()
+            BENCH.generate_fixture(folder, 3, False, verify_only=True)
+            for signals, full_width in ((4, False), (3, True)):
+                with self.subTest(signals=signals, full_width=full_width):
+                    with self.assertRaises(ValueError):
+                        BENCH.generate_fixture(folder, signals, full_width, verify_only=True)
+                    self.assertEqual(original, (folder / "Top.sv").read_bytes())
+
+    def test_baseline_can_be_the_cached_binary_being_replaced(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            folder = Path(temporary)
+            current = folder / "celox-vcd"
+            candidate = folder / "candidate"
+            current.write_bytes(b"before")
+            candidate.write_bytes(b"after")
+            binaries = BENCH.cache_celox_binaries(folder, candidate, current)
+            self.assertEqual(binaries["celox"].read_bytes(), b"after")
+            self.assertEqual(binaries["baseline_celox"].read_bytes(), b"before")
+            # Inputs may alias both destinations when swapping the two builds.
+            swapped = BENCH.cache_celox_binaries(
+                folder, binaries["baseline_celox"], binaries["celox"]
+            )
+            self.assertEqual(swapped["celox"].read_bytes(), b"before")
+            self.assertEqual(swapped["baseline_celox"].read_bytes(), b"after")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

VCD dumps previously scanned every signal, allocated arbitrary-width values for comparisons, and flushed each sample. This change records write activity alongside clock notifications, compares only affected signals when updates are sparse, and specializes buffered waveform encoding.

- Add independent waveform activity to stable stores/commits in the native x86/AArch64, Cranelift, Wasm, and interpreter backends. Preserve activity across clock processing and tier promotion; host setters use the same metadata. Retained mutable memory views, including JavaScript shared memory, use full scanning for correctness. That permanent fallback lives outside the writable image, survives whole-image restores, and moves with tier promotion. Internal testbench/component evaluation keeps sparse tracking active and observes any VM stores. Native JavaScript dumps consume backend activity, with distinct compiled-code cache entries for traced and untraced builds.
- Build typed trace plans with compact bit/64-bit records, precomputed suffixes, direct sparse traversal, batched activity collection, and SSE2 encoding on x86. Preserve registration order, aliases, four-state values, and external component traces. Validate external value counts before consuming write activity so invalid input can be retried without losing memory-backed changes. Retain consumed activity after a failed dump and merge it with subsequent writes on retry; clear the pending groups only after success. Cached values represent complete encoded records whose queue and accepted-byte offset survive partial I/O errors. Retry or explicit flush drains that queue before publishing another timestamp, including failures in headers and timestamps.
- Add explicit Rust flush methods and report flush failures from JavaScript `dispose()`. Enforce compatible packed array layouts when tracing native images.
- Add writer and native simulator benchmarks plus a Verilator comparison runner that validates waveforms before timing, rotates samples, and records build commands and executable hashes. Reject cached builds if recorded sources, compiler versions, flags/environment, checkout state, commands, or executable hashes change. Reuse verified executable snapshots. Document profiling results, controls, and measurement limitations.

The linked native benchmark measured at `9be224e64` is approximately at parity with Verilator 5.052 on the full-width dense fixture. These are five-process medians for 256 counters and 500,000 full cycles on a Ryzen 7 9800X3D/WSL host, pinned to CPU 0, writing to `/dev/null`. Construction/reset/initial snapshot are excluded; final flush is included.

| Full-width workload | Celox | Verilator | Celox / Verilator |
| --- | ---: | ---: | ---: |
| Idle | 181.5 ms | 290.2 ms | 0.625 |
| Sparse | 227.7 ms | 308.6 ms | 0.738 |
| Dense | 788.7 ms | 815.0 ms | 0.968 |

Dense sample ranges overlap, so this is fixture-specific parity, not a general performance lead. See [measurement details and reproduction commands](https://github.com/celox-sim/celox/blob/9be224e64/docs/internals/vcd-performance.md#typed-trace-plans).

**BREAKING CHANGE:** Native program image containers now use version 5; regenerate version 4 images. Dumps are buffered instead of flushed after every sample: Rust callers reading a live waveform must call `flush_vcd()` or `VcdWriter::flush()`; JavaScript callers should call `dispose()` to finish writing.

## Validation

The current review fixes passed:

- 142 focused Rust library/VCD tests across `celox`, `celox-runtime`, `celox-state-layout`, `celox-testbench`, and `celox-napi`, plus 213 native/testbench/component/Wasm/VCD integration tests. One existing upstream Veryl reverse-loop test remains ignored. New regressions cover repeated partial I/O failures, header/timestamp recovery, full-image restores, tier promotion with a retained pointer, VM stores, internal component reads, and fresh/cached/tiered N-API handles. The relevant regressions failed before their fixes.
- Native N-API rebuilt and linked with `build:debug`; all 228 JavaScript tests passed against that binding.
- WASI SDK 25 N-API build for `wasm32-wasip1-threads`, all 10 WASM tests, and 5 Playwright browser tests against the rebuilt artifact. Browser tests used the direct Node entry point, two workers, and a local preview server.
- All 12 Python comparison-runner tests. An actual Verilator build validated 12 waveforms; an unchanged `--reuse-builds` run succeeded, while changed compiler flags rejected reuse without overwriting the manifest.
- Formatting, diff checks, Clippy with warnings denied across all targets of the five changed Rust crates, workspace checking, Biome, and the AArch64 runtime cross-check.

The release/LTO writer benchmark was rebuilt into an isolated target directory and compared with `3b297e23f` using five alternating process samples on CPU 0 and `/dev/null`; waveform comparison counts, change counts, and byte counts matched. In the final run, dense ratios were 0.937–0.999 and sparse was 0.988 relative to that baseline. Idle took 23.55 ms versus 20.54 ms for one million steps: about 3.0 ns/step (14.7%) more. Earlier repeated runs put dense near parity and idle/sparse overhead at about 1–4 ns/step, so the small timing differences should not be treated as a general speedup. The error-recovery implementation keeps the short-write loop off the common path.

The broader original implementation also passed 800 Rust tests, 130 writer waveform/statistics comparisons, native-layout replay, native waveform validation against Verilator at 256 and 4,096 counters, and the documentation build. The native Celox/Verilator performance table above remains pinned to `9be224e64`; it has not been remeasured for these review fixes.

Local execution and performance measurements use x86-64; native AArch64 execution has not been tested locally.
