### PR TITLE
fix(compiler): reduce resource use for large Linux workloads

### DIFF
--- a/crates/celox-backend-x86/src/backend/native/mir_opt.rs
+++ b/crates/celox-backend-x86/src/backend/native/mir_opt.rs
@@ -3050,74 +3050,6 @@ fn global_gvn(func: &mut MFunction) {
     // subtrees see exactly the expression scope at their common dominator.
     // Load validity is carried by the structural MemorySSA version in its key,
     // rather than by a path-local store invalidation side table.
-    fn gvn_dfs(
-        node: usize,
-        dom_children: &[Vec<usize>],
-        func: &MFunction,
-        value_numbers: &mut [ValueNumber],
-        value_leaders: &mut [VReg],
-        leader_blocks: &mut [Option<usize>],
-        live_out: &[Vec<VReg>],
-        last_uses: &[HashMap<VReg, usize>],
-        load_versions: &HashMap<(usize, usize), GvnLoadVersion>,
-        value_table: &mut HashMap<GvnKey, ValueNumber>,
-        table_changes: &mut Vec<(GvnKey, Option<ValueNumber>)>,
-        leader_changes: &mut Vec<(ValueNumber, VReg, Option<usize>)>,
-        replacements: &mut Vec<(usize, usize, MInst)>,
-    ) {
-        let checkpoint = table_changes.len();
-        let leader_checkpoint = leader_changes.len();
-        let block = &func.blocks[node];
-
-        process_gvn_block(
-            node,
-            block,
-            value_numbers,
-            value_leaders,
-            leader_blocks,
-            &live_out[node],
-            &last_uses[node],
-            load_versions,
-            value_table,
-            table_changes,
-            leader_changes,
-            replacements,
-        );
-
-        for &child in &dom_children[node] {
-            gvn_dfs(
-                child,
-                dom_children,
-                func,
-                value_numbers,
-                value_leaders,
-                leader_blocks,
-                live_out,
-                last_uses,
-                load_versions,
-                value_table,
-                table_changes,
-                leader_changes,
-                replacements,
-            );
-        }
-
-        while leader_changes.len() > leader_checkpoint {
-            let (number, leader, leader_block) = leader_changes.pop().unwrap();
-            value_leaders[number as usize] = leader;
-            leader_blocks[number as usize] = leader_block;
-        }
-
-        while table_changes.len() > checkpoint {
-            let (key, previous) = table_changes.pop().unwrap();
-            if let Some(previous) = previous {
-                value_table.insert(key, previous);
-            } else {
-                value_table.remove(&key);
-            }
-        }
-    }
-
     fn process_gvn_block(
         node: usize,
         block: &MBlock,
@@ -3183,21 +3115,65 @@ fn global_gvn(func: &mut MFunction) {
         }
     }
 
-    gvn_dfs(
-        0,
-        &dom_children,
-        func,
-        &mut value_numbers,
-        &mut value_leaders,
-        &mut leader_blocks,
-        &live_out,
-        &last_uses,
-        &load_versions,
-        &mut value_table,
-        &mut table_changes,
-        &mut leader_changes,
-        &mut replacements,
-    );
+    enum GvnAction {
+        Enter(usize),
+        Exit {
+            table_checkpoint: usize,
+            leader_checkpoint: usize,
+        },
+    }
+    // Deep dominator chains in large designs must not consume the compiler
+    // thread's call stack. Preserve recursive DFS order and undo checkpoints.
+    let mut actions = vec![GvnAction::Enter(0)];
+    while let Some(action) = actions.pop() {
+        let node = match action {
+            GvnAction::Exit {
+                table_checkpoint,
+                leader_checkpoint,
+            } => {
+                while leader_changes.len() > leader_checkpoint {
+                    let (number, leader, leader_block) = leader_changes.pop().unwrap();
+                    value_leaders[number as usize] = leader;
+                    leader_blocks[number as usize] = leader_block;
+                }
+                while table_changes.len() > table_checkpoint {
+                    let (key, previous) = table_changes.pop().unwrap();
+                    if let Some(previous) = previous {
+                        value_table.insert(key, previous);
+                    } else {
+                        value_table.remove(&key);
+                    }
+                }
+                continue;
+            }
+            GvnAction::Enter(node) => node,
+        };
+        actions.push(GvnAction::Exit {
+            table_checkpoint: table_changes.len(),
+            leader_checkpoint: leader_changes.len(),
+        });
+        process_gvn_block(
+            node,
+            &func.blocks[node],
+            &mut value_numbers,
+            &mut value_leaders,
+            &mut leader_blocks,
+            &live_out[node],
+            &last_uses[node],
+            &load_versions,
+            &mut value_table,
+            &mut table_changes,
+            &mut leader_changes,
+            &mut replacements,
+        );
+        actions.extend(
+            dom_children[node]
+                .iter()
+                .rev()
+                .copied()
+                .map(GvnAction::Enter),
+        );
+    }
     debug_assert!(value_table.is_empty());
     debug_assert!(table_changes.is_empty());
     debug_assert!(leader_changes.is_empty());
@@ -13497,6 +13473,34 @@ mod tests {
                 size: OpSize::S64,
             }
         ));
+    }
+
+    #[test]
+    fn global_gvn_handles_deep_dominators_on_a_small_stack() {
+        std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(|| {
+                const BLOCKS: u32 = 10_000;
+                let mut func = make_func(Vec::new(), BLOCKS + 1);
+                func.blocks.clear();
+                for index in 0..BLOCKS {
+                    let mut block = MBlock::new(BlockId(index));
+                    if index == 0 {
+                        block.push(MInst::LoadImm { dst: VReg(0), value: 1 });
+                    }
+                    block.push(MInst::AddImm { dst: VReg(index + 1), src: VReg(0), imm: index as i32 });
+                    block.push(if index + 1 < BLOCKS {
+                        MInst::Jump { target: BlockId(index + 1) }
+                    } else { MInst::Return });
+                    func.blocks.push(block);
+                }
+                global_gvn(&mut func);
+                assert_eq!(func.blocks.len(), BLOCKS as usize);
+                for (index, block) in func.blocks.iter().enumerate() {
+                    assert!(block.insts.iter().any(|inst| matches!(inst, MInst::AddImm { dst, .. } if *dst == VReg(index as u32 + 1))));
+                }
+            })
+            .unwrap().join().unwrap();
     }
 
     #[test]

