### PR TITLE
fix(compiler)!: reduce resource use for large Heliodor benchmarks

### DIFF
--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -12,6 +12,8 @@ on:
       - "crates/**"
       - "!crates/celox-napi/package.json"
       - "scripts/convert-heliodor-bench.mjs"
+      - "scripts/heliodor-suite.mjs"
+      - "scripts/heliodor-suite.test.mjs"
       - "scripts/ci-changes.mjs"
       - "scripts/ci-changes.test.mjs"
       - "scripts/run-heliodor-bench.sh"
@@ -22,6 +24,18 @@ on:
     - cron: "37 2 * * *"
   workflow_dispatch:
     inputs:
+      suite_test:
+        description: Run only this Linux suite test (empty runs the full suite)
+        type: string
+        default: ""
+      suite_runner:
+        description: Run only this suite backend (empty runs all four)
+        type: string
+        default: ""
+      suite_arch:
+        description: Run only this suite architecture (empty runs both)
+        type: string
+        default: ""
       arm64_profile:
         description: Capture an ARM64 Linux boot profile without publishing history
         type: boolean
@@ -45,7 +59,7 @@ env:
 # benchmark runs. Serialize master publishers with bench.yml, while develop uses
 # a separate group so its dispatch cannot replace a pending master nightly run.
 concurrency:
-  group: ${{ inputs.arm64_profile && format('heliodor-arm64-profile-{0}', github.ref) || github.event_name == 'pull_request' && format('heliodor-pr-{0}', github.event.pull_request.number) || github.ref == 'refs/heads/develop' && 'heliodor-develop' || 'bench' }}
+  group: ${{ (inputs.suite_test || inputs.suite_runner || inputs.suite_arch) && format('heliodor-suite-{0}-{1}-{2}-{3}', github.ref, inputs.suite_test, inputs.suite_runner, inputs.suite_arch) || inputs.arm64_profile && format('heliodor-arm64-profile-{0}', github.ref) || github.event_name == 'pull_request' && format('heliodor-pr-{0}', github.event.pull_request.number) || github.ref == 'refs/heads/develop' && 'heliodor-develop' || 'bench' }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -87,12 +101,13 @@ jobs:
       - name: Test benchmark conversion fixtures
         shell: bash
         run: |
+          node --test scripts/heliodor-suite.test.mjs
           bash scripts/tests/convert-heliodor-bench.sh
           bash scripts/tests/run-heliodor-bench-results.sh
           bash scripts/tests/run-heliodor-bench-gate.sh
 
   heliodor:
-    if: ${{ !inputs.arm64_profile }}
+    if: ${{ !inputs.arm64_profile && !inputs.suite_test && !inputs.suite_runner && !inputs.suite_arch }}
     # Keep the x86_64 gate on every workflow trigger. Only the ARM64 PR lane is
     # change-gated by arm64-changes below.
     runs-on: ubuntu-latest
@@ -257,7 +272,7 @@ jobs:
 
   arm64-linux-boot-full:
     name: Nightly ARM64 Linux boot
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && !inputs.suite_test && !inputs.suite_runner && !inputs.suite_arch)
     permissions:
       contents: read
       actions: read
@@ -416,40 +431,41 @@ jobs:
             target/heliodor-arm64/results/profile-ir/native_optimized.sir
             heliodor-arm64-host.txt
 
-  linux-suite:
-    name: Linux suite (${{ matrix.arch }}, ${{ matrix.test }})
+  linux-suite-matrix:
     if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && !inputs.arm64_profile
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      - id: matrix
+        env:
+          SUITE_TEST: ${{ inputs.suite_test }}
+          SUITE_RUNNER: ${{ inputs.suite_runner }}
+          SUITE_ARCH: ${{ inputs.suite_arch }}
+        run: echo "matrix=$(node scripts/heliodor-suite.mjs matrix)" >> "$GITHUB_OUTPUT"
+
+  linux-suite:
+    name: Linux suite (${{ matrix.arch }}, ${{ matrix.test }}, ${{ matrix.runner }})
+    needs: linux-suite-matrix
     permissions:
       contents: read
     strategy:
       fail-fast: false
