### PR TITLE
fix(bench): enable expanded Heliodor Linux benchmarks without false fold cycles

### DIFF
--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -416,13 +416,83 @@ jobs:
             target/heliodor-arm64/results/profile-ir/native_optimized.sir
             heliodor-arm64-host.txt
 
+  linux-suite:
+    name: Linux suite (${{ matrix.arch }}, ${{ matrix.test }})
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && !inputs.arm64_profile
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, aarch64]
+        test:
+          - test_soc_linux_boot
+          - test_soc_smp_linux_boot_2hart
+          - test_soc_smp_linux_boot_4hart
+          - test_soc_smp_linux_boot_8hart
+          - test_soc_66_linux_boot
+          - test_soc_66_smp_linux_boot_2hart
+          - test_soc_66_smp_linux_boot_4hart
+          - test_soc_71_linux_boot
+          - test_soc_71_smp_linux_boot_2hart
+          - test_soc_71_smp_linux_boot_4hart
+          - test_soc_71v_linux_boot
+        include:
+          - arch: x86_64
+            os: ubuntu-24.04
+          - arch: aarch64
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 300
+    env:
+      # Keep expanded workloads separate from the historical fixed gate.
+      HELIODOR_REF: 6285682fa0a514077da9d17fee385c7841160025
+      HELIODOR_TESTS: ${{ matrix.test }}
+      HELIODOR_RUNNERS: veryl-cc-sync celox celox-tiered veryl-cc-tiered
+      HELIODOR_TIMEOUT_SEC: "3600"
+      HELIODOR_CELOX_CARGO_PROFILE: release
+      CELOX_OPT_LEVEL: O2
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/setup-rust
+      - uses: Swatinem/rust-cache@v2
+      - name: Record host
+        run: |
+          uname -a > heliodor-suite-host.txt
+          lscpu >> heliodor-suite-host.txt
+      - name: Run complete workload
+        shell: bash
+        run: set -o pipefail && bash scripts/run-heliodor-bench.sh run 2>&1 | tee heliodor-suite-output.txt
+      - name: Verify tiered promotion
+        shell: bash
+        run: |
+          source scripts/run-heliodor-bench.sh
+          logs=(target/heliodor/results/*_celox-tiered_*.log)
+          test "${#logs[@]}" -eq 1
+          validate_gate_tiered_stats "${logs[0]}" "$HELIODOR_TESTS"
+      - name: Upload workload results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: heliodor-suite-${{ matrix.arch }}-${{ matrix.test }}
+          path: |
+            heliodor-suite-host.txt
+            heliodor-suite-output.txt
+            target/heliodor/results/results.tsv
+            target/heliodor/results/*.log
+
   publish-linux-boot:
     name: Publish Linux boot benchmarks
     if: >-
+      !cancelled() &&
+      needs.heliodor.result == 'success' &&
+      needs.arm64-linux-boot-full.result == 'success' &&
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       !inputs.arm64_profile &&
       github.ref == 'refs/heads/master'
-    needs: [heliodor, arm64-linux-boot-full]
+    needs: [heliodor, arm64-linux-boot-full, linux-suite]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -455,6 +525,32 @@ jobs:
           node scripts/convert-heliodor-bench.mjs \
             "$native_results" heliodor-published.json \
             --arm64-results "$arm64_results" --require-tiered
+
+      - uses: actions/download-artifact@v8
+        if: needs.linux-suite.result == 'success'
+        with:
+          pattern: heliodor-suite-*
+          path: artifacts/suite
+
+      - name: Convert expanded Linux suite
+        if: needs.linux-suite.result == 'success'
+        shell: bash
+        run: |
+          python3 - <<'PYTHON'
+          from pathlib import Path
+          for arch in ("x86_64", "aarch64"):
+              files = sorted(Path("artifacts/suite").glob(f"heliodor-suite-{arch}-*/target/heliodor/results/results.tsv"))
+              if len(files) != 11:
+                  raise SystemExit(f"Expected 11 workloads for {arch}, found {len(files)}")
+              lines = [file.read_text().splitlines() for file in files]
+              Path(f"suite-{arch}.tsv").write_text("\n".join(lines[0][:1] + [row for result in lines for row in result[1:]]) + "\n")
+          PYTHON
+          node scripts/convert-heliodor-bench.mjs suite-x86_64.tsv heliodor-suite.json --arm64-results suite-aarch64.tsv --require-tiered --suite
+          node --input-type=module -e '
+            import { readFileSync, writeFileSync } from "node:fs";
+            const read = (path) => JSON.parse(readFileSync(path, "utf8"));
+            writeFileSync("heliodor-published.json", JSON.stringify([...read("heliodor-published.json"), ...read("heliodor-suite.json")]));
+          '
 
       - name: Store Heliodor benchmark history
         uses: benchmark-action/github-action-benchmark@v1

--- a/crates/celox-frontend-core/src/symbolic/assembly.rs
+++ b/crates/celox-frontend-core/src/symbolic/assembly.rs
@@ -380,6 +380,8 @@ pub fn schedule_symbolic_rtl(
     let ignored_loops = parse_ignored_loops(ignored_loops, &instance_modules, &modules, &expanded);
     let true_loops = parse_true_loops(true_loops, &instance_modules, &modules, &expanded);
 
+    flattening::refine_cyclic_fold_groups(&mut comb_blocks, &mut global_arena)?;
+
     // Build reset -> clock mapping with AbsoluteAddr
     let mut reset_clock_map: HashMap<AbsoluteAddr, AbsoluteAddr> = HashMap::default();
     for id in expanded.values() {

--- a/crates/celox-frontend-core/src/symbolic/flattening.rs
+++ b/crates/celox-frontend-core/src/symbolic/flattening.rs
@@ -18,6 +18,176 @@ pub struct FlattenedModule {
     pub pre_atomized_comb_blocks: Vec<LogicPath<AbsoluteAddr>>,
 }
 
+/// A recovered loop may bundle independent reductions into one atomic node.
+/// Its union of inputs can invent feedback through another combinational
+/// process. Split only groups on such cycles: keeping acyclic groups intact
+/// preserves their shared loop control and the existing scheduler's choices.
+pub(super) fn refine_cyclic_fold_groups(
+    paths: &mut [LogicPath<AbsoluteAddr>],
+    arena: &mut SLTNodeArena<AbsoluteAddr>,
+) -> Result<(), SLTNodeFactsError> {
+    // Other graph errors (for example multiple drivers) are diagnosed by the
+    // ordinary scheduler with source information, not by this refinement.
+    let Ok(cyclic) = celox_slt::scheduler::cyclic_logic_paths(paths) else {
+        return Ok(());
+    };
+    let mut groups = BTreeSet::new();
+    for index in cyclic {
+        if let Some((group, _)) = fold_projection(paths[index].expr, arena) {
+            groups.insert(group);
+        }
+    }
+    let mut replacements = HashMap::default();
+    for group in groups {
+        let SLTNode::ForFoldGroup {
+            loop_var,
+            loop_width,
+            loop_signed,
+            start,
+            step,
+            trip_count,
+            entry_guard,
+            states,
+        } = arena.get(group).clone()
+        else {
+            unreachable!();
+        };
+        let sources = states
+            .iter()
+            .map(|state| {
+                let mut inputs = crate::HashSet::default();
+                collect_inputs(state.update, arena, &mut inputs);
+                inputs
+            })
+            .collect::<Vec<_>>();
+        let depends_on = |from: usize, to: usize| {
+            sources[from].iter().any(|input| {
+                input.id == states[to].target.id && input.access.overlaps(&states[to].target.access)
+            })
+        };
+        // Weak components retain one-way and transitive carried-state
+        // recurrences. Initial expressions remain external inputs, since they
+        // execute before the loop's local state bindings exist.
+        let mut seen = vec![false; states.len()];
+        let mut components = Vec::new();
+        for seed in 0..states.len() {
+            if seen[seed] {
+                continue;
+            }
+            seen[seed] = true;
+            let mut pending = vec![seed];
+            let mut component = Vec::new();
+            while let Some(index) = pending.pop() {
+                component.push(index);
+                for (other, visited) in seen.iter_mut().enumerate() {
+                    if !*visited && (depends_on(index, other) || depends_on(other, index)) {
+                        *visited = true;
+                        pending.push(other);
+                    }
+                }
+            }
+            component.sort_unstable();
+            components.push(component);
+        }
+        if components.len() < 2 {
+            continue;
+        }
+        let mut offsets = Vec::new();
+        let mut offset = get_width(group, arena);
+        for state in &states {
+            let width = state.target.access.msb - state.target.access.lsb + 1;
+            offset -= width;
+            offsets.push(BitAccess::new(offset, offset + width - 1));
+        }
+        let mut fragments = Vec::new();
+        for component in components {
+            let split = arena.alloc(SLTNode::ForFoldGroup {
+                loop_var,
+                loop_width,
+                loop_signed,
+                start: start.clone(),
+                step: step.clone(),
+                trip_count,
+                entry_guard,
+                states: component.iter().map(|&i| states[i].clone()).collect(),
+            })?;
+            let mut offset = get_width(split, arena);
+            for index in component {
+                let original = offsets[index];
+                let width = original.msb - original.lsb + 1;
+                offset -= width;
+                let projection = arena.alloc(SLTNode::Slice {
+                    expr: split,
+                    access: BitAccess::new(offset, offset + width - 1),
+                })?;
+                fragments.push((original, projection));
+            }
+        }
+        fragments.sort_by_key(|(access, _)| std::cmp::Reverse(access.lsb));
+        replacements.insert(group, fragments);
+    }
+    for path in paths {
+        // These recipes carry additional source/statement-position semantics.
+        // Leave them intact rather than infer new masks from only `expr`.
+        if !path.local_inputs.is_empty()
+            || !path.pre_lower_nodes.is_empty()
+            || !path.previous_sources.is_empty()
+            || !path.address_sources.is_empty()
+            || path.target.var().is_none()
+        {
+            continue;
+        }
+        let Some((group, access)) = fold_projection(path.expr, arena) else {
+            continue;
+        };
+        let Some(fragments) = replacements.get(&group) else {
+            continue;
+        };
+        let mut parts = Vec::new();
+        for &(original, projection) in fragments {
+            if !access.overlaps(&original) {
+                continue;
+            }
+            let lsb = access.lsb.max(original.lsb) - original.lsb;
+            let msb = access.msb.min(original.msb) - original.lsb;
+            let part = arena.alloc(SLTNode::Slice {
+                expr: projection,
+                access: BitAccess::new(lsb, msb),
+            })?;
+            parts.push((part, msb - lsb + 1));
+        }
+        let expr = if parts.len() == 1 {
+            parts[0].0
+        } else {
+            arena.alloc(SLTNode::Concat(parts))?
+        };
+        let mut inputs = crate::HashSet::default();
+        collect_inputs(expr, arena, &mut inputs);
+        let original_ids: crate::HashSet<_> = path.sources.iter().map(|source| source.id).collect();
+        inputs.retain(|input| original_ids.contains(&input.id));
+        path.expr = expr;
+        path.sources = inputs;
+    }
+    Ok(())
+}
+
+fn fold_projection(
+    node: NodeId,
+    arena: &SLTNodeArena<AbsoluteAddr>,
+) -> Option<(NodeId, BitAccess)> {
+    match arena.get(node) {
+        SLTNode::ForFoldGroup { .. } => Some((node, BitAccess::new(0, get_width(node, arena) - 1))),
+        SLTNode::Slice { expr, access } => {
+            let (group, parent) = fold_projection(*expr, arena)?;
+            Some((
+                group,
+                BitAccess::new(parent.lsb + access.lsb, parent.lsb + access.msb),
+            ))
+        }
+        _ => None,
+    }
+}
+
 pub fn flatten_module(
     module: &SimModule,
     path: &InstancePath,
@@ -769,4 +939,174 @@ fn convert_glue_block(
         res.push(convert_logic_path(abb, arena, target_arena, cache, cv)?);
     }
     Ok(res)
+}
+
+#[cfg(test)]
+mod fold_refinement_tests {
+    use super::*;
+    use celox_slt::SLTForFoldGroupState;
+
+    fn addr(id: u32) -> AbsoluteAddr {
+        AbsoluteAddr {
+            instance_id: InstanceId(0),
+            var_id: SourceVarId(id),
+        }
+    }
+
+    fn atom(id: u32) -> VarAtomBase<AbsoluteAddr> {
+        VarAtomBase {
+            id: addr(id),
+            access: BitAccess::new(0, 0),
+        }
+    }
+
+    fn input(id: u32, arena: &mut SLTNodeArena<AbsoluteAddr>) -> NodeId {
+        arena
+            .alloc(SLTNode::Input {
+                variable: addr(id),
+                signed: false,
+                index: Vec::new(),
+                access: BitAccess::new(0, 0),
+            })
+            .unwrap()
+    }
+
+    fn path(id: u32, expr: NodeId, arena: &SLTNodeArena<AbsoluteAddr>) -> LogicPath<AbsoluteAddr> {
+        let mut sources = crate::HashSet::default();
+        collect_inputs(expr, arena, &mut sources);
+        LogicPath {
+            target: LogicPathTarget::Var(atom(id)),
+            sources,
+            previous_sources: Default::default(),
+            address_sources: Default::default(),
+            local_inputs: Vec::new(),
+            order_before: Default::default(),
+            comb_capture_enable_sites: Vec::new(),
+            comb_capture_enable_always: false,
+            pre_lower_nodes: Vec::new(),
+            expr,
+        }
+    }
+
+    // a reduces an external input; b reduces c. Connecting c to a creates
+    // artificial feedback only because the atomic group gives a a read of c.
+    fn fixture(coupled: bool) -> (SLTNodeArena<AbsoluteAddr>, Vec<LogicPath<AbsoluteAddr>>) {
+        let mut arena = SLTNodeArena::new();
+        let zero = arena
+            .alloc(SLTNode::Constant(0u8.into(), 0u8.into(), 1, false))
+            .unwrap();
+        let one = arena
+            .alloc(SLTNode::Constant(1u8.into(), 0u8.into(), 1, false))
+            .unwrap();
+        let a = input(0, &mut arena);
+        let b = input(1, &mut arena);
+        let c = input(2, &mut arena);
+        let external = input(3, &mut arena);
+        let update_a = arena
+            .alloc(SLTNode::Binary(a, BinaryOp::Or, external))
+            .unwrap();
+        let update_b = arena
+            .alloc(SLTNode::Binary(
+                b,
+                BinaryOp::Or,
+                if coupled { a } else { c },
+            ))
+            .unwrap();
+        let group = arena
+            .alloc(SLTNode::ForFoldGroup {
+                loop_var: addr(4),
+                loop_width: 2,
+                loop_signed: false,
+                start: 0.into(),
+                step: 1.into(),
+                trip_count: 2,
+                entry_guard: one,
+                states: vec![
+                    SLTForFoldGroupState {
+                        target: atom(0),
+                        initial: zero,
+                        update: update_a,
+                    },
+                    SLTForFoldGroupState {
+                        target: atom(1),
+                        initial: zero,
+                        update: update_b,
+                    },
+                ],
+            })
+            .unwrap();
+        let a_result = arena
+            .alloc(SLTNode::Slice {
+                expr: group,
+                access: BitAccess::new(1, 1),
+            })
+            .unwrap();
+        let b_result = arena
+            .alloc(SLTNode::Slice {
+                expr: group,
+                access: BitAccess::new(0, 0),
+            })
+            .unwrap();
+        let paths = vec![path(0, a_result, &arena), path(1, b_result, &arena)];
+        (arena, paths)
+    }
+
+    #[test]
+    fn acyclic_groups_keep_exact_expression_and_arena_identity() {
+        let (mut arena, mut paths) = fixture(false);
+        let original = paths.clone();
+        let nodes = arena.len();
+        refine_cyclic_fold_groups(&mut paths, &mut arena).unwrap();
+        assert_eq!(paths, original);
+        assert_eq!(arena.len(), nodes);
+    }
+
+    #[test]
+    fn independent_groups_remove_only_artificial_feedback() {
+        let (mut arena, mut paths) = fixture(false);
+        let a = input(0, &mut arena);
+        paths.push(path(2, a, &arena));
+        assert!(
+            !celox_slt::scheduler::cyclic_logic_paths(&paths)
+                .unwrap()
+                .is_empty()
+        );
+        refine_cyclic_fold_groups(&mut paths, &mut arena).unwrap();
+        assert!(
+            celox_slt::scheduler::cyclic_logic_paths(&paths)
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(paths[0].sources, [atom(3)].into_iter().collect());
+        assert_eq!(paths[1].sources, [atom(2)].into_iter().collect());
+    }
+
+    #[test]
+    fn actual_feedback_remains_a_cycle_after_refinement() {
+        let (mut arena, mut paths) = fixture(false);
+        let b = input(1, &mut arena);
+        paths.push(path(2, b, &arena));
+        refine_cyclic_fold_groups(&mut paths, &mut arena).unwrap();
+        assert_eq!(
+            celox_slt::scheduler::cyclic_logic_paths(&paths).unwrap(),
+            vec![1, 2]
+        );
+    }
+
+    #[test]
+    fn coupled_recurrences_are_not_split_to_hide_feedback() {
+        let (mut arena, mut paths) = fixture(true);
+        let b = input(1, &mut arena);
+        paths.push(path(3, b, &arena));
+        let original = paths.clone();
+        let nodes = arena.len();
+        refine_cyclic_fold_groups(&mut paths, &mut arena).unwrap();
+        assert_eq!(paths, original);
+        assert_eq!(arena.len(), nodes);
+        assert!(
+            !celox_slt::scheduler::cyclic_logic_paths(&paths)
+                .unwrap()
+                .is_empty()
+        );
+    }
 }

--- a/crates/celox-slt/src/scheduler.rs
+++ b/crates/celox-slt/src/scheduler.rs
@@ -693,6 +693,30 @@ where
     })
 }
 
+/// Paths participating in a semantic dependency cycle, including self loops.
+/// Frontends can use this before scheduling to refine atomic pure expressions
+/// without perturbing the representation of already acyclic logic.
+pub fn cyclic_logic_paths<Addr>(
+    input: &[LogicPath<Addr>],
+) -> Result<Vec<usize>, SchedulerError<Addr>>
+where
+    Addr: Copy + Ord + Hash + Eq + Display + Debug,
+{
+    let memory = build_logic_path_memory_ssa(input)?;
+    let edges = &memory.dependencies.users;
+    let components = component_map(edges);
+    Ok(edges
+        .iter()
+        .enumerate()
+        .filter_map(|(source, targets)| {
+            targets
+                .iter()
+                .any(|&target| components[source] == components[target])
+                .then_some(source)
+        })
+        .collect())
+}
+
 pub(crate) fn plan_ff_comb_schedule<Addr>(
     input: &[LogicPath<Addr>],
     ff: &[FfAccessSummary<Addr>],

--- a/crates/celox/tests/recovered_unrolled_fold.rs
+++ b/crates/celox/tests/recovered_unrolled_fold.rs
@@ -37,6 +37,79 @@ const MULTI_STATE_LOOP: &str = r#"
 
 all_backends! {
 
+// Independent reductions without feedback retain their shared loop and
+// induction variable. Check both reductions across changing external inputs.
+fn recovered_independent_reductions_share_input_correctly(sim) {
+    @ignore_on(sv);
+    @setup { let code = r#"
+        module Top (
+            values: input logic<32>,
+            sum: output logic<8>,
+            parity: output logic<8>,
+        ) {
+            always_comb {
+                sum = 8'd0;
+                parity = 8'd0;
+                for h in 0..4 {
+                    sum = sum + values[h * 8+:8];
+                    parity = parity ^ values[h * 8+:8];
+                }
+            }
+        }
+    "#; }
+    @build SimulatorBuilder::new(code, "Top");
+    let values = sim.signal("values");
+    let sum = sim.signal("sum");
+    let parity = sim.signal("parity");
+    for value in [0u32, 0x04030201, 0xffffffff, 0x12345678, 0x800100ff, 0] {
+        sim.modify(|io| io.set(values, value)).unwrap();
+        let bytes = value.to_le_bytes();
+        let expected_sum = bytes.iter().fold(0u8, |acc, byte| acc.wrapping_add(*byte));
+        let expected_parity = bytes.iter().fold(0u8, |acc, byte| acc ^ *byte);
+        assert_eq!(sim.get(sum), expected_sum.into());
+        assert_eq!(sim.get(parity), expected_parity.into());
+    }
+}
+
+// Read enables determine the write grant, but never read the granted writes.
+// Recovering both reductions as one atomic fold must not invent that feedback.
+fn recovered_mmio_read_write_dependencies_are_independent(sim) {
+    @ignore_on(sv);
+    @setup { let code = r#"
+        module Top (
+            reads : input logic<2>,
+            writes: input logic<2>,
+            read_enable : output logic,
+            write_enable: output logic,
+        ) {
+            var grant: logic;
+            var fired: logic<2>;
+            assign grant = !read_enable;
+            assign fired = if grant ? writes : 2'd0;
+            always_comb {
+                read_enable = 1'b0;
+                write_enable = 1'b0;
+                for h in 0..2 {
+                    if reads[h] { read_enable = 1'b1; }
+                    if fired[h] { write_enable = 1'b1; }
+                }
+            }
+        }
+    "#; }
+    @build SimulatorBuilder::new(code, "Top");
+    let reads = sim.signal("reads");
+    let writes = sim.signal("writes");
+    let read_enable = sim.signal("read_enable");
+    let write_enable = sim.signal("write_enable");
+    for r in [0u8, 1, 2, 3, 0] {
+        for w in [0u8, 1, 2, 3, 0] {
+            sim.modify(|io| { io.set(reads, r); io.set(writes, w); }).unwrap();
+            assert_eq!(sim.get(read_enable), ((r != 0) as u8).into());
+            assert_eq!(sim.get(write_enable), ((r == 0 && w != 0) as u8).into());
+        }
+    }
+}
+
 fn recovered_unrolled_store_forward_selects_older_entry(sim) {
     @ignore_on(sv);
     @setup { let code = r#"

--- a/docs/.vitepress/components/BenchmarkDashboard.vue
+++ b/docs/.vitepress/components/BenchmarkDashboard.vue
@@ -192,7 +192,8 @@ const overviewTabs: TabDef[] = [
   {
     key: "heliodor",
     label: "Heliodor Linux",
-    match: (n) => n.startsWith("heliodor_linux_boot_"),
+    match: (n) =>
+      n.startsWith("heliodor_linux_boot_") || n.startsWith("heliodor_suite_"),
     sections: heliodorSections,
   },
 ];
@@ -382,6 +383,24 @@ function formatChartTitle(benchName: string): string {
   s = s.replace(/_top_n1000/, "");
   // Strip optimize prefix patterns
   s = s.replace(/^optimize_/, "");
+  s = s.replace(
+    /^heliodor_suite_(?:(66|71|71v)_)?(smp_)?linux_boot(?:_([248])hart)?_(.+)$/,
+    (_match, version, _smp, harts, metric) => {
+      const kernels: Record<string, string> = {
+        "66": "6.6",
+        "71": "7.1",
+        "71v": "7.1 (vector)",
+      };
+      const labels: Record<string, string> = {
+        compilation: "compilation (synchronous)",
+        execution: "execution (after compilation)",
+        startup: "tiered startup",
+        end_to_end: "tiered end to end",
+        tiered_execution: "tiered execution (includes background compilation)",
+      };
+      return `Linux ${kernels[version] ?? "5.15"} / ${harts ?? "1"} hart / ${labels[metric] ?? metric}`;
+    },
+  );
   s = s.replace(/^heliodor_linux_boot_execution$/, "Linux boot execution (after compilation)");
   s = s.replace(/^heliodor_linux_boot_compilation$/, "Linux boot compilation (synchronous)");
   s = s.replace(/^heliodor_linux_boot_startup$/, "Tiered startup until simulation begins");
@@ -441,8 +460,11 @@ const allSeries = computed<Series[]>(() => {
         let benchName = normalizeBenchName(stripPrefix(b.name));
         // Historical Celox tiered points also include background compilation.
         // Keep their history, but do not mix them with post-compile throughput.
-        if (seriesRuntime.includes("tiered") && benchName === "heliodor_linux_boot_execution") {
-          benchName = "heliodor_linux_boot_tiered_execution";
+        if (
+          seriesRuntime.includes("tiered") &&
+          /^heliodor_(?:linux_boot|suite_.+)_execution$/.test(benchName)
+        ) {
+          benchName = benchName.replace(/_execution$/, "_tiered_execution");
         }
         const key = `${seriesRuntime}/${benchName}`;
         let series = seriesByKey.get(key);
@@ -474,7 +496,8 @@ const allSeries = computed<Series[]>(() => {
 function isPrimaryBench(benchName: string): boolean {
   return PRIMARY_COUNTER_BENCHES.has(benchName)
     || PRIMARY_STDLIB_BENCHES.has(benchName)
-    || benchName.startsWith("heliodor_linux_boot_");
+    || benchName.startsWith("heliodor_linux_boot_")
+    || benchName.startsWith("heliodor_suite_");
 }
 
 // --- Computed: tabs with chart cards ---

--- a/docs/benchmarks/heliodor.md
+++ b/docs/benchmarks/heliodor.md
@@ -73,3 +73,36 @@ and timings. Use the same machine and configuration for before/after comparisons
 
 Published results appear in the **Heliodor Linux** section of the
 [benchmark dashboard](./index.md).
+
+## Expanded Linux suite
+
+Nightly and non-profiling manual runs also measure the following workloads on
+x86-64 (`ubuntu-24.04`) and AArch64 (`ubuntu-24.04-arm`), using all four backends:
+
+| Guest Linux kernel | Hart counts |
+| --- | --- |
+| 5.15 | 1, 2, 4, 8 |
+| 6.6 | 1, 2, 4 |
+| 7.1 | 1, 2, 4 |
+| 7.1 with vector enabled | 1 |
+
+These 11 workloads use Heliodor revision
+`6285682fa0a514077da9d17fee385c7841160025`. Kernel versions refer to the
+simulated guest, not the benchmark host OS. Each runner has a one-hour timeout;
+timeouts and incomplete runs fail the job and are not published as timings.
+The nightly publisher requires the complete suite on both architectures.
+
+The dashboard labels each kernel and hart count separately. Expanded results
+use separate history from the older fixed gate because the design revision is
+different. Each chart retains the same compilation, execution, and tiered timing
+definitions described above. These large jobs do not run on pull requests.
+
+For example, to run the Linux 6.6 four-hart workload locally:
+
+```bash
+HELIODOR_REF=6285682fa0a514077da9d17fee385c7841160025 \
+HELIODOR_TESTS=test_soc_66_smp_linux_boot_4hart \
+HELIODOR_RUNNERS="veryl-cc-sync celox celox-tiered veryl-cc-tiered" \
+HELIODOR_CELOX_CARGO_PROFILE=release HELIODOR_TIMEOUT_SEC=3600 \
+bash scripts/run-heliodor-bench.sh run
+```

--- a/docs/ja/benchmarks/heliodor.md
+++ b/docs/ja/benchmarks/heliodor.md
@@ -66,3 +66,35 @@ CI の固定 `gate` は x86-64 で `veryl-cc-sync`、`celox`、`celox-tiered`、
 マシンと構成を使ってください。
 
 公開結果は[ベンチマークダッシュボード](./index.md)の **Heliodor Linux** に掲載します。
+
+## 大規模・Linux バージョン別の測定
+
+nightly とプロファイルを取らない手動実行では、次の 11 ケースを x86-64
+（`ubuntu-24.04`）と AArch64（`ubuntu-24.04-arm`）で測定します。
+各ケースで前述の 4 バックエンドを実行します。
+
+| ゲスト Linux カーネル | hart 数 |
+| --- | --- |
+| 5.15 | 1、2、4、8 |
+| 6.6 | 1、2、4 |
+| 7.1 | 1、2、4 |
+| 7.1（ベクトル有効） | 1 |
+
+Heliodor のリビジョンは `6285682fa0a514077da9d17fee385c7841160025` に固定します。
+Linux バージョンはシミュレーション内で起動するゲストのもので、ホスト OS の違いではありません。
+各実行のタイムアウトは 1 時間です。未完了・失敗は計測値として公開せず、
+両アーキテクチャの全ケースが成功した場合に nightly の結果を公開します。
+
+ダッシュボードにはカーネルと hart 数を区別して表示します。設計リビジョンが異なるため、
+従来の固定 gate とは別の履歴です。コンパイル・実行・tiered の時間の定義は共通です。
+大規模ケースは PR ごとには実行しません。
+
+Linux 6.6 の 4 hart をローカルで実行する例:
+
+```bash
+HELIODOR_REF=6285682fa0a514077da9d17fee385c7841160025 \
+HELIODOR_TESTS=test_soc_66_smp_linux_boot_4hart \
+HELIODOR_RUNNERS="veryl-cc-sync celox celox-tiered veryl-cc-tiered" \
+HELIODOR_CELOX_CARGO_PROFILE=release HELIODOR_TIMEOUT_SEC=3600 \
+bash scripts/run-heliodor-bench.sh run
+```

--- a/scripts/convert-heliodor-bench.mjs
+++ b/scripts/convert-heliodor-bench.mjs
@@ -6,16 +6,20 @@ import { readFileSync, writeFileSync } from "node:fs";
 const [inputPath, outputPath, ...options] = process.argv.slice(2);
 if (!inputPath || !outputPath) {
   console.error(
-    "Usage: node convert-heliodor-bench.mjs <results.tsv> <output.json> [--jit-only | --arm64-results <results.tsv>] [--require-tiered]",
+    "Usage: node convert-heliodor-bench.mjs <results.tsv> <output.json> [--jit-only | --arm64-results <results.tsv>] [--require-tiered] [--suite]",
   );
   process.exit(1);
 }
 
+let suite = false;
 let jitOnly = false;
 let requireTiered = false;
 let arm64ResultsPath;
 for (let index = 0; index < options.length; index += 1) {
   switch (options[index]) {
+    case "--suite":
+      suite = true;
+      break;
     case "--require-tiered":
       requireTiered = true;
       break;
@@ -109,110 +113,142 @@ function milliseconds(name, nanoseconds) {
   };
 }
 
-const celox = requirePassedRunner(rows, "celox", inputPath);
-const readTieredRunner = requireTiered ? requirePassedRunner : optionalPassedRunner;
-const tiered = readTieredRunner(rows, "celox-tiered", inputPath);
-const verylTiered = readTieredRunner(rows, "veryl-cc-tiered", inputPath);
-const veryl = requirePassedRunner(rows, "veryl-cc-sync", inputPath);
-if (celox.test !== veryl.test || (tiered && tiered.test !== celox.test)) {
-  throw new Error(
-    `runner tests differ: Celox=${celox.test}, tiered=${tiered?.test ?? "absent"}, Veryl=${veryl.test}`,
-  );
-}
-
-const results = [
-  milliseconds(
-    "heliodor-celox-jit/heliodor_linux_boot_execution",
-    ns(celox, "jit_execute_elapsed_ns"),
-  ),
-  milliseconds(
-    "heliodor-celox-total/heliodor_linux_boot_execution",
-    ns(celox, "execute_elapsed_ns"),
-  ),
-  milliseconds(
-    "heliodor-veryl/heliodor_linux_boot_execution",
-    ns(veryl, "execute_elapsed_ns"),
-  ),
-  milliseconds(
-    "heliodor-celox-compile/heliodor_linux_boot_compilation",
-    ns(celox, "compile_elapsed_ns"),
-  ),
-  milliseconds(
-    "heliodor-veryl-compile/heliodor_linux_boot_compilation",
-    ns(veryl, "compile_elapsed_ns"),
-  ),
-];
-
-function addTieredMetrics(platform, row) {
-  if (!row) return;
-  if (row.test !== celox.test) {
+function convertResults(rows, arm64Rows) {
+  const celox = requirePassedRunner(rows, "celox", inputPath);
+  const readTieredRunner = requireTiered ? requirePassedRunner : optionalPassedRunner;
+  const tiered = readTieredRunner(rows, "celox-tiered", inputPath);
+  const verylTiered = readTieredRunner(rows, "veryl-cc-tiered", inputPath);
+  const veryl = requirePassedRunner(rows, "veryl-cc-sync", inputPath);
+  if (celox.test !== veryl.test || (tiered && tiered.test !== celox.test)) {
     throw new Error(
-      `runner tests differ: Celox=${celox.test}, ${platform}=${row.test}`,
+      `runner tests differ: Celox=${celox.test}, tiered=${tiered?.test ?? "absent"}, Veryl=${veryl.test}`,
     );
   }
-  const startup = ns(row, "compile_elapsed_ns");
-  const execution = ns(row, "execute_elapsed_ns");
-  const total = ns(row, "reported_elapsed_ns");
-  if (startup + execution > total) {
-    throw new Error(`${platform} startup and execution exceed end-to-end time`);
-  }
-  results.push(
-    milliseconds(`heliodor-${platform}/heliodor_linux_boot_end_to_end`, total),
-    milliseconds(`heliodor-${platform}/heliodor_linux_boot_startup`, startup),
+
+  const results = [
     milliseconds(
-      `heliodor-${platform}/heliodor_linux_boot_execution`,
-      execution,
+      "heliodor-celox-jit/heliodor_linux_boot_execution",
+      ns(celox, "jit_execute_elapsed_ns"),
     ),
-  );
-}
+    milliseconds(
+      "heliodor-celox-total/heliodor_linux_boot_execution",
+      ns(celox, "execute_elapsed_ns"),
+    ),
+    milliseconds(
+      "heliodor-veryl/heliodor_linux_boot_execution",
+      ns(veryl, "execute_elapsed_ns"),
+    ),
+    milliseconds(
+      "heliodor-celox-compile/heliodor_linux_boot_compilation",
+      ns(celox, "compile_elapsed_ns"),
+    ),
+    milliseconds(
+      "heliodor-veryl-compile/heliodor_linux_boot_compilation",
+      ns(veryl, "compile_elapsed_ns"),
+    ),
+  ];
 
-addTieredMetrics("celox-tiered", tiered);
-addTieredMetrics("veryl-tiered-x86_64", verylTiered);
-
-if (arm64ResultsPath) {
-  const arm64Rows = readResults(arm64ResultsPath);
-  addTieredMetrics(
-    "celox-tiered-aarch64",
-    readTieredRunner(arm64Rows, "celox-tiered", arm64ResultsPath),
-  );
-  addTieredMetrics(
-    "veryl-tiered-aarch64",
-    readTieredRunner(arm64Rows, "veryl-cc-tiered", arm64ResultsPath),
-  );
-  const arm64 = requirePassedRunner(arm64Rows, "celox", arm64ResultsPath);
-  const verylArm64 = requirePassedRunner(
-    arm64Rows,
-    "veryl-cc-sync",
-    arm64ResultsPath,
-  );
-  for (const row of [arm64, verylArm64]) {
+  function addTieredMetrics(platform, row) {
+    if (!row) return;
     if (row.test !== celox.test) {
       throw new Error(
-        `runner tests differ: native-x86_64=${celox.test}, ${row.runner}=${row.test}`,
+        `runner tests differ: Celox=${celox.test}, ${platform}=${row.test}`,
+      );
+    }
+    const startup = ns(row, "compile_elapsed_ns");
+    const execution = ns(row, "execute_elapsed_ns");
+    const total = ns(row, "reported_elapsed_ns");
+    if (startup + execution > total) {
+      throw new Error(`${platform} startup and execution exceed end-to-end time`);
+    }
+    results.push(
+      milliseconds(`heliodor-${platform}/heliodor_linux_boot_end_to_end`, total),
+      milliseconds(`heliodor-${platform}/heliodor_linux_boot_startup`, startup),
+      milliseconds(
+        `heliodor-${platform}/heliodor_linux_boot_execution`,
+        execution,
+      ),
+    );
+  }
+
+  addTieredMetrics("celox-tiered", tiered);
+  addTieredMetrics("veryl-tiered-x86_64", verylTiered);
+
+  if (arm64ResultsPath) {
+    addTieredMetrics(
+      "celox-tiered-aarch64",
+      readTieredRunner(arm64Rows, "celox-tiered", arm64ResultsPath),
+    );
+    addTieredMetrics(
+      "veryl-tiered-aarch64",
+      readTieredRunner(arm64Rows, "veryl-cc-tiered", arm64ResultsPath),
+    );
+    const arm64 = requirePassedRunner(arm64Rows, "celox", arm64ResultsPath);
+    const verylArm64 = requirePassedRunner(
+      arm64Rows,
+      "veryl-cc-sync",
+      arm64ResultsPath,
+    );
+    for (const row of [arm64, verylArm64]) {
+      if (row.test !== celox.test) {
+        throw new Error(
+          `runner tests differ: native-x86_64=${celox.test}, ${row.runner}=${row.test}`,
+        );
+      }
+    }
+
+    for (const [platform, row] of [
+      ["native-x86_64", celox],
+      ["veryl-cc-x86_64", veryl],
+      ["native-aarch64", arm64],
+      ["veryl-cc-aarch64", verylArm64],
+    ]) {
+      results.push(
+        milliseconds(
+          `heliodor-${platform}/heliodor_linux_boot_compilation`,
+          ns(row, "compile_elapsed_ns"),
+        ),
+        milliseconds(
+          `heliodor-${platform}/heliodor_linux_boot_execution`,
+          ns(row, "execute_elapsed_ns"),
+        ),
       );
     }
   }
 
-  for (const [platform, row] of [
-    ["native-x86_64", celox],
-    ["veryl-cc-x86_64", veryl],
-    ["native-aarch64", arm64],
-    ["veryl-cc-aarch64", verylArm64],
-  ]) {
-    results.push(
-      milliseconds(
-        `heliodor-${platform}/heliodor_linux_boot_compilation`,
-        ns(row, "compile_elapsed_ns"),
-      ),
-      milliseconds(
-        `heliodor-${platform}/heliodor_linux_boot_execution`,
-        ns(row, "execute_elapsed_ns"),
-      ),
-    );
-  }
+  return jitOnly ? results.slice(0, 1) : results;
 }
 
-const selectedResults = jitOnly ? results.slice(0, 1) : results;
+const arm64Rows = arm64ResultsPath ? readResults(arm64ResultsPath) : undefined;
+let selectedResults;
+if (suite) {
+  const tests = [...new Set(rows.map((row) => row.test))];
+  if (tests.length === 0) throw new Error("empty Heliodor suite");
+  if (
+    arm64Rows &&
+    [...new Set(arm64Rows.map((row) => row.test))].sort().join() !==
+      [...tests].sort().join()
+  ) {
+    throw new Error("architecture workload sets differ");
+  }
+  selectedResults = tests.flatMap((test) => {
+    if (!/^test_soc_(?:(?:66|71|71v)_)?(?:smp_)?linux_boot(?:_[248]hart)?$/.test(test)) {
+      throw new Error(`unsupported suite workload: ${test}`);
+    }
+    return convertResults(
+      rows.filter((row) => row.test === test),
+      arm64Rows?.filter((row) => row.test === test),
+    ).map((metric) => ({
+      ...metric,
+      name: metric.name.replace(
+        "heliodor_linux_boot_",
+        `heliodor_suite_${test.slice("test_soc_".length)}_`,
+      ),
+    }));
+  });
+} else {
+  selectedResults = convertResults(rows, arm64Rows);
+}
 
 writeFileSync(outputPath, JSON.stringify(selectedResults, null, 2));
 console.log(`Converted ${selectedResults.length} Heliodor metrics → ${outputPath}`);

--- a/scripts/run-heliodor-bench.sh
+++ b/scripts/run-heliodor-bench.sh
@@ -1311,6 +1311,16 @@ test_source_files() {
         echo "error: could not canonicalize test source $tb_file" >&2
         return 1
     fi
+    # Versioned SMP benches instantiate the shared harness from the 5.15 file.
+    case "$test" in
+        test_soc_66_smp_linux_boot_*|test_soc_71_smp_linux_boot_*)
+            if [[ ! -f "$HELIODOR_DIR/tb/test_soc_smp_linux_boot.veryl" ]]; then
+                echo "error: missing shared SMP Linux boot harness" >&2
+                return 1
+            fi
+            source_output+=$'\n'"tb/test_soc_smp_linux_boot.veryl"
+            ;;
+    esac
     printf '%s\n%s\n' "$source_output" "$relative_tb"
 }
 
@@ -1345,9 +1355,9 @@ fallback_timeout_sec() {
     local test="$1"
     case "$test" in
         test_soc_smp_linux_boot_8hart) printf '%s\n' 3600 ;;
-        test_soc_smp_linux_boot_4hart|test_soc_smp_linux_boot_66_4hart|test_soc_smp_linux_boot_71_4hart) printf '%s\n' 1800 ;;
-        test_soc_smp_linux_boot_2hart|test_soc_smp_linux_boot_66_2hart|test_soc_smp_linux_boot_71_2hart) printf '%s\n' 600 ;;
-        test_soc_linux_boot|test_soc_linux_boot_66|test_soc_linux_boot_71|test_soc_linux_boot_71v) printf '%s\n' 300 ;;
+        test_soc_smp_linux_boot_4hart|test_soc_66_smp_linux_boot_4hart|test_soc_71_smp_linux_boot_4hart) printf '%s\n' 1800 ;;
+        test_soc_smp_linux_boot_2hart|test_soc_66_smp_linux_boot_2hart|test_soc_71_smp_linux_boot_2hart) printf '%s\n' 600 ;;
+        test_soc_linux_boot|test_soc_66_linux_boot|test_soc_71_linux_boot|test_soc_71v_linux_boot) printf '%s\n' 300 ;;
         test_soc_hvlinux) printf '%s\n' 900 ;;
         *) printf '%s\n' 600 ;;
     esac

--- a/scripts/tests/convert-heliodor-bench.sh
+++ b/scripts/tests/convert-heliodor-bench.sh
@@ -117,3 +117,27 @@ for source in results arm64-results; do
 done
 
 echo "convert-heliodor-bench fixture test: PASS"
+
+# Multiple kernels and hart counts must remain separate series on both hosts.
+for arch in results arm64-results; do
+    cp "$TMP/$arch.tsv" "$TMP/suite-$arch.tsv"
+    for test in test_soc_66_linux_boot test_soc_71_smp_linux_boot_4hart test_soc_smp_linux_boot_8hart; do
+        tail -n +2 "$TMP/$arch.tsv" | sed "s/test_soc_linux_boot/$test/g" >> "$TMP/suite-$arch.tsv"
+    done
+done
+node "$ROOT/scripts/convert-heliodor-bench.mjs" "$TMP/suite-results.tsv" "$TMP/suite.json" \
+    --arm64-results "$TMP/suite-arm64-results.tsv" --require-tiered --suite >/dev/null
+node - "$TMP/suite.json" <<'JS'
+const assert = require("node:assert/strict");
+const rows = require(process.argv[2]);
+assert.equal(rows.length, 25 * 4);
+assert.equal(new Set(rows.map(row => row.name)).size, rows.length);
+assert.equal(rows.find(row => row.name === "heliodor-native-aarch64/heliodor_suite_71_smp_linux_boot_4hart_execution").value, 8);
+JS
+sed '/test_soc_smp_linux_boot_8hart/d' "$TMP/suite-arm64-results.tsv" > "$TMP/missing.tsv"
+if node "$ROOT/scripts/convert-heliodor-bench.mjs" "$TMP/suite-results.tsv" "$TMP/bad.json" \
+    --arm64-results "$TMP/missing.tsv" --suite >/dev/null 2>&1; then
+    echo "accepted mismatched architecture workloads" >&2
+    exit 1
+fi
+echo "convert-heliodor-bench suite fixtures: PASS"

--- a/scripts/tests/run-heliodor-bench-gate.sh
+++ b/scripts/tests/run-heliodor-bench-gate.sh
@@ -415,6 +415,15 @@ assert_eq "$(sed -n '2p' "$TMP/cargo-env")" unset "CARGO_BUILD_TARGET neutraliza
         $'src/dummy.veryl\ntb/test.veryl' \
         "source enumeration without ripgrep"
     PATH="$saved_path"
+    printf '#[test(test_soc_66_smp_linux_boot_2hart)]\n' >"$HELIODOR_DIR/tb/linux66.veryl"
+    if test_source_files test_soc_66_smp_linux_boot_2hart >/dev/null 2>&1; then
+        fail "accepted versioned SMP without shared harness"
+    fi
+    touch "$HELIODOR_DIR/tb/test_soc_smp_linux_boot.veryl"
+    assert_eq "$(test_source_files test_soc_66_smp_linux_boot_2hart)" \
+        $'src/dummy.veryl\ntb/test_soc_smp_linux_boot.veryl\ntb/linux66.veryl' \
+        "versioned SMP includes its shared harness"
+
     mkdir -p "$HELIODOR_DIR/tb/duplicate"
     printf '%s\n' '#[test(test_soc_linux_boot)]' \
         >"$HELIODOR_DIR/tb/duplicate/test.veryl"


### PR DESCRIPTION
## Summary

Heliodor's SMP MMIO block reduces independent read and write enables in one loop. Recovering those reductions as one atomic fold introduces a false dependency cycle. Refine independent fold states only when their paths participate in a dependency cycle, preserving coupled recurrences and the original representation of acyclic workloads. Real feedback remains detectable; no loop exemptions are added.

Add a nightly/manual Linux suite at Heliodor `6285682fa0a514077da9d17fee385c7841160025`: 11 workloads covering Linux 5.15 (1/2/4/8 harts), 6.6 and 7.1 (1/2/4 harts), and vector-enabled 7.1. Each runs four simulator modes on x86-64 and AArch64. Include the shared versioned SMP harness, convert results into separate kernel/hart series, and display them on the benchmark dashboard with English/Japanese documentation. Preserve the historical gate and its series. Expanded results publish only when the complete suite succeeds.

## Validation

- Frontend-core and SLT unit tests: 163 passed. Includes acyclic representation preservation, removal of artificial feedback, and preservation of real feedback/coupled recurrences.
- Integration tests (`recovered_unrolled_fold`, `false_loop`, `true_loop`, `for_loop_unroll`, `synth_dynamic_loop`): 225 passed, 18 existing ignored cases. The MMIO reproduction passes native, Cranelift, interpreter, Wasm, and Veryl.
- Final release/O2 Linux 6.6 2-hart full boot: PASS, `cy=1ecb4d0 pass=1 r3=aa`, without loop exemptions.
- Formatting, diff checks, and Clippy for frontend-core/SLT passed.
- Heliodor converter/results/gate shell fixtures, script syntax checks, workflow matrix/source checks, synthetic 22-artifact publication conversion (275 distinct metrics), and documentation build passed.
- The full 22-job, four-runner suite has not been executed locally; in particular, AArch64 and the larger configurations remain to be validated by the workflow. Website publication has not been performed.

### Performance verification

On the same Ryzen 7 9800X3D host, release/O2 Linux 6.6 single-hart full boot was measured serially before/after/after/before (two samples per binary):

| Metric | Original mean | Final mean | Change |
| --- | ---: | ---: | ---: |
| Compilation | 35.147 s | 34.745 s | -1.14% |
| Execution | 126.618 s | 129.178 s | +2.02% |
| Total | 161.784 s | 163.941 s | +1.33% |

Execution samples were 127.855/125.381 s before and 130.842/127.514 s after. This small sample does not establish a small timing difference. The original and final approximately 11 MB native images are byte-for-byte identical, including generated machine code and runtime metadata (SHA-256 `856b2cc26fbb2c9de036bd151db29891d046ab3995e9efd8e823e580a235ac16`). The roughly 11% regression observed with eager splitting is removed from code generation for this workload.