--- a/crates/celox-backend-x86/src/backend/native/regalloc.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc.rs
@@ -444,8 +444,8 @@ fn run_regalloc_in_place(
     let allocation = ssa::allocate(
         func,
         &normalized_cfg,
-        &next_use,
-        &planning_recipes,
+        next_use,
+        planning_recipes,
         &allocation_constraints,
         trace,
         timing,

--- a/crates/celox-backend-x86/src/backend/native/regalloc/next_use.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/next_use.rs
@@ -8,6 +8,9 @@ use crate::{HashMap, HashSet};
 
 use super::cfg::NormalizedCfg;
 
+mod distance_map;
+pub(super) use distance_map::DistanceMap;
+
 /// Lexicographic next-use distance.
 ///
 /// Exiting any loop region is more expensive than every instruction-only path,
@@ -89,8 +92,8 @@ impl PartialOrd for NextUseDistance {
 
 #[derive(Debug)]
 pub(super) struct NextUseAnalysis {
-    pub entry: Vec<HashMap<VReg, NextUseDistance>>,
-    pub exit: Vec<HashMap<VReg, NextUseDistance>>,
+    pub entry: Vec<DistanceMap>,
+    pub exit: Vec<DistanceMap>,
     anticipated_after_phis: Vec<HashSet<VReg>>,
     pub block_max_pressure: Vec<usize>,
     pub loop_regions: Vec<LoopRegionFacts>,
@@ -194,18 +197,17 @@ pub(super) fn analyze(
     let phi_uses = phi_edge_uses(func, cfg)?;
     let region_topology = RegionTopology::build(cfg)?;
     let edge_loop_exits = &region_topology.edge_exits;
-    let mut entry: Vec<HashMap<VReg, NextUseDistance>> =
-        vec![HashMap::default(); func.blocks.len()];
-    let mut exit: Vec<HashMap<VReg, NextUseDistance>> = vec![HashMap::default(); func.blocks.len()];
+    let mut entry = vec![DistanceMap::default(); func.blocks.len()];
+    let mut exit = vec![DistanceMap::default(); func.blocks.len()];
     let mut anticipated_after_phis = vec![HashSet::<VReg>::default(); func.blocks.len()];
     let mut queue = (0..func.blocks.len()).rev().collect::<VecDeque<_>>();
     let mut queued = vec![true; func.blocks.len()];
     while let Some(block) = queue.pop_front() {
         queued[block] = false;
-        let mut next_exit = HashMap::<VReg, NextUseDistance>::default();
+        let mut next_exit = DistanceMap::default();
         for (edge, &successor) in cfg.successors[block].iter().enumerate() {
             let edge_exits = edge_loop_exits[block][edge];
-            for (&value, &distance) in &entry[successor] {
+            for (&value, distance) in &entry[successor] {
                 let Some(distance) = distance.checked_across_edge(edge_exits) else {
                     return Err(NextUseError::new(
                         "NEXT_USE.DISTANCE_RANGE",
@@ -215,25 +217,19 @@ pub(super) fn analyze(
                         "loop-region exit distance exceeds addressable CFG size",
                     ));
                 };
-                next_exit
-                    .entry(value)
-                    .and_modify(|current| *current = (*current).min(distance))
-                    .or_insert(distance);
+                next_exit.insert_min(value, distance);
             }
             for &value in &phi_uses[block][edge] {
                 let distance = NextUseDistance::Finite {
                     loop_exits: edge_exits,
                     instructions: 0,
                 };
-                next_exit
-                    .entry(value)
-                    .and_modify(|current| *current = (*current).min(distance))
-                    .or_insert(distance);
+                next_exit.insert_min(value, distance);
             }
         }
         let transfer = &transfers[block];
-        let mut next_entry = HashMap::default();
-        for (&value, &distance) in &next_exit {
+        let mut next_entry = DistanceMap::default();
+        for (&value, distance) in &next_exit {
             if !transfer.definitions.contains(&value) {
                 let Some(distance) = distance.checked_prepend_instructions(transfer.length) else {
                     return Err(NextUseError::new(
@@ -394,7 +390,7 @@ impl NextUseAnalysis {
                     ));
                 }
             }
-            for (&value, &distance) in self.entry[block].iter().chain(&self.exit[block]) {
+            for (&value, distance) in self.entry[block].iter().chain(&self.exit[block]) {
                 if distance.is_dead() {
                     return Err(NextUseError::new(
                         "NEXT_USE.DATAFLOW_EQUATION",
@@ -737,7 +733,7 @@ fn verify_dataflow_equations(
         let mut expected_exit = HashMap::<VReg, NextUseDistance>::default();
         for (edge, &successor) in cfg.successors[block].iter().enumerate() {
             let loop_exits = edge_loop_exits[edge];
-            for (&value, &successor_distance) in &analysis.entry[successor] {
+            for (&value, successor_distance) in &analysis.entry[successor] {
                 let Some(distance) = successor_distance.checked_across_edge(loop_exits) else {
                     return Err(NextUseError::new(
                         "NEXT_USE.DISTANCE_RANGE",
@@ -917,10 +913,14 @@ fn verify_distance_map(
     block: BlockId,
     instruction: usize,
     boundary: &'static str,
-    actual: &HashMap<VReg, NextUseDistance>,
+    actual: &DistanceMap,
     expected: &HashMap<VReg, NextUseDistance>,
 ) -> Result<(), NextUseError> {
-    if actual == expected {
+    if actual.len() == expected.len()
+        && actual
+            .iter()
+            .all(|(key, value)| expected.get(key).copied() == Some(value))
+    {
         return Ok(());
     }
     let values = actual
@@ -930,7 +930,7 @@ fn verify_distance_map(
         .collect::<BTreeSet<_>>();
     let value = values
         .into_iter()
-        .find(|value| actual.get(value) != expected.get(value));
+        .find(|value| actual.get(value) != expected.get(value).copied());
     let detail = value.map_or_else(
         || "no differing value could be identified".to_string(),
         |value| {
@@ -1130,7 +1130,7 @@ struct RegionAggregationWork {
 /// Scan every block once to obtain both inputs of loop-region aggregation.
 fn block_region_summaries(
     func: &MFunction,
-    exit: &[HashMap<VReg, NextUseDistance>],
+    exit: &[DistanceMap],
 ) -> Result<(Vec<BlockRegionSummary>, RegionAggregationWork), NextUseError> {
     if exit.len() != func.blocks.len() {
         return Err(NextUseError::new(
@@ -2415,14 +2415,16 @@ mod tests {
         let header = cfg.block_index[&BlockId(1)];
         analysis.verify(&func, &cfg).unwrap();
         assert!(matches!(
-            analysis.exit[header][&value],
+            analysis.exit[header].get(&value).unwrap(),
             NextUseDistance::Finite {
                 loop_exits: 1..,
                 ..
             }
         ));
 
-        let NextUseDistance::Finite { instructions, .. } = analysis.exit[header][&value] else {
+        let NextUseDistance::Finite { instructions, .. } =
+            analysis.exit[header].get(&value).unwrap()
+        else {
             unreachable!("loop-exit value must have a finite distance")
         };
         analysis.exit[header].insert(

--- a/crates/celox-backend-x86/src/backend/native/regalloc/next_use/distance_map.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/next_use/distance_map.rs
@@ -1,7 +1,8 @@
 //! Compact storage for live next-use rows, with lossless wide fallback.
 //!
-//! Ordinary rows contain only finite distances that fit two u32 values. On
-//! 64-bit targets this shrinks each key/distance pair from 32 to 12 bytes.
+//! Ordinary rows pack 8 bits of loop exits and 24 bits of instructions into
+//! one u32. Rows needing more range fall back to two u32 values or usize.
+//! On 64-bit targets the ordinary key/distance pair shrinks from 32 to 8 bytes.
 //! Keep the usize-based distance API: a row that needs greater range promotes
 //! to the original representation, without saturation or a new compiler limit.
 
@@ -11,8 +12,28 @@ use crate::native::mir::VReg;
 
 #[derive(Debug, Clone)]
 pub(in crate::native::regalloc) enum DistanceMap {
+    Packed(HashMap<VReg, u32>),
     Compact(HashMap<VReg, [u32; 2]>),
     Wide(HashMap<VReg, NextUseDistance>),
+}
+
+const PACKED_INSTRUCTION_BITS: u32 = 24;
+const PACKED_INSTRUCTION_MASK: u32 = (1 << PACKED_INSTRUCTION_BITS) - 1;
+
+fn pack(distance: NextUseDistance) -> Option<u32> {
+    let [loop_exits, instructions] = compact(distance)?;
+    if loop_exits <= u8::MAX as u32 && instructions <= PACKED_INSTRUCTION_MASK {
+        Some((loop_exits << PACKED_INSTRUCTION_BITS) | instructions)
+    } else {
+        None
+    }
+}
+
+fn unpack(value: u32) -> NextUseDistance {
+    expand([
+        value >> PACKED_INSTRUCTION_BITS,
+        value & PACKED_INSTRUCTION_MASK,
+    ])
 }
 
 fn compact(distance: NextUseDistance) -> Option<[u32; 2]> {
@@ -34,13 +55,14 @@ fn expand([loop_exits, instructions]: [u32; 2]) -> NextUseDistance {
 
 impl Default for DistanceMap {
     fn default() -> Self {
-        Self::Compact(HashMap::default())
+        Self::Packed(HashMap::default())
     }
 }
 
 impl PartialEq for DistanceMap {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
+            (Self::Packed(left), Self::Packed(right)) => left == right,
             (Self::Compact(left), Self::Compact(right)) => left == right,
             (Self::Wide(left), Self::Wide(right)) => left == right,
             _ => {
@@ -57,6 +79,7 @@ impl Eq for DistanceMap {}
 impl DistanceMap {
     pub(in crate::native::regalloc) fn len(&self) -> usize {
         match self {
+            Self::Packed(map) => map.len(),
             Self::Compact(map) => map.len(),
             Self::Wide(map) => map.len(),
         }
@@ -64,6 +87,7 @@ impl DistanceMap {
 
     pub(in crate::native::regalloc) fn get(&self, key: &VReg) -> Option<NextUseDistance> {
         match self {
+            Self::Packed(map) => map.get(key).copied().map(unpack),
             Self::Compact(map) => map.get(key).copied().map(expand),
             Self::Wide(map) => map.get(key).copied(),
         }
@@ -78,6 +102,25 @@ impl DistanceMap {
         key: VReg,
         value: NextUseDistance,
     ) -> Option<NextUseDistance> {
+        if let Self::Packed(map) = self {
+            if let Some(value) = pack(value) {
+                return map.insert(key, value).map(unpack);
+            }
+            *self = Self::Compact(
+                std::mem::take(map)
+                    .into_iter()
+                    .map(|(key, value)| {
+                        (
+                            key,
+                            [
+                                value >> PACKED_INSTRUCTION_BITS,
+                                value & PACKED_INSTRUCTION_MASK,
+                            ],
+                        )
+                    })
+                    .collect(),
+            );
+        }
         if let Self::Compact(map) = self {
             if let Some(value) = compact(value) {
                 return map.insert(key, value).map(expand);
@@ -106,6 +149,7 @@ impl DistanceMap {
     #[cfg(test)]
     pub(in crate::native::regalloc) fn remove(&mut self, key: &VReg) -> Option<NextUseDistance> {
         match self {
+            Self::Packed(map) => map.remove(key).map(unpack),
             Self::Compact(map) => map.remove(key).map(expand),
             Self::Wide(map) => map.remove(key),
         }
@@ -113,6 +157,7 @@ impl DistanceMap {
 
     pub(in crate::native::regalloc) fn iter(&self) -> Iter<'_> {
         match self {
+            Self::Packed(map) => Iter::Packed(map.iter()),
             Self::Compact(map) => Iter::Compact(map.iter()),
             Self::Wide(map) => Iter::Wide(map.iter()),
         }
@@ -124,6 +169,7 @@ impl DistanceMap {
 }
 
 pub(in crate::native::regalloc) enum Iter<'a> {
+    Packed(std::collections::hash_map::Iter<'a, VReg, u32>),
     Compact(std::collections::hash_map::Iter<'a, VReg, [u32; 2]>),
     Wide(std::collections::hash_map::Iter<'a, VReg, NextUseDistance>),
 }
@@ -132,6 +178,7 @@ impl<'a> Iterator for Iter<'a> {
     type Item = (&'a VReg, NextUseDistance);
     fn next(&mut self) -> Option<Self::Item> {
         match self {
+            Self::Packed(iter) => iter.next().map(|(key, value)| (key, unpack(*value))),
             Self::Compact(iter) => iter.next().map(|(key, value)| (key, expand(*value))),
             Self::Wide(iter) => iter.next().map(|(key, value)| (key, *value)),
         }
@@ -149,6 +196,34 @@ impl<'a> IntoIterator for &'a DistanceMap {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn packed_boundaries_fall_back_independently_without_changing_rows() {
+        for overflow in [
+            NextUseDistance::Finite {
+                loop_exits: 256,
+                instructions: 0,
+            },
+            NextUseDistance::Finite {
+                loop_exits: 0,
+                instructions: 1 << 24,
+            },
+            NextUseDistance::Dead,
+        ] {
+            let mut row = DistanceMap::default();
+            let boundary = NextUseDistance::Finite {
+                loop_exits: 255,
+                instructions: (1 << 24) - 1,
+            };
+            row.insert(VReg(0), boundary);
+            assert!(matches!(row, DistanceMap::Packed(_)));
+            let packed = row.clone();
+            row.insert(VReg(1), overflow);
+            assert_eq!(row.get(&VReg(0)), Some(boundary));
+            assert_eq!(row.remove(&VReg(1)), Some(overflow));
+            assert_eq!(row, packed);
+        }
+    }
 
     #[test]
     fn compact_rows_preserve_boundaries_and_promote_without_truncation() {
@@ -175,7 +250,9 @@ mod tests {
             let key = VReg(index as u32);
             row.insert(key, distance);
             expected.insert(key, distance);
-            if index < 2 {
+            if index == 0 {
+                assert!(matches!(row, DistanceMap::Packed(_)));
+            } else if index == 1 {
                 assert!(matches!(row, DistanceMap::Compact(_)));
             }
             assert_eq!(

--- a/crates/celox-backend-x86/src/backend/native/regalloc/next_use/distance_map.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/next_use/distance_map.rs
@@ -1,0 +1,212 @@
+//! Compact storage for live next-use rows, with lossless wide fallback.
+//!
+//! Ordinary rows contain only finite distances that fit two u32 values. On
+//! 64-bit targets this shrinks each key/distance pair from 32 to 12 bytes.
+//! Keep the usize-based distance API: a row that needs greater range promotes
+//! to the original representation, without saturation or a new compiler limit.
+
+use super::NextUseDistance;
+use crate::HashMap;
+use crate::native::mir::VReg;
+
+#[derive(Debug, Clone)]
+pub(in crate::native::regalloc) enum DistanceMap {
+    Compact(HashMap<VReg, [u32; 2]>),
+    Wide(HashMap<VReg, NextUseDistance>),
+}
+
+fn compact(distance: NextUseDistance) -> Option<[u32; 2]> {
+    match distance {
+        NextUseDistance::Finite {
+            loop_exits,
+            instructions,
+        } => Some([loop_exits.try_into().ok()?, instructions.try_into().ok()?]),
+        NextUseDistance::Dead => None,
+    }
+}
+
+fn expand([loop_exits, instructions]: [u32; 2]) -> NextUseDistance {
+    NextUseDistance::Finite {
+        loop_exits: loop_exits as usize,
+        instructions: instructions as usize,
+    }
+}
+
+impl Default for DistanceMap {
+    fn default() -> Self {
+        Self::Compact(HashMap::default())
+    }
+}
+
+impl PartialEq for DistanceMap {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Compact(left), Self::Compact(right)) => left == right,
+            (Self::Wide(left), Self::Wide(right)) => left == right,
+            _ => {
+                self.len() == other.len()
+                    && self
+                        .iter()
+                        .all(|(key, value)| other.get(key) == Some(value))
+            }
+        }
+    }
+}
+impl Eq for DistanceMap {}
+
+impl DistanceMap {
+    pub(in crate::native::regalloc) fn len(&self) -> usize {
+        match self {
+            Self::Compact(map) => map.len(),
+            Self::Wide(map) => map.len(),
+        }
+    }
+
+    pub(in crate::native::regalloc) fn get(&self, key: &VReg) -> Option<NextUseDistance> {
+        match self {
+            Self::Compact(map) => map.get(key).copied().map(expand),
+            Self::Wide(map) => map.get(key).copied(),
+        }
+    }
+
+    pub(in crate::native::regalloc) fn contains_key(&self, key: &VReg) -> bool {
+        self.get(key).is_some()
+    }
+
+    pub(in crate::native::regalloc) fn insert(
+        &mut self,
+        key: VReg,
+        value: NextUseDistance,
+    ) -> Option<NextUseDistance> {
+        if let Self::Compact(map) = self {
+            if let Some(value) = compact(value) {
+                return map.insert(key, value).map(expand);
+            }
+            // Distances still have usize precision. Only rows needing a large
+            // distance (or an explicit Dead in verifier tests) use wide storage.
+            *self = Self::Wide(
+                std::mem::take(map)
+                    .into_iter()
+                    .map(|(key, value)| (key, expand(value)))
+                    .collect(),
+            );
+        }
+        let Self::Wide(map) = self else {
+            unreachable!()
+        };
+        map.insert(key, value)
+    }
+
+    pub(in crate::native::regalloc) fn insert_min(&mut self, key: VReg, value: NextUseDistance) {
+        if self.get(&key).is_none_or(|old| value < old) {
+            self.insert(key, value);
+        }
+    }
+
+    #[cfg(test)]
+    pub(in crate::native::regalloc) fn remove(&mut self, key: &VReg) -> Option<NextUseDistance> {
+        match self {
+            Self::Compact(map) => map.remove(key).map(expand),
+            Self::Wide(map) => map.remove(key),
+        }
+    }
+
+    pub(in crate::native::regalloc) fn iter(&self) -> Iter<'_> {
+        match self {
+            Self::Compact(map) => Iter::Compact(map.iter()),
+            Self::Wide(map) => Iter::Wide(map.iter()),
+        }
+    }
+
+    pub(in crate::native::regalloc) fn keys(&self) -> impl Iterator<Item = &VReg> {
+        self.iter().map(|(key, _)| key)
+    }
+}
+
+pub(in crate::native::regalloc) enum Iter<'a> {
+    Compact(std::collections::hash_map::Iter<'a, VReg, [u32; 2]>),
+    Wide(std::collections::hash_map::Iter<'a, VReg, NextUseDistance>),
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = (&'a VReg, NextUseDistance);
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Compact(iter) => iter.next().map(|(key, value)| (key, expand(*value))),
+            Self::Wide(iter) => iter.next().map(|(key, value)| (key, *value)),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a DistanceMap {
+    type Item = (&'a VReg, NextUseDistance);
+    type IntoIter = Iter<'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_rows_preserve_boundaries_and_promote_without_truncation() {
+        let mut row = DistanceMap::default();
+        let mut expected = HashMap::default();
+        for (index, distance) in [
+            NextUseDistance::Finite {
+                loop_exits: 0,
+                instructions: 0,
+            },
+            NextUseDistance::Finite {
+                loop_exits: u32::MAX as usize,
+                instructions: u32::MAX as usize,
+            },
+            NextUseDistance::Finite {
+                loop_exits: usize::MAX,
+                instructions: usize::MAX,
+            },
+            NextUseDistance::Dead,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let key = VReg(index as u32);
+            row.insert(key, distance);
+            expected.insert(key, distance);
+            if index < 2 {
+                assert!(matches!(row, DistanceMap::Compact(_)));
+            }
+            assert_eq!(
+                row.iter()
+                    .map(|(&key, value)| (key, value))
+                    .collect::<HashMap<_, _>>(),
+                expected
+            );
+            for (key, value) in &expected {
+                assert_eq!(row.get(key), Some(*value));
+            }
+        }
+        for key in expected.keys() {
+            assert_eq!(row.remove(key), expected.get(key).copied());
+        }
+        assert_eq!(row.len(), 0);
+    }
+
+    #[test]
+    fn minimum_updates_and_equality_do_not_depend_on_storage() {
+        let mut compact = DistanceMap::default();
+        let mut wide = DistanceMap::Wide(HashMap::default());
+        for instructions in [30, 10, 20, 0, 40] {
+            let distance = NextUseDistance::Finite {
+                loop_exits: 0,
+                instructions,
+            };
+            compact.insert_min(VReg(1), distance);
+            wide.insert_min(VReg(1), distance);
+            assert_eq!(compact, wide);
+        }
+        assert_eq!(compact.get(&VReg(1)), Some(NextUseDistance::local(0)));
+    }
+}

--- a/crates/celox-backend-x86/src/backend/native/regalloc/reconstruct.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/reconstruct.rs
@@ -10,7 +10,6 @@ use crate::native::mir::{
 
 use super::cfg::NormalizedCfg;
 use super::materialized_state_home::{MaterializedStateReload, MaterializedStateStore};
-use super::next_use::NextUseAnalysis;
 use super::reload::{
     ExpectedMaterializedReload, MemoryPhiFactoring, PointUse, ReloadRecipeAnalysis, ResolvedBase,
     ResolvedRecipe, materialize_pure_step,
@@ -149,7 +148,6 @@ pub(super) fn reconstruct(
     func: &mut MFunction,
     cfg: &NormalizedCfg,
     plan: &SpillPlan,
-    _next_use: &NextUseAnalysis,
     reload_recipes: &ReloadRecipeAnalysis,
     timing: bool,
     verify: bool,
@@ -2675,7 +2673,7 @@ mod tests {
         plan.verify(&func, &cfg, registers).unwrap();
         plan.verify_recipe_homes(&func, &cfg, &recipes).unwrap();
         super::super::home_verify::verify(&func, &cfg, &plan).unwrap();
-        let result = reconstruct(&mut func, &cfg, &plan, &next_use, &recipes, false, true).unwrap();
+        let result = reconstruct(&mut func, &cfg, &plan, &recipes, false, true).unwrap();
         let rebuilt_cfg = (!result.shared_reload_blocks.is_empty())
             .then(|| super::super::cfg::normalize(&mut func).unwrap());
         let cfg = rebuilt_cfg.as_ref().unwrap_or(&cfg);
@@ -2762,7 +2760,7 @@ mod tests {
         plan.verify(&func, &cfg, 2).unwrap();
         plan.verify_recipe_homes(&func, &cfg, &recipes).unwrap();
         super::super::home_verify::verify(&func, &cfg, &plan).unwrap();
-        let result = reconstruct(&mut func, &cfg, &plan, &next_use, &recipes, false, true).unwrap();
+        let result = reconstruct(&mut func, &cfg, &plan, &recipes, false, true).unwrap();
         super::super::reload::verify_expected_materialized_reloads(
             &func,
             &cfg,
@@ -3038,7 +3036,7 @@ mod tests {
         plan.verify(&func, &cfg, 2).unwrap();
         plan.verify_recipe_homes(&func, &cfg, &recipes).unwrap();
         super::super::home_verify::verify(&func, &cfg, &plan).unwrap();
-        let result = reconstruct(&mut func, &cfg, &plan, &next_use, &recipes, false, true).unwrap();
+        let result = reconstruct(&mut func, &cfg, &plan, &recipes, false, true).unwrap();
         super::super::reload::verify_expected_materialized_reloads(
             &func,
             &cfg,

--- a/crates/celox-backend-x86/src/backend/native/regalloc/spill_plan.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/spill_plan.rs
@@ -7,7 +7,7 @@ use crate::HashMap;
 use crate::native::mir::{BlockId, MFunction, MInst, PackedStateHome, VReg};
 
 use super::cfg::NormalizedCfg;
-use super::next_use::{NextUseAnalysis, NextUseDistance};
+use super::next_use::{DistanceMap, NextUseAnalysis, NextUseDistance};
 use super::reload::{EdgeUse, PlanningRecipes, PointUse, ReloadRecipeAnalysis, ResolvedRecipe};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -2060,7 +2060,7 @@ struct RemainingBlockUses<'a> {
     block: BlockId,
     preferred_rank: Vec<usize>,
     remaining: HashMap<LogicalValue, RemainingUses>,
-    exit: &'a HashMap<VReg, NextUseDistance>,
+    exit: &'a DistanceMap,
     exit_reload_costs: &'a HashMap<LogicalValue, u32>,
     emitted: Vec<bool>,
     emitted_count: usize,
@@ -2218,7 +2218,7 @@ impl<'a> RemainingBlockUses<'a> {
             };
         }
         let remaining_instructions = self.emitted.len().saturating_sub(self.emitted_count);
-        match self.exit.get(&VReg(value.0)).copied() {
+        match self.exit.get(&VReg(value.0)) {
             Some(NextUseDistance::Finite {
                 loop_exits,
                 instructions,

--- a/crates/celox-backend-x86/src/backend/native/regalloc/ssa.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/ssa.rs
@@ -20,8 +20,8 @@ pub(super) struct Allocation {
 pub(super) fn allocate(
     func: &mut MFunction,
     cfg: &NormalizedCfg,
-    next_use: &NextUseAnalysis,
-    planning_recipes: &PlanningRecipes,
+    next_use: NextUseAnalysis,
+    planning_recipes: PlanningRecipes,
     constraints: &super::constraints::ConstraintModel,
     trace: Option<&mut super::RegallocTrace>,
     timing: bool,
@@ -42,8 +42,8 @@ pub(super) fn allocate(
     let mut plan = super::spill_plan::plan_with_integrated_schedule(
         func,
         cfg,
-        next_use,
-        planning_recipes,
+        &next_use,
+        &planning_recipes,
         register_count,
         constraints,
     )
@@ -57,6 +57,9 @@ pub(super) fn allocate(
             error.message,
         )
     })?;
+    // Scheduling has consumed these analyses. Do not retain their potentially
+    // huge CFG/value tables while constructing stack-home liveness and unions.
+    drop((next_use, planning_recipes));
     if let Some(trace) = trace {
         trace.mir_after_scheduling = func.to_string();
     }
@@ -220,25 +223,18 @@ pub(super) fn allocate(
     checkpoint()?;
 
     let phase = timing.then(crate::timing::now);
-    let reconstruction = super::reconstruct::reconstruct(
-        func,
-        cfg,
-        &plan,
-        next_use,
-        &reload_recipes,
-        timing,
-        verify,
-    )
-    .map_err(|error| {
-        super::RegallocError::new(
-            "SSA reconstruction",
-            error.rule,
-            error.block,
-            error.instruction,
-            error.values,
-            error.message,
-        )
-    })?;
+    let reconstruction =
+        super::reconstruct::reconstruct(func, cfg, &plan, &reload_recipes, timing, verify)
+            .map_err(|error| {
+                super::RegallocError::new(
+                    "SSA reconstruction",
+                    error.rule,
+                    error.block,
+                    error.instruction,
+                    error.values,
+                    error.message,
+                )
+            })?;
     if let Some(start) = phase {
         tracing::debug!(
             "[regalloc-timing] ssa reconstruct vregs={} insts={} frame={} shared_reload_blocks={} elapsed={:?}",

--- a/crates/celox-backend-x86/src/backend/native/regalloc/ssa_state_home.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/ssa_state_home.rs
@@ -881,16 +881,9 @@ mod tests {
 
         let requested = super::super::ssa::planner_reload_queries(&func, &cfg, &plan).unwrap();
         let ordinary_recipes = reload::analyze_with_queries(&func, &cfg, &requested).unwrap();
-        let result = reconstruct::reconstruct(
-            &mut func,
-            &cfg,
-            &plan,
-            &next_use,
-            &ordinary_recipes,
-            false,
-            true,
-        )
-        .unwrap();
+        let result =
+            reconstruct::reconstruct(&mut func, &cfg, &plan, &ordinary_recipes, false, true)
+                .unwrap();
         assert_eq!(result.frame_size, 0);
         assert!(func.blocks[0].insts.iter().any(|inst| {
             matches!(
@@ -996,16 +989,9 @@ mod tests {
         assert!(plan.state_reload_recipes.is_empty());
         let requested = super::super::ssa::planner_reload_queries(&func, &cfg, &plan).unwrap();
         let ordinary_recipes = reload::analyze_with_queries(&func, &cfg, &requested).unwrap();
-        let result = reconstruct::reconstruct(
-            &mut func,
-            &cfg,
-            &plan,
-            &next_use,
-            &ordinary_recipes,
-            false,
-            true,
-        )
-        .unwrap();
+        let result =
+            reconstruct::reconstruct(&mut func, &cfg, &plan, &ordinary_recipes, false, true)
+                .unwrap();
         assert_eq!(result.frame_size, 8);
         assert!(func.blocks[0].insts.iter().any(|inst| {
             matches!(

--- a/crates/celox-backend-x86/src/backend/native/regalloc/stack_color.rs
+++ b/crates/celox-backend-x86/src/backend/native/regalloc/stack_color.rs
@@ -486,6 +486,65 @@ fn build_planned_stack_program(
     build_planned_stack_program_from_events(func, cfg, events, homes)
 }
 
+// Homes have independent liveness and iterated dominance frontiers. Process
+// one home at a time so transient relations scale with the CFG, rather than
+// the product of all live homes and blocks.
+fn planned_phi_relations(
+    events: &[Vec<PlannedStackEvent>],
+    cfg: &NormalizedCfg,
+) -> Vec<(SpillHome, usize)> {
+    let mut rows = BTreeMap::<SpillHome, (Vec<usize>, Vec<usize>)>::new();
+    for (block, block_events) in events.iter().enumerate() {
+        let mut locally_defined = HashSet::default();
+        for event in block_events {
+            match event.kind {
+                PlannedStackEventKind::Store => {
+                    if locally_defined.insert(event.home) {
+                        rows.entry(event.home).or_default().0.push(block);
+                    }
+                }
+                PlannedStackEventKind::Reload => {
+                    if !locally_defined.contains(&event.home) {
+                        let uses = &mut rows.entry(event.home).or_default().1;
+                        if uses.last() != Some(&block) {
+                            uses.push(block);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let mut ordered_phis = Vec::new();
+    for (home, (definitions, upward_uses)) in rows {
+        let definitions = definitions.into_iter().collect::<HashSet<_>>();
+        let mut live_in = upward_uses.iter().copied().collect::<HashSet<_>>();
+        let mut live_work = VecDeque::from(upward_uses);
+        while let Some(block) = live_work.pop_front() {
+            for &predecessor in &cfg.predecessors[block] {
+                if !definitions.contains(&predecessor) && live_in.insert(predecessor) {
+                    live_work.push_back(predecessor);
+                }
+            }
+        }
+        let mut phis = HashSet::default();
+        let mut queued = definitions.clone();
+        let mut phi_work = definitions.into_iter().collect::<Vec<_>>();
+        while let Some(block) = phi_work.pop() {
+            for &frontier in &cfg.dominance_frontier[block] {
+                if frontier == 0 || !live_in.contains(&frontier) || !phis.insert(frontier) {
+                    continue;
+                }
+                if queued.insert(frontier) {
+                    phi_work.push(frontier);
+                }
+            }
+        }
+        ordered_phis.extend(phis.into_iter().map(|block| (home, block)));
+    }
+    ordered_phis.sort_unstable_by_key(|(home, block)| (*block, *home));
+    ordered_phis
+}
+
 fn build_planned_stack_program_from_events(
     func: &MFunction,
     cfg: &NormalizedCfg,
@@ -520,57 +579,9 @@ fn build_planned_stack_program_from_events(
         ));
     }
 
-    // Sparse pruned MemorySSA.  `definitions` and `live_in` contain only
-    // relations which actually occur; no home-by-block matrix is built.
-    let mut definitions = HashSet::<(SpillHome, usize)>::default();
-    let mut upward_uses = HashSet::<(SpillHome, usize)>::default();
-    for (block, block_events) in events.iter().enumerate() {
-        let mut locally_defined = HashSet::<SpillHome>::default();
-        for event in block_events {
-            match event.kind {
-                PlannedStackEventKind::Store => {
-                    locally_defined.insert(event.home);
-                    definitions.insert((event.home, block));
-                }
-                PlannedStackEventKind::Reload => {
-                    if !locally_defined.contains(&event.home) {
-                        upward_uses.insert((event.home, block));
-                    }
-                }
-            }
-        }
-    }
-    let mut live_in = upward_uses.clone();
-    let mut live_work = upward_uses.iter().copied().collect::<VecDeque<_>>();
-    while let Some((home, block)) = live_work.pop_front() {
-        for &predecessor in &cfg.predecessors[block] {
-            let relation = (home, predecessor);
-            if !definitions.contains(&relation) && live_in.insert(relation) {
-                live_work.push_back(relation);
-            }
-        }
-    }
-
-    let mut phi_relations = HashSet::<(SpillHome, usize)>::default();
-    let mut queued = definitions.clone();
-    let mut phi_work = definitions.iter().copied().collect::<Vec<_>>();
-    while let Some((home, block)) = phi_work.pop() {
-        for &frontier in &cfg.dominance_frontier[block] {
-            let relation = (home, frontier);
-            if frontier == 0 || !live_in.contains(&relation) || !phi_relations.insert(relation) {
-                continue;
-            }
-            if queued.insert(relation) {
-                phi_work.push(relation);
-            }
-        }
-    }
-
     let mut version_homes = Vec::<SpillHome>::new();
     let mut phis_by_block = vec![Vec::<PlannedStackPhi>::new(); func.blocks.len()];
-    let mut ordered_phis = phi_relations.into_iter().collect::<Vec<_>>();
-    ordered_phis.sort_unstable_by_key(|(home, block)| (*block, *home));
-    for (home, block) in ordered_phis {
+    for (home, block) in planned_phi_relations(&events, cfg) {
         let destination = allocate_planned_version(&mut version_homes, home)?;
         phis_by_block[block].push(PlannedStackPhi {
             home,
@@ -855,11 +866,11 @@ fn color_planned_stack_program(
     }
     let phase = timing.then(crate::timing::now);
     let ranges = merge_home_segments(&intervals, &program.version_homes, &homes)?;
-    let bundle_homes = homes.iter().copied().collect::<Vec<_>>();
-    let mut bundle_ranges = Vec::with_capacity(bundle_homes.len());
-    for &home in &bundle_homes {
-        bundle_ranges.push(ranges[&home].clone());
-    }
+    // The merged ranges own everything coloring needs. Release MemorySSA
+    // and its intervals before constructing the interval matrix.
+    drop(intervals);
+    drop(program);
+    let (bundle_homes, bundle_ranges): (Vec<_>, Vec<_>) = ranges.into_iter().unzip();
 
     // General live-range unions are not necessarily chordal after all
     // MemorySSA versions of a physical home are coalesced. Largest ranges
@@ -1099,6 +1110,107 @@ mod tests {
         function
     }
 
+    fn reference_phi_relations(
+        events: &[Vec<PlannedStackEvent>],
+        cfg: &NormalizedCfg,
+    ) -> Vec<(SpillHome, usize)> {
+        let mut definitions = HashSet::<(SpillHome, usize)>::default();
+        let mut upward_uses = HashSet::<(SpillHome, usize)>::default();
+        for (block, block_events) in events.iter().enumerate() {
+            let mut locally_defined = HashSet::<SpillHome>::default();
+            for event in block_events {
+                match event.kind {
+                    PlannedStackEventKind::Store => {
+                        locally_defined.insert(event.home);
+                        definitions.insert((event.home, block));
+                    }
+                    PlannedStackEventKind::Reload => {
+                        if !locally_defined.contains(&event.home) {
+                            upward_uses.insert((event.home, block));
+                        }
+                    }
+                }
+            }
+        }
+        let mut live_in = upward_uses.clone();
+        let mut live_work = upward_uses.iter().copied().collect::<VecDeque<_>>();
+        while let Some((home, block)) = live_work.pop_front() {
+            for &predecessor in &cfg.predecessors[block] {
+                let relation = (home, predecessor);
+                if !definitions.contains(&relation) && live_in.insert(relation) {
+                    live_work.push_back(relation);
+                }
+            }
+        }
+
+        let mut phi_relations = HashSet::<(SpillHome, usize)>::default();
+        let mut queued = definitions.clone();
+        let mut phi_work = definitions.iter().copied().collect::<Vec<_>>();
+        while let Some((home, block)) = phi_work.pop() {
+            for &frontier in &cfg.dominance_frontier[block] {
+                let relation = (home, frontier);
+                if frontier == 0 || !live_in.contains(&relation) || !phi_relations.insert(relation)
+                {
+                    continue;
+                }
+                if queued.insert(relation) {
+                    phi_work.push(relation);
+                }
+            }
+        }
+
+        let mut result = phi_relations.into_iter().collect::<Vec<_>>();
+        result.sort_unstable_by_key(|(home, block)| (*block, *home));
+        result
+    }
+
+    #[test]
+    fn per_home_phis_match_global_dataflow() {
+        use PlannedStackEventKind::{Reload as R, Store as S};
+        let patterns: &[&[PlannedStackEventKind]] =
+            &[&[], &[S], &[R], &[S, R], &[R, S], &[R, S, R]];
+        for loop_back in [false, true] {
+            let mut func = diamond_function();
+            if loop_back {
+                func.blocks[0].insts.pop();
+                func.blocks[0].push(MInst::Jump { target: BlockId(1) });
+                func.blocks[1].insts = vec![MInst::Branch {
+                    cond: VReg(0),
+                    true_bb: BlockId(2),
+                    false_bb: BlockId(3),
+                }];
+                func.blocks[2].insts = vec![MInst::Jump { target: BlockId(1) }];
+            }
+            let cfg = cfg::normalize(&mut func).unwrap();
+            for mut pattern in 0usize..patterns.len().pow(4) {
+                let mut events = vec![Vec::new(); func.blocks.len()];
+                for row in &mut events {
+                    let choice = pattern % patterns.len();
+                    pattern /= patterns.len();
+                    // Sparse, unrelated home IDs also exercise independence.
+                    for (home, kinds) in [
+                        (SpillHome(3), patterns[choice]),
+                        (SpillHome(10001), patterns[patterns.len() - 1 - choice]),
+                    ] {
+                        for &kind in kinds {
+                            row.push(PlannedStackEvent {
+                                instruction: row.len(),
+                                sequence: row.len(),
+                                home,
+                                kind,
+                                definition: None,
+                                reaching: None,
+                            });
+                        }
+                    }
+                }
+                assert_eq!(
+                    planned_phi_relations(&events, &cfg),
+                    reference_phi_relations(&events, &cfg)
+                );
+            }
+        }
+    }
     #[test]
     fn production_sequential_homes_reuse_one_slot() {
         let mut source = function(0, vec![MInst::Return]);

--- a/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_sparse_case_dispatch.rs
+++ b/crates/celox-sir-opt/src/optimizer/passes/control_flow/pass_sparse_case_dispatch.rs
@@ -225,6 +225,11 @@ fn find_sparse_case_plans(
                 nonmaximal_same_selector_muxes(eu, block, &local_defs, &def_sites, &use_counts);
             let dense_lookup_indices =
                 dense_constant_lookup_mux_indices(eu, block, &local_defs, &def_sites, &deferred);
+            // The CFG is unchanged during discovery. Reuse producer-block
+            // dominance proofs across candidates for this target block; each
+            // proof otherwise walks the whole CFG again. Clear the cache for
+            // each target so storage stays bounded by the block count.
+            let mut dominance = HashMap::<BlockId, bool>::default();
             let mut best: Option<SparseCasePlan> = None;
             for (root_index, inst) in block.instructions.iter().enumerate() {
                 if !matches!(inst, SIRInstruction::Mux(..))
@@ -242,6 +247,7 @@ fn find_sparse_case_plans(
                     &def_sites,
                     &use_counts,
                     stable_alias_class,
+                    &mut dominance,
                 ) else {
                     continue;
                 };
@@ -411,6 +417,7 @@ fn recognize_sparse_case_chain(
     def_sites: &HashMap<RegisterId, DefSite>,
     use_counts: &HashMap<RegisterId, usize>,
     stable_alias_class: &HashMap<AbsoluteAddr, AbsoluteAddr>,
+    dominance: &mut HashMap<BlockId, bool>,
 ) -> Option<SparseCasePlan> {
     let SIRInstruction::Mux(result, _, _, _) = &block.instructions[root_index] else {
         return None;
@@ -615,6 +622,7 @@ fn recognize_sparse_case_chain(
         &reachable_arms,
         use_counts,
         def_sites,
+        dominance,
     )?;
     let profitability = sparse_case_profitability(
         eu,
@@ -1255,6 +1263,7 @@ fn cross_block_exact_dead_defs_after_rewrite(
     reachable_arms: &[usize],
     use_counts: &HashMap<RegisterId, usize>,
     def_sites: &HashMap<RegisterId, DefSite>,
+    dominance: &mut HashMap<BlockId, bool>,
 ) -> Option<HashSet<DefSite>> {
     // Matching proves the shape of every condition, but the definitions can
     // live in a predecessor after an earlier CFG rewrite.  Restrict the
@@ -1272,7 +1281,6 @@ fn cross_block_exact_dead_defs_after_rewrite(
         );
     }
 
-    let mut dominance = HashMap::<BlockId, bool>::default();
     for &reg in &candidates {
         let site = def_sites.get(&reg)?;
         if site.block != block.id


### PR DESCRIPTION
## Summary

Large Heliodor Linux workloads exhaust memory during x86 compilation; the reported two-hart tiered CI job lost its runner. Reduce next-use storage with lossless per-row representations (packed 8-bit loop-exit / 24-bit instruction counters, then two u32 counters, then the original usize representation). Supported distances and allocation decisions remain unchanged. Release next-use and planning data after scheduling.

Build stack-home phi relations independently per home, then release MemorySSA and interval data once merged ranges are ready for coloring. Cache repeated dominance queries per target block during sparse-case discovery; the CFG remains immutable during discovery and the cache is discarded before rewrites.

Replace recursive x86 GVN dominator-tree traversal with an explicit action stack, preserving traversal order and undo checkpoints. This fixes the stack overflow captured while compiling the eight-hart workload.

## Validation

- 562 x86 backend tests, 407 optimizer tests, and 39 native/MIR/boundary/tiered integration tests passed. Clippy, formatting, diff checks, and workspace checks passed.
- Differential stack-phi tests compare branching/looping CFGs and store/reload orderings with the previous global dataflow. A 10,000-block dominator chain runs on a 256 KiB thread stack. Distance tests cover packed boundaries, each overflow dimension, wide fallback, minimum updates, and equality across representations.
- Linux 5.15 two-hart native and tiered boots passed locally on the initial PR fix; the focused tiered CI also passed. Both reach cycle `0x1245bc0` with identical per-hart PC/retirement/trap counters and tiered promotion succeeds.
- Two-hart native images remain byte-identical after stack-liveness and packed-distance changes: SHA-256 `928a11d36dcd81207757ca3820bb8d82d57358caac03251c1fdf387f065624a1`. Peak RSS changed from 21,617,720 KiB before the PR to 8,303,824 KiB with these storage changes.

Local checks use Heliodor `6285682fa0a514077da9d17fee385c7841160025`, O2 and `heliodor-dev`. Concurrent timings are not runtime speedup measurements.

## Completed full-matrix validation

All 44 configurations were attempted locally on x86. Normal runs use a 12 GiB virtual-memory cap: 28 passed, seven failed heap allocation, and eight failed guest boot assertions. The remaining configuration, Linux 5.15 four-hart native, passed with a 24 GiB cap (23.1 GiB peak RSS); its 12/14 GiB attempts failed. Its final cycle, PCs, retirement and trap counters match Veryl. Successful tiered runs exercised compiled execution. Repeated Veryl Linux-variant runs have identical pass/fail outcomes.

- Latest x86 full CI at `ab656c0dd`: **28/44 passed, 16 failed**. https://github.com/celox-sim/celox/actions/runs/34646995062
- Native ARM full CI at the earlier `19a70c95b`: **32/44 passed, 12 failed**. This is not full ARM validation of the latest revision. https://github.com/celox-sim/celox/actions/runs/34640846713
- Latest regular PR checks all passed, including Rust, ARM backend, JS, lint/format, Heliodor and compile-time checks.

Remaining failures: x86 Celox four/eight-hart CI jobs exit 143; corresponding bounded local runs establish heap allocation failures, but CI logs alone do not prove OOM. ARM Celox eight-hart jobs also exit 143. Veryl eight-hart guest boots fail on both architectures. Linux 7.1 SMP fails across backends (guest failure or ARM timeout), so this is not confined to the x86 backend. Four-hart ARM Linux 5.15/6.6 passes across all four runners.

The recursive GVN stack overflow is fixed; the latest eight-hart native and tiered local reruns encounter heap allocation failure instead. Two-hart native output remains byte-identical to the pre-PR image after all fixes, with latest peak RSS 8,186,280 KiB versus 21,617,720 KiB before the PR. Concurrent timings do not establish runtime speedup.

Full-suite success and site publication remain unresolved. Failed or incomplete suites have not been published as successful benchmark results.