-      matrix:
-        arch: [x86_64, aarch64]
-        test:
-          - test_soc_linux_boot
-          - test_soc_smp_linux_boot_2hart
-          - test_soc_smp_linux_boot_4hart
-          - test_soc_smp_linux_boot_8hart
-          - test_soc_66_linux_boot
-          - test_soc_66_smp_linux_boot_2hart
-          - test_soc_66_smp_linux_boot_4hart
-          - test_soc_71_linux_boot
-          - test_soc_71_smp_linux_boot_2hart
-          - test_soc_71_smp_linux_boot_4hart
-          - test_soc_71v_linux_boot
-        include:
-          - arch: x86_64
-            os: ubuntu-24.04
-          - arch: aarch64
-            os: ubuntu-24.04-arm
+      matrix: ${{ fromJSON(needs.linux-suite-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 300
     env:
       # Keep expanded workloads separate from the historical fixed gate.
       HELIODOR_REF: 6285682fa0a514077da9d17fee385c7841160025
       HELIODOR_TESTS: ${{ matrix.test }}
-      HELIODOR_RUNNERS: veryl-cc-sync celox celox-tiered veryl-cc-tiered
-      HELIODOR_TIMEOUT_SEC: "3600"
+      HELIODOR_RUNNERS: ${{ matrix.runner }}
+      HELIODOR_TIMEOUT_SEC: ${{ matrix.timeout_sec }}
       HELIODOR_CELOX_CARGO_PROFILE: release
       CELOX_OPT_LEVEL: O2
     steps:
@@ -462,10 +478,14 @@ jobs:
         run: |
           uname -a > heliodor-suite-host.txt
           lscpu >> heliodor-suite-host.txt
+          free -h >> heliodor-suite-host.txt
+          swapon --show >> heliodor-suite-host.txt
+          df -h >> heliodor-suite-host.txt
       - name: Run complete workload
         shell: bash
-        run: set -o pipefail && bash scripts/run-heliodor-bench.sh run 2>&1 | tee heliodor-suite-output.txt
+        run: set -o pipefail && /usr/bin/time -v bash scripts/run-heliodor-bench.sh run 2>&1 | tee heliodor-suite-output.txt
       - name: Verify tiered promotion
+        if: matrix.runner == 'celox-tiered'
         shell: bash
         run: |
           source scripts/run-heliodor-bench.sh
@@ -476,7 +496,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: heliodor-suite-${{ matrix.arch }}-${{ matrix.test }}
+          name: heliodor-suite-${{ matrix.arch }}-${{ matrix.test }}-${{ matrix.runner }}
           path: |
             heliodor-suite-host.txt
             heliodor-suite-output.txt
@@ -527,24 +547,16 @@ jobs:
             --arm64-results "$arm64_results" --require-tiered
 
       - uses: actions/download-artifact@v8
-        if: needs.linux-suite.result == 'success'
+        if: needs.linux-suite.result == 'success' && !inputs.suite_test && !inputs.suite_runner && !inputs.suite_arch
         with:
           pattern: heliodor-suite-*
           path: artifacts/suite
 
       - name: Convert expanded Linux suite
-        if: needs.linux-suite.result == 'success'
+        if: needs.linux-suite.result == 'success' && !inputs.suite_test && !inputs.suite_runner && !inputs.suite_arch
         shell: bash
         run: |
-          python3 - <<'PYTHON'
-          from pathlib import Path
-          for arch in ("x86_64", "aarch64"):
-              files = sorted(Path("artifacts/suite").glob(f"heliodor-suite-{arch}-*/target/heliodor/results/results.tsv"))
-              if len(files) != 11:
-                  raise SystemExit(f"Expected 11 workloads for {arch}, found {len(files)}")
-              lines = [file.read_text().splitlines() for file in files]
-              Path(f"suite-{arch}.tsv").write_text("\n".join(lines[0][:1] + [row for result in lines for row in result[1:]]) + "\n")
-          PYTHON
+          node scripts/heliodor-suite.mjs merge artifacts/suite suite
           node scripts/convert-heliodor-bench.mjs suite-x86_64.tsv heliodor-suite.json --arm64-results suite-aarch64.tsv --require-tiered --suite
           node --input-type=module -e '
             import { readFileSync, writeFileSync } from "node:fs";

--- a/.github/workflows/heliodor-bench.yml
+++ b/.github/workflows/heliodor-bench.yml
@@ -63,6 +63,25 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  validate-dispatch:
+    name: Validate dispatch inputs
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      - name: Reject conflicting or invalid inputs
+        env:
+          ARM64_PROFILE: ${{ inputs.arm64_profile }}
+          SUITE_TEST: ${{ inputs.suite_test }}
+          SUITE_RUNNER: ${{ inputs.suite_runner }}
+          SUITE_ARCH: ${{ inputs.suite_arch }}
+        run: node scripts/heliodor-suite.mjs validate
+
   # PRs use this gate to avoid spending a dedicated ARM runner on unrelated
   # Rust changes. Detection failures fail open in arm64-linux-boot below.
   arm64-changes:
@@ -582,7 +601,8 @@ jobs:
     name: Heliodor HEAD compatibility
     if: >-
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop')
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop' &&
+       !inputs.suite_test && !inputs.suite_runner && !inputs.suite_arch)
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/crates/celox-backend-arm64/src/regalloc.rs
+++ b/crates/celox-backend-arm64/src/regalloc.rs
@@ -6,7 +6,7 @@
 //! analyses and algorithms are shared.
 
 use std::cmp::Reverse;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 use std::fmt;
 
 use celox_backend_common::regalloc::{
@@ -482,16 +482,39 @@ fn select_spill_batch(
     let target_capacity = ALLOCATABLE_REGISTERS.len().saturating_sub(4);
     let mut selected = BTreeSet::new();
     let mut peak = Vec::new();
-    let mut block_segments = vec![Vec::new(); function.blocks.len()];
-    for (&value, interval) in intervals.iter() {
-        for segment in &interval.segments {
-            block_segments[segment.block].push((segment.start, segment.end, value));
+    // Merge the already block-sorted intervals one block at a time. Building
+    // a second copy of every segment can consume gigabytes on large designs.
+    let interval_segments = intervals
+        .iter()
+        .map(|(&value, interval)| (value, interval.segments.as_slice()))
+        .collect::<Vec<_>>();
+    let mut next_segments = interval_segments
+        .iter()
+        .enumerate()
+        .filter_map(|(index, (_, segments))| {
+            segments
+                .first()
+                .map(|segment| Reverse((segment.block, index, 0)))
+        })
+        .collect::<BinaryHeap<_>>();
+    let mut segments = Vec::new();
+    while let Some(&Reverse((block, _, _))) = next_segments.peek() {
+        segments.clear();
+        while let Some(&Reverse((next_block, index, position))) = next_segments.peek() {
+            if next_block != block {
+                break;
+            }
+            next_segments.pop();
+            let (value, interval) = interval_segments[index];
+            let segment = interval[position];
+            segments.push((segment.start, segment.end, value));
+            if let Some(next) = interval.get(position + 1) {
+                next_segments.push(Reverse((next.block, index, position + 1)));
+            }
         }
-    }
-    for mut segments in block_segments {
         segments.sort_unstable();
         let mut active = Vec::<(u64, VReg)>::new();
-        for (start, end, value) in segments {
+        for &(start, end, value) in &segments {
             active.retain(|(active_end, active_value)| {
                 *active_end > start && !selected.contains(active_value)
             });

--- a/crates/celox-backend-common/src/regalloc/live_interval.rs
+++ b/crates/celox-backend-common/src/regalloc/live_interval.rs
@@ -4,9 +4,12 @@
 //! control-flow, SSA definitions, uses, and phi edges exported at the
 //! allocation boundary.
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+#[cfg(test)]
+use std::collections::VecDeque;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::hash::Hash;
+use std::sync::OnceLock;
 
 use super::FunctionAllocationFacts;
 
@@ -77,12 +80,22 @@ impl<V> LiveInterval<V> {
 }
 
 /// Exact SSA liveness reconstructed from allocation facts.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct LiveIntervals<V> {
     intervals: BTreeMap<V, LiveInterval<V>>,
-    live_in: Vec<BTreeSet<V>>,
-    live_out: Vec<BTreeSet<V>>,
+    // Most allocators only query intervals. Materialize the legacy block-set
+    // views on demand, without making every analysis retain them twice.
+    live_in: Vec<OnceLock<BTreeSet<V>>>,
+    live_out: Vec<OnceLock<BTreeSet<V>>>,
+    block_exits: Vec<u64>,
 }
+
+impl<V: PartialEq> PartialEq for LiveIntervals<V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.intervals == other.intervals && self.block_exits == other.block_exits
+    }
+}
+impl<V: Eq> Eq for LiveIntervals<V> {}
 
 impl<V: Ord> LiveIntervals<V> {
     pub fn get(&self, value: &V) -> Option<&LiveInterval<V>> {
@@ -92,13 +105,39 @@ impl<V: Ord> LiveIntervals<V> {
     pub fn iter(&self) -> impl Iterator<Item = (&V, &LiveInterval<V>)> {
         self.intervals.iter()
     }
+}
 
+impl<V: Copy + Ord> LiveIntervals<V> {
     pub fn live_in(&self, block: usize) -> Option<&BTreeSet<V>> {
-        self.live_in.get(block)
+        self.live_in.get(block).map(|cache| {
+            cache.get_or_init(|| {
+                self.intervals
+                    .iter()
+                    .filter_map(|(&value, interval)| {
+                        interval
+                            .segment_in_block(block)
+                            .filter(|segment| segment.start == 0)
+                            .map(|_| value)
+                    })
+                    .collect()
+            })
+        })
     }
 
     pub fn live_out(&self, block: usize) -> Option<&BTreeSet<V>> {
-        self.live_out.get(block)
+        self.live_out.get(block).map(|cache| {
+            cache.get_or_init(|| {
+                self.intervals
+                    .iter()
+                    .filter_map(|(&value, interval)| {
+                        interval
+                            .segment_in_block(block)
+                            .filter(|segment| segment.end == self.block_exits[block])
+                            .map(|_| value)
+                    })
+                    .collect()
+            })
+        })
     }
 }
 
@@ -148,12 +187,14 @@ impl<V: fmt::Debug> fmt::Display for LiveIntervalError<V> {
 
 impl<V: fmt::Debug> std::error::Error for LiveIntervalError<V> {}
 
+#[cfg(test)]
 struct BlockFacts<V> {
     definitions: BTreeSet<V>,
     upward_uses: BTreeSet<V>,
     last_use: BTreeMap<V, u64>,
 }
 
+#[cfg(test)]
 impl<V> Default for BlockFacts<V> {
     fn default() -> Self {
         Self {
@@ -167,7 +208,9 @@ impl<V> Default for BlockFacts<V> {
 struct ModelFacts<V> {
     definitions: BTreeMap<V, DefinitionSite>,
     uses: BTreeMap<V, Vec<UseSite>>,
+    #[cfg(test)]
     blocks: Vec<BlockFacts<V>>,
+    #[cfg(test)]
     edge_uses: BTreeMap<(usize, usize), BTreeSet<V>>,
 }
 
@@ -241,6 +284,7 @@ where
 {
     let mut definitions = BTreeMap::new();
     let mut uses = BTreeMap::<V, Vec<UseSite>>::new();
+    #[cfg(test)]
     let mut blocks = (0..facts.blocks.len())
         .map(|_| BlockFacts::default())
         .collect::<Vec<_>>();
@@ -253,9 +297,11 @@ where
                 slot: slots[block_index].phi_def,
             };
             record_definition(&mut definitions, phi.destination, site)?;
+            #[cfg(test)]
             blocks[block_index].definitions.insert(phi.destination);
         }
 
+        #[cfg(test)]
         let mut seen_definitions = blocks[block_index].definitions.clone();
         for (instruction_index, instruction) in block.instructions.iter().enumerate() {
             let use_slot = instruction_use_slot(instruction_index).ok_or_else(|| {
@@ -277,14 +323,17 @@ where
                     slot: use_slot,
                 };
                 uses.entry(value).or_default().push(site);
-                if !seen_definitions.contains(&value) {
-                    blocks[block_index].upward_uses.insert(value);
+                #[cfg(test)]
+                {
+                    if !seen_definitions.contains(&value) {
+                        blocks[block_index].upward_uses.insert(value);
+                    }
+                    blocks[block_index]
+                        .last_use
+                        .entry(value)
+                        .and_modify(|current| *current = (*current).max(use_slot))
+                        .or_insert(use_slot);
                 }
-                blocks[block_index]
-                    .last_use
-                    .entry(value)
-                    .and_modify(|current| *current = (*current).max(use_slot))
-                    .or_insert(use_slot);
             }
             let def_slot = instruction_def_slot(instruction_index).ok_or_else(|| {
                 LiveIntervalError::new(
@@ -302,12 +351,16 @@ where
                     slot: def_slot,
                 };
                 record_definition(&mut definitions, value, site)?;
-                blocks[block_index].definitions.insert(value);
-                seen_definitions.insert(value);
+                #[cfg(test)]
+                {
+                    blocks[block_index].definitions.insert(value);
+                    seen_definitions.insert(value);
+                }
             }
         }
     }
 
+    #[cfg(test)]
     let mut edge_uses = BTreeMap::<(usize, usize), BTreeSet<V>>::new();
     for (successor, block) in facts.blocks.iter().enumerate() {
         for phi in &block.phis {
@@ -328,15 +381,18 @@ where
                     slot: slots[source.predecessor].exit,
                 };
                 uses.entry(source.value).or_default().push(site);
-                edge_uses
-                    .entry((source.predecessor, successor))
-                    .or_default()
-                    .insert(source.value);
-                blocks[source.predecessor]
-                    .last_use
-                    .entry(source.value)
-                    .and_modify(|current| *current = (*current).max(site.slot))
-                    .or_insert(site.slot);
+                #[cfg(test)]
+                {
+                    edge_uses
+                        .entry((source.predecessor, successor))
+                        .or_default()
+                        .insert(source.value);
+                    blocks[source.predecessor]
+                        .last_use
+                        .entry(source.value)
+                        .and_modify(|current| *current = (*current).max(site.slot))
+                        .or_insert(site.slot);
+                }
             }
             if seen_predecessors.len() != predecessors[successor].len() {
                 return Err(LiveIntervalError::new(
@@ -357,11 +413,14 @@ where
     Ok(ModelFacts {
         definitions,
         uses,
+        #[cfg(test)]
         blocks,
+        #[cfg(test)]
         edge_uses,
     })
 }
 
+#[cfg(test)]
 fn solve_liveness<V: Copy + Ord, R>(
     facts: &FunctionAllocationFacts<V, R>,
     predecessors: &[Vec<usize>],
@@ -550,103 +609,42 @@ where
     let dominators = compute_dominators(facts.entry, &successors, &predecessors)?;
     let slots = block_slots(facts)?;
     let model = collect_model(facts, &predecessors, &slots)?;
-    let (live_in, live_out) = solve_liveness(facts, &predecessors, &model);
-    let mut segments = BTreeMap::<V, Vec<LiveSegment>>::new();
-
-    for block in 0..facts.blocks.len() {
-        let mut values = BTreeSet::new();
-        values.extend(live_in[block].iter().copied());
-        values.extend(live_out[block].iter().copied());
-        values.extend(model.blocks[block].definitions.iter().copied());
-        values.extend(model.blocks[block].last_use.keys().copied());
-        for value in values {
-            let Some(definition) = model.definitions.get(&value).copied() else {
-                return Err(LiveIntervalError::new(
-                    "LIVE_INTERVAL.MISSING_DEFINITION",
-                    Some(block),
-                    None,
-                    vec![value],
-                    "live or used value has no target-MIR definition",
-                ));
-            };
-            if definition.block == block && live_in[block].contains(&value) {
-                return Err(LiveIntervalError::new(
-                    "LIVE_INTERVAL.USE_BEFORE_DEFINITION",
-                    Some(block),
-                    definition.instruction,
-                    vec![value],
-                    "value is live at entry of its defining block",
-                ));
-            }
-            let start = if definition.block == block {
-                definition.slot
-            } else {
-                0
-            };
-            let end = if live_out[block].contains(&value) {
-                slots[block].exit.checked_add(1)
-            } else if let Some(last_use) = model.blocks[block].last_use.get(&value) {
-                last_use.checked_add(1)
-            } else if definition.block == block {
-                definition.slot.checked_add(1)
-            } else {
-                None
-            }
-            .ok_or_else(|| {
+    let block_exits = slots
+        .iter()
+        .map(|slot| {
+            slot.exit.checked_add(1).ok_or_else(|| {
                 LiveIntervalError::new(
                     "LIVE_INTERVAL.SLOT_RANGE",
-                    Some(block),
                     None,
-                    vec![value],
-                    "live segment end overflows or has no local reason to exist",
+                    None,
+                    Vec::new(),
+                    "block exit overflows",
                 )
-            })?;
-            if start >= end {
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut intervals = BTreeMap::new();
+    // Walk backwards from each SSA use, stopping at its definition. Keep only
+    // the final sparse segments, rather than two complete block/value sets in
+    // addition to those segments. Scratch space is reused for every value.
+    let mut ends = vec![0_u64; facts.blocks.len()];
+    let mut touched = Vec::new();
+    let mut pending = Vec::new();
+    for (&value, &definition) in &model.definitions {
+        ends[definition.block] = definition.slot + 1;
+        touched.push(definition.block);
+        for site in model.uses.get(&value).into_iter().flatten() {
+            if definition.block == site.block && definition.slot >= site.slot {
                 return Err(LiveIntervalError::new(
-                    "LIVE_INTERVAL.EMPTY_SEGMENT",
-                    Some(block),
-                    None,
+                    "LIVE_INTERVAL.USE_BEFORE_DEFINITION",
+                    Some(site.block),
+                    site.instruction,
                     vec![value],
-                    format!("segment {start}..{end} is empty or reversed"),
+                    "value is used before its definition",
                 ));
             }
-            segments
-                .entry(value)
-                .or_default()
-                .push(LiveSegment { block, start, end });
-        }
-    }
-
-    let mut intervals = BTreeMap::new();
-    for (&value, &definition) in &model.definitions {
-        let mut value_segments = segments.remove(&value).unwrap_or_default();
-        value_segments.sort_unstable_by_key(|segment| (segment.block, segment.start));
-        let interval = LiveInterval {
-            value,
-            segments: value_segments,
-        };
-        if !interval
-            .segment_in_block(definition.block)
-            .is_some_and(|segment| segment.contains(definition.slot))
-        {
-            return Err(LiveIntervalError::new(
-                "LIVE_INTERVAL.DEFINITION_COVERAGE",
-                Some(definition.block),
-                definition.instruction,
-                vec![value],
-                "definition is not covered by its live interval",
-            ));
-        }
-        for site in model.uses.get(&value).into_iter().flatten() {
-            let covered = interval
-                .segment_in_block(site.block)
-                .is_some_and(|segment| segment.contains(site.slot));
-            let dominated = if definition.block == site.block {
-                definition.slot < site.slot
-            } else {
-                dominators.dominates(definition.block, site.block)
-            };
-            if !covered || !dominated {
+            if definition.block != site.block && !dominators.dominates(definition.block, site.block)
+            {
                 return Err(LiveIntervalError::new(
                     "LIVE_INTERVAL.DEFINITION_DOMINANCE",
                     Some(site.block),
@@ -655,8 +653,36 @@ where
                     "definition does not dominate the target-MIR use",
                 ));
             }
+            pending.push((site.block, site.slot + 1));
         }
-        intervals.insert(value, interval);
+        while let Some((block, end)) = pending.pop() {
+            let first_visit = ends[block] == 0;
+            if first_visit {
+                touched.push(block);
+            }
+            ends[block] = ends[block].max(end);
+            if first_visit && block != definition.block {
+                pending.extend(
+                    predecessors[block]
+                        .iter()
+                        .map(|&predecessor| (predecessor, block_exits[predecessor])),
+                );
+            }
+        }
+        touched.sort_unstable();
+        let segments = touched
+            .drain(..)
+            .map(|block| LiveSegment {
+                block,
+                start: if block == definition.block {
+                    definition.slot
+                } else {
+                    0
+                },
+                end: std::mem::take(&mut ends[block]),
+            })
+            .collect();
+        intervals.insert(value, LiveInterval { value, segments });
     }
     if let Some((&value, sites)) = model
         .uses
@@ -671,11 +697,11 @@ where
             "used value has no target-MIR definition",
         ));
     }
-
     Ok(LiveIntervals {
         intervals,
-        live_in,
-        live_out,
+        live_in: (0..facts.blocks.len()).map(|_| OnceLock::new()).collect(),
+        live_out: (0..facts.blocks.len()).map(|_| OnceLock::new()).collect(),
+        block_exits,
     })
 }
 
@@ -736,6 +762,7 @@ mod tests {
             ],
         };
 
+        assert_matches_dataflow(&facts);
         let intervals = analyze_live_intervals(&facts).unwrap();
         assert!(
             !intervals
@@ -746,6 +773,174 @@ mod tests {
         assert!(intervals.live_out(1).unwrap().contains(&1));
         assert!(intervals.live_out(2).unwrap().contains(&2));
         assert!(!intervals.live_in(3).unwrap().contains(&1));
+    }
+
+    fn assert_matches_dataflow(facts: &FunctionAllocationFacts<u32, ()>) {
+        let actual = analyze_live_intervals(facts).unwrap();
+        let unqueried = actual.clone();
+        assert!(actual.live_in.iter().all(|cache| cache.get().is_none()));
+        assert!(actual.live_out.iter().all(|cache| cache.get().is_none()));
+        let mut predecessors = vec![Vec::new(); facts.blocks.len()];
+        for (block, facts) in facts.blocks.iter().enumerate() {
+            for &successor in &facts.successors {
+                predecessors[successor].push(block);
+            }
+        }
+        let slots = block_slots(facts).unwrap();
+        let model = collect_model(facts, &predecessors, &slots).unwrap();
+        let (live_in, live_out) = solve_liveness(facts, &predecessors, &model);
+        for block in 0..facts.blocks.len() {
+            assert_eq!(actual.live_in(block).unwrap(), &live_in[block]);
+            assert_eq!(actual.live_out(block).unwrap(), &live_out[block]);
+            for (&value, definition) in &model.definitions {
+                let expected = if live_in[block].contains(&value)
+                    || live_out[block].contains(&value)
+                    || model.blocks[block].definitions.contains(&value)
+                    || model.blocks[block].last_use.contains_key(&value)
+                {
+                    Some(LiveSegment {
+                        block,
+                        start: if definition.block == block {
+                            definition.slot
+                        } else {
+                            0
+                        },
+                        end: if live_out[block].contains(&value) {
+                            slots[block].exit + 1
+                        } else {
+                            model.blocks[block]
+                                .last_use
+                                .get(&value)
+                                .copied()
+                                .unwrap_or(definition.slot)
+                                + 1
+                        },
+                    })
+                } else {
+                    None
+                };
+                assert_eq!(
+                    actual.get(&value).unwrap().segment_in_block(block),
+                    expected
+                );
+            }
+        }
+        assert_eq!(
+            actual, unqueried,
+            "queries must not change interval equality"
+        );
+    }
+
+    #[test]
+    fn backward_segments_match_dataflow_across_loops_and_branches() {
+        let mut random = 123_u64;
+        for _ in 0..32 {
+            let mut blocks = Vec::new();
+            for block in 0..16 {
+                random = random.wrapping_mul(6364136223846793005).wrapping_add(1);
+                let mut successors = if block < 15 {
+                    vec![block + 1]
+                } else {
+                    Vec::new()
+                };
+                let target = 1 + ((random >> 32) as usize % 15);
+                if target != block && !successors.contains(&target) {
+                    successors.push(target);
+                }
+                let uses = if block == 0 {
+                    Vec::new()
+                } else {
+                    (0..8).filter(|bit| (random >> bit) & 1 != 0).collect()
+                };
+                blocks.push(BlockAllocationFacts {
+                    successors,
+                    phis: Vec::new(),
+                    instructions: vec![instruction(
+                        uses,
+                        if block == 0 {
+                            (0..8).collect()
+                        } else {
+                            vec![8 + block as u32]
+                        },
+                    )],
+                });
+            }
+            assert_matches_dataflow(&FunctionAllocationFacts { entry: 0, blocks });
+        }
+    }
+
+    #[test]
+    fn backward_segments_match_loop_carried_phi_lifetimes() {
+        assert_matches_dataflow(&FunctionAllocationFacts {
+            entry: 0,
+            blocks: vec![
+                BlockAllocationFacts {
+                    successors: vec![1],
+                    phis: Vec::new(),
+                    instructions: vec![instruction(Vec::new(), vec![0])],
+                },
+                BlockAllocationFacts {
+                    successors: vec![2, 3],
+                    phis: vec![PhiAllocationFacts {
+                        destination: 1,
+                        sources: vec![
+                            PhiSource {
+                                predecessor: 0,
+                                value: 0,
+                            },
+                            PhiSource {
+                                predecessor: 2,
+                                value: 2,
+                            },
+                        ],
+                    }],
+                    instructions: Vec::new(),
+                },
+                BlockAllocationFacts {
+                    successors: vec![1],
+                    phis: Vec::new(),
+                    instructions: vec![instruction(vec![1], vec![2])],
+                },
+                BlockAllocationFacts {
+                    successors: Vec::new(),
+                    phis: Vec::new(),
+                    instructions: vec![instruction(vec![1], Vec::new())],
+                },
+            ],
+        });
+    }
+
+    #[test]
+    fn long_live_ranges_do_not_materialize_block_sets() {
+        let blocks = (0..512)
+            .map(|block| BlockAllocationFacts {
+                successors: if block < 511 {
+                    vec![block + 1]
+                } else {
+                    Vec::new()
+                },
+                phis: Vec::new(),
+                instructions: if block == 0 {
+                    vec![instruction(Vec::new(), (0..256).collect())]
+                } else if block == 511 {
+                    vec![instruction((0..256).collect(), Vec::new())]
+                } else {
+                    Vec::new()
+                },
+            })
+            .collect();
+        let intervals =
+            analyze_live_intervals(&FunctionAllocationFacts { entry: 0, blocks }).unwrap();
+        assert_eq!(
+            intervals
+                .iter()
+                .map(|(_, interval)| interval.segments.len())
+                .sum::<usize>(),
+            512 * 256
+        );
+        assert!(intervals.live_in.iter().all(|cache| cache.get().is_none()));
+        assert!(intervals.live_out.iter().all(|cache| cache.get().is_none()));
+        assert_eq!(intervals.live_in(256).unwrap().len(), 256);
     }
 
     #[test]

--- a/crates/celox-frontend-core/src/error.rs
+++ b/crates/celox-frontend-core/src/error.rs
@@ -5,7 +5,8 @@ use thiserror::Error;
 #[derive(Debug, Clone)]
 pub struct SourceLocation {
     pub path: String,
-    pub text: String,
+    /// Shared file contents: per-variable locations must not copy whole files.
+    pub text: std::sync::Arc<str>,
     pub span: miette::SourceSpan,
 }
 

--- a/crates/celox-frontend-veryl/src/artifact.rs
+++ b/crates/celox-frontend-veryl/src/artifact.rs
@@ -293,6 +293,7 @@ pub(crate) fn project_module_with_ids(
     let mut source_variables = ir.variables.iter().collect::<Vec<_>>();
     source_variables.sort_unstable_by_key(|(id, _)| **id);
 
+    let mut source_texts = HashMap::default();
     let variables = source_variables
         .into_iter()
         .map(|(id, variable)| {
@@ -329,7 +330,12 @@ pub(crate) fn project_module_with_ids(
                     packed_dims,
                     source: Some(celox_frontend_core::SourceLocation {
                         path: variable.token.beg.source.to_string(),
-                        text: variable.token.beg.source.get_text(),
+                        text: source_texts
+                            .entry(variable.token.beg.source)
+                            .or_insert_with(|| {
+                                std::sync::Arc::<str>::from(variable.token.beg.source.get_text())
+                            })
+                            .clone(),
                         span: (&variable.token).into(),
                     }),
                     module_affiliated: variable.affiliation == Affiliation::Module,
@@ -487,5 +493,50 @@ mod tests {
     fn enum_state_kind_follows_its_backing_type() {
         assert!(is_4state(&enum_with_backing(TypeKind::Logic)));
         assert!(!is_4state(&enum_with_backing(TypeKind::Bit)));
+    }
+}
+
+#[cfg(test)]
+mod source_location_tests {
+    use super::*;
+    use veryl_analyzer::{Analyzer, Context};
+    use veryl_parser::{Parser, resource_table};
+
+    #[test]
+    fn projected_locations_share_file_contents_and_preserve_spans() {
+        let code = "module Top (a: input logic, b: output logic) { assign b = a; }\n";
+        let metadata = veryl_metadata::Metadata::create_default("prj").unwrap();
+        let parser = Parser::parse(code, &"shared.veryl").unwrap();
+        let analyzer = Analyzer::new(&metadata);
+        assert!(analyzer.analyze_pass1("prj", &parser.veryl).is_empty());
+        assert!(Analyzer::analyze_post_pass1().is_empty());
+        let mut ir = veryl_analyzer::ir::Ir::default();
+        let mut context = Context::default();
+        assert!(
+            analyzer
+                .analyze_pass2(&parser.veryl, &mut context, Some(&mut ir))
+                .is_empty()
+        );
+        assert!(Analyzer::analyze_post_pass2(&ir).is_empty());
+        let top = resource_table::insert_str("Top");
+        let rtl = crate::parse_ir(&ir, &BuildConfig::default(), &top).unwrap();
+        let module = &rtl.symbolic.modules[&rtl.symbolic.root_id];
+        let locations = module
+            .variables
+            .values()
+            .filter_map(|v| v.source.as_ref())
+            .collect::<Vec<_>>();
+        assert!(locations.len() >= 2);
+        for location in &locations {
+            assert_eq!(location.text.as_ref(), code);
+            assert!(std::sync::Arc::ptr_eq(&locations[0].text, &location.text));
+            let cloned = (**location).clone();
+            assert!(std::sync::Arc::ptr_eq(&location.text, &cloned.text));
+        }
+        assert!(
+            locations
+                .iter()
+                .any(|location| location.span != locations[0].span)
+        );
     }
 }

--- a/crates/celox-frontend-veryl/src/error.rs
+++ b/crates/celox-frontend-veryl/src/error.rs
@@ -35,7 +35,7 @@ impl From<celox_frontend_core::SourceLocation> for SourceLocation {
     fn from(location: celox_frontend_core::SourceLocation) -> Self {
         Self {
             source: MultiSources {
-                sources: vec![Source::new(location.path, location.text)],
+                sources: vec![Source::new(location.path, location.text.to_string())],
             },
             span: location.span,
         }

--- a/crates/celox-frontend-veryl/src/lowering/logic_tree/recover_unrolled.rs
+++ b/crates/celox-frontend-veryl/src/lowering/logic_tree/recover_unrolled.rs
@@ -2898,6 +2898,7 @@ fn specialize_slt_node(
 struct ProofBitCanonicalizer {
     bit_cache: HashMap<(NodeId, usize), NodeId>,
     opaque_bits: HashMap<OpaqueProofKey, NodeId>,
+    signed_cache: HashMap<NodeId, bool>,
     /// Dense low-to-high mapping for each Concat. Building this once avoids
     /// rescanning an increasingly long part list independently for every bit.
     concat_layouts: HashMap<NodeId, Vec<(NodeId, usize)>>,
@@ -2998,6 +2999,98 @@ fn proof_outputs_match(
 }
 
 fn canonicalize_proof_bit(
+    node: NodeId,
+    bit: usize,
+    arena: &mut SLTNodeArena<VarId>,
+    canonicalizer: &mut ProofBitCanonicalizer,
+) -> Option<NodeId> {
+    if canonicalizer.bit_cache.contains_key(&(node, bit)) {
+        return canonicalize_proof_bit_ready(node, bit, arena, canonicalizer);
+    }
+    // Demand-driven postorder traversal. The reducer below only visits cached
+    // children, so deeply unrolled expressions consume heap worklist space,
+    // not one native stack frame per expression/bit.
+    let mut pending = vec![(node, bit, false)];
+    while let Some((current, current_bit, ready)) = pending.pop() {
+        if canonicalizer
+            .bit_cache
+            .contains_key(&(current, current_bit))
+        {
+            continue;
+        }
+        if current_bit >= get_width(current, arena) {
+            return None;
+        }
+        if ready {
+            canonicalize_proof_bit_ready(current, current_bit, arena, canonicalizer)?;
+            continue;
+        }
+        let mut children = Vec::new();
+        match arena.get(current) {
+            SLTNode::Binary(lhs, BinaryOp::And | BinaryOp::Or | BinaryOp::Xor, rhs)
+                if current_bit < get_width(*lhs, arena) && current_bit < get_width(*rhs, arena) =>
+            {
+                children.extend([(*lhs, current_bit), (*rhs, current_bit)]);
+            }
+            SLTNode::Binary(lhs, op @ (BinaryOp::Shl | BinaryOp::Shr), rhs) => {
+                if let Some(shift) = specialized_constant(*rhs, arena)
+                    .filter(|constant| constant.mask.is_zero())
+                    .and_then(|constant| constant.value.to_usize())
+                {
+                    let source = if *op == BinaryOp::Shl {
+                        current_bit.checked_sub(shift)
+                    } else {
+                        current_bit.checked_add(shift)
+                    };
+                    if let Some(source) = source.filter(|&bit| bit < get_width(*lhs, arena)) {
+                        children.push((*lhs, source));
+                    }
+                }
+            }
+            SLTNode::Unary(UnaryOp::BitNot, inner) if current_bit < get_width(*inner, arena) => {
+                children.push((*inner, current_bit));
+            }
+            SLTNode::Mux {
+                cond,
+                then_expr,
+                else_expr,
+            } if get_width(*cond, arena) == 1
+                && current_bit < get_width(*then_expr, arena)
+                && current_bit < get_width(*else_expr, arena) =>
+            {
+                children.extend([
+                    (*cond, 0),
+                    (*then_expr, current_bit),
+                    (*else_expr, current_bit),
+                ]);
+            }
+            SLTNode::Concat(parts) => {
+                children.push(canonicalizer.concat_bit_source(current, parts, current_bit)?);
+            }
+            SLTNode::Slice { expr, access } => {
+                children.push((*expr, access.lsb.checked_add(current_bit)?));
+            }
+            SLTNode::Binary(lhs, _, rhs) => {
+                children.extend((0..get_width(*lhs, arena)).map(|bit| (*lhs, bit)));
+                children.extend((0..get_width(*rhs, arena)).map(|bit| (*rhs, bit)));
+            }
+            SLTNode::Unary(_, inner) => {
+                children.extend((0..get_width(*inner, arena)).map(|bit| (*inner, bit)));
+            }
+            _ => {}
+        }
+        pending.push((current, current_bit, true));
+        pending.extend(
+            children
+                .into_iter()
+                .rev()
+                .map(|(child, bit)| (child, bit, false)),
+        );
+    }
+    canonicalizer.bit_cache.get(&(node, bit)).copied()
+}
+
+fn canonicalize_proof_bit_ready(
     node: NodeId,
     bit: usize,
     arena: &mut SLTNodeArena<VarId>,
@@ -3180,8 +3273,8 @@ fn canonicalize_opaque_binary_operands(
     ) || matches!(
         op,
         BinaryOp::Eq | BinaryOp::Ne | BinaryOp::EqWildcard | BinaryOp::NeWildcard
-    ) && proof_node_signed(lhs, arena)
-        && proof_node_signed(rhs, arena);
+    ) && proof_node_signed(lhs, arena, &mut canonicalizer.signed_cache)
+        && proof_node_signed(rhs, arena, &mut canonicalizer.signed_cache);
 
     let canonicalize_operand = |operand: NodeId,
                                 width: usize,
@@ -3207,60 +3300,94 @@ fn canonicalize_opaque_binary_operands(
     ))
 }
 
-fn proof_node_signed(node: NodeId, arena: &SLTNodeArena<VarId>) -> bool {
-    match arena.get(node) {
-        SLTNode::Input { signed, .. } | SLTNode::Constant(_, _, _, signed) => *signed,
-        SLTNode::Binary(lhs, op, rhs) => match op {
-            BinaryOp::Eq
-            | BinaryOp::Ne
-            | BinaryOp::EqCase
-            | BinaryOp::NeCase
-            | BinaryOp::EqWildcard
-            | BinaryOp::NeWildcard
-            | BinaryOp::LtU
-            | BinaryOp::LtS
-            | BinaryOp::LeU
-            | BinaryOp::LeS
-            | BinaryOp::GtU
-            | BinaryOp::GtS
-            | BinaryOp::GeU
-            | BinaryOp::GeS
-            | BinaryOp::LogicAnd
-            | BinaryOp::LogicOr
-            | BinaryOp::DivU
-            | BinaryOp::RemU => false,
-            BinaryOp::DivS | BinaryOp::RemS => true,
-            BinaryOp::Shl | BinaryOp::Shr | BinaryOp::Sar => proof_node_signed(*lhs, arena),
-            BinaryOp::Add
-            | BinaryOp::Sub
-            | BinaryOp::Mul
-            | BinaryOp::And
-            | BinaryOp::Or
-            | BinaryOp::Xor => proof_node_signed(*lhs, arena) && proof_node_signed(*rhs, arena),
-        },
-        SLTNode::Unary(
-            UnaryOp::LogicNot
-            | UnaryOp::And
-            | UnaryOp::Or
-            | UnaryOp::Xor
-            | UnaryOp::PopCount
-            | UnaryOp::CountLeadingZeros
-            | UnaryOp::CountTrailingZeros,
-            _,
-        ) => false,
-        SLTNode::Unary(
-            UnaryOp::Ident | UnaryOp::ToTwoState | UnaryOp::Minus | UnaryOp::BitNot,
-            inner,
-        ) => proof_node_signed(*inner, arena),
-        SLTNode::Capture { expr, .. } => proof_node_signed(*expr, arena),
-        SLTNode::Mux {
-            then_expr,
-            else_expr,
-            ..
-        } => proof_node_signed(*then_expr, arena) && proof_node_signed(*else_expr, arena),
-        SLTNode::ForFold { loop_signed, .. } => *loop_signed,
-        SLTNode::ForFoldGroup { .. } | SLTNode::Concat(_) | SLTNode::Slice { .. } => false,
+fn proof_node_signed(
+    root: NodeId,
+    arena: &SLTNodeArena<VarId>,
+    cache: &mut HashMap<NodeId, bool>,
+) -> bool {
+    enum Rule {
+        Known(bool),
+        Copy(NodeId),
+        Both(NodeId, NodeId),
     }
+    let mut pending = vec![(root, false)];
+    while let Some((node, ready)) = pending.pop() {
+        if cache.contains_key(&node) {
+            continue;
+        }
+        let rule = match arena.get(node) {
+            SLTNode::Input { signed, .. } | SLTNode::Constant(_, _, _, signed) => {
+                Rule::Known(*signed)
+            }
+            SLTNode::Binary(lhs, op, rhs) => match op {
+                BinaryOp::Eq
+                | BinaryOp::Ne
+                | BinaryOp::EqCase
+                | BinaryOp::NeCase
+                | BinaryOp::EqWildcard
+                | BinaryOp::NeWildcard
+                | BinaryOp::LtU
+                | BinaryOp::LtS
+                | BinaryOp::LeU
+                | BinaryOp::LeS
+                | BinaryOp::GtU
+                | BinaryOp::GtS
+                | BinaryOp::GeU
+                | BinaryOp::GeS
+                | BinaryOp::LogicAnd
+                | BinaryOp::LogicOr
+                | BinaryOp::DivU
+                | BinaryOp::RemU => Rule::Known(false),
+                BinaryOp::DivS | BinaryOp::RemS => Rule::Known(true),
+                BinaryOp::Shl | BinaryOp::Shr | BinaryOp::Sar => Rule::Copy(*lhs),
+                BinaryOp::Add
+                | BinaryOp::Sub
+                | BinaryOp::Mul
+                | BinaryOp::And
+                | BinaryOp::Or
+                | BinaryOp::Xor => Rule::Both(*lhs, *rhs),
+            },
+            SLTNode::Unary(
+                UnaryOp::LogicNot
+                | UnaryOp::And
+                | UnaryOp::Or
+                | UnaryOp::Xor
+                | UnaryOp::PopCount
+                | UnaryOp::CountLeadingZeros
+                | UnaryOp::CountTrailingZeros,
+                _,
+            ) => Rule::Known(false),
+            SLTNode::Unary(
+                UnaryOp::Ident | UnaryOp::ToTwoState | UnaryOp::Minus | UnaryOp::BitNot,
+                inner,
+            ) => Rule::Copy(*inner),
+            SLTNode::Capture { expr, .. } => Rule::Copy(*expr),
+            SLTNode::Mux {
+                then_expr,
+                else_expr,
+                ..
+            } => Rule::Both(*then_expr, *else_expr),
+            SLTNode::ForFold { loop_signed, .. } => Rule::Known(*loop_signed),
+            SLTNode::ForFoldGroup { .. } | SLTNode::Concat(_) | SLTNode::Slice { .. } => {
+                Rule::Known(false)
+            }
+        };
+        let value = match rule {
+            Rule::Known(value) => value,
+            Rule::Copy(child) if ready => cache[&child],
+            Rule::Both(lhs, rhs) if ready => cache[&lhs] && cache[&rhs],
+            Rule::Copy(child) => {
+                pending.extend([(node, true), (child, false)]);
+                continue;
+            }
+            Rule::Both(lhs, rhs) => {
+                pending.extend([(node, true), (rhs, false), (lhs, false)]);
+                continue;
+            }
+        };
+        cache.insert(node, value);
+    }
+    cache[&root]
 }
 
 fn alloc_opaque_proof_bit(
@@ -5283,6 +5410,50 @@ mod tests {
             BitAccess::new(8, 15),
             "a fixed array element must not become a whole-array carried state"
         );
+    }
+
+    #[test]
+    fn proof_bit_canonicalizer_handles_deep_arithmetic_on_a_small_stack() {
+        let (module, _) = analyze(MULTI_STATE_LOOP);
+        let bits = variable(&module, "bits");
+        std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(move || {
+                let mut arena = SLTNodeArena::new();
+                let input = arena
+                    .alloc(SLTNode::Input {
+                        variable: bits,
+                        signed: false,
+                        index: Vec::new(),
+                        access: BitAccess::new(0, 3),
+                    })
+                    .unwrap();
+                let mut node = input;
+                for _ in 0..10_000 {
+                    node = arena
+                        .alloc(SLTNode::Binary(node, BinaryOp::Add, input))
+                        .unwrap();
+                }
+                let mut canonicalizer = ProofBitCanonicalizer::default();
+                assert!(!proof_node_signed(
+                    node,
+                    &arena,
+                    &mut canonicalizer.signed_cache
+                ));
+                let result = canonicalize_proof_bit(node, 0, &mut arena, &mut canonicalizer);
+                assert!(result.is_some());
+                assert_eq!(
+                    result,
+                    canonicalize_proof_bit(node, 0, &mut arena, &mut canonicalizer)
+                );
+                assert_ne!(
+                    result,
+                    canonicalize_proof_bit(input, 0, &mut arena, &mut canonicalizer)
+                );
+            })
+            .unwrap()
+            .join()
+            .unwrap();
     }
 
     #[test]

--- a/docs/benchmarks/heliodor.md
+++ b/docs/benchmarks/heliodor.md
@@ -88,7 +88,11 @@ x86-64 (`ubuntu-24.04`) and AArch64 (`ubuntu-24.04-arm`), using all four backend
 
 These 11 workloads use Heliodor revision
 `6285682fa0a514077da9d17fee385c7841160025`. Kernel versions refer to the
-simulated guest, not the benchmark host OS. Each runner has a one-hour timeout;
+simulated guest, not the benchmark host OS. Backends run in separate jobs (88 jobs
+for the complete suite). These jobs use separate hosted machines; their CPU and
+memory details are retained in each artifact for interpreting comparisons.
+Each runner has a one-hour timeout for 1/2 harts,
+three hours for 4 harts, and four hours for 8 harts;
 timeouts and incomplete runs fail the job and are not published as timings.
 The nightly publisher requires the complete suite on both architectures.
 
@@ -103,6 +107,16 @@ For example, to run the Linux 6.6 four-hart workload locally:
 HELIODOR_REF=6285682fa0a514077da9d17fee385c7841160025 \
 HELIODOR_TESTS=test_soc_66_smp_linux_boot_4hart \
 HELIODOR_RUNNERS="veryl-cc-sync celox celox-tiered veryl-cc-tiered" \
-HELIODOR_CELOX_CARGO_PROFILE=release HELIODOR_TIMEOUT_SEC=3600 \
+HELIODOR_CELOX_CARGO_PROFILE=release HELIODOR_TIMEOUT_SEC=10800 \
 bash scripts/run-heliodor-bench.sh run
+```
+
+For a focused manual rerun, set `suite_test`, `suite_runner`, and/or `suite_arch`
+in the workflow dispatch inputs. Empty inputs select the complete suite. Filtered
+runs skip the historical gate and never publish dashboard history. For example:
+
+```bash
+gh workflow run heliodor-bench.yml --ref <branch> \
+  -f suite_test=test_soc_66_smp_linux_boot_4hart \
+  -f suite_runner=celox -f suite_arch=aarch64
 ```

--- a/docs/ja/benchmarks/heliodor.md
+++ b/docs/ja/benchmarks/heliodor.md
@@ -82,7 +82,9 @@ nightly とプロファイルを取らない手動実行では、次の 11 ケ�
 
 Heliodor のリビジョンは `6285682fa0a514077da9d17fee385c7841160025` に固定します。
 Linux バージョンはシミュレーション内で起動するゲストのもので、ホスト OS の違いではありません。
-各実行のタイムアウトは 1 時間です。未完了・失敗は計測値として公開せず、
+バックエンドごとに別ホストのジョブで測定し、全体で 88 ジョブを実行します。
+比較時に確認できるよう、各ホストの CPU とメモリ情報を成果物に記録します。
+各実行のタイムアウトは 1・2 hart が 1 時間、4 hart が 3 時間、8 hart が 4 時間です。未完了・失敗は計測値として公開せず、
 両アーキテクチャの全ケースが成功した場合に nightly の結果を公開します。
 
 ダッシュボードにはカーネルと hart 数を区別して表示します。設計リビジョンが異なるため、
@@ -95,6 +97,16 @@ Linux 6.6 の 4 hart をローカルで実行する例:
 HELIODOR_REF=6285682fa0a514077da9d17fee385c7841160025 \
 HELIODOR_TESTS=test_soc_66_smp_linux_boot_4hart \
 HELIODOR_RUNNERS="veryl-cc-sync celox celox-tiered veryl-cc-tiered" \
-HELIODOR_CELOX_CARGO_PROFILE=release HELIODOR_TIMEOUT_SEC=3600 \
+HELIODOR_CELOX_CARGO_PROFILE=release HELIODOR_TIMEOUT_SEC=10800 \
 bash scripts/run-heliodor-bench.sh run
+```
+
+一部の構成だけを再実行する場合は、手動実行の `suite_test`、`suite_runner`、
+`suite_arch` を指定します。空欄なら全構成が対象です。絞り込み実行では従来の gate を
+実行せず、ダッシュボードの履歴も更新しません。例:
+
+```bash
+gh workflow run heliodor-bench.yml --ref <branch> \
+  -f suite_test=test_soc_66_smp_linux_boot_4hart \
+  -f suite_runner=celox -f suite_arch=aarch64
 ```

--- a/scripts/heliodor-suite.mjs
+++ b/scripts/heliodor-suite.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const workloads = [
+  "test_soc_linux_boot",
+  "test_soc_smp_linux_boot_2hart",
+  "test_soc_smp_linux_boot_4hart",
+  "test_soc_smp_linux_boot_8hart",
+  "test_soc_66_linux_boot",
+  "test_soc_66_smp_linux_boot_2hart",
+  "test_soc_66_smp_linux_boot_4hart",
+  "test_soc_71_linux_boot",
+  "test_soc_71_smp_linux_boot_2hart",
+  "test_soc_71_smp_linux_boot_4hart",
+  "test_soc_71v_linux_boot",
+];
+export const runners = ["veryl-cc-sync", "celox", "celox-tiered", "veryl-cc-tiered"];
+const hosts = { x86_64: "ubuntu-24.04", aarch64: "ubuntu-24.04-arm" };
+
+export function matrix({ test = "", runner = "", arch = "" } = {}) {
+  for (const [label, value, choices] of [
+    ["test", test, workloads], ["runner", runner, runners], ["arch", arch, Object.keys(hosts)],
+  ]) {
+    if (value && !choices.includes(value)) throw new Error(`Unknown suite ${label}: ${value}`);
+  }
+  return { include: Object.entries(hosts).flatMap(([a, os]) =>
+    workloads.flatMap(t => runners.map(r => ({
+      arch: a, os, test: t, runner: r,
+      timeout_sec: t.endsWith("8hart") ? 14400 : t.endsWith("4hart") ? 10800 : 3600,
+    }))),
+  ).filter(job => (!test || job.test === test) && (!runner || job.runner === runner) && (!arch || job.arch === arch)) };
+}
+
+// Require each expected backend artifact, not merely a count of TSV files.
+// A partial manual rerun must never be accepted as a full nightly result.
+export function mergeArtifacts(root, outputPrefix) {
+  const output = new Map();
+  let header;
+  for (const job of matrix().include) {
+    const name = `heliodor-suite-${job.arch}-${job.test}-${job.runner}`;
+    const file = join(root, name, "target/heliodor/results/results.tsv");
+    const lines = readFileSync(file, "utf8").trimEnd().split("\n");
+    if (lines.length !== 2) throw new Error(`${name}: expected exactly one result`);
+    header ??= lines[0];
+    if (lines[0] !== header) throw new Error(`${name}: inconsistent TSV header`);
+    const fields = header.split("\t");
+    const row = Object.fromEntries(fields.map((field, i) => [field, lines[1].split("\t")[i]]));
+    if (row.test !== job.test || row.runner !== job.runner || row.semantic_status !== "pass" || row.exit_status !== "0") {
+      throw new Error(`${name}: missing, mismatched or unsuccessful result`);
+    }
+    if (!output.has(job.arch)) output.set(job.arch, []);
+    output.get(job.arch).push(lines[1]);
+  }
+  for (const [arch, rows] of output) writeFileSync(`${outputPrefix}-${arch}.tsv`, [header, ...rows, ""].join("\n"));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  if (process.argv[2] === "matrix") {
+    console.log(JSON.stringify(matrix({ test: process.env.SUITE_TEST, runner: process.env.SUITE_RUNNER, arch: process.env.SUITE_ARCH })));
+  } else if (process.argv[2] === "merge" && process.argv.length === 5) {
+    mergeArtifacts(process.argv[3], process.argv[4]);
+  } else {
+    throw new Error("Usage: heliodor-suite.mjs matrix | merge <artifact-dir> <output-prefix>");
+  }
+}

--- a/scripts/heliodor-suite.mjs
+++ b/scripts/heliodor-suite.mjs
@@ -19,7 +19,10 @@ export const workloads = [
 export const runners = ["veryl-cc-sync", "celox", "celox-tiered", "veryl-cc-tiered"];
 const hosts = { x86_64: "ubuntu-24.04", aarch64: "ubuntu-24.04-arm" };
 
-export function matrix({ test = "", runner = "", arch = "" } = {}) {
+export function matrix({ test = "", runner = "", arch = "", profile = false } = {}) {
+  if (profile && (test || runner || arch)) {
+    throw new Error("arm64_profile cannot be combined with suite_test, suite_runner, or suite_arch");
+  }
   for (const [label, value, choices] of [
     ["test", test, workloads], ["runner", runner, runners], ["arch", arch, Object.keys(hosts)],
   ]) {
@@ -57,11 +60,12 @@ export function mergeArtifacts(root, outputPrefix) {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  if (process.argv[2] === "matrix") {
-    console.log(JSON.stringify(matrix({ test: process.env.SUITE_TEST, runner: process.env.SUITE_RUNNER, arch: process.env.SUITE_ARCH })));
+  if (process.argv[2] === "matrix" || process.argv[2] === "validate") {
+    const result = matrix({ test: process.env.SUITE_TEST, runner: process.env.SUITE_RUNNER, arch: process.env.SUITE_ARCH, profile: process.env.ARM64_PROFILE === "true" });
+    if (process.argv[2] === "matrix") console.log(JSON.stringify(result));
   } else if (process.argv[2] === "merge" && process.argv.length === 5) {
     mergeArtifacts(process.argv[3], process.argv[4]);
   } else {
-    throw new Error("Usage: heliodor-suite.mjs matrix | merge <artifact-dir> <output-prefix>");
+    throw new Error("Usage: heliodor-suite.mjs validate | matrix | merge <artifact-dir> <output-prefix>");
   }
 }

--- a/scripts/heliodor-suite.test.mjs
+++ b/scripts/heliodor-suite.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { matrix, mergeArtifacts } from "./heliodor-suite.mjs";
+
+test("suite isolates all 88 backend runs and reserves time for large designs", () => {
+  const jobs = matrix().include;
+  assert.equal(jobs.length, 88);
+  assert.equal(new Set(jobs.map(j => `${j.arch}/${j.test}/${j.runner}`)).size, 88);
+  for (const job of jobs) {
+    assert.ok(job.timeout_sec < 300 * 60);
+    if (job.test.endsWith("4hart") || job.test.endsWith("8hart")) assert.ok(job.timeout_sec > 3600);
+  }
+  assert.deepEqual(matrix({ test: "test_soc_66_smp_linux_boot_4hart", runner: "celox", arch: "aarch64" }).include,
+    jobs.filter(j => j.test === "test_soc_66_smp_linux_boot_4hart" && j.runner === "celox" && j.arch === "aarch64"));
+  for (const field of ["test", "runner", "arch"]) assert.throws(() => matrix({ [field]: "invalid" }), /Unknown suite/);
+});
+
+test("publication requires one successful matching result from every backend", () => {
+  const root = mkdtempSync(join(tmpdir(), "heliodor-suite-"));
+  try {
+    const files = [];
+    for (const job of matrix().include) {
+      const dir = join(root, `heliodor-suite-${job.arch}-${job.test}-${job.runner}`, "target/heliodor/results");
+      mkdirSync(dir, { recursive: true });
+      const file = join(dir, "results.tsv");
+      const content = `runner\ttest\texit_status\tsemantic_status\n${job.runner}\t${job.test}\t0\tpass\n`;
+      writeFileSync(file, content);
+      files.push([file, content]);
+    }
+    const output = join(root, "suite");
+    mergeArtifacts(root, output);
+    for (const arch of ["x86_64", "aarch64"]) assert.equal(readFileSync(`${output}-${arch}.tsv`, "utf8").trim().split("\n").length, 45);
+    const [file, content] = files[0];
+    for (const invalid of [content.replace("\tpass", "\tfail"), content.replace("\t0\t", "\t124\t"), content.replace("veryl-cc-sync\t", "celox\t"), content + content.split("\n")[1] + "\n"]) {
+      writeFileSync(file, invalid);
+      assert.throws(() => mergeArtifacts(root, output));
+    }
+    rmSync(file);
+    assert.throws(() => mergeArtifacts(root, output), /ENOENT/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/heliodor-suite.test.mjs
+++ b/scripts/heliodor-suite.test.mjs
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { spawnSync } from "node:child_process";
 import { matrix, mergeArtifacts } from "./heliodor-suite.mjs";
 
 test("suite isolates all 88 backend runs and reserves time for large designs", () => {
@@ -43,4 +44,25 @@ test("publication requires one successful matching result from every backend", (
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("dispatch validation rejects profile/filter conflicts instead of succeeding without work", () => {
+  const validate = (inputs) => spawnSync(process.execPath, ["scripts/heliodor-suite.mjs", "validate"], {
+    encoding: "utf8",
+    env: { ...process.env, ARM64_PROFILE: "", SUITE_TEST: "", SUITE_RUNNER: "", SUITE_ARCH: "", ...inputs },
+  });
+  for (const filter of [
+    { SUITE_TEST: "test_soc_66_smp_linux_boot_4hart" },
+    { SUITE_RUNNER: "celox" },
+    { SUITE_ARCH: "aarch64" },
+  ]) {
+    const conflict = validate({ ...filter, ARM64_PROFILE: "true" });
+    assert.notEqual(conflict.status, 0);
+    assert.match(conflict.stderr, /arm64_profile cannot be combined/);
+    assert.equal(validate(filter).status, 0);
+    assert.equal(validate({ ...filter, ARM64_PROFILE: "false" }).status, 0);
+  }
+  assert.equal(validate({}).status, 0);
+  assert.equal(validate({ ARM64_PROFILE: "true" }).status, 0);
+  assert.notEqual(validate({ SUITE_ARCH: "invalid" }).status, 0);
 });


### PR DESCRIPTION
## Summary

Follow up on the failed [Linux 6.6 four-hart ARM64 nightly job](https://github.com/celox-sim/celox/actions/runs/34574482144/job/103183727971): Veryl-CC exhausted the one-hour timeout, then the runner terminated during Celox compilation.

- Share source text between projected variable locations instead of copying the entire file for each variable and clone.
- Traverse proof bits and signedness iteratively, with memoization, to avoid native-stack exhaustion on deeply unrolled expressions observed in the eight-hart workload.
- Construct exact SSA live intervals by walking backwards from uses, and materialize block-level liveness sets only on demand. Stream AArch64 spill selection one block at a time instead of duplicating every live segment.
- Run each backend in its own suite job, give four/eight-hart workloads three/four hours, retain resource diagnostics, and support filtered manual reruns. Require all 88 successful artifacts before publishing expanded results.

Breaking change: `celox_frontend_core::SourceLocation.text` is now `Arc<str>`; callers constructing it from a `String` should use `.into()`. `LiveIntervals::live_in`/`live_out` now require `V: Copy`, matching the existing analysis input bound.

## Validation

- Frontend unit tests: 87 passed, including shared-text/span preservation and 10,000-deep proof traversal on a 256 KiB stack.
- Focused loop integration tests: 225 passed, 18 existing ignored tests.
- Frontend Clippy, workspace formatting, workflow actionlint, suite matrix/publication tests, benchmark converter/result/gate fixtures, and VitePress documentation build passed.
- Register-allocation validation: 18 common tests (including differential checks against the previous dataflow solver), 40 ARM64 tests, 557 x86 tests, and 36 native integration tests passed. Backend Clippy passed.
- Linux 6.6 one-hart AArch64 images before/after both register-allocation changes are byte-identical (SHA-256 `17e299bd06385c76d7ca026dc28f9deffff0bcd7dfb69c98f1a449be41b0c435`).
- Pre-push workspace cargo check and Biome passed.

Linux 6.6 four-hart AArch64 cross-codegen now completes under a 12 GiB virtual-memory cap. Peak RSS fell from 20,632,008 KiB (19.7 GiB) to 9,517,008 KiB (9.1 GiB), about 54%. Observed compile times were 303.6 s and 280.6 s; these single runs are not a runtime-performance comparison. The baseline here already includes shared source text and iterative proof traversal, isolating the register-allocation changes.

The four-hart AArch64 image is also byte-identical before/after both register-allocation changes (SHA-256 `257b596a018d010d96657ff56da53447e5812bb20fb4c01a5c3179874c0a3e8a`). Eight-hart cross-codegen gets past the former stack overflow but still exceeds the local 12 GiB virtual-memory cap while retaining live intervals; successful full eight-hart execution is not established. All four backends of the reported four-hart ARM64 workload have been dispatched for full Linux-boot validation; those CI runs are pending/in progress. This PR does not claim the full expanded suite passes. The existing Linux 7.1 two-hart guest also reaches its cycle limit on all four backends in the original run.
