### PR TITLE
perf(x86): reduce MIR optimization work and emitted code size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,7 @@ dependencies = [
  "celox-sir",
  "celox-sir-opt",
  "celox-state-layout",
+ "criterion",
  "fxhash",
  "iced-x86",
  "libc",

--- a/crates/celox-backend-x86/Cargo.toml
+++ b/crates/celox-backend-x86/Cargo.toml
@@ -28,6 +28,11 @@ iced-x86 = { version = "1.21", default-features = false, features = ["std", "enc
 
 [dev-dependencies]
 celox-sir-opt = { workspace = true }
+criterion = "0.8"
+
+[[bench]]
+name = "compilation"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/celox-backend-x86/benches/compilation.rs
+++ b/crates/celox-backend-x86/benches/compilation.rs
@@ -1,4 +1,4 @@
-//! Isolate backend cleanup from frontend parsing and circuit elaboration.
+//! Isolate MIR optimization from frontend parsing and circuit elaboration.
 
 use std::hint::black_box;
 
@@ -63,5 +63,75 @@ fn compilation(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, compilation);
+fn live_through_blocks(block_count: u32, reverse_storage: bool) -> MFunction {
+    let mut vregs = VRegAllocator::new();
+    let mut entry = MBlock::new(BlockId(0));
+    let mut exit = MBlock::new(BlockId(block_count + 1));
+    for index in 0..64 {
+        let value = vregs.alloc();
+        entry.push(MInst::Load {
+            dst: value,
+            base: BaseReg::SimState,
+            offset: index * 8,
+            size: OpSize::S64,
+        });
+        exit.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: (index + 64) * 8,
+            src: value,
+            size: OpSize::S64,
+        });
+    }
+    entry.push(MInst::Jump { target: BlockId(1) });
+    exit.push(MInst::Return);
+    let spill_descs = vec![SpillDesc::transient(); vregs.count() as usize];
+    let mut function = MFunction::new(vregs, spill_descs);
+    function.blocks.push(entry);
+    for index in 1..=block_count {
+        let mut block = MBlock::new(BlockId(index));
+        block.push(MInst::Jump {
+            target: BlockId(index + 1),
+        });
+        function.blocks.push(block);
+    }
+    function.blocks.push(exit);
+    if reverse_storage {
+        // Entry remains first, but MIR storage need not follow CFG order.
+        function.blocks[1..].reverse();
+    }
+    function
+}
+
+fn optimization(c: &mut Criterion) {
+    let mut group = c.benchmark_group("x86/optimize");
+    for reverse_storage in [false, true] {
+        for block_count in [128, 512] {
+            let function = live_through_blocks(block_count, reverse_storage);
+            group.bench_with_input(
+                BenchmarkId::new(
+                    if reverse_storage {
+                        "reverse_blocks"
+                    } else {
+                        "forward_blocks"
+                    },
+                    block_count,
+                ),
+                &function,
+                |b, function| {
+                    b.iter_batched(
+                        || function.clone(),
+                        |mut function| {
+                            mir_opt::optimize(&mut function);
+                            black_box(function)
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, compilation, optimization);
 criterion_main!(benches);

--- a/crates/celox-backend-x86/benches/compilation.rs
+++ b/crates/celox-backend-x86/benches/compilation.rs
@@ -1,0 +1,67 @@
+//! Isolate backend cleanup from frontend parsing and circuit elaboration.
+
+use std::hint::black_box;
+
+use celox_backend_x86::native::{mir::*, mir_opt};
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+
+fn chain(length: u32, observed: bool) -> MFunction {
+    let mut vregs = VRegAllocator::new();
+    let mut block = MBlock::new(BlockId(0));
+    let mut value = vregs.alloc();
+    block.push(MInst::Load {
+        dst: value,
+        base: BaseReg::SimState,
+        offset: 0,
+        size: OpSize::S64,
+    });
+    for _ in 0..length {
+        let dst = vregs.alloc();
+        block.push(MInst::AddImm {
+            dst,
+            src: value,
+            imm: 1,
+        });
+        value = dst;
+    }
+    if observed {
+        block.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 8,
+            src: value,
+            size: OpSize::S64,
+        });
+    }
+    block.push(MInst::Return);
+    let spill_descs = vec![SpillDesc::transient(); vregs.count() as usize];
+    let mut function = MFunction::new(vregs, spill_descs);
+    function.blocks.push(block);
+    function
+}
+
+fn compilation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("x86/cleanup");
+    for observed in [false, true] {
+        for length in [256, 1024, 4096] {
+            let function = chain(length, observed);
+            group.bench_with_input(
+                BenchmarkId::new(if observed { "live_chain" } else { "dead_chain" }, length),
+                &function,
+                |b, function| {
+                    b.iter_batched(
+                        || function.clone(),
+                        |mut function| {
+                            mir_opt::post_regalloc_cleanup(&mut function);
+                            black_box(function)
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, compilation);
+criterion_main!(benches);

--- a/crates/celox-backend-x86/src/backend/native/emit.rs
+++ b/crates/celox-backend-x86/src/backend/native/emit.rs
@@ -3155,15 +3155,11 @@ fn emit_inst_with_memory(
             memory,
         ),
         MInst::AndImm { dst, src, imm } if *src == memory_vreg => {
-            let d = preg_to_reg64(resolve(assignment, *dst));
-            asm.mov(d, qword_ptr(memory))?;
-            emit_and_imm64(asm, d, *imm)?;
+            emit_and_memory_imm(asm, resolve(assignment, *dst), memory, *imm)?;
             Ok(true)
         }
         MInst::AndImm32 { dst, src, imm } if *src == memory_vreg => {
-            let d = preg_to_reg32(resolve(assignment, *dst));
-            asm.mov(d, dword_ptr(memory))?;
-            asm.and(d, *imm as i32)?;
+            emit_and_memory_imm(asm, resolve(assignment, *dst), memory, u64::from(*imm))?;
             Ok(true)
         }
         MInst::OrImm { dst, src, imm } if *src == memory_vreg => {
@@ -4545,20 +4541,20 @@ fn emit_inst(
 
         // Immediate ALU widths are explicit for the same reason as binary ALU.
         MInst::AndImm { dst, src, imm } => {
-            let d = preg_to_reg64(resolve(assignment, *dst));
-            let s = preg_to_reg64(resolve(assignment, *src));
-            if d != s {
-                asm.mov(d, s)?;
-            }
-            emit_and_imm64(asm, d, *imm)?;
+            emit_and_imm(
+                asm,
+                resolve(assignment, *dst),
+                resolve(assignment, *src),
+                *imm,
+            )?;
         }
         MInst::AndImm32 { dst, src, imm } => {
-            let d = preg_to_reg32(resolve(assignment, *dst));
-            let s = preg_to_reg32(resolve(assignment, *src));
-            if d != s {
-                asm.mov(d, s)?;
-            }
-            asm.and(d, *imm as i32)?;
+            emit_and_imm(
+                asm,
+                resolve(assignment, *dst),
+                resolve(assignment, *src),
+                u64::from(*imm),
+            )?;
         }
         MInst::OrImm { dst, src, imm } => {
             let d = preg_to_reg64(resolve(assignment, *dst));
@@ -5494,7 +5490,7 @@ fn emit_select_memory(
     Ok(false)
 }
 
-/// Emit AND with a potentially 64-bit immediate.
+/// Emit OR with a potentially 64-bit immediate.
 /// Uses the most efficient encoding available.
 fn emit_or_imm64(asm: &mut CodeAssembler, d: AsmRegister64, imm: u64) -> Result<(), IcedError> {
     if imm == 0 {
@@ -5510,38 +5506,68 @@ fn emit_or_imm64(asm: &mut CodeAssembler, d: AsmRegister64, imm: u64) -> Result<
     Ok(())
 }
 
-fn emit_and_imm64(asm: &mut CodeAssembler, d: AsmRegister64, imm: u64) -> Result<(), IcedError> {
-    if imm == u64::MAX {
-        // AND with all-ones is a no-op
-        return Ok(());
+/// Truncation masks can copy and clear the high bits in one instruction. MIR
+/// does not expose the flags written by AND, so MOVZX/MOV may replace it.
+fn emit_and_imm(
+    asm: &mut CodeAssembler,
+    dst: PhysReg,
+    src: PhysReg,
+    imm: u64,
+) -> Result<(), IcedError> {
+    let d32 = preg_to_reg32(dst);
+    match imm {
+        0 => asm.xor(d32, d32)?,
+        0xff => asm.movzx(d32, preg_to_reg8(src))?,
+        0xffff => asm.movzx(d32, preg_to_reg16(src))?,
+        0xffff_ffff => {
+            // Even a self-copy must clear the upper half of the register.
+            asm.mov(d32, preg_to_reg32(src))?;
+        }
+        1..=0xffff_fffe => {
+            if dst != src {
+                asm.mov(d32, preg_to_reg32(src))?;
+            }
+            asm.and(d32, imm as i32)?;
+        }
+        _ => {
+            let signed = imm as i64;
+            assert!(
+                i32::try_from(signed).is_ok(),
+                "AndImm {imm:#x} exceeds u32: ISel should emit LoadImm + And instead"
+            );
+            let d64 = preg_to_reg64(dst);
+            if dst != src {
+                asm.mov(d64, preg_to_reg64(src))?;
+            }
+            if imm != u64::MAX {
+                asm.and(d64, signed as i32)?;
+            }
+        }
     }
-    let signed = imm as i64;
-    if signed >= i32::MIN as i64 && signed <= i32::MAX as i64 {
-        // Fits in sign-extended imm32
-        asm.and(d, signed as i32)?;
-    } else if imm <= u32::MAX as u64 {
-        // Fits in zero-extended 32-bit: use 32-bit AND (clears upper 32 bits)
-        let d32 = match d {
-            _ if d == rax => eax,
-            _ if d == rcx => ecx,
-            _ if d == rdx => edx,
-            _ if d == rbx => ebx,
-            _ if d == rbp => ebp,
-            _ if d == rsi => esi,
-            _ if d == rdi => edi,
-            _ if d == r8 => r8d,
-            _ if d == r9 => r9d,
-            _ if d == r10 => r10d,
-            _ if d == r11 => r11d,
-            _ if d == r12 => r12d,
-            _ if d == r13 => r13d,
-            _ if d == r14 => r14d,
-            _ if d == r15 => r15d,
-            _ => unreachable!(),
-        };
-        asm.and(d32, imm as i32)?;
-    } else {
-        panic!("AndImm {imm:#x} exceeds u32: ISel should emit LoadImm + And instead");
+    Ok(())
+}
+
+fn emit_and_memory_imm(
+    asm: &mut CodeAssembler,
+    dst: PhysReg,
+    memory: AsmMemoryOperand,
+    imm: u64,
+) -> Result<(), IcedError> {
+    let d32 = preg_to_reg32(dst);
+    match imm {
+        0 => asm.xor(d32, d32)?,
+        0xff => asm.movzx(d32, byte_ptr(memory))?,
+        0xffff => asm.movzx(d32, word_ptr(memory))?,
+        0xffff_ffff => asm.mov(d32, dword_ptr(memory))?,
+        _ => {
+            // Only the low bytes contribute to a zero-extended u32 mask.
+            if imm <= u64::from(u32::MAX) {
+                asm.mov(d32, dword_ptr(memory))?;
+            } else {
+                asm.mov(preg_to_reg64(dst), qword_ptr(memory))?;
+            }
+            emit_and_imm(asm, dst, dst, imm)?;
+        }
     }
     Ok(())
 }
@@ -7017,16 +7043,177 @@ mod shift_encoding_tests {
     }
 
     #[test]
-    fn and_u32_immediate_supports_r15() {
-        let mut asm = CodeAssembler::new(64).unwrap();
-        emit_and_imm64(&mut asm, r15, u32::MAX as u64).unwrap();
-        let code = asm.assemble(0).unwrap();
-        let mut decoder = Decoder::new(64, &code, DecoderOptions::NONE);
-        let instruction = decoder.decode();
+    fn truncation_masks_use_one_instruction_for_all_registers() {
+        use crate::native::regalloc::assignment::ALLOCATABLE_REGS;
+        use iced_x86::Code;
 
-        assert_eq!(instruction.mnemonic(), Mnemonic::And);
-        assert_eq!(instruction.op0_register(), Register::R15D);
-        assert!(!decoder.can_decode());
+        for &src in ALLOCATABLE_REGS {
+            for &dst in ALLOCATABLE_REGS {
+                for (mask, expected) in [
+                    (0xff, Code::Movzx_r32_rm8),
+                    (0xffff, Code::Movzx_r32_rm16),
+                    (0xffff_ffff, Code::Mov_r32_rm32),
+                ] {
+                    let mut asm = CodeAssembler::new(64).unwrap();
+                    emit_and_imm(&mut asm, dst, src, mask).unwrap();
+                    let code = asm.assemble(0).unwrap();
+                    let mut decoder = Decoder::new(64, &code, DecoderOptions::NONE);
+                    let instruction = decoder.decode();
+                    // Register MOV has two interchangeable direction encodings.
+                    if mask == 0xffff_ffff {
+                        assert!(matches!(
+                            instruction.code(),
+                            Code::Mov_r32_rm32 | Code::Mov_rm32_r32
+                        ));
+                    } else {
+                        assert_eq!(instruction.code(), expected);
+                    }
+                    assert_eq!(
+                        instruction.op0_register(),
+                        Register::from(preg_to_reg32(dst))
+                    );
+                    assert_eq!(
+                        instruction.op1_register(),
+                        match mask {
+                            0xff => Register::from(preg_to_reg8(src)),
+                            0xffff => Register::from(preg_to_reg16(src)),
+                            _ => Register::from(preg_to_reg32(src)),
+                        }
+                    );
+                    assert!(!decoder.can_decode(), "{src:?} -> {dst:?}, mask={mask:#x}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn folded_truncation_loads_read_only_the_required_bytes() {
+        use iced_x86::MemorySize;
+        for (mask, mnemonic, size) in [
+            (0xff, Mnemonic::Movzx, MemorySize::UInt8),
+            (0xffff, Mnemonic::Movzx, MemorySize::UInt16),
+            (0xffff_ffff, Mnemonic::Mov, MemorySize::UInt32),
+        ] {
+            let mut asm = CodeAssembler::new(64).unwrap();
+            emit_and_memory_imm(&mut asm, PhysReg::R12, ptr(r15 + 24), mask).unwrap();
+            let code = asm.assemble(0).unwrap();
+            let mut decoder = Decoder::new(64, &code, DecoderOptions::NONE);
+            let instruction = decoder.decode();
+            assert_eq!(instruction.mnemonic(), mnemonic);
+            assert_eq!(instruction.memory_size(), size);
+            assert_eq!(instruction.memory_base(), Register::R15);
+            assert_eq!(instruction.memory_displacement64(), 24);
+            assert_eq!(instruction.op0_register(), Register::R12D);
+            assert!(!decoder.can_decode());
+        }
+    }
+
+    #[test]
+    fn immediate_masks_preserve_widths_aliases_and_folded_load_values() {
+        for word32 in [false, true] {
+            for folded_load in [false, true] {
+                // Include the REX-only low-byte names BPL/SIL and extended GPRs.
+                for source in [
+                    PhysReg::RAX,
+                    PhysReg::RBP,
+                    PhysReg::RSI,
+                    PhysReg::R8,
+                    PhysReg::R12,
+                ] {
+                    for destination in [source, PhysReg::R11] {
+                        for mask in [
+                            0,
+                            1,
+                            0xff,
+                            0xffff,
+                            0x7fff_ffff,
+                            0x8000_0000,
+                            0xffff_ffff,
+                            0xffff_ffff_8000_0000,
+                            u64::MAX,
+                        ] {
+                            if word32 && mask > u64::from(u32::MAX) {
+                                continue;
+                            }
+                            let mut vregs = VRegAllocator::new();
+                            let input = vregs.alloc();
+                            let output = vregs.alloc();
+                            let mut function =
+                                MFunction::new(vregs, vec![SpillDesc::transient(); 2]);
+                            function.target_features = X86Features::for_test(false);
+                            let mut block = MBlock::new(BlockId(0));
+                            block.push(MInst::Load {
+                                dst: input,
+                                base: BaseReg::SimState,
+                                offset: 0,
+                                size: OpSize::S64,
+                            });
+                            if !folded_load {
+                                // A second use prevents the load/AND memory fold.
+                                block.push(MInst::Store {
+                                    base: BaseReg::SimState,
+                                    offset: 16,
+                                    src: input,
+                                    size: OpSize::S64,
+                                });
+                            }
+                            block.push(if word32 {
+                                MInst::AndImm32 {
+                                    dst: output,
+                                    src: input,
+                                    imm: mask as u32,
+                                }
+                            } else {
+                                MInst::AndImm {
+                                    dst: output,
+                                    src: input,
+                                    imm: mask,
+                                }
+                            });
+                            block.push(MInst::Store {
+                                base: BaseReg::SimState,
+                                offset: 8,
+                                src: output,
+                                size: OpSize::S64,
+                            });
+                            block.push(MInst::Return);
+                            function.push_block(block);
+                            let mut assignment = AssignmentMap::default();
+                            assignment.set(input, source);
+                            assignment.set(output, destination);
+                            let emitted = emit(&function, &assignment, 0).unwrap();
+                            let jit = JitCode::new(&emitted.code).unwrap();
+                            for value in [
+                                0u64,
+                                0xff,
+                                0xffff,
+                                0xffff_ffff,
+                                1 << 32,
+                                1 << 63,
+                                0xfedc_ba98_7654_3210,
+                                u64::MAX,
+                            ] {
+                                let mut state =
+                                    vec![0xffu8; emitted.required_state_size.max(24) as usize];
+                                state[..8].copy_from_slice(&value.to_le_bytes());
+                                assert_eq!(unsafe { jit.call(&mut state) }, 0);
+                                assert_eq!(
+                                    u64::from_le_bytes(state[8..16].try_into().unwrap()),
+                                    value & mask,
+                                    "word32={word32}, folded={folded_load}, {source:?} -> {destination:?}, value={value:#x}, mask={mask:#x}"
+                                );
+                                if !folded_load {
+                                    assert_eq!(
+                                        u64::from_le_bytes(state[16..24].try_into().unwrap()),
+                                        value
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/celox-backend-x86/src/backend/native/mir_opt.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt.rs
@@ -17,6 +17,7 @@ mod circular_scan;
 mod counted_loop;
 mod dead_code;
 mod exclusive_loop;
+mod gvn_liveness;
 mod known_bits;
 mod loop_guard;
 #[cfg(test)]
@@ -3007,7 +3008,7 @@ fn global_gvn(func: &mut MFunction) {
     // Compute dominators using simple iterative algorithm (Cooper, Harvey, Kennedy)
     let idom = compute_dominators(num_blocks, &preds, &succs);
     let load_versions = compute_gvn_load_versions(func, &preds, &idom).unwrap_or_default();
-    let (_, live_out) = compute_gvn_liveness(func, &block_id_to_idx, &succs);
+    let live_out = gvn_liveness::live_out(func, &block_id_to_idx, &preds);
     let last_uses = func
         .blocks
         .iter()
@@ -3205,121 +3206,6 @@ fn global_gvn(func: &mut MFunction) {
     for (bi, inst_idx, new_inst) in replacements {
         func.blocks[bi].insts[inst_idx] = new_inst;
     }
-}
-
-/// Compute conventional SSA block-entry and block-exit liveness for GVN's
-/// profitability check. Phi sources are uses on predecessor edges; phi
-/// destinations are definitions at the successor entry.
-fn compute_gvn_liveness(
-    func: &MFunction,
-    block_id_to_idx: &HashMap<BlockId, usize>,
-    succs: &[Vec<usize>],
-) -> (Vec<Vec<VReg>>, Vec<Vec<VReg>>) {
-    let block_count = func.blocks.len();
-    let mut uses = vec![HashSet::default(); block_count];
-    let mut defs = vec![HashSet::default(); block_count];
-
-    for (block_index, block) in func.blocks.iter().enumerate() {
-        defs[block_index].extend(block.phis.iter().map(|phi| phi.dst));
-        for inst in &block.insts {
-            for used in inst.uses() {
-                if !defs[block_index].contains(&used) {
-                    uses[block_index].insert(used);
-                }
-            }
-            if let Some(defined) = inst.def() {
-                defs[block_index].insert(defined);
-            }
-        }
-    }
-
-    let uses = uses
-        .into_iter()
-        .map(|set| {
-            let mut values = set.into_iter().collect::<Vec<_>>();
-            values.sort_unstable();
-            values
-        })
-        .collect::<Vec<_>>();
-
-    fn sorted_union(left: &[VReg], right: &[VReg]) -> Vec<VReg> {
-        let mut merged = Vec::with_capacity(left.len().saturating_add(right.len()));
-        let (mut left_index, mut right_index) = (0usize, 0usize);
-        while left_index < left.len() && right_index < right.len() {
-            match left[left_index].cmp(&right[right_index]) {
-                std::cmp::Ordering::Less => {
-                    merged.push(left[left_index]);
-                    left_index += 1;
-                }
-                std::cmp::Ordering::Equal => {
-                    merged.push(left[left_index]);
-                    left_index += 1;
-                    right_index += 1;
-                }
-                std::cmp::Ordering::Greater => {
-                    merged.push(right[right_index]);
-                    right_index += 1;
-                }
-            }
-        }
-        merged.extend_from_slice(&left[left_index..]);
-        merged.extend_from_slice(&right[right_index..]);
-        merged
-    }
-
-    fn merged_successor_live(
-        func: &MFunction,
-        succs: &[Vec<usize>],
-        live_in: &[Vec<VReg>],
-        block_index: usize,
-    ) -> Vec<VReg> {
-        let block_id = func.blocks[block_index].id;
-        let mut live_out = Vec::new();
-        for &successor in &succs[block_index] {
-            let mut edge_uses = func.blocks[successor]
-                .phis
-                .iter()
-                .filter_map(|phi| {
-                    phi.sources
-                        .iter()
-                        .find(|(predecessor, _)| *predecessor == block_id)
-                        .map(|(_, source)| *source)
-                })
-                .collect::<Vec<_>>();
-            edge_uses.sort_unstable();
-            edge_uses.dedup();
-            let successor_live = sorted_union(&live_in[successor], &edge_uses);
-            live_out = sorted_union(&live_out, &successor_live);
-        }
-        live_out
-    }
-
-    let mut live_in = vec![Vec::new(); block_count];
-    let mut changed = true;
-    while changed {
-        changed = false;
-        for block_index in (0..block_count).rev() {
-            let mut live_out = merged_successor_live(func, succs, &live_in, block_index);
-            live_out.retain(|value| !defs[block_index].contains(value));
-            let next = sorted_union(&uses[block_index], &live_out);
-            if next != live_in[block_index] {
-                live_in[block_index] = next;
-                changed = true;
-            }
-        }
-    }
-
-    let mut live_out = vec![Vec::new(); block_count];
-    for (block_index, values) in live_out.iter_mut().enumerate() {
-        *values = merged_successor_live(func, succs, &live_in, block_index);
-    }
-
-    debug_assert!(
-        func.blocks
-            .iter()
-            .all(|block| block_id_to_idx.contains_key(&block.id))
-    );
-    (live_in, live_out)
 }
 
 /// Compute immediate dominators using the iterative algorithm.

--- a/crates/celox-backend-x86/src/backend/native/mir_opt.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt.rs
@@ -15,6 +15,7 @@ mod boolean;
 mod branch_merge;
 mod circular_scan;
 mod counted_loop;
+mod dead_code;
 mod exclusive_loop;
 mod known_bits;
 mod loop_guard;
@@ -4162,14 +4163,18 @@ fn fold_contiguous_load_packs(func: &mut MFunction) {
 
 /// Select flag-consuming branch forms before allocation.
 ///
-/// A compare or direct load whose only use is the immediately following
-/// branch has no independently observable SSA result. Keeping that result
+/// A compare or direct load whose only use is a branch has no independently
+/// observable SSA result. Keeping that result
 /// until emission invents a live range and can make the allocator spill around
 /// a value which the machine code never materializes.
 ///
 /// Direct-memory predicates are selected by a separate late pass after
 /// StateSSA forwarding. Register comparisons are selected exactly once at the
 /// register-allocation boundary, before pressure scheduling.
+/// An immediate comparison can move past intervening instructions: carrying
+/// its one SSA input instead of its boolean result does not add register
+/// pressure. Two-register comparisons and memory reads remain adjacent to
+/// avoid extending two input live ranges or moving a read across a write.
 pub(crate) fn fold_register_branch_predicates(func: &mut MFunction) -> usize {
     fold_branch_predicates(func, BranchPredicateClass::Register)
 }
@@ -4185,16 +4190,19 @@ enum BranchPredicateClass {
 }
 
 fn fold_branch_predicates(func: &mut MFunction, class: BranchPredicateClass) -> usize {
-    let mut use_counts = HashMap::<VReg, usize>::default();
+    // Only distinguish unused, single-use, and shared values.
+    let mut use_counts = vec![0u8; func.vregs.count() as usize];
     for block in &func.blocks {
         for phi in &block.phis {
             for &(_, source) in &phi.sources {
-                *use_counts.entry(source).or_default() += 1;
+                let count = &mut use_counts[source.0 as usize];
+                *count = count.saturating_add(1);
             }
         }
         for instruction in &block.insts {
             for source in instruction.uses() {
-                *use_counts.entry(source).or_default() += 1;
+                let count = &mut use_counts[source.0 as usize];
+                *count = count.saturating_add(1);
             }
         }
     }
@@ -4212,17 +4220,32 @@ fn fold_branch_predicates(func: &mut MFunction, class: BranchPredicateClass) -> 
         else {
             continue;
         };
-        if use_counts.get(&cond).copied() != Some(1) {
+        if use_counts[cond.0 as usize] != 1 {
             continue;
         }
 
-        let predicate = match block.insts[block.insts.len() - 2].clone() {
+        let adjacent = block.insts.len() - 2;
+        let definition = if matches!(class, BranchPredicateClass::Register) {
+            let Some(index) = block.insts[..=adjacent]
+                .iter()
+                .rposition(|inst| inst.def() == Some(cond))
+            else {
+                continue;
+            };
+            index
+        } else {
+            adjacent
+        };
+        let predicate = match block.insts[definition].clone() {
             MInst::Cmp {
                 dst,
                 lhs,
                 rhs,
                 kind,
-            } if matches!(class, BranchPredicateClass::Register) && dst == cond => {
+            } if matches!(class, BranchPredicateClass::Register)
+                && definition == adjacent
+                && dst == cond =>
+            {
                 BranchPredicate::Compare { lhs, rhs, kind }
             }
             MInst::CmpImm {
@@ -4243,7 +4266,8 @@ fn fold_branch_predicates(func: &mut MFunction, class: BranchPredicateClass) -> 
             }
             _ => continue,
         };
-        block.insts.truncate(block.insts.len() - 2);
+        block.insts.pop();
+        block.insts.remove(definition);
         block.insts.push(MInst::BranchPred {
             predicate,
             true_bb,
@@ -7616,75 +7640,15 @@ fn copy_propagate(func: &mut MFunction) {
     }
 }
 
-/// Dead code elimination: remove instructions whose defs are never used.
+/// Remove scalar definitions that cannot affect an observable instruction.
 fn dead_code_eliminate(func: &mut MFunction) {
-    dead_code_eliminate_impl(func, true);
+    dead_code::eliminate(func, true);
 }
 
 /// Post-allocation DCE must preserve the phi rows used to construct the
 /// already-verified parallel-copy plan.
 fn dead_code_eliminate_preserving_phis(func: &mut MFunction) {
-    dead_code_eliminate_impl(func, false);
-}
-
-fn dead_code_eliminate_impl(func: &mut MFunction, remove_unused_phis: bool) {
-    // Iterate until no more dead code is removed (cascading DCE).
-    loop {
-        let mut used: HashSet<VReg> = HashSet::default();
-        for block in &func.blocks {
-            for inst in &block.insts {
-                for u in inst.uses() {
-                    used.insert(u);
-                }
-            }
-            for phi in &block.phis {
-                for (_, src) in &phi.sources {
-                    used.insert(*src);
-                }
-            }
-        }
-
-        let mut removed = false;
-        for block in &mut func.blocks {
-            let before = block.insts.len();
-            block.insts.retain(|inst| {
-                if let Some(def) = inst.def() {
-                    if !used.contains(&def) {
-                        return matches!(
-                            inst,
-                            MInst::Store { .. }
-                                | MInst::StorePtr { .. }
-                                | MInst::ReleaseStorePtr { .. }
-                                | MInst::StoreIndexed { .. }
-                                | MInst::OrStoreIndexed { .. }
-                                | MInst::StorePtrIndexed { .. }
-                                | MInst::ReleaseStorePtrIndexed { .. }
-                                | MInst::Branch { .. }
-                                | MInst::Jump { .. }
-                                | MInst::Return
-                                | MInst::ReturnError { .. }
-                        );
-                    }
-                }
-                true
-            });
-            if block.insts.len() < before {
-                removed = true;
-            }
-
-            if remove_unused_phis {
-                let phi_before = block.phis.len();
-                block.phis.retain(|phi| used.contains(&phi.dst));
-                if block.phis.len() < phi_before {
-                    removed = true;
-                }
-            }
-        }
-
-        if !removed {
-            break;
-        }
-    }
+    dead_code::eliminate(func, false);
 }
 
 /// Rewrite all use operands in an instruction according to the alias map.
@@ -9305,6 +9269,166 @@ mod tests {
                 ..
             }]
         ));
+    }
+
+    fn delayed_immediate_branch(kind: CmpKind, imm: i32) -> MFunction {
+        let mut function = make_func(
+            vec![
+                MInst::Load {
+                    dst: VReg(0),
+                    base: BaseReg::SimState,
+                    offset: 0,
+                    size: OpSize::S64,
+                },
+                MInst::CmpImm {
+                    dst: VReg(1),
+                    lhs: VReg(0),
+                    imm,
+                    kind,
+                },
+                // Clobber flags and overwrite the original memory. The
+                // delayed predicate must still compare the loaded SSA value.
+                MInst::AddImm {
+                    dst: VReg(2),
+                    src: VReg(0),
+                    imm: 1,
+                },
+                MInst::Store {
+                    base: BaseReg::SimState,
+                    offset: 0,
+                    src: VReg(2),
+                    size: OpSize::S64,
+                },
+                MInst::Branch {
+                    cond: VReg(1),
+                    true_bb: BlockId(1),
+                    false_bb: BlockId(2),
+                },
+            ],
+            3,
+        );
+        for (block, code) in [(1, 1), (2, 2)] {
+            let mut body = MBlock::new(BlockId(block));
+            body.push(MInst::ReturnError { code });
+            function.blocks.push(body);
+        }
+        function
+    }
+
+    #[test]
+    fn delayed_branch_predicates_keep_shared_results_and_memory_order() {
+        let mut shared = delayed_immediate_branch(CmpKind::Ne, 0);
+        // More than 255 uses must not wrap the compact use count back to one.
+        for _ in 0..256 {
+            shared.blocks[0].insts.insert(
+                2,
+                MInst::Store {
+                    base: BaseReg::SimState,
+                    offset: 8,
+                    src: VReg(1),
+                    size: OpSize::S64,
+                },
+            );
+        }
+        shared.verify_result().unwrap();
+        assert_eq!(fold_register_branch_predicates(&mut shared), 0);
+
+        let mut memory = delayed_immediate_branch(CmpKind::Ne, 0);
+        memory.blocks[0].insts[1] = MInst::Load {
+            dst: VReg(1),
+            base: BaseReg::SimState,
+            offset: 0,
+            size: OpSize::S64,
+        };
+        memory.verify_result().unwrap();
+        assert_eq!(fold_memory_branch_predicates(&mut memory), 0);
+        assert_eq!(fold_register_branch_predicates(&mut memory), 0);
+
+        let mut registers = delayed_immediate_branch(CmpKind::Ne, 0);
+        registers.blocks[0].insts[1] = MInst::Cmp {
+            dst: VReg(1),
+            lhs: VReg(0),
+            rhs: VReg(0),
+            kind: CmpKind::Ne,
+        };
+        assert_eq!(fold_register_branch_predicates(&mut registers), 0);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn delayed_immediate_branches_emit_less_code_and_preserve_signedness() {
+        use crate::native::{emit, jit_mem::JitCode, regalloc};
+
+        let mut assignment = AssignmentMap::default();
+        for (value, register) in [PhysReg::RAX, PhysReg::RCX, PhysReg::RDX]
+            .into_iter()
+            .enumerate()
+        {
+            assignment.set(VReg(value as u32), register);
+        }
+        for kind in [
+            CmpKind::Eq,
+            CmpKind::Ne,
+            CmpKind::LtU,
+            CmpKind::LeU,
+            CmpKind::GtU,
+            CmpKind::GeU,
+            CmpKind::LtS,
+            CmpKind::LeS,
+            CmpKind::GtS,
+            CmpKind::GeS,
+        ] {
+            for imm in [i32::MIN, -1, 0, 1, i32::MAX] {
+                let mut function = delayed_immediate_branch(kind, imm);
+                function.verify_result().unwrap();
+                let before = emit::emit(&function, &assignment, 0).unwrap();
+                assert_eq!(fold_register_branch_predicates(&mut function), 1);
+                function.verify_result().unwrap();
+                let after = emit::emit(&function, &assignment, 0).unwrap();
+                assert!(after.text_size < before.text_size);
+                let allocation = regalloc::run_regalloc(&mut function).unwrap();
+                let allocated = emit::emit(
+                    &function,
+                    &allocation.assignment,
+                    allocation.spill_frame_size,
+                )
+                .unwrap();
+                let before_jit = JitCode::new(&before.code).unwrap();
+                let after_jit = JitCode::new(&allocated.code).unwrap();
+                for input in [0u64, 1, u32::MAX as u64, i64::MAX as u64, 1 << 63, u64::MAX] {
+                    let rhs = imm as i64 as u64;
+                    let matched = match kind {
+                        CmpKind::Eq => input == rhs,
+                        CmpKind::Ne => input != rhs,
+                        CmpKind::LtU => input < rhs,
+                        CmpKind::LeU => input <= rhs,
+                        CmpKind::GtU => input > rhs,
+                        CmpKind::GeU => input >= rhs,
+                        CmpKind::LtS => (input as i64) < (rhs as i64),
+                        CmpKind::LeS => (input as i64) <= (rhs as i64),
+                        CmpKind::GtS => (input as i64) > (rhs as i64),
+                        CmpKind::GeS => (input as i64) >= (rhs as i64),
+                    };
+                    let mut original = vec![
+                        0u8;
+                        before
+                            .required_state_size
+                            .max(allocated.required_state_size)
+                            .max(8) as usize
+                    ];
+                    original[..8].copy_from_slice(&input.to_le_bytes());
+                    let mut optimized = original.clone();
+                    let expected = if matched { 1 } else { 2 };
+                    assert_eq!(unsafe { before_jit.call(&mut original) }, expected);
+                    assert_eq!(unsafe { after_jit.call(&mut optimized) }, expected);
+                    assert_eq!(&original[..8], &optimized[..8]);
+                    assert_eq!(
+                        u64::from_le_bytes(optimized[..8].try_into().unwrap()),
+                        input.wrapping_add(1)
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/dead_code.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/dead_code.rs
@@ -1,0 +1,305 @@
+//! Keep the SSA values reachable from observable instructions.
+
+use super::ValueDefinition;
+use crate::native::mir::*;
+
+pub(super) fn eliminate(func: &mut MFunction, remove_unused_phis: bool) {
+    let value_count = func.vregs.count() as usize;
+    let mut definitions = vec![None; value_count];
+    let mut live = vec![false; value_count];
+    let mut work = Vec::new();
+    let mark = |value: VReg, live: &mut [bool], work: &mut Vec<VReg>| {
+        if !std::mem::replace(&mut live[value.0 as usize], true) {
+            work.push(value);
+        }
+    };
+
+    for (block_index, block) in func.blocks.iter().enumerate() {
+        for (phi_index, phi) in block.phis.iter().enumerate() {
+            definitions[phi.dst.0 as usize] = Some(ValueDefinition::Phi {
+                block: block_index,
+                phi: phi_index,
+            });
+            // After allocation, every retained phi row still needs its edge
+            // inputs, even when the destination has no instruction users.
+            if !remove_unused_phis {
+                mark(phi.dst, &mut live, &mut work);
+            }
+        }
+        for (instruction, inst) in block.insts.iter().enumerate() {
+            if let Some(dst) = inst.def() {
+                definitions[dst.0 as usize] = Some(ValueDefinition::Instruction {
+                    block: block_index,
+                    instruction,
+                });
+            } else {
+                // Stores, control flow, memory pseudos, and SIMD operations
+                // have no scalar definition. Preserve them and their scalar
+                // inputs; vector liveness belongs to the SIMD pipeline.
+                for source in inst.uses() {
+                    mark(source, &mut live, &mut work);
+                }
+            }
+        }
+    }
+
+    // Visit each live definition once. Unlike repeated use-set scans, this
+    // is linear in the SSA graph and also removes unobserved phi cycles.
+    // The explicit worklist keeps long dependency chains off the call stack.
+    while let Some(value) = work.pop() {
+        match definitions[value.0 as usize] {
+            Some(ValueDefinition::Phi { block, phi }) => {
+                for &(_, source) in &func.blocks[block].phis[phi].sources {
+                    mark(source, &mut live, &mut work);
+                }
+            }
+            Some(ValueDefinition::Instruction { block, instruction }) => {
+                for source in func.blocks[block].insts[instruction].uses() {
+                    mark(source, &mut live, &mut work);
+                }
+            }
+            None => {}
+        }
+    }
+
+    for block in &mut func.blocks {
+        block
+            .insts
+            .retain(|inst| inst.def().is_none_or(|dst| live[dst.0 as usize]));
+        if remove_unused_phis {
+            block.phis.retain(|phi| live[phi.dst.0 as usize]);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loop_function(observe_recurrence: bool) -> MFunction {
+        let mut vregs = VRegAllocator::new();
+        for _ in 0..8 {
+            vregs.alloc();
+        }
+        let mut function = MFunction::new(vregs, vec![SpillDesc::transient(); 8]);
+        let mut entry = MBlock::new(BlockId(0));
+        entry.push(MInst::Load {
+            dst: VReg(0),
+            base: BaseReg::SimState,
+            offset: 0,
+            size: OpSize::S64,
+        });
+        entry.push(MInst::Load {
+            dst: VReg(1),
+            base: BaseReg::SimState,
+            offset: 8,
+            size: OpSize::S64,
+        });
+        entry.push(MInst::Jump { target: BlockId(1) });
+        let mut header = MBlock::new(BlockId(1));
+        header.phis = vec![
+            PhiNode {
+                dst: VReg(2),
+                sources: vec![(BlockId(0), VReg(0)), (BlockId(2), VReg(5))],
+            },
+            PhiNode {
+                dst: VReg(3),
+                sources: vec![(BlockId(0), VReg(1)), (BlockId(2), VReg(6))],
+            },
+        ];
+        header.push(MInst::CmpImm {
+            dst: VReg(4),
+            lhs: VReg(2),
+            imm: 8,
+            kind: CmpKind::LtU,
+        });
+        header.push(MInst::Branch {
+            cond: VReg(4),
+            true_bb: BlockId(2),
+            false_bb: BlockId(3),
+        });
+        let mut latch = MBlock::new(BlockId(2));
+        latch.push(MInst::AddImm {
+            dst: VReg(5),
+            src: VReg(2),
+            imm: 1,
+        });
+        latch.push(MInst::Add {
+            dst: VReg(6),
+            lhs: VReg(3),
+            rhs: VReg(3),
+        });
+        latch.push(MInst::Jump { target: BlockId(1) });
+        let mut exit = MBlock::new(BlockId(3));
+        exit.push(MInst::Store {
+            base: BaseReg::SimState,
+            offset: 16,
+            src: if observe_recurrence { VReg(3) } else { VReg(2) },
+            size: OpSize::S64,
+        });
+        exit.push(MInst::LoadImm {
+            dst: VReg(7),
+            value: 42,
+        });
+        exit.push(MInst::Return);
+        function.blocks = vec![entry, header, latch, exit];
+        function
+    }
+
+    #[test]
+    fn removes_unobserved_phi_cycles_but_keeps_control_dependencies() {
+        for observed in [false, true] {
+            let mut function = loop_function(observed);
+            function.verify_result().unwrap();
+            eliminate(&mut function, true);
+            function.verify_result().unwrap();
+            assert_eq!(function.blocks[1].phis.len(), if observed { 2 } else { 1 });
+            for value in [VReg(1), VReg(6)] {
+                assert_eq!(
+                    function
+                        .blocks
+                        .iter()
+                        .flat_map(|block| &block.insts)
+                        .any(|inst| inst.def() == Some(value)),
+                    observed,
+                );
+            }
+            assert_eq!(function.blocks[3].insts.len(), 2);
+        }
+    }
+
+    #[test]
+    fn preserves_allocated_phi_rows_and_their_transitive_inputs() {
+        let mut function = loop_function(false);
+        let phis = function.blocks[1].phis.clone();
+        eliminate(&mut function, false);
+        function.verify_result().unwrap();
+        assert_eq!(function.blocks[1].phis.len(), phis.len());
+        for (actual, expected) in function.blocks[1].phis.iter().zip(phis) {
+            assert_eq!(actual.dst, expected.dst);
+            assert_eq!(actual.sources, expected.sources);
+        }
+        assert_eq!(function.blocks[0].insts.len(), 3);
+        assert_eq!(function.blocks[2].insts.len(), 3);
+        assert_eq!(function.blocks[3].insts.len(), 2);
+    }
+
+    #[test]
+    fn handles_long_live_and_dead_dependency_chains() {
+        const LENGTH: u32 = 16_384;
+        for observed in [false, true] {
+            let mut vregs = VRegAllocator::new();
+            let mut block = MBlock::new(BlockId(0));
+            let mut source = vregs.alloc();
+            block.push(MInst::LoadImm {
+                dst: source,
+                value: 1,
+            });
+            for _ in 0..LENGTH {
+                let dst = vregs.alloc();
+                block.push(MInst::Add {
+                    dst,
+                    lhs: source,
+                    rhs: source,
+                });
+                source = dst;
+            }
+            if observed {
+                block.push(MInst::Store {
+                    base: BaseReg::SimState,
+                    offset: 0,
+                    src: source,
+                    size: OpSize::S64,
+                });
+            }
+            block.push(MInst::Return);
+            let spill_descs = vec![SpillDesc::transient(); vregs.count() as usize];
+            let mut function = MFunction::new(vregs, spill_descs);
+            function.blocks.push(block);
+            eliminate(&mut function, true);
+            assert_eq!(
+                function.blocks[0].insts.len(),
+                if observed { LENGTH as usize + 3 } else { 1 }
+            );
+        }
+    }
+
+    #[test]
+    fn preserves_scalar_dependencies_of_vector_packs() {
+        let mut function = loop_function(true);
+        let vector = function.alloc_x86_vec();
+        let scratch = function.alloc_x86_vec();
+        function.blocks[3].insts[0] = MInst::X86Simd(X86SimdInst::Pack128 {
+            dst: vector,
+            scratch: Some(scratch),
+            low: VReg(2),
+            high: VReg(3),
+        });
+        function.blocks[3]
+            .insts
+            .insert(0, MInst::X86Simd(X86SimdInst::Scratch128 { dst: scratch }));
+        eliminate(&mut function, true);
+        function.verify_result().unwrap();
+        assert_eq!(function.blocks[1].phis.len(), 2);
+        assert_eq!(function.blocks[0].insts.len(), 3);
+        assert_eq!(function.blocks[2].insts.len(), 3);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn loop_cleanup_preserves_execution() {
+        use crate::native::{emit, jit_mem::JitCode, regalloc};
+
+        fn compile(mut function: MFunction) -> (JitCode, usize, usize) {
+            let allocation = regalloc::run_regalloc(&mut function).unwrap();
+            let emitted = emit::emit(
+                &function,
+                &allocation.assignment,
+                allocation.spill_frame_size,
+            )
+            .unwrap();
+            (
+                JitCode::new(&emitted.code).unwrap(),
+                emitted.required_state_size.max(32) as usize,
+                emitted.text_size,
+            )
+        }
+
+        for observed in [false, true] {
+            let mut function = loop_function(observed);
+            let (original, original_state, original_size) = compile(function.clone());
+            eliminate(&mut function, true);
+            let (optimized, optimized_state, optimized_size) = compile(function);
+            if !observed {
+                assert!(
+                    optimized_size <= original_size,
+                    "{optimized_size} > {original_size}"
+                );
+            }
+            for start in [0u64, 1, 7, 8, 9, u64::MAX] {
+                for seed in [0u64, 1, u64::MAX, 1 << 63] {
+                    let mut before = vec![0u8; original_state.max(optimized_state)];
+                    before[..8].copy_from_slice(&start.to_le_bytes());
+                    before[8..16].copy_from_slice(&seed.to_le_bytes());
+                    let mut after = before.clone();
+                    assert_eq!(unsafe { original.call(&mut before) }, 0);
+                    assert_eq!(unsafe { optimized.call(&mut after) }, 0);
+                    assert_eq!(
+                        &before[..24],
+                        &after[..24],
+                        "start={start}, seed={seed}, observed={observed}"
+                    );
+                    let expected = if observed {
+                        seed.wrapping_shl(8u64.saturating_sub(start) as u32)
+                    } else {
+                        start.max(8)
+                    };
+                    assert_eq!(
+                        u64::from_le_bytes(after[16..24].try_into().unwrap()),
+                        expected
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/celox-backend-x86/src/backend/native/mir_opt/gvn_liveness.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt/gvn_liveness.rs
@@ -1,0 +1,371 @@
+//! Sparse SSA liveness for GVN's register-pressure profitability check.
+
+use crate::HashMap;
+use crate::native::mir::*;
+
+#[derive(Clone, Copy)]
+enum LivePoint {
+    Entry(usize),
+    Exit(usize),
+}
+
+/// Return sorted live-out values for each block. Trace each value backwards
+/// from its uses, stopping at its unique SSA definition. This visits each live
+/// block/value pair once, independently of block storage order, without
+/// repeatedly allocating and merging sets in whole-function fixed-point scans.
+pub(super) fn live_out(
+    func: &MFunction,
+    block_indices: &HashMap<BlockId, usize>,
+    predecessors: &[Vec<usize>],
+) -> Vec<Vec<VReg>> {
+    let value_count = func.vregs.count() as usize;
+    let block_count = func.blocks.len();
+    let mut definition_blocks = vec![usize::MAX; value_count];
+    let mut uses = vec![Vec::new(); value_count];
+    for (block_index, block) in func.blocks.iter().enumerate() {
+        for phi in &block.phis {
+            definition_blocks[phi.dst.0 as usize] = block_index;
+        }
+        for inst in &block.insts {
+            for used in inst.uses() {
+                let value = used.0 as usize;
+                if definition_blocks[value] != block_index
+                    && !matches!(uses[value].last(), Some(LivePoint::Entry(b)) if *b == block_index)
+                {
+                    uses[value].push(LivePoint::Entry(block_index));
+                }
+            }
+            if let Some(defined) = inst.def() {
+                definition_blocks[defined.0 as usize] = block_index;
+            }
+        }
+    }
+    for block in &func.blocks {
+        for phi in &block.phis {
+            for &(predecessor, source) in &phi.sources {
+                // A phi input is live at its own predecessor's exit, even
+                // when that predecessor is also the value's defining block.
+                uses[source.0 as usize].push(LivePoint::Exit(block_indices[&predecessor]));
+            }
+        }
+    }
+
+    let mut live_out = vec![Vec::new(); block_count];
+    let mut visited_entry = vec![u32::MAX; block_count];
+    let mut visited_exit = vec![u32::MAX; block_count];
+    let mut work = Vec::new();
+    for (value, use_sites) in uses.iter().enumerate() {
+        let vreg = VReg(value as u32);
+        work.extend_from_slice(use_sites);
+        while let Some(point) = work.pop() {
+            match point {
+                LivePoint::Entry(block) => {
+                    if visited_entry[block] == vreg.0 {
+                        continue;
+                    }
+                    visited_entry[block] = vreg.0;
+                    work.extend(predecessors[block].iter().copied().map(LivePoint::Exit));
+                }
+                LivePoint::Exit(block) => {
+                    if visited_exit[block] == vreg.0 {
+                        continue;
+                    }
+                    visited_exit[block] = vreg.0;
+                    // Processing VRegs in order produces sorted sets directly.
+                    live_out[block].push(vreg);
+                    if definition_blocks[value] != block {
+                        work.push(LivePoint::Entry(block));
+                    }
+                }
+            }
+        }
+    }
+    live_out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::HashSet;
+
+    fn analyze(function: &MFunction) -> Vec<Vec<VReg>> {
+        let indices = function
+            .blocks
+            .iter()
+            .enumerate()
+            .map(|(index, block)| (block.id, index))
+            .collect::<HashMap<_, _>>();
+        let mut predecessors = vec![Vec::new(); function.blocks.len()];
+        for (index, block) in function.blocks.iter().enumerate() {
+            for successor in block.successors() {
+                predecessors[indices[&successor]].push(index);
+            }
+        }
+        live_out(function, &indices, &predecessors)
+    }
+
+    // Conventional block equations provide an independent oracle for loops,
+    // phi edges, duplicate successors, and disconnected components.
+    fn reference(function: &MFunction) -> Vec<Vec<VReg>> {
+        let count = function.blocks.len();
+        let indices = function
+            .blocks
+            .iter()
+            .enumerate()
+            .map(|(index, block)| (block.id, index))
+            .collect::<HashMap<_, _>>();
+        let mut uses = vec![HashSet::default(); count];
+        let mut defs = vec![HashSet::default(); count];
+        for (index, block) in function.blocks.iter().enumerate() {
+            defs[index].extend(block.phis.iter().map(|phi| phi.dst));
+            for inst in &block.insts {
+                for source in inst.uses() {
+                    if !defs[index].contains(&source) {
+                        uses[index].insert(source);
+                    }
+                }
+                defs[index].extend(inst.def());
+            }
+        }
+        let mut live_in = vec![HashSet::default(); count];
+        let mut live_out = vec![HashSet::default(); count];
+        loop {
+            let mut changed = false;
+            for (index, block) in function.blocks.iter().enumerate().rev() {
+                let mut outgoing = HashSet::default();
+                for successor in block.successors() {
+                    let successor = indices[&successor];
+                    outgoing.extend(&live_in[successor]);
+                    for phi in &function.blocks[successor].phis {
+                        outgoing.extend(
+                            phi.sources
+                                .iter()
+                                .filter_map(|&(pred, source)| (pred == block.id).then_some(source)),
+                        );
+                    }
+                }
+                let incoming = uses[index]
+                    .union(&outgoing.difference(&defs[index]).copied().collect())
+                    .copied()
+                    .collect::<HashSet<_>>();
+                changed |= incoming != live_in[index];
+                live_in[index] = incoming;
+                live_out[index] = outgoing;
+            }
+            if !changed {
+                break;
+            }
+        }
+        live_out
+            .into_iter()
+            .map(|set| {
+                let mut values = set.into_iter().collect::<Vec<_>>();
+                values.sort_unstable();
+                values
+            })
+            .collect()
+    }
+
+    fn function(blocks: Vec<MBlock>, value_count: u32) -> MFunction {
+        let mut vregs = VRegAllocator::new();
+        for _ in 0..value_count {
+            vregs.alloc();
+        }
+        let mut function =
+            MFunction::new(vregs, vec![SpillDesc::transient(); value_count as usize]);
+        function.blocks = blocks;
+        function
+    }
+
+    #[test]
+    fn phi_inputs_are_live_only_on_their_own_edges() {
+        let mut entry = MBlock::new(BlockId(0));
+        entry.insts = vec![
+            MInst::LoadImm {
+                dst: VReg(0),
+                value: 8,
+            },
+            MInst::LoadImm {
+                dst: VReg(1),
+                value: 9,
+            },
+            MInst::Jump { target: BlockId(1) },
+        ];
+        let mut header = MBlock::new(BlockId(1));
+        header.phis = vec![
+            PhiNode {
+                dst: VReg(2),
+                sources: vec![(BlockId(0), VReg(0)), (BlockId(2), VReg(3))],
+            },
+            PhiNode {
+                dst: VReg(4),
+                sources: vec![(BlockId(0), VReg(1)), (BlockId(2), VReg(4))],
+            },
+        ];
+        header.push(MInst::Branch {
+            cond: VReg(2),
+            true_bb: BlockId(2),
+            false_bb: BlockId(3),
+        });
+        let mut latch = MBlock::new(BlockId(2));
+        latch.insts = vec![
+            MInst::SubImm {
+                dst: VReg(3),
+                src: VReg(2),
+                imm: 1,
+            },
+            MInst::Jump { target: BlockId(1) },
+        ];
+        let mut exit = MBlock::new(BlockId(3));
+        exit.insts = vec![
+            MInst::Store {
+                base: BaseReg::SimState,
+                offset: 0,
+                src: VReg(2),
+                size: OpSize::S64,
+            },
+            MInst::Return,
+        ];
+        let function = function(vec![entry, header, latch, exit], 5);
+        function.verify_result().unwrap();
+        assert_eq!(
+            analyze(&function),
+            vec![
+                vec![VReg(0), VReg(1)],
+                vec![VReg(2), VReg(4)],
+                vec![VReg(3), VReg(4)],
+                vec![]
+            ]
+        );
+        assert_eq!(analyze(&function), reference(&function));
+    }
+
+    #[test]
+    fn matches_block_equations_on_reordered_cyclic_graphs() {
+        let mut state = 0x2545_f491_4f6c_dd1du64;
+        let mut next = || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state as usize
+        };
+        for case in 0..512 {
+            let count = 2 + next() % 23;
+            let id = |block: usize| BlockId((block * 7 + 10) as u32);
+            let local = |block: usize| VReg((3 + block * 2) as u32);
+            let merged = |block: usize| VReg((4 + block * 2) as u32);
+            let mut blocks = Vec::new();
+            for index in 0..count {
+                let mut block = MBlock::new(id(index));
+                if index == 0 {
+                    for value in 0..3 {
+                        block.push(MInst::LoadImm {
+                            dst: VReg(value),
+                            value: value.into(),
+                        });
+                    }
+                }
+                block.push(MInst::LoadImm {
+                    dst: local(index),
+                    value: next() as u64,
+                });
+                for _ in 0..4 {
+                    let source = match next() % 5 {
+                        3 => local(index),
+                        4 => merged(index),
+                        value => VReg(value as u32),
+                    };
+                    block.push(MInst::Store {
+                        base: BaseReg::SimState,
+                        offset: 8,
+                        src: source,
+                        size: OpSize::S64,
+                    });
+                }
+                block.push(if index + 1 == count {
+                    MInst::Return
+                } else {
+                    MInst::Branch {
+                        cond: VReg((next() % 3) as u32),
+                        true_bb: id(1 + next() % (count - 1)),
+                        false_bb: id(1 + next() % (count - 1)),
+                    }
+                });
+                blocks.push(block);
+            }
+            for index in 0..count {
+                let sources = blocks
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, block)| block.successors().contains(&id(index)))
+                    .map(|(pred, block)| (block.id, local(pred)))
+                    .collect::<Vec<_>>();
+                if sources.is_empty() {
+                    blocks[index].insts.insert(
+                        0,
+                        MInst::LoadImm {
+                            dst: merged(index),
+                            value: 0,
+                        },
+                    );
+                } else {
+                    blocks[index].phis.push(PhiNode {
+                        dst: merged(index),
+                        sources,
+                    });
+                }
+            }
+            for index in (2..count).rev() {
+                blocks.swap(index, 1 + next() % index);
+            }
+            let function = function(blocks, (3 + 2 * count) as u32);
+            assert_eq!(
+                analyze(&function),
+                reference(&function),
+                "case {case}: {function:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn long_reverse_order_chain_does_not_need_repeated_sweeps() {
+        const COUNT: u32 = 16_384;
+        let mut entry = MBlock::new(BlockId(0));
+        entry.insts = vec![
+            MInst::LoadImm {
+                dst: VReg(0),
+                value: 42,
+            },
+            MInst::Jump { target: BlockId(1) },
+        ];
+        let mut blocks = vec![entry];
+        for index in (1..=COUNT).rev() {
+            let mut block = MBlock::new(BlockId(index));
+            if index == COUNT {
+                block.push(MInst::Store {
+                    base: BaseReg::SimState,
+                    offset: 0,
+                    src: VReg(0),
+                    size: OpSize::S64,
+                });
+                block.push(MInst::Return);
+            } else {
+                block.push(MInst::Jump {
+                    target: BlockId(index + 1),
+                });
+            }
+            blocks.push(block);
+        }
+        let function = function(blocks, 1);
+        for (block, live) in function.blocks.iter().zip(analyze(&function)) {
+            assert_eq!(
+                live,
+                if block.id == BlockId(COUNT) {
+                    vec![]
+                } else {
+                    vec![VReg(0)]
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Long dead-value chains and unfavorable block layouts made x86 MIR optimization repeatedly scan and merge the same data. This change follows SSA dependencies directly and emits fewer instructions for branch predicates and truncation masks.

- Mark scalar definitions reachable from observable instructions for dead-code elimination, preserving allocated phi rows and scalar inputs to SIMD operations.
- Compute GVN live-out sets by tracing each value back to its definition, with phi inputs kept on their own predecessor edges.
- Fold single-use immediate comparisons into terminal branches across intervening instructions, and use dense saturating use counts.
- Emit byte/word truncation as `movzx` and dword truncation as a 32-bit `mov`, including register aliases and folded loads.
- Add Criterion benchmarks for dead/live chains and forward/reverse block layouts, plus differential and JIT regression tests.

On Heliodor `test_soc_linux_boot`, the complete change compared with `f11418139` reduces the code image from **986,455 to 985,235 bytes** and static instructions from **171,248 to 171,111**.

A separate comparison isolating GVN and mask emission (`44dbaea82` → `0d46ee451`) measured the reverse-order 512-block MIR case at **35.27 → 4.41 ms**; forward-order cases were statistically unchanged. Compiler CPU instructions fell **1.06%** over two alternating pairs using `perf stat` with `--compile-only`. End-to-end compile medians were 13.294 → 13.165 seconds over five alternating pairs, but run-to-run variation was too large to claim a wall-clock speedup.

Measurements used Ryzen 7 9800X3D, WSL2 x86_64, CPU 12, Rust 1.98.1, `heliodor-dev` (optimized, no LTO), native O2/two-state, and Heliodor `a78d04730cf2b37c616e039b4a5bd437c1cfd355`.

## Validation

- `cargo check --workspace --locked`, `pnpm run lint`, and submodule consistency checks passed during pre-push.
- `cargo fmt --all -- --check` and `git diff --check`.
- `cargo clippy -p celox-backend-x86 --all-targets --locked --offline -- -D warnings`.
- `cargo test -p celox-backend-x86 --locked --offline`: **557 passed**.
- `XDG_CACHE_HOME=/tmp/celox-x86-cache cargo test -p celox --lib --tests --locked --offline`: **4,444 passed**, 462 existing ignored tests. The temporary cache contains a copy of the existing Veryl dependency cache.
- Heliodor compiled with `CELOX_SIR_VERIFY=1 CELOX_MIR_VERIFY=1 CELOX_MIR_VERIFY_PASSES=1 CELOX_REGALLOC_VERIFY=1`; MIR and register assignments were unchanged by the GVN analysis replacement.
- All ten final Heliodor Linux boot runs passed with `cy=87cda0 x3=aa pass=1`.
- Criterion cleanup and optimization benchmarks: 1-second warm-up, 2-second measurement, 20 samples, with inputs cloned outside the measured interval. Reproduce with `cargo bench -p celox-backend-x86 --bench compilation --profile heliodor-dev -- --warm-up-time 1 --measurement-time 2 --sample-size 20`.
