### PR TITLE
fix(ci): prevent duplicate npm platform publication

### DIFF
--- a/.github/workflows/ci-napi.yml
+++ b/.github/workflows/ci-napi.yml
@@ -358,7 +358,9 @@ jobs:
           if npm view "$package_name@$package_version" version >/dev/null 2>&1; then
             echo "$package_name@$package_version is already published; skipping."
           else
-            npm publish --provenance --access public --tag "$NPM_TAG"
+            # Prepublish already ran explicitly above. The package's
+            # prepublishOnly hook would publish the platform packages again.
+            npm publish --ignore-scripts --provenance --access public --tag "$NPM_TAG"
           fi
 
   publish-js:


### PR DESCRIPTION
## Summary

The NAPI publish job successfully publishes the platform packages, then `npm publish` for the main package invokes `prepublishOnly`, which tries to publish those same versions again. This fails with 403/409 conflicts and prevents the main and downstream JS packages from being published.

Add `--ignore-scripts` to the main package publication because the workflow already runs the prepublish preparation explicitly. Keeping the fix in the workflow also supports publishing existing release tags whose package.json still contains the hook.

Failure: https://github.com/celox-sim/celox/actions/runs/34597563432/job/103264117855

## Validation

- Reproduced lifecycle-hook failure with an isolated fixture using `npm publish --dry-run --offline`; confirmed the same command succeeds with `--ignore-scripts`.
- `git diff --check` passed.
- Actual npm publication and OIDC authentication require the merged workflow and have not been exercised locally.
- Pre-push checks passed: submodule validation, `cargo fmt --all -- --check`, `pnpm run lint`, and `cargo check --workspace --locked`.
